### PR TITLE
feat: improve Cloudflare support for custom domains

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -355,6 +355,7 @@ services:
 
       # Nginx Configuration (for dynamic domain mapping)
       PRIMARY_DOMAIN: ${PRIMARY_DOMAIN:-yourdomain.com}
+      PLATFORM_IP: ${PLATFORM_IP:-}
       BACKEND_HOST: backend
       BACKEND_PORT: 3000
       NGINX_SITES_PATH: /etc/nginx/sites-enabled
@@ -375,6 +376,9 @@ services:
       # Optional Services Configuration
       ENABLE_MINIO: ${ENABLE_MINIO:-true}
       ENABLE_REDIS: ${ENABLE_REDIS:-true}
+
+      # Proxy/CDN Mode (cloudflare or none)
+      PROXY_MODE: ${PROXY_MODE:-none}
 
       # Feature Flags (optional overrides - defaults defined in code)
       # SSL Feature Flags (set to false when using Cloudflare proxy)


### PR DESCRIPTION
When using Cloudflare (PROXY_MODE=cloudflare), DNS verification for custom domains now works correctly:

- Add Cloudflare IPv4 CIDR ranges to detect proxied domains
- Accept Cloudflare IPs as valid during DNS verification (since Cloudflare proxies hide the origin IP)
- Pass PROXY_MODE to backend container for runtime detection

Setup improvements for Cloudflare users:
- Auto-detect server IP and prompt for PLATFORM_IP during setup
- Set FEATURE_DOMAIN_SSL_TOGGLE=false (Cloudflare handles SSL)
- Pass PLATFORM_IP to backend for accurate DNS instructions

This fixes DNS verification failing for custom domains that are also behind Cloudflare, where DNS lookups return Cloudflare edge IPs instead of the origin server IP.