### PR TITLE
fix: delegate presigned URL methods in DynamicStorageAdapter

### DIFF
--- a/apps/backend/src/storage/dynamic-storage.adapter.ts
+++ b/apps/backend/src/storage/dynamic-storage.adapter.ts
@@ -112,4 +112,15 @@ export class DynamicStorageAdapter implements IStorageAdapter {
   async deletePrefix(prefix: string): Promise<{ deleted: number; failed: string[] }> {
     return this.adapter.deletePrefix(prefix);
   }
+
+  supportsPresignedUrls(): boolean {
+    return this.adapter.supportsPresignedUrls?.() ?? false;
+  }
+
+  async getPresignedUploadUrl(key: string, expiresIn?: number): Promise<string> {
+    if (!this.adapter.getPresignedUploadUrl) {
+      throw new Error('Presigned URLs not supported by current storage adapter');
+    }
+    return this.adapter.getPresignedUploadUrl(key, expiresIn);
+  }
 }


### PR DESCRIPTION
The DynamicStorageAdapter wrapper was missing delegation for supportsPresignedUrls() and getPresignedUploadUrl(), causing presigned URL uploads to fail even when using S3/MinIO storage.