### PR TITLE
feat: add batch download endpoints for download-artifact action

### DIFF
--- a/apps/backend/src/deployments/deployments.dto.ts
+++ b/apps/backend/src/deployments/deployments.dto.ts
@@ -766,3 +766,70 @@ export class FinalizeUploadDto {
  * Response DTO for finalize-upload endpoint (reuses CreateDeploymentResponseDto)
  */
 export class FinalizeUploadResponseDto extends CreateDeploymentResponseDto {}
+
+// Phase: Batch Download Endpoints (download-artifact action)
+
+/**
+ * Request DTO for prepare-batch-download endpoint
+ */
+export class PrepareBatchDownloadDto {
+  @ApiProperty({ description: 'GitHub repository (e.g., "owner/repo")' })
+  @IsString()
+  repository: string;
+
+  @ApiProperty({ description: 'Path prefix of files to download (e.g., "dist", "apps/frontend/dist")' })
+  @IsString()
+  path: string;
+
+  @ApiPropertyOptional({ description: 'Deployment alias to download from (e.g., "production", "preview")' })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[a-zA-Z0-9_-]+$/, {
+    message: 'Alias must contain only letters, numbers, underscores, and hyphens',
+  })
+  alias?: string;
+
+  @ApiPropertyOptional({ description: 'Specific commit SHA to download from' })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[a-f0-9]{7,40}$/i, { message: 'Invalid commit SHA format' })
+  commitSha?: string;
+
+  @ApiPropertyOptional({ description: 'Branch to download from (resolves to latest deployment)' })
+  @IsOptional()
+  @IsString()
+  branch?: string;
+}
+
+/**
+ * File info in batch download response
+ */
+export class DownloadFileInfoDto {
+  @ApiProperty({ description: 'Relative path within the deployment' })
+  path: string;
+
+  @ApiProperty({ description: 'File size in bytes' })
+  size: number;
+
+  @ApiProperty({ description: 'Presigned download URL (if presigned URLs supported)' })
+  downloadUrl: string;
+}
+
+/**
+ * Response DTO for prepare-batch-download endpoint
+ */
+export class PrepareBatchDownloadResponseDto {
+  @ApiProperty({
+    description: 'Whether presigned URLs are supported by the storage backend',
+  })
+  presignedUrlsSupported: boolean;
+
+  @ApiProperty({ description: 'Commit SHA of the resolved deployment' })
+  commitSha: string;
+
+  @ApiProperty({
+    description: 'Files available for download with presigned URLs',
+    type: [DownloadFileInfoDto],
+  })
+  files: DownloadFileInfoDto[];
+}

--- a/apps/backend/src/deployments/deployments.module.ts
+++ b/apps/backend/src/deployments/deployments.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { DeploymentsService } from './deployments.service';
 import { PendingUploadsService } from './pending-uploads.service';
 import { PendingUploadsScheduler } from './pending-uploads.scheduler';
-import { DeploymentsController, AliasesController } from './deployments.controller';
+import { DeploymentsController, AliasesController, FilesController } from './deployments.controller';
 import { PublicController } from './public.controller';
 import { ProjectsModule } from '../projects/projects.module';
 import { PermissionsModule } from '../permissions/permissions.module';
@@ -13,7 +13,7 @@ import { PlatformModule } from '../platform/platform.module';
 
 @Module({
   imports: [ProjectsModule, PermissionsModule, DomainsModule, CacheRulesModule, ShareLinksModule, PlatformModule],
-  controllers: [DeploymentsController, AliasesController, PublicController],
+  controllers: [DeploymentsController, AliasesController, PublicController, FilesController],
   providers: [DeploymentsService, PendingUploadsService, PendingUploadsScheduler],
   exports: [DeploymentsService, PendingUploadsService],
 })


### PR DESCRIPTION
- Add POST /api/deployments/prepare-batch-download endpoint
  - Resolves alias/branch/commitSha to deployment
  - Returns file manifest with presigned download URLs
  - Falls back to API URLs when presigned not supported
- Add GET /api/files/* endpoint (FilesController)
  - Fallback for local storage without presigned URL support
  - Streams files directly from storage
- Add PrepareBatchDownloadDto and PrepareBatchDownloadResponseDto