### PR TITLE
feat: add user onboarding automation rules

### DIFF
--- a/apps/backend/drizzle/0003_left_hammerhead.sql
+++ b/apps/backend/drizzle/0003_left_hammerhead.sql
@@ -1,0 +1,35 @@
+CREATE TABLE "onboarding_rule_executions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"rule_id" uuid,
+	"rule_name" varchar(100) NOT NULL,
+	"user_id" uuid NOT NULL,
+	"trigger" varchar(50) NOT NULL,
+	"status" varchar(20) NOT NULL,
+	"details" jsonb,
+	"error_message" varchar(1000),
+	"executed_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "onboarding_rules" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"description" varchar(500),
+	"trigger" varchar(50) DEFAULT 'user_signup' NOT NULL,
+	"actions" jsonb NOT NULL,
+	"conditions" jsonb,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"priority" integer DEFAULT 100 NOT NULL,
+	"created_by" uuid,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "onboarding_rule_executions" ADD CONSTRAINT "onboarding_rule_executions_rule_id_onboarding_rules_id_fk" FOREIGN KEY ("rule_id") REFERENCES "public"."onboarding_rules"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "onboarding_rule_executions" ADD CONSTRAINT "onboarding_rule_executions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "onboarding_rules" ADD CONSTRAINT "onboarding_rules_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "onboarding_rule_executions_user_idx" ON "onboarding_rule_executions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "onboarding_rule_executions_rule_idx" ON "onboarding_rule_executions" USING btree ("rule_id");--> statement-breakpoint
+CREATE INDEX "onboarding_rule_executions_executed_at_idx" ON "onboarding_rule_executions" USING btree ("executed_at");--> statement-breakpoint
+CREATE INDEX "onboarding_rule_executions_status_idx" ON "onboarding_rule_executions" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "onboarding_rules_enabled_trigger_idx" ON "onboarding_rules" USING btree ("enabled","trigger");--> statement-breakpoint
+CREATE INDEX "onboarding_rules_priority_idx" ON "onboarding_rules" USING btree ("priority");

--- a/apps/backend/drizzle/meta/0003_snapshot.json
+++ b/apps/backend/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,4629 @@
+{
+  "id": "56bc529c-9ff1-4942-8522-c6e12c42e4af",
+  "prevId": "d12d4338-8043-40e2-a215-370d55e6536f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_project_id_idx": {
+          "name": "api_keys_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_path": {
+          "name": "original_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_number": {
+          "name": "workflow_run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'commits'"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_project_id_idx": {
+          "name": "assets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_type_idx": {
+          "name": "assets_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_path_idx": {
+          "name": "assets_project_commit_path_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_branch_idx": {
+          "name": "assets_project_branch_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_idx": {
+          "name": "assets_project_commit_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_created_at_idx": {
+          "name": "assets_project_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_committed_at_idx": {
+          "name": "assets_project_committed_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_path_idx": {
+          "name": "assets_deployment_path_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_id_idx": {
+          "name": "assets_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_size_idx": {
+          "name": "assets_deployment_size_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_uploaded_by_users_id_fk": {
+          "name": "assets_uploaded_by_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cache_rules": {
+      "name": "cache_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_max_age": {
+          "name": "browser_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "cdn_max_age": {
+          "name": "cdn_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stale_while_revalidate": {
+          "name": "stale_while_revalidate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immutable": {
+          "name": "immutable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cacheability": {
+          "name": "cacheability",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cache_rules_project_pattern_unique": {
+          "name": "cache_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_id_idx": {
+          "name": "cache_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_priority_idx": {
+          "name": "cache_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cache_rules_project_id_projects_id_fk": {
+          "name": "cache_rules_project_id_projects_id_fk",
+          "tableFrom": "cache_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_aliases": {
+      "name": "deployment_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_preview": {
+          "name": "is_auto_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployment_aliases_project_alias_unique": {
+          "name": "deployment_aliases_project_alias_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_project_id_idx": {
+          "name": "deployment_aliases_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_alias_unique": {
+          "name": "deployment_aliases_repository_alias_unique",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_idx": {
+          "name": "deployment_aliases_repository_idx",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_commit_sha_idx": {
+          "name": "deployment_aliases_commit_sha_idx",
+          "columns": [
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_deployment_id_idx": {
+          "name": "deployment_aliases_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_aliases_project_id_projects_id_fk": {
+          "name": "deployment_aliases_project_id_projects_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_mappings": {
+      "name": "domain_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_type": {
+          "name": "domain_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ssl_expires_at": {
+          "name": "ssl_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_verified": {
+          "name": "dns_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dns_verified_at": {
+          "name": "dns_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_renew_ssl": {
+          "name": "auto_renew_ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_renewed_at": {
+          "name": "ssl_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_status": {
+          "name": "ssl_renewal_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_error": {
+          "name": "ssl_renewal_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sticky_sessions_enabled": {
+          "name": "sticky_sessions_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sticky_session_duration": {
+          "name": "sticky_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 86400
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_mappings_project_id_idx": {
+          "name": "domain_mappings_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_domain_idx": {
+          "name": "domain_mappings_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_is_active_idx": {
+          "name": "domain_mappings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_mappings_project_id_projects_id_fk": {
+          "name": "domain_mappings_project_id_projects_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_mappings_created_by_users_id_fk": {
+          "name": "domain_mappings_created_by_users_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_mappings_domain_unique": {
+          "name": "domain_mappings_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_redirects": {
+      "name": "domain_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_domain": {
+          "name": "source_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_domain_id": {
+          "name": "target_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_redirects_target_domain_id_idx": {
+          "name": "domain_redirects_target_domain_id_idx",
+          "columns": [
+            {
+              "expression": "target_domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_redirects_source_domain_idx": {
+          "name": "domain_redirects_source_domain_idx",
+          "columns": [
+            {
+              "expression": "source_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_redirects_target_domain_id_domain_mappings_id_fk": {
+          "name": "domain_redirects_target_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "target_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_redirects_created_by_users_id_fk": {
+          "name": "domain_redirects_created_by_users_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_redirects_source_domain_unique": {
+          "name": "domain_redirects_source_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_rules": {
+      "name": "domain_traffic_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_key": {
+          "name": "condition_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_value": {
+          "name": "condition_value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_rules_domain_id_idx": {
+          "name": "domain_traffic_rules_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_traffic_rules_domain_id_priority_idx": {
+          "name": "domain_traffic_rules_domain_id_priority_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_rules_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_rules_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_rules",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_weights": {
+      "name": "domain_traffic_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_weights_domain_id_idx": {
+          "name": "domain_traffic_weights_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_weights_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_weights_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_weights",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_traffic_weights_domain_alias_unique": {
+          "name": "domain_traffic_weights_domain_alias_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain_id",
+            "alias"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flags_key_idx": {
+          "name": "feature_flags_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rule_executions": {
+      "name": "onboarding_rule_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rule_executions_user_idx": {
+          "name": "onboarding_rule_executions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_rule_idx": {
+          "name": "onboarding_rule_executions_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_executed_at_idx": {
+          "name": "onboarding_rule_executions_executed_at_idx",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_status_idx": {
+          "name": "onboarding_rule_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rule_executions_rule_id_onboarding_rules_id_fk": {
+          "name": "onboarding_rule_executions_rule_id_onboarding_rules_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "onboarding_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "onboarding_rule_executions_user_id_users_id_fk": {
+          "name": "onboarding_rule_executions_user_id_users_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rules": {
+      "name": "onboarding_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_signup'"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rules_enabled_trigger_idx": {
+          "name": "onboarding_rules_enabled_trigger_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rules_priority_idx": {
+          "name": "onboarding_rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rules_created_by_users_id_fk": {
+          "name": "onboarding_rules_created_by_users_id_fk",
+          "tableFrom": "onboarding_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_preferences": {
+      "name": "path_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spa_mode": {
+          "name": "spa_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_path_preferences_project_id": {
+          "name": "idx_path_preferences_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_preferences_project_id_projects_id_fk": {
+          "name": "path_preferences_project_id_projects_id_fk",
+          "tableFrom": "path_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "path_preferences_project_filepath_unique": {
+          "name": "path_preferences_project_filepath_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "filepath"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_redirects": {
+      "name": "path_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'100'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "path_redirects_domain_mapping_id_idx": {
+          "name": "path_redirects_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "path_redirects_source_path_idx": {
+          "name": "path_redirects_source_path_idx",
+          "columns": [
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_redirects_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "path_redirects_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "path_redirects_created_by_users_id_fk": {
+          "name": "path_redirects_created_by_users_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_token": {
+          "name": "upload_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_token_idx": {
+          "name": "pending_uploads_token_idx",
+          "columns": [
+            {
+              "expression": "upload_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_project_idx": {
+          "name": "pending_uploads_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_project_id_projects_id_fk": {
+          "name": "pending_uploads_project_id_projects_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_uploaded_by_users_id_fk": {
+          "name": "pending_uploads_uploaded_by_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_uploads_upload_token_unique": {
+          "name": "pending_uploads_upload_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.primary_content": {
+      "name": "primary_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "www_enabled": {
+          "name": "www_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'redirect-to-www'"
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "primary_content_project_id_projects_id_fk": {
+          "name": "primary_content_project_id_projects_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "primary_content_configured_by_users_id_fk": {
+          "name": "primary_content_configured_by_users_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_group_permissions": {
+      "name": "project_group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_group_permissions_project_idx": {
+          "name": "project_group_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_permissions_group_idx": {
+          "name": "project_group_permissions_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_permissions_project_id_projects_id_fk": {
+          "name": "project_group_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_group_id_user_groups_id_fk": {
+          "name": "project_group_permissions_group_id_user_groups_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_granted_by_users_id_fk": {
+          "name": "project_group_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_group_permissions_unique": {
+          "name": "project_group_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "group_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_permissions": {
+      "name": "project_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_permissions_project_idx": {
+          "name": "project_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_permissions_user_idx": {
+          "name": "project_permissions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_permissions_project_id_projects_id_fk": {
+          "name": "project_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_user_id_users_id_fk": {
+          "name": "project_permissions_user_id_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_granted_by_users_id_fk": {
+          "name": "project_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_permissions_unique": {
+          "name": "project_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_found'"
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authenticated'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_proxy_rule_set_id": {
+          "name": "default_proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_created_by_idx": {
+          "name": "projects_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_owner_idx": {
+          "name": "projects_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_owner_name_unique": {
+          "name": "projects_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_sets": {
+      "name": "proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_sets_project_name_unique": {
+          "name": "proxy_rule_sets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_project_id_idx": {
+          "name": "proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_environment_idx": {
+          "name": "proxy_rule_sets_environment_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rules": {
+      "name": "proxy_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strip_prefix": {
+          "name": "strip_prefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "preserve_host": {
+          "name": "preserve_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forward_cookies": {
+          "name": "forward_cookies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "header_config": {
+          "name": "header_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_transform": {
+          "name": "auth_transform",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_rewrite": {
+          "name": "internal_rewrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rules_rule_set_path_unique": {
+          "name": "proxy_rules_rule_set_path_unique",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_id_idx": {
+          "name": "proxy_rules_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_order_idx": {
+          "name": "proxy_rules_rule_set_order_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rules_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rules_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rules",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_logs": {
+      "name": "retention_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_count": {
+          "name": "asset_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "freed_bytes": {
+          "name": "freed_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_partial": {
+          "name": "is_partial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_logs_project_id_idx": {
+          "name": "retention_logs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_rule_id_idx": {
+          "name": "retention_logs_rule_id_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_deleted_at_idx": {
+          "name": "retention_logs_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_project_deleted_at_idx": {
+          "name": "retention_logs_project_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_logs_project_id_projects_id_fk": {
+          "name": "retention_logs_project_id_projects_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retention_logs_rule_id_retention_rules_id_fk": {
+          "name": "retention_logs_rule_id_retention_rules_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "retention_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_rules": {
+      "name": "retention_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_pattern": {
+          "name": "branch_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_branches": {
+          "name": "exclude_branches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keep_with_alias": {
+          "name": "keep_with_alias",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "keep_minimum": {
+          "name": "keep_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "path_patterns": {
+          "name": "path_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_mode": {
+          "name": "path_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_summary": {
+          "name": "last_run_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_rules_project_id_idx": {
+          "name": "retention_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_next_run_idx": {
+          "name": "retention_rules_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_enabled_next_run_idx": {
+          "name": "retention_rules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_rules_project_id_projects_id_fk": {
+          "name": "retention_rules_project_id_projects_id_fk",
+          "tableFrom": "retention_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "share_links_project_id_idx": {
+          "name": "share_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_domain_mapping_id_idx": {
+          "name": "share_links_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_token_idx": {
+          "name": "share_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_is_active_idx": {
+          "name": "share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_project_id_projects_id_fk": {
+          "name": "share_links_project_id_projects_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "share_links_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_created_by_users_id_fk": {
+          "name": "share_links_created_by_users_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "share_links_token_unique": {
+          "name": "share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_challenges": {
+      "name": "ssl_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "base_domain": {
+          "name": "base_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_type": {
+          "name": "challenge_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_name": {
+          "name": "record_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_value": {
+          "name": "record_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_data": {
+          "name": "order_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authz_data": {
+          "name": "authz_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_authorization": {
+          "name": "key_authorization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_challenges_base_domain_idx": {
+          "name": "ssl_challenges_base_domain_idx",
+          "columns": [
+            {
+              "expression": "base_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_challenges_status_idx": {
+          "name": "ssl_challenges_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ssl_challenges_base_domain_unique": {
+          "name": "ssl_challenges_base_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "base_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_renewal_history": {
+      "name": "ssl_renewal_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_type": {
+          "name": "certificate_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_expires_at": {
+          "name": "new_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_renewal_history_domain_id_idx": {
+          "name": "ssl_renewal_history_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_renewal_history_created_at_idx": {
+          "name": "ssl_renewal_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssl_renewal_history_domain_id_domain_mappings_id_fk": {
+          "name": "ssl_renewal_history_domain_id_domain_mappings_id_fk",
+          "tableFrom": "ssl_renewal_history",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_settings": {
+      "name": "ssl_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_config": {
+      "name": "system_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_setup_complete": {
+          "name": "is_setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_config": {
+          "name": "storage_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_provider": {
+          "name": "email_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_config": {
+          "name": "email_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_configured": {
+          "name": "email_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "smtp_config": {
+          "name": "smtp_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_configured": {
+          "name": "smtp_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_config": {
+          "name": "cache_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwt_secret": {
+          "name": "jwt_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_salt": {
+          "name": "api_key_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_public_signups": {
+          "name": "allow_public_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_group_members": {
+      "name": "user_group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_members_group_idx": {
+          "name": "user_group_members_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_group_members_user_idx": {
+          "name": "user_group_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_group_members_group_id_user_groups_id_fk": {
+          "name": "user_group_members_group_id_user_groups_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_user_id_users_id_fk": {
+          "name": "user_group_members_user_id_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_added_by_users_id_fk": {
+          "name": "user_group_members_added_by_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_group_members_unique": {
+          "name": "user_group_members_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_groups_created_by_idx": {
+          "name": "user_groups_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_created_by_users_id_fk": {
+          "name": "user_groups_created_by_users_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_invitations_email": {
+          "name": "idx_workspace_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_invitations_token": {
+          "name": "idx_workspace_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invitations_invited_by_users_id_fk": {
+          "name": "workspace_invitations_invited_by_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_accepted_user_id_users_id_fk": {
+          "name": "workspace_invitations_accepted_user_id_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitations_token_unique": {
+          "name": "workspace_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1771162644786,
       "tag": "0002_flashy_deathstrike",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1771499499752,
+      "tag": "0003_left_hammerhead",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -33,6 +33,7 @@ import { CacheRulesModule } from './cache-rules/cache-rules.module';
 import { ShareLinksModule } from './share-links/share-links.module';
 import { PlatformModule } from './platform/platform.module';
 import { StorageUsageModule } from './storage/storage-usage.module';
+import { OnboardingRulesModule } from './onboarding-rules/onboarding-rules.module';
 
 @Module({
   imports: [
@@ -144,6 +145,7 @@ import { StorageUsageModule } from './storage/storage-usage.module';
     InternalModule,
     InvitationsModule,
     StorageUsageModule,
+    OnboardingRulesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/backend/src/auth/auth.module.ts
+++ b/apps/backend/src/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { RolesGuard } from './roles.guard';
 import { EmailVerificationGuard } from './email-verification.guard';
 import { initSuperTokens } from './supertokens.config';
 import { SetupModule } from '../setup/setup.module';
+import { OnboardingRulesModule } from '../onboarding-rules/onboarding-rules.module';
 
 @Module({})
 export class AuthModule implements NestModule {
@@ -20,7 +21,7 @@ export class AuthModule implements NestModule {
     return {
       module: AuthModule,
       global: true,
-      imports: [forwardRef(() => SetupModule)],
+      imports: [forwardRef(() => SetupModule), forwardRef(() => OnboardingRulesModule)],
       controllers: [AuthController],
       providers: [
         AuthService,

--- a/apps/backend/src/db/schema/index.ts
+++ b/apps/backend/src/db/schema/index.ts
@@ -25,3 +25,5 @@ export * from './retention-rules.schema';
 export * from './cache-rules.schema';
 export * from './share-links.schema';
 export * from './pending-uploads.schema';
+export * from './onboarding-rules.schema';
+export * from './onboarding-rule-executions.schema';

--- a/apps/backend/src/db/schema/onboarding-rule-executions.schema.ts
+++ b/apps/backend/src/db/schema/onboarding-rule-executions.schema.ts
@@ -1,0 +1,107 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  jsonb,
+  timestamp,
+  index,
+} from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { users } from './users.schema';
+import { onboardingRules, OnboardingAction, OnboardingTrigger } from './onboarding-rules.schema';
+
+/**
+ * Execution status for onboarding rule execution
+ */
+export type ExecutionStatus = 'success' | 'partial' | 'failed' | 'skipped';
+
+/**
+ * Details about individual action results
+ */
+export interface ActionExecutionResult {
+  action: OnboardingAction;
+  success: boolean;
+  message?: string;
+  error?: string;
+}
+
+/**
+ * Audit log of onboarding rule executions.
+ * Tracks when rules were executed, for which users, and the outcome.
+ */
+export const onboardingRuleExecutions = pgTable(
+  'onboarding_rule_executions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    /**
+     * Reference to the rule that was executed
+     * May be null if rule was deleted after execution
+     */
+    ruleId: uuid('rule_id').references(() => onboardingRules.id, { onDelete: 'set null' }),
+
+    /**
+     * Snapshot of rule name at execution time (for audit trail)
+     */
+    ruleName: varchar('rule_name', { length: 100 }).notNull(),
+
+    /**
+     * User the rule was executed for
+     */
+    userId: uuid('user_id')
+      .references(() => users.id, { onDelete: 'cascade' })
+      .notNull(),
+
+    /**
+     * What triggered the execution
+     */
+    trigger: varchar('trigger', { length: 50 }).$type<OnboardingTrigger>().notNull(),
+
+    /**
+     * Overall execution status
+     * - 'success': All actions completed successfully
+     * - 'partial': Some actions succeeded, some failed
+     * - 'failed': All actions failed
+     * - 'skipped': Rule conditions not met
+     */
+    status: varchar('status', { length: 20 }).$type<ExecutionStatus>().notNull(),
+
+    /**
+     * Detailed results for each action
+     */
+    details: jsonb('details').$type<ActionExecutionResult[]>(),
+
+    /**
+     * Summary error message if execution failed
+     */
+    errorMessage: varchar('error_message', { length: 1000 }),
+
+    /**
+     * When the execution occurred
+     */
+    executedAt: timestamp('executed_at').defaultNow().notNull(),
+  },
+  (table) => [
+    index('onboarding_rule_executions_user_idx').on(table.userId),
+    index('onboarding_rule_executions_rule_idx').on(table.ruleId),
+    index('onboarding_rule_executions_executed_at_idx').on(table.executedAt),
+    index('onboarding_rule_executions_status_idx').on(table.status),
+  ],
+);
+
+/**
+ * Relations for onboarding rule executions
+ */
+export const onboardingRuleExecutionsRelations = relations(onboardingRuleExecutions, ({ one }) => ({
+  rule: one(onboardingRules, {
+    fields: [onboardingRuleExecutions.ruleId],
+    references: [onboardingRules.id],
+  }),
+  user: one(users, {
+    fields: [onboardingRuleExecutions.userId],
+    references: [users.id],
+  }),
+}));
+
+export type OnboardingRuleExecution = typeof onboardingRuleExecutions.$inferSelect;
+export type NewOnboardingRuleExecution = typeof onboardingRuleExecutions.$inferInsert;

--- a/apps/backend/src/db/schema/onboarding-rules.schema.ts
+++ b/apps/backend/src/db/schema/onboarding-rules.schema.ts
@@ -1,0 +1,151 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  jsonb,
+  boolean,
+  integer,
+  timestamp,
+  index,
+} from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { users } from './users.schema';
+
+/**
+ * Action types for onboarding rules
+ */
+export type OnboardingActionType = 'grant_repo_access' | 'assign_role' | 'add_to_group';
+
+/**
+ * Parameters for grant_repo_access action
+ */
+export interface GrantRepoAccessParams {
+  /** Repository identifier in format "owner/name" */
+  repository: string;
+  /** Role to grant: viewer, contributor, admin */
+  role: 'viewer' | 'contributor' | 'admin';
+}
+
+/**
+ * Parameters for assign_role action
+ */
+export interface AssignRoleParams {
+  /** Workspace role to assign */
+  role: 'admin' | 'user' | 'member';
+}
+
+/**
+ * Parameters for add_to_group action
+ */
+export interface AddToGroupParams {
+  /** Group ID to add user to */
+  groupId: string;
+}
+
+/**
+ * Union type for action parameters
+ */
+export type OnboardingActionParams = GrantRepoAccessParams | AssignRoleParams | AddToGroupParams;
+
+/**
+ * An onboarding action to execute
+ */
+export interface OnboardingAction {
+  type: OnboardingActionType;
+  params: OnboardingActionParams;
+}
+
+/**
+ * Condition types for filtering when rules apply
+ */
+export interface OnboardingCondition {
+  /** Type of condition check */
+  type: 'email_domain' | 'email_pattern';
+  /** Value to match against */
+  value: string;
+}
+
+/**
+ * Trigger types for onboarding rules
+ */
+export type OnboardingTrigger = 'user_signup' | 'invite_accepted';
+
+/**
+ * Onboarding rules define automatic actions when users sign up or accept invitations.
+ * Rules are evaluated in priority order; all matching rules are executed.
+ */
+export const onboardingRules = pgTable(
+  'onboarding_rules',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    /**
+     * Human-readable name for the rule
+     */
+    name: varchar('name', { length: 100 }).notNull(),
+
+    /**
+     * Optional description explaining the rule's purpose
+     */
+    description: varchar('description', { length: 500 }),
+
+    /**
+     * Event that triggers this rule
+     * - 'user_signup': New user signs up (public or via invitation)
+     * - 'invite_accepted': User accepts an invitation (already registered)
+     */
+    trigger: varchar('trigger', { length: 50 })
+      .$type<OnboardingTrigger>()
+      .notNull()
+      .default('user_signup'),
+
+    /**
+     * Actions to execute when rule matches
+     * Array of {type, params} objects
+     */
+    actions: jsonb('actions').$type<OnboardingAction[]>().notNull(),
+
+    /**
+     * Optional conditions that must match for rule to execute
+     * If null/empty, rule always executes for the trigger
+     */
+    conditions: jsonb('conditions').$type<OnboardingCondition[] | null>(),
+
+    /**
+     * Whether this rule is active
+     */
+    enabled: boolean('enabled').default(true).notNull(),
+
+    /**
+     * Execution priority. Lower = higher priority (executed first).
+     * Rules with same priority are executed in creation order.
+     */
+    priority: integer('priority').default(100).notNull(),
+
+    /**
+     * User who created this rule (used as grantedBy for permissions)
+     */
+    createdBy: uuid('created_by').references(() => users.id),
+
+    // Timestamps
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => [
+    index('onboarding_rules_enabled_trigger_idx').on(table.enabled, table.trigger),
+    index('onboarding_rules_priority_idx').on(table.priority),
+  ],
+);
+
+/**
+ * Relations for onboarding rules
+ */
+export const onboardingRulesRelations = relations(onboardingRules, ({ one }) => ({
+  creator: one(users, {
+    fields: [onboardingRules.createdBy],
+    references: [users.id],
+  }),
+}));
+
+export type OnboardingRule = typeof onboardingRules.$inferSelect;
+export type NewOnboardingRule = typeof onboardingRules.$inferInsert;

--- a/apps/backend/src/onboarding-rules/dto/create-onboarding-rule.dto.ts
+++ b/apps/backend/src/onboarding-rules/dto/create-onboarding-rule.dto.ts
@@ -1,0 +1,124 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsBoolean,
+  IsInt,
+  IsOptional,
+  IsArray,
+  IsIn,
+  MaxLength,
+  Min,
+  ValidateNested,
+  IsObject,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  OnboardingActionType,
+  OnboardingActionParams,
+  OnboardingTrigger,
+} from '../../db/schema/onboarding-rules.schema';
+
+export class OnboardingActionDto {
+  @ApiProperty({
+    description: 'Type of action to execute',
+    enum: ['grant_repo_access', 'assign_role', 'add_to_group'],
+    example: 'grant_repo_access',
+  })
+  @IsString()
+  @IsIn(['grant_repo_access', 'assign_role', 'add_to_group'])
+  type: OnboardingActionType;
+
+  @ApiProperty({
+    description: 'Parameters for the action (varies by type)',
+    example: { repository: 'bffless/demo', role: 'viewer' },
+  })
+  @IsObject()
+  params: OnboardingActionParams;
+}
+
+export class OnboardingConditionDto {
+  @ApiProperty({
+    description: 'Type of condition',
+    enum: ['email_domain', 'email_pattern'],
+    example: 'email_domain',
+  })
+  @IsString()
+  @IsIn(['email_domain', 'email_pattern'])
+  type: 'email_domain' | 'email_pattern';
+
+  @ApiProperty({
+    description: 'Value to match against',
+    example: 'example.com',
+  })
+  @IsString()
+  @MaxLength(255)
+  value: string;
+}
+
+export class CreateOnboardingRuleDto {
+  @ApiProperty({
+    description: 'Human-readable name for the rule',
+    example: 'Grant demo repo access',
+  })
+  @IsString()
+  @MaxLength(100)
+  name: string;
+
+  @ApiPropertyOptional({
+    description: 'Description explaining the rule purpose',
+    example: 'Automatically grants viewer access to demo repo for all new signups',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @ApiPropertyOptional({
+    description: 'Event that triggers this rule',
+    enum: ['user_signup', 'invite_accepted'],
+    default: 'user_signup',
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(['user_signup', 'invite_accepted'])
+  trigger?: OnboardingTrigger;
+
+  @ApiProperty({
+    description: 'Actions to execute when rule matches',
+    type: [OnboardingActionDto],
+    example: [{ type: 'grant_repo_access', params: { repository: 'bffless/demo', role: 'viewer' } }],
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => OnboardingActionDto)
+  actions: OnboardingActionDto[];
+
+  @ApiPropertyOptional({
+    description: 'Conditions that must match for rule to execute',
+    type: [OnboardingConditionDto],
+    example: [{ type: 'email_domain', value: 'example.com' }],
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => OnboardingConditionDto)
+  conditions?: OnboardingConditionDto[] | null;
+
+  @ApiPropertyOptional({
+    description: 'Whether this rule is enabled',
+    default: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Execution priority. Lower = higher priority (executed first).',
+    default: 100,
+    example: 10,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  priority?: number;
+}

--- a/apps/backend/src/onboarding-rules/dto/index.ts
+++ b/apps/backend/src/onboarding-rules/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './create-onboarding-rule.dto';
+export * from './update-onboarding-rule.dto';
+export * from './onboarding-rule-response.dto';

--- a/apps/backend/src/onboarding-rules/dto/onboarding-rule-response.dto.ts
+++ b/apps/backend/src/onboarding-rules/dto/onboarding-rule-response.dto.ts
@@ -1,0 +1,91 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  OnboardingAction,
+  OnboardingCondition,
+  OnboardingTrigger,
+} from '../../db/schema/onboarding-rules.schema';
+import {
+  ActionExecutionResult,
+  ExecutionStatus,
+} from '../../db/schema/onboarding-rule-executions.schema';
+
+export class OnboardingRuleResponseDto {
+  @ApiProperty({ description: 'Rule ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Human-readable name for the rule' })
+  name: string;
+
+  @ApiPropertyOptional({ description: 'Description explaining the rule purpose' })
+  description: string | null;
+
+  @ApiProperty({
+    description: 'Event that triggers this rule',
+    enum: ['user_signup', 'invite_accepted'],
+  })
+  trigger: OnboardingTrigger;
+
+  @ApiProperty({ description: 'Actions to execute when rule matches' })
+  actions: OnboardingAction[];
+
+  @ApiPropertyOptional({ description: 'Conditions that must match for rule to execute' })
+  conditions: OnboardingCondition[] | null;
+
+  @ApiProperty({ description: 'Whether this rule is enabled' })
+  enabled: boolean;
+
+  @ApiProperty({ description: 'Execution priority (lower = higher priority)' })
+  priority: number;
+
+  @ApiPropertyOptional({ description: 'ID of user who created this rule' })
+  createdBy: string | null;
+
+  @ApiProperty({ description: 'Rule creation timestamp' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Rule last updated timestamp' })
+  updatedAt: Date;
+}
+
+export class OnboardingRuleExecutionResponseDto {
+  @ApiProperty({ description: 'Execution ID' })
+  id: string;
+
+  @ApiPropertyOptional({ description: 'Rule ID (null if rule was deleted)' })
+  ruleId: string | null;
+
+  @ApiProperty({ description: 'Rule name at time of execution' })
+  ruleName: string;
+
+  @ApiProperty({ description: 'User ID the rule was executed for' })
+  userId: string;
+
+  @ApiProperty({
+    description: 'Trigger type',
+    enum: ['user_signup', 'invite_accepted'],
+  })
+  trigger: OnboardingTrigger;
+
+  @ApiProperty({
+    description: 'Execution status',
+    enum: ['success', 'partial', 'failed', 'skipped'],
+  })
+  status: ExecutionStatus;
+
+  @ApiPropertyOptional({ description: 'Detailed results for each action' })
+  details: ActionExecutionResult[] | null;
+
+  @ApiPropertyOptional({ description: 'Error message if execution failed' })
+  errorMessage: string | null;
+
+  @ApiProperty({ description: 'When the execution occurred' })
+  executedAt: Date;
+}
+
+export class OnboardingRuleWithStatsDto extends OnboardingRuleResponseDto {
+  @ApiPropertyOptional({ description: 'Total execution count' })
+  executionCount?: number;
+
+  @ApiPropertyOptional({ description: 'Last execution timestamp' })
+  lastExecutedAt?: Date | null;
+}

--- a/apps/backend/src/onboarding-rules/dto/update-onboarding-rule.dto.ts
+++ b/apps/backend/src/onboarding-rules/dto/update-onboarding-rule.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateOnboardingRuleDto } from './create-onboarding-rule.dto';
+
+export class UpdateOnboardingRuleDto extends PartialType(CreateOnboardingRuleDto) {}

--- a/apps/backend/src/onboarding-rules/onboarding-executor.service.ts
+++ b/apps/backend/src/onboarding-rules/onboarding-executor.service.ts
@@ -1,0 +1,379 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { eq, and } from 'drizzle-orm';
+import { db } from '../db/client';
+import {
+  OnboardingRule,
+  OnboardingTrigger,
+  OnboardingAction,
+  OnboardingCondition,
+  GrantRepoAccessParams,
+  AssignRoleParams,
+  AddToGroupParams,
+} from '../db/schema/onboarding-rules.schema';
+import {
+  onboardingRuleExecutions,
+  ActionExecutionResult,
+  ExecutionStatus,
+  NewOnboardingRuleExecution,
+} from '../db/schema/onboarding-rule-executions.schema';
+import { projects, projectPermissions, users, userGroupMembers } from '../db/schema';
+import { OnboardingRulesService } from './onboarding-rules.service';
+
+/**
+ * Context for executing onboarding rules
+ */
+export interface OnboardingContext {
+  userId: string;
+  userEmail: string;
+  trigger: OnboardingTrigger;
+  /** Role from invitation (only for invite_accepted trigger) */
+  invitationRole?: string;
+}
+
+@Injectable()
+export class OnboardingExecutorService {
+  private readonly logger = new Logger(OnboardingExecutorService.name);
+
+  constructor(private readonly rulesService: OnboardingRulesService) {}
+
+  /**
+   * Execute all matching onboarding rules for a user event
+   */
+  async executeRulesForUser(context: OnboardingContext): Promise<void> {
+    const { userId, userEmail, trigger } = context;
+
+    this.logger.log(`Executing onboarding rules for user ${userEmail} (trigger: ${trigger})`);
+
+    // Get all enabled rules for this trigger
+    const rules = await this.rulesService.getEnabledRulesByTrigger(trigger);
+
+    if (rules.length === 0) {
+      this.logger.debug(`No onboarding rules configured for trigger: ${trigger}`);
+      return;
+    }
+
+    this.logger.log(`Found ${rules.length} rules to evaluate`);
+
+    // Execute each rule
+    for (const rule of rules) {
+      await this.executeRule(rule, context);
+    }
+  }
+
+  /**
+   * Execute a single onboarding rule
+   */
+  private async executeRule(rule: OnboardingRule, context: OnboardingContext): Promise<void> {
+    const { userId, userEmail, trigger } = context;
+
+    // Check if conditions match
+    if (rule.conditions && rule.conditions.length > 0) {
+      const conditionsMatch = this.evaluateConditions(rule.conditions, userEmail);
+      if (!conditionsMatch) {
+        this.logger.debug(`Rule "${rule.name}" skipped: conditions not met for ${userEmail}`);
+        await this.logExecution(rule, userId, trigger, 'skipped', [], null);
+        return;
+      }
+    }
+
+    this.logger.log(`Executing rule "${rule.name}" for user ${userEmail}`);
+
+    // Execute each action
+    const results: ActionExecutionResult[] = [];
+
+    for (const action of rule.actions) {
+      const result = await this.executeAction(action, rule, context);
+      results.push(result);
+    }
+
+    // Determine overall status
+    const successCount = results.filter((r) => r.success).length;
+    const totalCount = results.length;
+    let status: ExecutionStatus;
+    let errorMessage: string | null = null;
+
+    if (successCount === totalCount) {
+      status = 'success';
+    } else if (successCount === 0) {
+      status = 'failed';
+      errorMessage = results.map((r) => r.error).filter(Boolean).join('; ');
+    } else {
+      status = 'partial';
+      errorMessage = results
+        .filter((r) => !r.success)
+        .map((r) => r.error)
+        .filter(Boolean)
+        .join('; ');
+    }
+
+    await this.logExecution(rule, userId, trigger, status, results, errorMessage);
+
+    this.logger.log(
+      `Rule "${rule.name}" execution complete: ${status} (${successCount}/${totalCount} actions)`,
+    );
+  }
+
+  /**
+   * Evaluate conditions against user email
+   */
+  private evaluateConditions(conditions: OnboardingCondition[], email: string): boolean {
+    // All conditions must match (AND logic)
+    return conditions.every((condition) => this.evaluateCondition(condition, email));
+  }
+
+  /**
+   * Evaluate a single condition
+   */
+  private evaluateCondition(condition: OnboardingCondition, email: string): boolean {
+    const emailLower = email.toLowerCase();
+
+    switch (condition.type) {
+      case 'email_domain': {
+        // Check if email ends with @domain
+        const domain = condition.value.toLowerCase();
+        return emailLower.endsWith(`@${domain}`);
+      }
+      case 'email_pattern': {
+        // Glob-like pattern matching
+        try {
+          const pattern = condition.value.toLowerCase();
+          const regex = new RegExp(
+            '^' + pattern.replace(/\*/g, '.*').replace(/\?/g, '.') + '$',
+          );
+          return regex.test(emailLower);
+        } catch {
+          this.logger.warn(`Invalid email pattern: ${condition.value}`);
+          return false;
+        }
+      }
+      default:
+        this.logger.warn(`Unknown condition type: ${(condition as any).type}`);
+        return false;
+    }
+  }
+
+  /**
+   * Execute a single action
+   */
+  private async executeAction(
+    action: OnboardingAction,
+    rule: OnboardingRule,
+    context: OnboardingContext,
+  ): Promise<ActionExecutionResult> {
+    try {
+      switch (action.type) {
+        case 'grant_repo_access':
+          return await this.executeGrantRepoAccess(
+            action.params as GrantRepoAccessParams,
+            rule,
+            context,
+          );
+        case 'assign_role':
+          return await this.executeAssignRole(
+            action.params as AssignRoleParams,
+            context,
+          );
+        case 'add_to_group':
+          return await this.executeAddToGroup(
+            action.params as AddToGroupParams,
+            context,
+          );
+        default:
+          return {
+            action,
+            success: false,
+            error: `Unknown action type: ${(action as any).type}`,
+          };
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Action ${action.type} failed: ${message}`);
+      return {
+        action,
+        success: false,
+        error: message,
+      };
+    }
+  }
+
+  /**
+   * Execute grant_repo_access action
+   */
+  private async executeGrantRepoAccess(
+    params: GrantRepoAccessParams,
+    rule: OnboardingRule,
+    context: OnboardingContext,
+  ): Promise<ActionExecutionResult> {
+    const { repository, role } = params;
+    const { userId } = context;
+
+    // Parse repository "owner/name"
+    const [owner, name] = repository.split('/');
+    if (!owner || !name) {
+      return {
+        action: { type: 'grant_repo_access', params },
+        success: false,
+        error: `Invalid repository format: ${repository} (expected "owner/name")`,
+      };
+    }
+
+    // Find the project
+    const [project] = await db
+      .select()
+      .from(projects)
+      .where(and(eq(projects.owner, owner), eq(projects.name, name)))
+      .limit(1);
+
+    if (!project) {
+      return {
+        action: { type: 'grant_repo_access', params },
+        success: false,
+        error: `Repository not found: ${repository}`,
+      };
+    }
+
+    // Check if user already has permission
+    const [existing] = await db
+      .select()
+      .from(projectPermissions)
+      .where(
+        and(
+          eq(projectPermissions.projectId, project.id),
+          eq(projectPermissions.userId, userId),
+        ),
+      )
+      .limit(1);
+
+    if (existing) {
+      // User already has access - idempotent, treat as success
+      this.logger.debug(`User already has ${existing.role} access to ${repository}`);
+      return {
+        action: { type: 'grant_repo_access', params },
+        success: true,
+        message: `User already has ${existing.role} access (unchanged)`,
+      };
+    }
+
+    // Grant permission using rule creator as grantedBy
+    await db.insert(projectPermissions).values({
+      projectId: project.id,
+      userId,
+      role,
+      grantedBy: rule.createdBy,
+    });
+
+    this.logger.log(`Granted ${role} access to ${repository} for user ${userId}`);
+
+    return {
+      action: { type: 'grant_repo_access', params },
+      success: true,
+      message: `Granted ${role} access to ${repository}`,
+    };
+  }
+
+  /**
+   * Execute assign_role action (workspace-level role)
+   */
+  private async executeAssignRole(
+    params: AssignRoleParams,
+    context: OnboardingContext,
+  ): Promise<ActionExecutionResult> {
+    const { role } = params;
+    const { userId } = context;
+
+    // Update user's role
+    const [updated] = await db
+      .update(users)
+      .set({ role, updatedAt: new Date() })
+      .where(eq(users.id, userId))
+      .returning();
+
+    if (!updated) {
+      return {
+        action: { type: 'assign_role', params },
+        success: false,
+        error: `User not found: ${userId}`,
+      };
+    }
+
+    this.logger.log(`Assigned workspace role ${role} to user ${userId}`);
+
+    return {
+      action: { type: 'assign_role', params },
+      success: true,
+      message: `Assigned workspace role: ${role}`,
+    };
+  }
+
+  /**
+   * Execute add_to_group action
+   */
+  private async executeAddToGroup(
+    params: AddToGroupParams,
+    context: OnboardingContext,
+  ): Promise<ActionExecutionResult> {
+    const { groupId } = params;
+    const { userId } = context;
+
+    // Check if user is already in group
+    const [existing] = await db
+      .select()
+      .from(userGroupMembers)
+      .where(
+        and(
+          eq(userGroupMembers.groupId, groupId),
+          eq(userGroupMembers.userId, userId),
+        ),
+      )
+      .limit(1);
+
+    if (existing) {
+      return {
+        action: { type: 'add_to_group', params },
+        success: true,
+        message: 'User already in group (unchanged)',
+      };
+    }
+
+    // Add user to group
+    await db.insert(userGroupMembers).values({
+      groupId,
+      userId,
+    });
+
+    this.logger.log(`Added user ${userId} to group ${groupId}`);
+
+    return {
+      action: { type: 'add_to_group', params },
+      success: true,
+      message: `Added to group ${groupId}`,
+    };
+  }
+
+  /**
+   * Log execution result to audit table
+   */
+  private async logExecution(
+    rule: OnboardingRule,
+    userId: string,
+    trigger: OnboardingTrigger,
+    status: ExecutionStatus,
+    details: ActionExecutionResult[],
+    errorMessage: string | null,
+  ): Promise<void> {
+    try {
+      await db.insert(onboardingRuleExecutions).values({
+        ruleId: rule.id,
+        ruleName: rule.name,
+        userId,
+        trigger,
+        status,
+        details,
+        errorMessage,
+      } satisfies NewOnboardingRuleExecution);
+    } catch (error) {
+      // Don't fail the onboarding if logging fails
+      this.logger.error(`Failed to log execution: ${error}`);
+    }
+  }
+}

--- a/apps/backend/src/onboarding-rules/onboarding-rules.controller.ts
+++ b/apps/backend/src/onboarding-rules/onboarding-rules.controller.ts
@@ -1,0 +1,163 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  ParseUUIDPipe,
+  NotFoundException,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { OnboardingRulesService } from './onboarding-rules.service';
+import {
+  CreateOnboardingRuleDto,
+  UpdateOnboardingRuleDto,
+  OnboardingRuleResponseDto,
+  OnboardingRuleExecutionResponseDto,
+} from './dto';
+import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
+
+@ApiTags('Onboarding Rules')
+@ApiBearerAuth()
+@Controller('api/onboarding-rules')
+@UseGuards(SessionAuthGuard, RolesGuard)
+@Roles('admin')
+export class OnboardingRulesController {
+  constructor(private readonly onboardingRulesService: OnboardingRulesService) {}
+
+  /**
+   * Get all onboarding rules
+   */
+  @Get()
+  @ApiOperation({ summary: 'List all onboarding rules' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of onboarding rules',
+    type: [OnboardingRuleResponseDto],
+  })
+  async getAllRules(): Promise<{ rules: OnboardingRuleResponseDto[] }> {
+    const rules = await this.onboardingRulesService.getAllRules();
+    return { rules: rules as OnboardingRuleResponseDto[] };
+  }
+
+  /**
+   * Get a specific onboarding rule
+   */
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a specific onboarding rule' })
+  @ApiParam({ name: 'id', type: 'string', description: 'Onboarding rule ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Onboarding rule details',
+    type: OnboardingRuleResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Rule not found' })
+  async getRule(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<OnboardingRuleResponseDto> {
+    const rule = await this.onboardingRulesService.getRuleById(id);
+    if (!rule) {
+      throw new NotFoundException(`Onboarding rule ${id} not found`);
+    }
+    return rule as OnboardingRuleResponseDto;
+  }
+
+  /**
+   * Create a new onboarding rule
+   */
+  @Post()
+  @ApiOperation({ summary: 'Create a new onboarding rule' })
+  @ApiResponse({
+    status: 201,
+    description: 'Created onboarding rule',
+    type: OnboardingRuleResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input' })
+  @ApiResponse({ status: 403, description: 'Not authorized (admin only)' })
+  async createRule(
+    @Body() dto: CreateOnboardingRuleDto,
+    @CurrentUser() user: CurrentUserData,
+  ): Promise<OnboardingRuleResponseDto> {
+    const rule = await this.onboardingRulesService.create(dto, user.id);
+    return rule as OnboardingRuleResponseDto;
+  }
+
+  /**
+   * Update an onboarding rule
+   */
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update an onboarding rule' })
+  @ApiParam({ name: 'id', type: 'string', description: 'Onboarding rule ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Updated onboarding rule',
+    type: OnboardingRuleResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input' })
+  @ApiResponse({ status: 403, description: 'Not authorized (admin only)' })
+  @ApiResponse({ status: 404, description: 'Rule not found' })
+  async updateRule(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateOnboardingRuleDto,
+  ): Promise<OnboardingRuleResponseDto> {
+    const rule = await this.onboardingRulesService.update(id, dto);
+    return rule as OnboardingRuleResponseDto;
+  }
+
+  /**
+   * Delete an onboarding rule
+   */
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete an onboarding rule' })
+  @ApiParam({ name: 'id', type: 'string', description: 'Onboarding rule ID' })
+  @ApiResponse({ status: 200, description: 'Rule deleted' })
+  @ApiResponse({ status: 403, description: 'Not authorized (admin only)' })
+  @ApiResponse({ status: 404, description: 'Rule not found' })
+  async deleteRule(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<{ success: boolean }> {
+    await this.onboardingRulesService.delete(id);
+    return { success: true };
+  }
+
+  /**
+   * Get recent rule execution audit log
+   */
+  @Get('executions/recent')
+  @ApiOperation({ summary: 'Get recent onboarding rule executions' })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: 'number',
+    description: 'Maximum number of executions to return (default: 50)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Recent rule executions',
+    type: [OnboardingRuleExecutionResponseDto],
+  })
+  async getRecentExecutions(
+    @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit: number,
+  ): Promise<{ executions: OnboardingRuleExecutionResponseDto[] }> {
+    const executions = await this.onboardingRulesService.getRecentExecutions(
+      Math.min(limit, 100),
+    );
+    return { executions: executions as OnboardingRuleExecutionResponseDto[] };
+  }
+}

--- a/apps/backend/src/onboarding-rules/onboarding-rules.module.ts
+++ b/apps/backend/src/onboarding-rules/onboarding-rules.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { OnboardingRulesController } from './onboarding-rules.controller';
+import { OnboardingRulesService } from './onboarding-rules.service';
+import { OnboardingExecutorService } from './onboarding-executor.service';
+
+@Module({
+  controllers: [OnboardingRulesController],
+  providers: [OnboardingRulesService, OnboardingExecutorService],
+  exports: [OnboardingRulesService, OnboardingExecutorService],
+})
+export class OnboardingRulesModule {}

--- a/apps/backend/src/onboarding-rules/onboarding-rules.service.ts
+++ b/apps/backend/src/onboarding-rules/onboarding-rules.service.ts
@@ -1,0 +1,158 @@
+import {
+  Injectable,
+  NotFoundException,
+  Logger,
+} from '@nestjs/common';
+import { eq, asc, and, desc } from 'drizzle-orm';
+import { db } from '../db/client';
+import {
+  onboardingRules,
+  OnboardingRule,
+  NewOnboardingRule,
+  OnboardingTrigger,
+  OnboardingAction,
+  OnboardingCondition,
+} from '../db/schema/onboarding-rules.schema';
+import {
+  onboardingRuleExecutions,
+  OnboardingRuleExecution,
+} from '../db/schema/onboarding-rule-executions.schema';
+import { CreateOnboardingRuleDto, UpdateOnboardingRuleDto } from './dto';
+
+@Injectable()
+export class OnboardingRulesService {
+  private readonly logger = new Logger(OnboardingRulesService.name);
+
+  /**
+   * Get all onboarding rules, ordered by priority
+   */
+  async getAllRules(): Promise<OnboardingRule[]> {
+    return db
+      .select()
+      .from(onboardingRules)
+      .orderBy(asc(onboardingRules.priority), asc(onboardingRules.createdAt));
+  }
+
+  /**
+   * Get enabled rules for a specific trigger, ordered by priority
+   */
+  async getEnabledRulesByTrigger(trigger: OnboardingTrigger): Promise<OnboardingRule[]> {
+    return db
+      .select()
+      .from(onboardingRules)
+      .where(
+        and(
+          eq(onboardingRules.enabled, true),
+          eq(onboardingRules.trigger, trigger),
+        ),
+      )
+      .orderBy(asc(onboardingRules.priority), asc(onboardingRules.createdAt));
+  }
+
+  /**
+   * Get a single rule by ID
+   */
+  async getRuleById(id: string): Promise<OnboardingRule | null> {
+    const [rule] = await db
+      .select()
+      .from(onboardingRules)
+      .where(eq(onboardingRules.id, id))
+      .limit(1);
+    return rule || null;
+  }
+
+  /**
+   * Create a new onboarding rule
+   */
+  async create(dto: CreateOnboardingRuleDto, userId: string): Promise<OnboardingRule> {
+    // Cast DTOs to schema types (DTOs have the same structure)
+    const actions = dto.actions as OnboardingAction[];
+    const conditions = dto.conditions as OnboardingCondition[] | null;
+
+    const [rule] = await db
+      .insert(onboardingRules)
+      .values({
+        name: dto.name,
+        description: dto.description ?? null,
+        trigger: dto.trigger ?? 'user_signup',
+        actions,
+        conditions: conditions ?? null,
+        enabled: dto.enabled ?? true,
+        priority: dto.priority ?? 100,
+        createdBy: userId,
+      } satisfies NewOnboardingRule)
+      .returning();
+
+    this.logger.log(`Created onboarding rule: ${rule.name} (id: ${rule.id})`);
+
+    return rule;
+  }
+
+  /**
+   * Update an onboarding rule
+   */
+  async update(id: string, dto: UpdateOnboardingRuleDto): Promise<OnboardingRule> {
+    const existing = await this.getRuleById(id);
+    if (!existing) {
+      throw new NotFoundException(`Onboarding rule ${id} not found`);
+    }
+
+    const updateData: Partial<NewOnboardingRule> = {
+      updatedAt: new Date(),
+    };
+
+    if ('name' in dto) updateData.name = dto.name;
+    if ('description' in dto) updateData.description = dto.description ?? null;
+    if ('trigger' in dto) updateData.trigger = dto.trigger;
+    if ('actions' in dto) updateData.actions = dto.actions as OnboardingAction[] | undefined;
+    if ('conditions' in dto) updateData.conditions = (dto.conditions as OnboardingCondition[] | null) ?? null;
+    if ('enabled' in dto) updateData.enabled = dto.enabled;
+    if ('priority' in dto) updateData.priority = dto.priority;
+
+    const [updated] = await db
+      .update(onboardingRules)
+      .set(updateData)
+      .where(eq(onboardingRules.id, id))
+      .returning();
+
+    this.logger.log(`Updated onboarding rule: ${updated.name} (id: ${id})`);
+
+    return updated;
+  }
+
+  /**
+   * Delete an onboarding rule
+   */
+  async delete(id: string): Promise<void> {
+    const existing = await this.getRuleById(id);
+    if (!existing) {
+      throw new NotFoundException(`Onboarding rule ${id} not found`);
+    }
+
+    await db.delete(onboardingRules).where(eq(onboardingRules.id, id));
+
+    this.logger.log(`Deleted onboarding rule: ${existing.name} (id: ${id})`);
+  }
+
+  /**
+   * Get recent rule executions for audit log
+   */
+  async getRecentExecutions(limit: number = 50): Promise<OnboardingRuleExecution[]> {
+    return db
+      .select()
+      .from(onboardingRuleExecutions)
+      .orderBy(desc(onboardingRuleExecutions.executedAt))
+      .limit(limit);
+  }
+
+  /**
+   * Get executions for a specific user
+   */
+  async getExecutionsByUserId(userId: string): Promise<OnboardingRuleExecution[]> {
+    return db
+      .select()
+      .from(onboardingRuleExecutions)
+      .where(eq(onboardingRuleExecutions.userId, userId))
+      .orderBy(desc(onboardingRuleExecutions.executedAt));
+  }
+}

--- a/apps/frontend/src/components/project/ProjectMembersTab.tsx
+++ b/apps/frontend/src/components/project/ProjectMembersTab.tsx
@@ -356,15 +356,13 @@ export function ProjectMembersTab({ owner, repo }: ProjectMembersTabProps) {
                               setRemovingMember(open ? permission.userId : null)
                             }
                           >
-                            <DialogTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => setRemovingMember(permission.userId)}
-                              >
-                                <Trash2 className="h-4 w-4 text-destructive" />
-                              </Button>
-                            </DialogTrigger>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => setRemovingMember(permission.userId)}
+                            >
+                              <Trash2 className="h-4 w-4 text-destructive" />
+                            </Button>
                             <AlertDialogContent>
                               <AlertDialogHeader>
                                 <AlertDialogTitle>Remove Member</AlertDialogTitle>

--- a/apps/frontend/src/components/proxy-rules/ProxyRuleSetsTab.tsx
+++ b/apps/frontend/src/components/proxy-rules/ProxyRuleSetsTab.tsx
@@ -22,6 +22,7 @@ import {
 import { Plus, MoreHorizontal, Edit2, Trash2, Settings, Layers } from 'lucide-react';
 import { useGetProjectRuleSetsQuery, useDeleteRuleSetMutation } from '@/services/proxyRulesApi';
 import { useGetProjectQuery } from '@/services/projectsApi';
+import { useProjectRole } from '@/hooks/useProjectRole';
 import { useToast } from '@/hooks/use-toast';
 import { CreateRuleSetDialog } from './CreateRuleSetDialog';
 import { RuleSetEditorDialog } from './RuleSetEditorDialog';
@@ -37,6 +38,7 @@ interface ProxyRuleSetsTabProps {
  */
 export function ProxyRuleSetsTab({ owner, repo }: ProxyRuleSetsTabProps) {
   const { toast } = useToast();
+  const { canEdit } = useProjectRole(owner, repo);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [editingRuleSet, setEditingRuleSet] = useState<{
     id: string;
@@ -140,25 +142,31 @@ export function ProxyRuleSetsTab({ owner, repo }: ProxyRuleSetsTabProps) {
               <CardTitle>Proxy Rule Sets</CardTitle>
               <CardDescription>Manage reusable proxy rule configurations</CardDescription>
             </div>
-            <Button size="sm" className="gap-2" onClick={() => setIsCreateDialogOpen(true)}>
-              <Plus className="h-4 w-4" />
-              Create Rule Set
-            </Button>
+            {canEdit && (
+              <Button size="sm" className="gap-2" onClick={() => setIsCreateDialogOpen(true)}>
+                <Plus className="h-4 w-4" />
+                Create Rule Set
+              </Button>
+            )}
           </CardHeader>
           <CardContent className="p-8 text-center">
             <Layers className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
             <p className="text-muted-foreground font-medium">No proxy rule sets found</p>
             <p className="text-sm text-muted-foreground mt-2">
-              Create a rule set to define proxy rules that can be assigned to aliases
+              {canEdit
+                ? 'Create a rule set to define proxy rules that can be assigned to aliases'
+                : 'No proxy rule sets have been created for this repository yet'}
             </p>
           </CardContent>
         </Card>
 
-        <CreateRuleSetDialog
-          projectId={project?.id || ''}
-          open={isCreateDialogOpen}
-          onOpenChange={setIsCreateDialogOpen}
-        />
+        {canEdit && (
+          <CreateRuleSetDialog
+            projectId={project?.id || ''}
+            open={isCreateDialogOpen}
+            onOpenChange={setIsCreateDialogOpen}
+          />
+        )}
       </>
     );
   }
@@ -171,10 +179,12 @@ export function ProxyRuleSetsTab({ owner, repo }: ProxyRuleSetsTabProps) {
             <CardTitle>Proxy Rule Sets</CardTitle>
             <CardDescription>Manage reusable proxy rule configurations</CardDescription>
           </div>
-          <Button size="sm" className="gap-2" onClick={() => setIsCreateDialogOpen(true)}>
-            <Plus className="h-4 w-4" />
-            Create Rule Set
-          </Button>
+          {canEdit && (
+            <Button size="sm" className="gap-2" onClick={() => setIsCreateDialogOpen(true)}>
+              <Plus className="h-4 w-4" />
+              Create Rule Set
+            </Button>
+          )}
         </CardHeader>
         <CardContent>
           {/* Rule Sets List */}
@@ -206,33 +216,35 @@ export function ProxyRuleSetsTab({ owner, repo }: ProxyRuleSetsTabProps) {
                   </div>
                 </div>
 
-                <div className="flex items-center gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="gap-1"
-                    onClick={() => setEditingRuleSet({ id: ruleSet.id, name: ruleSet.name })}
-                  >
-                    <Edit2 className="h-3 w-3" />
-                    Edit Rules
-                  </Button>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="icon">
-                        <MoreHorizontal className="h-4 w-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem
-                        onClick={() => setDeletingRuleSet({ id: ruleSet.id, name: ruleSet.name })}
-                        className="text-destructive"
-                      >
-                        <Trash2 className="h-4 w-4 mr-2" />
-                        Delete
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
+                {canEdit && (
+                  <div className="flex items-center gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="gap-1"
+                      onClick={() => setEditingRuleSet({ id: ruleSet.id, name: ruleSet.name })}
+                    >
+                      <Edit2 className="h-3 w-3" />
+                      Edit Rules
+                    </Button>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" size="icon">
+                          <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          onClick={() => setDeletingRuleSet({ id: ruleSet.id, name: ruleSet.name })}
+                          className="text-destructive"
+                        >
+                          <Trash2 className="h-4 w-4 mr-2" />
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                )}
               </div>
             ))}
           </div>
@@ -240,14 +252,16 @@ export function ProxyRuleSetsTab({ owner, repo }: ProxyRuleSetsTabProps) {
       </Card>
 
       {/* Create Dialog */}
-      <CreateRuleSetDialog
-        projectId={project?.id || ''}
-        open={isCreateDialogOpen}
-        onOpenChange={setIsCreateDialogOpen}
-      />
+      {canEdit && (
+        <CreateRuleSetDialog
+          projectId={project?.id || ''}
+          open={isCreateDialogOpen}
+          onOpenChange={setIsCreateDialogOpen}
+        />
+      )}
 
       {/* Edit Rules Dialog */}
-      {editingRuleSet && (
+      {canEdit && editingRuleSet && (
         <RuleSetEditorDialog
           ruleSetId={editingRuleSet.id}
           ruleSetName={editingRuleSet.name}
@@ -257,28 +271,30 @@ export function ProxyRuleSetsTab({ owner, repo }: ProxyRuleSetsTabProps) {
       )}
 
       {/* Delete Confirmation Dialog */}
-      <AlertDialog open={!!deletingRuleSet} onOpenChange={(open) => !open && setDeletingRuleSet(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete Rule Set</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete the rule set "{deletingRuleSet?.name}"? This will
-              remove all rules in this set and unassign it from any aliases using it. This action
-              cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              disabled={isDeleting}
-            >
-              {isDeleting ? 'Deleting...' : 'Delete'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {canEdit && (
+        <AlertDialog open={!!deletingRuleSet} onOpenChange={(open) => !open && setDeletingRuleSet(null)}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete Rule Set</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete the rule set "{deletingRuleSet?.name}"? This will
+                remove all rules in this set and unassign it from any aliases using it. This action
+                cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleDelete}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                disabled={isDeleting}
+              >
+                {isDeleting ? 'Deleting...' : 'Delete'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
     </>
   );
 }

--- a/apps/frontend/src/components/settings/OnboardingRulesSettings.tsx
+++ b/apps/frontend/src/components/settings/OnboardingRulesSettings.tsx
@@ -1,0 +1,702 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import {
+  useGetOnboardingRulesQuery,
+  useCreateOnboardingRuleMutation,
+  useUpdateOnboardingRuleMutation,
+  useDeleteOnboardingRuleMutation,
+  useGetRecentExecutionsQuery,
+  OnboardingRule,
+  OnboardingAction,
+  OnboardingTrigger,
+} from '@/services/onboardingRulesApi';
+import { useListUserProjectsQuery, Project } from '@/services/projectsApi';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormDescription,
+} from '@/components/ui/form';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import {
+  CheckCircle,
+  XCircle,
+  Loader2,
+  UserPlus,
+  Plus,
+  Trash2,
+  Edit,
+  Clock,
+  AlertTriangle,
+  GitBranch,
+  History,
+} from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+
+const ruleSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  description: z.string().max(500).optional(),
+  trigger: z.enum(['user_signup', 'invite_accepted']),
+  repository: z.string().min(1, 'Repository is required'),
+  role: z.enum(['viewer', 'contributor', 'admin']),
+  priority: z.coerce.number().min(0).default(100),
+});
+
+type RuleFormValues = z.infer<typeof ruleSchema>;
+
+export function OnboardingRulesSettings() {
+  const { toast } = useToast();
+  const { data: rulesData, isLoading: rulesLoading, error: rulesError } = useGetOnboardingRulesQuery();
+  const { data: projects } = useListUserProjectsQuery();
+  const { data: executionsData } = useGetRecentExecutionsQuery(20);
+  const [createRule, { isLoading: isCreating }] = useCreateOnboardingRuleMutation();
+  const [updateRule] = useUpdateOnboardingRuleMutation();
+  const [deleteRule, { isLoading: isDeleting }] = useDeleteOnboardingRuleMutation();
+
+  const [showRuleForm, setShowRuleForm] = useState(false);
+  const [editingRule, setEditingRule] = useState<OnboardingRule | null>(null);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [ruleToDelete, setRuleToDelete] = useState<OnboardingRule | null>(null);
+
+  const form = useForm<RuleFormValues>({
+    resolver: zodResolver(ruleSchema),
+    defaultValues: {
+      name: '',
+      description: '',
+      trigger: 'user_signup',
+      repository: '',
+      role: 'viewer',
+      priority: 100,
+    },
+  });
+
+  const openCreateForm = () => {
+    form.reset({
+      name: '',
+      description: '',
+      trigger: 'user_signup',
+      repository: '',
+      role: 'viewer',
+      priority: 100,
+    });
+    setEditingRule(null);
+    setShowRuleForm(true);
+  };
+
+  const openEditForm = (rule: OnboardingRule) => {
+    // Extract repository and role from first action
+    const firstAction = rule.actions[0];
+    const repository = firstAction?.type === 'grant_repo_access'
+      ? (firstAction.params as { repository: string }).repository
+      : '';
+    const role = firstAction?.type === 'grant_repo_access'
+      ? (firstAction.params as { role: string }).role as 'viewer' | 'contributor' | 'admin'
+      : 'viewer';
+
+    form.reset({
+      name: rule.name,
+      description: rule.description || '',
+      trigger: rule.trigger,
+      repository,
+      role,
+      priority: rule.priority,
+    });
+    setEditingRule(rule);
+    setShowRuleForm(true);
+  };
+
+  const onSubmit = async (data: RuleFormValues) => {
+    const actions: OnboardingAction[] = [
+      {
+        type: 'grant_repo_access',
+        params: {
+          repository: data.repository,
+          role: data.role,
+        },
+      },
+    ];
+
+    try {
+      if (editingRule) {
+        await updateRule({
+          id: editingRule.id,
+          data: {
+            name: data.name,
+            description: data.description || undefined,
+            trigger: data.trigger,
+            actions,
+            priority: data.priority,
+          },
+        }).unwrap();
+        toast({
+          title: 'Rule updated',
+          description: `Onboarding rule "${data.name}" has been updated`,
+        });
+      } else {
+        await createRule({
+          name: data.name,
+          description: data.description || undefined,
+          trigger: data.trigger,
+          actions,
+          priority: data.priority,
+        }).unwrap();
+        toast({
+          title: 'Rule created',
+          description: `Onboarding rule "${data.name}" has been created`,
+        });
+      }
+      form.reset();
+      setShowRuleForm(false);
+      setEditingRule(null);
+    } catch (err: any) {
+      toast({
+        title: editingRule ? 'Failed to update rule' : 'Failed to create rule',
+        description: err?.data?.message || 'An error occurred',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleToggleEnabled = async (rule: OnboardingRule) => {
+    try {
+      await updateRule({
+        id: rule.id,
+        data: { enabled: !rule.enabled },
+      }).unwrap();
+      toast({
+        title: rule.enabled ? 'Rule disabled' : 'Rule enabled',
+        description: `"${rule.name}" has been ${rule.enabled ? 'disabled' : 'enabled'}`,
+      });
+    } catch (err: any) {
+      toast({
+        title: 'Failed to update rule',
+        description: err?.data?.message || 'An error occurred',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleDeleteClick = (rule: OnboardingRule) => {
+    setRuleToDelete(rule);
+    setDeleteDialogOpen(true);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!ruleToDelete) return;
+
+    try {
+      await deleteRule(ruleToDelete.id).unwrap();
+      toast({
+        title: 'Rule deleted',
+        description: `"${ruleToDelete.name}" has been deleted`,
+      });
+    } catch (err: any) {
+      toast({
+        title: 'Failed to delete rule',
+        description: err?.data?.message || 'An error occurred',
+        variant: 'destructive',
+      });
+    } finally {
+      setDeleteDialogOpen(false);
+      setRuleToDelete(null);
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const getTriggerBadge = (trigger: OnboardingTrigger) => {
+    if (trigger === 'user_signup') {
+      return <Badge variant="default">User Signup</Badge>;
+    }
+    return <Badge variant="secondary">Invite Accepted</Badge>;
+  };
+
+  const getStatusBadge = (status: string) => {
+    switch (status) {
+      case 'success':
+        return (
+          <Badge variant="default" className="bg-green-500">
+            <CheckCircle className="h-3 w-3 mr-1" />
+            Success
+          </Badge>
+        );
+      case 'partial':
+        return (
+          <Badge variant="default" className="bg-yellow-500">
+            <AlertTriangle className="h-3 w-3 mr-1" />
+            Partial
+          </Badge>
+        );
+      case 'failed':
+        return (
+          <Badge variant="destructive">
+            <XCircle className="h-3 w-3 mr-1" />
+            Failed
+          </Badge>
+        );
+      case 'skipped':
+        return (
+          <Badge variant="secondary">
+            <Clock className="h-3 w-3 mr-1" />
+            Skipped
+          </Badge>
+        );
+      default:
+        return <Badge variant="outline">{status}</Badge>;
+    }
+  };
+
+  const getActionDescription = (action: OnboardingAction) => {
+    if (action.type === 'grant_repo_access') {
+      const params = action.params as { repository: string; role: string };
+      return `Grant ${params.role} access to ${params.repository}`;
+    }
+    if (action.type === 'assign_role') {
+      const params = action.params as { role: string };
+      return `Assign workspace role: ${params.role}`;
+    }
+    if (action.type === 'add_to_group') {
+      const params = action.params as { groupId: string };
+      return `Add to group: ${params.groupId}`;
+    }
+    return action.type;
+  };
+
+  const rules = rulesData?.rules || [];
+  const executions = executionsData?.executions || [];
+  const enabledCount = rules.filter((r) => r.enabled).length;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <UserPlus className="h-5 w-5" />
+            <div>
+              <CardTitle>User Onboarding Rules</CardTitle>
+              <CardDescription>
+                Configure automatic actions when users sign up
+              </CardDescription>
+            </div>
+          </div>
+          <Button onClick={openCreateForm}>
+            <Plus className="h-4 w-4 mr-2" />
+            Add Rule
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Stats */}
+        <div className="flex gap-4 text-sm text-muted-foreground">
+          <span>{enabledCount} enabled</span>
+          <span>{rules.length} total rules</span>
+        </div>
+
+        {/* Error State */}
+        {rulesError && (
+          <Alert variant="destructive">
+            <XCircle className="h-4 w-4" />
+            <AlertDescription>
+              Failed to load onboarding rules. Please try again.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* Loading State */}
+        {rulesLoading && (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {/* Rules Table */}
+        {!rulesLoading && !rulesError && rules.length > 0 && (
+          <div className="border rounded-lg">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Trigger</TableHead>
+                  <TableHead>Actions</TableHead>
+                  <TableHead>Priority</TableHead>
+                  <TableHead className="text-center">Enabled</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rules.map((rule) => (
+                  <TableRow key={rule.id}>
+                    <TableCell>
+                      <div>
+                        <p className="font-medium">{rule.name}</p>
+                        {rule.description && (
+                          <p className="text-sm text-muted-foreground truncate max-w-xs">
+                            {rule.description}
+                          </p>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>{getTriggerBadge(rule.trigger)}</TableCell>
+                    <TableCell>
+                      <div className="space-y-1">
+                        {rule.actions.map((action, idx) => (
+                          <div key={idx} className="flex items-center gap-1 text-sm">
+                            <GitBranch className="h-3 w-3" />
+                            <span>{getActionDescription(action)}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">{rule.priority}</TableCell>
+                    <TableCell className="text-center">
+                      <Switch
+                        checked={rule.enabled}
+                        onCheckedChange={() => handleToggleEnabled(rule)}
+                      />
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => openEditForm(rule)}
+                          title="Edit rule"
+                        >
+                          <Edit className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleDeleteClick(rule)}
+                          disabled={isDeleting}
+                          title="Delete rule"
+                        >
+                          <Trash2 className="h-4 w-4 text-destructive" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        {/* Empty State */}
+        {!rulesLoading && !rulesError && rules.length === 0 && (
+          <div className="text-center py-8 text-muted-foreground">
+            <UserPlus className="h-12 w-12 mx-auto mb-4 opacity-50" />
+            <p>No onboarding rules configured</p>
+            <p className="text-sm">
+              Click "Add Rule" to automatically grant repository access to new users
+            </p>
+          </div>
+        )}
+
+        {/* Recent Executions Accordion */}
+        {executions.length > 0 && (
+          <Accordion type="single" collapsible className="w-full">
+            <AccordionItem value="executions">
+              <AccordionTrigger>
+                <div className="flex items-center gap-2">
+                  <History className="h-4 w-4" />
+                  Recent Executions ({executions.length})
+                </div>
+              </AccordionTrigger>
+              <AccordionContent>
+                <div className="border rounded-lg">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Rule</TableHead>
+                        <TableHead>Trigger</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Executed</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {executions.map((execution) => (
+                        <TableRow key={execution.id}>
+                          <TableCell className="font-medium">
+                            {execution.ruleName}
+                          </TableCell>
+                          <TableCell>{getTriggerBadge(execution.trigger)}</TableCell>
+                          <TableCell>
+                            <div>
+                              {getStatusBadge(execution.status)}
+                              {execution.errorMessage && (
+                                <p className="text-xs text-destructive mt-1">
+                                  {execution.errorMessage}
+                                </p>
+                              )}
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-muted-foreground text-sm">
+                            {formatDate(execution.executedAt)}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        )}
+
+        {/* Rule Form Dialog */}
+        <Dialog open={showRuleForm} onOpenChange={setShowRuleForm}>
+          <DialogContent className="sm:max-w-[500px]">
+            <DialogHeader>
+              <DialogTitle>
+                {editingRule ? 'Edit Onboarding Rule' : 'Create Onboarding Rule'}
+              </DialogTitle>
+              <DialogDescription>
+                Configure automatic actions for new user signups.
+              </DialogDescription>
+            </DialogHeader>
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Rule Name</FormLabel>
+                      <FormControl>
+                        <Input placeholder="e.g., Grant demo repo access" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Description (Optional)</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="Describe what this rule does..."
+                          className="resize-none"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="trigger"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Trigger</FormLabel>
+                      <Select onValueChange={field.onChange} defaultValue={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select trigger" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="user_signup">User Signup</SelectItem>
+                          <SelectItem value="invite_accepted">Invite Accepted</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        When should this rule be executed?
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="repository"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Repository</FormLabel>
+                      <Select onValueChange={field.onChange} defaultValue={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select repository" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {projects?.map((project: Project) => (
+                            <SelectItem
+                              key={project.id}
+                              value={`${project.owner}/${project.name}`}
+                            >
+                              {project.owner}/{project.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Grant access to this repository
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="role"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Role</FormLabel>
+                      <Select onValueChange={field.onChange} defaultValue={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select role" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="viewer">Viewer (read-only)</SelectItem>
+                          <SelectItem value="contributor">Contributor (read/write)</SelectItem>
+                          <SelectItem value="admin">Admin (full access)</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Permission level to grant
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="priority"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Priority</FormLabel>
+                      <FormControl>
+                        <Input type="number" min={0} {...field} />
+                      </FormControl>
+                      <FormDescription>
+                        Lower numbers execute first (default: 100)
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <DialogFooter>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setShowRuleForm(false);
+                      setEditingRule(null);
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={isCreating}>
+                    {isCreating ? (
+                      <>
+                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                        Saving...
+                      </>
+                    ) : editingRule ? (
+                      'Update Rule'
+                    ) : (
+                      'Create Rule'
+                    )}
+                  </Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          </DialogContent>
+        </Dialog>
+
+        {/* Delete Confirmation Dialog */}
+        <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete Onboarding Rule</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete "{ruleToDelete?.name}"? This action
+                cannot be undone. New users will no longer receive automatic access.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleDeleteConfirm}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/hooks/useProjectRole.ts
+++ b/apps/frontend/src/hooks/useProjectRole.ts
@@ -1,0 +1,43 @@
+import { useGetSessionQuery } from '@/services/authApi';
+import { useGetProjectPermissionsQuery, type ProjectRole } from '@/services/permissionsApi';
+
+interface UseProjectRoleResult {
+  role: ProjectRole | null;
+  isLoading: boolean;
+  canEdit: boolean; // contributor, admin, or owner
+  canAdmin: boolean; // admin or owner
+  isOwner: boolean;
+}
+
+/**
+ * Hook to get the current user's role for a project
+ * Returns the effective role based on direct user permissions
+ */
+export function useProjectRole(owner: string, repo: string): UseProjectRoleResult {
+  const { data: sessionData, isLoading: isLoadingSession } = useGetSessionQuery();
+  const currentUser = sessionData?.user;
+
+  const { data: permissions, isLoading: isLoadingPermissions } = useGetProjectPermissionsQuery(
+    { owner, repo },
+    { skip: !owner || !repo || !currentUser }
+  );
+
+  const isLoading = isLoadingSession || isLoadingPermissions;
+
+  // Find user's direct permission
+  const userPermission = permissions?.userPermissions.find(
+    (perm) => perm.userId === currentUser?.id
+  );
+
+  // For now, we only check direct user permissions
+  // TODO: Also check group memberships for inherited permissions
+  const role = userPermission?.role ?? null;
+
+  return {
+    role,
+    isLoading,
+    canEdit: role ? ['owner', 'admin', 'contributor'].includes(role) : false,
+    canAdmin: role ? ['owner', 'admin'].includes(role) : false,
+    isOwner: role === 'owner',
+  };
+}

--- a/apps/frontend/src/pages/AdminSettingsPage.tsx
+++ b/apps/frontend/src/pages/AdminSettingsPage.tsx
@@ -3,6 +3,7 @@ import { PrimaryContentSettings } from '@/components/settings/PrimaryContentSett
 import { EmailSettings } from '@/components/settings/EmailSettings';
 import { InvitationsSettings } from '@/components/settings/InvitationsSettings';
 import { RegistrationSettings } from '@/components/settings/RegistrationSettings';
+import { OnboardingRulesSettings } from '@/components/settings/OnboardingRulesSettings';
 import { SslSettings } from '@/components/settings/SslSettings';
 import { CacheSettings } from '@/components/settings/CacheSettings';
 import { StorageSettings } from '@/components/settings/StorageSettings';
@@ -62,6 +63,11 @@ export function AdminSettingsPage() {
       {/* User Invitations */}
       <section>
         <InvitationsSettings />
+      </section>
+
+      {/* User Onboarding Rules */}
+      <section>
+        <OnboardingRulesSettings />
       </section>
 
       {/* SSL Certificate Settings */}

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -58,8 +58,9 @@ export function HomePage() {
   };
 
   // Show onboarding modal if user hasn't completed onboarding
+  // Skip for members since they can't create repos (the modal guides through repo creation)
   useEffect(() => {
-    if (sessionData?.user && !hasCompletedOnboarding) {
+    if (sessionData?.user && !hasCompletedOnboarding && sessionData.user.role !== 'member') {
       setShowOnboarding(true);
     }
   }, [sessionData, hasCompletedOnboarding]);
@@ -142,23 +143,21 @@ export function HomePage() {
         )}
 
         {/* Navigation Cards */}
-        <div className={`grid gap-4 ${user?.role === 'admin' ? 'md:grid-cols-4' : user?.role === 'member' ? 'md:grid-cols-1' : 'md:grid-cols-2'}`}>
-          {user?.role !== 'member' && (
-            <Link to="/repo" className="group block">
-              <div className="bg-white dark:bg-card border border-[#3a3a3a]/10 dark:border-border rounded-lg p-6 hover:border-[#d96459]/50 hover:shadow-md transition-all duration-200">
-                <div className="flex items-start justify-between">
-                  <FolderGit2 className="h-8 w-8 text-[#d96459]" />
-                  <ArrowRight className="h-5 w-5 text-[#4a4a4a]/30 group-hover:text-[#d96459] group-hover:translate-x-1 transition-all" />
-                </div>
-                <h2 className="text-lg font-semibold text-[#3a3a3a] dark:text-foreground mt-4">
-                  Repositories
-                </h2>
-                <p className="text-sm text-[#4a4a4a] dark:text-muted-foreground mt-1">
-                  Manage your repositories and deployments
-                </p>
+        <div className={`grid gap-4 ${user?.role === 'admin' ? 'md:grid-cols-4' : 'md:grid-cols-2'}`}>
+          <Link to="/repo" className="group block">
+            <div className="bg-white dark:bg-card border border-[#3a3a3a]/10 dark:border-border rounded-lg p-6 hover:border-[#d96459]/50 hover:shadow-md transition-all duration-200">
+              <div className="flex items-start justify-between">
+                <FolderGit2 className="h-8 w-8 text-[#d96459]" />
+                <ArrowRight className="h-5 w-5 text-[#4a4a4a]/30 group-hover:text-[#d96459] group-hover:translate-x-1 transition-all" />
               </div>
-            </Link>
-          )}
+              <h2 className="text-lg font-semibold text-[#3a3a3a] dark:text-foreground mt-4">
+                Repositories
+              </h2>
+              <p className="text-sm text-[#4a4a4a] dark:text-muted-foreground mt-1">
+                {user?.role === 'member' ? 'View your accessible repositories' : 'Manage your repositories and deployments'}
+              </p>
+            </div>
+          </Link>
 
           {user?.role === 'admin' && (
             <Link to="/users" className="group block">

--- a/apps/frontend/src/pages/RepositoryOverviewPage.tsx
+++ b/apps/frontend/src/pages/RepositoryOverviewPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { useAppDispatch } from '@/store/hooks';
 import { setCurrentRepo } from '@/store/slices/repoSlice';
 import { useGetRepositoryStatsQuery } from '@/services/repoApi';
+import { useProjectRole } from '@/hooks/useProjectRole';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -50,6 +51,9 @@ export function RepositoryOverviewPage() {
       dispatch(setCurrentRepo({ owner, repo }));
     }
   }, [owner, repo, dispatch]);
+
+  // Check user's role for this project
+  const { canAdmin } = useProjectRole(owner!, repo!);
 
   // Fetch repository stats
   const {
@@ -127,15 +131,17 @@ export function RepositoryOverviewPage() {
           <h1 className="text-2xl font-bold">
             {owner}/{repo}
           </h1>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => navigate(`/repo/${owner}/${repo}/settings`)}
-            className="flex items-center gap-2"
-          >
-            <Settings className="h-4 w-4" />
-            Settings
-          </Button>
+          {canAdmin && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => navigate(`/repo/${owner}/${repo}/settings`)}
+              className="flex items-center gap-2"
+            >
+              <Settings className="h-4 w-4" />
+              Settings
+            </Button>
+          )}
         </div>
 
         {/* Stats Header */}

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -192,6 +192,7 @@ export const api = createApi({
     'PathRedirects',
     'ShareLink',
     'TrafficRule',
+    'OnboardingRule',
   ],
   endpoints: () => ({}),
 });

--- a/apps/frontend/src/services/onboardingRulesApi.ts
+++ b/apps/frontend/src/services/onboardingRulesApi.ts
@@ -1,0 +1,148 @@
+import { api } from './api';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type OnboardingTrigger = 'user_signup' | 'invite_accepted';
+export type OnboardingActionType = 'grant_repo_access' | 'assign_role' | 'add_to_group';
+
+export interface OnboardingAction {
+  type: OnboardingActionType;
+  params: Record<string, unknown>;
+}
+
+export interface OnboardingCondition {
+  type: 'email_domain' | 'email_pattern';
+  value: string;
+}
+
+export interface OnboardingRule {
+  id: string;
+  name: string;
+  description: string | null;
+  trigger: OnboardingTrigger;
+  actions: OnboardingAction[];
+  conditions: OnboardingCondition[] | null;
+  enabled: boolean;
+  priority: number;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateOnboardingRuleDto {
+  name: string;
+  description?: string;
+  trigger?: OnboardingTrigger;
+  actions: OnboardingAction[];
+  conditions?: OnboardingCondition[] | null;
+  enabled?: boolean;
+  priority?: number;
+}
+
+export interface UpdateOnboardingRuleDto {
+  name?: string;
+  description?: string | null;
+  trigger?: OnboardingTrigger;
+  actions?: OnboardingAction[];
+  conditions?: OnboardingCondition[] | null;
+  enabled?: boolean;
+  priority?: number;
+}
+
+export type ExecutionStatus = 'success' | 'partial' | 'failed' | 'skipped';
+
+export interface ActionExecutionResult {
+  action: OnboardingAction;
+  success: boolean;
+  message?: string;
+  error?: string;
+}
+
+export interface OnboardingRuleExecution {
+  id: string;
+  ruleId: string | null;
+  ruleName: string;
+  userId: string;
+  trigger: OnboardingTrigger;
+  status: ExecutionStatus;
+  details: ActionExecutionResult[] | null;
+  errorMessage: string | null;
+  executedAt: string;
+}
+
+export interface ListOnboardingRulesResponse {
+  rules: OnboardingRule[];
+}
+
+export interface ListExecutionsResponse {
+  executions: OnboardingRuleExecution[];
+}
+
+// ============================================================================
+// API Endpoints
+// ============================================================================
+
+export const onboardingRulesApi = api.injectEndpoints({
+  endpoints: (builder) => ({
+    // Get all onboarding rules
+    getOnboardingRules: builder.query<ListOnboardingRulesResponse, void>({
+      query: () => '/api/onboarding-rules',
+      providesTags: ['OnboardingRule'],
+    }),
+
+    // Get a single onboarding rule
+    getOnboardingRule: builder.query<OnboardingRule, string>({
+      query: (id) => `/api/onboarding-rules/${id}`,
+      providesTags: (_result, _error, id) => [{ type: 'OnboardingRule', id }],
+    }),
+
+    // Create a new onboarding rule
+    createOnboardingRule: builder.mutation<OnboardingRule, CreateOnboardingRuleDto>({
+      query: (data) => ({
+        url: '/api/onboarding-rules',
+        method: 'POST',
+        body: data,
+      }),
+      invalidatesTags: ['OnboardingRule'],
+    }),
+
+    // Update an onboarding rule
+    updateOnboardingRule: builder.mutation<OnboardingRule, { id: string; data: UpdateOnboardingRuleDto }>({
+      query: ({ id, data }) => ({
+        url: `/api/onboarding-rules/${id}`,
+        method: 'PATCH',
+        body: data,
+      }),
+      invalidatesTags: (_result, _error, { id }) => [
+        'OnboardingRule',
+        { type: 'OnboardingRule', id },
+      ],
+    }),
+
+    // Delete an onboarding rule
+    deleteOnboardingRule: builder.mutation<{ success: boolean }, string>({
+      query: (id) => ({
+        url: `/api/onboarding-rules/${id}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['OnboardingRule'],
+    }),
+
+    // Get recent rule executions (audit log)
+    getRecentExecutions: builder.query<ListExecutionsResponse, number | void>({
+      query: (limit = 50) => `/api/onboarding-rules/executions/recent?limit=${limit}`,
+      providesTags: ['OnboardingRule'],
+    }),
+  }),
+});
+
+export const {
+  useGetOnboardingRulesQuery,
+  useGetOnboardingRuleQuery,
+  useCreateOnboardingRuleMutation,
+  useUpdateOnboardingRuleMutation,
+  useDeleteOnboardingRuleMutation,
+  useGetRecentExecutionsQuery,
+} = onboardingRulesApi;


### PR DESCRIPTION
## Summary

- **Onboarding Rules System**: Allows workspace admins to configure automatic actions when users sign up (e.g., auto-grant viewer access to specific repos)
- **Member UX fixes**: Members can now see repositories they have access to, onboarding modal skipped for members
- **Viewer permissions**: Hide edit controls (Settings, Create/Edit/Delete aliases, proxy rules) from viewers on repo pages

## Changes

### Backend
- New `onboarding_rules` and `onboarding_rule_executions` database tables
- `OnboardingRulesModule` with CRUD endpoints for managing rules
- `OnboardingExecutorService` that executes rules on user signup/invite acceptance
- Integration with auth controller to trigger rules after user creation

### Frontend
- Admin settings UI for managing onboarding rules (`OnboardingRulesSettings.tsx`)
- `useProjectRole` hook for permission-based UI rendering
- Hide edit controls from viewers on RepositoryOverviewPage, AliasesTab, ProxyRuleSetsTab
- Fix DialogTrigger/AlertDialog nesting issue in ProjectMembersTab
- Show Repositories link and skip onboarding modal for members

## Test plan

- [x] Create an onboarding rule via admin settings (Site Settings → Onboarding Rules)
- [x] Enable public signups and register a new user
- [x] Verify user has expected repository access from the rule
- [x] Check audit log shows rule execution
- [x] Log in as a viewer and verify edit buttons are hidden on repo page
- [x] Log in as a member and verify they can see accessible repositories

🤖 Generated with [Claude Code](https://claude.com/claude-code)