### PR TITLE
feat: refactor proxy rules to full-page views with path-based routing

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -3,6 +3,9 @@ import { RepositoryPage } from '@/pages/RepositoryPage';
 import { RepositoryOverviewPage } from '@/pages/RepositoryOverviewPage';
 import { RepositoriesPage } from '@/pages/RepositoriesPage';
 import { ProjectSettingsPage } from '@/pages/ProjectSettingsPage';
+import { ProxyRuleSetsPage } from '@/pages/ProxyRuleSetsPage';
+import { RuleSetDetailPage } from '@/pages/RuleSetDetailPage';
+import { RuleEditorPage } from '@/pages/RuleEditorPage';
 import { UserGroupsPage } from '@/pages/UserGroupsPage';
 import { GroupDetailPage } from '@/pages/GroupDetailPage';
 import { UsersPage } from '@/pages/UsersPage';
@@ -54,6 +57,12 @@ function App() {
         {/* Repository routes */}
         <Route path="/repo" element={<ProtectedRoute><RepositoriesPage /></ProtectedRoute>} />
         <Route path="/repo/:owner/:repo/settings" element={<ProtectedRoute><ProjectSettingsPage /></ProtectedRoute>} />
+        {/* Proxy Rules path-based routes */}
+        <Route path="/repo/:owner/:repo/tab/proxy-rules" element={<ProtectedRoute><ProxyRuleSetsPage /></ProtectedRoute>} />
+        <Route path="/repo/:owner/:repo/tab/proxy-rules/:ruleSetId" element={<ProtectedRoute><RuleSetDetailPage /></ProtectedRoute>} />
+        <Route path="/repo/:owner/:repo/tab/proxy-rules/:ruleSetId/new" element={<ProtectedRoute><RuleEditorPage /></ProtectedRoute>} />
+        <Route path="/repo/:owner/:repo/tab/proxy-rules/:ruleSetId/:ruleId" element={<ProtectedRoute><RuleEditorPage /></ProtectedRoute>} />
+        {/* File browser routes */}
         <Route path="/repo/:owner/:repo/:ref/*" element={<RepositoryPage />} />
         <Route path="/repo/:owner/:repo/:ref" element={<RepositoryPage />} />
         <Route path="/repo/:owner/:repo" element={<RepositoryOverviewPage />} />

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,11 +1,15 @@
 import { Routes, Route } from 'react-router-dom';
 import { RepositoryPage } from '@/pages/RepositoryPage';
-import { RepositoryOverviewPage } from '@/pages/RepositoryOverviewPage';
+import { RepositoryLayout } from '@/pages/RepositoryLayout';
 import { RepositoriesPage } from '@/pages/RepositoriesPage';
 import { ProjectSettingsPage } from '@/pages/ProjectSettingsPage';
+import { DeploymentsTab } from '@/pages/DeploymentsTab';
+import { BranchesPage } from '@/pages/BranchesPage';
+import { AliasesPage } from '@/pages/AliasesPage';
 import { ProxyRuleSetsPage } from '@/pages/ProxyRuleSetsPage';
 import { RuleSetDetailPage } from '@/pages/RuleSetDetailPage';
 import { RuleEditorPage } from '@/pages/RuleEditorPage';
+import { RepositoryTabRedirect } from '@/pages/RepositoryTabRedirect';
 import { UserGroupsPage } from '@/pages/UserGroupsPage';
 import { GroupDetailPage } from '@/pages/GroupDetailPage';
 import { UsersPage } from '@/pages/UsersPage';
@@ -54,18 +58,28 @@ function App() {
         {/* Admin Settings route (requires admin) */}
         <Route path="/admin/settings" element={<ProtectedRoute requireAdmin><AdminSettingsPage /></ProtectedRoute>} />
 
-        {/* Repository routes */}
+        {/* Repository list */}
         <Route path="/repo" element={<ProtectedRoute><RepositoriesPage /></ProtectedRoute>} />
+
+        {/* Repository settings (outside of tab layout) */}
         <Route path="/repo/:owner/:repo/settings" element={<ProtectedRoute><ProjectSettingsPage /></ProtectedRoute>} />
-        {/* Proxy Rules path-based routes */}
-        <Route path="/repo/:owner/:repo/tab/proxy-rules" element={<ProtectedRoute><ProxyRuleSetsPage /></ProtectedRoute>} />
-        <Route path="/repo/:owner/:repo/tab/proxy-rules/:ruleSetId" element={<ProtectedRoute><RuleSetDetailPage /></ProtectedRoute>} />
-        <Route path="/repo/:owner/:repo/tab/proxy-rules/:ruleSetId/new" element={<ProtectedRoute><RuleEditorPage /></ProtectedRoute>} />
-        <Route path="/repo/:owner/:repo/tab/proxy-rules/:ruleSetId/:ruleId" element={<ProtectedRoute><RuleEditorPage /></ProtectedRoute>} />
-        {/* File browser routes */}
+
+        {/* File browser routes (must come before the layout to avoid matching) */}
         <Route path="/repo/:owner/:repo/:ref/*" element={<RepositoryPage />} />
         <Route path="/repo/:owner/:repo/:ref" element={<RepositoryPage />} />
-        <Route path="/repo/:owner/:repo" element={<RepositoryOverviewPage />} />
+
+        {/* Repository tabs layout with nested routes */}
+        <Route path="/repo/:owner/:repo" element={<ProtectedRoute><RepositoryLayout /></ProtectedRoute>}>
+          {/* Handle old query param URLs and redirect to deployments by default */}
+          <Route index element={<RepositoryTabRedirect />} />
+          <Route path="deployments" element={<DeploymentsTab />} />
+          <Route path="branches" element={<BranchesPage />} />
+          <Route path="aliases" element={<AliasesPage />} />
+          <Route path="proxy-rules" element={<ProxyRuleSetsPage />} />
+          <Route path="proxy-rules/:ruleSetId" element={<RuleSetDetailPage />} />
+          <Route path="proxy-rules/:ruleSetId/new" element={<RuleEditorPage />} />
+          <Route path="proxy-rules/:ruleSetId/:ruleId" element={<RuleEditorPage />} />
+        </Route>
 
         {/* User Groups routes (admin only) */}
         <Route path="/groups" element={<ProtectedRoute requireAdmin><UserGroupsPage /></ProtectedRoute>} />

--- a/apps/frontend/src/components/proxy-rules/ExpandedProxyRuleForm.tsx
+++ b/apps/frontend/src/components/proxy-rules/ExpandedProxyRuleForm.tsx
@@ -1,0 +1,628 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type {
+  ProxyRule,
+  CreateProxyRuleDto,
+  ProxyType,
+  EmailHandlerConfig,
+} from '@/services/proxyRulesApi';
+import { useGetEmailConfigStatusQuery } from '@/services/proxyRulesApi';
+import { AlertTriangle } from 'lucide-react';
+
+interface ExpandedProxyRuleFormProps {
+  initialData?: ProxyRule;
+  onSubmit: (data: CreateProxyRuleDto) => Promise<void>;
+  onCancel: () => void;
+  isSubmitting?: boolean;
+}
+
+/**
+ * Get the effective proxy type from a rule, handling backward compatibility.
+ */
+function getEffectiveProxyType(rule?: ProxyRule): ProxyType {
+  if (rule?.proxyType && rule.proxyType !== 'external_proxy') {
+    return rule.proxyType;
+  }
+  // Backward compatibility: if internalRewrite is true, treat as internal_rewrite
+  if (rule?.internalRewrite) {
+    return 'internal_rewrite';
+  }
+  return rule?.proxyType || 'external_proxy';
+}
+
+/**
+ * ExpandedProxyRuleForm - Full-page form for creating/editing proxy rules.
+ * Refactored from ProxyRuleForm with expanded layout and section headers.
+ */
+export function ExpandedProxyRuleForm({
+  initialData,
+  onSubmit,
+  onCancel,
+  isSubmitting: externalIsSubmitting,
+}: ExpandedProxyRuleFormProps) {
+  // Get email config status
+  const { data: emailStatus } = useGetEmailConfigStatusQuery();
+
+  // Basic fields
+  const [pathPattern, setPathPattern] = useState(initialData?.pathPattern || '');
+  const [targetUrl, setTargetUrl] = useState(initialData?.targetUrl || '');
+  const [proxyType, setProxyType] = useState<ProxyType>(getEffectiveProxyType(initialData));
+  const [order, setOrder] = useState<number | undefined>(initialData?.order);
+  const [description, setDescription] = useState(initialData?.description || '');
+
+  // External proxy options
+  const [stripPrefix, setStripPrefix] = useState(initialData?.stripPrefix ?? true);
+  const [timeout, setTimeout] = useState(initialData?.timeout || 30000);
+  const [preserveHost, setPreserveHost] = useState(initialData?.preserveHost ?? false);
+  const [forwardCookies, setForwardCookies] = useState(initialData?.forwardCookies ?? false);
+  const [apiKey, setApiKey] = useState('');
+
+  // Auth transformation (cookie to bearer)
+  const [authTransformEnabled, setAuthTransformEnabled] = useState(
+    !!initialData?.authTransform?.type,
+  );
+  const [cookieName, setCookieName] = useState(
+    initialData?.authTransform?.cookieName || 'sAccessToken',
+  );
+
+  // Email handler config
+  const [destinationEmail, setDestinationEmail] = useState(
+    initialData?.emailHandlerConfig?.destinationEmail || '',
+  );
+  const [emailSubject, setEmailSubject] = useState(
+    initialData?.emailHandlerConfig?.subject || '',
+  );
+  const [successRedirect, setSuccessRedirect] = useState(
+    initialData?.emailHandlerConfig?.successRedirect || '',
+  );
+  const [corsOrigin, setCorsOrigin] = useState(
+    initialData?.emailHandlerConfig?.corsOrigin || '',
+  );
+  const [honeypotField, setHoneypotField] = useState(
+    initialData?.emailHandlerConfig?.honeypotField || '',
+  );
+  const [replyToField, setReplyToField] = useState(
+    initialData?.emailHandlerConfig?.replyToField || '',
+  );
+  const [requireAuth, setRequireAuth] = useState(
+    initialData?.emailHandlerConfig?.requireAuth ?? false,
+  );
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  // Derived state
+  const isEmailHandler = proxyType === 'email_form_handler';
+  const isInternalRewrite = proxyType === 'internal_rewrite';
+  const isExternalProxy = proxyType === 'external_proxy';
+  // Pipeline is a future feature - for now just display as disabled option
+  const isPipeline = (proxyType as string) === 'pipeline';
+  const submitting = externalIsSubmitting || isSubmitting;
+
+  const validate = (): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    // Validate path pattern
+    if (!pathPattern) {
+      newErrors.pathPattern = 'Path pattern is required';
+    } else if (!/^(\/[a-zA-Z0-9\-_\/\*\.]*|\*[a-zA-Z0-9\-_\/\.]*)$/.test(pathPattern)) {
+      newErrors.pathPattern =
+        'Path pattern must start with / or * and contain valid URL characters';
+    }
+
+    // Validate based on proxy type
+    if (isEmailHandler) {
+      // Validate email handler fields
+      if (!destinationEmail) {
+        newErrors.destinationEmail = 'Destination email is required';
+      } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(destinationEmail)) {
+        newErrors.destinationEmail = 'Invalid email format';
+      }
+
+      // Validate success redirect URL if provided
+      if (successRedirect) {
+        try {
+          new URL(successRedirect);
+        } catch {
+          newErrors.successRedirect = 'Invalid URL format';
+        }
+      }
+    } else if (isInternalRewrite) {
+      // Validate target path
+      if (!targetUrl) {
+        newErrors.targetUrl = 'Target path is required';
+      } else if (!targetUrl.startsWith('/')) {
+        newErrors.targetUrl =
+          'Target path must start with "/" (e.g., /environments/production.json)';
+      } else if (targetUrl.includes('://')) {
+        newErrors.targetUrl =
+          'Target path cannot contain a protocol (use a path like /path/to/file.json)';
+      }
+    } else if (isExternalProxy) {
+      // External proxy - validate target URL
+      if (!targetUrl) {
+        newErrors.targetUrl = 'Target URL is required';
+      } else {
+        try {
+          const url = new URL(targetUrl);
+          const isHttps = url.protocol === 'https:';
+          const isInternalK8s =
+            url.protocol === 'http:' &&
+            (url.hostname.endsWith('.svc') || url.hostname.endsWith('.svc.cluster.local'));
+          const isLocalhost =
+            url.protocol === 'http:' &&
+            (url.hostname === 'localhost' || url.hostname === '127.0.0.1');
+          if (!isHttps && !isInternalK8s && !isLocalhost) {
+            newErrors.targetUrl =
+              'Target URL must use HTTPS, or HTTP for internal services (*.svc, localhost)';
+          }
+        } catch {
+          newErrors.targetUrl = 'Invalid URL format';
+        }
+      }
+
+      // Validate timeout
+      if (timeout < 1000 || timeout > 60000) {
+        newErrors.timeout = 'Timeout must be between 1000ms and 60000ms';
+      }
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validate()) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      // Build email handler config if applicable
+      let emailHandlerConfig: EmailHandlerConfig | undefined;
+      if (isEmailHandler) {
+        emailHandlerConfig = {
+          destinationEmail,
+          ...(emailSubject && { subject: emailSubject }),
+          ...(successRedirect && { successRedirect }),
+          ...(corsOrigin && { corsOrigin }),
+          ...(honeypotField && { honeypotField }),
+          ...(replyToField && { replyToField }),
+          ...(requireAuth && { requireAuth }),
+        };
+      }
+
+      await onSubmit({
+        pathPattern,
+        targetUrl: isEmailHandler ? '' : targetUrl, // Email handler doesn't use targetUrl
+        proxyType,
+        // Include internalRewrite for backward compatibility
+        internalRewrite: isInternalRewrite,
+        // Email handler config
+        ...(isEmailHandler && { emailHandlerConfig }),
+        // Only include external proxy options when using external proxy
+        ...(isExternalProxy && {
+          stripPrefix,
+          timeout,
+          preserveHost,
+          forwardCookies,
+          headerConfig: apiKey ? { add: { Authorization: apiKey } } : undefined,
+          authTransform: authTransformEnabled
+            ? { type: 'cookie-to-bearer' as const, cookieName }
+            : undefined,
+        }),
+        order,
+        description: description || undefined,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {/* Basic Configuration */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Basic Configuration</CardTitle>
+          <CardDescription>Define the path pattern and rule type</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Path Pattern */}
+          <div className="space-y-2">
+            <Label htmlFor="pathPattern">Path Pattern *</Label>
+            <Input
+              id="pathPattern"
+              value={pathPattern}
+              onChange={(e) => setPathPattern(e.target.value)}
+              placeholder="/api/*"
+              className={errors.pathPattern ? 'border-destructive' : ''}
+            />
+            {errors.pathPattern ? (
+              <p className="text-xs text-destructive">{errors.pathPattern}</p>
+            ) : (
+              <p className="text-xs text-muted-foreground">Examples: /api/*, /graphql, *.json</p>
+            )}
+          </div>
+
+          {/* Proxy Type Selector */}
+          <div className="space-y-2">
+            <Label htmlFor="proxyType">Rule Type</Label>
+            <Select value={proxyType} onValueChange={(v) => setProxyType(v as ProxyType)}>
+              <SelectTrigger id="proxyType">
+                <SelectValue placeholder="Select rule type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="external_proxy">External Proxy</SelectItem>
+                <SelectItem value="internal_rewrite">Internal Rewrite</SelectItem>
+                <SelectItem value="email_form_handler">Email Form Handler</SelectItem>
+                <SelectItem value="pipeline" disabled>
+                  <span className="flex items-center gap-2">
+                    Pipeline
+                    <Badge variant="secondary" className="text-xs">Coming Soon</Badge>
+                  </span>
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              {isExternalProxy && 'Forward requests to an external URL'}
+              {isInternalRewrite && 'Serve a different path from the same deployment'}
+              {isEmailHandler && 'Capture form submissions and email them'}
+              {isPipeline && 'Execute a serverless pipeline function'}
+            </p>
+          </div>
+
+          {/* Priority/Order */}
+          <div className="space-y-2">
+            <Label htmlFor="order">Priority (Order)</Label>
+            <Input
+              id="order"
+              type="number"
+              min={0}
+              value={order ?? ''}
+              onChange={(e) => setOrder(e.target.value ? parseInt(e.target.value, 10) : undefined)}
+              placeholder="Auto-assigned"
+              className="max-w-32"
+            />
+            <p className="text-xs text-muted-foreground">
+              Lower numbers are matched first. Leave empty to auto-assign.
+            </p>
+          </div>
+
+          {/* Description */}
+          <div className="space-y-2">
+            <Label htmlFor="description">Description (optional)</Label>
+            <Input
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={
+                isEmailHandler
+                  ? 'Contact form handler'
+                  : isInternalRewrite
+                    ? 'Environment config rewrite'
+                    : 'Main backend API'
+              }
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Email not configured warning */}
+      {isEmailHandler && emailStatus && !emailStatus.isConfigured && (
+        <div className="border border-yellow-500/50 bg-yellow-500/10 rounded-lg p-4 flex items-start gap-3">
+          <AlertTriangle className="h-5 w-5 text-yellow-500 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-sm font-medium text-yellow-600 dark:text-yellow-400">
+              Email not configured
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              Email form handler requires email to be configured in Settings &gt; Email.
+              Form submissions will fail until email is set up.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Target Configuration (External Proxy & Internal Rewrite) */}
+      {!isEmailHandler && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Target Configuration</CardTitle>
+            <CardDescription>
+              {isInternalRewrite
+                ? 'Specify the internal path to serve'
+                : 'Specify the external URL to proxy requests to'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="targetUrl">{isInternalRewrite ? 'Target Path *' : 'Target URL *'}</Label>
+              <Input
+                id="targetUrl"
+                type={isInternalRewrite ? 'text' : 'url'}
+                value={targetUrl}
+                onChange={(e) => setTargetUrl(e.target.value)}
+                placeholder={
+                  isInternalRewrite ? '/environments/production.json' : 'https://api.example.com'
+                }
+                className={errors.targetUrl ? 'border-destructive' : ''}
+              />
+              {errors.targetUrl ? (
+                <p className="text-xs text-destructive">{errors.targetUrl}</p>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  {isInternalRewrite
+                    ? 'Path within the deployment to serve (e.g., /environments/production.json)'
+                    : 'HTTPS required, or HTTP for internal services (*.svc, localhost)'}
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Email Handler Configuration */}
+      {isEmailHandler && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Email Handler Settings</CardTitle>
+            <CardDescription>Configure where form submissions are sent</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="destinationEmail">Destination Email *</Label>
+              <Input
+                id="destinationEmail"
+                type="email"
+                value={destinationEmail}
+                onChange={(e) => setDestinationEmail(e.target.value)}
+                placeholder="contact@example.com"
+                className={errors.destinationEmail ? 'border-destructive' : ''}
+              />
+              {errors.destinationEmail ? (
+                <p className="text-xs text-destructive">{errors.destinationEmail}</p>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Form submissions will be sent to this email address
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="emailSubject">Email Subject (optional)</Label>
+              <Input
+                id="emailSubject"
+                value={emailSubject}
+                onChange={(e) => setEmailSubject(e.target.value)}
+                placeholder="Form Submission"
+              />
+              <p className="text-xs text-muted-foreground">Default: "Form Submission"</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="successRedirect">Success Redirect URL (optional)</Label>
+              <Input
+                id="successRedirect"
+                type="url"
+                value={successRedirect}
+                onChange={(e) => setSuccessRedirect(e.target.value)}
+                placeholder="https://example.com/thank-you"
+                className={errors.successRedirect ? 'border-destructive' : ''}
+              />
+              {errors.successRedirect ? (
+                <p className="text-xs text-destructive">{errors.successRedirect}</p>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Redirect user here after successful submission (otherwise returns JSON)
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="corsOrigin">CORS Origin (optional)</Label>
+              <Input
+                id="corsOrigin"
+                value={corsOrigin}
+                onChange={(e) => setCorsOrigin(e.target.value)}
+                placeholder="https://example.com"
+              />
+              <p className="text-xs text-muted-foreground">
+                Allow cross-origin form submissions from this origin
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="honeypotField">Honeypot Field Name (optional)</Label>
+              <Input
+                id="honeypotField"
+                value={honeypotField}
+                onChange={(e) => setHoneypotField(e.target.value)}
+                placeholder="website"
+              />
+              <p className="text-xs text-muted-foreground">
+                Spam protection: if this field is filled, submission is silently ignored
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="replyToField">Reply-To Field Name (optional)</Label>
+              <Input
+                id="replyToField"
+                value={replyToField}
+                onChange={(e) => setReplyToField(e.target.value)}
+                placeholder="email"
+              />
+              <p className="text-xs text-muted-foreground">
+                Use this form field value as the reply-to address in the email
+              </p>
+            </div>
+
+            <div className="border-t pt-4 mt-4">
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="requireAuth"
+                  checked={requireAuth}
+                  onCheckedChange={setRequireAuth}
+                />
+                <Label htmlFor="requireAuth" className="cursor-pointer font-medium">
+                  Require Authentication
+                </Label>
+              </div>
+              <p className="text-xs text-muted-foreground mt-2 ml-7">
+                When enabled, only logged-in users can submit the form. User details (email, name)
+                will be included in the notification email.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* External Proxy Options */}
+      {isExternalProxy && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Proxy Options</CardTitle>
+            <CardDescription>Configure how requests are forwarded</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center gap-2">
+              <Switch id="stripPrefix" checked={stripPrefix} onCheckedChange={setStripPrefix} />
+              <Label htmlFor="stripPrefix" className="cursor-pointer">
+                Strip matched path prefix
+              </Label>
+            </div>
+            <p className="text-xs text-muted-foreground -mt-2 ml-7">
+              When enabled, /api/users with pattern /api/* forwards to target/users
+            </p>
+
+            <div className="flex items-center gap-2">
+              <Switch id="preserveHost" checked={preserveHost} onCheckedChange={setPreserveHost} />
+              <Label htmlFor="preserveHost" className="cursor-pointer">
+                Preserve original Host header
+              </Label>
+            </div>
+            <p className="text-xs text-muted-foreground -mt-2 ml-7">
+              Forward the original Host header instead of using the target host
+            </p>
+
+            <div className="flex items-center gap-2">
+              <Switch
+                id="forwardCookies"
+                checked={forwardCookies}
+                onCheckedChange={setForwardCookies}
+              />
+              <Label htmlFor="forwardCookies" className="cursor-pointer">
+                Forward cookies to target
+              </Label>
+            </div>
+            <p className="text-xs text-muted-foreground -mt-2 ml-7">
+              Enable for session-based authentication with trusted backends
+            </p>
+
+            <div className="space-y-2">
+              <Label htmlFor="timeout">Timeout (ms)</Label>
+              <Input
+                id="timeout"
+                type="number"
+                min={1000}
+                max={60000}
+                value={timeout}
+                onChange={(e) => setTimeout(Number(e.target.value))}
+                className={errors.timeout ? 'border-destructive max-w-32' : 'max-w-32'}
+              />
+              {errors.timeout ? (
+                <p className="text-xs text-destructive">{errors.timeout}</p>
+              ) : (
+                <p className="text-xs text-muted-foreground">1000ms - 60000ms (default: 30000ms)</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Authentication Options (External Proxy Only) */}
+      {isExternalProxy && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Authentication</CardTitle>
+            <CardDescription>Configure authentication for proxied requests</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="apiKey">API Key / Authorization Header (optional)</Label>
+              <Input
+                id="apiKey"
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder={
+                  initialData ? '(unchanged - enter new value to update)' : 'Bearer sk_live_xxx'
+                }
+              />
+              <p className="text-xs text-muted-foreground">
+                Stored encrypted. Sent as Authorization header with each proxied request.
+              </p>
+            </div>
+
+            <div className="border rounded-lg p-4 space-y-3 bg-muted/50">
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="authTransform"
+                  checked={authTransformEnabled}
+                  onCheckedChange={setAuthTransformEnabled}
+                />
+                <Label htmlFor="authTransform" className="cursor-pointer font-medium">
+                  Cookie to Bearer Token
+                </Label>
+              </div>
+              <p className="text-xs text-muted-foreground ml-7">
+                Extract a cookie value and send it as Authorization: Bearer header. Useful for
+                proxying to APIs that validate JWTs.
+              </p>
+              {authTransformEnabled && (
+                <div className="space-y-2 ml-7">
+                  <Label htmlFor="cookieName">Cookie Name</Label>
+                  <Input
+                    id="cookieName"
+                    value={cookieName}
+                    onChange={(e) => setCookieName(e.target.value)}
+                    placeholder="sAccessToken"
+                    className="max-w-xs"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Default: sAccessToken (SuperTokens JWT cookie)
+                  </p>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Submit buttons */}
+      <div className="flex justify-end gap-2 pt-4">
+        <Button type="button" variant="outline" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={submitting}>
+          {submitting ? 'Saving...' : initialData ? 'Update Rule' : 'Create Rule'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/frontend/src/components/proxy-rules/RuleSetCard.tsx
+++ b/apps/frontend/src/components/proxy-rules/RuleSetCard.tsx
@@ -1,0 +1,55 @@
+import { Link } from 'react-router-dom';
+import { Badge } from '@/components/ui/badge';
+import { ChevronRight, Settings } from 'lucide-react';
+
+interface RuleSetCardProps {
+  id: string;
+  name: string;
+  description: string | null;
+  environment: string | null;
+  isDefault: boolean;
+  href: string;
+}
+
+/**
+ * RuleSetCard - Clickable card displaying a proxy rule set.
+ * Used in ProxyRuleSetsPage to navigate to rule set details.
+ */
+export function RuleSetCard({
+  name,
+  description,
+  environment,
+  isDefault,
+  href,
+}: RuleSetCardProps) {
+  return (
+    <Link
+      to={href}
+      className="flex items-center justify-between p-4 rounded-lg border hover:bg-accent transition-colors group"
+    >
+      <div className="flex items-center gap-4">
+        <Settings className="h-5 w-5 text-muted-foreground" />
+        <div>
+          <div className="flex items-center gap-2">
+            <span className="font-medium">{name}</span>
+            {environment && (
+              <Badge variant="outline" className="text-xs">
+                {environment}
+              </Badge>
+            )}
+            {isDefault && (
+              <Badge variant="secondary" className="text-xs">
+                Default
+              </Badge>
+            )}
+          </div>
+          {description && (
+            <p className="text-sm text-muted-foreground mt-1">{description}</p>
+          )}
+        </div>
+      </div>
+
+      <ChevronRight className="h-5 w-5 text-muted-foreground group-hover:text-foreground transition-colors" />
+    </Link>
+  );
+}

--- a/apps/frontend/src/components/proxy-rules/RulesList.tsx
+++ b/apps/frontend/src/components/proxy-rules/RulesList.tsx
@@ -1,0 +1,228 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Trash2, Edit2, AlertCircle, ArrowRight, RotateCcw, Mail } from 'lucide-react';
+import type { ProxyRule, UpdateProxyRuleDto } from '@/services/proxyRulesApi';
+
+interface RulesListProps {
+  rules: ProxyRule[];
+  isLoading: boolean;
+  error?: unknown;
+  onRuleClick: (rule: ProxyRule) => void;
+  onUpdateRule: (id: string, updates: UpdateProxyRuleDto) => Promise<void>;
+  onDeleteRule: (id: string) => Promise<void>;
+}
+
+/**
+ * RulesList - Displays a list of proxy rules with toggle and delete actions.
+ * Rules are clickable to navigate to edit page.
+ */
+export function RulesList({
+  rules,
+  isLoading,
+  error,
+  onRuleClick,
+  onUpdateRule,
+  onDeleteRule,
+}: RulesListProps) {
+  const [deletingRule, setDeletingRule] = useState<ProxyRule | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // Sort rules by order (lower = first)
+  const sortedRules = [...rules].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+
+  const handleDelete = async () => {
+    if (!deletingRule) return;
+    setIsDeleting(true);
+    try {
+      await onDeleteRule(deletingRule.id);
+      setDeletingRule(null);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleToggleEnabled = async (rule: ProxyRule, e: React.MouseEvent) => {
+    e.stopPropagation();
+    await onUpdateRule(rule.id, { isEnabled: !rule.isEnabled });
+  };
+
+  const handleDeleteClick = (rule: ProxyRule, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setDeletingRule(rule);
+  };
+
+  const handleEditClick = (rule: ProxyRule, e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRuleClick(rule);
+  };
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {[...Array(3)].map((_, i) => (
+          <Skeleton key={i} className="h-16 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription>
+          Failed to load proxy rules. {(error as { data?: { message?: string } })?.data?.message || 'Unknown error'}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  // Empty state
+  if (sortedRules.length === 0) {
+    return (
+      <div className="text-center py-8">
+        <p className="text-muted-foreground">No proxy rules configured.</p>
+        <p className="text-sm text-muted-foreground mt-2">
+          Add a rule to forward requests matching specific paths to external backends.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="space-y-2">
+        {sortedRules.map((rule) => (
+          <div
+            key={rule.id}
+            onClick={() => onRuleClick(rule)}
+            className={`flex items-center gap-3 p-3 border rounded-md bg-background transition-colors cursor-pointer hover:bg-accent ${
+              !rule.isEnabled ? 'opacity-50' : ''
+            }`}
+          >
+            <div
+              className="flex items-center justify-center w-6 h-6 rounded bg-muted text-xs font-mono flex-shrink-0"
+              title="Priority order (lower = first)"
+            >
+              {rule.order}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 text-sm">
+                <code className="font-mono bg-muted px-2 py-0.5 rounded truncate">
+                  {rule.pathPattern}
+                </code>
+                {rule.proxyType === 'email_form_handler' ? (
+                  <span title="Email form handler">
+                    <Mail className="h-3 w-3 text-emerald-500 flex-shrink-0" />
+                  </span>
+                ) : rule.internalRewrite ? (
+                  <span title="Internal rewrite">
+                    <RotateCcw className="h-3 w-3 text-blue-500 flex-shrink-0" />
+                  </span>
+                ) : (
+                  <ArrowRight className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+                )}
+                <span className="text-muted-foreground truncate">
+                  {rule.proxyType === 'email_form_handler'
+                    ? rule.emailHandlerConfig?.destinationEmail || 'No email configured'
+                    : rule.targetUrl}
+                </span>
+                {rule.proxyType === 'email_form_handler' && (
+                  <span className="text-xs bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300 px-1.5 py-0.5 rounded flex-shrink-0">
+                    email
+                  </span>
+                )}
+                {rule.internalRewrite && (
+                  <span className="text-xs bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300 px-1.5 py-0.5 rounded flex-shrink-0">
+                    rewrite
+                  </span>
+                )}
+              </div>
+              {rule.description && (
+                <p className="text-xs text-muted-foreground mt-1 truncate">
+                  {rule.description}
+                </p>
+              )}
+              <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
+                {rule.proxyType === 'email_form_handler' ? (
+                  <>
+                    <span>Sends form data to email</span>
+                    {rule.emailHandlerConfig?.honeypotField && <span>Spam protection</span>}
+                  </>
+                ) : rule.internalRewrite ? (
+                  <span>Internal rewrite (no HTTP request)</span>
+                ) : (
+                  <>
+                    {rule.stripPrefix && <span>Strip prefix</span>}
+                    <span>Timeout: {rule.timeout}ms</span>
+                  </>
+                )}
+              </div>
+            </div>
+            <Switch
+              checked={rule.isEnabled}
+              onCheckedChange={() => {}}
+              onClick={(e) => handleToggleEnabled(rule, e)}
+              title={rule.isEnabled ? 'Disable rule' : 'Enable rule'}
+            />
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={(e) => handleEditClick(rule, e)}
+              title="Edit rule"
+            >
+              <Edit2 className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={(e) => handleDeleteClick(rule, e)}
+              title="Delete rule"
+            >
+              <Trash2 className="h-4 w-4 text-destructive" />
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      {/* Delete Confirmation Dialog */}
+      <AlertDialog open={!!deletingRule} onOpenChange={(open) => !open && setDeletingRule(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Proxy Rule</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete the proxy rule for{' '}
+              <code className="font-mono bg-muted px-1 rounded">{deletingRule?.pathPattern}</code>?
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={isDeleting}
+            >
+              {isDeleting ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/frontend/src/components/proxy-rules/index.ts
+++ b/apps/frontend/src/components/proxy-rules/index.ts
@@ -3,3 +3,6 @@ export { ProxyRuleForm } from './ProxyRuleForm';
 export { ProxyRuleSetsTab } from './ProxyRuleSetsTab';
 export { CreateRuleSetDialog } from './CreateRuleSetDialog';
 export { RuleSetEditorDialog } from './RuleSetEditorDialog';
+export { RuleSetCard } from './RuleSetCard';
+export { RulesList } from './RulesList';
+export { ExpandedProxyRuleForm } from './ExpandedProxyRuleForm';

--- a/apps/frontend/src/pages/AliasesPage.tsx
+++ b/apps/frontend/src/pages/AliasesPage.tsx
@@ -1,0 +1,11 @@
+import { useParams } from 'react-router-dom';
+import { AliasesTab } from '@/components/repo/AliasesTab';
+
+/**
+ * AliasesPage - Wrapper for AliasesTab that extracts URL params.
+ * Route: /repo/:owner/:repo/aliases
+ */
+export function AliasesPage() {
+  const { owner, repo } = useParams<{ owner: string; repo: string }>();
+  return <AliasesTab owner={owner!} repo={repo!} />;
+}

--- a/apps/frontend/src/pages/BranchesPage.tsx
+++ b/apps/frontend/src/pages/BranchesPage.tsx
@@ -1,0 +1,11 @@
+import { useParams } from 'react-router-dom';
+import { BranchesTab } from '@/components/repo/BranchesTab';
+
+/**
+ * BranchesPage - Wrapper for BranchesTab that extracts URL params.
+ * Route: /repo/:owner/:repo/branches
+ */
+export function BranchesPage() {
+  const { owner, repo } = useParams<{ owner: string; repo: string }>();
+  return <BranchesTab owner={owner!} repo={repo!} />;
+}

--- a/apps/frontend/src/pages/DeploymentsTab.tsx
+++ b/apps/frontend/src/pages/DeploymentsTab.tsx
@@ -1,0 +1,11 @@
+import { useParams } from 'react-router-dom';
+import { DeploymentsList } from '@/components/repo/DeploymentsList';
+
+/**
+ * DeploymentsTab - Wrapper for DeploymentsList that extracts URL params.
+ * Route: /repo/:owner/:repo/deployments
+ */
+export function DeploymentsTab() {
+  const { owner, repo } = useParams<{ owner: string; repo: string }>();
+  return <DeploymentsList owner={owner!} repo={repo!} />;
+}

--- a/apps/frontend/src/pages/ProxyRuleSetsPage.tsx
+++ b/apps/frontend/src/pages/ProxyRuleSetsPage.tsx
@@ -1,0 +1,290 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useAppDispatch } from '@/store/hooks';
+import { setCurrentRepo } from '@/store/slices/repoSlice';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import { Plus, Layers, MoreHorizontal, Trash2 } from 'lucide-react';
+import { useGetProjectRuleSetsQuery, useDeleteRuleSetMutation } from '@/services/proxyRulesApi';
+import { useGetProjectQuery } from '@/services/projectsApi';
+import { useProjectRole } from '@/hooks/useProjectRole';
+import { useToast } from '@/hooks/use-toast';
+import { CreateRuleSetDialog } from '@/components/proxy-rules/CreateRuleSetDialog';
+import { RuleSetCard } from '@/components/proxy-rules/RuleSetCard';
+import { routes } from '@/utils/routes';
+
+/**
+ * ProxyRuleSetsPage - Full page listing all proxy rule sets for a repository.
+ * Route: /repo/:owner/:repo/tab/proxy-rules
+ */
+export function ProxyRuleSetsPage() {
+  const { owner, repo } = useParams<{ owner: string; repo: string }>();
+  const dispatch = useAppDispatch();
+  const { toast } = useToast();
+  const { canEdit } = useProjectRole(owner!, repo!);
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [deletingRuleSet, setDeletingRuleSet] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+
+  // Update Redux store when URL params change
+  useEffect(() => {
+    if (owner && repo) {
+      dispatch(setCurrentRepo({ owner, repo }));
+    }
+  }, [owner, repo, dispatch]);
+
+  // Fetch project to get projectId
+  const { data: project, isLoading: isLoadingProject } = useGetProjectQuery(
+    { owner: owner!, name: repo! },
+    { skip: !owner || !repo },
+  );
+
+  // Fetch rule sets for this project
+  const {
+    data: ruleSetsData,
+    isLoading: isLoadingRuleSets,
+    error: ruleSetsError,
+  } = useGetProjectRuleSetsQuery(project?.id || '', {
+    skip: !project?.id,
+  });
+
+  // Delete mutation
+  const [deleteRuleSet, { isLoading: isDeleting }] = useDeleteRuleSetMutation();
+
+  const handleDelete = async () => {
+    if (!deletingRuleSet) return;
+    try {
+      await deleteRuleSet(deletingRuleSet.id).unwrap();
+      toast({
+        title: 'Rule set deleted',
+        description: `Rule set "${deletingRuleSet.name}" has been deleted.`,
+      });
+      setDeletingRuleSet(null);
+    } catch (err: unknown) {
+      const errorMessage =
+        (err as { data?: { message?: string } })?.data?.message || 'Failed to delete rule set';
+      toast({
+        title: 'Error',
+        description: errorMessage,
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const isLoading = isLoadingProject || isLoadingRuleSets;
+  const ruleSets = ruleSetsData?.ruleSets || [];
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="bg-background">
+        <div className="p-4 md:p-8 max-w-5xl mx-auto">
+          <Skeleton className="h-6 w-64 mb-6" />
+          <Card>
+            <CardHeader>
+              <CardTitle>Proxy Rule Sets</CardTitle>
+              <CardDescription>Manage reusable proxy rule configurations</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                <div className="flex justify-end">
+                  <Skeleton className="h-10 w-40" />
+                </div>
+                {[...Array(3)].map((_, i) => (
+                  <Skeleton key={i} className="h-24 w-full" />
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (ruleSetsError) {
+    return (
+      <div className="bg-background">
+        <div className="p-4 md:p-8 max-w-5xl mx-auto">
+          <BreadcrumbNav owner={owner!} repo={repo!} />
+          <Card>
+            <CardHeader>
+              <CardTitle>Proxy Rule Sets</CardTitle>
+            </CardHeader>
+            <CardContent className="p-8 text-center">
+              <p className="text-destructive">Failed to load proxy rule sets</p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-4"
+                onClick={() => window.location.reload()}
+              >
+                Retry
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-background">
+      <div className="p-4 md:p-8 max-w-5xl mx-auto">
+        {/* Breadcrumb Navigation */}
+        <BreadcrumbNav owner={owner!} repo={repo!} />
+
+        {/* Main Content */}
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <div>
+              <CardTitle>Proxy Rule Sets</CardTitle>
+              <CardDescription>Manage reusable proxy rule configurations</CardDescription>
+            </div>
+            {canEdit && (
+              <Button size="sm" className="gap-2" onClick={() => setIsCreateDialogOpen(true)}>
+                <Plus className="h-4 w-4" />
+                Create Rule Set
+              </Button>
+            )}
+          </CardHeader>
+          <CardContent>
+            {ruleSets.length === 0 ? (
+              <div className="p-8 text-center">
+                <Layers className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+                <p className="text-muted-foreground font-medium">No proxy rule sets found</p>
+                <p className="text-sm text-muted-foreground mt-2">
+                  {canEdit
+                    ? 'Create a rule set to define proxy rules that can be assigned to aliases'
+                    : 'No proxy rule sets have been created for this repository yet'}
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {ruleSets.map((ruleSet) => (
+                  <div key={ruleSet.id} className="relative">
+                    <RuleSetCard
+                      id={ruleSet.id}
+                      name={ruleSet.name}
+                      description={ruleSet.description}
+                      environment={ruleSet.environment}
+                      isDefault={project?.defaultProxyRuleSetId === ruleSet.id}
+                      href={routes.ruleSet(owner!, repo!, ruleSet.id)}
+                    />
+                    {canEdit && (
+                      <div className="absolute right-12 top-1/2 -translate-y-1/2">
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <MoreHorizontal className="h-4 w-4" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setDeletingRuleSet({ id: ruleSet.id, name: ruleSet.name });
+                              }}
+                              className="text-destructive"
+                            >
+                              <Trash2 className="h-4 w-4 mr-2" />
+                              Delete
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Create Dialog */}
+        {canEdit && (
+          <CreateRuleSetDialog
+            projectId={project?.id || ''}
+            open={isCreateDialogOpen}
+            onOpenChange={setIsCreateDialogOpen}
+          />
+        )}
+
+        {/* Delete Confirmation Dialog */}
+        {canEdit && (
+          <AlertDialog open={!!deletingRuleSet} onOpenChange={(open) => !open && setDeletingRuleSet(null)}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete Rule Set</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Are you sure you want to delete the rule set "{deletingRuleSet?.name}"? This will
+                  remove all rules in this set and unassign it from any aliases using it. This action
+                  cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={handleDelete}
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  disabled={isDeleting}
+                >
+                  {isDeleting ? 'Deleting...' : 'Delete'}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function BreadcrumbNav({ owner, repo }: { owner: string; repo: string }) {
+  return (
+    <Breadcrumb className="mb-6">
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link to={routes.repository(owner, repo)}>{owner}/{repo}</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Proxy Rules</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/apps/frontend/src/pages/ProxyRuleSetsPage.tsx
+++ b/apps/frontend/src/pages/ProxyRuleSetsPage.tsx
@@ -1,7 +1,5 @@
-import { useState, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
-import { useAppDispatch } from '@/store/hooks';
-import { setCurrentRepo } from '@/store/slices/repoSlice';
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -21,14 +19,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from '@/components/ui/breadcrumb';
 import { Plus, Layers, MoreHorizontal, Trash2 } from 'lucide-react';
 import { useGetProjectRuleSetsQuery, useDeleteRuleSetMutation } from '@/services/proxyRulesApi';
 import { useGetProjectQuery } from '@/services/projectsApi';
@@ -39,12 +29,12 @@ import { RuleSetCard } from '@/components/proxy-rules/RuleSetCard';
 import { routes } from '@/utils/routes';
 
 /**
- * ProxyRuleSetsPage - Full page listing all proxy rule sets for a repository.
- * Route: /repo/:owner/:repo/tab/proxy-rules
+ * ProxyRuleSetsPage - Content for the Proxy Rules tab showing all rule sets.
+ * Rendered inside RepositoryLayout via Outlet.
+ * Route: /repo/:owner/:repo/proxy-rules
  */
 export function ProxyRuleSetsPage() {
   const { owner, repo } = useParams<{ owner: string; repo: string }>();
-  const dispatch = useAppDispatch();
   const { toast } = useToast();
   const { canEdit } = useProjectRole(owner!, repo!);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
@@ -52,13 +42,6 @@ export function ProxyRuleSetsPage() {
     id: string;
     name: string;
   } | null>(null);
-
-  // Update Redux store when URL params change
-  useEffect(() => {
-    if (owner && repo) {
-      dispatch(setCurrentRepo({ owner, repo }));
-    }
-  }, [owner, repo, dispatch]);
 
   // Fetch project to get projectId
   const { data: project, isLoading: isLoadingProject } = useGetProjectQuery(
@@ -104,187 +87,153 @@ export function ProxyRuleSetsPage() {
   // Loading state
   if (isLoading) {
     return (
-      <div className="bg-background">
-        <div className="p-4 md:p-8 max-w-5xl mx-auto">
-          <Skeleton className="h-6 w-64 mb-6" />
-          <Card>
-            <CardHeader>
-              <CardTitle>Proxy Rule Sets</CardTitle>
-              <CardDescription>Manage reusable proxy rule configurations</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                <div className="flex justify-end">
-                  <Skeleton className="h-10 w-40" />
-                </div>
-                {[...Array(3)].map((_, i) => (
-                  <Skeleton key={i} className="h-24 w-full" />
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Proxy Rule Sets</CardTitle>
+          <CardDescription>Manage reusable proxy rule configurations</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            <div className="flex justify-end">
+              <Skeleton className="h-10 w-40" />
+            </div>
+            {[...Array(3)].map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
     );
   }
 
   // Error state
   if (ruleSetsError) {
     return (
-      <div className="bg-background">
-        <div className="p-4 md:p-8 max-w-5xl mx-auto">
-          <BreadcrumbNav owner={owner!} repo={repo!} />
-          <Card>
-            <CardHeader>
-              <CardTitle>Proxy Rule Sets</CardTitle>
-            </CardHeader>
-            <CardContent className="p-8 text-center">
-              <p className="text-destructive">Failed to load proxy rule sets</p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="mt-4"
-                onClick={() => window.location.reload()}
-              >
-                Retry
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Proxy Rule Sets</CardTitle>
+        </CardHeader>
+        <CardContent className="p-8 text-center">
+          <p className="text-destructive">Failed to load proxy rule sets</p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-4"
+            onClick={() => window.location.reload()}
+          >
+            Retry
+          </Button>
+        </CardContent>
+      </Card>
     );
   }
 
   return (
-    <div className="bg-background">
-      <div className="p-4 md:p-8 max-w-5xl mx-auto">
-        {/* Breadcrumb Navigation */}
-        <BreadcrumbNav owner={owner!} repo={repo!} />
-
-        {/* Main Content */}
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <div>
-              <CardTitle>Proxy Rule Sets</CardTitle>
-              <CardDescription>Manage reusable proxy rule configurations</CardDescription>
+    <>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle>Proxy Rule Sets</CardTitle>
+            <CardDescription>Manage reusable proxy rule configurations</CardDescription>
+          </div>
+          {canEdit && (
+            <Button size="sm" className="gap-2" onClick={() => setIsCreateDialogOpen(true)}>
+              <Plus className="h-4 w-4" />
+              Create Rule Set
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          {ruleSets.length === 0 ? (
+            <div className="p-8 text-center">
+              <Layers className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+              <p className="text-muted-foreground font-medium">No proxy rule sets found</p>
+              <p className="text-sm text-muted-foreground mt-2">
+                {canEdit
+                  ? 'Create a rule set to define proxy rules that can be assigned to aliases'
+                  : 'No proxy rule sets have been created for this repository yet'}
+              </p>
             </div>
-            {canEdit && (
-              <Button size="sm" className="gap-2" onClick={() => setIsCreateDialogOpen(true)}>
-                <Plus className="h-4 w-4" />
-                Create Rule Set
-              </Button>
-            )}
-          </CardHeader>
-          <CardContent>
-            {ruleSets.length === 0 ? (
-              <div className="p-8 text-center">
-                <Layers className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-                <p className="text-muted-foreground font-medium">No proxy rule sets found</p>
-                <p className="text-sm text-muted-foreground mt-2">
-                  {canEdit
-                    ? 'Create a rule set to define proxy rules that can be assigned to aliases'
-                    : 'No proxy rule sets have been created for this repository yet'}
-                </p>
-              </div>
-            ) : (
-              <div className="space-y-3">
-                {ruleSets.map((ruleSet) => (
-                  <div key={ruleSet.id} className="relative">
-                    <RuleSetCard
-                      id={ruleSet.id}
-                      name={ruleSet.name}
-                      description={ruleSet.description}
-                      environment={ruleSet.environment}
-                      isDefault={project?.defaultProxyRuleSetId === ruleSet.id}
-                      href={routes.ruleSet(owner!, repo!, ruleSet.id)}
-                    />
-                    {canEdit && (
-                      <div className="absolute right-12 top-1/2 -translate-y-1/2">
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={(e) => e.stopPropagation()}
-                            >
-                              <MoreHorizontal className="h-4 w-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            <DropdownMenuItem
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setDeletingRuleSet({ id: ruleSet.id, name: ruleSet.name });
-                              }}
-                              className="text-destructive"
-                            >
-                              <Trash2 className="h-4 w-4 mr-2" />
-                              Delete
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+          ) : (
+            <div className="space-y-3">
+              {ruleSets.map((ruleSet) => (
+                <div key={ruleSet.id} className="relative">
+                  <RuleSetCard
+                    id={ruleSet.id}
+                    name={ruleSet.name}
+                    description={ruleSet.description}
+                    environment={ruleSet.environment}
+                    isDefault={project?.defaultProxyRuleSetId === ruleSet.id}
+                    href={routes.ruleSet(owner!, repo!, ruleSet.id)}
+                  />
+                  {canEdit && (
+                    <div className="absolute right-12 top-1/2 -translate-y-1/2">
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setDeletingRuleSet({ id: ruleSet.id, name: ruleSet.name });
+                            }}
+                            className="text-destructive"
+                          >
+                            <Trash2 className="h-4 w-4 mr-2" />
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
-        {/* Create Dialog */}
-        {canEdit && (
-          <CreateRuleSetDialog
-            projectId={project?.id || ''}
-            open={isCreateDialogOpen}
-            onOpenChange={setIsCreateDialogOpen}
-          />
-        )}
+      {/* Create Dialog */}
+      {canEdit && (
+        <CreateRuleSetDialog
+          projectId={project?.id || ''}
+          open={isCreateDialogOpen}
+          onOpenChange={setIsCreateDialogOpen}
+        />
+      )}
 
-        {/* Delete Confirmation Dialog */}
-        {canEdit && (
-          <AlertDialog open={!!deletingRuleSet} onOpenChange={(open) => !open && setDeletingRuleSet(null)}>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Delete Rule Set</AlertDialogTitle>
-                <AlertDialogDescription>
-                  Are you sure you want to delete the rule set "{deletingRuleSet?.name}"? This will
-                  remove all rules in this set and unassign it from any aliases using it. This action
-                  cannot be undone.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={handleDelete}
-                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                  disabled={isDeleting}
-                >
-                  {isDeleting ? 'Deleting...' : 'Delete'}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function BreadcrumbNav({ owner, repo }: { owner: string; repo: string }) {
-  return (
-    <Breadcrumb className="mb-6">
-      <BreadcrumbList>
-        <BreadcrumbItem>
-          <BreadcrumbLink asChild>
-            <Link to={routes.repository(owner, repo)}>{owner}/{repo}</Link>
-          </BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbSeparator />
-        <BreadcrumbItem>
-          <BreadcrumbPage>Proxy Rules</BreadcrumbPage>
-        </BreadcrumbItem>
-      </BreadcrumbList>
-    </Breadcrumb>
+      {/* Delete Confirmation Dialog */}
+      {canEdit && (
+        <AlertDialog open={!!deletingRuleSet} onOpenChange={(open) => !open && setDeletingRuleSet(null)}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete Rule Set</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete the rule set "{deletingRuleSet?.name}"? This will
+                remove all rules in this set and unassign it from any aliases using it. This action
+                cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleDelete}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                disabled={isDeleting}
+              >
+                {isDeleting ? 'Deleting...' : 'Delete'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </>
   );
 }

--- a/apps/frontend/src/pages/RepositoryLayout.tsx
+++ b/apps/frontend/src/pages/RepositoryLayout.tsx
@@ -1,0 +1,165 @@
+import { useEffect } from 'react';
+import { useParams, useNavigate, Link, Outlet, useLocation } from 'react-router-dom';
+import { useAppDispatch } from '@/store/hooks';
+import { setCurrentRepo } from '@/store/slices/repoSlice';
+import { useGetRepositoryStatsQuery } from '@/services/repoApi';
+import { useProjectRole } from '@/hooks/useProjectRole';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { AlertCircle, RefreshCw, Settings } from 'lucide-react';
+import { RepositoryStatsHeader } from '@/components/repo/RepositoryStatsHeader';
+import { routes } from '@/utils/routes';
+
+/**
+ * RepositoryLayout - Shared layout for repository pages with nested routes.
+ * Displays the header, stats, and tabs. Child routes render via <Outlet />.
+ * Route: /repo/:owner/:repo/*
+ */
+export function RepositoryLayout() {
+  const { owner, repo } = useParams<{ owner: string; repo: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const dispatch = useAppDispatch();
+
+  // Determine current tab from pathname
+  const pathAfterRepo = location.pathname.replace(`/repo/${owner}/${repo}`, '');
+  const currentTab = pathAfterRepo.startsWith('/proxy-rules')
+    ? 'proxy-rules'
+    : pathAfterRepo.startsWith('/aliases')
+      ? 'aliases'
+      : pathAfterRepo.startsWith('/branches')
+        ? 'branches'
+        : 'deployments';
+
+  // Update Redux store when URL params change
+  useEffect(() => {
+    if (owner && repo) {
+      dispatch(setCurrentRepo({ owner, repo }));
+    }
+  }, [owner, repo, dispatch]);
+
+  // Check user's role for this project
+  const { canAdmin } = useProjectRole(owner!, repo!);
+
+  // Fetch repository stats
+  const {
+    data: statsData,
+    isLoading: isLoadingStats,
+    error: statsError,
+  } = useGetRepositoryStatsQuery(
+    { owner: owner!, repo: repo! },
+    { skip: !owner || !repo },
+  );
+
+  // Loading state
+  if (isLoadingStats) {
+    return (
+      <div className="bg-background">
+        <div className="p-4 md:p-8 max-w-7xl mx-auto space-y-6">
+          {/* Title skeleton */}
+          <Skeleton className="h-8 w-48" />
+          {/* Stats skeleton */}
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <Skeleton className="h-32" />
+            <Skeleton className="h-32" />
+            <Skeleton className="h-32" />
+            <Skeleton className="h-32" />
+          </div>
+          {/* Tabs skeleton */}
+          <Skeleton className="h-10 w-96" />
+          {/* Content skeleton */}
+          <Skeleton className="h-96" />
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (statsError) {
+    return (
+      <div className="bg-background">
+        <div className="p-8">
+          <Alert variant="destructive" className="max-w-2xl">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              <div className="space-y-3">
+                <div>
+                  <p className="font-medium">Error Loading Repository</p>
+                  <p className="text-sm mt-1">Failed to load repository statistics</p>
+                  <p className="text-sm mt-2">
+                    Repository: {owner}/{repo}
+                  </p>
+                </div>
+                <Button
+                  onClick={() => window.location.reload()}
+                  size="sm"
+                  variant="outline"
+                  className="w-fit"
+                >
+                  <RefreshCw className="h-4 w-4 mr-2" />
+                  Reload Page
+                </Button>
+              </div>
+            </AlertDescription>
+          </Alert>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-background">
+      <div className="p-4 md:p-8 max-w-7xl mx-auto">
+        {/* Repository Title with Settings */}
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-2xl font-bold">
+            {owner}/{repo}
+          </h1>
+          {canAdmin && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => navigate(routes.repositorySettings(owner!, repo!))}
+              className="flex items-center gap-2"
+            >
+              <Settings className="h-4 w-4" />
+              Settings
+            </Button>
+          )}
+        </div>
+
+        {/* Stats Header */}
+        {statsData && (
+          <div className="mb-6">
+            <RepositoryStatsHeader stats={statsData} />
+          </div>
+        )}
+
+        {/* Tabs Navigation */}
+        <Tabs value={currentTab} className="w-full">
+          <TabsList>
+            <TabsTrigger value="deployments" asChild>
+              <Link to={routes.deployments(owner!, repo!)}>Deployments</Link>
+            </TabsTrigger>
+            <TabsTrigger value="branches" asChild>
+              <Link to={routes.branches(owner!, repo!)}>Branches</Link>
+            </TabsTrigger>
+            <TabsTrigger value="aliases" asChild>
+              <Link to={routes.aliases(owner!, repo!)}>Aliases</Link>
+            </TabsTrigger>
+            <TabsTrigger value="proxy-rules" asChild>
+              <Link to={routes.proxyRules(owner!, repo!)}>Proxy Rules</Link>
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+
+        {/* Tab Content - rendered via Outlet */}
+        <div className="mt-6">
+          <Outlet />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/RepositoryOverviewPage.tsx
+++ b/apps/frontend/src/pages/RepositoryOverviewPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
+import { useParams, useSearchParams, useNavigate, Link } from 'react-router-dom';
 import { useAppDispatch } from '@/store/hooks';
 import { setCurrentRepo } from '@/store/slices/repoSlice';
 import { useGetRepositoryStatsQuery } from '@/services/repoApi';
@@ -13,9 +13,9 @@ import { DeploymentsList } from '@/components/repo/DeploymentsList';
 import { RepositoryStatsHeader } from '@/components/repo/RepositoryStatsHeader';
 import { AliasesTab } from '@/components/repo/AliasesTab';
 import { BranchesTab } from '@/components/repo/BranchesTab';
-import { ProxyRuleSetsTab } from '@/components/proxy-rules';
+import { routes } from '@/utils/routes';
 
-type TabValue = 'deployments' | 'branches' | 'aliases' | 'proxy-rules';
+type TabValue = 'deployments' | 'branches' | 'aliases';
 
 /**
  * RepositoryOverviewPage - Main page showing deployments, stats, and aliases
@@ -32,11 +32,17 @@ export function RepositoryOverviewPage() {
   const dispatch = useAppDispatch();
 
   // Get tab from query params, default to 'deployments'
+  // Note: proxy-rules now has its own route, so redirect if that tab was requested
   const tabParam = searchParams.get('tab');
   const currentTab: TabValue =
-    tabParam === 'branches' || tabParam === 'aliases' || tabParam === 'proxy-rules'
-      ? tabParam
-      : 'deployments';
+    tabParam === 'branches' || tabParam === 'aliases' ? tabParam : 'deployments';
+
+  // Redirect to proxy rules page if that tab was requested via query param
+  useEffect(() => {
+    if (tabParam === 'proxy-rules' && owner && repo) {
+      navigate(routes.proxyRules(owner, repo), { replace: true });
+    }
+  }, [tabParam, owner, repo, navigate]);
 
   // Handler for tab changes
   const handleTabChange = (value: string) => {
@@ -157,7 +163,9 @@ export function RepositoryOverviewPage() {
             <TabsTrigger value="deployments">Deployments</TabsTrigger>
             <TabsTrigger value="branches">Branches</TabsTrigger>
             <TabsTrigger value="aliases">Aliases</TabsTrigger>
-            <TabsTrigger value="proxy-rules">Proxy Rules</TabsTrigger>
+            <TabsTrigger value="proxy-rules" asChild>
+              <Link to={routes.proxyRules(owner!, repo!)}>Proxy Rules</Link>
+            </TabsTrigger>
           </TabsList>
 
           <TabsContent value="deployments" className="mt-6">
@@ -170,10 +178,6 @@ export function RepositoryOverviewPage() {
 
           <TabsContent value="aliases" className="mt-6">
             <AliasesTab owner={owner!} repo={repo!} />
-          </TabsContent>
-
-          <TabsContent value="proxy-rules" className="mt-6">
-            <ProxyRuleSetsTab owner={owner!} repo={repo!} />
           </TabsContent>
         </Tabs>
       </div>

--- a/apps/frontend/src/pages/RepositoryTabRedirect.tsx
+++ b/apps/frontend/src/pages/RepositoryTabRedirect.tsx
@@ -1,0 +1,23 @@
+import { Navigate, useSearchParams } from 'react-router-dom';
+
+/**
+ * RepositoryTabRedirect - Handles backward compatibility for old query param URLs.
+ * Redirects ?tab=X to the new path-based routes.
+ */
+export function RepositoryTabRedirect() {
+  const [searchParams] = useSearchParams();
+  const tab = searchParams.get('tab');
+
+  // Map old tab query params to new paths
+  switch (tab) {
+    case 'branches':
+      return <Navigate to="branches" replace />;
+    case 'aliases':
+      return <Navigate to="aliases" replace />;
+    case 'proxy-rules':
+      return <Navigate to="proxy-rules" replace />;
+    case 'deployments':
+    default:
+      return <Navigate to="deployments" replace />;
+  }
+}

--- a/apps/frontend/src/pages/RuleEditorPage.tsx
+++ b/apps/frontend/src/pages/RuleEditorPage.tsx
@@ -1,0 +1,248 @@
+import { useEffect } from 'react';
+import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
+import { useAppDispatch } from '@/store/hooks';
+import { setCurrentRepo } from '@/store/slices/repoSlice';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import {
+  useGetProxyRuleQuery,
+  useGetRuleSetQuery,
+  useCreateRuleInSetMutation,
+  useUpdateProxyRuleMutation,
+  type CreateProxyRuleDto,
+} from '@/services/proxyRulesApi';
+import { useProjectRole } from '@/hooks/useProjectRole';
+import { useToast } from '@/hooks/use-toast';
+import { ExpandedProxyRuleForm } from '@/components/proxy-rules/ExpandedProxyRuleForm';
+import { routes } from '@/utils/routes';
+
+/**
+ * RuleEditorPage - Full page for creating or editing a proxy rule.
+ * Routes:
+ *   - /repo/:owner/:repo/tab/proxy-rules/:ruleSetId/new (create)
+ *   - /repo/:owner/:repo/tab/proxy-rules/:ruleSetId/:ruleId (edit)
+ */
+export function RuleEditorPage() {
+  const { owner, repo, ruleSetId, ruleId } = useParams<{
+    owner: string;
+    repo: string;
+    ruleSetId: string;
+    ruleId: string;
+  }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const dispatch = useAppDispatch();
+  const { toast } = useToast();
+  const { canEdit } = useProjectRole(owner!, repo!);
+
+  // Determine mode: create or edit
+  const isCreateMode = location.pathname.endsWith('/new');
+  const isEditMode = !isCreateMode && !!ruleId;
+
+  // Update Redux store when URL params change
+  useEffect(() => {
+    if (owner && repo) {
+      dispatch(setCurrentRepo({ owner, repo }));
+    }
+  }, [owner, repo, dispatch]);
+
+  // Fetch rule set to get the name for breadcrumb
+  const { data: ruleSet, isLoading: isLoadingRuleSet } = useGetRuleSetQuery(ruleSetId!, {
+    skip: !ruleSetId,
+  });
+
+  // Fetch rule data for edit mode
+  const {
+    data: rule,
+    isLoading: isLoadingRule,
+    error: ruleError,
+  } = useGetProxyRuleQuery(ruleId!, {
+    skip: !isEditMode || !ruleId,
+  });
+
+  // Mutations
+  const [createRule, { isLoading: isCreating }] = useCreateRuleInSetMutation();
+  const [updateRule, { isLoading: isUpdating }] = useUpdateProxyRuleMutation();
+
+  const handleSubmit = async (data: CreateProxyRuleDto) => {
+    try {
+      if (isCreateMode) {
+        await createRule({ ruleSetId: ruleSetId!, rule: data }).unwrap();
+        toast({
+          title: 'Rule created',
+          description: `Proxy rule for "${data.pathPattern}" has been created.`,
+        });
+      } else if (isEditMode && ruleId) {
+        await updateRule({ id: ruleId, updates: data }).unwrap();
+        toast({
+          title: 'Rule updated',
+          description: 'Proxy rule has been updated.',
+        });
+      }
+      // Navigate back to rule set detail page
+      navigate(routes.ruleSet(owner!, repo!, ruleSetId!));
+    } catch (err: unknown) {
+      const errorMessage =
+        (err as { data?: { message?: string } })?.data?.message ||
+        `Failed to ${isCreateMode ? 'create' : 'update'} proxy rule`;
+      toast({
+        title: 'Error',
+        description: errorMessage,
+        variant: 'destructive',
+      });
+      throw err;
+    }
+  };
+
+  const handleCancel = () => {
+    navigate(routes.ruleSet(owner!, repo!, ruleSetId!));
+  };
+
+  // Check permissions
+  if (!canEdit) {
+    return (
+      <div className="bg-background">
+        <div className="p-4 md:p-8 max-w-5xl mx-auto">
+          <Card>
+            <CardContent className="p-8 text-center">
+              <p className="text-destructive">You do not have permission to edit proxy rules.</p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-4"
+                onClick={() => navigate(routes.ruleSet(owner!, repo!, ruleSetId!))}
+              >
+                Back to Rule Set
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  // Loading state
+  const isLoading = isLoadingRuleSet || (isEditMode && isLoadingRule);
+  if (isLoading) {
+    return (
+      <div className="bg-background">
+        <div className="p-4 md:p-8 max-w-5xl mx-auto">
+          <Skeleton className="h-6 w-96 mb-6" />
+          <div className="space-y-6">
+            <Skeleton className="h-64 w-full" />
+            <Skeleton className="h-48 w-full" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state for edit mode
+  if (isEditMode && (ruleError || !rule)) {
+    return (
+      <div className="bg-background">
+        <div className="p-4 md:p-8 max-w-5xl mx-auto">
+          <BreadcrumbNav
+            owner={owner!}
+            repo={repo!}
+            ruleSetId={ruleSetId!}
+            ruleSetName={ruleSet?.name || 'Rule Set'}
+            pageName="Error"
+          />
+          <Card>
+            <CardContent className="p-8 text-center">
+              <p className="text-destructive">Failed to load rule</p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-4"
+                onClick={() => navigate(routes.ruleSet(owner!, repo!, ruleSetId!))}
+              >
+                Back to Rule Set
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  const pageTitle = isCreateMode ? 'New Rule' : 'Edit Rule';
+
+  return (
+    <div className="bg-background">
+      <div className="p-4 md:p-8 max-w-5xl mx-auto">
+        {/* Breadcrumb Navigation */}
+        <BreadcrumbNav
+          owner={owner!}
+          repo={repo!}
+          ruleSetId={ruleSetId!}
+          ruleSetName={ruleSet?.name || 'Rule Set'}
+          pageName={pageTitle}
+        />
+
+        {/* Page Title */}
+        <h1 className="text-2xl font-bold mb-6">{pageTitle}</h1>
+
+        {/* Form */}
+        <ExpandedProxyRuleForm
+          initialData={isEditMode ? rule : undefined}
+          onSubmit={handleSubmit}
+          onCancel={handleCancel}
+          isSubmitting={isCreating || isUpdating}
+        />
+      </div>
+    </div>
+  );
+}
+
+function BreadcrumbNav({
+  owner,
+  repo,
+  ruleSetId,
+  ruleSetName,
+  pageName,
+}: {
+  owner: string;
+  repo: string;
+  ruleSetId: string;
+  ruleSetName: string;
+  pageName: string;
+}) {
+  return (
+    <Breadcrumb className="mb-6">
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link to={routes.repository(owner, repo)}>{owner}/{repo}</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link to={routes.proxyRules(owner, repo)}>Proxy Rules</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link to={routes.ruleSet(owner, repo, ruleSetId)}>{ruleSetName}</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>{pageName}</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/apps/frontend/src/pages/RuleEditorPage.tsx
+++ b/apps/frontend/src/pages/RuleEditorPage.tsx
@@ -1,7 +1,4 @@
-import { useEffect } from 'react';
 import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
-import { useAppDispatch } from '@/store/hooks';
-import { setCurrentRepo } from '@/store/slices/repoSlice';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -13,6 +10,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
+import { ArrowLeft } from 'lucide-react';
 import {
   useGetProxyRuleQuery,
   useGetRuleSetQuery,
@@ -27,9 +25,10 @@ import { routes } from '@/utils/routes';
 
 /**
  * RuleEditorPage - Full page for creating or editing a proxy rule.
+ * Rendered inside RepositoryLayout via Outlet.
  * Routes:
- *   - /repo/:owner/:repo/tab/proxy-rules/:ruleSetId/new (create)
- *   - /repo/:owner/:repo/tab/proxy-rules/:ruleSetId/:ruleId (edit)
+ *   - /repo/:owner/:repo/proxy-rules/:ruleSetId/new (create)
+ *   - /repo/:owner/:repo/proxy-rules/:ruleSetId/:ruleId (edit)
  */
 export function RuleEditorPage() {
   const { owner, repo, ruleSetId, ruleId } = useParams<{
@@ -40,20 +39,12 @@ export function RuleEditorPage() {
   }>();
   const navigate = useNavigate();
   const location = useLocation();
-  const dispatch = useAppDispatch();
   const { toast } = useToast();
   const { canEdit } = useProjectRole(owner!, repo!);
 
   // Determine mode: create or edit
   const isCreateMode = location.pathname.endsWith('/new');
   const isEditMode = !isCreateMode && !!ruleId;
-
-  // Update Redux store when URL params change
-  useEffect(() => {
-    if (owner && repo) {
-      dispatch(setCurrentRepo({ owner, repo }));
-    }
-  }, [owner, repo, dispatch]);
 
   // Fetch rule set to get the name for breadcrumb
   const { data: ruleSet, isLoading: isLoadingRuleSet } = useGetRuleSetQuery(ruleSetId!, {
@@ -110,23 +101,19 @@ export function RuleEditorPage() {
   // Check permissions
   if (!canEdit) {
     return (
-      <div className="bg-background">
-        <div className="p-4 md:p-8 max-w-5xl mx-auto">
-          <Card>
-            <CardContent className="p-8 text-center">
-              <p className="text-destructive">You do not have permission to edit proxy rules.</p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="mt-4"
-                onClick={() => navigate(routes.ruleSet(owner!, repo!, ruleSetId!))}
-              >
-                Back to Rule Set
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
+      <Card>
+        <CardContent className="p-8 text-center">
+          <p className="text-destructive">You do not have permission to edit proxy rules.</p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-4"
+            onClick={() => navigate(routes.ruleSet(owner!, repo!, ruleSetId!))}
+          >
+            Back to Rule Set
+          </Button>
+        </CardContent>
+      </Card>
     );
   }
 
@@ -134,13 +121,12 @@ export function RuleEditorPage() {
   const isLoading = isLoadingRuleSet || (isEditMode && isLoadingRule);
   if (isLoading) {
     return (
-      <div className="bg-background">
-        <div className="p-4 md:p-8 max-w-5xl mx-auto">
-          <Skeleton className="h-6 w-96 mb-6" />
-          <div className="space-y-6">
-            <Skeleton className="h-64 w-full" />
-            <Skeleton className="h-48 w-full" />
-          </div>
+      <div className="space-y-4">
+        <Skeleton className="h-6 w-64" />
+        <Skeleton className="h-8 w-32" />
+        <div className="space-y-6">
+          <Skeleton className="h-64 w-full" />
+          <Skeleton className="h-48 w-full" />
         </div>
       </div>
     );
@@ -149,100 +135,68 @@ export function RuleEditorPage() {
   // Error state for edit mode
   if (isEditMode && (ruleError || !rule)) {
     return (
-      <div className="bg-background">
-        <div className="p-4 md:p-8 max-w-5xl mx-auto">
-          <BreadcrumbNav
-            owner={owner!}
-            repo={repo!}
-            ruleSetId={ruleSetId!}
-            ruleSetName={ruleSet?.name || 'Rule Set'}
-            pageName="Error"
-          />
-          <Card>
-            <CardContent className="p-8 text-center">
-              <p className="text-destructive">Failed to load rule</p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="mt-4"
-                onClick={() => navigate(routes.ruleSet(owner!, repo!, ruleSetId!))}
-              >
-                Back to Rule Set
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
+      <Card>
+        <CardContent className="p-8 text-center">
+          <p className="text-destructive">Failed to load rule</p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-4"
+            onClick={() => navigate(routes.ruleSet(owner!, repo!, ruleSetId!))}
+          >
+            Back to Rule Set
+          </Button>
+        </CardContent>
+      </Card>
     );
   }
 
   const pageTitle = isCreateMode ? 'New Rule' : 'Edit Rule';
 
   return (
-    <div className="bg-background">
-      <div className="p-4 md:p-8 max-w-5xl mx-auto">
-        {/* Breadcrumb Navigation */}
-        <BreadcrumbNav
-          owner={owner!}
-          repo={repo!}
-          ruleSetId={ruleSetId!}
-          ruleSetName={ruleSet?.name || 'Rule Set'}
-          pageName={pageTitle}
-        />
-
-        {/* Page Title */}
-        <h1 className="text-2xl font-bold mb-6">{pageTitle}</h1>
-
-        {/* Form */}
-        <ExpandedProxyRuleForm
-          initialData={isEditMode ? rule : undefined}
-          onSubmit={handleSubmit}
-          onCancel={handleCancel}
-          isSubmitting={isCreating || isUpdating}
-        />
+    <div className="space-y-4">
+      {/* Breadcrumb Navigation */}
+      <div className="flex items-center gap-4">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate(routes.ruleSet(owner!, repo!, ruleSetId!))}
+          className="gap-1 -ml-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back
+        </Button>
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                <Link to={routes.proxyRules(owner!, repo!)}>Proxy Rules</Link>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                <Link to={routes.ruleSet(owner!, repo!, ruleSetId!)}>{ruleSet?.name || 'Rule Set'}</Link>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>{pageTitle}</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
       </div>
-    </div>
-  );
-}
 
-function BreadcrumbNav({
-  owner,
-  repo,
-  ruleSetId,
-  ruleSetName,
-  pageName,
-}: {
-  owner: string;
-  repo: string;
-  ruleSetId: string;
-  ruleSetName: string;
-  pageName: string;
-}) {
-  return (
-    <Breadcrumb className="mb-6">
-      <BreadcrumbList>
-        <BreadcrumbItem>
-          <BreadcrumbLink asChild>
-            <Link to={routes.repository(owner, repo)}>{owner}/{repo}</Link>
-          </BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbSeparator />
-        <BreadcrumbItem>
-          <BreadcrumbLink asChild>
-            <Link to={routes.proxyRules(owner, repo)}>Proxy Rules</Link>
-          </BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbSeparator />
-        <BreadcrumbItem>
-          <BreadcrumbLink asChild>
-            <Link to={routes.ruleSet(owner, repo, ruleSetId)}>{ruleSetName}</Link>
-          </BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbSeparator />
-        <BreadcrumbItem>
-          <BreadcrumbPage>{pageName}</BreadcrumbPage>
-        </BreadcrumbItem>
-      </BreadcrumbList>
-    </Breadcrumb>
+      {/* Page Title */}
+      <h2 className="text-xl font-semibold">{pageTitle}</h2>
+
+      {/* Form */}
+      <ExpandedProxyRuleForm
+        initialData={isEditMode ? rule : undefined}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+        isSubmitting={isCreating || isUpdating}
+      />
+    </div>
   );
 }

--- a/apps/frontend/src/pages/RuleSetDetailPage.tsx
+++ b/apps/frontend/src/pages/RuleSetDetailPage.tsx
@@ -1,0 +1,226 @@
+import { useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useAppDispatch } from '@/store/hooks';
+import { setCurrentRepo } from '@/store/slices/repoSlice';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Badge } from '@/components/ui/badge';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import { Plus } from 'lucide-react';
+import {
+  useGetRuleSetQuery,
+  useUpdateProxyRuleMutation,
+  useDeleteProxyRuleMutation,
+  type UpdateProxyRuleDto,
+} from '@/services/proxyRulesApi';
+import { useProjectRole } from '@/hooks/useProjectRole';
+import { useToast } from '@/hooks/use-toast';
+import { RulesList } from '@/components/proxy-rules/RulesList';
+import { routes } from '@/utils/routes';
+
+/**
+ * RuleSetDetailPage - Full page showing rules within a rule set.
+ * Route: /repo/:owner/:repo/tab/proxy-rules/:ruleSetId
+ */
+export function RuleSetDetailPage() {
+  const { owner, repo, ruleSetId } = useParams<{
+    owner: string;
+    repo: string;
+    ruleSetId: string;
+  }>();
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const { toast } = useToast();
+  const { canEdit } = useProjectRole(owner!, repo!);
+
+  // Update Redux store when URL params change
+  useEffect(() => {
+    if (owner && repo) {
+      dispatch(setCurrentRepo({ owner, repo }));
+    }
+  }, [owner, repo, dispatch]);
+
+  // Fetch the rule set with its rules
+  const { data: ruleSet, isLoading, error } = useGetRuleSetQuery(ruleSetId!, {
+    skip: !ruleSetId,
+  });
+
+  // Mutations
+  const [updateRule] = useUpdateProxyRuleMutation();
+  const [deleteRule] = useDeleteProxyRuleMutation();
+
+  const handleUpdateRule = async (id: string, updates: UpdateProxyRuleDto) => {
+    try {
+      await updateRule({ id, updates }).unwrap();
+      toast({
+        title: 'Rule updated',
+        description: 'Proxy rule has been updated.',
+      });
+    } catch (err: unknown) {
+      const errorMessage =
+        (err as { data?: { message?: string } })?.data?.message || 'Failed to update proxy rule';
+      toast({
+        title: 'Error',
+        description: errorMessage,
+        variant: 'destructive',
+      });
+      throw err;
+    }
+  };
+
+  const handleDeleteRule = async (id: string) => {
+    try {
+      await deleteRule(id).unwrap();
+      toast({
+        title: 'Rule deleted',
+        description: 'Proxy rule has been deleted.',
+      });
+    } catch (err: unknown) {
+      const errorMessage =
+        (err as { data?: { message?: string } })?.data?.message || 'Failed to delete proxy rule';
+      toast({
+        title: 'Error',
+        description: errorMessage,
+        variant: 'destructive',
+      });
+      throw err;
+    }
+  };
+
+  const handleRuleClick = (rule: { id: string }) => {
+    navigate(routes.editRule(owner!, repo!, ruleSetId!, rule.id));
+  };
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="bg-background">
+        <div className="p-4 md:p-8 max-w-5xl mx-auto">
+          <Skeleton className="h-6 w-96 mb-6" />
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-8 w-48" />
+              <Skeleton className="h-4 w-64 mt-2" />
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-2">
+                {[...Array(3)].map((_, i) => (
+                  <Skeleton key={i} className="h-16 w-full" />
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error || !ruleSet) {
+    return (
+      <div className="bg-background">
+        <div className="p-4 md:p-8 max-w-5xl mx-auto">
+          <BreadcrumbNav owner={owner!} repo={repo!} ruleSetName="Error" />
+          <Card>
+            <CardContent className="p-8 text-center">
+              <p className="text-destructive">Failed to load rule set</p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-4"
+                onClick={() => navigate(routes.proxyRules(owner!, repo!))}
+              >
+                Back to Rule Sets
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-background">
+      <div className="p-4 md:p-8 max-w-5xl mx-auto">
+        {/* Breadcrumb Navigation */}
+        <BreadcrumbNav owner={owner!} repo={repo!} ruleSetName={ruleSet.name} />
+
+        {/* Rule Set Header */}
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <div>
+              <div className="flex items-center gap-2">
+                <CardTitle>{ruleSet.name}</CardTitle>
+                {ruleSet.environment && (
+                  <Badge variant="outline">{ruleSet.environment}</Badge>
+                )}
+              </div>
+              <CardDescription className="mt-1">
+                {ruleSet.description || 'Configure proxy rules for this rule set. Rules are evaluated in order.'}
+              </CardDescription>
+            </div>
+            {canEdit && (
+              <Button
+                size="sm"
+                className="gap-2"
+                onClick={() => navigate(routes.newRule(owner!, repo!, ruleSetId!))}
+              >
+                <Plus className="h-4 w-4" />
+                Add Rule
+              </Button>
+            )}
+          </CardHeader>
+          <CardContent>
+            <RulesList
+              rules={ruleSet.rules || []}
+              isLoading={false}
+              onRuleClick={handleRuleClick}
+              onUpdateRule={handleUpdateRule}
+              onDeleteRule={handleDeleteRule}
+            />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function BreadcrumbNav({
+  owner,
+  repo,
+  ruleSetName,
+}: {
+  owner: string;
+  repo: string;
+  ruleSetName: string;
+}) {
+  return (
+    <Breadcrumb className="mb-6">
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link to={routes.repository(owner, repo)}>{owner}/{repo}</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link to={routes.proxyRules(owner, repo)}>Proxy Rules</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>{ruleSetName}</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/apps/frontend/src/pages/RuleSetDetailPage.tsx
+++ b/apps/frontend/src/pages/RuleSetDetailPage.tsx
@@ -1,7 +1,4 @@
-import { useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
-import { useAppDispatch } from '@/store/hooks';
-import { setCurrentRepo } from '@/store/slices/repoSlice';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -14,7 +11,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
-import { Plus } from 'lucide-react';
+import { Plus, ArrowLeft } from 'lucide-react';
 import {
   useGetRuleSetQuery,
   useUpdateProxyRuleMutation,
@@ -27,8 +24,9 @@ import { RulesList } from '@/components/proxy-rules/RulesList';
 import { routes } from '@/utils/routes';
 
 /**
- * RuleSetDetailPage - Full page showing rules within a rule set.
- * Route: /repo/:owner/:repo/tab/proxy-rules/:ruleSetId
+ * RuleSetDetailPage - Shows rules within a rule set.
+ * Rendered inside RepositoryLayout via Outlet.
+ * Route: /repo/:owner/:repo/proxy-rules/:ruleSetId
  */
 export function RuleSetDetailPage() {
   const { owner, repo, ruleSetId } = useParams<{
@@ -37,16 +35,8 @@ export function RuleSetDetailPage() {
     ruleSetId: string;
   }>();
   const navigate = useNavigate();
-  const dispatch = useAppDispatch();
   const { toast } = useToast();
   const { canEdit } = useProjectRole(owner!, repo!);
-
-  // Update Redux store when URL params change
-  useEffect(() => {
-    if (owner && repo) {
-      dispatch(setCurrentRepo({ owner, repo }));
-    }
-  }, [owner, repo, dispatch]);
 
   // Fetch the rule set with its rules
   const { data: ruleSet, isLoading, error } = useGetRuleSetQuery(ruleSetId!, {
@@ -102,23 +92,21 @@ export function RuleSetDetailPage() {
   // Loading state
   if (isLoading) {
     return (
-      <div className="bg-background">
-        <div className="p-4 md:p-8 max-w-5xl mx-auto">
-          <Skeleton className="h-6 w-96 mb-6" />
-          <Card>
-            <CardHeader>
-              <Skeleton className="h-8 w-48" />
-              <Skeleton className="h-4 w-64 mt-2" />
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-2">
-                {[...Array(3)].map((_, i) => (
-                  <Skeleton key={i} className="h-16 w-full" />
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
+      <div className="space-y-4">
+        <Skeleton className="h-6 w-48" />
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-8 w-48" />
+            <Skeleton className="h-4 w-64 mt-2" />
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {[...Array(3)].map((_, i) => (
+                <Skeleton key={i} className="h-16 w-full" />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
       </div>
     );
   }
@@ -126,101 +114,85 @@ export function RuleSetDetailPage() {
   // Error state
   if (error || !ruleSet) {
     return (
-      <div className="bg-background">
-        <div className="p-4 md:p-8 max-w-5xl mx-auto">
-          <BreadcrumbNav owner={owner!} repo={repo!} ruleSetName="Error" />
-          <Card>
-            <CardContent className="p-8 text-center">
-              <p className="text-destructive">Failed to load rule set</p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="mt-4"
-                onClick={() => navigate(routes.proxyRules(owner!, repo!))}
-              >
-                Back to Rule Sets
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
+      <Card>
+        <CardContent className="p-8 text-center">
+          <p className="text-destructive">Failed to load rule set</p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-4"
+            onClick={() => navigate(routes.proxyRules(owner!, repo!))}
+          >
+            Back to Rule Sets
+          </Button>
+        </CardContent>
+      </Card>
     );
   }
 
   return (
-    <div className="bg-background">
-      <div className="p-4 md:p-8 max-w-5xl mx-auto">
-        {/* Breadcrumb Navigation */}
-        <BreadcrumbNav owner={owner!} repo={repo!} ruleSetName={ruleSet.name} />
-
-        {/* Rule Set Header */}
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <div>
-              <div className="flex items-center gap-2">
-                <CardTitle>{ruleSet.name}</CardTitle>
-                {ruleSet.environment && (
-                  <Badge variant="outline">{ruleSet.environment}</Badge>
-                )}
-              </div>
-              <CardDescription className="mt-1">
-                {ruleSet.description || 'Configure proxy rules for this rule set. Rules are evaluated in order.'}
-              </CardDescription>
-            </div>
-            {canEdit && (
-              <Button
-                size="sm"
-                className="gap-2"
-                onClick={() => navigate(routes.newRule(owner!, repo!, ruleSetId!))}
-              >
-                <Plus className="h-4 w-4" />
-                Add Rule
-              </Button>
-            )}
-          </CardHeader>
-          <CardContent>
-            <RulesList
-              rules={ruleSet.rules || []}
-              isLoading={false}
-              onRuleClick={handleRuleClick}
-              onUpdateRule={handleUpdateRule}
-              onDeleteRule={handleDeleteRule}
-            />
-          </CardContent>
-        </Card>
+    <div className="space-y-4">
+      {/* Breadcrumb Navigation */}
+      <div className="flex items-center gap-4">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate(routes.proxyRules(owner!, repo!))}
+          className="gap-1 -ml-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back
+        </Button>
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                <Link to={routes.proxyRules(owner!, repo!)}>Proxy Rules</Link>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>{ruleSet.name}</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
       </div>
-    </div>
-  );
-}
 
-function BreadcrumbNav({
-  owner,
-  repo,
-  ruleSetName,
-}: {
-  owner: string;
-  repo: string;
-  ruleSetName: string;
-}) {
-  return (
-    <Breadcrumb className="mb-6">
-      <BreadcrumbList>
-        <BreadcrumbItem>
-          <BreadcrumbLink asChild>
-            <Link to={routes.repository(owner, repo)}>{owner}/{repo}</Link>
-          </BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbSeparator />
-        <BreadcrumbItem>
-          <BreadcrumbLink asChild>
-            <Link to={routes.proxyRules(owner, repo)}>Proxy Rules</Link>
-          </BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbSeparator />
-        <BreadcrumbItem>
-          <BreadcrumbPage>{ruleSetName}</BreadcrumbPage>
-        </BreadcrumbItem>
-      </BreadcrumbList>
-    </Breadcrumb>
+      {/* Rule Set Content */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <CardTitle>{ruleSet.name}</CardTitle>
+              {ruleSet.environment && (
+                <Badge variant="outline">{ruleSet.environment}</Badge>
+              )}
+            </div>
+            <CardDescription className="mt-1">
+              {ruleSet.description || 'Configure proxy rules for this rule set. Rules are evaluated in order.'}
+            </CardDescription>
+          </div>
+          {canEdit && (
+            <Button
+              size="sm"
+              className="gap-2"
+              onClick={() => navigate(routes.newRule(owner!, repo!, ruleSetId!))}
+            >
+              <Plus className="h-4 w-4" />
+              Add Rule
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          <RulesList
+            rules={ruleSet.rules || []}
+            isLoading={false}
+            onRuleClick={handleRuleClick}
+            onUpdateRule={handleUpdateRule}
+            onDeleteRule={handleDeleteRule}
+          />
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/apps/frontend/src/utils/routes.ts
+++ b/apps/frontend/src/utils/routes.ts
@@ -1,0 +1,27 @@
+/**
+ * URL route helper functions for the application.
+ * Provides type-safe route generation for common navigation patterns.
+ */
+
+export const routes = {
+  /** Repository overview page */
+  repository: (owner: string, name: string) => `/repo/${owner}/${name}`,
+
+  /** Repository settings page */
+  repositorySettings: (owner: string, name: string) => `/repo/${owner}/${name}/settings`,
+
+  /** Proxy rule sets list page */
+  proxyRules: (owner: string, name: string) => `/repo/${owner}/${name}/tab/proxy-rules`,
+
+  /** Rule set detail page showing all rules */
+  ruleSet: (owner: string, name: string, ruleSetId: string) =>
+    `/repo/${owner}/${name}/tab/proxy-rules/${ruleSetId}`,
+
+  /** New rule creation page */
+  newRule: (owner: string, name: string, ruleSetId: string) =>
+    `/repo/${owner}/${name}/tab/proxy-rules/${ruleSetId}/new`,
+
+  /** Edit rule page */
+  editRule: (owner: string, name: string, ruleSetId: string, ruleId: string) =>
+    `/repo/${owner}/${name}/tab/proxy-rules/${ruleSetId}/${ruleId}`,
+};

--- a/apps/frontend/src/utils/routes.ts
+++ b/apps/frontend/src/utils/routes.ts
@@ -4,24 +4,33 @@
  */
 
 export const routes = {
-  /** Repository overview page */
+  /** Repository base path */
   repository: (owner: string, name: string) => `/repo/${owner}/${name}`,
 
   /** Repository settings page */
   repositorySettings: (owner: string, name: string) => `/repo/${owner}/${name}/settings`,
 
+  /** Deployments tab (default) */
+  deployments: (owner: string, name: string) => `/repo/${owner}/${name}/deployments`,
+
+  /** Branches tab */
+  branches: (owner: string, name: string) => `/repo/${owner}/${name}/branches`,
+
+  /** Aliases tab */
+  aliases: (owner: string, name: string) => `/repo/${owner}/${name}/aliases`,
+
   /** Proxy rule sets list page */
-  proxyRules: (owner: string, name: string) => `/repo/${owner}/${name}/tab/proxy-rules`,
+  proxyRules: (owner: string, name: string) => `/repo/${owner}/${name}/proxy-rules`,
 
   /** Rule set detail page showing all rules */
   ruleSet: (owner: string, name: string, ruleSetId: string) =>
-    `/repo/${owner}/${name}/tab/proxy-rules/${ruleSetId}`,
+    `/repo/${owner}/${name}/proxy-rules/${ruleSetId}`,
 
   /** New rule creation page */
   newRule: (owner: string, name: string, ruleSetId: string) =>
-    `/repo/${owner}/${name}/tab/proxy-rules/${ruleSetId}/new`,
+    `/repo/${owner}/${name}/proxy-rules/${ruleSetId}/new`,
 
   /** Edit rule page */
   editRule: (owner: string, name: string, ruleSetId: string, ruleId: string) =>
-    `/repo/${owner}/${name}/tab/proxy-rules/${ruleSetId}/${ruleId}`,
+    `/repo/${owner}/${name}/proxy-rules/${ruleSetId}/${ruleId}`,
 };


### PR DESCRIPTION
Transform proxy rules from modal-based editing with query params to full-page views with path-based routing for improved UX and navigation.

New routes:
- /repo/:owner/:repo/tab/proxy-rules - Rule sets list
- /repo/:owner/:repo/tab/proxy-rules/:ruleSetId - Rule set detail
- /repo/:owner/:repo/tab/proxy-rules/:ruleSetId/new - Create rule
- /repo/:owner/:repo/tab/proxy-rules/:ruleSetId/:ruleId - Edit rule

Changes:
- Add routes.ts URL helper utility
- Add RuleSetCard, RulesList, ExpandedProxyRuleForm components
- Add ProxyRuleSetsPage, RuleSetDetailPage, RuleEditorPage pages
- Update RepositoryOverviewPage to link to new proxy rules path
- Add breadcrumb navigation on all new pages
- Add "Pipeline" as disabled option with "Coming Soon" badge