### PR TITLE
feat: add AI pipeline skills support

### DIFF
--- a/apps/backend/scripts/test-zip-upload.sh
+++ b/apps/backend/scripts/test-zip-upload.sh
@@ -282,6 +282,85 @@ cat > "$TEST_DIR/assets/logo.svg" << 'EOF'
 </svg>
 EOF
 
+# Create skills directory with test skills
+mkdir -p "$TEST_DIR/.bffless/skills/greeting"
+cat > "$TEST_DIR/.bffless/skills/greeting/SKILL.md" << 'EOF'
+---
+name: greeting
+description: Helps generate friendly, personalized greeting messages
+---
+
+# Greeting Skill
+
+You are an expert at crafting warm, personalized greetings.
+
+## Guidelines
+
+1. **Be warm and welcoming** - Use friendly language that makes people feel valued
+2. **Personalize when possible** - If you know the person's name, use it
+3. **Match the context** - Formal greetings for business, casual for friends
+4. **Keep it concise** - Greetings should be brief but meaningful
+
+## Examples
+
+### Casual Greeting
+"Hey there! Great to see you again. How's your day going?"
+
+### Formal Greeting
+"Good morning. Thank you for reaching out. How may I assist you today?"
+
+### Personalized Greeting
+"Hello, [Name]! Welcome back. It's wonderful to hear from you."
+
+## Response Format
+
+When generating greetings, consider:
+- Time of day (morning/afternoon/evening)
+- Relationship context (new user, returning user, VIP)
+- Tone preference (casual, professional, friendly)
+EOF
+
+cat > "$TEST_DIR/.bffless/skills/support.md" << 'EOF'
+---
+name: support
+description: Provides guidance for handling customer support inquiries
+---
+
+# Support Skill
+
+You are a helpful customer support assistant.
+
+## Key Principles
+
+1. **Empathy first** - Acknowledge the customer's situation
+2. **Clear communication** - Use simple, direct language
+3. **Solution-oriented** - Focus on resolving the issue
+4. **Follow up** - Ensure the customer is satisfied
+
+## Common Scenarios
+
+### Technical Issues
+1. Ask clarifying questions
+2. Gather relevant details (error messages, steps to reproduce)
+3. Provide step-by-step solutions
+4. Offer escalation if needed
+
+### Billing Questions
+1. Verify account details (securely)
+2. Explain charges clearly
+3. Process refunds when appropriate
+4. Document the interaction
+
+## Tone Guidelines
+
+- Be patient and understanding
+- Avoid jargon unless the customer uses it first
+- Thank them for their patience
+- End on a positive note
+EOF
+
+echo -e "${GREEN}✓ Skills created (.bffless/skills/)${NC}"
+
 # Create nested directory structure
 mkdir -p "$TEST_DIR/js"
 cat > "$TEST_DIR/js/app.js" << EOF
@@ -316,7 +395,7 @@ echo -e "${GREEN}✓ Test files created${NC}\n"
 ZIP_FILE="$TEST_DIR/deployment.zip"
 echo -e "${YELLOW}Creating zip file...${NC}"
 cd "$TEST_DIR"
-zip -q -r deployment.zip index.html style.css about.html assets/ js/
+zip -q -r deployment.zip index.html style.css about.html assets/ js/ .bffless/
 cd - > /dev/null
 
 echo -e "${GREEN}✓ Zip file created: $(ls -lh "$ZIP_FILE" | awk '{print $5}')${NC}\n"

--- a/apps/backend/src/auth/auth.middleware.ts
+++ b/apps/backend/src/auth/auth.middleware.ts
@@ -12,7 +12,7 @@ import * as jwt from 'jsonwebtoken';
  * - Custom domain auth (bffless_access cookie) - for custom domain auth
  *
  * For API requests with expired access tokens, returns a 401 with
- * "session expired" message (no "unauthorised") so clients know to
+ * "try refresh token" message (SuperTokens format) so clients know to
  * attempt a token refresh before giving up.
  *
  * For browser requests, continues normally - guards will redirect to login.
@@ -22,9 +22,13 @@ export class AuthMiddleware implements NestMiddleware {
   private readonly logger = new Logger(AuthMiddleware.name);
 
   use(req: Request, res: Response, next: NextFunction) {
+    // Use originalUrl which preserves the full path even after nginx proxy_pass
+    // req.path may be stripped by nginx depending on proxy configuration
+    const requestPath = req.originalUrl?.split('?')[0] || req.path;
+
     // Skip expired token check for auth endpoints - they need to work with expired tokens!
     // These are the endpoints used to sign in, refresh, or manage sessions
-    if (this.isAuthEndpoint(req.path)) {
+    if (this.isAuthEndpoint(requestPath)) {
       return middleware()(req, res, next);
     }
 
@@ -43,18 +47,18 @@ export class AuthMiddleware implements NestMiddleware {
         if (decoded?.exp && decoded.exp * 1000 < Date.now()) {
           // Token is expired
           const tokenType = supertokensToken ? 'SuperTokens' : 'custom domain';
-          this.logger.debug(`${tokenType} access token expired for ${req.method} ${req.path}`);
+          this.logger.debug(`${tokenType} access token expired for ${req.method} ${requestPath}`);
 
           // Set flag for downstream use
           (req as any).tokenExpired = true;
 
           // For API requests, return "try refresh" response immediately
           // This prevents unnecessary pipeline/controller execution
+          // Uses SuperTokens response format for consistency
           if (this.isApiRequest(req)) {
-            this.logger.debug('Returning session expired response for API request');
+            this.logger.debug('Returning try refresh token response for API request');
             return res.status(401).json({
-              message: 'session expired',
-              code: 'TRY_REFRESH_TOKEN',
+              message: 'try refresh token',
             });
           }
 

--- a/apps/backend/src/deployments/deployments.module.ts
+++ b/apps/backend/src/deployments/deployments.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { DeploymentsService } from './deployments.service';
 import { PendingUploadsService } from './pending-uploads.service';
 import { PendingUploadsScheduler } from './pending-uploads.scheduler';
@@ -12,7 +12,14 @@ import { ShareLinksModule } from '../share-links/share-links.module';
 import { PlatformModule } from '../platform/platform.module';
 
 @Module({
-  imports: [ProjectsModule, PermissionsModule, DomainsModule, CacheRulesModule, ShareLinksModule, PlatformModule],
+  imports: [
+    forwardRef(() => ProjectsModule),
+    PermissionsModule,
+    forwardRef(() => DomainsModule),
+    CacheRulesModule,
+    ShareLinksModule,
+    PlatformModule,
+  ],
   controllers: [DeploymentsController, AliasesController, PublicController, FilesController],
   providers: [DeploymentsService, PendingUploadsService, PendingUploadsScheduler],
   exports: [DeploymentsService, PendingUploadsService],

--- a/apps/backend/src/deployments/deployments.service.ts
+++ b/apps/backend/src/deployments/deployments.service.ts
@@ -198,8 +198,14 @@ export class DeploymentsService {
         // Get file path (remove leading slash if present)
         const filePath = entryPath.replace(/^\/+/, '');
 
-        // Skip hidden files and system files
-        if (filePath.startsWith('.') || filePath.includes('/__MACOSX/')) {
+        // Skip hidden files and system files, but allow .bffless/ (skills directory)
+        const isHiddenFile =
+          (filePath.startsWith('.') && !filePath.startsWith('.bffless/')) ||
+          filePath.includes('/__MACOSX/') ||
+          filePath.includes('/.') || // Hidden files in subdirectories (e.g., assets/.DS_Store)
+          filePath === '.DS_Store';
+
+        if (isHiddenFile) {
           fileCount--; // Don't count these
           continue;
         }

--- a/apps/backend/src/domains/domains.module.ts
+++ b/apps/backend/src/domains/domains.module.ts
@@ -20,7 +20,7 @@ import { ProxyRulesModule } from '../proxy-rules/proxy-rules.module';
 
 @Module({
   imports: [
-    ProjectsModule,
+    forwardRef(() => ProjectsModule),
     ScheduleModule.forRoot(),
     FeatureFlagsModule,
     forwardRef(() => ProxyRulesModule),

--- a/apps/backend/src/pipelines/dto/test-pipeline.dto.ts
+++ b/apps/backend/src/pipelines/dto/test-pipeline.dto.ts
@@ -104,6 +104,14 @@ export class TestPipelineDto {
   @IsOptional()
   @IsBoolean()
   dryRun?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Deployment alias to use for skills/deployment context (e.g., "production", "staging")',
+    example: 'production',
+  })
+  @IsOptional()
+  @IsString()
+  deploymentAlias?: string;
 }
 
 /**

--- a/apps/backend/src/pipelines/execution/pipeline-context.interface.ts
+++ b/apps/backend/src/pipelines/execution/pipeline-context.interface.ts
@@ -50,6 +50,16 @@ export interface PipelineContext {
     ip?: string;
     userAgent?: string;
   };
+
+  /**
+   * Deployment context for accessing deployment-specific resources like skills.
+   * Populated when pipeline is executed in the context of a deployment.
+   */
+  deployment?: {
+    owner: string;
+    repo: string;
+    commitSha: string;
+  };
 }
 
 /**

--- a/apps/backend/src/pipelines/execution/pipeline-execution.service.ts
+++ b/apps/backend/src/pipelines/execution/pipeline-execution.service.ts
@@ -33,14 +33,17 @@ export class PipelineExecutionService {
    * @param pipeline The pipeline to execute with inline steps
    * @param req Express request object
    * @param user Optional authenticated user
-   * @param options Execution options (dryRun not yet implemented)
+   * @param options Execution options (deployment context for skills, dryRun not yet implemented)
    * @returns Pipeline execution result with debug info
    */
   async executePipelineWithDebug(
     pipeline: Pipeline & { steps: PipelineStep[] },
     req: Request,
     user?: { id: string; email?: string; role?: string },
-    _options?: { dryRun?: boolean },
+    options?: {
+      dryRun?: boolean;
+      deployment?: { owner: string; repo: string; commitSha: string };
+    },
   ): Promise<PipelineDebugResult> {
     const executionStartTime = Date.now();
     const executionStartIso = new Date(executionStartTime).toISOString();
@@ -63,6 +66,7 @@ export class PipelineExecutionService {
         ip: req.ip || req.socket.remoteAddress,
         userAgent: req.get('user-agent'),
       },
+      deployment: options?.deployment,
     };
 
     // Debug info collections

--- a/apps/backend/src/pipelines/execution/step-handler.interface.ts
+++ b/apps/backend/src/pipelines/execution/step-handler.interface.ts
@@ -378,6 +378,26 @@ export interface AIHandlerConfig extends BaseHandlerConfig {
   temperature?: number;
 
   /**
+   * Skills configuration for AI agent capabilities.
+   * Skills are markdown files with specialized knowledge that the AI can load on demand.
+   */
+  skills?: {
+    /**
+     * Skills mode:
+     * - 'none': Disable skills (default)
+     * - 'all': Enable all discovered skills from the deployment
+     * - 'selected': Enable only specified skills
+     */
+    mode: 'none' | 'all' | 'selected';
+
+    /**
+     * Skill names to enable when mode is 'selected'.
+     * Each name should match a skill's `name` field in its frontmatter.
+     */
+    enabled?: string[];
+  };
+
+  /**
    * Schema ID for conversations table (for automatic updates).
    * When provided, handler updates token counts after completion.
    */

--- a/apps/backend/src/pipelines/handlers/ai.handler.ts
+++ b/apps/backend/src/pipelines/handlers/ai.handler.ts
@@ -5,19 +5,19 @@ import { StepHandlerRegistry } from '../execution/step-handler.registry';
 import { ExpressionEvaluator } from '../execution/expression-evaluator';
 import { PipelineContext, StepResult } from '../execution/pipeline-context.interface';
 import { PipelineStep } from '../types';
-import { ProjectAISettingsService, AIProviderType } from '../../projects/project-ai-settings.service';
+import {
+  ProjectAISettingsService,
+  AIProviderType,
+} from '../../projects/project-ai-settings.service';
 import { PipelineDataService } from '../pipeline-data.service';
 import { PipelineSchemasService } from '../pipeline-schemas.service';
+import { SkillsService, SkillSummary } from '../skills.service';
 import { ConfigurationError, SchemaNotFoundError } from '../errors';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
-import {
-  streamText,
-  generateText,
-  LanguageModel,
-  ModelMessage,
-} from 'ai';
+import { streamText, generateText, LanguageModel, ModelMessage, stepCountIs } from 'ai';
+import { z } from 'zod';
 
 /**
  * AI Handler
@@ -40,6 +40,7 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
     private readonly projectAISettingsService: ProjectAISettingsService,
     private readonly dataService: PipelineDataService,
     private readonly schemasService: PipelineSchemasService,
+    private readonly skillsService: SkillsService,
   ) {
     this.registry.register(this);
   }
@@ -105,9 +106,21 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
     const mode = config.mode || 'completion';
 
     // Default responseMode based on mode
-    const responseMode = config.responseMode || (mode === 'chat' ? 'stream' : 'message');
+    let responseMode = config.responseMode || (mode === 'chat' ? 'stream' : 'message');
 
-    this.logger.debug(`Executing AI handler for step '${stepName}' in ${mode} mode (${responseMode})`);
+    // Force 'message' mode if no response object available (e.g., in test/debug mode)
+    const hasResponseObject =
+      context.request?.res && typeof (context.request.res as any).write === 'function';
+    if (responseMode === 'stream' && !hasResponseObject) {
+      this.logger.debug(
+        `Forcing responseMode to 'message' for step '${stepName}' - no response object available (test/debug mode)`,
+      );
+      responseMode = 'message';
+    }
+
+    this.logger.debug(
+      `Executing AI handler for step '${stepName}' in ${mode} mode (${responseMode})`,
+    );
 
     // Get AI provider configuration from project settings
     const aiConfig = await this.projectAISettingsService.getProviderConfig(
@@ -141,11 +154,7 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
           stepName,
         ) as string;
       } else {
-        systemPrompt = this.expressionEvaluator.evaluateTemplate(
-          systemPrompt,
-          context,
-          stepName,
-        );
+        systemPrompt = this.expressionEvaluator.evaluateTemplate(systemPrompt, context, stepName);
       }
 
       if (systemPrompt) {
@@ -253,6 +262,63 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
       messages.push({ role: 'user', content: userMessage });
     }
 
+    // Handle skills if deployment context is available
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let tools: Record<string, any> | undefined;
+
+    // Log skills configuration for debugging
+    this.logger.debug(`Skills config for step '${stepName}': mode=${config.skills?.mode || 'undefined'}`);
+    this.logger.debug(
+      `Deployment context for step '${stepName}': ${context.deployment ? `${context.deployment.owner}/${context.deployment.repo}@${context.deployment.commitSha?.substring(0, 8)}` : 'NOT SET'}`,
+    );
+
+    if (config.skills?.mode !== 'none' && context.deployment) {
+      const { owner, repo, commitSha } = context.deployment;
+      const skillsPath = await this.projectAISettingsService.getSkillsPath(context.projectId);
+      this.logger.debug(`Skills path for project ${context.projectId}: ${skillsPath}`);
+
+      try {
+        const allSkills = await this.skillsService.listSkills(owner, repo, commitSha, skillsPath);
+        this.logger.debug(`Found ${allSkills.length} skills: ${allSkills.map((s) => s.name).join(', ') || 'none'}`);
+
+        const enabledSkills = this.filterSkills(allSkills, config.skills);
+        this.logger.debug(
+          `Enabled ${enabledSkills.length} skills after filtering: ${enabledSkills.map((s) => s.name).join(', ') || 'none'}`,
+        );
+
+        if (enabledSkills.length > 0) {
+          // Append skills section to system prompt
+          const skillsPromptSection = this.buildSkillsPromptSection(enabledSkills);
+          const systemMessageIndex = messages.findIndex((m) => m.role === 'system');
+
+          if (systemMessageIndex >= 0) {
+            messages[systemMessageIndex].content += `\n\n${skillsPromptSection}`;
+            this.logger.debug(`Appended skills section to existing system message`);
+          } else {
+            // Add system message if none exists
+            messages.unshift({ role: 'system', content: skillsPromptSection });
+            this.logger.debug(`Created new system message with skills section`);
+          }
+
+          // Create load_skill tool
+          tools = {
+            load_skill: this.createLoadSkillTool(owner, repo, commitSha, skillsPath, enabledSkills),
+          };
+
+          this.logger.debug(
+            `Injected load_skill tool with ${enabledSkills.length} skills: ${enabledSkills.map((s) => s.name).join(', ')}`,
+          );
+        }
+      } catch (error) {
+        this.logger.warn(`Failed to load skills: ${error.message}`);
+        // Continue without skills - don't fail the entire request
+      }
+    } else if (config.skills?.mode && config.skills.mode !== 'none' && !context.deployment) {
+      this.logger.debug(
+        `Skills mode is '${config.skills.mode}' but deployment context is not set - skills disabled`,
+      );
+    }
+
     // Create the AI model instance
     const model = this.createModel(
       aiConfig.provider,
@@ -275,7 +341,7 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
     const temperature = config.temperature ?? 0.7;
 
     // Extract the last user message content for persistence
-    const lastUserMessage = [...messages].reverse().find(m => m.role === 'user');
+    const lastUserMessage = [...messages].reverse().find((m) => m.role === 'user');
     const userContent = lastUserMessage?.content || '';
 
     try {
@@ -289,15 +355,10 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
           maxTokens,
           temperature,
           userContent as string,
+          tools,
         );
       } else {
-        return await this.executeMessage(
-          stepName,
-          model,
-          messages,
-          maxTokens,
-          temperature,
-        );
+        return await this.executeMessage(stepName, model, messages, maxTokens, temperature, tools);
       }
     } catch (error) {
       this.logger.error(`AI handler error: ${error.message}`, error.stack);
@@ -328,6 +389,8 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
     maxTokens: number,
     temperature: number,
     userContent: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tools?: Record<string, any>,
   ): Promise<StepResult> {
     const response = context.request.res as Response;
 
@@ -354,11 +417,16 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
       }
     }
 
+    const hasTools = tools && Object.keys(tools).length > 0;
     const result = streamText({
       model,
       messages,
       maxOutputTokens: maxTokens,
       temperature,
+      tools,
+      // Enable multi-step execution when tools are available
+      // Default is stepCountIs(1), increase to allow tool calls
+      stopWhen: hasTools ? stepCountIs(5) : stepCountIs(1),
       onFinish: async ({ text, usage, finishReason }) => {
         // Save AI response after streaming completes if persistence is enabled
         if (config.persistMessages && config.persistMessagesSchemaId) {
@@ -417,8 +485,13 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
     messages: ModelMessage[],
     maxTokens: number,
     temperature: number,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tools?: Record<string, any>,
   ): Promise<StepResult> {
-    this.logger.debug(`Generating message response for step '${stepName}'`);
+    const hasTools = tools && Object.keys(tools).length > 0;
+    this.logger.debug(
+      `Generating message response for step '${stepName}' (tools: ${hasTools ? Object.keys(tools).join(', ') : 'none'})`,
+    );
 
     const startTime = Date.now();
 
@@ -427,14 +500,50 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
       messages,
       maxOutputTokens: maxTokens,
       temperature,
+      tools,
+      // Enable tool calling when tools are available
+      toolChoice: hasTools ? 'auto' : undefined,
+      // Enable multi-step execution when tools are available
+      // Default is stepCountIs(1), increase to allow tool calls
+      stopWhen: hasTools ? stepCountIs(5) : stepCountIs(1),
     });
 
     const latencyMs = Date.now() - startTime;
     const totalTokens = result.usage?.totalTokens || 0;
 
+    // Extract tool call info from steps
+    const allToolCalls: Array<{ toolName: string; input: unknown }> = [];
+    const allToolResults: Array<{ toolName: string; output: unknown }> = [];
+    const steps = (result as any).steps;
+
     this.logger.debug(
-      `Message generation complete for step '${stepName}', ${totalTokens} tokens in ${latencyMs}ms`,
+      `AI generation complete for '${stepName}': ${totalTokens} tokens, ${latencyMs}ms, ${steps?.length || 1} steps`,
     );
+
+    // Extract tool calls from steps
+    if (steps) {
+      for (const step of steps) {
+        if (step.toolCalls?.length) {
+          for (const tc of step.toolCalls) {
+            allToolCalls.push({
+              toolName: tc.toolName,
+              input: tc.args || tc.input,
+            });
+          }
+        }
+        if (step.toolResults?.length) {
+          for (const tr of step.toolResults) {
+            allToolResults.push({
+              toolName: tr.toolName,
+              output: tr.result || tr.output,
+            });
+          }
+        }
+      }
+    }
+
+    const toolCalls = allToolCalls.length > 0 ? allToolCalls : undefined;
+    const toolResults = allToolResults.length > 0 ? allToolResults : undefined;
 
     return {
       success: true,
@@ -449,6 +558,9 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
         },
         latencyMs,
         finishReason: result.finishReason,
+        // Include tool call info if any tools were called
+        ...(toolCalls?.length && { toolCalls }),
+        ...(toolResults?.length && { toolResults }),
       },
     };
   }
@@ -522,12 +634,10 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
     let data: Record<string, unknown>;
 
     if (config.userMessageFields && Object.keys(config.userMessageFields).length > 0) {
-      data = this.evaluateFieldMappings(
-        config.userMessageFields,
-        context,
-        stepName,
-        { __userContent: userContent, __conversationId: chatId },
-      );
+      data = this.evaluateFieldMappings(config.userMessageFields, context, stepName, {
+        __userContent: userContent,
+        __conversationId: chatId,
+      });
     } else {
       data = {
         conversation_id: chatId,
@@ -579,17 +689,12 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
     let data: Record<string, unknown>;
 
     if (config.aiResponseFields && Object.keys(config.aiResponseFields).length > 0) {
-      data = this.evaluateFieldMappings(
-        config.aiResponseFields,
-        context,
-        stepName,
-        {
-          __aiContent: aiContent,
-          __tokensUsed: tokensUsed,
-          __finishReason: finishReason,
-          __conversationId: chatId,
-        },
-      );
+      data = this.evaluateFieldMappings(config.aiResponseFields, context, stepName, {
+        __aiContent: aiContent,
+        __tokensUsed: tokensUsed,
+        __finishReason: finishReason,
+        __conversationId: chatId,
+      });
     } else {
       data = {
         conversation_id: chatId,
@@ -658,7 +763,9 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
         context.user?.id,
       );
 
-      this.logger.debug(`Created conversation ${chatId} in schema ${config.persistConversationsSchemaId}`);
+      this.logger.debug(
+        `Created conversation ${chatId} in schema ${config.persistConversationsSchemaId}`,
+      );
     }
   }
 
@@ -709,7 +816,9 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
           'admin',
         );
 
-        this.logger.debug(`Updated conversation ${chatId}: messages=${newMessageCount}, tokens=${newTotalTokens}`);
+        this.logger.debug(
+          `Updated conversation ${chatId}: messages=${newMessageCount}, tokens=${newTotalTokens}`,
+        );
       }
     } catch (error) {
       // Log but don't fail - conversation updates are not critical
@@ -743,5 +852,105 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
     }
 
     return data;
+  }
+
+  // ===== Skills Helper Methods =====
+
+  /**
+   * Filter skills based on the skills configuration mode.
+   */
+  private filterSkills(
+    skills: SkillSummary[],
+    config?: { mode: 'none' | 'all' | 'selected'; enabled?: string[] },
+  ): SkillSummary[] {
+    if (!config || config.mode === 'none') {
+      return [];
+    }
+
+    if (config.mode === 'all') {
+      return skills;
+    }
+
+    if (config.mode === 'selected' && config.enabled) {
+      return skills.filter((s) => config.enabled!.includes(s.name));
+    }
+
+    return [];
+  }
+
+  /**
+   * Build a prompt section describing available skills for the AI.
+   */
+  private buildSkillsPromptSection(skills: SkillSummary[]): string {
+    const skillList = skills.map((s) => `- **${s.name}**: ${s.description}`).join('\n');
+
+    return `## Available Skills
+
+You have access to specialized skills that provide domain-specific knowledge and instructions. Use the \`load_skill\` tool to get full instructions when you need detailed guidance for a specific task.
+
+${skillList}`;
+  }
+
+  /**
+   * Create a load_skill tool that allows the AI to dynamically load skill content.
+   */
+  private createLoadSkillTool(
+    owner: string,
+    repo: string,
+    commitSha: string,
+    skillsPath: string,
+    enabledSkills: SkillSummary[],
+  ) {
+    const skillNames = new Set(enabledSkills.map((s) => s.name));
+    const skillsService = this.skillsService;
+    const logger = this.logger;
+
+    // Use simple string schema with description listing valid values
+    // Validation happens in execute to avoid complex type inference
+    const skillNamesDescription = Array.from(skillNames).join(', ');
+
+    // Create tool object directly without the tool() helper to avoid deep type inference
+    // The tool() helper just returns its input as-is anyway
+    return {
+      description: `Load detailed instructions and guidance for a specific skill. Available skills: ${skillNamesDescription}`,
+      inputSchema: z.object({
+        skillName: z
+          .string()
+          .describe(`Name of the skill to load. Must be one of: ${skillNamesDescription}`),
+      }),
+      execute: async ({ skillName }: { skillName: string }) => {
+        // Validate skill name
+        if (!skillNames.has(skillName)) {
+          logger.warn(`Invalid skill name requested: '${skillName}'`);
+          return {
+            error: `Invalid skill name '${skillName}'. Available skills: ${skillNamesDescription}`,
+          };
+        }
+
+        try {
+          const skill = await skillsService.loadSkill(
+            owner,
+            repo,
+            commitSha,
+            skillsPath,
+            skillName,
+          );
+
+          if (!skill) {
+            logger.warn(`Skill '${skillName}' not found during tool call`);
+            return { error: `Skill '${skillName}' not found` };
+          }
+
+          return {
+            name: skill.name,
+            description: skill.description,
+            instructions: skill.content,
+          };
+        } catch (error) {
+          logger.error(`Error loading skill '${skillName}': ${error.message}`);
+          return { error: `Failed to load skill '${skillName}': ${error.message}` };
+        }
+      },
+    };
   }
 }

--- a/apps/backend/src/pipelines/pipelines.module.ts
+++ b/apps/backend/src/pipelines/pipelines.module.ts
@@ -29,6 +29,7 @@ import {
 } from './handlers';
 // Services
 import { FunctionRunnerService } from './function-runner.service';
+import { SkillsService } from './skills.service';
 // Validators
 import { AuthRequiredValidator, RateLimitValidator } from './execution/validators';
 
@@ -51,6 +52,8 @@ import { AuthRequiredValidator, RateLimitValidator } from './execution/validator
     ExpressionEvaluator,
     // Function runner service
     FunctionRunnerService,
+    // Skills service for AI agent skills
+    SkillsService,
     // Step handlers (auto-register on construction)
     FormHandler,
     ResponseHandler,
@@ -70,6 +73,7 @@ import { AuthRequiredValidator, RateLimitValidator } from './execution/validator
     PipelineExecutionService,
     PipelineSchemasService,
     PipelineDataService,
+    SkillsService,
   ],
 })
 export class PipelinesModule {}

--- a/apps/backend/src/pipelines/skills.service.ts
+++ b/apps/backend/src/pipelines/skills.service.ts
@@ -1,0 +1,215 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { STORAGE_ADAPTER, IStorageAdapter } from '../storage/storage.interface';
+
+/**
+ * Summary of a skill (returned from listSkills)
+ */
+export interface SkillSummary {
+  name: string;
+  description: string;
+}
+
+/**
+ * Full skill content (returned from loadSkill)
+ */
+export interface Skill extends SkillSummary {
+  content: string;
+}
+
+/**
+ * Parsed SKILL.md frontmatter
+ */
+interface ParsedSkillFile {
+  name: string;
+  description: string;
+  body: string;
+}
+
+/**
+ * Service for listing and loading AI skills from storage.
+ *
+ * Skills are markdown files with YAML frontmatter that provide specialized
+ * knowledge and instructions to AI agents. They are stored in the deployment's
+ * storage under a configurable path (default: .bffless/skills/).
+ *
+ * Skill file formats:
+ * 1. Directory with SKILL.md: .bffless/skills/{skill-name}/SKILL.md
+ * 2. Single file: .bffless/skills/{skill-name}.md
+ *
+ * Required frontmatter:
+ * ---
+ * name: skill-name
+ * description: Brief description of what this skill does
+ * ---
+ */
+@Injectable()
+export class SkillsService {
+  private readonly logger = new Logger(SkillsService.name);
+
+  constructor(
+    @Inject(STORAGE_ADAPTER) private readonly storageAdapter: IStorageAdapter,
+  ) {}
+
+  /**
+   * List all available skills for a deployment.
+   *
+   * @param owner Repository owner
+   * @param repo Repository name
+   * @param commitSha Commit SHA
+   * @param skillsPath Path to skills directory (default: .bffless/skills)
+   * @returns Array of skill summaries with name and description
+   */
+  async listSkills(
+    owner: string,
+    repo: string,
+    commitSha: string,
+    skillsPath: string = '.bffless/skills',
+  ): Promise<SkillSummary[]> {
+    const prefix = `${owner}/${repo}/commits/${commitSha}/${skillsPath}/`;
+
+    try {
+      const keys = await this.storageAdapter.listKeys(prefix);
+
+      // Filter for skill files: either SKILL.md in directories or {name}.md files
+      const skillFiles = keys.filter((k) => {
+        const relativePath = k.slice(prefix.length);
+        // Match: {name}/SKILL.md or {name}.md (not nested further)
+        return (
+          relativePath.endsWith('/SKILL.md') ||
+          (relativePath.endsWith('.md') && !relativePath.includes('/'))
+        );
+      });
+
+      const skills: SkillSummary[] = [];
+
+      for (const key of skillFiles) {
+        try {
+          const content = await this.storageAdapter.download(key);
+          const parsed = this.parseSkillFile(content.toString('utf-8'));
+
+          if (parsed) {
+            skills.push({
+              name: parsed.name,
+              description: parsed.description,
+            });
+          }
+        } catch (e) {
+          this.logger.warn(`Failed to parse skill at ${key}: ${e.message}`);
+        }
+      }
+
+      this.logger.debug(`Found ${skills.length} skills at ${prefix}`);
+      return skills;
+    } catch (e) {
+      this.logger.debug(`No skills found at ${prefix}: ${e.message}`);
+      return [];
+    }
+  }
+
+  /**
+   * Load a specific skill by name.
+   *
+   * @param owner Repository owner
+   * @param repo Repository name
+   * @param commitSha Commit SHA
+   * @param skillsPath Path to skills directory
+   * @param skillName Name of the skill to load
+   * @returns Full skill content or null if not found
+   */
+  async loadSkill(
+    owner: string,
+    repo: string,
+    commitSha: string,
+    skillsPath: string,
+    skillName: string,
+  ): Promise<Skill | null> {
+    const basePath = `${owner}/${repo}/commits/${commitSha}/${skillsPath}/${skillName}`;
+
+    // Try SKILL.md first (directory format), then {name}.md (single file format)
+    const pathsToTry = [`${basePath}/SKILL.md`, `${basePath}.md`];
+
+    for (const path of pathsToTry) {
+      try {
+        const content = await this.storageAdapter.download(path);
+        const parsed = this.parseSkillFile(content.toString('utf-8'));
+
+        if (parsed) {
+          this.logger.debug(`Loaded skill '${skillName}' from ${path}`);
+          return {
+            name: parsed.name,
+            description: parsed.description,
+            content: parsed.body,
+          };
+        }
+      } catch (e) {
+        // File not found, try next path
+        continue;
+      }
+    }
+
+    this.logger.warn(`Skill '${skillName}' not found at ${basePath}`);
+    return null;
+  }
+
+  /**
+   * Parse a skill file with YAML frontmatter.
+   *
+   * Expected format:
+   * ---
+   * name: skill-name
+   * description: Brief description
+   * ---
+   * # Skill content markdown...
+   *
+   * @param content Raw file content
+   * @returns Parsed skill data or null if invalid
+   */
+  private parseSkillFile(content: string): ParsedSkillFile | null {
+    // Match YAML frontmatter delimited by ---
+    const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+
+    if (!match) {
+      return null;
+    }
+
+    const frontmatter = match[1];
+    const body = match[2].trim();
+
+    // Extract name and description from frontmatter
+    // Simple line-based parsing (not full YAML parser to avoid dependencies)
+    const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
+    const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
+
+    if (!nameMatch || !descMatch) {
+      return null;
+    }
+
+    // Handle quoted strings in YAML
+    const name = this.unquoteYamlString(nameMatch[1].trim());
+    const description = this.unquoteYamlString(descMatch[1].trim());
+
+    if (!name || !description) {
+      return null;
+    }
+
+    return {
+      name,
+      description,
+      body,
+    };
+  }
+
+  /**
+   * Remove surrounding quotes from a YAML string value.
+   */
+  private unquoteYamlString(value: string): string {
+    // Remove single or double quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      return value.slice(1, -1);
+    }
+    return value;
+  }
+}

--- a/apps/backend/src/projects/project-ai-settings.service.ts
+++ b/apps/backend/src/projects/project-ai-settings.service.ts
@@ -443,6 +443,44 @@ export class ProjectAISettingsService {
     }));
   }
 
+  // ===== Skills Path Settings =====
+
+  /**
+   * Get the skills path for a project (default: .bffless/skills)
+   */
+  async getSkillsPath(projectId: string): Promise<string> {
+    const project = await this.getProject(projectId);
+    if (!project?.settings) {
+      return '.bffless/skills';
+    }
+
+    const settings = project.settings as Record<string, unknown>;
+    return (settings.skillsPath as string) ?? '.bffless/skills';
+  }
+
+  /**
+   * Set the skills path for a project
+   */
+  async setSkillsPath(projectId: string, skillsPath: string): Promise<void> {
+    const project = await this.getProject(projectId);
+    if (!project) {
+      throw new NotFoundException('Project not found');
+    }
+
+    const settings = (project.settings || {}) as Record<string, unknown>;
+    settings.skillsPath = skillsPath;
+
+    await db
+      .update(projects)
+      .set({
+        settings,
+        updatedAt: new Date(),
+      })
+      .where(eq(projects.id, projectId));
+
+    this.logger.log(`Updated skillsPath for project ${projectId}: ${skillsPath}`);
+  }
+
   // ===== Private methods =====
 
   private async getProject(projectId: string) {

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -10,6 +10,9 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
+  NotFoundException,
+  Inject,
+  forwardRef,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { ProjectsService } from './projects.service';
@@ -32,6 +35,8 @@ import {
   AIProvidersResponseDto,
   AIProviderEnum,
 } from '../settings/dto/ai-settings.dto';
+import { SkillsService, SkillSummary } from '../pipelines/skills.service';
+import { DeploymentsService } from '../deployments/deployments.service';
 
 @ApiTags('projects')
 @Controller('api/projects')
@@ -39,6 +44,9 @@ export class ProjectsController {
   constructor(
     private readonly projectsService: ProjectsService,
     private readonly aiSettingsService: ProjectAISettingsService,
+    private readonly skillsService: SkillsService,
+    @Inject(forwardRef(() => DeploymentsService))
+    private readonly deploymentsService: DeploymentsService,
   ) {}
 
   @Get()
@@ -141,6 +149,55 @@ export class ProjectsController {
     return {
       providers: this.aiSettingsService.getAvailableProviders(),
     };
+  }
+
+  @Get(':id/ai/skills')
+  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @RequireProjectRole('contributor')
+  @ApiOperation({ summary: 'List available AI skills for the project deployment' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of available skills',
+  })
+  async listSkills(
+    @Param('id') projectId: string,
+    @Query('commitSha') commitSha?: string,
+    @CurrentUser('id') userId?: string,
+  ): Promise<{ skills: SkillSummary[] }> {
+    const project = await this.projectsService.getProjectById(projectId);
+    if (!project) {
+      throw new NotFoundException('Project not found');
+    }
+
+    // Resolve commitSha: use provided, or try to get from production alias
+    let sha = commitSha;
+    if (!sha) {
+      try {
+        const alias = await this.deploymentsService.getAlias(
+          projectId,
+          'production',
+          userId || 'system',
+          'admin',
+        );
+        sha = alias?.commitSha;
+      } catch {
+        // No production alias - that's OK
+      }
+    }
+
+    if (!sha) {
+      return { skills: [] };
+    }
+
+    const skillsPath = await this.aiSettingsService.getSkillsPath(projectId);
+    const skills = await this.skillsService.listSkills(
+      project.owner,
+      project.name,
+      sha,
+      skillsPath,
+    );
+
+    return { skills };
   }
 
   // ==========================================================================

--- a/apps/backend/src/projects/projects.module.ts
+++ b/apps/backend/src/projects/projects.module.ts
@@ -4,9 +4,15 @@ import { ProjectAISettingsService } from './project-ai-settings.service';
 import { ProjectsController } from './projects.controller';
 import { RepositoriesController } from './repositories.controller';
 import { PermissionsModule } from '../permissions/permissions.module';
+import { PipelinesModule } from '../pipelines/pipelines.module';
+import { DeploymentsModule } from '../deployments/deployments.module';
 
 @Module({
-  imports: [forwardRef(() => PermissionsModule)],
+  imports: [
+    forwardRef(() => PermissionsModule),
+    forwardRef(() => PipelinesModule),
+    forwardRef(() => DeploymentsModule),
+  ],
   controllers: [ProjectsController, RepositoriesController],
   providers: [ProjectsService, ProjectAISettingsService],
   exports: [ProjectsService, ProjectAISettingsService],

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
@@ -3,12 +3,16 @@ import { NotFoundException } from '@nestjs/common';
 import { ProxyRulesController } from './proxy-rules.controller';
 import { ProxyRulesService } from './proxy-rules.service';
 import { PipelineExecutionService } from '../pipelines/execution';
+import { DeploymentsService } from '../deployments/deployments.service';
+import { ProjectsService } from '../projects/projects.service';
 import { CurrentUserData } from '../auth/decorators/current-user.decorator';
 
 describe('ProxyRulesController', () => {
   let controller: ProxyRulesController;
   let mockProxyRulesService: jest.Mocked<ProxyRulesService>;
   let mockPipelineExecutionService: jest.Mocked<PipelineExecutionService>;
+  let mockDeploymentsService: jest.Mocked<DeploymentsService>;
+  let mockProjectsService: jest.Mocked<ProjectsService>;
 
   const mockUser: CurrentUserData = {
     id: 'user-1',
@@ -55,11 +59,21 @@ describe('ProxyRulesController', () => {
       executePipelineWithDebug: jest.fn(),
     } as unknown as jest.Mocked<PipelineExecutionService>;
 
+    mockDeploymentsService = {
+      resolveAlias: jest.fn(),
+    } as unknown as jest.Mocked<DeploymentsService>;
+
+    mockProjectsService = {
+      getProjectById: jest.fn(),
+    } as unknown as jest.Mocked<ProjectsService>;
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ProxyRulesController],
       providers: [
         { provide: ProxyRulesService, useValue: mockProxyRulesService },
         { provide: PipelineExecutionService, useValue: mockPipelineExecutionService },
+        { provide: DeploymentsService, useValue: mockDeploymentsService },
+        { provide: ProjectsService, useValue: mockProjectsService },
       ],
     }).compile();
 

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.ts
@@ -10,6 +10,8 @@ import {
   ParseUUIDPipe,
   NotFoundException,
   BadRequestException,
+  Inject,
+  forwardRef,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -25,6 +27,8 @@ import { ApiKeyGuard } from '../auth/api-key.guard';
 import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
 import { PipelineExecutionService } from '../pipelines/execution';
 import { TestPipelineDto, PipelineTestResultDto } from '../pipelines/dto';
+import { DeploymentsService } from '../deployments/deployments.service';
+import { ProjectsService } from '../projects/projects.service';
 
 /**
  * Controller for individual proxy rule operations.
@@ -39,6 +43,10 @@ export class ProxyRulesController {
   constructor(
     private readonly proxyRulesService: ProxyRulesService,
     private readonly pipelineExecutionService: PipelineExecutionService,
+    @Inject(forwardRef(() => DeploymentsService))
+    private readonly deploymentsService: DeploymentsService,
+    @Inject(forwardRef(() => ProjectsService))
+    private readonly projectsService: ProjectsService,
   ) {}
 
   @Get(':id')
@@ -184,12 +192,41 @@ export class ProxyRulesController {
       }
     }
 
+    // Resolve deployment context if alias is provided (for skills testing)
+    // Auto-fallback to "production" alias when skills are configured but no alias specified
+    let deployment: { owner: string; repo: string; commitSha: string } | undefined;
+
+    // Check if skills are configured in any step
+    const hasSkillsConfig = (pipelineConfig.steps || []).some(
+      (step) => step.config?.skills && (step.config.skills as any).mode !== 'none',
+    );
+
+    // Use provided alias, or fallback to "production" if skills are configured
+    const aliasToResolve = dto.deploymentAlias || (hasSkillsConfig ? 'production' : undefined);
+
+    if (aliasToResolve) {
+      const project = await this.projectsService.getProjectById(ruleSet.projectId);
+
+      if (project) {
+        const repoPath = `${project.owner}/${project.name}`;
+        const commitSha = await this.deploymentsService.resolveAlias(repoPath, aliasToResolve);
+
+        if (commitSha) {
+          deployment = {
+            owner: project.owner,
+            repo: project.name,
+            commitSha,
+          };
+        }
+      }
+    }
+
     // Use debug execution mode
     const result = await this.pipelineExecutionService.executePipelineWithDebug(
       pipelineLike as any,
       mockReq,
       testUser,
-      { dryRun: dto.dryRun },
+      { dryRun: dto.dryRun, deployment },
     );
 
     return {

--- a/apps/backend/src/proxy-rules/proxy-rules.module.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.module.ts
@@ -9,9 +9,17 @@ import { EmailFormHandlerService } from './email-form-handler.service';
 import { PermissionsModule } from '../permissions/permissions.module';
 import { DomainsModule } from '../domains/domains.module';
 import { PipelinesModule } from '../pipelines/pipelines.module';
+import { DeploymentsModule } from '../deployments/deployments.module';
+import { ProjectsModule } from '../projects/projects.module';
 
 @Module({
-  imports: [PermissionsModule, forwardRef(() => DomainsModule), PipelinesModule],
+  imports: [
+    PermissionsModule,
+    forwardRef(() => DomainsModule),
+    forwardRef(() => PipelinesModule),
+    forwardRef(() => DeploymentsModule),
+    forwardRef(() => ProjectsModule),
+  ],
   controllers: [ProxyRulesController, ProxyRuleSetsController],
   providers: [ProxyRulesService, ProxyRuleSetsService, ProxyService, ProxyMiddleware, EmailFormHandlerService],
   exports: [ProxyRulesService, ProxyRuleSetsService, ProxyService],

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -105,14 +105,18 @@ export class ProxyMiddleware implements NestMiddleware {
       const isSha = /^[a-f0-9]{40}$/i.test(ref);
       let effectiveRuleSetId: string | null = project.defaultProxyRuleSetId;
       let aliasName: string | null = null;
+      let resolvedCommitSha: string | null = isSha ? ref : null;
 
       if (!isSha) {
         aliasName = ref;
-        // Look up alias to get its proxyRuleSetId
+        // Look up alias to get its proxyRuleSetId and commitSha
         const alias = await this.getAliasByName(project.id, ref);
         if (alias?.proxyRuleSetId) {
           // Alias has its own rule set - use it (overrides project default)
           effectiveRuleSetId = alias.proxyRuleSetId;
+        }
+        if (alias?.commitSha) {
+          resolvedCommitSha = alias.commitSha;
         }
         // If alias doesn't have a rule set, fall through to project default
       }
@@ -167,12 +171,7 @@ export class ProxyMiddleware implements NestMiddleware {
 
       // For all other proxy types (pipeline, email_form_handler, external_proxy),
       // check visibility BEFORE handling - these bypass PublicController
-      const visibilityResult = await this.checkVisibilityAndAuth(
-        req,
-        res,
-        project,
-        aliasName,
-      );
+      const visibilityResult = await this.checkVisibilityAndAuth(req, res, project, aliasName);
       if (visibilityResult === 'blocked') {
         return; // Response already sent
       }
@@ -186,7 +185,10 @@ export class ProxyMiddleware implements NestMiddleware {
       // Handle pipeline execution
       if (proxyType === 'pipeline') {
         this.logger.debug(`Pipeline execution: ${subpathForMatching} (rule: ${matchedRule.id})`);
-        return this.handlePipelineExecution(req, res, matchedRule, project.id);
+        const deployment = resolvedCommitSha
+          ? { owner: project.owner, repo: project.name, commitSha: resolvedCommitSha }
+          : undefined;
+        return this.handlePipelineExecution(req, res, matchedRule, project.id, deployment);
       }
 
       this.logger.debug(
@@ -352,7 +354,10 @@ export class ProxyMiddleware implements NestMiddleware {
       this.logger.debug(
         `Subdomain pipeline execution: ${subpathForMatching} (alias: ${resolvedAliasName}, rule: ${matchedRule.id})`,
       );
-      return this.handlePipelineExecution(req, res, matchedRule, project.id);
+      const deployment = alias?.commitSha
+        ? { owner: project.owner, repo: project.name, commitSha: alias.commitSha }
+        : undefined;
+      return this.handlePipelineExecution(req, res, matchedRule, project.id, deployment);
     }
 
     this.logger.debug(
@@ -401,8 +406,15 @@ export class ProxyMiddleware implements NestMiddleware {
         // No alias - use project defaults
         accessControl = {
           isPublic: project.isPublic,
-          unauthorizedBehavior: (project.unauthorizedBehavior as 'not_found' | 'redirect_login') || 'not_found',
-          requiredRole: (project.requiredRole as 'authenticated' | 'viewer' | 'contributor' | 'admin' | 'owner') || 'authenticated',
+          unauthorizedBehavior:
+            (project.unauthorizedBehavior as 'not_found' | 'redirect_login') || 'not_found',
+          requiredRole:
+            (project.requiredRole as
+              | 'authenticated'
+              | 'viewer'
+              | 'contributor'
+              | 'admin'
+              | 'owner') || 'authenticated',
           source: 'project',
         };
       }
@@ -427,16 +439,14 @@ export class ProxyMiddleware implements NestMiddleware {
         const tokenExpired = (req as any).tokenExpired;
 
         if (tokenExpired) {
-          // Token was expired - signal try refresh
+          // Token was expired - signal try refresh (SuperTokens format)
           res.status(401).json({
-            message: 'session expired',
-            code: 'TRY_REFRESH_TOKEN',
+            message: 'try refresh token',
           });
         } else {
-          // No token at all
+          // No token at all (SuperTokens format)
           res.status(401).json({
             message: 'unauthorised',
-            code: 'AUTH_REQUIRED',
           });
         }
       } else {
@@ -831,6 +841,7 @@ export class ProxyMiddleware implements NestMiddleware {
     res: Response,
     rule: ProxyRule,
     projectId: string,
+    deployment?: { owner: string; repo: string; commitSha: string },
   ): Promise<void> {
     const pipelineConfig = rule.pipelineConfig as PipelineConfig | null;
 
@@ -864,11 +875,12 @@ export class ProxyMiddleware implements NestMiddleware {
       // Extract user from session if available (optional - don't fail if not authenticated)
       const user = await this.getOptionalUser(req, res);
 
-      // Execute the pipeline
+      // Execute the pipeline with deployment context for skills access
       const result = await this.pipelineExecutionService.executePipelineWithDebug(
         pipeline,
         req,
         user,
+        { deployment },
       );
 
       if (result.success && result.response) {

--- a/apps/frontend/src/components/pipelines/handlers/AIHandlerConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/AIHandlerConfig.tsx
@@ -43,6 +43,7 @@ import {
   MessageSquare,
   FileText,
   Database,
+  BookOpen,
 } from 'lucide-react';
 import {
   Tooltip,
@@ -56,6 +57,7 @@ import type { AIHandlerConfig as AIHandlerConfigType, ModelTier, ModelInfo } fro
 import type { PreviousStep } from './AvailableVariables';
 import { ExpressionInput } from './ExpressionInput';
 import { SchemaPicker } from './SchemaPicker';
+import { SkillsConfig, SkillsConfigValue } from './SkillsConfig';
 import { cn } from '@/lib/utils';
 
 // Lazy load Monaco Editor
@@ -122,6 +124,12 @@ export function AIHandlerConfig({ config, onChange, projectId, previousSteps = [
   const [conversationIdField, setConversationIdField] = useState(config.conversationIdField || 'request.body.id');
   const [showPersistence, setShowPersistence] = useState(config.persistMessages ?? false);
 
+  // Skills state
+  const [skills, setSkills] = useState<SkillsConfigValue>(
+    (config.skills as SkillsConfigValue) || { mode: 'none' }
+  );
+  const [showSkills, setShowSkills] = useState(config.skills?.mode !== 'none' && config.skills?.mode !== undefined);
+
   // Initialize provider/model from AI status
   useEffect(() => {
     if (defaultProvider && !provider) {
@@ -179,8 +187,10 @@ export function AIHandlerConfig({ config, onChange, projectId, previousSteps = [
       persistMessagesSchemaId: shouldPersist && persistMessagesSchemaId ? persistMessagesSchemaId : undefined,
       persistConversationsSchemaId: shouldPersist && persistConversationsSchemaId ? persistConversationsSchemaId : undefined,
       conversationIdField: shouldPersist && conversationIdField !== 'request.body.id' ? conversationIdField : undefined,
+      // Skills
+      skills: skills.mode !== 'none' ? skills : undefined,
     });
-  }, [mode, provider, model, responseMode, systemPrompt, messageField, messagesField, maxHistoryMessages, maxTokens, temperature, persistMessages, persistMessagesSchemaId, persistConversationsSchemaId, conversationIdField]);
+  }, [mode, provider, model, responseMode, systemPrompt, messageField, messagesField, maxHistoryMessages, maxTokens, temperature, persistMessages, persistMessagesSchemaId, persistConversationsSchemaId, conversationIdField, skills]);
 
   // Find selected model info
   const selectedModelInfo = suggestedModels.find(m => m.id === model);
@@ -665,6 +675,27 @@ export function AIHandlerConfig({ config, onChange, projectId, previousSteps = [
             </CollapsibleContent>
           </Collapsible>
         )}
+
+        {/* Skills Configuration */}
+        <Collapsible open={showSkills} onOpenChange={setShowSkills}>
+          <CollapsibleTrigger asChild>
+            <Button variant="ghost" size="sm" className="w-full justify-between">
+              <span className="flex items-center gap-2">
+                <BookOpen className="h-4 w-4" />
+                Skills
+                {skills.mode !== 'none' && (
+                  <Badge variant="secondary" className="text-xs">
+                    {skills.mode === 'all' ? 'All' : `${skills.enabled?.length ?? 0} selected`}
+                  </Badge>
+                )}
+              </span>
+              <ChevronDown className={cn('h-4 w-4 transition-transform', showSkills && 'rotate-180')} />
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="pt-4">
+            <SkillsConfig config={skills} onChange={setSkills} projectId={projectId} />
+          </CollapsibleContent>
+        </Collapsible>
 
         {/* Advanced Options */}
         <Collapsible open={showAdvanced} onOpenChange={setShowAdvanced}>

--- a/apps/frontend/src/components/pipelines/handlers/SkillsConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/SkillsConfig.tsx
@@ -1,0 +1,115 @@
+import { useListProjectSkillsQuery } from '@/services/projectsApi';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Info } from 'lucide-react';
+
+export interface SkillsConfigValue {
+  mode: 'none' | 'all' | 'selected';
+  enabled?: string[];
+}
+
+interface SkillsConfigProps {
+  config: SkillsConfigValue;
+  onChange: (config: SkillsConfigValue) => void;
+  projectId: string;
+}
+
+export function SkillsConfig({ config, onChange, projectId }: SkillsConfigProps) {
+  const { data, isLoading } = useListProjectSkillsQuery({ projectId });
+  const skills = data?.skills ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label>Skills Mode</Label>
+        <Select
+          value={config.mode}
+          onValueChange={(v) =>
+            onChange({ ...config, mode: v as SkillsConfigValue['mode'] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">Disabled</SelectItem>
+            <SelectItem value="all">Enable All Skills</SelectItem>
+            <SelectItem value="selected">Select Skills</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          {config.mode === 'none' && 'Skills are disabled for this handler.'}
+          {config.mode === 'all' && 'All available skills will be enabled.'}
+          {config.mode === 'selected' && 'Choose specific skills to enable.'}
+        </p>
+      </div>
+
+      {config.mode === 'selected' && (
+        <div className="space-y-2">
+          <Label>Enabled Skills</Label>
+          {isLoading ? (
+            <Skeleton className="h-20" />
+          ) : skills.length === 0 ? (
+            <Alert>
+              <Info className="h-4 w-4" />
+              <AlertDescription>
+                No skills found. Add <code className="bg-muted px-1 rounded">SKILL.md</code> files
+                to <code className="bg-muted px-1 rounded">.bffless/skills/</code> in your deployment.
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <div className="space-y-2 max-h-48 overflow-y-auto rounded-md border p-3">
+              {skills.map((skill) => (
+                <div key={skill.name} className="flex items-start gap-3">
+                  <Checkbox
+                    id={`skill-${skill.name}`}
+                    checked={config.enabled?.includes(skill.name) ?? false}
+                    onCheckedChange={(checked) => {
+                      const current = config.enabled ?? [];
+                      onChange({
+                        ...config,
+                        enabled: checked
+                          ? [...current, skill.name]
+                          : current.filter((n) => n !== skill.name),
+                      });
+                    }}
+                  />
+                  <div className="flex-1 leading-none">
+                    <label
+                      htmlFor={`skill-${skill.name}`}
+                      className="font-medium text-sm cursor-pointer"
+                    >
+                      {skill.name}
+                    </label>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {skill.description}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {config.mode !== 'none' && (
+        <Alert className="border-blue-500/30 bg-blue-500/5">
+          <Info className="h-4 w-4 text-blue-600" />
+          <AlertDescription className="text-xs">
+            When skills are enabled, the AI can use the <code className="bg-muted px-1 rounded">load_skill</code> tool
+            to retrieve detailed instructions for specific tasks.
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/pipelines/handlers/types.ts
+++ b/apps/frontend/src/components/pipelines/handlers/types.ts
@@ -142,6 +142,23 @@ export interface AIHandlerConfig extends BaseHandlerConfig {
   maxTokens?: number;
   /** Temperature for generation (0-2). Default: 0.7 */
   temperature?: number;
+  /**
+   * Skills configuration for AI agent capabilities.
+   * Skills are markdown files with specialized knowledge that the AI can load on demand.
+   */
+  skills?: {
+    /**
+     * Skills mode:
+     * - 'none': Disable skills (default)
+     * - 'all': Enable all discovered skills from the deployment
+     * - 'selected': Enable only specified skills
+     */
+    mode: 'none' | 'all' | 'selected';
+    /**
+     * Skill names to enable when mode is 'selected'.
+     */
+    enabled?: string[];
+  };
   /** Schema ID for conversations table (for automatic updates) */
   conversationsSchemaId?: string;
   /** Schema ID for messages table (for automatic saving) @deprecated Use persistMessages instead */

--- a/apps/frontend/src/components/proxy-rules/ExpandedProxyRuleForm.tsx
+++ b/apps/frontend/src/components/proxy-rules/ExpandedProxyRuleForm.tsx
@@ -915,6 +915,7 @@ function PipelineTestCard({ ruleId, pathPattern, method }: PipelineTestCardProps
   const [mockUserId, setMockUserId] = useState('');
   const [mockUserEmail, setMockUserEmail] = useState('');
   const [mockUserRole, setMockUserRole] = useState('');
+  const [deploymentAlias, setDeploymentAlias] = useState('production');
   const [result, setResult] = useState<TestPipelineResult | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -998,6 +999,7 @@ function PipelineTestCard({ ruleId, pathPattern, method }: PipelineTestCardProps
           headers: headersObj,
           simulateAuth,
           mockUser,
+          deploymentAlias: deploymentAlias || undefined,
         },
       }).unwrap();
 
@@ -1197,6 +1199,21 @@ function PipelineTestCard({ ruleId, pathPattern, method }: PipelineTestCardProps
                   </div>
                 </div>
               )}
+            </div>
+
+            {/* Deployment / Skills Context */}
+            <div className="space-y-2">
+              <Label htmlFor="deploymentAlias">Deployment Alias (for Skills)</Label>
+              <Input
+                id="deploymentAlias"
+                placeholder="production"
+                value={deploymentAlias}
+                onChange={(e) => setDeploymentAlias(e.target.value)}
+                className="max-w-xs"
+              />
+              <p className="text-xs text-muted-foreground">
+                Used to load skills from a specific deployment (e.g., production, staging)
+              </p>
             </div>
 
             {/* Run Button */}

--- a/apps/frontend/src/services/pipelinesApi.ts
+++ b/apps/frontend/src/services/pipelinesApi.ts
@@ -81,6 +81,7 @@ export interface TestPipelineDto {
   mockUser?: MockUser;
   simulateAuth?: boolean;
   dryRun?: boolean;
+  deploymentAlias?: string;
 }
 
 export interface ValidatorDebugInfo {

--- a/apps/frontend/src/services/projectsApi.ts
+++ b/apps/frontend/src/services/projectsApi.ts
@@ -57,6 +57,12 @@ export interface AvailableProvider {
   models: ModelInfo[];
 }
 
+// Skill types
+export interface SkillSummary {
+  name: string;
+  description: string;
+}
+
 export interface Project {
   id: string;
   owner: string;
@@ -221,6 +227,20 @@ export const projectsApi = api.injectEndpoints({
     >({
       query: (projectId) => `/api/projects/${projectId}/ai/providers`,
     }),
+
+    // Skills endpoint
+    listProjectSkills: builder.query<
+      { skills: SkillSummary[] },
+      { projectId: string; commitSha?: string }
+    >({
+      query: ({ projectId, commitSha }) => ({
+        url: `/api/projects/${projectId}/ai/skills`,
+        params: commitSha ? { commitSha } : undefined,
+      }),
+      providesTags: (_result, _error, { projectId }) => [
+        { type: 'ProjectAI' as const, id: `${projectId}-skills` },
+      ],
+    }),
   }),
 });
 
@@ -238,4 +258,6 @@ export const {
   useSetProjectDefaultAIProviderMutation,
   useTestProjectAIMutation,
   useGetAvailableAIProvidersQuery,
+  // Skills
+  useListProjectSkillsQuery,
 } = projectsApi;


### PR DESCRIPTION
## Summary

- Add support for AI agent skills that users can define in their repository
- Skills are markdown files with YAML frontmatter stored in `.bffless/skills/`
- AI can dynamically load skill content using a `load_skill` tool
- Skills provide specialized knowledge and instructions to the AI

## Changes

### Backend
- Add `SkillsService` to list/load skills from deployment storage
- Extend `AIHandler` to inject `load_skill` tool when skills are configured
- Add skills config to `AIHandlerConfig` (mode: `none`/`all`/`selected`)
- Add deployment context to pipeline execution for skills access
- Add `skillsPath` setting to project AI settings
- Add `/api/projects/:id/ai/skills` endpoint to list available skills
- Auto-resolve "production" alias for skills in pipeline test endpoint
- Allow `.bffless` directory in zip uploads (was filtered as hidden)

### Frontend
- Add `SkillsConfig` component for selecting skills in AI handler config
- Add `deploymentAlias` field to pipeline test UI
- Add skills API endpoints to `projectsApi`

### Also includes
- Auth middleware fix to skip token expiry check for `/auth` endpoints

## Test plan

- [ ] Upload a deployment with `.bffless/skills/` containing skill markdown files
- [ ] Configure an AI handler step with skills mode set to "all" or "selected"
- [ ] Test pipeline and verify `load_skill` tool is called and skill content is used
- [ ] Verify tool calls and results appear in test response

🤖 Generated with [Claude Code](https://claude.com/claude-code)