### PR TITLE
feat: add custom headers for proxy rules and header-based traffic rules

### DIFF
--- a/apps/backend/src/deployments/public.controller.ts
+++ b/apps/backend/src/deployments/public.controller.ts
@@ -362,6 +362,7 @@ export class PublicController {
         variantCookie,
         req.query as Record<string, string>,
         req.cookies,
+        req.headers as Record<string, string | string[] | undefined>,
       );
 
       if (variantSelection) {
@@ -876,6 +877,7 @@ export class PublicController {
       variantCookie,
       req.query as Record<string, string>,
       req.cookies,
+      req.headers as Record<string, string | string[] | undefined>,
     );
 
     if (variantSelection) {

--- a/apps/backend/src/domains/dto/traffic-rule.dto.ts
+++ b/apps/backend/src/domains/dto/traffic-rule.dto.ts
@@ -9,11 +9,11 @@ export class CreateTrafficRuleDto {
 
   @ApiProperty({
     description: 'Condition type',
-    enum: ['query_param', 'cookie'],
+    enum: ['query_param', 'cookie', 'header'],
   })
   @IsString()
-  @IsIn(['query_param', 'cookie'])
-  conditionType: 'query_param' | 'cookie';
+  @IsIn(['query_param', 'cookie', 'header'])
+  conditionType: 'query_param' | 'cookie' | 'header';
 
   @ApiProperty({ description: 'Parameter or cookie name to match', example: 'token' })
   @IsString()
@@ -50,12 +50,12 @@ export class UpdateTrafficRuleDto {
 
   @ApiPropertyOptional({
     description: 'Condition type',
-    enum: ['query_param', 'cookie'],
+    enum: ['query_param', 'cookie', 'header'],
   })
   @IsOptional()
   @IsString()
-  @IsIn(['query_param', 'cookie'])
-  conditionType?: 'query_param' | 'cookie';
+  @IsIn(['query_param', 'cookie', 'header'])
+  conditionType?: 'query_param' | 'cookie' | 'header';
 
   @ApiPropertyOptional({ description: 'Parameter or cookie name to match' })
   @IsOptional()

--- a/apps/backend/src/domains/traffic-routing.service.ts
+++ b/apps/backend/src/domains/traffic-routing.service.ts
@@ -145,6 +145,7 @@ export class TrafficRoutingService {
     existingVariantCookie: string | undefined,
     queryParams?: Record<string, string>,
     cookies?: Record<string, string>,
+    headers?: Record<string, string | string[] | undefined>,
   ): Promise<VariantSelectionResult | null> {
     // Find domain by name (also check www/non-www alternate for redirect-to-www/root cases)
     const alternate = domainName.startsWith('www.') ? domainName.slice(4) : `www.${domainName}`;
@@ -174,11 +175,12 @@ export class TrafficRoutingService {
     // Rule aliases don't need to be in the weights list — they can route to any
     // valid deployment alias (e.g., a share link forcing alias "netflix" while
     // normal traffic splits between "skills" and "production").
-    if (queryParams || cookies) {
+    if (queryParams || cookies || headers) {
       const ruleMatch = await this.trafficRulesService.evaluateRules(
         domain.id,
         queryParams,
         cookies,
+        headers,
       );
       if (ruleMatch) {
         return {

--- a/apps/backend/src/domains/traffic-rules.service.ts
+++ b/apps/backend/src/domains/traffic-rules.service.ts
@@ -110,6 +110,7 @@ export class TrafficRulesService {
     domainId: string,
     queryParams: Record<string, string> | undefined,
     cookies: Record<string, string> | undefined,
+    headers?: Record<string, string | string[] | undefined>,
   ): Promise<string | null> {
     const rules = await db
       .select()
@@ -126,6 +127,12 @@ export class TrafficRulesService {
         match = queryParams?.[rule.conditionKey] === rule.conditionValue;
       } else if (rule.conditionType === 'cookie') {
         match = cookies?.[rule.conditionKey] === rule.conditionValue;
+      } else if (rule.conditionType === 'header') {
+        // Headers are lowercase in Express
+        const headerKey = rule.conditionKey.toLowerCase();
+        const headerValue = headers?.[headerKey];
+        // Header value can be string or string[] - compare against first value if array
+        match = (Array.isArray(headerValue) ? headerValue[0] : headerValue) === rule.conditionValue;
       }
 
       if (match) {

--- a/apps/frontend/src/components/domains/TrafficTab.tsx
+++ b/apps/frontend/src/components/domains/TrafficTab.tsx
@@ -10,7 +10,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Plus, Trash2, AlertCircle, BarChart3, Scale, Info, Search, Cookie } from 'lucide-react';
+import { Plus, Trash2, AlertCircle, BarChart3, Scale, Info, Search, Cookie, FileCode } from 'lucide-react';
 import {
   useGetTrafficConfigQuery,
   useSetTrafficWeightsMutation,
@@ -411,7 +411,7 @@ function TrafficRulesSection({ domainId, availableAliases, weightAliases }: Traf
 
   const [showAddForm, setShowAddForm] = useState(false);
   const [newRule, setNewRule] = useState({
-    conditionType: 'query_param' as 'query_param' | 'cookie',
+    conditionType: 'query_param' as 'query_param' | 'cookie' | 'header',
     conditionKey: '',
     conditionValue: '',
     alias: '',
@@ -442,7 +442,7 @@ function TrafficRulesSection({ domainId, availableAliases, weightAliases }: Traf
       toast({ title: 'Success', description: 'Traffic rule created' });
       setShowAddForm(false);
       setNewRule({
-        conditionType: 'query_param',
+        conditionType: 'query_param' as 'query_param' | 'cookie' | 'header',
         conditionKey: '',
         conditionValue: '',
         alias: '',
@@ -503,12 +503,14 @@ function TrafficRulesSection({ domainId, availableAliases, weightAliases }: Traf
               <div className="flex items-center gap-1.5 flex-1 min-w-0">
                 {rule.conditionType === 'query_param' ? (
                   <Search className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                ) : (
+                ) : rule.conditionType === 'cookie' ? (
                   <Cookie className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                ) : (
+                  <FileCode className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
                 )}
                 <span className="text-sm truncate">
                   <span className="text-muted-foreground">
-                    {rule.conditionType === 'query_param' ? 'Query param' : 'Cookie'}
+                    {rule.conditionType === 'query_param' ? 'Query param' : rule.conditionType === 'cookie' ? 'Cookie' : 'Header'}
                   </span>{' '}
                   <code className="text-xs bg-muted px-1 py-0.5 rounded">{rule.conditionKey}</code>
                   {' = '}
@@ -559,7 +561,7 @@ function TrafficRulesSection({ domainId, availableAliases, weightAliases }: Traf
               <Select
                 value={newRule.conditionType}
                 onValueChange={(v) =>
-                  setNewRule({ ...newRule, conditionType: v as 'query_param' | 'cookie' })
+                  setNewRule({ ...newRule, conditionType: v as 'query_param' | 'cookie' | 'header' })
                 }
               >
                 <SelectTrigger>
@@ -568,6 +570,7 @@ function TrafficRulesSection({ domainId, availableAliases, weightAliases }: Traf
                 <SelectContent>
                   <SelectItem value="query_param">Query Parameter</SelectItem>
                   <SelectItem value="cookie">Cookie</SelectItem>
+                  <SelectItem value="header">Header</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/apps/frontend/src/components/proxy-rules/ExpandedProxyRuleForm.tsx
+++ b/apps/frontend/src/components/proxy-rules/ExpandedProxyRuleForm.tsx
@@ -92,7 +92,16 @@ export function ExpandedProxyRuleForm({
   const [timeout, setTimeout] = useState(initialData?.timeout || 30000);
   const [preserveHost, setPreserveHost] = useState(initialData?.preserveHost ?? false);
   const [forwardCookies, setForwardCookies] = useState(initialData?.forwardCookies ?? false);
-  const [apiKey, setApiKey] = useState('');
+
+  // Custom headers for proxy requests (replaces single apiKey)
+  const [customHeaders, setCustomHeaders] = useState<{ key: string; value: string }[]>(() => {
+    if (initialData?.headerConfig?.add) {
+      return Object.entries(initialData.headerConfig.add).map(([key, value]) => ({ key, value }));
+    }
+    return [];
+  });
+  // Track if headers have been modified (to know when to include them in submit)
+  const [headersModified, setHeadersModified] = useState(false);
 
   // Auth transformation (cookie to bearer)
   const [authTransformEnabled, setAuthTransformEnabled] = useState(
@@ -227,7 +236,8 @@ export function ExpandedProxyRuleForm({
     timeout,
     preserveHost,
     forwardCookies,
-    apiKey,
+    customHeaders,
+    headersModified,
     authTransformEnabled,
     cookieName,
     destinationEmail,
@@ -393,7 +403,14 @@ export function ExpandedProxyRuleForm({
           timeout,
           preserveHost,
           forwardCookies,
-          headerConfig: apiKey ? { add: { Authorization: apiKey } } : undefined,
+          // Only include headerConfig if headers were modified or there are headers to send
+          headerConfig: headersModified || customHeaders.some(h => h.key)
+            ? {
+                add: Object.fromEntries(
+                  customHeaders.filter(h => h.key).map(h => [h.key, h.value])
+                ),
+              }
+            : undefined,
           authTransform: authTransformEnabled
             ? { type: 'cookie-to-bearer' as const, cookieName }
             : undefined,
@@ -805,23 +822,76 @@ export function ExpandedProxyRuleForm({
       {isExternalProxy && (
         <Card>
           <CardHeader>
-            <CardTitle>Authentication</CardTitle>
-            <CardDescription>Configure authentication for proxied requests</CardDescription>
+            <CardTitle>Authentication & Headers</CardTitle>
+            <CardDescription>Configure headers sent with proxied requests</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
+            {/* Custom Headers */}
             <div className="space-y-2">
-              <Label htmlFor="apiKey">API Key / Authorization Header (optional)</Label>
-              <Input
-                id="apiKey"
-                type="password"
-                value={apiKey}
-                onChange={(e) => setApiKey(e.target.value)}
-                placeholder={
-                  initialData ? '(unchanged - enter new value to update)' : 'Bearer sk_live_xxx'
-                }
-              />
+              <div className="flex items-center justify-between">
+                <Label>Custom Headers (optional)</Label>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setCustomHeaders([...customHeaders, { key: '', value: '' }]);
+                    setHeadersModified(true);
+                  }}
+                >
+                  <Plus className="h-3 w-3 mr-1" />
+                  Add Header
+                </Button>
+              </div>
+              {customHeaders.length === 0 ? (
+                <p className="text-xs text-muted-foreground py-2">
+                  No custom headers configured. Add headers like Authorization, X-API-Key, etc.
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {customHeaders.map((header, index) => (
+                    <div key={index} className="flex gap-2">
+                      <Input
+                        placeholder="Header name (e.g. Authorization)"
+                        value={header.key}
+                        onChange={(e) => {
+                          const newHeaders = [...customHeaders];
+                          newHeaders[index] = { ...newHeaders[index], key: e.target.value };
+                          setCustomHeaders(newHeaders);
+                          setHeadersModified(true);
+                        }}
+                        className="flex-1"
+                      />
+                      <Input
+                        type="password"
+                        placeholder={initialData?.headerConfig?.add?.[header.key] ? '(unchanged)' : 'Value'}
+                        value={header.value}
+                        onChange={(e) => {
+                          const newHeaders = [...customHeaders];
+                          newHeaders[index] = { ...newHeaders[index], value: e.target.value };
+                          setCustomHeaders(newHeaders);
+                          setHeadersModified(true);
+                        }}
+                        className="flex-1"
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => {
+                          setCustomHeaders(customHeaders.filter((_, i) => i !== index));
+                          setHeadersModified(true);
+                        }}
+                        className="shrink-0"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
               <p className="text-xs text-muted-foreground">
-                Stored encrypted. Sent as Authorization header with each proxied request.
+                Stored encrypted. Headers are sent with each proxied request.
               </p>
             </div>
 

--- a/apps/frontend/src/services/domainsApi.ts
+++ b/apps/frontend/src/services/domainsApi.ts
@@ -314,7 +314,7 @@ export interface TrafficRule {
   id: string;
   domainId: string;
   alias: string;
-  conditionType: 'query_param' | 'cookie';
+  conditionType: 'query_param' | 'cookie' | 'header';
   conditionKey: string;
   conditionValue: string;
   priority: number;
@@ -326,7 +326,7 @@ export interface TrafficRule {
 
 export interface CreateTrafficRuleRequest {
   alias: string;
-  conditionType: 'query_param' | 'cookie';
+  conditionType: 'query_param' | 'cookie' | 'header';
   conditionKey: string;
   conditionValue: string;
   priority?: number;
@@ -335,7 +335,7 @@ export interface CreateTrafficRuleRequest {
 
 export interface UpdateTrafficRuleRequest {
   alias?: string;
-  conditionType?: 'query_param' | 'cookie';
+  conditionType?: 'query_param' | 'cookie' | 'header';
   conditionKey?: string;
   conditionValue?: string;
   priority?: number;


### PR DESCRIPTION
## Summary

- Add dynamic custom headers UI for external proxy rules (replaces single API key field)
- Add header-based traffic rules to route requests based on incoming HTTP headers

## Test plan

- [ ] Edit an External Proxy rule, add custom headers (e.g., `X-API-Key: secret-token`), save and verify requests include headers
- [ ] Configure traffic splitting with header rule: Type=Header, Key=`X-Test-Token`, Value=`abc123`, Alias=`staging`
- [ ] Test with `curl -H "X-Test-Token: abc123"` - should route to staging alias
- [ ] Request without header should use weighted distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)