### PR TITLE
feat: AI plugin system for chat pipelines

### DIFF
--- a/apps/backend/src/pipelines/ai-plugins/ai-plugins.controller.ts
+++ b/apps/backend/src/pipelines/ai-plugins/ai-plugins.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Param,
+  Body,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { SessionAuthGuard } from '../../auth/session-auth.guard';
+import { ProjectPermissionGuard } from '../../auth/guards/project-permission.guard';
+import { RequireProjectRole } from '../../auth/decorators/project-permission.decorator';
+import { AIToolPluginService, PluginListItem } from './ai-tool-plugin.service';
+
+/**
+ * REST API for managing AI tool plugins per project.
+ *
+ * Routes are nested under /api/projects/:projectId/ai-plugins
+ * to match the existing project settings pattern.
+ */
+@ApiTags('AI Plugins')
+@Controller('api/projects/:projectId/ai-plugins')
+@UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+@RequireProjectRole('admin')
+export class AIPluginsController {
+  constructor(private readonly pluginService: AIToolPluginService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all plugins with enabled status for this project' })
+  @ApiResponse({ status: 200, description: 'List of plugins' })
+  @ApiParam({ name: 'projectId', description: 'Project UUID' })
+  async listPlugins(@Param('projectId') projectId: string): Promise<PluginListItem[]> {
+    return this.pluginService.getAvailablePlugins(projectId);
+  }
+
+  @Post(':pluginId')
+  @ApiOperation({ summary: 'Enable a plugin for this project' })
+  @ApiResponse({ status: 200, description: 'Plugin enabled' })
+  @ApiParam({ name: 'projectId', description: 'Project UUID' })
+  @ApiParam({ name: 'pluginId', description: 'Plugin identifier' })
+  async enablePlugin(
+    @Param('projectId') projectId: string,
+    @Param('pluginId') pluginId: string,
+    @Body() body: { config?: Record<string, unknown> },
+  ): Promise<PluginListItem> {
+    return this.pluginService.enablePlugin(projectId, pluginId, body.config);
+  }
+
+  @Put(':pluginId')
+  @ApiOperation({ summary: 'Update plugin configuration' })
+  @ApiResponse({ status: 200, description: 'Plugin config updated' })
+  @ApiParam({ name: 'projectId', description: 'Project UUID' })
+  @ApiParam({ name: 'pluginId', description: 'Plugin identifier' })
+  async updatePluginConfig(
+    @Param('projectId') projectId: string,
+    @Param('pluginId') pluginId: string,
+    @Body() body: { config: Record<string, unknown> },
+  ): Promise<PluginListItem> {
+    return this.pluginService.updatePluginConfig(projectId, pluginId, body.config);
+  }
+
+  @Delete(':pluginId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Disable a plugin for this project' })
+  @ApiResponse({ status: 204, description: 'Plugin disabled' })
+  @ApiParam({ name: 'projectId', description: 'Project UUID' })
+  @ApiParam({ name: 'pluginId', description: 'Plugin identifier' })
+  async disablePlugin(
+    @Param('projectId') projectId: string,
+    @Param('pluginId') pluginId: string,
+  ): Promise<void> {
+    return this.pluginService.disablePlugin(projectId, pluginId);
+  }
+}

--- a/apps/backend/src/pipelines/ai-plugins/ai-tool-plugin.interface.ts
+++ b/apps/backend/src/pipelines/ai-plugins/ai-tool-plugin.interface.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+
+/**
+ * Context passed to plugin tool execution
+ */
+export interface AIToolContext {
+  projectId: string;
+  userId?: string;
+  pluginConfig: Record<string, unknown>;
+}
+
+/**
+ * A single tool definition provided by a plugin
+ */
+export interface AIToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: z.ZodObject<any>;
+  execute: (args: any, context: AIToolContext) => Promise<any>;
+}
+
+/**
+ * Metadata describing a plugin (used for UI display and configuration)
+ */
+export interface AIToolPluginMetadata {
+  /** Unique identifier, e.g. 'google-calendar' */
+  id: string;
+  /** Display name, e.g. 'Google Calendar' */
+  name: string;
+  /** Brief description of what the plugin does */
+  description: string;
+  /** Category for grouping, e.g. 'scheduling', 'communication', 'utility' */
+  category: string;
+  /** Optional icon identifier */
+  icon?: string;
+  /** Zod schema for plugin configuration/credentials */
+  configSchema?: z.ZodObject<any>;
+  /** Whether this plugin requires OAuth authentication */
+  requiresOAuth?: boolean;
+  /** OAuth provider identifier (e.g. 'google') */
+  oauthProvider?: string;
+}
+
+/**
+ * Interface that all AI tool plugins must implement.
+ * Plugins are NestJS @Injectable() classes that self-register with the AIToolPluginRegistry.
+ */
+export interface AIToolPlugin {
+  readonly metadata: AIToolPluginMetadata;
+
+  /**
+   * Return the tools this plugin provides, configured with the given config.
+   * Called only when the plugin is enabled for a project.
+   */
+  getTools(config: Record<string, unknown>): AIToolDefinition[];
+
+  /**
+   * Optional: validate plugin configuration before storing.
+   * Called when a user enables the plugin or updates its config.
+   */
+  validateConfig?(config: Record<string, unknown>): Promise<{ valid: boolean; error?: string }>;
+}
+
+/**
+ * Stored plugin configuration in projects.settings.aiPlugins
+ */
+export interface StoredPluginConfig {
+  enabled: boolean;
+  config?: string; // encrypted JSON string
+}

--- a/apps/backend/src/pipelines/ai-plugins/ai-tool-plugin.registry.ts
+++ b/apps/backend/src/pipelines/ai-plugins/ai-tool-plugin.registry.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AIToolPlugin, AIToolPluginMetadata } from './ai-tool-plugin.interface';
+
+/**
+ * Registry for AI tool plugins.
+ * Plugins self-register via constructor injection, same pattern as StepHandlerRegistry.
+ */
+@Injectable()
+export class AIToolPluginRegistry {
+  private readonly logger = new Logger(AIToolPluginRegistry.name);
+  private readonly plugins = new Map<string, AIToolPlugin>();
+
+  /**
+   * Register a plugin. Called by plugin constructors.
+   */
+  register(plugin: AIToolPlugin): void {
+    const { id } = plugin.metadata;
+    if (this.plugins.has(id)) {
+      this.logger.warn(`Plugin '${id}' is being overwritten`);
+    }
+    this.plugins.set(id, plugin);
+    this.logger.log(`Registered AI plugin: ${id}`);
+  }
+
+  /**
+   * Get a plugin by ID
+   */
+  get(pluginId: string): AIToolPlugin | undefined {
+    return this.plugins.get(pluginId);
+  }
+
+  /**
+   * Check if a plugin is registered
+   */
+  has(pluginId: string): boolean {
+    return this.plugins.has(pluginId);
+  }
+
+  /**
+   * Get all registered plugins
+   */
+  getAll(): AIToolPlugin[] {
+    return Array.from(this.plugins.values());
+  }
+
+  /**
+   * Get metadata for all registered plugins
+   */
+  getMetadataList(): AIToolPluginMetadata[] {
+    return this.getAll().map((p) => p.metadata);
+  }
+
+  /**
+   * Get all registered plugin IDs
+   */
+  getRegisteredIds(): string[] {
+    return Array.from(this.plugins.keys());
+  }
+}

--- a/apps/backend/src/pipelines/ai-plugins/ai-tool-plugin.service.ts
+++ b/apps/backend/src/pipelines/ai-plugins/ai-tool-plugin.service.ts
@@ -1,0 +1,281 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { db } from '../../db/client';
+import { projects } from '../../db/schema';
+import { eq } from 'drizzle-orm';
+import * as crypto from 'crypto';
+import { z } from 'zod';
+import { AIToolPluginRegistry } from './ai-tool-plugin.registry';
+import {
+  AIToolPlugin,
+  AIToolPluginMetadata,
+  AIToolContext,
+  StoredPluginConfig,
+} from './ai-tool-plugin.interface';
+
+/**
+ * Response shape for plugin list endpoints
+ */
+export interface PluginListItem extends AIToolPluginMetadata {
+  enabled: boolean;
+  hasConfig: boolean;
+}
+
+/**
+ * Service for managing AI tool plugins per project.
+ *
+ * Responsibilities:
+ * - List available/enabled plugins
+ * - Enable/disable plugins with encrypted config storage
+ * - Build Vercel AI SDK tool objects for enabled plugins
+ */
+@Injectable()
+export class AIToolPluginService {
+  private readonly logger = new Logger(AIToolPluginService.name);
+  private readonly ENCRYPTION_KEY: Buffer;
+  private readonly ENCRYPTION_ALGORITHM = 'aes-256-gcm';
+
+  constructor(
+    private readonly registry: AIToolPluginRegistry,
+    private configService: ConfigService,
+  ) {
+    const encryptionKey = this.configService.get<string>('ENCRYPTION_KEY');
+    if (encryptionKey) {
+      this.ENCRYPTION_KEY = Buffer.from(encryptionKey, 'base64');
+    } else {
+      this.ENCRYPTION_KEY = crypto.randomBytes(32);
+      this.logger.warn('No ENCRYPTION_KEY found. Generated temporary key.');
+    }
+  }
+
+  /**
+   * Get all registered plugins with their enabled status for a project
+   */
+  async getAvailablePlugins(projectId: string): Promise<PluginListItem[]> {
+    const storedPlugins = await this.getStoredPlugins(projectId);
+    const allPlugins = this.registry.getAll();
+
+    return allPlugins.map((plugin) => {
+      const stored = storedPlugins[plugin.metadata.id];
+      return {
+        ...plugin.metadata,
+        enabled: stored?.enabled ?? false,
+        hasConfig: !!stored?.config,
+      };
+    });
+  }
+
+  /**
+   * Enable a plugin for a project, optionally with configuration
+   */
+  async enablePlugin(
+    projectId: string,
+    pluginId: string,
+    config?: Record<string, unknown>,
+  ): Promise<PluginListItem> {
+    const plugin = this.registry.get(pluginId);
+    if (!plugin) {
+      throw new NotFoundException(`Plugin '${pluginId}' not found`);
+    }
+
+    // Validate config if plugin requires it
+    if (config && plugin.validateConfig) {
+      const validation = await plugin.validateConfig(config);
+      if (!validation.valid) {
+        throw new Error(validation.error || 'Invalid plugin configuration');
+      }
+    }
+
+    const storedPlugins = await this.getStoredPlugins(projectId);
+    const storedConfig: StoredPluginConfig = {
+      enabled: true,
+      config: config ? this.encryptData(JSON.stringify(config)) : storedPlugins[pluginId]?.config,
+    };
+
+    storedPlugins[pluginId] = storedConfig;
+    await this.saveStoredPlugins(projectId, storedPlugins);
+
+    this.logger.log(`Enabled plugin '${pluginId}' for project ${projectId}`);
+
+    return {
+      ...plugin.metadata,
+      enabled: true,
+      hasConfig: !!storedConfig.config,
+    };
+  }
+
+  /**
+   * Disable a plugin for a project
+   */
+  async disablePlugin(projectId: string, pluginId: string): Promise<void> {
+    const plugin = this.registry.get(pluginId);
+    if (!plugin) {
+      throw new NotFoundException(`Plugin '${pluginId}' not found`);
+    }
+
+    const storedPlugins = await this.getStoredPlugins(projectId);
+    if (storedPlugins[pluginId]) {
+      delete storedPlugins[pluginId];
+      await this.saveStoredPlugins(projectId, storedPlugins);
+    }
+
+    this.logger.log(`Disabled plugin '${pluginId}' for project ${projectId}`);
+  }
+
+  /**
+   * Update plugin configuration for an already-enabled plugin
+   */
+  async updatePluginConfig(
+    projectId: string,
+    pluginId: string,
+    config: Record<string, unknown>,
+  ): Promise<PluginListItem> {
+    const plugin = this.registry.get(pluginId);
+    if (!plugin) {
+      throw new NotFoundException(`Plugin '${pluginId}' not found`);
+    }
+
+    const storedPlugins = await this.getStoredPlugins(projectId);
+    if (!storedPlugins[pluginId]?.enabled) {
+      throw new NotFoundException(`Plugin '${pluginId}' is not enabled for this project`);
+    }
+
+    // Validate config if plugin supports it
+    if (plugin.validateConfig) {
+      const validation = await plugin.validateConfig(config);
+      if (!validation.valid) {
+        throw new Error(validation.error || 'Invalid plugin configuration');
+      }
+    }
+
+    storedPlugins[pluginId] = {
+      enabled: true,
+      config: this.encryptData(JSON.stringify(config)),
+    };
+    await this.saveStoredPlugins(projectId, storedPlugins);
+
+    this.logger.log(`Updated config for plugin '${pluginId}' in project ${projectId}`);
+
+    return {
+      ...plugin.metadata,
+      enabled: true,
+      hasConfig: true,
+    };
+  }
+
+  /**
+   * Build Vercel AI SDK tools for all enabled plugins for a project.
+   * Tools are namespaced as {pluginId}_{toolName} to prevent collisions.
+   */
+  async buildToolsForProject(projectId: string): Promise<Record<string, any>> {
+    const storedPlugins = await this.getStoredPlugins(projectId);
+    const tools: Record<string, any> = {};
+
+    for (const [pluginId, stored] of Object.entries(storedPlugins)) {
+      if (!stored.enabled) continue;
+
+      const plugin = this.registry.get(pluginId);
+      if (!plugin) {
+        this.logger.warn(`Enabled plugin '${pluginId}' not found in registry — skipping`);
+        continue;
+      }
+
+      try {
+        const decryptedConfig = stored.config
+          ? JSON.parse(this.decryptData(stored.config))
+          : {};
+
+        const pluginTools = plugin.getTools(decryptedConfig);
+        const context: AIToolContext = {
+          projectId,
+          pluginConfig: decryptedConfig,
+        };
+
+        for (const toolDef of pluginTools) {
+          const namespacedName = `${pluginId}_${toolDef.name}`;
+          tools[namespacedName] = {
+            description: toolDef.description,
+            inputSchema: toolDef.inputSchema,
+            execute: async (args: any) => toolDef.execute(args, context),
+          };
+        }
+
+        this.logger.debug(
+          `Built ${pluginTools.length} tools for plugin '${pluginId}': ${pluginTools.map((t) => t.name).join(', ')}`,
+        );
+      } catch (error) {
+        this.logger.warn(`Failed to build tools for plugin '${pluginId}': ${error.message}`);
+        // Continue — don't let one broken plugin block others
+      }
+    }
+
+    return tools;
+  }
+
+  // ===== Private helpers =====
+
+  private async getStoredPlugins(
+    projectId: string,
+  ): Promise<Record<string, StoredPluginConfig>> {
+    const [project] = await db
+      .select({ settings: projects.settings })
+      .from(projects)
+      .where(eq(projects.id, projectId))
+      .limit(1);
+
+    if (!project?.settings) return {};
+
+    const settings = project.settings as Record<string, unknown>;
+    return (settings.aiPlugins as Record<string, StoredPluginConfig>) ?? {};
+  }
+
+  private async saveStoredPlugins(
+    projectId: string,
+    plugins: Record<string, StoredPluginConfig>,
+  ): Promise<void> {
+    const [project] = await db
+      .select({ settings: projects.settings })
+      .from(projects)
+      .where(eq(projects.id, projectId))
+      .limit(1);
+
+    if (!project) {
+      throw new NotFoundException('Project not found');
+    }
+
+    const settings = (project.settings || {}) as Record<string, unknown>;
+    settings.aiPlugins = plugins;
+
+    await db
+      .update(projects)
+      .set({ settings, updatedAt: new Date() })
+      .where(eq(projects.id, projectId));
+  }
+
+  private encryptData(data: string): string {
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv(this.ENCRYPTION_ALGORITHM, this.ENCRYPTION_KEY, iv);
+
+    let encrypted = cipher.update(data, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+
+    const authTag = cipher.getAuthTag();
+
+    return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`;
+  }
+
+  private decryptData(encryptedData: string): string {
+    const [ivHex, authTagHex, encrypted] = encryptedData.split(':');
+
+    const iv = Buffer.from(ivHex, 'hex');
+    const authTag = Buffer.from(authTagHex, 'hex');
+
+    const decipher = crypto.createDecipheriv(this.ENCRYPTION_ALGORITHM, this.ENCRYPTION_KEY, iv);
+    decipher.setAuthTag(authTag);
+
+    let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+
+    return decrypted;
+  }
+}

--- a/apps/backend/src/pipelines/ai-plugins/index.ts
+++ b/apps/backend/src/pipelines/ai-plugins/index.ts
@@ -1,0 +1,5 @@
+export * from './ai-tool-plugin.interface';
+export * from './ai-tool-plugin.registry';
+export * from './ai-tool-plugin.service';
+export * from './ai-plugins.controller';
+export * from './plugins';

--- a/apps/backend/src/pipelines/ai-plugins/plugins/calculator.plugin.ts
+++ b/apps/backend/src/pipelines/ai-plugins/plugins/calculator.plugin.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import {
+  AIToolPlugin,
+  AIToolPluginMetadata,
+  AIToolDefinition,
+  AIToolContext,
+} from '../ai-tool-plugin.interface';
+import { AIToolPluginRegistry } from '../ai-tool-plugin.registry';
+
+/**
+ * Calculator plugin — a simple built-in plugin for validating the plugin system end-to-end.
+ * No external credentials required.
+ */
+@Injectable()
+export class CalculatorPlugin implements AIToolPlugin {
+  readonly metadata: AIToolPluginMetadata = {
+    id: 'calculator',
+    name: 'Calculator',
+    description:
+      'Perform mathematical calculations. Useful for arithmetic, unit conversions, and numeric operations.',
+    category: 'utility',
+    icon: 'calculator',
+  };
+
+  constructor(private readonly registry: AIToolPluginRegistry) {
+    this.registry.register(this);
+  }
+
+  getTools(_config: Record<string, unknown>): AIToolDefinition[] {
+    return [
+      {
+        name: 'evaluate',
+        description:
+          'Evaluate a mathematical expression. Supports +, -, *, /, **, %, parentheses, and Math functions (sqrt, abs, ceil, floor, round, min, max, sin, cos, tan, log, PI, E).',
+        inputSchema: z.object({
+          expression: z
+            .string()
+            .describe(
+              'The mathematical expression to evaluate, e.g. "2 + 3 * 4" or "Math.sqrt(144)"',
+            ),
+        }),
+        execute: async (args: { expression: string }, _context: AIToolContext) => {
+          return this.evaluateExpression(args.expression);
+        },
+      },
+    ];
+  }
+
+  private evaluateExpression(expression: string): { result: number } | { error: string } {
+    // Whitelist safe characters and Math functions
+    const sanitized = expression.trim();
+
+    // Only allow digits, operators, parentheses, dots, spaces, and Math references
+    const safePattern =
+      /^[\d\s+\-*/().,%^]+$|^[\d\s+\-*/().,%^]*Math\.(sqrt|abs|ceil|floor|round|min|max|sin|cos|tan|log|PI|E)[\d\s+\-*/().,%^(]*$/;
+
+    // More permissive: allow combinations of numbers, operators, and Math calls
+    const allowedChars = /^[0-9\s+\-*/().,%Math.sqrtabceilflooroundminmaxsincostanlgPIE]+$/;
+
+    if (!allowedChars.test(sanitized)) {
+      return { error: `Expression contains disallowed characters: ${sanitized}` };
+    }
+
+    // Block dangerous patterns
+    const dangerous =
+      /(?:eval|Function|require|import|process|global|window|document|fetch|XMLHttp|setTimeout|setInterval|constructor|\[|\]|=)/i;
+    if (dangerous.test(sanitized)) {
+      return { error: 'Expression contains disallowed patterns' };
+    }
+
+    try {
+      // Create a sandboxed evaluation context with Math functions
+      const mathFn = new Function('Math', `"use strict"; return (${sanitized});`);
+      const result = mathFn(Math);
+
+      if (typeof result !== 'number' || !isFinite(result)) {
+        return { error: `Expression did not evaluate to a finite number: ${result}` };
+      }
+
+      return { result };
+    } catch (error) {
+      return { error: `Failed to evaluate expression: ${error.message}` };
+    }
+  }
+}

--- a/apps/backend/src/pipelines/ai-plugins/plugins/index.ts
+++ b/apps/backend/src/pipelines/ai-plugins/plugins/index.ts
@@ -1,0 +1,2 @@
+export * from './calculator.plugin';
+export * from './web-search.plugin';

--- a/apps/backend/src/pipelines/ai-plugins/plugins/web-search.plugin.ts
+++ b/apps/backend/src/pipelines/ai-plugins/plugins/web-search.plugin.ts
@@ -1,0 +1,109 @@
+import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import {
+  AIToolPlugin,
+  AIToolPluginMetadata,
+  AIToolDefinition,
+  AIToolContext,
+} from '../ai-tool-plugin.interface';
+import { AIToolPluginRegistry } from '../ai-tool-plugin.registry';
+
+/**
+ * Web Search plugin — uses a configurable search API to find web results.
+ * Supports Google Custom Search API. Requires API key and Search Engine ID.
+ */
+@Injectable()
+export class WebSearchPlugin implements AIToolPlugin {
+  readonly metadata: AIToolPluginMetadata = {
+    id: 'web-search',
+    name: 'Web Search',
+    description: 'Search the web for current information using Google Custom Search API.',
+    category: 'information',
+    icon: 'search',
+    configSchema: z.object({
+      apiKey: z.string().min(1).describe('Google Custom Search API key'),
+      searchEngineId: z.string().min(1).describe('Google Custom Search Engine ID (cx)'),
+    }),
+  };
+
+  constructor(private readonly registry: AIToolPluginRegistry) {
+    this.registry.register(this);
+  }
+
+  async validateConfig(
+    config: Record<string, unknown>,
+  ): Promise<{ valid: boolean; error?: string }> {
+    if (!config.apiKey || typeof config.apiKey !== 'string') {
+      return { valid: false, error: 'API key is required' };
+    }
+    if (!config.searchEngineId || typeof config.searchEngineId !== 'string') {
+      return { valid: false, error: 'Search Engine ID is required' };
+    }
+    return { valid: true };
+  }
+
+  getTools(config: Record<string, unknown>): AIToolDefinition[] {
+    return [
+      {
+        name: 'search',
+        description:
+          'Search the web for information. Returns titles, snippets, and URLs of top results.',
+        inputSchema: z.object({
+          query: z.string().describe('The search query'),
+          numResults: z
+            .number()
+            .min(1)
+            .max(10)
+            .optional()
+            .describe('Number of results to return (1-10, default 5)'),
+        }),
+        execute: async (args: { query: string; numResults?: number }, context: AIToolContext) => {
+          return this.search(
+            args.query,
+            args.numResults ?? 5,
+            context.pluginConfig.apiKey as string,
+            context.pluginConfig.searchEngineId as string,
+          );
+        },
+      },
+    ];
+  }
+
+  private async search(
+    query: string,
+    numResults: number,
+    apiKey: string,
+    searchEngineId: string,
+  ): Promise<
+    { results: Array<{ title: string; snippet: string; url: string }> } | { error: string }
+  > {
+    try {
+      const params = new URLSearchParams({
+        key: apiKey,
+        cx: searchEngineId,
+        q: query,
+        num: String(numResults),
+      });
+
+      const response = await fetch(
+        `https://www.googleapis.com/customsearch/v1?${params.toString()}`,
+      );
+
+      if (!response.ok) {
+        const error = await response.json();
+        return { error: error.error?.message || `Search API returned HTTP ${response.status}` };
+      }
+
+      const data = await response.json();
+      const results = (data.items || []).map((item: any) => ({
+        title: item.title,
+        snippet: item.snippet,
+        url: item.link,
+      }));
+
+      return { results };
+    } catch (error) {
+      return { error: `Search failed: ${error.message}` };
+    }
+  }
+}

--- a/apps/backend/src/pipelines/execution/step-handler.interface.ts
+++ b/apps/backend/src/pipelines/execution/step-handler.interface.ts
@@ -398,6 +398,27 @@ export interface AIHandlerConfig extends BaseHandlerConfig {
   };
 
   /**
+   * Plugins configuration for AI tool plugins.
+   * Plugins are executable tools (calculator, web search, etc.) enabled at the project level.
+   * This controls which project-enabled plugins are available to this specific pipeline step.
+   */
+  plugins?: {
+    /**
+     * Plugins mode:
+     * - 'none': Disable plugins (default)
+     * - 'all': Enable all project-enabled plugins
+     * - 'selected': Enable only specified plugins
+     */
+    mode: 'none' | 'all' | 'selected';
+
+    /**
+     * Plugin IDs to enable when mode is 'selected'.
+     * Each ID should match a plugin's `metadata.id` (e.g., 'calculator', 'web-search').
+     */
+    enabled?: string[];
+  };
+
+  /**
    * Schema ID for conversations table (for automatic updates).
    * When provided, handler updates token counts after completion.
    */

--- a/apps/backend/src/pipelines/handlers/ai.handler.ts
+++ b/apps/backend/src/pipelines/handlers/ai.handler.ts
@@ -12,6 +12,7 @@ import {
 import { PipelineDataService } from '../pipeline-data.service';
 import { PipelineSchemasService } from '../pipeline-schemas.service';
 import { SkillsService, SkillSummary } from '../skills.service';
+import { AIToolPluginService } from '../ai-plugins/ai-tool-plugin.service';
 import { ConfigurationError, SchemaNotFoundError } from '../errors';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createAnthropic } from '@ai-sdk/anthropic';
@@ -41,6 +42,7 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
     private readonly dataService: PipelineDataService,
     private readonly schemasService: PipelineSchemasService,
     private readonly skillsService: SkillsService,
+    private readonly pluginService: AIToolPluginService,
   ) {
     this.registry.register(this);
   }
@@ -317,6 +319,37 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
       this.logger.debug(
         `Skills mode is '${config.skills.mode}' but deployment context is not set - skills disabled`,
       );
+    }
+
+    // Build plugin tools (independent of skills system)
+    // Only load plugins if the step config enables them
+    if (config.plugins?.mode && config.plugins.mode !== 'none') {
+      try {
+        const allPluginTools = await this.pluginService.buildToolsForProject(context.projectId);
+        const filteredPluginTools = this.filterPluginTools(allPluginTools, config.plugins);
+        const pluginToolNames = Object.keys(filteredPluginTools);
+
+        if (pluginToolNames.length > 0) {
+          tools = { ...(tools || {}), ...filteredPluginTools };
+
+          // Append plugin tool descriptions to system prompt
+          const pluginPromptSection = this.buildPluginToolsPromptSection(pluginToolNames);
+          const systemMessageIndex = messages.findIndex((m) => m.role === 'system');
+
+          if (systemMessageIndex >= 0) {
+            messages[systemMessageIndex].content += `\n\n${pluginPromptSection}`;
+          } else {
+            messages.unshift({ role: 'system', content: pluginPromptSection });
+          }
+
+          this.logger.debug(
+            `Injected ${pluginToolNames.length} plugin tools: ${pluginToolNames.join(', ')}`,
+          );
+        }
+      } catch (error) {
+        this.logger.warn(`Failed to load AI plugin tools: ${error.message}`);
+        // Continue without plugin tools - don't fail the entire request
+      }
     }
 
     // Create the AI model instance
@@ -852,6 +885,50 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
     }
 
     return data;
+  }
+
+  // ===== Plugin Helper Methods =====
+
+  /**
+   * Filter plugin tools based on the step's plugins configuration.
+   * Tool names are namespaced as {pluginId}_{toolName}.
+   */
+  private filterPluginTools(
+    allTools: Record<string, any>,
+    config: { mode: 'none' | 'all' | 'selected'; enabled?: string[] },
+  ): Record<string, any> {
+    if (config.mode === 'all') {
+      return allTools;
+    }
+
+    if (config.mode === 'selected' && config.enabled) {
+      const enabledSet = new Set(config.enabled);
+      const filtered: Record<string, any> = {};
+      for (const [toolName, tool] of Object.entries(allTools)) {
+        // Tool names are {pluginId}_{toolName}, extract pluginId
+        const pluginId = toolName.substring(0, toolName.indexOf('_'));
+        if (enabledSet.has(pluginId)) {
+          filtered[toolName] = tool;
+        }
+      }
+      return filtered;
+    }
+
+    return {};
+  }
+
+  /**
+   * Build a prompt section describing available plugin tools for the AI.
+   */
+  private buildPluginToolsPromptSection(toolNames: string[]): string {
+    const toolList = toolNames.map((name) => `- \`${name}\``).join('\n');
+    return `## Available Plugin Tools
+
+You have access to the following plugin tools that can perform actions:
+
+${toolList}
+
+Use these tools when they are relevant to the user's request.`;
   }
 
   // ===== Skills Helper Methods =====

--- a/apps/backend/src/pipelines/pipelines.module.ts
+++ b/apps/backend/src/pipelines/pipelines.module.ts
@@ -32,6 +32,13 @@ import { FunctionRunnerService } from './function-runner.service';
 import { SkillsService } from './skills.service';
 // Validators
 import { AuthRequiredValidator, RateLimitValidator } from './execution/validators';
+// AI Plugin system
+import {
+  AIToolPluginRegistry,
+  AIToolPluginService,
+  CalculatorPlugin,
+  WebSearchPlugin,
+} from './ai-plugins';
 
 @Module({
   imports: [PermissionsModule, SettingsModule, forwardRef(() => ProjectsModule)],
@@ -68,12 +75,20 @@ import { AuthRequiredValidator, RateLimitValidator } from './execution/validator
     // Validators (auto-register on construction)
     AuthRequiredValidator,
     RateLimitValidator,
+    // AI Plugin system
+    AIToolPluginRegistry,
+    AIToolPluginService,
+    // Built-in plugins (self-register via constructor)
+    // To add a new plugin: create the class in ai-plugins/plugins/, add it here
+    CalculatorPlugin,
+    WebSearchPlugin,
   ],
   exports: [
     PipelineExecutionService,
     PipelineSchemasService,
     PipelineDataService,
     SkillsService,
+    AIToolPluginService,
   ],
 })
 export class PipelinesModule {}

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Put,
   Patch,
   Delete,
   Param,
@@ -36,6 +37,7 @@ import {
   AIProviderEnum,
 } from '../settings/dto/ai-settings.dto';
 import { SkillsService, SkillSummary } from '../pipelines/skills.service';
+import { AIToolPluginService, PluginListItem } from '../pipelines/ai-plugins/ai-tool-plugin.service';
 import { DeploymentsService } from '../deployments/deployments.service';
 
 @ApiTags('projects')
@@ -45,6 +47,7 @@ export class ProjectsController {
     private readonly projectsService: ProjectsService,
     private readonly aiSettingsService: ProjectAISettingsService,
     private readonly skillsService: SkillsService,
+    private readonly pluginService: AIToolPluginService,
     @Inject(forwardRef(() => DeploymentsService))
     private readonly deploymentsService: DeploymentsService,
   ) {}
@@ -198,6 +201,59 @@ export class ProjectsController {
     );
 
     return { skills };
+  }
+
+  // ==========================================================================
+  // AI Plugin Endpoints (Project-Level)
+  // NOTE: These MUST be defined BEFORE :owner/:name to avoid route conflicts
+  // ==========================================================================
+
+  @Get(':id/ai-plugins')
+  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @RequireProjectRole('admin')
+  @ApiOperation({ summary: 'List all plugins with enabled status for this project' })
+  @ApiResponse({ status: 200, description: 'List of plugins' })
+  async listPlugins(@Param('id') id: string): Promise<PluginListItem[]> {
+    return this.pluginService.getAvailablePlugins(id);
+  }
+
+  @Post(':id/ai-plugins/:pluginId')
+  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @RequireProjectRole('admin')
+  @ApiOperation({ summary: 'Enable a plugin for this project' })
+  @ApiResponse({ status: 200, description: 'Plugin enabled' })
+  async enablePlugin(
+    @Param('id') id: string,
+    @Param('pluginId') pluginId: string,
+    @Body() body: { config?: Record<string, unknown> },
+  ): Promise<PluginListItem> {
+    return this.pluginService.enablePlugin(id, pluginId, body.config);
+  }
+
+  @Put(':id/ai-plugins/:pluginId')
+  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @RequireProjectRole('admin')
+  @ApiOperation({ summary: 'Update plugin configuration' })
+  @ApiResponse({ status: 200, description: 'Plugin config updated' })
+  async updatePluginConfig(
+    @Param('id') id: string,
+    @Param('pluginId') pluginId: string,
+    @Body() body: { config: Record<string, unknown> },
+  ): Promise<PluginListItem> {
+    return this.pluginService.updatePluginConfig(id, pluginId, body.config);
+  }
+
+  @Delete(':id/ai-plugins/:pluginId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @RequireProjectRole('admin')
+  @ApiOperation({ summary: 'Disable a plugin for this project' })
+  @ApiResponse({ status: 204, description: 'Plugin disabled' })
+  async disablePlugin(
+    @Param('id') id: string,
+    @Param('pluginId') pluginId: string,
+  ): Promise<void> {
+    return this.pluginService.disablePlugin(id, pluginId);
   }
 
   // ==========================================================================

--- a/apps/frontend/src/components/pipelines/handlers/AIHandlerConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/AIHandlerConfig.tsx
@@ -44,6 +44,7 @@ import {
   FileText,
   Database,
   BookOpen,
+  Puzzle,
 } from 'lucide-react';
 import {
   Tooltip,
@@ -58,6 +59,7 @@ import type { PreviousStep } from './AvailableVariables';
 import { ExpressionInput } from './ExpressionInput';
 import { SchemaPicker } from './SchemaPicker';
 import { SkillsConfig, SkillsConfigValue } from './SkillsConfig';
+import { PluginsConfig, PluginsConfigValue } from './PluginsConfig';
 import { cn } from '@/lib/utils';
 
 // Lazy load Monaco Editor
@@ -130,6 +132,12 @@ export function AIHandlerConfig({ config, onChange, projectId, previousSteps = [
   );
   const [showSkills, setShowSkills] = useState(config.skills?.mode !== 'none' && config.skills?.mode !== undefined);
 
+  // Plugins state
+  const [plugins, setPlugins] = useState<PluginsConfigValue>(
+    (config.plugins as PluginsConfigValue) || { mode: 'none' }
+  );
+  const [showPlugins, setShowPlugins] = useState(config.plugins?.mode !== 'none' && config.plugins?.mode !== undefined);
+
   // Initialize provider/model from AI status
   useEffect(() => {
     if (defaultProvider && !provider) {
@@ -189,8 +197,10 @@ export function AIHandlerConfig({ config, onChange, projectId, previousSteps = [
       conversationIdField: shouldPersist && conversationIdField !== 'request.body.id' ? conversationIdField : undefined,
       // Skills
       skills: skills.mode !== 'none' ? skills : undefined,
+      // Plugins
+      plugins: plugins.mode !== 'none' ? plugins : undefined,
     });
-  }, [mode, provider, model, responseMode, systemPrompt, messageField, messagesField, maxHistoryMessages, maxTokens, temperature, persistMessages, persistMessagesSchemaId, persistConversationsSchemaId, conversationIdField, skills]);
+  }, [mode, provider, model, responseMode, systemPrompt, messageField, messagesField, maxHistoryMessages, maxTokens, temperature, persistMessages, persistMessagesSchemaId, persistConversationsSchemaId, conversationIdField, skills, plugins]);
 
   // Find selected model info
   const selectedModelInfo = suggestedModels.find(m => m.id === model);
@@ -694,6 +704,27 @@ export function AIHandlerConfig({ config, onChange, projectId, previousSteps = [
           </CollapsibleTrigger>
           <CollapsibleContent className="pt-4">
             <SkillsConfig config={skills} onChange={setSkills} projectId={projectId} />
+          </CollapsibleContent>
+        </Collapsible>
+
+        {/* Plugins Configuration */}
+        <Collapsible open={showPlugins} onOpenChange={setShowPlugins}>
+          <CollapsibleTrigger asChild>
+            <Button variant="ghost" size="sm" className="w-full justify-between">
+              <span className="flex items-center gap-2">
+                <Puzzle className="h-4 w-4" />
+                Plugins
+                {plugins.mode !== 'none' && (
+                  <Badge variant="secondary" className="text-xs">
+                    {plugins.mode === 'all' ? 'All' : `${plugins.enabled?.length ?? 0} selected`}
+                  </Badge>
+                )}
+              </span>
+              <ChevronDown className={cn('h-4 w-4 transition-transform', showPlugins && 'rotate-180')} />
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="pt-4">
+            <PluginsConfig config={plugins} onChange={setPlugins} projectId={projectId} />
           </CollapsibleContent>
         </Collapsible>
 

--- a/apps/frontend/src/components/pipelines/handlers/PluginsConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/PluginsConfig.tsx
@@ -1,0 +1,116 @@
+import { useListProjectPluginsQuery } from '@/services/projectsApi';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Info } from 'lucide-react';
+
+export interface PluginsConfigValue {
+  mode: 'none' | 'all' | 'selected';
+  enabled?: string[];
+}
+
+interface PluginsConfigProps {
+  config: PluginsConfigValue;
+  onChange: (config: PluginsConfigValue) => void;
+  projectId: string;
+}
+
+export function PluginsConfig({ config, onChange, projectId }: PluginsConfigProps) {
+  const { data: plugins, isLoading } = useListProjectPluginsQuery(projectId);
+  // Only show plugins that are enabled at the project level
+  const enabledPlugins = (plugins ?? []).filter((p) => p.enabled);
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label>Plugins Mode</Label>
+        <Select
+          value={config.mode}
+          onValueChange={(v) =>
+            onChange({ ...config, mode: v as PluginsConfigValue['mode'] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">Disabled</SelectItem>
+            <SelectItem value="all">Enable All Plugins</SelectItem>
+            <SelectItem value="selected">Select Plugins</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          {config.mode === 'none' && 'Plugins are disabled for this handler.'}
+          {config.mode === 'all' && 'All project-enabled plugins will be available.'}
+          {config.mode === 'selected' && 'Choose specific plugins to enable for this handler.'}
+        </p>
+      </div>
+
+      {config.mode === 'selected' && (
+        <div className="space-y-2">
+          <Label>Enabled Plugins</Label>
+          {isLoading ? (
+            <Skeleton className="h-20" />
+          ) : enabledPlugins.length === 0 ? (
+            <Alert>
+              <Info className="h-4 w-4" />
+              <AlertDescription>
+                No plugins are enabled at the project level. Enable plugins in{' '}
+                <strong>Project Settings &gt; AI</strong> first.
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <div className="space-y-2 max-h-48 overflow-y-auto rounded-md border p-3">
+              {enabledPlugins.map((plugin) => (
+                <div key={plugin.id} className="flex items-start gap-3">
+                  <Checkbox
+                    id={`plugin-${plugin.id}`}
+                    checked={config.enabled?.includes(plugin.id) ?? false}
+                    onCheckedChange={(checked) => {
+                      const current = config.enabled ?? [];
+                      onChange({
+                        ...config,
+                        enabled: checked
+                          ? [...current, plugin.id]
+                          : current.filter((id) => id !== plugin.id),
+                      });
+                    }}
+                  />
+                  <div className="flex-1 leading-none">
+                    <label
+                      htmlFor={`plugin-${plugin.id}`}
+                      className="font-medium text-sm cursor-pointer"
+                    >
+                      {plugin.name}
+                    </label>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {plugin.description}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {config.mode !== 'none' && (
+        <Alert className="border-blue-500/30 bg-blue-500/5">
+          <Info className="h-4 w-4 text-blue-600" />
+          <AlertDescription className="text-xs">
+            When plugins are enabled, the AI can use plugin tools to perform actions like calculations,
+            web searches, and more. Only plugins enabled at the project level are available.
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/pipelines/handlers/types.ts
+++ b/apps/frontend/src/components/pipelines/handlers/types.ts
@@ -159,6 +159,23 @@ export interface AIHandlerConfig extends BaseHandlerConfig {
      */
     enabled?: string[];
   };
+  /**
+   * Plugins configuration for AI tool plugins.
+   * Controls which project-enabled plugins are available to this pipeline step.
+   */
+  plugins?: {
+    /**
+     * Plugins mode:
+     * - 'none': Disable plugins (default)
+     * - 'all': Enable all project-enabled plugins
+     * - 'selected': Enable only specified plugins
+     */
+    mode: 'none' | 'all' | 'selected';
+    /**
+     * Plugin IDs to enable when mode is 'selected'.
+     */
+    enabled?: string[];
+  };
   /** Schema ID for conversations table (for automatic updates) */
   conversationsSchemaId?: string;
   /** Schema ID for messages table (for automatic saving) @deprecated Use persistMessages instead */

--- a/apps/frontend/src/components/project/ProjectAIPluginsSection.tsx
+++ b/apps/frontend/src/components/project/ProjectAIPluginsSection.tsx
@@ -1,0 +1,362 @@
+import { useState } from 'react';
+import {
+  useListProjectPluginsQuery,
+  useEnableProjectPluginMutation,
+  useDisableProjectPluginMutation,
+  useUpdateProjectPluginConfigMutation,
+  PluginListItem,
+  Project,
+} from '@/services/projectsApi';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Loader2,
+  Puzzle,
+  Calculator,
+  Search,
+  Settings2,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useToast } from '@/hooks/use-toast';
+
+// Icon mapping for plugins
+const PLUGIN_ICONS: Record<string, React.ElementType> = {
+  calculator: Calculator,
+  search: Search,
+};
+
+// Category display config
+const CATEGORY_COLORS: Record<string, string> = {
+  utility: 'bg-blue-50 text-blue-700',
+  information: 'bg-purple-50 text-purple-700',
+  scheduling: 'bg-green-50 text-green-700',
+  communication: 'bg-orange-50 text-orange-700',
+};
+
+function PluginCard({
+  plugin,
+  onToggle,
+  onConfigure,
+  isToggling,
+}: {
+  plugin: PluginListItem;
+  onToggle: (enabled: boolean) => void;
+  onConfigure: () => void;
+  isToggling: boolean;
+}) {
+  const Icon = PLUGIN_ICONS[plugin.icon || ''] || Puzzle;
+  const categoryColor = CATEGORY_COLORS[plugin.category] || 'bg-gray-50 text-gray-700';
+
+  return (
+    <div className="border rounded-lg p-4">
+      <div className="flex items-start justify-between">
+        <div className="flex items-start gap-3">
+          <div className="p-2 rounded-lg bg-muted">
+            <Icon className="w-5 h-5 text-muted-foreground" />
+          </div>
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              <h4 className="font-medium text-sm">{plugin.name}</h4>
+              <Badge variant="outline" className={cn('text-xs', categoryColor)}>
+                {plugin.category}
+              </Badge>
+            </div>
+            <p className="text-sm text-muted-foreground mt-0.5">{plugin.description}</p>
+            {plugin.enabled && plugin.configSchema && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="mt-1 h-7 px-2 text-xs"
+                onClick={onConfigure}
+              >
+                <Settings2 className="h-3 w-3 mr-1" />
+                Configure
+              </Button>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {isToggling ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Switch
+              checked={plugin.enabled}
+              onCheckedChange={onToggle}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PluginConfigDialog({
+  plugin,
+  open,
+  onOpenChange,
+  onSave,
+  isSaving,
+}: {
+  plugin: PluginListItem | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (config: Record<string, unknown>) => void;
+  isSaving: boolean;
+}) {
+  const [configValues, setConfigValues] = useState<Record<string, string>>({});
+
+  if (!plugin) return null;
+
+  // Derive config fields from plugin metadata
+  // The configSchema from the backend is a Zod schema serialized — for now we handle known plugins
+  const configFields = getConfigFieldsForPlugin(plugin.id);
+
+  const handleSave = () => {
+    const config: Record<string, unknown> = {};
+    for (const field of configFields) {
+      config[field.key] = configValues[field.key] || '';
+    }
+    onSave(config);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[450px]">
+        <DialogHeader>
+          <DialogTitle>Configure {plugin.name}</DialogTitle>
+          <DialogDescription>
+            Enter the required credentials for this plugin.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {configFields.map((field) => (
+            <div key={field.key}>
+              <Label htmlFor={`plugin-${field.key}`}>{field.label}</Label>
+              <Input
+                id={`plugin-${field.key}`}
+                type={field.secret ? 'password' : 'text'}
+                value={configValues[field.key] || ''}
+                onChange={(e) =>
+                  setConfigValues((prev) => ({ ...prev, [field.key]: e.target.value }))
+                }
+                placeholder={field.placeholder}
+                className="mt-1"
+              />
+              {field.helpText && (
+                <p className="mt-1 text-xs text-muted-foreground">{field.helpText}</p>
+              )}
+            </div>
+          ))}
+
+          {configFields.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              This plugin does not require any configuration.
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={isSaving}>
+            {isSaving ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              'Save Configuration'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface ConfigField {
+  key: string;
+  label: string;
+  placeholder?: string;
+  helpText?: string;
+  secret?: boolean;
+}
+
+function getConfigFieldsForPlugin(pluginId: string): ConfigField[] {
+  switch (pluginId) {
+    case 'web-search':
+      return [
+        {
+          key: 'apiKey',
+          label: 'Google Custom Search API Key',
+          placeholder: 'AIza...',
+          helpText: 'Get your API key from the Google Cloud Console',
+          secret: true,
+        },
+        {
+          key: 'searchEngineId',
+          label: 'Search Engine ID',
+          placeholder: 'abc123...',
+          helpText: 'The Custom Search Engine ID (cx parameter)',
+        },
+      ];
+    default:
+      return [];
+  }
+}
+
+interface ProjectAIPluginsSectionProps {
+  project: Project;
+}
+
+export function ProjectAIPluginsSection({ project }: ProjectAIPluginsSectionProps) {
+  const { toast } = useToast();
+  const { data: plugins, isLoading } = useListProjectPluginsQuery(project.id);
+  const [enablePlugin] = useEnableProjectPluginMutation();
+  const [disablePlugin] = useDisableProjectPluginMutation();
+  const [updatePluginConfig, { isLoading: isUpdatingConfig }] =
+    useUpdateProjectPluginConfigMutation();
+
+  const [togglingPlugin, setTogglingPlugin] = useState<string | null>(null);
+  const [configuringPlugin, setConfiguringPlugin] = useState<PluginListItem | null>(null);
+
+  const handleToggle = async (plugin: PluginListItem, enabled: boolean) => {
+    setTogglingPlugin(plugin.id);
+    try {
+      if (enabled) {
+        // If plugin needs config, open the config dialog instead
+        const configFields = getConfigFieldsForPlugin(plugin.id);
+        if (configFields.length > 0 && !plugin.hasConfig) {
+          setConfiguringPlugin(plugin);
+          setTogglingPlugin(null);
+          return;
+        }
+        await enablePlugin({ projectId: project.id, pluginId: plugin.id }).unwrap();
+        toast({ title: `${plugin.name} enabled` });
+      } else {
+        await disablePlugin({ projectId: project.id, pluginId: plugin.id }).unwrap();
+        toast({ title: `${plugin.name} disabled` });
+      }
+    } catch (error: unknown) {
+      const err = error as { data?: { message?: string } };
+      toast({
+        title: 'Error',
+        description: err.data?.message || `Failed to ${enabled ? 'enable' : 'disable'} plugin`,
+        variant: 'destructive',
+      });
+    } finally {
+      setTogglingPlugin(null);
+    }
+  };
+
+  const handleSaveConfig = async (config: Record<string, unknown>) => {
+    if (!configuringPlugin) return;
+    try {
+      if (configuringPlugin.enabled) {
+        await updatePluginConfig({
+          projectId: project.id,
+          pluginId: configuringPlugin.id,
+          config,
+        }).unwrap();
+      } else {
+        await enablePlugin({
+          projectId: project.id,
+          pluginId: configuringPlugin.id,
+          config,
+        }).unwrap();
+      }
+      toast({ title: `${configuringPlugin.name} configured` });
+      setConfiguringPlugin(null);
+    } catch (error: unknown) {
+      const err = error as { data?: { message?: string } };
+      toast({
+        title: 'Error',
+        description: err.data?.message || 'Failed to save plugin configuration',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Puzzle className="h-5 w-5" />
+            AI Plugins
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const pluginList = plugins || [];
+  const enabledCount = pluginList.filter((p) => p.enabled).length;
+
+  return (
+    <>
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Puzzle className="h-5 w-5" />
+            AI Plugins
+          </CardTitle>
+          <CardDescription>
+            Enable plugins to give your AI chat tools that can perform actions like calculations, web searches, and more.
+            {enabledCount > 0 && (
+              <span className="ml-1 font-medium">
+                {enabledCount} plugin{enabledCount > 1 ? 's' : ''} enabled.
+              </span>
+            )}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {pluginList.length > 0 ? (
+            pluginList.map((plugin) => (
+              <PluginCard
+                key={plugin.id}
+                plugin={plugin}
+                onToggle={(enabled) => handleToggle(plugin, enabled)}
+                onConfigure={() => setConfiguringPlugin(plugin)}
+                isToggling={togglingPlugin === plugin.id}
+              />
+            ))
+          ) : (
+            <p className="text-sm text-muted-foreground py-4 text-center">
+              No plugins available.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <PluginConfigDialog
+        plugin={configuringPlugin}
+        open={!!configuringPlugin}
+        onOpenChange={(open) => {
+          if (!open) setConfiguringPlugin(null);
+        }}
+        onSave={handleSaveConfig}
+        isSaving={isUpdatingConfig}
+      />
+    </>
+  );
+}

--- a/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
+++ b/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
@@ -55,6 +55,7 @@ import {
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
+import { ProjectAIPluginsSection } from './ProjectAIPluginsSection';
 
 // Provider display config
 const PROVIDER_CONFIG: Record<string, { color: string; bgColor: string; displayName: string }> = {
@@ -659,6 +660,8 @@ export function ProjectAISettingsTab({ project }: ProjectAISettingsTabProps) {
           )}
         </CardContent>
       </Card>
+
+      <ProjectAIPluginsSection project={project} />
 
       <AddProviderDialog
         open={showAddDialog}

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -198,6 +198,7 @@ export const api = createApi({
     'PipelineSchema',
     'PipelineData',
     'ProjectAI',
+    'ProjectPlugin',
   ],
   endpoints: () => ({}),
 });

--- a/apps/frontend/src/services/projectsApi.ts
+++ b/apps/frontend/src/services/projectsApi.ts
@@ -57,6 +57,20 @@ export interface AvailableProvider {
   models: ModelInfo[];
 }
 
+// Plugin types
+export interface PluginListItem {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  icon?: string;
+  requiresOAuth?: boolean;
+  oauthProvider?: string;
+  enabled: boolean;
+  hasConfig: boolean;
+  configSchema?: Record<string, unknown>;
+}
+
 // Skill types
 export interface SkillSummary {
   name: string;
@@ -228,6 +242,55 @@ export const projectsApi = api.injectEndpoints({
       query: (projectId) => `/api/projects/${projectId}/ai/providers`,
     }),
 
+    // AI Plugin endpoints
+    listProjectPlugins: builder.query<PluginListItem[], string>({
+      query: (id) => `/api/projects/${id}/ai-plugins`,
+      providesTags: (_result, _error, projectId) => [
+        { type: 'ProjectPlugin' as const, id: projectId },
+      ],
+    }),
+
+    enableProjectPlugin: builder.mutation<
+      PluginListItem,
+      { projectId: string; pluginId: string; config?: Record<string, unknown> }
+    >({
+      query: ({ projectId, pluginId, config }) => ({
+        url: `/api/projects/${projectId}/ai-plugins/${pluginId}`,
+        method: 'POST',
+        body: { config },
+      }),
+      invalidatesTags: (_result, _error, { projectId }) => [
+        { type: 'ProjectPlugin' as const, id: projectId },
+      ],
+    }),
+
+    updateProjectPluginConfig: builder.mutation<
+      PluginListItem,
+      { projectId: string; pluginId: string; config: Record<string, unknown> }
+    >({
+      query: ({ projectId, pluginId, config }) => ({
+        url: `/api/projects/${projectId}/ai-plugins/${pluginId}`,
+        method: 'PUT',
+        body: { config },
+      }),
+      invalidatesTags: (_result, _error, { projectId }) => [
+        { type: 'ProjectPlugin' as const, id: projectId },
+      ],
+    }),
+
+    disableProjectPlugin: builder.mutation<
+      void,
+      { projectId: string; pluginId: string }
+    >({
+      query: ({ projectId, pluginId }) => ({
+        url: `/api/projects/${projectId}/ai-plugins/${pluginId}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: (_result, _error, { projectId }) => [
+        { type: 'ProjectPlugin' as const, id: projectId },
+      ],
+    }),
+
     // Skills endpoint
     listProjectSkills: builder.query<
       { skills: SkillSummary[] },
@@ -258,6 +321,11 @@ export const {
   useSetProjectDefaultAIProviderMutation,
   useTestProjectAIMutation,
   useGetAvailableAIProvidersQuery,
+  // Plugins
+  useListProjectPluginsQuery,
+  useEnableProjectPluginMutation,
+  useUpdateProjectPluginConfigMutation,
+  useDisableProjectPluginMutation,
   // Skills
   useListProjectSkillsQuery,
 } = projectsApi;


### PR DESCRIPTION
## Summary

- Adds an AI plugin architecture that allows chat handlers to call executable tools (calculator, web search, etc.) on behalf of users
- Plugins are enabled/disabled per-project in Settings > AI, then selectively activated per-pipeline step (like skills with `none/all/selected` mode)
- Ships with two built-in plugins: **Calculator** (no credentials) and **Web Search** (Google Custom Search API)
- Self-registration pattern (same as StepHandlerRegistry) — adding a new plugin is just 2 steps: create the class, add to module providers

## Key changes

**Backend** (`apps/backend/src/pipelines/ai-plugins/`):
- `AIToolPlugin` interface, `AIToolPluginRegistry`, `AIToolPluginService`
- Encrypted config storage in `projects.settings.aiPlugins` JSONB
- Plugin tools namespaced as `{pluginId}_{toolName}` to prevent collisions
- REST endpoints on `ProjectsController` (before `:owner/:name` catch-all)
- AI handler filters plugins per step config, graceful failure on errors

**Frontend**:
- Plugin cards with toggles and config dialogs in Project Settings > AI
- `PluginsConfig` component in pipeline step editor (mirrors `SkillsConfig`)
- RTK Query endpoints with `ProjectPlugin` cache tags

## Test plan

- [x] Backend type-checks clean
- [x] Frontend type-checks clean
- [x] All 903 backend tests pass (zero regressions)
- [x] Calculator plugin verified end-to-end via chat
- [x] Plugin enable/disable UI works in project settings
- [x] Plugin selection in pipeline step editor works

🤖 Generated with [Claude Code](https://claude.com/claude-code)