### PR TITLE
feat: Google Calendar AI plugin with OAuth2

### DIFF
--- a/apps/backend/src/pipelines/ai-plugins/ai-plugins.controller.ts
+++ b/apps/backend/src/pipelines/ai-plugins/ai-plugins.controller.ts
@@ -6,6 +6,7 @@ import {
   Delete,
   Param,
   Body,
+  Query,
   UseGuards,
   HttpCode,
   HttpStatus,
@@ -15,6 +16,7 @@ import { SessionAuthGuard } from '../../auth/session-auth.guard';
 import { ProjectPermissionGuard } from '../../auth/guards/project-permission.guard';
 import { RequireProjectRole } from '../../auth/decorators/project-permission.decorator';
 import { AIToolPluginService, PluginListItem } from './ai-tool-plugin.service';
+import { GoogleOAuthService } from './google-oauth.service';
 
 /**
  * REST API for managing AI tool plugins per project.
@@ -27,7 +29,10 @@ import { AIToolPluginService, PluginListItem } from './ai-tool-plugin.service';
 @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
 @RequireProjectRole('admin')
 export class AIPluginsController {
-  constructor(private readonly pluginService: AIToolPluginService) {}
+  constructor(
+    private readonly pluginService: AIToolPluginService,
+    private readonly oauthService: GoogleOAuthService,
+  ) {}
 
   @Get()
   @ApiOperation({ summary: 'List all plugins with enabled status for this project' })
@@ -74,5 +79,75 @@ export class AIPluginsController {
     @Param('pluginId') pluginId: string,
   ): Promise<void> {
     return this.pluginService.disablePlugin(projectId, pluginId);
+  }
+
+  // ===== OAuth Endpoints =====
+
+  @Get(':pluginId/oauth/initiate')
+  @ApiOperation({ summary: 'Initiate OAuth flow for a plugin' })
+  @ApiParam({ name: 'projectId', description: 'Project UUID' })
+  @ApiParam({ name: 'pluginId', description: 'Plugin identifier' })
+  async initiateOAuth(
+    @Param('projectId') projectId: string,
+    @Param('pluginId') pluginId: string,
+    @Query('redirectUri') redirectUri: string,
+  ): Promise<{ authUrl: string }> {
+    return this.oauthService.getAuthorizationUrl(projectId, pluginId, redirectUri);
+  }
+
+  @Post(':pluginId/oauth/callback')
+  @ApiOperation({ summary: 'Complete OAuth flow with authorization code' })
+  @ApiParam({ name: 'projectId', description: 'Project UUID' })
+  @ApiParam({ name: 'pluginId', description: 'Plugin identifier' })
+  async completeOAuth(
+    @Param('projectId') projectId: string,
+    @Param('pluginId') pluginId: string,
+    @Body() body: { code: string; state: string; redirectUri: string },
+  ): Promise<{ success: boolean; connectedEmail: string }> {
+    const result = await this.oauthService.exchangeCodeForTokens(
+      projectId,
+      pluginId,
+      body.code,
+      body.state,
+      body.redirectUri,
+    );
+    return { success: true, ...result };
+  }
+
+  @Delete(':pluginId/oauth')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Disconnect OAuth (revoke tokens, keep app credentials)' })
+  @ApiParam({ name: 'projectId', description: 'Project UUID' })
+  @ApiParam({ name: 'pluginId', description: 'Plugin identifier' })
+  async disconnectOAuth(
+    @Param('projectId') projectId: string,
+    @Param('pluginId') pluginId: string,
+  ): Promise<void> {
+    const config = await this.pluginService.getDecryptedPluginConfig(projectId, pluginId);
+    if (!config) return;
+
+    // Revoke the refresh token
+    if (config.refreshToken) {
+      await this.oauthService.revokeToken(config.refreshToken as string);
+    }
+
+    // Clear OAuth fields but keep clientId/clientSecret
+    const updatedConfig = {
+      clientId: config.clientId,
+      clientSecret: config.clientSecret,
+    };
+    await this.pluginService.updatePluginConfig(projectId, pluginId, updatedConfig);
+  }
+
+  // ===== Calendars List Endpoint =====
+
+  @Get('google-calendar/calendars')
+  @ApiOperation({ summary: 'List calendars from connected Google account' })
+  @ApiParam({ name: 'projectId', description: 'Project UUID' })
+  async listCalendars(
+    @Param('projectId') projectId: string,
+  ): Promise<{ calendars: Array<{ id: string; summary: string; primary: boolean }> }> {
+    const calendars = await this.oauthService.listCalendars(projectId, 'google-calendar');
+    return { calendars };
   }
 }

--- a/apps/backend/src/pipelines/ai-plugins/ai-tool-plugin.interface.ts
+++ b/apps/backend/src/pipelines/ai-plugins/ai-tool-plugin.interface.ts
@@ -7,6 +7,8 @@ export interface AIToolContext {
   projectId: string;
   userId?: string;
   pluginConfig: Record<string, unknown>;
+  /** Per-pipeline options set in the pipeline editor (e.g., calendarId) */
+  pipelineOptions?: Record<string, unknown>;
 }
 
 /**
@@ -39,6 +41,8 @@ export interface AIToolPluginMetadata {
   requiresOAuth?: boolean;
   /** OAuth provider identifier (e.g. 'google') */
   oauthProvider?: string;
+  /** Optional Zod schema for per-pipeline options (e.g., calendarId selection) */
+  pipelineOptionsSchema?: z.ZodObject<any>;
 }
 
 /**

--- a/apps/backend/src/pipelines/ai-plugins/ai-tool-plugin.service.ts
+++ b/apps/backend/src/pipelines/ai-plugins/ai-tool-plugin.service.ts
@@ -19,6 +19,7 @@ import {
 export interface PluginListItem extends AIToolPluginMetadata {
   enabled: boolean;
   hasConfig: boolean;
+  oauthConnectedEmail?: string;
 }
 
 /**
@@ -57,10 +58,23 @@ export class AIToolPluginService {
 
     return allPlugins.map((plugin) => {
       const stored = storedPlugins[plugin.metadata.id];
+      let oauthConnectedEmail: string | undefined;
+
+      // For OAuth plugins, extract connectedEmail from stored config
+      if (plugin.metadata.requiresOAuth && stored?.config) {
+        try {
+          const decrypted = JSON.parse(this.decryptData(stored.config));
+          oauthConnectedEmail = decrypted.connectedEmail;
+        } catch {
+          // Ignore decryption errors
+        }
+      }
+
       return {
         ...plugin.metadata,
         enabled: stored?.enabled ?? false,
         hasConfig: !!stored?.config,
+        oauthConnectedEmail,
       };
     });
   }
@@ -164,10 +178,32 @@ export class AIToolPluginService {
   }
 
   /**
+   * Get the decrypted config for an enabled plugin.
+   * Used by OAuth services that need to read stored credentials.
+   */
+  async getDecryptedPluginConfig(
+    projectId: string,
+    pluginId: string,
+  ): Promise<Record<string, unknown> | null> {
+    const storedPlugins = await this.getStoredPlugins(projectId);
+    const stored = storedPlugins[pluginId];
+    if (!stored?.enabled || !stored.config) return null;
+
+    try {
+      return JSON.parse(this.decryptData(stored.config));
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Build Vercel AI SDK tools for all enabled plugins for a project.
    * Tools are namespaced as {pluginId}_{toolName} to prevent collisions.
    */
-  async buildToolsForProject(projectId: string): Promise<Record<string, any>> {
+  async buildToolsForProject(
+    projectId: string,
+    pipelinePluginOptions?: Record<string, Record<string, unknown>>,
+  ): Promise<Record<string, any>> {
     const storedPlugins = await this.getStoredPlugins(projectId);
     const tools: Record<string, any> = {};
 
@@ -189,6 +225,7 @@ export class AIToolPluginService {
         const context: AIToolContext = {
           projectId,
           pluginConfig: decryptedConfig,
+          pipelineOptions: pipelinePluginOptions?.[pluginId],
         };
 
         for (const toolDef of pluginTools) {

--- a/apps/backend/src/pipelines/ai-plugins/google-oauth.service.ts
+++ b/apps/backend/src/pipelines/ai-plugins/google-oauth.service.ts
@@ -1,0 +1,276 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as crypto from 'crypto';
+import { AIToolPluginService } from './ai-tool-plugin.service';
+
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
+const GOOGLE_REVOKE_URL = 'https://oauth2.googleapis.com/revoke';
+
+const SCOPES = [
+  'https://www.googleapis.com/auth/calendar.freebusy',
+  'https://www.googleapis.com/auth/calendar.events',
+  'https://www.googleapis.com/auth/calendar.readonly',
+  'https://www.googleapis.com/auth/userinfo.email',
+];
+
+const STATE_EXPIRY_MS = 10 * 60 * 1000; // 10 minutes
+
+@Injectable()
+export class GoogleOAuthService {
+  private readonly logger = new Logger(GoogleOAuthService.name);
+  private readonly ENCRYPTION_KEY: Buffer;
+  private readonly ENCRYPTION_ALGORITHM = 'aes-256-gcm';
+
+  constructor(
+    private readonly pluginService: AIToolPluginService,
+    private readonly configService: ConfigService,
+  ) {
+    const encryptionKey = this.configService.get<string>('ENCRYPTION_KEY');
+    if (encryptionKey) {
+      this.ENCRYPTION_KEY = Buffer.from(encryptionKey, 'base64');
+    } else {
+      this.ENCRYPTION_KEY = crypto.randomBytes(32);
+      this.logger.warn('No ENCRYPTION_KEY found. Generated temporary key.');
+    }
+  }
+
+  /**
+   * Build the Google OAuth2 authorization URL.
+   * Reads clientId from the stored plugin config.
+   */
+  async getAuthorizationUrl(
+    projectId: string,
+    pluginId: string,
+    redirectUri: string,
+  ): Promise<{ authUrl: string }> {
+    const config = await this.pluginService.getDecryptedPluginConfig(projectId, pluginId);
+    if (!config?.clientId) {
+      throw new Error('Google OAuth Client ID not configured');
+    }
+
+    const state = this.encryptState({
+      projectId,
+      pluginId,
+      timestamp: Date.now(),
+    });
+
+    const params = new URLSearchParams({
+      client_id: config.clientId as string,
+      redirect_uri: redirectUri,
+      response_type: 'code',
+      scope: SCOPES.join(' '),
+      access_type: 'offline',
+      prompt: 'consent',
+      state,
+    });
+
+    return { authUrl: `${GOOGLE_AUTH_URL}?${params.toString()}` };
+  }
+
+  /**
+   * Exchange authorization code for tokens and store them.
+   */
+  async exchangeCodeForTokens(
+    projectId: string,
+    pluginId: string,
+    code: string,
+    state: string,
+    redirectUri: string,
+  ): Promise<{ connectedEmail: string }> {
+    // Validate state
+    const stateData = this.decryptState(state);
+    if (stateData.projectId !== projectId || stateData.pluginId !== pluginId) {
+      throw new Error('Invalid OAuth state: project/plugin mismatch');
+    }
+    if (Date.now() - stateData.timestamp > STATE_EXPIRY_MS) {
+      throw new Error('OAuth state expired');
+    }
+
+    // Get client credentials from stored config
+    const config = await this.pluginService.getDecryptedPluginConfig(projectId, pluginId);
+    if (!config?.clientId || !config?.clientSecret) {
+      throw new Error('Google OAuth credentials not configured');
+    }
+
+    // Exchange code for tokens
+    const tokenResponse = await fetch(GOOGLE_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        code,
+        client_id: config.clientId as string,
+        client_secret: config.clientSecret as string,
+        redirect_uri: redirectUri,
+        grant_type: 'authorization_code',
+      }),
+    });
+
+    if (!tokenResponse.ok) {
+      const error = await tokenResponse.json();
+      this.logger.error(`Token exchange failed: ${JSON.stringify(error)}`);
+      throw new Error(error.error_description || 'Failed to exchange authorization code');
+    }
+
+    const tokens = await tokenResponse.json();
+
+    // Fetch user email
+    const userInfoResponse = await fetch(GOOGLE_USERINFO_URL, {
+      headers: { Authorization: `Bearer ${tokens.access_token}` },
+    });
+
+    let connectedEmail = 'unknown';
+    if (userInfoResponse.ok) {
+      const userInfo = await userInfoResponse.json();
+      connectedEmail = userInfo.email || 'unknown';
+    }
+
+    // Merge tokens into existing plugin config
+    const updatedConfig = {
+      ...config,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      tokenExpiry: Date.now() + tokens.expires_in * 1000,
+      connectedEmail,
+    };
+
+    await this.pluginService.updatePluginConfig(projectId, pluginId, updatedConfig);
+    this.logger.log(`Google OAuth connected for project ${projectId}: ${connectedEmail}`);
+
+    return { connectedEmail };
+  }
+
+  /**
+   * Refresh an expired access token.
+   */
+  async refreshAccessToken(
+    clientId: string,
+    clientSecret: string,
+    refreshToken: string,
+  ): Promise<{ accessToken: string; expiresIn: number }> {
+    const response = await fetch(GOOGLE_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: refreshToken,
+        grant_type: 'refresh_token',
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.error_description || 'Failed to refresh access token');
+    }
+
+    const data = await response.json();
+    return {
+      accessToken: data.access_token,
+      expiresIn: data.expires_in,
+    };
+  }
+
+  /**
+   * Revoke a refresh token.
+   */
+  async revokeToken(refreshToken: string): Promise<void> {
+    try {
+      await fetch(`${GOOGLE_REVOKE_URL}?token=${refreshToken}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      });
+    } catch (error) {
+      this.logger.warn(`Token revocation failed: ${error.message}`);
+      // Continue — revoking is best-effort
+    }
+  }
+
+  /**
+   * List calendars from the connected Google account.
+   */
+  async listCalendars(
+    projectId: string,
+    pluginId: string,
+  ): Promise<Array<{ id: string; summary: string; primary: boolean }>> {
+    const config = await this.pluginService.getDecryptedPluginConfig(projectId, pluginId);
+    if (!config?.refreshToken) {
+      throw new Error('Google account not connected');
+    }
+
+    const accessToken = await this.getValidAccessToken(projectId, pluginId, config);
+
+    const response = await fetch(
+      'https://www.googleapis.com/calendar/v3/users/me/calendarList',
+      { headers: { Authorization: `Bearer ${accessToken}` } },
+    );
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.error?.message || 'Failed to list calendars');
+    }
+
+    const data = await response.json();
+    return (data.items || []).map((item: any) => ({
+      id: item.id,
+      summary: item.summary || item.id,
+      primary: item.primary || false,
+    }));
+  }
+
+  /**
+   * Get a valid access token, refreshing if expired.
+   */
+  async getValidAccessToken(
+    projectId: string,
+    pluginId: string,
+    config: Record<string, unknown>,
+  ): Promise<string> {
+    const tokenExpiry = config.tokenExpiry as number;
+    const isExpired = !tokenExpiry || Date.now() > tokenExpiry - 60_000; // 1 min buffer
+
+    if (!isExpired && config.accessToken) {
+      return config.accessToken as string;
+    }
+
+    // Refresh
+    const { accessToken, expiresIn } = await this.refreshAccessToken(
+      config.clientId as string,
+      config.clientSecret as string,
+      config.refreshToken as string,
+    );
+
+    // Update stored config with new token
+    const updatedConfig = {
+      ...config,
+      accessToken,
+      tokenExpiry: Date.now() + expiresIn * 1000,
+    };
+    await this.pluginService.updatePluginConfig(projectId, pluginId, updatedConfig);
+
+    return accessToken;
+  }
+
+  // ===== State encryption helpers =====
+
+  private encryptState(data: Record<string, unknown>): string {
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv(this.ENCRYPTION_ALGORITHM, this.ENCRYPTION_KEY, iv);
+    let encrypted = cipher.update(JSON.stringify(data), 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+    const authTag = cipher.getAuthTag();
+    return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`;
+  }
+
+  private decryptState(state: string): { projectId: string; pluginId: string; timestamp: number } {
+    const [ivHex, authTagHex, encrypted] = state.split(':');
+    const iv = Buffer.from(ivHex, 'hex');
+    const authTag = Buffer.from(authTagHex, 'hex');
+    const decipher = crypto.createDecipheriv(this.ENCRYPTION_ALGORITHM, this.ENCRYPTION_KEY, iv);
+    decipher.setAuthTag(authTag);
+    let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+    return JSON.parse(decrypted);
+  }
+}

--- a/apps/backend/src/pipelines/ai-plugins/index.ts
+++ b/apps/backend/src/pipelines/ai-plugins/index.ts
@@ -2,4 +2,5 @@ export * from './ai-tool-plugin.interface';
 export * from './ai-tool-plugin.registry';
 export * from './ai-tool-plugin.service';
 export * from './ai-plugins.controller';
+export * from './google-oauth.service';
 export * from './plugins';

--- a/apps/backend/src/pipelines/ai-plugins/plugins/google-calendar.plugin.ts
+++ b/apps/backend/src/pipelines/ai-plugins/plugins/google-calendar.plugin.ts
@@ -1,0 +1,291 @@
+import { Injectable, Inject, forwardRef } from '@nestjs/common';
+import { z } from 'zod';
+import {
+  AIToolPlugin,
+  AIToolPluginMetadata,
+  AIToolDefinition,
+  AIToolContext,
+} from '../ai-tool-plugin.interface';
+import { AIToolPluginRegistry } from '../ai-tool-plugin.registry';
+import { AIToolPluginService } from '../ai-tool-plugin.service';
+import { GoogleOAuthService } from '../google-oauth.service';
+
+const FREEBUSY_URL = 'https://www.googleapis.com/calendar/v3/freeBusy';
+const EVENTS_URL = 'https://www.googleapis.com/calendar/v3/calendars';
+
+@Injectable()
+export class GoogleCalendarPlugin implements AIToolPlugin {
+  readonly metadata: AIToolPluginMetadata = {
+    id: 'google-calendar',
+    name: 'Google Calendar',
+    description: 'Check schedule availability and create calendar events via Google Calendar.',
+    category: 'scheduling',
+    icon: 'calendar',
+    requiresOAuth: true,
+    oauthProvider: 'google',
+    configSchema: z.object({
+      clientId: z.string().min(1).describe('Google OAuth Client ID'),
+      clientSecret: z.string().min(1).describe('Google OAuth Client Secret'),
+    }),
+    pipelineOptionsSchema: z.object({
+      calendarId: z.string().optional().describe('Calendar to use (defaults to primary)'),
+      lookAheadDays: z
+        .number()
+        .min(1)
+        .max(90)
+        .optional()
+        .describe('Days to look ahead for availability (default 7)'),
+      maxSlots: z
+        .number()
+        .min(1)
+        .max(20)
+        .optional()
+        .describe('Maximum number of free slots to return (default: all)'),
+    }),
+  };
+
+  constructor(
+    private readonly registry: AIToolPluginRegistry,
+    @Inject(forwardRef(() => AIToolPluginService))
+    private readonly pluginService: AIToolPluginService,
+    @Inject(forwardRef(() => GoogleOAuthService))
+    private readonly oauthService: GoogleOAuthService,
+  ) {
+    this.registry.register(this);
+  }
+
+  async validateConfig(
+    config: Record<string, unknown>,
+  ): Promise<{ valid: boolean; error?: string }> {
+    if (!config.clientId || typeof config.clientId !== 'string') {
+      return { valid: false, error: 'Google OAuth Client ID is required' };
+    }
+    if (!config.clientSecret || typeof config.clientSecret !== 'string') {
+      return { valid: false, error: 'Google OAuth Client Secret is required' };
+    }
+    return { valid: true };
+  }
+
+  getTools(config: Record<string, unknown>): AIToolDefinition[] {
+    // Only return tools if OAuth flow has been completed
+    if (!config.refreshToken) {
+      return [];
+    }
+
+    return [
+      {
+        name: 'get_availability',
+        description:
+          'Check Google Calendar availability (free/busy times) for a date range. Returns both busy and free time slots.',
+        inputSchema: z.object({
+          startDate: z
+            .string()
+            .optional()
+            .describe(
+              'Start date/time in ISO 8601 format (e.g., "2024-03-15T09:00:00Z"). Defaults to now.',
+            ),
+          endDate: z
+            .string()
+            .optional()
+            .describe(
+              'End date/time in ISO 8601 format. Defaults to start + lookAheadDays (default 7 days).',
+            ),
+          timezone: z
+            .string()
+            .optional()
+            .describe('IANA timezone (e.g., "America/New_York"). Defaults to UTC.'),
+        }),
+        execute: async (
+          args: { startDate?: string; endDate?: string; timezone?: string },
+          context: AIToolContext,
+        ) => {
+          return this.getAvailability(args, context);
+        },
+      },
+      {
+        name: 'create_event',
+        description:
+          'Create a new event on Google Calendar. Returns event details including a link to the event.',
+        inputSchema: z.object({
+          title: z.string().describe('Event title/summary'),
+          startTime: z
+            .string()
+            .describe('Start time in ISO 8601 format (e.g., "2024-03-15T14:00:00Z")'),
+          endTime: z
+            .string()
+            .describe('End time in ISO 8601 format (e.g., "2024-03-15T15:00:00Z")'),
+          description: z.string().optional().describe('Optional event description'),
+          timezone: z
+            .string()
+            .optional()
+            .describe('IANA timezone (e.g., "America/New_York"). Defaults to UTC.'),
+        }),
+        execute: async (
+          args: {
+            title: string;
+            startTime: string;
+            endTime: string;
+            description?: string;
+            timezone?: string;
+          },
+          context: AIToolContext,
+        ) => {
+          return this.createEvent(args, context);
+        },
+      },
+    ];
+  }
+
+  private async getAvailability(
+    args: { startDate?: string; endDate?: string; timezone?: string },
+    context: AIToolContext,
+  ): Promise<any> {
+    try {
+      const accessToken = await this.getAccessToken(context);
+      const calendarId = (context.pipelineOptions?.calendarId as string) || 'primary';
+      const lookAheadDays = (context.pipelineOptions?.lookAheadDays as number) || 7;
+      const timezone = args.timezone || 'UTC';
+
+      const now = new Date();
+      const start = args.startDate ? new Date(args.startDate) : now;
+      const end = args.endDate
+        ? new Date(args.endDate)
+        : new Date(start.getTime() + lookAheadDays * 24 * 60 * 60 * 1000);
+
+      const response = await fetch(FREEBUSY_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          timeMin: start.toISOString(),
+          timeMax: end.toISOString(),
+          timeZone: timezone,
+          items: [{ id: calendarId }],
+        }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        return {
+          error: error.error?.message || `Calendar API returned HTTP ${response.status}`,
+        };
+      }
+
+      const data = await response.json();
+      const busySlots = data.calendars?.[calendarId]?.busy || [];
+
+      // Compute free slots from busy intervals
+      let freeSlots = this.computeFreeSlots(busySlots, start.toISOString(), end.toISOString());
+
+      // Truncate if maxSlots is configured
+      const maxSlots = context.pipelineOptions?.maxSlots as number | undefined;
+      if (maxSlots && freeSlots.length > maxSlots) {
+        freeSlots = freeSlots.slice(0, maxSlots);
+      }
+
+      return { busySlots, freeSlots, timezone, calendarId };
+    } catch (error) {
+      return { error: `Failed to check availability: ${error.message}` };
+    }
+  }
+
+  private async createEvent(
+    args: {
+      title: string;
+      startTime: string;
+      endTime: string;
+      description?: string;
+      timezone?: string;
+    },
+    context: AIToolContext,
+  ): Promise<any> {
+    try {
+      const accessToken = await this.getAccessToken(context);
+      const calendarId = (context.pipelineOptions?.calendarId as string) || 'primary';
+      const timezone = args.timezone || 'UTC';
+
+      const eventBody: any = {
+        summary: args.title,
+        start: { dateTime: args.startTime, timeZone: timezone },
+        end: { dateTime: args.endTime, timeZone: timezone },
+      };
+
+      if (args.description) {
+        eventBody.description = args.description;
+      }
+
+      const response = await fetch(`${EVENTS_URL}/${encodeURIComponent(calendarId)}/events`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(eventBody),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        return {
+          error: error.error?.message || `Calendar API returned HTTP ${response.status}`,
+        };
+      }
+
+      const event = await response.json();
+
+      return {
+        event: {
+          id: event.id,
+          title: event.summary,
+          start: event.start?.dateTime || event.start?.date,
+          end: event.end?.dateTime || event.end?.date,
+          htmlLink: event.htmlLink,
+        },
+      };
+    } catch (error) {
+      return { error: `Failed to create event: ${error.message}` };
+    }
+  }
+
+  private async getAccessToken(context: AIToolContext): Promise<string> {
+    return this.oauthService.getValidAccessToken(
+      context.projectId,
+      'google-calendar',
+      context.pluginConfig,
+    );
+  }
+
+  private computeFreeSlots(
+    busySlots: Array<{ start: string; end: string }>,
+    rangeStart: string,
+    rangeEnd: string,
+  ): Array<{ start: string; end: string }> {
+    if (busySlots.length === 0) {
+      return [{ start: rangeStart, end: rangeEnd }];
+    }
+
+    // Sort busy slots by start time
+    const sorted = [...busySlots].sort(
+      (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+    );
+
+    const freeSlots: Array<{ start: string; end: string }> = [];
+    let current = rangeStart;
+
+    for (const busy of sorted) {
+      if (new Date(busy.start).getTime() > new Date(current).getTime()) {
+        freeSlots.push({ start: current, end: busy.start });
+      }
+      if (new Date(busy.end).getTime() > new Date(current).getTime()) {
+        current = busy.end;
+      }
+    }
+
+    if (new Date(current).getTime() < new Date(rangeEnd).getTime()) {
+      freeSlots.push({ start: current, end: rangeEnd });
+    }
+
+    return freeSlots;
+  }
+}

--- a/apps/backend/src/pipelines/ai-plugins/plugins/index.ts
+++ b/apps/backend/src/pipelines/ai-plugins/plugins/index.ts
@@ -1,2 +1,3 @@
 export * from './calculator.plugin';
 export * from './web-search.plugin';
+export * from './google-calendar.plugin';

--- a/apps/backend/src/pipelines/execution/step-handler.interface.ts
+++ b/apps/backend/src/pipelines/execution/step-handler.interface.ts
@@ -416,6 +416,13 @@ export interface AIHandlerConfig extends BaseHandlerConfig {
      * Each ID should match a plugin's `metadata.id` (e.g., 'calculator', 'web-search').
      */
     enabled?: string[];
+
+    /**
+     * Per-plugin options configured at the pipeline level.
+     * Keys are plugin IDs, values are option objects.
+     * e.g., { 'google-calendar': { calendarId: 'demos@group.calendar.google.com' } }
+     */
+    options?: Record<string, Record<string, unknown>>;
   };
 
   /**

--- a/apps/backend/src/pipelines/handlers/ai.handler.ts
+++ b/apps/backend/src/pipelines/handlers/ai.handler.ts
@@ -325,7 +325,10 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
     // Only load plugins if the step config enables them
     if (config.plugins?.mode && config.plugins.mode !== 'none') {
       try {
-        const allPluginTools = await this.pluginService.buildToolsForProject(context.projectId);
+        const allPluginTools = await this.pluginService.buildToolsForProject(
+          context.projectId,
+          config.plugins.options,
+        );
         const filteredPluginTools = this.filterPluginTools(allPluginTools, config.plugins);
         const pluginToolNames = Object.keys(filteredPluginTools);
 

--- a/apps/backend/src/pipelines/pipelines.module.ts
+++ b/apps/backend/src/pipelines/pipelines.module.ts
@@ -36,8 +36,11 @@ import { AuthRequiredValidator, RateLimitValidator } from './execution/validator
 import {
   AIToolPluginRegistry,
   AIToolPluginService,
+  AIPluginsController,
+  GoogleOAuthService,
   CalculatorPlugin,
   WebSearchPlugin,
+  GoogleCalendarPlugin,
 } from './ai-plugins';
 
 @Module({
@@ -45,6 +48,7 @@ import {
   controllers: [
     PipelineSchemasController,
     PipelineDataController,
+    AIPluginsController,
   ],
   providers: [
     // Core services
@@ -78,10 +82,12 @@ import {
     // AI Plugin system
     AIToolPluginRegistry,
     AIToolPluginService,
+    GoogleOAuthService,
     // Built-in plugins (self-register via constructor)
     // To add a new plugin: create the class in ai-plugins/plugins/, add it here
     CalculatorPlugin,
     WebSearchPlugin,
+    GoogleCalendarPlugin,
   ],
   exports: [
     PipelineExecutionService,

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { ResetPasswordPage } from '@/pages/ResetPasswordPage';
 import { VerifyEmailPage } from '@/pages/VerifyEmailPage';
 import { SetupPage } from '@/pages/SetupPage';
 import { InvitationAcceptPage } from '@/pages/InvitationAcceptPage';
+import { OAuthCallbackPage } from '@/pages/OAuthCallbackPage';
 import { Toaster } from '@/components/ui/toaster';
 import { Header } from '@/components/layout/Header';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
@@ -54,6 +55,9 @@ function App() {
         <Route path="/reset-password" element={<ResetPasswordPage />} />
         <Route path="/verify-email" element={<VerifyEmailPage />} />
         <Route path="/invite/:token" element={<InvitationAcceptPage />} />
+
+        {/* OAuth callback (handles plugin OAuth redirects) */}
+        <Route path="/oauth/callback" element={<ProtectedRoute><OAuthCallbackPage /></ProtectedRoute>} />
 
         {/* User Settings route (requires auth) */}
         <Route path="/settings" element={<ProtectedRoute><UserSettingsPage /></ProtectedRoute>} />

--- a/apps/frontend/src/components/pipelines/handlers/PluginsConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/PluginsConfig.tsx
@@ -1,4 +1,4 @@
-import { useListProjectPluginsQuery } from '@/services/projectsApi';
+import { useListProjectPluginsQuery, useListPluginCalendarsQuery } from '@/services/projectsApi';
 import { Label } from '@/components/ui/label';
 import {
   Select,
@@ -10,11 +10,13 @@ import {
 import { Checkbox } from '@/components/ui/checkbox';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Input } from '@/components/ui/input';
 import { Info } from 'lucide-react';
 
 export interface PluginsConfigValue {
   mode: 'none' | 'all' | 'selected';
   enabled?: string[];
+  options?: Record<string, Record<string, unknown>>;
 }
 
 interface PluginsConfigProps {
@@ -23,10 +25,106 @@ interface PluginsConfigProps {
   projectId: string;
 }
 
+function GoogleCalendarOptions({
+  projectId,
+  options,
+  onChange,
+}: {
+  projectId: string;
+  options: Record<string, unknown>;
+  onChange: (opts: Record<string, unknown>) => void;
+}) {
+  const { data: calendarsData, isLoading, isError } = useListPluginCalendarsQuery(projectId);
+  const calendars = calendarsData?.calendars || [];
+
+  return (
+    <div className="ml-7 mt-2 space-y-3 border-l-2 border-muted pl-3">
+      <div className="space-y-1">
+        <Label className="text-xs">Calendar</Label>
+        {isLoading ? (
+          <Skeleton className="h-8 w-full" />
+        ) : isError ? (
+          <p className="text-xs text-muted-foreground">
+            Could not load calendars. Ensure the Google Calendar API is enabled in your GCP project.
+          </p>
+        ) : calendars.length > 0 ? (
+          <Select
+            value={(options.calendarId as string) || 'primary'}
+            onValueChange={(v) => onChange({ ...options, calendarId: v === 'primary' ? undefined : v })}
+          >
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue placeholder="Primary calendar" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="primary">Primary calendar</SelectItem>
+              {calendars
+                .filter((c) => !c.primary)
+                .map((cal) => (
+                  <SelectItem key={cal.id} value={cal.id}>
+                    {cal.summary}
+                  </SelectItem>
+                ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Connect a Google account in project settings to select a calendar.
+          </p>
+        )}
+      </div>
+      <div className="space-y-1">
+        <Label className="text-xs">Look-ahead days</Label>
+        <Input
+          type="number"
+          min={1}
+          max={90}
+          className="h-8 text-xs w-24"
+          value={(options.lookAheadDays as number) || 7}
+          onChange={(e) =>
+            onChange({ ...options, lookAheadDays: parseInt(e.target.value) || 7 })
+          }
+        />
+        <p className="text-xs text-muted-foreground">
+          Default days to look ahead for availability (1-90)
+        </p>
+      </div>
+      <div className="space-y-1">
+        <Label className="text-xs">Max slots</Label>
+        <Input
+          type="number"
+          min={1}
+          max={20}
+          className="h-8 text-xs w-24"
+          value={(options.maxSlots as number) || ''}
+          placeholder="All"
+          onChange={(e) => {
+            const val = parseInt(e.target.value);
+            onChange({ ...options, maxSlots: val > 0 ? val : undefined });
+          }}
+        />
+        <p className="text-xs text-muted-foreground">
+          Maximum free slots to return (leave empty for all)
+        </p>
+      </div>
+    </div>
+  );
+}
+
 export function PluginsConfig({ config, onChange, projectId }: PluginsConfigProps) {
   const { data: plugins, isLoading } = useListProjectPluginsQuery(projectId);
   // Only show plugins that are enabled at the project level
   const enabledPlugins = (plugins ?? []).filter((p) => p.enabled);
+
+  const getPluginOptions = (pluginId: string): Record<string, unknown> => {
+    return config.options?.[pluginId] || {};
+  };
+
+  const setPluginOptions = (pluginId: string, opts: Record<string, unknown>) => {
+    onChange({
+      ...config,
+      options: { ...(config.options || {}), [pluginId]: opts },
+    });
+  };
 
   return (
     <div className="space-y-4">
@@ -68,37 +166,60 @@ export function PluginsConfig({ config, onChange, projectId }: PluginsConfigProp
               </AlertDescription>
             </Alert>
           ) : (
-            <div className="space-y-2 max-h-48 overflow-y-auto rounded-md border p-3">
+            <div className="space-y-2 max-h-64 overflow-y-auto rounded-md border p-3">
               {enabledPlugins.map((plugin) => (
-                <div key={plugin.id} className="flex items-start gap-3">
-                  <Checkbox
-                    id={`plugin-${plugin.id}`}
-                    checked={config.enabled?.includes(plugin.id) ?? false}
-                    onCheckedChange={(checked) => {
-                      const current = config.enabled ?? [];
-                      onChange({
-                        ...config,
-                        enabled: checked
-                          ? [...current, plugin.id]
-                          : current.filter((id) => id !== plugin.id),
-                      });
-                    }}
-                  />
-                  <div className="flex-1 leading-none">
-                    <label
-                      htmlFor={`plugin-${plugin.id}`}
-                      className="font-medium text-sm cursor-pointer"
-                    >
-                      {plugin.name}
-                    </label>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      {plugin.description}
-                    </p>
+                <div key={plugin.id}>
+                  <div className="flex items-start gap-3">
+                    <Checkbox
+                      id={`plugin-${plugin.id}`}
+                      checked={config.enabled?.includes(plugin.id) ?? false}
+                      onCheckedChange={(checked) => {
+                        const current = config.enabled ?? [];
+                        onChange({
+                          ...config,
+                          enabled: checked
+                            ? [...current, plugin.id]
+                            : current.filter((id) => id !== plugin.id),
+                        });
+                      }}
+                    />
+                    <div className="flex-1 leading-none">
+                      <label
+                        htmlFor={`plugin-${plugin.id}`}
+                        className="font-medium text-sm cursor-pointer"
+                      >
+                        {plugin.name}
+                      </label>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {plugin.description}
+                      </p>
+                    </div>
                   </div>
+                  {/* Per-plugin options for Google Calendar */}
+                  {plugin.id === 'google-calendar' &&
+                    config.enabled?.includes(plugin.id) && (
+                      <GoogleCalendarOptions
+                        projectId={projectId}
+                        options={getPluginOptions(plugin.id)}
+                        onChange={(opts) => setPluginOptions(plugin.id, opts)}
+                      />
+                    )}
                 </div>
               ))}
             </div>
           )}
+        </div>
+      )}
+
+      {/* Show per-plugin options for "all" mode too */}
+      {config.mode === 'all' && !isLoading && enabledPlugins.some((p) => p.id === 'google-calendar') && (
+        <div className="space-y-2">
+          <Label>Google Calendar Options</Label>
+          <GoogleCalendarOptions
+            projectId={projectId}
+            options={getPluginOptions('google-calendar')}
+            onChange={(opts) => setPluginOptions('google-calendar', opts)}
+          />
         </div>
       )}
 

--- a/apps/frontend/src/components/project/ProjectAIPluginsSection.tsx
+++ b/apps/frontend/src/components/project/ProjectAIPluginsSection.tsx
@@ -4,6 +4,8 @@ import {
   useEnableProjectPluginMutation,
   useDisableProjectPluginMutation,
   useUpdateProjectPluginConfigMutation,
+  useLazyInitiatePluginOAuthQuery,
+  useDisconnectPluginOAuthMutation,
   PluginListItem,
   Project,
 } from '@/services/projectsApi';
@@ -26,15 +28,20 @@ import {
   Puzzle,
   Calculator,
   Search,
+  Calendar,
   Settings2,
+  ExternalLink,
+  Unplug,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useToast } from '@/hooks/use-toast';
+import { useParams } from 'react-router-dom';
 
 // Icon mapping for plugins
 const PLUGIN_ICONS: Record<string, React.ElementType> = {
   calculator: Calculator,
   search: Search,
+  calendar: Calendar,
 };
 
 // Category display config
@@ -49,15 +56,24 @@ function PluginCard({
   plugin,
   onToggle,
   onConfigure,
+  onConnectOAuth,
+  onDisconnectOAuth,
   isToggling,
+  isConnecting,
 }: {
   plugin: PluginListItem;
   onToggle: (enabled: boolean) => void;
   onConfigure: () => void;
+  onConnectOAuth: () => void;
+  onDisconnectOAuth: () => void;
   isToggling: boolean;
+  isConnecting: boolean;
 }) {
   const Icon = PLUGIN_ICONS[plugin.icon || ''] || Puzzle;
   const categoryColor = CATEGORY_COLORS[plugin.category] || 'bg-gray-50 text-gray-700';
+  const isOAuthPlugin = plugin.requiresOAuth;
+  const isOAuthConnected = isOAuthPlugin && plugin.oauthConnectedEmail;
+  const needsOAuthConnect = isOAuthPlugin && plugin.enabled && !plugin.oauthConnectedEmail && plugin.hasConfig;
 
   return (
     <div className="border rounded-lg p-4">
@@ -74,6 +90,44 @@ function PluginCard({
               </Badge>
             </div>
             <p className="text-sm text-muted-foreground mt-0.5">{plugin.description}</p>
+
+            {/* OAuth connected state */}
+            {isOAuthConnected && (
+              <div className="flex items-center gap-2 mt-2">
+                <Badge variant="secondary" className="text-xs font-normal">
+                  Connected: {plugin.oauthConnectedEmail}
+                </Badge>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs text-destructive hover:text-destructive"
+                  onClick={onDisconnectOAuth}
+                >
+                  <Unplug className="h-3 w-3 mr-1" />
+                  Disconnect
+                </Button>
+              </div>
+            )}
+
+            {/* OAuth needs connect */}
+            {needsOAuthConnect && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-2 h-7 text-xs"
+                onClick={onConnectOAuth}
+                disabled={isConnecting}
+              >
+                {isConnecting ? (
+                  <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                ) : (
+                  <ExternalLink className="h-3 w-3 mr-1" />
+                )}
+                Connect Google Account
+              </Button>
+            )}
+
+            {/* Configure button */}
             {plugin.enabled && plugin.configSchema && (
               <Button
                 variant="ghost"
@@ -120,7 +174,6 @@ function PluginConfigDialog({
   if (!plugin) return null;
 
   // Derive config fields from plugin metadata
-  // The configSchema from the backend is a Zod schema serialized — for now we handle known plugins
   const configFields = getConfigFieldsForPlugin(plugin.id);
 
   const handleSave = () => {
@@ -214,6 +267,22 @@ function getConfigFieldsForPlugin(pluginId: string): ConfigField[] {
           helpText: 'The Custom Search Engine ID (cx parameter)',
         },
       ];
+    case 'google-calendar':
+      return [
+        {
+          key: 'clientId',
+          label: 'Google OAuth Client ID',
+          placeholder: 'xxxxx.apps.googleusercontent.com',
+          helpText: 'From Google Cloud Console > APIs & Services > Credentials',
+        },
+        {
+          key: 'clientSecret',
+          label: 'Google OAuth Client Secret',
+          placeholder: 'GOCSPX-...',
+          secret: true,
+          helpText: 'The client secret for your OAuth 2.0 application',
+        },
+      ];
     default:
       return [];
   }
@@ -225,13 +294,17 @@ interface ProjectAIPluginsSectionProps {
 
 export function ProjectAIPluginsSection({ project }: ProjectAIPluginsSectionProps) {
   const { toast } = useToast();
+  const { owner, repo } = useParams<{ owner: string; repo: string }>();
   const { data: plugins, isLoading } = useListProjectPluginsQuery(project.id);
   const [enablePlugin] = useEnableProjectPluginMutation();
   const [disablePlugin] = useDisableProjectPluginMutation();
   const [updatePluginConfig, { isLoading: isUpdatingConfig }] =
     useUpdateProjectPluginConfigMutation();
+  const [initiateOAuth] = useLazyInitiatePluginOAuthQuery();
+  const [disconnectOAuth] = useDisconnectPluginOAuthMutation();
 
   const [togglingPlugin, setTogglingPlugin] = useState<string | null>(null);
+  const [connectingPlugin, setConnectingPlugin] = useState<string | null>(null);
   const [configuringPlugin, setConfiguringPlugin] = useState<PluginListItem | null>(null);
 
   const handleToggle = async (plugin: PluginListItem, enabled: boolean) => {
@@ -291,6 +364,58 @@ export function ProjectAIPluginsSection({ project }: ProjectAIPluginsSectionProp
     }
   };
 
+  const handleConnectOAuth = async (plugin: PluginListItem) => {
+    setConnectingPlugin(plugin.id);
+    try {
+      const redirectUri = window.location.origin + '/oauth/callback';
+
+      // Store context for the callback page
+      sessionStorage.setItem(
+        'oauth_plugin_context',
+        JSON.stringify({
+          projectId: project.id,
+          pluginId: plugin.id,
+          owner,
+          repo,
+        }),
+      );
+
+      const result = await initiateOAuth({
+        projectId: project.id,
+        pluginId: plugin.id,
+        redirectUri,
+      }).unwrap();
+
+      // Redirect to Google OAuth
+      window.location.href = result.authUrl;
+    } catch (error: unknown) {
+      const err = error as { data?: { message?: string } };
+      toast({
+        title: 'Error',
+        description: err.data?.message || 'Failed to initiate OAuth connection',
+        variant: 'destructive',
+      });
+      setConnectingPlugin(null);
+    }
+  };
+
+  const handleDisconnectOAuth = async (plugin: PluginListItem) => {
+    try {
+      await disconnectOAuth({
+        projectId: project.id,
+        pluginId: plugin.id,
+      }).unwrap();
+      toast({ title: `${plugin.name} disconnected` });
+    } catch (error: unknown) {
+      const err = error as { data?: { message?: string } };
+      toast({
+        title: 'Error',
+        description: err.data?.message || 'Failed to disconnect',
+        variant: 'destructive',
+      });
+    }
+  };
+
   if (isLoading) {
     return (
       <Card className="mt-6">
@@ -337,7 +462,10 @@ export function ProjectAIPluginsSection({ project }: ProjectAIPluginsSectionProp
                 plugin={plugin}
                 onToggle={(enabled) => handleToggle(plugin, enabled)}
                 onConfigure={() => setConfiguringPlugin(plugin)}
+                onConnectOAuth={() => handleConnectOAuth(plugin)}
+                onDisconnectOAuth={() => handleDisconnectOAuth(plugin)}
                 isToggling={togglingPlugin === plugin.id}
+                isConnecting={connectingPlugin === plugin.id}
               />
             ))
           ) : (

--- a/apps/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/apps/frontend/src/pages/OAuthCallbackPage.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useCompletePluginOAuthMutation } from '@/services/projectsApi';
+import { Loader2, CheckCircle2, XCircle } from 'lucide-react';
+
+export function OAuthCallbackPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [completeOAuth] = useCompletePluginOAuthMutation();
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [connectedEmail, setConnectedEmail] = useState('');
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    const state = searchParams.get('state');
+    const error = searchParams.get('error');
+
+    if (error) {
+      setStatus('error');
+      setErrorMessage(
+        error === 'access_denied'
+          ? 'Access was denied. Please try again.'
+          : `OAuth error: ${error}`,
+      );
+      return;
+    }
+
+    if (!code || !state) {
+      setStatus('error');
+      setErrorMessage('Missing authorization code or state parameter.');
+      return;
+    }
+
+    // Read stored context from sessionStorage
+    const storedData = sessionStorage.getItem('oauth_plugin_context');
+    if (!storedData) {
+      setStatus('error');
+      setErrorMessage('OAuth session expired. Please try connecting again.');
+      return;
+    }
+
+    const { projectId, pluginId, owner, repo } = JSON.parse(storedData);
+    sessionStorage.removeItem('oauth_plugin_context');
+
+    const redirectUri = window.location.origin + '/oauth/callback';
+
+    completeOAuth({ projectId, pluginId, code, state, redirectUri })
+      .unwrap()
+      .then((result) => {
+        setConnectedEmail(result.connectedEmail);
+        setStatus('success');
+        // Redirect to project settings after a brief delay
+        setTimeout(() => {
+          if (owner && repo) {
+            navigate(`/repo/${owner}/${repo}/settings?tab=ai`);
+          } else {
+            navigate('/');
+          }
+        }, 2000);
+      })
+      .catch((err) => {
+        setStatus('error');
+        setErrorMessage(
+          err.data?.message || 'Failed to complete OAuth connection. Please try again.',
+        );
+      });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="flex items-center justify-center min-h-[60vh]">
+      <div className="text-center space-y-4 max-w-md">
+        {status === 'loading' && (
+          <>
+            <Loader2 className="h-8 w-8 animate-spin mx-auto text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              Completing Google account connection...
+            </p>
+          </>
+        )}
+
+        {status === 'success' && (
+          <>
+            <CheckCircle2 className="h-8 w-8 mx-auto text-green-600" />
+            <div>
+              <p className="font-medium">Google Account Connected</p>
+              <p className="text-sm text-muted-foreground mt-1">
+                Connected as {connectedEmail}
+              </p>
+              <p className="text-xs text-muted-foreground mt-2">
+                Redirecting to project settings...
+              </p>
+            </div>
+          </>
+        )}
+
+        {status === 'error' && (
+          <>
+            <XCircle className="h-8 w-8 mx-auto text-destructive" />
+            <div>
+              <p className="font-medium">Connection Failed</p>
+              <p className="text-sm text-muted-foreground mt-1">{errorMessage}</p>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/services/projectsApi.ts
+++ b/apps/frontend/src/services/projectsApi.ts
@@ -69,6 +69,14 @@ export interface PluginListItem {
   enabled: boolean;
   hasConfig: boolean;
   configSchema?: Record<string, unknown>;
+  oauthConnectedEmail?: string;
+  pipelineOptionsSchema?: Record<string, unknown>;
+}
+
+export interface CalendarListItem {
+  id: string;
+  summary: string;
+  primary: boolean;
 }
 
 // Skill types
@@ -291,6 +299,50 @@ export const projectsApi = api.injectEndpoints({
       ],
     }),
 
+    // OAuth Plugin endpoints
+    initiatePluginOAuth: builder.query<
+      { authUrl: string },
+      { projectId: string; pluginId: string; redirectUri: string }
+    >({
+      query: ({ projectId, pluginId, redirectUri }) =>
+        `/api/projects/${projectId}/ai-plugins/${pluginId}/oauth/initiate?redirectUri=${encodeURIComponent(redirectUri)}`,
+    }),
+
+    completePluginOAuth: builder.mutation<
+      { success: boolean; connectedEmail: string },
+      { projectId: string; pluginId: string; code: string; state: string; redirectUri: string }
+    >({
+      query: ({ projectId, pluginId, code, state, redirectUri }) => ({
+        url: `/api/projects/${projectId}/ai-plugins/${pluginId}/oauth/callback`,
+        method: 'POST',
+        body: { code, state, redirectUri },
+      }),
+      invalidatesTags: (_result, _error, { projectId }) => [
+        { type: 'ProjectPlugin' as const, id: projectId },
+      ],
+    }),
+
+    disconnectPluginOAuth: builder.mutation<
+      void,
+      { projectId: string; pluginId: string }
+    >({
+      query: ({ projectId, pluginId }) => ({
+        url: `/api/projects/${projectId}/ai-plugins/${pluginId}/oauth`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: (_result, _error, { projectId }) => [
+        { type: 'ProjectPlugin' as const, id: projectId },
+      ],
+    }),
+
+    listPluginCalendars: builder.query<
+      { calendars: CalendarListItem[] },
+      string
+    >({
+      query: (projectId) =>
+        `/api/projects/${projectId}/ai-plugins/google-calendar/calendars`,
+    }),
+
     // Skills endpoint
     listProjectSkills: builder.query<
       { skills: SkillSummary[] },
@@ -326,6 +378,11 @@ export const {
   useEnableProjectPluginMutation,
   useUpdateProjectPluginConfigMutation,
   useDisableProjectPluginMutation,
+  // Plugin OAuth
+  useLazyInitiatePluginOAuthQuery,
+  useCompletePluginOAuthMutation,
+  useDisconnectPluginOAuthMutation,
+  useListPluginCalendarsQuery,
   // Skills
   useListProjectSkillsQuery,
 } = projectsApi;


### PR DESCRIPTION
## Summary

- Adds a **Google Calendar** AI plugin with two tools: `get_availability` (FreeBusy API) and `create_event` (Events API)
- Full **OAuth2 flow**: admin enters Client ID/Secret, connects Google account, tokens stored encrypted per-project
- **Per-pipeline plugin options**: calendarId dropdown (target different calendars per pipeline), lookAheadDays, maxSlots
- OAuth callback page with redirect back to AI settings tab
- Frontend plugin cards show connected email with Disconnect button

## Files Changed

| Area | Files | What |
|------|-------|------|
| Backend | `google-oauth.service.ts` | OAuth2 flow (auth URL, token exchange, refresh, revoke, calendar list) |
| Backend | `google-calendar.plugin.ts` | Plugin with get_availability + create_event tools |
| Backend | `ai-plugins.controller.ts` | OAuth + calendars list endpoints |
| Backend | `ai-tool-plugin.interface.ts` | Added pipelineOptions to context, pipelineOptionsSchema to metadata |
| Backend | `ai-tool-plugin.service.ts` | oauthConnectedEmail in list, pipeline options in buildTools |
| Backend | `step-handler.interface.ts` | Added options to plugins config |
| Backend | `ai.handler.ts` | Pass plugin options to buildToolsForProject |
| Frontend | `ProjectAIPluginsSection.tsx` | OAuth-aware plugin cards (Connect/Disconnect) |
| Frontend | `PluginsConfig.tsx` | Per-pipeline Google Calendar options (calendar, lookAheadDays, maxSlots) |
| Frontend | `OAuthCallbackPage.tsx` | Handles OAuth redirect |
| Frontend | `projectsApi.ts` | OAuth + calendars RTK Query endpoints |
| Frontend | `App.tsx` | /oauth/callback route |

## Test plan

- [ ] Enable Google Calendar plugin → config dialog asks for Client ID + Client Secret
- [ ] After saving, "Connect Google Account" button appears → completes OAuth flow
- [ ] Connected email shown with Disconnect button
- [ ] Pipeline editor shows calendar dropdown, look-ahead days, max slots options
- [ ] Chat: "What's your schedule this week?" → returns free/busy slots
- [ ] Chat: "Schedule a meeting tomorrow at 2pm" → creates event
- [ ] Disconnect → clears tokens, keeps client credentials for re-connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)