### PR TITLE
feat: add file upload/serve pipeline handlers with schema generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ lerna-debug.log*
 *.sw?
 
 # Uploads directory (local development)
-uploads/
+/uploads/
 apps/backend/uploads/
 
 # Database

--- a/apps/backend/src/pipelines/dto/generate-upload-schema.dto.ts
+++ b/apps/backend/src/pipelines/dto/generate-upload-schema.dto.ts
@@ -1,0 +1,131 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsUUID,
+  IsIn,
+  IsOptional,
+  IsBoolean,
+  IsNumber,
+  IsArray,
+  MaxLength,
+  Matches,
+  Min,
+} from 'class-validator';
+
+/**
+ * DTO for generating an upload schema with associated pipelines.
+ * Creates a schema for file upload metadata with POST (upload) and GET (serve) pipelines.
+ */
+export class GenerateUploadSchemaDto {
+  @ApiProperty({
+    description: 'Project ID this schema belongs to',
+  })
+  @IsUUID()
+  projectId: string;
+
+  @ApiProperty({
+    description:
+      'Schema name (unique within project). Use lowercase letters, numbers, and underscores.',
+    example: 'product_images',
+  })
+  @IsString()
+  @MaxLength(255)
+  @Matches(/^[a-z][a-z0-9_]*$/, {
+    message:
+      'Schema name must start with a letter and contain only lowercase letters, numbers, and underscores',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: 'Storage sub-directory name for uploaded files',
+    example: 'images',
+  })
+  @IsString()
+  @MaxLength(100)
+  @Matches(/^[a-z][a-z0-9_-]*$/, {
+    message:
+      'Sub-directory must start with a letter and contain only lowercase letters, numbers, hyphens, and underscores',
+  })
+  subDir: string;
+
+  @ApiPropertyOptional({
+    description: 'Enable YYYY-MM-DD date folders in storage path',
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  dateBucket?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Maximum file size in bytes',
+    example: 10485760,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  maxFileSize?: number;
+
+  @ApiPropertyOptional({
+    description: 'Allowed MIME type patterns (e.g. ["image/*", "application/pdf"])',
+    example: ['image/*'],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  allowedMimeTypes?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Access control for the GET (serve) pipeline',
+    enum: ['public', 'authenticated', 'role'],
+    default: 'public',
+  })
+  @IsOptional()
+  @IsIn(['public', 'authenticated', 'role'])
+  accessControl?: 'public' | 'authenticated' | 'role';
+
+  @ApiPropertyOptional({
+    description: 'Required role when accessControl is "role"',
+  })
+  @IsOptional()
+  @IsString()
+  requiredRole?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Existing rule set ID to add pipelines to. If not provided, a new rule set will be created.',
+  })
+  @IsOptional()
+  @IsUUID()
+  ruleSetId?: string;
+}
+
+/**
+ * Response DTO for upload schema generation
+ */
+export class GenerateUploadSchemaResponseDto {
+  @ApiProperty({
+    description: 'The created schema',
+  })
+  schema: {
+    id: string;
+    name: string;
+    projectId: string;
+    fields: { name: string; type: string; required: boolean }[];
+    createdAt: string;
+    updatedAt: string;
+  };
+
+  @ApiProperty({
+    description: 'The created pipelines',
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        path: { type: 'string' },
+        method: { type: 'string' },
+      },
+    },
+  })
+  pipelines: { id: string; path: string; method: string }[];
+}

--- a/apps/backend/src/pipelines/dto/index.ts
+++ b/apps/backend/src/pipelines/dto/index.ts
@@ -5,3 +5,4 @@ export * from './pipeline-data.dto';
 export * from './response.dto';
 export * from './generate-state-schema.dto';
 export * from './generate-chat-schema.dto';
+export * from './generate-upload-schema.dto';

--- a/apps/backend/src/pipelines/execution/step-handler.interface.ts
+++ b/apps/backend/src/pipelines/execution/step-handler.interface.ts
@@ -514,5 +514,54 @@ export interface AIHandlerConfig extends BaseHandlerConfig {
   aiResponseFields?: Record<string, string>;
 }
 
+/**
+ * Configuration for file_upload_handler
+ */
+export interface FileUploadHandlerConfig extends BaseHandlerConfig {
+  /**
+   * Schema ID for storing upload metadata records
+   */
+  schemaId: string;
+
+  /**
+   * Storage sub-directory (e.g. "images", "documents")
+   */
+  subDir: string;
+
+  /**
+   * Enable YYYY-MM-DD date folders in storage path
+   * @default false
+   */
+  dateBucket?: boolean;
+
+  /**
+   * Maximum file size in bytes
+   * @default 10485760 (10MB)
+   */
+  maxFileSize?: number;
+
+  /**
+   * Allowed MIME type patterns (e.g. ["image/*", "application/pdf"])
+   * @default ["*\/*"]
+   */
+  allowedMimeTypes?: string[];
+}
+
+/**
+ * Configuration for file_serve_handler
+ */
+export interface FileServeHandlerConfig extends BaseHandlerConfig {
+  /**
+   * Storage sub-directory to serve from
+   */
+  subDir: string;
+
+  /**
+   * Cache-Control max-age in seconds
+   * @default 3600
+   */
+  cacheMaxAge?: number;
+}
+
 // Backwards compatibility alias
 export type ChatHandlerConfig = AIHandlerConfig;

--- a/apps/backend/src/pipelines/handlers/file-serve.handler.ts
+++ b/apps/backend/src/pipelines/handlers/file-serve.handler.ts
@@ -1,0 +1,170 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { StepHandler, FileServeHandlerConfig } from '../execution/step-handler.interface';
+import { StepHandlerRegistry } from '../execution/step-handler.registry';
+import { PipelineContext, StepResult } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+import { ConfigurationError } from '../errors';
+import { IStorageAdapter, STORAGE_ADAPTER } from '../../storage/storage.interface';
+import * as path from 'path';
+
+// Common MIME type lookup
+const MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.pdf': 'application/pdf',
+  '.zip': 'application/zip',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mp3': 'audio/mpeg',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.txt': 'text/plain',
+  '.csv': 'text/csv',
+  '.xml': 'application/xml',
+};
+
+/**
+ * File Serve Handler
+ *
+ * Serves files from storage through a pipeline.
+ * Access control is handled by pipeline validators, not this handler.
+ */
+@Injectable()
+export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
+  readonly type = 'file_serve_handler' as const;
+  private readonly logger = new Logger(FileServeHandler.name);
+
+  constructor(
+    private readonly registry: StepHandlerRegistry,
+    @Inject(STORAGE_ADAPTER) private readonly storageAdapter: IStorageAdapter,
+  ) {
+    this.registry.register(this);
+  }
+
+  validateConfig(config: FileServeHandlerConfig): void {
+    if (!config.subDir) {
+      throw new ConfigurationError('subDir is required', 'file_serve_handler');
+    }
+  }
+
+  async execute(context: PipelineContext, step: PipelineStep): Promise<StepResult> {
+    const config = step.config as FileServeHandlerConfig;
+    const stepName = step.name || 'file_serve_handler';
+
+    this.logger.debug(`Executing file serve handler for step '${stepName}'`);
+
+    const owner = context.deployment?.owner;
+    const repo = context.deployment?.repo;
+    if (!owner || !repo) {
+      throw new ConfigurationError(
+        'Deployment context (owner/repo) is required for file serving',
+        stepName,
+      );
+    }
+
+    // Extract the file path from the request URL
+    // The wildcard portion comes after /api/uploads/{subDir}/
+    const requestPath = context.metadata.path;
+    const prefix = `/api/uploads/${config.subDir}/`;
+    let filePath = '';
+
+    if (requestPath.startsWith(prefix)) {
+      filePath = requestPath.slice(prefix.length);
+    } else {
+      // Try to extract from X-Original-URI if available
+      const originalUri = context.metadata.headers['x-original-uri'] as string | undefined;
+      if (originalUri && originalUri.includes(prefix)) {
+        filePath = originalUri.slice(originalUri.indexOf(prefix) + prefix.length);
+      }
+    }
+
+    if (!filePath) {
+      return {
+        success: false,
+        error: {
+          code: 'FILE_NOT_FOUND',
+          message: 'No file path specified',
+        },
+      };
+    }
+
+    // Sanitize path to prevent traversal attacks
+    const sanitized = filePath.replace(/\.\./g, '').replace(/\/\//g, '/');
+    const storageKey = `${owner}/${repo}/uploads/${config.subDir}/${sanitized}`;
+
+    try {
+      // Check if storage adapter supports downloadWithCacheInfo
+      let data: Buffer;
+      let etag: string | undefined;
+
+      if (this.storageAdapter.downloadWithCacheInfo) {
+        const result = await this.storageAdapter.downloadWithCacheInfo(storageKey);
+        data = result.data;
+      } else {
+        data = await this.storageAdapter.download(storageKey);
+      }
+
+      // Try to get metadata for ETag
+      try {
+        const metadata = await this.storageAdapter.getMetadata(storageKey);
+        etag = metadata.etag;
+      } catch {
+        // Non-fatal
+      }
+
+      // Determine content type from file extension
+      const ext = path.extname(sanitized).toLowerCase();
+      const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+      const cacheMaxAge = config.cacheMaxAge ?? 3600;
+
+      // Set response headers and stream content
+      const res = context.request.res;
+      if (!res) {
+        return {
+          success: false,
+          error: {
+            code: 'NO_RESPONSE',
+            message: 'Response object not available',
+          },
+        };
+      }
+
+      res.setHeader('Content-Type', contentType);
+      res.setHeader('Content-Length', data.length);
+      res.setHeader('Cache-Control', `public, max-age=${cacheMaxAge}`);
+      if (etag) {
+        res.setHeader('ETag', etag);
+      }
+
+      res.status(200).end(data);
+
+      return {
+        success: true,
+        terminates: true, // Signal that response was already sent
+      };
+    } catch (error) {
+      this.logger.debug(`File not found: ${storageKey}`);
+      const res = context.request.res;
+      if (res && !res.headersSent) {
+        res.status(404).json({
+          error: 'File not found',
+          code: 'FILE_NOT_FOUND',
+        });
+      }
+      return {
+        success: true,
+        terminates: true,
+      };
+    }
+  }
+}

--- a/apps/backend/src/pipelines/handlers/file-upload.handler.ts
+++ b/apps/backend/src/pipelines/handlers/file-upload.handler.ts
@@ -1,0 +1,204 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { StepHandler, FileUploadHandlerConfig } from '../execution/step-handler.interface';
+import { StepHandlerRegistry } from '../execution/step-handler.registry';
+import { PipelineContext, StepResult } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+import { PipelineDataService } from '../pipeline-data.service';
+import { PipelineSchemasService } from '../pipeline-schemas.service';
+import { ConfigurationError, SchemaNotFoundError } from '../errors';
+import { IStorageAdapter, STORAGE_ADAPTER } from '../../storage/storage.interface';
+import { db } from '../../db/client';
+import { assets } from '../../db/schema';
+import { AssetType } from '../../types/asset-type.enum';
+import { randomUUID } from 'crypto';
+import { createHash } from 'crypto';
+
+/**
+ * File Upload Handler
+ *
+ * Handles file uploads via multipart form data.
+ * Stores files in the storage adapter and creates pipeline_data + asset records.
+ */
+@Injectable()
+export class FileUploadHandler implements StepHandler<FileUploadHandlerConfig> {
+  readonly type = 'file_upload_handler' as const;
+  private readonly logger = new Logger(FileUploadHandler.name);
+
+  constructor(
+    private readonly registry: StepHandlerRegistry,
+    private readonly dataService: PipelineDataService,
+    private readonly schemasService: PipelineSchemasService,
+    @Inject(STORAGE_ADAPTER) private readonly storageAdapter: IStorageAdapter,
+  ) {
+    this.registry.register(this);
+  }
+
+  validateConfig(config: FileUploadHandlerConfig): void {
+    if (!config.schemaId) {
+      throw new ConfigurationError('schemaId is required', 'file_upload_handler');
+    }
+    if (!config.subDir) {
+      throw new ConfigurationError('subDir is required', 'file_upload_handler');
+    }
+  }
+
+  async execute(context: PipelineContext, step: PipelineStep): Promise<StepResult> {
+    const config = step.config as FileUploadHandlerConfig;
+    const stepName = step.name || 'file_upload_handler';
+
+    this.logger.debug(`Executing file upload handler for step '${stepName}'`);
+
+    // Verify schema exists and belongs to project
+    const schema = await this.schemasService.getById(config.schemaId);
+    if (!schema) {
+      throw new SchemaNotFoundError(config.schemaId, stepName);
+    }
+    if (schema.projectId !== context.projectId) {
+      throw new ConfigurationError(
+        `Schema '${config.schemaId}' does not belong to this project`,
+        stepName,
+      );
+    }
+
+    // Extract file from multer-parsed request
+    const file = (context.request as any).file as Express.Multer.File | undefined;
+    if (!file) {
+      return {
+        success: false,
+        error: {
+          code: 'NO_FILE',
+          message: 'No file uploaded. Send a multipart form with a "file" field.',
+        },
+      };
+    }
+
+    // Validate MIME type
+    const allowedMimeTypes = config.allowedMimeTypes || ['*/*'];
+    if (!this.isMimeTypeAllowed(file.mimetype, allowedMimeTypes)) {
+      return {
+        success: false,
+        error: {
+          code: 'INVALID_MIME_TYPE',
+          message: `File type "${file.mimetype}" is not allowed. Allowed types: ${allowedMimeTypes.join(', ')}`,
+        },
+      };
+    }
+
+    // Validate file size
+    const maxFileSize = config.maxFileSize || 10 * 1024 * 1024; // default 10MB
+    if (file.size > maxFileSize) {
+      return {
+        success: false,
+        error: {
+          code: 'FILE_TOO_LARGE',
+          message: `File size ${file.size} bytes exceeds maximum ${maxFileSize} bytes`,
+        },
+      };
+    }
+
+    // Build storage key
+    const owner = context.deployment?.owner;
+    const repo = context.deployment?.repo;
+    if (!owner || !repo) {
+      throw new ConfigurationError(
+        'Deployment context (owner/repo) is required for file uploads',
+        stepName,
+      );
+    }
+
+    const uuid = randomUUID();
+    const sanitizedFilename = file.originalname.replace(/[^a-zA-Z0-9._-]/g, '_');
+    let storageKey = `${owner}/${repo}/uploads/${config.subDir}`;
+
+    if (config.dateBucket) {
+      const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+      storageKey += `/${today}`;
+    }
+
+    storageKey += `/${uuid}-${sanitizedFilename}`;
+
+    // Upload to storage
+    await this.storageAdapter.upload(file.buffer, storageKey, {
+      mimeType: file.mimetype,
+    });
+
+    // Build the public URL path
+    const alias = context.deployment?.alias ?? 'production';
+    const publicPath = `/api/uploads/${config.subDir}/${uuid}-${sanitizedFilename}`;
+
+    // Compute content hash
+    const contentHash = createHash('md5').update(file.buffer).digest('hex');
+
+    // Create pipeline_data record with metadata
+    const data: Record<string, unknown> = {
+      filename: sanitizedFilename,
+      storage_path: storageKey,
+      content_type: file.mimetype,
+      size: file.size,
+      url: publicPath,
+      sub_dir: config.subDir,
+      original_name: file.originalname,
+    };
+
+    const record = await this.dataService.create(
+      config.schemaId,
+      context.projectId,
+      data,
+      context.user?.id,
+      context.deployment?.alias ?? null,
+      schema.version,
+    );
+
+    // Create asset record
+    try {
+      await db.insert(assets).values({
+        fileName: sanitizedFilename,
+        originalPath: file.originalname,
+        storageKey,
+        mimeType: file.mimetype,
+        size: file.size,
+        projectId: context.projectId,
+        uploadedBy: context.user?.id || null,
+        assetType: AssetType.UPLOADS,
+        publicPath,
+        contentHash,
+      });
+    } catch (err) {
+      this.logger.warn(`Failed to create asset record: ${err}`);
+      // Non-fatal - the upload and pipeline_data record are the source of truth
+    }
+
+    this.logger.debug(
+      `Uploaded file "${sanitizedFilename}" to ${storageKey} (record ${record.id})`,
+    );
+
+    return {
+      success: true,
+      output: {
+        id: record.id,
+        filename: sanitizedFilename,
+        url: publicPath,
+        storage_path: storageKey,
+        content_type: file.mimetype,
+        size: file.size,
+        original_name: file.originalname,
+      },
+    };
+  }
+
+  /**
+   * Check if a MIME type matches allowed patterns (supports glob like "image/*")
+   */
+  private isMimeTypeAllowed(mimeType: string, allowedTypes: string[]): boolean {
+    for (const pattern of allowedTypes) {
+      if (pattern === '*/*') return true;
+      if (pattern === mimeType) return true;
+      // Handle wildcard patterns like "image/*"
+      if (pattern.endsWith('/*')) {
+        const prefix = pattern.slice(0, -2);
+        if (mimeType.startsWith(prefix + '/')) return true;
+      }
+    }
+    return false;
+  }
+}

--- a/apps/backend/src/pipelines/handlers/index.ts
+++ b/apps/backend/src/pipelines/handlers/index.ts
@@ -8,3 +8,5 @@ export * from './email.handler';
 export * from './db-aggregate.handler';
 export * from './function.handler';
 export * from './ai.handler';
+export * from './file-upload.handler';
+export * from './file-serve.handler';

--- a/apps/backend/src/pipelines/pipeline-schemas.controller.ts
+++ b/apps/backend/src/pipelines/pipeline-schemas.controller.ts
@@ -21,6 +21,7 @@ import {
 import { PipelineSchemasService } from './pipeline-schemas.service';
 import { StateSchemaGeneratorService } from './state-schema-generator.service';
 import { ChatSchemaGeneratorService } from './chat-schema-generator.service';
+import { UploadSchemaGeneratorService } from './upload-schema-generator.service';
 import {
   CreatePipelineSchemaDto,
   UpdatePipelineSchemaDto,
@@ -31,6 +32,8 @@ import {
   GenerateStateSchemaResponseDto,
   GenerateChatSchemaDto,
   GenerateChatSchemaResponseDto,
+  GenerateUploadSchemaDto,
+  GenerateUploadSchemaResponseDto,
 } from './dto';
 import { ApiKeyGuard } from '../auth/api-key.guard';
 import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
@@ -49,6 +52,7 @@ export class PipelineSchemasController {
     private readonly schemasService: PipelineSchemasService,
     private readonly stateSchemaGenerator: StateSchemaGeneratorService,
     private readonly chatSchemaGenerator: ChatSchemaGeneratorService,
+    private readonly uploadSchemaGenerator: UploadSchemaGeneratorService,
   ) {}
 
   @Get('project/:projectId')
@@ -121,6 +125,32 @@ export class PipelineSchemasController {
     @CurrentUser() user: CurrentUserData,
   ): Promise<GenerateChatSchemaResponseDto> {
     return this.chatSchemaGenerator.generateChatSchema(
+      dto,
+      user.id,
+      user.role || 'user',
+    );
+  }
+
+  @Post('generate-upload')
+  @ApiOperation({
+    summary: 'Generate an upload schema with POST/GET pipelines',
+    description:
+      'Creates a schema for file upload metadata with ' +
+      'automatic POST (upload) and GET (serve) pipelines.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Upload schema and pipelines created',
+    type: GenerateUploadSchemaResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input' })
+  @ApiResponse({ status: 403, description: 'Not authorized' })
+  @ApiResponse({ status: 409, description: 'Schema name already exists' })
+  async generateUploadSchema(
+    @Body() dto: GenerateUploadSchemaDto,
+    @CurrentUser() user: CurrentUserData,
+  ): Promise<GenerateUploadSchemaResponseDto> {
+    return this.uploadSchemaGenerator.generateUploadSchema(
       dto,
       user.id,
       user.role || 'user',

--- a/apps/backend/src/pipelines/pipelines.module.ts
+++ b/apps/backend/src/pipelines/pipelines.module.ts
@@ -5,6 +5,7 @@ import { PipelineSchemasService } from './pipeline-schemas.service';
 import { PipelineDataService } from './pipeline-data.service';
 import { StateSchemaGeneratorService } from './state-schema-generator.service';
 import { ChatSchemaGeneratorService } from './chat-schema-generator.service';
+import { UploadSchemaGeneratorService } from './upload-schema-generator.service';
 import {
   PipelineExecutionService,
   StepHandlerRegistry,
@@ -26,6 +27,8 @@ import {
   DbAggregateHandler,
   FunctionHandler,
   AIHandler,
+  FileUploadHandler,
+  FileServeHandler,
 } from './handlers';
 // Services
 import { FunctionRunnerService } from './function-runner.service';
@@ -56,6 +59,7 @@ import {
     PipelineDataService,
     StateSchemaGeneratorService,
     ChatSchemaGeneratorService,
+    UploadSchemaGeneratorService,
     // Execution engine
     PipelineExecutionService,
     StepHandlerRegistry,
@@ -76,6 +80,8 @@ import {
     DbAggregateHandler,
     FunctionHandler,
     AIHandler,
+    FileUploadHandler,
+    FileServeHandler,
     // Validators (auto-register on construction)
     AuthRequiredValidator,
     RateLimitValidator,

--- a/apps/backend/src/pipelines/types.ts
+++ b/apps/backend/src/pipelines/types.ts
@@ -66,7 +66,9 @@ export type HandlerType =
   | 'response_handler'
   | 'function_handler'
   | 'db_aggregate'
-  | 'ai_handler';
+  | 'ai_handler'
+  | 'file_upload_handler'
+  | 'file_serve_handler';
 
 /**
  * Pipeline step definition for execution.

--- a/apps/backend/src/pipelines/upload-schema-generator.service.ts
+++ b/apps/backend/src/pipelines/upload-schema-generator.service.ts
@@ -1,0 +1,305 @@
+import { Injectable, Logger, ConflictException } from '@nestjs/common';
+import { db } from '../db/client';
+import { pipelineSchemas, proxyRuleSets, proxyRules, NewPipelineSchema } from '../db/schema';
+import { PermissionsService } from '../permissions/permissions.service';
+import {
+  GenerateUploadSchemaDto,
+  GenerateUploadSchemaResponseDto,
+} from './dto/generate-upload-schema.dto';
+import type { SchemaField } from '../db/schema/pipeline-schemas.schema';
+import type { PipelineConfig, PipelineStepConfig } from '../db/schema/proxy-rules.schema';
+import type { ValidatorConfig } from './types';
+import { eq, and } from 'drizzle-orm';
+
+/**
+ * Service for generating upload schemas with associated pipelines.
+ * Creates a schema for file metadata plus POST (upload) and GET (serve) pipelines.
+ */
+@Injectable()
+export class UploadSchemaGeneratorService {
+  private readonly logger = new Logger(UploadSchemaGeneratorService.name);
+
+  constructor(private readonly permissionsService: PermissionsService) {}
+
+  /**
+   * Generate an upload schema with POST (upload) and GET (serve) pipelines.
+   *
+   * Creates:
+   * 1. A pipeline schema with upload metadata fields
+   * 2. A rule set for the upload endpoints
+   * 3. POST pipeline for uploading files (always requires auth)
+   * 4. GET pipeline for serving files (access control configurable)
+   */
+  async generateUploadSchema(
+    dto: GenerateUploadSchemaDto,
+    userId: string,
+    userRole: string,
+  ): Promise<GenerateUploadSchemaResponseDto> {
+    // Check project access
+    await this.checkProjectAccess(dto.projectId, userId, userRole, 'contributor');
+
+    // Check for existing schema with same name
+    const [existingSchema] = await db
+      .select()
+      .from(pipelineSchemas)
+      .where(
+        and(
+          eq(pipelineSchemas.projectId, dto.projectId),
+          eq(pipelineSchemas.name, dto.name),
+        ),
+      )
+      .limit(1);
+
+    if (existingSchema) {
+      throw new ConflictException(`A schema with name "${dto.name}" already exists`);
+    }
+
+    // Define upload metadata schema fields
+    const fields: SchemaField[] = [
+      { name: 'filename', type: 'string', required: true },
+      { name: 'storage_path', type: 'string', required: true },
+      { name: 'content_type', type: 'string', required: true },
+      { name: 'size', type: 'number', required: true },
+      { name: 'url', type: 'string', required: true },
+      { name: 'sub_dir', type: 'string', required: true },
+      { name: 'original_name', type: 'string', required: true },
+    ];
+
+    // Create the schema
+    const [schema] = await db
+      .insert(pipelineSchemas)
+      .values({
+        projectId: dto.projectId,
+        name: dto.name,
+        fields,
+      } as NewPipelineSchema)
+      .returning();
+
+    this.logger.log(`Created upload schema '${dto.name}' (${schema.id})`);
+
+    // Use existing rule set or create a new one
+    let ruleSet: { id: string; name: string };
+
+    if (dto.ruleSetId) {
+      const [existingRuleSet] = await db
+        .select()
+        .from(proxyRuleSets)
+        .where(
+          and(
+            eq(proxyRuleSets.id, dto.ruleSetId),
+            eq(proxyRuleSets.projectId, dto.projectId),
+          ),
+        )
+        .limit(1);
+
+      if (!existingRuleSet) {
+        throw new Error(
+          `Rule set ${dto.ruleSetId} not found or does not belong to this project`,
+        );
+      }
+
+      ruleSet = existingRuleSet;
+      this.logger.log(`Using existing rule set '${ruleSet.name}' (${ruleSet.id})`);
+    } else {
+      const ruleSetName = `${dto.name}_pipelines`;
+      const [newRuleSet] = await db
+        .insert(proxyRuleSets)
+        .values({
+          projectId: dto.projectId,
+          name: ruleSetName,
+          description: `Auto-generated pipelines for ${dto.name} upload schema`,
+        })
+        .returning();
+
+      ruleSet = newRuleSet;
+      this.logger.log(`Created rule set '${ruleSet.name}' (${ruleSet.id})`);
+    }
+
+    // Create POST and GET pipelines
+    const pipelines: { id: string; path: string; method: string }[] = [];
+    const uploadPath = `/api/uploads/${dto.subDir}`;
+    const servePath = `/api/uploads/${dto.subDir}/*`;
+
+    // POST pipeline (upload) - always requires auth
+    const postConfig = this.createUploadPipelineConfig(dto, schema.id);
+    const [postRule] = await db
+      .insert(proxyRules)
+      .values({
+        ruleSetId: ruleSet.id,
+        pathPattern: uploadPath,
+        method: 'POST',
+        targetUrl: 'http://internal/pipeline',
+        proxyType: 'pipeline',
+        pipelineConfig: postConfig,
+        order: 0,
+        isEnabled: true,
+        description: `Upload files to ${dto.name}`,
+      })
+      .returning();
+
+    pipelines.push({
+      id: postRule.id,
+      path: uploadPath,
+      method: 'POST',
+    });
+
+    // GET pipeline (serve) - access control configurable
+    const getConfig = this.createServePipelineConfig(dto);
+    const [getRule] = await db
+      .insert(proxyRules)
+      .values({
+        ruleSetId: ruleSet.id,
+        pathPattern: servePath,
+        method: 'GET',
+        targetUrl: 'http://internal/pipeline',
+        proxyType: 'pipeline',
+        pipelineConfig: getConfig,
+        order: 1,
+        isEnabled: true,
+        description: `Serve files from ${dto.name}`,
+      })
+      .returning();
+
+    pipelines.push({
+      id: getRule.id,
+      path: servePath,
+      method: 'GET',
+    });
+
+    this.logger.log(
+      `Created ${pipelines.length} pipelines for upload schema '${dto.name}'`,
+    );
+
+    return {
+      schema: {
+        id: schema.id,
+        name: schema.name,
+        projectId: schema.projectId,
+        fields: schema.fields.map((f) => ({
+          name: f.name,
+          type: f.type,
+          required: f.required,
+        })),
+        createdAt: schema.createdAt.toISOString(),
+        updatedAt: schema.updatedAt.toISOString(),
+      },
+      pipelines,
+    };
+  }
+
+  /**
+   * Create pipeline config for POST (upload) endpoint.
+   * Always requires authentication.
+   */
+  private createUploadPipelineConfig(
+    dto: GenerateUploadSchemaDto,
+    schemaId: string,
+  ): PipelineConfig {
+    const steps: PipelineStepConfig[] = [];
+
+    // Step 1: File upload handler
+    steps.push({
+      id: 'upload',
+      name: 'upload',
+      handlerType: 'file_upload_handler',
+      config: {
+        schemaId,
+        subDir: dto.subDir,
+        dateBucket: dto.dateBucket ?? false,
+        maxFileSize: dto.maxFileSize,
+        allowedMimeTypes: dto.allowedMimeTypes,
+      },
+      isEnabled: true,
+    });
+
+    // Step 2: Response handler
+    steps.push({
+      id: 'response',
+      name: 'Return Upload Result',
+      handlerType: 'response_handler',
+      config: {
+        status: 200,
+        body: '{{{steps.upload}}}',
+        contentType: 'application/json',
+      },
+      isEnabled: true,
+    });
+
+    return {
+      name: `Upload ${dto.name}`,
+      description: `Upload files to ${dto.name}`,
+      validators: [
+        { type: 'auth_required', config: { allowApiKey: true } },
+      ] as ValidatorConfig[],
+      steps,
+    };
+  }
+
+  /**
+   * Create pipeline config for GET (serve) endpoint.
+   * Access control based on dto.accessControl.
+   */
+  private createServePipelineConfig(dto: GenerateUploadSchemaDto): PipelineConfig {
+    const steps: PipelineStepConfig[] = [];
+
+    // Step 1: File serve handler
+    steps.push({
+      id: 'serve',
+      name: 'serve',
+      handlerType: 'file_serve_handler',
+      config: {
+        subDir: dto.subDir,
+      },
+      isEnabled: true,
+    });
+
+    // Build validators based on access control
+    const validators: ValidatorConfig[] = [];
+    const accessControl = dto.accessControl || 'public';
+
+    if (accessControl === 'authenticated') {
+      validators.push({ type: 'auth_required', config: {} });
+    } else if (accessControl === 'role') {
+      validators.push({
+        type: 'auth_required',
+        config: { roles: dto.requiredRole ? [dto.requiredRole] : [] },
+      });
+    }
+    // 'public' = no validators
+
+    return {
+      name: `Serve ${dto.name}`,
+      description: `Serve files from ${dto.name}`,
+      validators,
+      steps,
+    };
+  }
+
+  /**
+   * Check project access
+   */
+  private async checkProjectAccess(
+    projectId: string,
+    userId: string,
+    userRole: string,
+    requiredRole: 'viewer' | 'contributor' | 'admin' | 'owner' = 'contributor',
+  ): Promise<void> {
+    if (userRole === 'admin') {
+      return;
+    }
+
+    const role = await this.permissionsService.getUserProjectRole(userId, projectId);
+
+    if (!role) {
+      throw new Error('You do not have access to this project');
+    }
+
+    const roleHierarchy = { viewer: 1, contributor: 2, admin: 3, owner: 4 };
+    const userLevel = roleHierarchy[role] || 0;
+    const requiredLevel = roleHierarchy[requiredRole] || 0;
+
+    if (userLevel < requiredLevel) {
+      throw new Error(`This action requires ${requiredRole} role or higher`);
+    }
+  }
+}

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -12,6 +12,7 @@ import { ProxyRule, ProxyType, PipelineConfig } from '../db/schema/proxy-rules.s
 import { ConfigService } from '@nestjs/config';
 import { PipelineExecutionService } from '../pipelines/execution';
 import { Pipeline, PipelineStep } from '../pipelines/types';
+import multer from 'multer';
 import { CustomDomainAuthService } from '../auth/custom-domain-auth.service';
 import { VisibilityService, AccessControlInfo } from '../domains/visibility.service';
 import { PermissionsService } from '../permissions/permissions.service';
@@ -968,6 +969,11 @@ export class ProxyMiddleware implements NestMiddleware {
     };
 
     try {
+      // If pipeline has file_upload_handler, parse multipart before executing
+      if (pipelineConfig.steps.some((s) => s.handlerType === 'file_upload_handler')) {
+        await this.parseMultipartUpload(req);
+      }
+
       // Extract user from session if available (optional - don't fail if not authenticated)
       const user = await this.getOptionalUser(req, res);
 
@@ -1023,6 +1029,20 @@ export class ProxyMiddleware implements NestMiddleware {
         });
       }
     }
+  }
+
+  /**
+   * Parse multipart form data using multer (for file upload pipelines).
+   * Populates req.file with the uploaded file buffer.
+   */
+  private parseMultipartUpload(req: Request): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const upload = multer({
+        storage: multer.memoryStorage(),
+        limits: { fileSize: 50 * 1024 * 1024 }, // 50MB hard limit
+      }).single('file');
+      upload(req, {} as any, (err: any) => (err ? reject(err) : resolve()));
+    });
   }
 
   /**

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -12,6 +12,8 @@ import { RuleEditorPage } from '@/pages/RuleEditorPage';
 import { SchemasListPage } from '@/pages/SchemasListPage';
 import { SchemaDetailPage } from '@/pages/SchemaDetailPage';
 import { SchemaEditorPage } from '@/pages/SchemaEditorPage';
+import { UploadsListPage } from '@/pages/UploadsListPage';
+import { UploadDetailPage } from '@/pages/UploadDetailPage';
 import { RepositoryTabRedirect } from '@/pages/RepositoryTabRedirect';
 import { UserGroupsPage } from '@/pages/UserGroupsPage';
 import { GroupDetailPage } from '@/pages/GroupDetailPage';
@@ -90,6 +92,8 @@ function App() {
           <Route path="data/new" element={<SchemaEditorPage />} />
           <Route path="data/:schemaId" element={<SchemaDetailPage />} />
           <Route path="data/:schemaId/edit" element={<SchemaEditorPage />} />
+          <Route path="uploads" element={<UploadsListPage />} />
+          <Route path="uploads/:schemaId" element={<UploadDetailPage />} />
         </Route>
 
         {/* User Groups routes (admin only) */}

--- a/apps/frontend/src/components/data/GenerateSchemaTypeModal.tsx
+++ b/apps/frontend/src/components/data/GenerateSchemaTypeModal.tsx
@@ -6,9 +6,9 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog';
 import { Card, CardContent } from '@/components/ui/card';
-import { Database, MessageSquare, ArrowRight } from 'lucide-react';
+import { Database, MessageSquare, Upload, ArrowRight } from 'lucide-react';
 
-export type SchemaType = 'state' | 'chat';
+export type SchemaType = 'state' | 'chat' | 'upload';
 
 interface GenerateSchemaTypeModalProps {
   open: boolean;
@@ -92,6 +92,34 @@ export function GenerateSchemaTypeModal({
                     <span className="text-xs bg-muted px-2 py-0.5 rounded">Conversations</span>
                     <span className="text-xs bg-muted px-2 py-0.5 rounded">Messages</span>
                     <span className="text-xs bg-muted px-2 py-0.5 rounded">5 pipelines</span>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+          {/* Upload Schema Option */}
+          <Card
+            className="cursor-pointer hover:bg-muted/50 transition-colors border-2 hover:border-primary/50"
+            onClick={() => handleSelect('upload')}
+          >
+            <CardContent className="p-4">
+              <div className="flex items-start gap-4">
+                <div className="h-12 w-12 rounded-lg bg-green-500/10 flex items-center justify-center shrink-0">
+                  <Upload className="h-6 w-6 text-green-500" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <h3 className="font-semibold">Upload Schema</h3>
+                    <ArrowRight className="h-4 w-4 text-muted-foreground" />
+                  </div>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    For file uploads with metadata tracking and configurable access control.
+                    Includes upload and serve endpoints.
+                  </p>
+                  <div className="flex flex-wrap gap-2 mt-2">
+                    <span className="text-xs bg-muted px-2 py-0.5 rounded">File Storage</span>
+                    <span className="text-xs bg-muted px-2 py-0.5 rounded">Date Bucketing</span>
+                    <span className="text-xs bg-muted px-2 py-0.5 rounded">2 pipelines</span>
                   </div>
                 </div>
               </div>

--- a/apps/frontend/src/components/uploads/FileUploadZone.tsx
+++ b/apps/frontend/src/components/uploads/FileUploadZone.tsx
@@ -1,0 +1,174 @@
+import { useState, useCallback, useRef } from 'react';
+import { Upload, X, Loader2, CheckCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
+
+interface FileUploadZoneProps {
+  uploadUrl: string;
+  onUploadComplete?: () => void;
+  disabled?: boolean;
+}
+
+interface UploadState {
+  file: File;
+  status: 'pending' | 'uploading' | 'complete' | 'error';
+  error?: string;
+}
+
+export function FileUploadZone({
+  uploadUrl,
+  onUploadComplete,
+  disabled,
+}: FileUploadZoneProps) {
+  const { toast } = useToast();
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [uploads, setUploads] = useState<UploadState[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFiles = useCallback(
+    async (files: FileList | File[]) => {
+      const fileArray = Array.from(files);
+      if (fileArray.length === 0) return;
+
+      for (const file of fileArray) {
+        const uploadState: UploadState = { file, status: 'uploading' };
+        setUploads((prev) => [...prev, uploadState]);
+
+        try {
+          const formData = new FormData();
+          formData.append('file', file);
+
+          const response = await fetch(uploadUrl, {
+            method: 'POST',
+            body: formData,
+            credentials: 'include',
+          });
+
+          if (!response.ok) {
+            const errorData = await response.json().catch(() => ({}));
+            throw new Error(errorData.error?.message || `Upload failed (${response.status})`);
+          }
+
+          setUploads((prev) =>
+            prev.map((u) => (u.file === file ? { ...u, status: 'complete' } : u)),
+          );
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Upload failed';
+          setUploads((prev) =>
+            prev.map((u) => (u.file === file ? { ...u, status: 'error', error: message } : u)),
+          );
+          toast({
+            title: 'Upload Failed',
+            description: `${file.name}: ${message}`,
+            variant: 'destructive',
+          });
+        }
+      }
+
+      onUploadComplete?.();
+    },
+    [uploadUrl, onUploadComplete, toast],
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragOver(false);
+      if (!disabled) {
+        handleFiles(e.dataTransfer.files);
+      }
+    },
+    [disabled, handleFiles],
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+  }, []);
+
+  const removeUpload = (index: number) => {
+    setUploads((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const formatFileSize = (bytes: number): string => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
+
+  return (
+    <div className="space-y-3">
+      <div
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onClick={() => !disabled && fileInputRef.current?.click()}
+        className={`
+          border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors
+          ${isDragOver ? 'border-primary bg-primary/5' : 'border-muted-foreground/25 hover:border-muted-foreground/50'}
+          ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
+        `}
+      >
+        <Upload className="h-8 w-8 mx-auto text-muted-foreground mb-3" />
+        <p className="text-sm font-medium">
+          {isDragOver ? 'Drop files here' : 'Drag and drop files here, or click to browse'}
+        </p>
+        <p className="text-xs text-muted-foreground mt-1">
+          Files will be uploaded to storage
+        </p>
+        <input
+          ref={fileInputRef}
+          type="file"
+          className="hidden"
+          multiple
+          onChange={(e) => {
+            if (e.target.files) handleFiles(e.target.files);
+            e.target.value = '';
+          }}
+          disabled={disabled}
+        />
+      </div>
+
+      {/* Upload progress list */}
+      {uploads.length > 0 && (
+        <div className="space-y-2">
+          {uploads.map((upload, index) => (
+            <div
+              key={`${upload.file.name}-${index}`}
+              className="flex items-center gap-3 p-2 rounded-md bg-muted/50 text-sm"
+            >
+              {upload.status === 'uploading' && (
+                <Loader2 className="h-4 w-4 animate-spin text-primary shrink-0" />
+              )}
+              {upload.status === 'complete' && (
+                <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0" />
+              )}
+              {upload.status === 'error' && (
+                <X className="h-4 w-4 text-destructive shrink-0" />
+              )}
+              <span className="flex-1 truncate">{upload.file.name}</span>
+              <span className="text-muted-foreground shrink-0">
+                {formatFileSize(upload.file.size)}
+              </span>
+              {upload.status !== 'uploading' && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  onClick={() => removeUpload(index)}
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/uploads/GenerateUploadModal.tsx
+++ b/apps/frontend/src/components/uploads/GenerateUploadModal.tsx
@@ -1,0 +1,355 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import { useGenerateUploadSchemaMutation } from '@/services/pipelineSchemasApi';
+import { useGetProjectRuleSetsQuery } from '@/services/proxyRulesApi';
+
+type AccessControl = 'public' | 'authenticated' | 'role';
+
+interface GenerateUploadModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  onSuccess?: () => void;
+}
+
+export function GenerateUploadModal({
+  open,
+  onOpenChange,
+  projectId,
+  onSuccess,
+}: GenerateUploadModalProps) {
+  const { toast } = useToast();
+  const [schemaName, setSchemaName] = useState('');
+  const [subDir, setSubDir] = useState('');
+  const [dateBucket, setDateBucket] = useState(false);
+  const [accessControl, setAccessControl] = useState<AccessControl>('public');
+  const [requiredRole, setRequiredRole] = useState('');
+  const [allowedMimeTypes, setAllowedMimeTypes] = useState('');
+  const [maxFileSize, setMaxFileSize] = useState('');
+  const [ruleSetId, setRuleSetId] = useState<string>('');
+
+  const [generateUploadSchema, { isLoading }] = useGenerateUploadSchemaMutation();
+  const { data: ruleSetsData } = useGetProjectRuleSetsQuery(projectId, {
+    skip: !open,
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!schemaName.trim()) {
+      toast({
+        title: 'Validation Error',
+        description: 'Please enter a schema name',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const nameRegex = /^[a-z][a-z0-9_]*$/;
+    if (!nameRegex.test(schemaName)) {
+      toast({
+        title: 'Invalid Schema Name',
+        description:
+          'Schema name must start with a letter and contain only lowercase letters, numbers, and underscores',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (!subDir.trim()) {
+      toast({
+        title: 'Validation Error',
+        description: 'Please enter a sub-directory name',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const subDirRegex = /^[a-z][a-z0-9_-]*$/;
+    if (!subDirRegex.test(subDir)) {
+      toast({
+        title: 'Invalid Sub-directory',
+        description:
+          'Sub-directory must start with a letter and contain only lowercase letters, numbers, hyphens, and underscores',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (accessControl === 'role' && !requiredRole.trim()) {
+      toast({
+        title: 'Validation Error',
+        description: 'Please enter a required role',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      const dto: Record<string, unknown> = {
+        projectId,
+        name: schemaName,
+        subDir,
+        dateBucket,
+        accessControl,
+      };
+
+      if (accessControl === 'role') {
+        dto.requiredRole = requiredRole;
+      }
+
+      if (allowedMimeTypes.trim()) {
+        dto.allowedMimeTypes = allowedMimeTypes.split(',').map((t) => t.trim());
+      }
+
+      if (maxFileSize.trim()) {
+        const sizeBytes = parseInt(maxFileSize, 10) * 1024 * 1024; // Convert MB to bytes
+        if (!isNaN(sizeBytes) && sizeBytes > 0) {
+          dto.maxFileSize = sizeBytes;
+        }
+      }
+
+      if (ruleSetId && ruleSetId !== 'new') {
+        dto.ruleSetId = ruleSetId;
+      }
+
+      const result = await generateUploadSchema(dto as any).unwrap();
+
+      toast({
+        title: 'Upload Schema Generated',
+        description: `Created schema "${result.schema.name}" with ${result.pipelines.length} pipeline(s)`,
+      });
+
+      onOpenChange(false);
+      resetForm();
+      onSuccess?.();
+    } catch (err: unknown) {
+      const errorMessage =
+        (err as { data?: { message?: string } })?.data?.message ||
+        'Failed to generate upload schema';
+      toast({
+        title: 'Error',
+        description: errorMessage,
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const resetForm = () => {
+    setSchemaName('');
+    setSubDir('');
+    setDateBucket(false);
+    setAccessControl('public');
+    setRequiredRole('');
+    setAllowedMimeTypes('');
+    setMaxFileSize('');
+    setRuleSetId('');
+  };
+
+  const handleClose = (open: boolean) => {
+    if (!open) {
+      resetForm();
+    }
+    onOpenChange(open);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Generate Upload Schema</DialogTitle>
+          <DialogDescription>
+            Create a schema and pipelines for file uploads. This will generate POST (upload)
+            and GET (serve) endpoints with configurable access control.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="upload-schema-name">Schema Name</Label>
+              <Input
+                id="upload-schema-name"
+                value={schemaName}
+                onChange={(e) => setSchemaName(e.target.value.toLowerCase())}
+                placeholder="e.g., product_images, user_avatars"
+                disabled={isLoading}
+              />
+              <p className="text-xs text-muted-foreground">
+                Use lowercase letters, numbers, and underscores.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="upload-sub-dir">Sub-directory</Label>
+              <Input
+                id="upload-sub-dir"
+                value={subDir}
+                onChange={(e) => setSubDir(e.target.value.toLowerCase())}
+                placeholder="e.g., images, documents, avatars"
+                disabled={isLoading}
+              />
+              <p className="text-xs text-muted-foreground">
+                Storage sub-directory for uploaded files. Endpoint will be{' '}
+                <code className="text-xs">/api/uploads/{subDir || '{subDir}'}</code>
+              </p>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="date-bucket">Date Bucketing</Label>
+                <p className="text-xs text-muted-foreground">
+                  Organize files in YYYY-MM-DD folders
+                </p>
+              </div>
+              <Switch
+                id="date-bucket"
+                checked={dateBucket}
+                onCheckedChange={setDateBucket}
+                disabled={isLoading}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Access Control (for serving files)</Label>
+              <RadioGroup
+                value={accessControl}
+                onValueChange={(value) => setAccessControl(value as AccessControl)}
+                disabled={isLoading}
+              >
+                <div className="flex items-start space-x-3">
+                  <RadioGroupItem value="public" id="access-public" />
+                  <div className="grid gap-1.5 leading-none">
+                    <Label htmlFor="access-public" className="font-medium cursor-pointer">
+                      Public
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Anyone can access uploaded files.
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start space-x-3">
+                  <RadioGroupItem value="authenticated" id="access-auth" />
+                  <div className="grid gap-1.5 leading-none">
+                    <Label htmlFor="access-auth" className="font-medium cursor-pointer">
+                      Authenticated
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Only authenticated users can access files.
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start space-x-3">
+                  <RadioGroupItem value="role" id="access-role" />
+                  <div className="grid gap-1.5 leading-none">
+                    <Label htmlFor="access-role" className="font-medium cursor-pointer">
+                      Role-based
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Only users with a specific role can access files.
+                    </p>
+                  </div>
+                </div>
+              </RadioGroup>
+            </div>
+
+            {accessControl === 'role' && (
+              <div className="space-y-2">
+                <Label htmlFor="required-role">Required Role</Label>
+                <Input
+                  id="required-role"
+                  value={requiredRole}
+                  onChange={(e) => setRequiredRole(e.target.value)}
+                  placeholder="e.g., admin, editor"
+                  disabled={isLoading}
+                />
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="mime-types">Allowed MIME Types (optional)</Label>
+              <Input
+                id="mime-types"
+                value={allowedMimeTypes}
+                onChange={(e) => setAllowedMimeTypes(e.target.value)}
+                placeholder="e.g., image/*, application/pdf"
+                disabled={isLoading}
+              />
+              <p className="text-xs text-muted-foreground">
+                Comma-separated. Leave empty to allow all file types.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="max-file-size">Max File Size in MB (optional)</Label>
+              <Input
+                id="max-file-size"
+                type="number"
+                value={maxFileSize}
+                onChange={(e) => setMaxFileSize(e.target.value)}
+                placeholder="10"
+                disabled={isLoading}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="upload-rule-set">Proxy Rule Set</Label>
+              <Select
+                value={ruleSetId}
+                onValueChange={setRuleSetId}
+                disabled={isLoading}
+              >
+                <SelectTrigger id="upload-rule-set">
+                  <SelectValue placeholder="Create new rule set" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="new">Create new rule set</SelectItem>
+                  {ruleSetsData?.ruleSets?.map((ruleSet) => (
+                    <SelectItem key={ruleSet.id} value={ruleSet.id}>
+                      {ruleSet.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Add upload/serve pipelines to an existing rule set or create a new one.
+              </p>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleClose(false)}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isLoading}>
+              {isLoading ? 'Generating...' : 'Generate'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/pages/RepositoryLayout.tsx
+++ b/apps/frontend/src/pages/RepositoryLayout.tsx
@@ -25,15 +25,17 @@ export function RepositoryLayout() {
 
   // Determine current tab from pathname
   const pathAfterRepo = location.pathname.replace(`/repo/${owner}/${repo}`, '');
-  const currentTab = pathAfterRepo.startsWith('/data')
-    ? 'data'
-    : pathAfterRepo.startsWith('/proxy-rules')
-      ? 'proxy-rules'
-      : pathAfterRepo.startsWith('/aliases')
-        ? 'aliases'
-        : pathAfterRepo.startsWith('/branches')
-          ? 'branches'
-          : 'deployments';
+  const currentTab = pathAfterRepo.startsWith('/uploads')
+    ? 'uploads'
+    : pathAfterRepo.startsWith('/data')
+      ? 'data'
+      : pathAfterRepo.startsWith('/proxy-rules')
+        ? 'proxy-rules'
+        : pathAfterRepo.startsWith('/aliases')
+          ? 'aliases'
+          : pathAfterRepo.startsWith('/branches')
+            ? 'branches'
+            : 'deployments';
 
   // Update Redux store when URL params change
   useEffect(() => {
@@ -156,6 +158,9 @@ export function RepositoryLayout() {
             </TabsTrigger>
             <TabsTrigger value="data" asChild>
               <Link to={`/repo/${owner}/${repo}/data`}>Data</Link>
+            </TabsTrigger>
+            <TabsTrigger value="uploads" asChild>
+              <Link to={`/repo/${owner}/${repo}/uploads`}>Uploads</Link>
             </TabsTrigger>
           </TabsList>
         </Tabs>

--- a/apps/frontend/src/pages/SchemasListPage.tsx
+++ b/apps/frontend/src/pages/SchemasListPage.tsx
@@ -28,6 +28,7 @@ import { SchemaCard } from '@/components/data/SchemaCard';
 import { GenerateStateModal } from '@/components/data/GenerateStateModal';
 import { GenerateSchemaTypeModal, SchemaType } from '@/components/data/GenerateSchemaTypeModal';
 import { GenerateChatModal } from '@/components/data/GenerateChatModal';
+import { GenerateUploadModal } from '@/components/uploads/GenerateUploadModal';
 
 /**
  * SchemasListPage - Content for the Data tab showing all schemas.
@@ -47,12 +48,15 @@ export function SchemasListPage() {
   const [showGenerateTypeModal, setShowGenerateTypeModal] = useState(false);
   const [showGenerateStateModal, setShowGenerateStateModal] = useState(false);
   const [showGenerateChatModal, setShowGenerateChatModal] = useState(false);
+  const [showGenerateUploadModal, setShowGenerateUploadModal] = useState(false);
 
   const handleSchemaTypeSelected = (type: SchemaType) => {
     if (type === 'state') {
       setShowGenerateStateModal(true);
     } else if (type === 'chat') {
       setShowGenerateChatModal(true);
+    } else if (type === 'upload') {
+      setShowGenerateUploadModal(true);
     }
   };
 
@@ -288,6 +292,15 @@ export function SchemasListPage() {
         <GenerateChatModal
           open={showGenerateChatModal}
           onOpenChange={setShowGenerateChatModal}
+          projectId={project.id}
+        />
+      )}
+
+      {/* Generate Upload Schema Modal */}
+      {canEdit && project && (
+        <GenerateUploadModal
+          open={showGenerateUploadModal}
+          onOpenChange={setShowGenerateUploadModal}
           projectId={project.id}
         />
       )}

--- a/apps/frontend/src/pages/UploadDetailPage.tsx
+++ b/apps/frontend/src/pages/UploadDetailPage.tsx
@@ -1,0 +1,312 @@
+import { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { ArrowLeft, Trash2, Copy, ChevronLeft, ChevronRight, Image } from 'lucide-react';
+import {
+  useGetSchemaQuery,
+  useGetSchemaDataQuery,
+  useDeleteRecordMutation,
+  PipelineDataRecord,
+} from '@/services/pipelineSchemasApi';
+import { useProjectRole } from '@/hooks/useProjectRole';
+import { useToast } from '@/hooks/use-toast';
+import { FileUploadZone } from '@/components/uploads/FileUploadZone';
+
+/**
+ * UploadDetailPage - Shows uploaded files for a specific upload schema.
+ * Route: /repo/:owner/:repo/uploads/:schemaId
+ */
+export function UploadDetailPage() {
+  const { owner, repo, schemaId } = useParams<{
+    owner: string;
+    repo: string;
+    schemaId: string;
+  }>();
+  const { toast } = useToast();
+  const { canEdit } = useProjectRole(owner!, repo!);
+  const [page, setPage] = useState(1);
+  const [deletingRecord, setDeletingRecord] = useState<PipelineDataRecord | null>(null);
+  const pageSize = 20;
+
+  // Fetch schema details
+  const { data: schema, isLoading: isLoadingSchema } = useGetSchemaQuery(schemaId!, {
+    skip: !schemaId,
+  });
+
+  // Fetch uploaded files (pipeline data records)
+  const {
+    data: filesData,
+    isLoading: isLoadingFiles,
+    refetch: refetchFiles,
+  } = useGetSchemaDataQuery(
+    { schemaId: schemaId!, page, pageSize },
+    { skip: !schemaId },
+  );
+
+  const [deleteRecord, { isLoading: isDeleting }] = useDeleteRecordMutation();
+
+  const handleDelete = async () => {
+    if (!deletingRecord || !schemaId) return;
+    try {
+      await deleteRecord({ schemaId, recordId: deletingRecord.id }).unwrap();
+      toast({
+        title: 'File deleted',
+        description: `File record has been deleted.`,
+      });
+      setDeletingRecord(null);
+    } catch (err: unknown) {
+      const errorMessage =
+        (err as { data?: { message?: string } })?.data?.message || 'Failed to delete file';
+      toast({
+        title: 'Error',
+        description: errorMessage,
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleCopyUrl = (url: string) => {
+    navigator.clipboard.writeText(url);
+    toast({ title: 'Copied', description: 'URL copied to clipboard' });
+  };
+
+  const isLoading = isLoadingSchema || isLoadingFiles;
+  const files = filesData?.records || [];
+  const totalPages = filesData?.totalPages || 1;
+
+  // Determine upload URL from schema's sub_dir field
+  // We look at the first record's sub_dir, or fallback to the schema name
+  const subDir =
+    files.length > 0
+      ? (files[0].data?.sub_dir as string)
+      : schema?.name || '';
+  const uploadUrl = subDir ? `/public/${owner}/${repo}/alias/production/api/uploads/${subDir}` : '';
+
+  const formatFileSize = (bytes: unknown): string => {
+    const size = Number(bytes);
+    if (isNaN(size)) return '—';
+    if (size < 1024) return `${size} B`;
+    if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+    return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+  };
+
+  const isImageType = (contentType: unknown): boolean => {
+    return typeof contentType === 'string' && contentType.startsWith('image/');
+  };
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {[...Array(5)].map((_, i) => (
+              <Skeleton key={i} className="h-12 w-full" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      <div className="space-y-6">
+        {/* Back link */}
+        <Link
+          to={`/repo/${owner}/${repo}/uploads`}
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Uploads
+        </Link>
+
+        {/* Upload zone */}
+        {canEdit && uploadUrl && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Upload Files</CardTitle>
+              <CardDescription>
+                Upload files to {schema?.name || 'this schema'}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <FileUploadZone
+                uploadUrl={uploadUrl}
+                onUploadComplete={() => refetchFiles()}
+              />
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Files table */}
+        <Card>
+          <CardHeader>
+            <CardTitle>{schema?.name || 'Upload Schema'}</CardTitle>
+            <CardDescription>
+              {filesData?.total || 0} uploaded file{(filesData?.total || 0) !== 1 ? 's' : ''}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {files.length === 0 ? (
+              <div className="p-8 text-center">
+                <Image className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+                <p className="text-muted-foreground">No files uploaded yet</p>
+              </div>
+            ) : (
+              <>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Preview</TableHead>
+                      <TableHead>Filename</TableHead>
+                      <TableHead>Type</TableHead>
+                      <TableHead>Size</TableHead>
+                      <TableHead>Uploaded</TableHead>
+                      <TableHead>URL</TableHead>
+                      {canEdit && <TableHead className="w-12" />}
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {files.map((record) => {
+                      const data = record.data || {};
+                      return (
+                        <TableRow key={record.id}>
+                          <TableCell className="w-16">
+                            {isImageType(data.content_type) && data.url ? (
+                              <img
+                                src={`/public/${owner}/${repo}/alias/production${data.url}`}
+                                alt={String(data.filename || '')}
+                                className="h-10 w-10 object-cover rounded"
+                              />
+                            ) : (
+                              <div className="h-10 w-10 bg-muted rounded flex items-center justify-center">
+                                <Image className="h-4 w-4 text-muted-foreground" />
+                              </div>
+                            )}
+                          </TableCell>
+                          <TableCell className="font-medium max-w-[200px] truncate">
+                            {String(data.original_name || data.filename || '—')}
+                          </TableCell>
+                          <TableCell className="text-sm text-muted-foreground">
+                            {String(data.content_type || '—')}
+                          </TableCell>
+                          <TableCell className="text-sm text-muted-foreground">
+                            {formatFileSize(data.size)}
+                          </TableCell>
+                          <TableCell className="text-sm text-muted-foreground">
+                            {new Date(record.createdAt).toLocaleDateString()}
+                          </TableCell>
+                          <TableCell>
+                            {typeof data.url === 'string' && (
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-8 w-8"
+                                onClick={() => handleCopyUrl(data.url as string)}
+                              >
+                                <Copy className="h-3.5 w-3.5" />
+                              </Button>
+                            )}
+                          </TableCell>
+                          {canEdit && (
+                            <TableCell>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-8 w-8 text-destructive hover:text-destructive"
+                                onClick={() => setDeletingRecord(record)}
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </Button>
+                            </TableCell>
+                          )}
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+
+                {/* Pagination */}
+                {totalPages > 1 && (
+                  <div className="flex items-center justify-between mt-4">
+                    <p className="text-sm text-muted-foreground">
+                      Page {page} of {totalPages}
+                    </p>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setPage((p) => Math.max(1, p - 1))}
+                        disabled={page <= 1}
+                      >
+                        <ChevronLeft className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                        disabled={page >= totalPages}
+                      >
+                        <ChevronRight className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Delete Confirmation Dialog */}
+      <AlertDialog
+        open={!!deletingRecord}
+        onOpenChange={(open) => !open && setDeletingRecord(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete File</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete this file record? The file in storage will not be
+              automatically removed. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={isDeleting}
+            >
+              {isDeleting ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/frontend/src/pages/UploadsListPage.tsx
+++ b/apps/frontend/src/pages/UploadsListPage.tsx
@@ -1,0 +1,243 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Upload, Zap, FileImage, ArrowRight } from 'lucide-react';
+import { useGetProjectSchemasQuery, PipelineSchemaWithCount } from '@/services/pipelineSchemasApi';
+import { useGetProjectQuery } from '@/services/projectsApi';
+import { useProjectRole } from '@/hooks/useProjectRole';
+import { GenerateUploadModal } from '@/components/uploads/GenerateUploadModal';
+
+/**
+ * Heuristic: a schema is "likely" an upload schema if it has these fields.
+ * Used only for sorting — generated upload schemas appear first in the list.
+ */
+function looksLikeUploadSchema(schema: PipelineSchemaWithCount): boolean {
+  const fieldNames = new Set(schema.fields.map((f) => f.name));
+  return fieldNames.has('storage_path') && fieldNames.has('content_type') && fieldNames.has('url');
+}
+
+/**
+ * UploadsListPage - Content for the Uploads tab.
+ * Shows all schemas and lets the user pick any as an upload target.
+ * Schemas generated via "Generate Upload Schema" appear first.
+ * Route: /repo/:owner/:repo/uploads
+ */
+export function UploadsListPage() {
+  const { owner, repo } = useParams<{ owner: string; repo: string }>();
+  const navigate = useNavigate();
+  const { canEdit } = useProjectRole(owner!, repo!);
+  const [showGenerateModal, setShowGenerateModal] = useState(false);
+  const [selectedSchemaId, setSelectedSchemaId] = useState<string>('');
+
+  // Fetch project to get projectId
+  const { data: project, isLoading: isLoadingProject } = useGetProjectQuery(
+    { owner: owner!, name: repo! },
+    { skip: !owner || !repo },
+  );
+
+  // Fetch all schemas for this project
+  const {
+    data: schemasData,
+    isLoading: isLoadingSchemas,
+    error: schemasError,
+  } = useGetProjectSchemasQuery(project?.id || '', {
+    skip: !project?.id,
+  });
+
+  const isLoading = isLoadingProject || isLoadingSchemas;
+  const allSchemas = schemasData?.schemas || [];
+
+  // Sort: upload-like schemas first, then alphabetical
+  const sortedSchemas = [...allSchemas].sort((a, b) => {
+    const aUpload = looksLikeUploadSchema(a);
+    const bUpload = looksLikeUploadSchema(b);
+    if (aUpload && !bUpload) return -1;
+    if (!aUpload && bUpload) return 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  const uploadLikeSchemas = sortedSchemas.filter(looksLikeUploadSchema);
+  const otherSchemas = sortedSchemas.filter((s) => !looksLikeUploadSchema(s));
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Uploads</CardTitle>
+          <CardDescription>Manage file uploads and uploaded files</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            <div className="flex justify-end">
+              <Skeleton className="h-10 w-48" />
+            </div>
+            {[...Array(3)].map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Error state
+  if (schemasError) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Uploads</CardTitle>
+        </CardHeader>
+        <CardContent className="p-8 text-center">
+          <p className="text-destructive">Failed to load schemas</p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-4"
+            onClick={() => window.location.reload()}
+          >
+            Retry
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle>Uploads</CardTitle>
+            <CardDescription>Manage file uploads and uploaded files</CardDescription>
+          </div>
+          {canEdit && (
+            <Button
+              size="sm"
+              className="gap-2"
+              onClick={() => setShowGenerateModal(true)}
+            >
+              <Zap className="h-4 w-4" />
+              Generate Upload Schema
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          {allSchemas.length === 0 ? (
+            <div className="p-8 text-center">
+              <Upload className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+              <p className="text-muted-foreground font-medium">No schemas found</p>
+              <p className="text-sm text-muted-foreground mt-2">
+                {canEdit
+                  ? 'Generate an upload schema to start uploading files'
+                  : 'No schemas have been created for this repository yet'}
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {/* Upload schemas section */}
+              {uploadLikeSchemas.length > 0 && (
+                <div className="space-y-3">
+                  <h3 className="text-sm font-medium text-muted-foreground">Upload Schemas</h3>
+                  {uploadLikeSchemas.map((schema) => (
+                    <SchemaCard
+                      key={schema.id}
+                      schema={schema}
+                      onClick={() => navigate(`/repo/${owner}/${repo}/uploads/${schema.id}`)}
+                    />
+                  ))}
+                </div>
+              )}
+
+              {/* Browse any schema */}
+              {otherSchemas.length > 0 && (
+                <div className="space-y-3">
+                  <h3 className="text-sm font-medium text-muted-foreground">
+                    {uploadLikeSchemas.length > 0 ? 'Other Schemas' : 'All Schemas'}
+                  </h3>
+                  <div className="flex items-center gap-2">
+                    <Select value={selectedSchemaId} onValueChange={setSelectedSchemaId}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select a schema to browse uploads..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {otherSchemas.map((schema) => (
+                          <SelectItem key={schema.id} value={schema.id}>
+                            {schema.name} ({schema.recordCount} record{schema.recordCount !== 1 ? 's' : ''})
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      variant="outline"
+                      disabled={!selectedSchemaId}
+                      onClick={() => {
+                        if (selectedSchemaId) {
+                          navigate(`/repo/${owner}/${repo}/uploads/${selectedSchemaId}`);
+                        }
+                      }}
+                    >
+                      View
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Generate Upload Schema Modal */}
+      {canEdit && project && (
+        <GenerateUploadModal
+          open={showGenerateModal}
+          onOpenChange={setShowGenerateModal}
+          projectId={project.id}
+        />
+      )}
+    </>
+  );
+}
+
+function SchemaCard({
+  schema,
+  onClick,
+}: {
+  schema: PipelineSchemaWithCount;
+  onClick: () => void;
+}) {
+  return (
+    <Card
+      className="cursor-pointer hover:bg-muted/50 transition-colors"
+      onClick={onClick}
+    >
+      <CardContent className="p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="h-10 w-10 rounded-lg bg-green-500/10 flex items-center justify-center shrink-0">
+              <FileImage className="h-5 w-5 text-green-500" />
+            </div>
+            <div>
+              <h3 className="font-medium">{schema.name}</h3>
+              <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                <span>
+                  {schema.recordCount} file{schema.recordCount !== 1 ? 's' : ''}
+                </span>
+              </div>
+            </div>
+          </div>
+          <ArrowRight className="h-4 w-4 text-muted-foreground" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/services/pipelineSchemasApi.ts
+++ b/apps/frontend/src/services/pipelineSchemasApi.ts
@@ -94,6 +94,23 @@ export interface GenerateChatSchemaResponse {
   pipelines: { id: string; path: string; method: string }[];
 }
 
+export interface GenerateUploadSchemaDto {
+  projectId: string;
+  name: string;
+  subDir: string;
+  dateBucket?: boolean;
+  maxFileSize?: number;
+  allowedMimeTypes?: string[];
+  accessControl?: 'public' | 'authenticated' | 'role';
+  requiredRole?: string;
+  ruleSetId?: string;
+}
+
+export interface GenerateUploadSchemaResponse {
+  schema: PipelineSchema;
+  pipelines: { id: string; path: string; method: string }[];
+}
+
 export interface FieldFilter {
   op: 'eq' | 'ne' | 'gt' | 'lt' | 'gte' | 'lte' | 'like';
   value: string;
@@ -194,6 +211,20 @@ export const pipelineSchemasApi = api.injectEndpoints({
     generateChatSchema: builder.mutation<GenerateChatSchemaResponse, GenerateChatSchemaDto>({
       query: (data) => ({
         url: '/api/pipeline-schemas/generate-chat',
+        method: 'POST',
+        body: data,
+      }),
+      invalidatesTags: (_result, _error, { projectId }) => [
+        { type: 'PipelineSchema' as const, id: `project-${projectId}` },
+        'PipelineSchema',
+        'Pipeline',
+        'ProxyRuleSet',
+      ],
+    }),
+
+    generateUploadSchema: builder.mutation<GenerateUploadSchemaResponse, GenerateUploadSchemaDto>({
+      query: (data) => ({
+        url: '/api/pipeline-schemas/generate-upload',
         method: 'POST',
         body: data,
       }),
@@ -314,6 +345,7 @@ export const {
   useDeleteSchemaMutation,
   useGenerateStateSchemaMutation,
   useGenerateChatSchemaMutation,
+  useGenerateUploadSchemaMutation,
   // Data
   useGetSchemaDataQuery,
   useGetRecordQuery,


### PR DESCRIPTION
Add file_upload_handler and file_serve_handler pipeline step types that enable file uploads through the existing proxy middleware pipeline system. Includes an upload schema generator (like state/chat generators) that creates POST upload and GET serve proxy rules with configurable access control. Frontend adds an Uploads tab with schema listing, file browser, drag-and-drop upload zone, and Generate Upload Schema modal.