### PR TITLE
feat: add change password to settings page

### DIFF
--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -55,6 +55,11 @@ interface ResetPasswordDto {
   password: string;
 }
 
+interface ChangePasswordDto {
+  currentPassword: string;
+  newPassword: string;
+}
+
 @ApiTags('Authentication')
 @Controller('api/auth')
 export class AuthController {
@@ -970,5 +975,135 @@ export class AuthController {
     );
 
     return { token, redirectUrl };
+  }
+
+  @Get('login-methods')
+  @UseGuards(SessionAuthGuard)
+  @ApiOperation({
+    summary: 'Get login methods for the current user',
+    description:
+      'Returns which login methods the user has (e.g., email/password). Used to conditionally show change password UI.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Login methods retrieved',
+    schema: {
+      type: 'object',
+      properties: {
+        hasPassword: { type: 'boolean', description: 'Whether the user has email/password login' },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: 'Not authenticated' })
+  async getLoginMethods(@Req() req: Request & { session?: SessionContainer }) {
+    if (!req.session) {
+      throw new UnauthorizedException('No active session');
+    }
+
+    const userId = req.session.getUserId();
+    const stUser = await getUser(userId);
+
+    if (!stUser) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    const hasPassword = stUser.loginMethods.some(
+      (method) => method.recipeId === 'emailpassword',
+    );
+
+    return { hasPassword };
+  }
+
+  @Post('change-password')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(SessionAuthGuard)
+  @ApiOperation({
+    summary: 'Change password for the current user',
+    description:
+      'Verifies the current password and updates to a new password. Only works for users with email/password login.',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        currentPassword: { type: 'string', example: 'OldPassword123!' },
+        newPassword: { type: 'string', minLength: 8, example: 'NewSecurePassword123!' },
+      },
+      required: ['currentPassword', 'newPassword'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Password updated successfully' })
+  @ApiResponse({ status: 400, description: 'Incorrect current password or invalid new password' })
+  @ApiResponse({ status: 401, description: 'Not authenticated' })
+  async changePassword(
+    @Body() body: ChangePasswordDto,
+    @Req() req: Request & { session?: SessionContainer },
+  ) {
+    const { currentPassword, newPassword } = body;
+
+    if (!currentPassword || !newPassword) {
+      throw new BadRequestException('Current password and new password are required');
+    }
+
+    if (newPassword.length < 8) {
+      throw new BadRequestException('New password must be at least 8 characters long');
+    }
+
+    if (!req.session) {
+      throw new UnauthorizedException('No active session');
+    }
+
+    const userId = req.session.getUserId();
+    const stUser = await getUser(userId);
+
+    if (!stUser) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    // Find the email/password login method
+    const emailPasswordMethod = stUser.loginMethods.find(
+      (method) => method.recipeId === 'emailpassword',
+    );
+
+    if (!emailPasswordMethod) {
+      throw new BadRequestException('User does not have email/password login');
+    }
+
+    const email = emailPasswordMethod.email;
+    if (!email) {
+      throw new BadRequestException('Could not determine user email');
+    }
+
+    const tenantId = this.getTenantId();
+
+    // Verify current password by attempting sign-in
+    const signInResponse = await EmailPassword.signIn(tenantId, email, currentPassword);
+
+    if (signInResponse.status === 'WRONG_CREDENTIALS_ERROR') {
+      throw new BadRequestException('Incorrect current password');
+    }
+
+    if (signInResponse.status !== 'OK') {
+      throw new BadRequestException('Failed to verify current password');
+    }
+
+    // Update password
+    const recipeUserId = emailPasswordMethod.recipeUserId;
+    const updateResponse = await EmailPassword.updateEmailOrPassword({
+      recipeUserId,
+      password: newPassword,
+    });
+
+    if (updateResponse.status === 'PASSWORD_POLICY_VIOLATED_ERROR') {
+      throw new BadRequestException(
+        updateResponse.failureReason || 'Password does not meet the required policy',
+      );
+    }
+
+    if (updateResponse.status !== 'OK') {
+      throw new BadRequestException('Failed to update password');
+    }
+
+    return { message: 'Password updated successfully' };
   }
 }

--- a/apps/frontend/src/components/settings/ChangePasswordCard.tsx
+++ b/apps/frontend/src/components/settings/ChangePasswordCard.tsx
@@ -1,0 +1,252 @@
+import { useState, useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { Eye, EyeOff, Lock } from 'lucide-react';
+import { useChangePasswordMutation } from '@/services/authApi';
+import { useToast } from '@/hooks/use-toast';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormDescription,
+} from '@/components/ui/form';
+
+const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, 'Current password is required'),
+    newPassword: z.string().min(8, 'Password must be at least 8 characters'),
+    confirmPassword: z.string().min(1, 'Please confirm your new password'),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+type ChangePasswordFormValues = z.infer<typeof changePasswordSchema>;
+
+interface PasswordStrength {
+  score: number;
+  label: string;
+  color: string;
+}
+
+function calculatePasswordStrength(password: string): PasswordStrength {
+  let score = 0;
+
+  if (password.length >= 8) score++;
+  if (password.length >= 12) score++;
+  if (/[a-z]/.test(password) && /[A-Z]/.test(password)) score++;
+  if (/[0-9]/.test(password)) score++;
+  if (/[^a-zA-Z0-9]/.test(password)) score++;
+
+  if (score <= 1) {
+    return { score, label: 'Weak', color: 'bg-red-500' };
+  } else if (score === 2) {
+    return { score, label: 'Fair', color: 'bg-orange-500' };
+  } else if (score === 3) {
+    return { score, label: 'Good', color: 'bg-yellow-500' };
+  } else {
+    return { score, label: 'Strong', color: 'bg-green-500' };
+  }
+}
+
+export function ChangePasswordCard() {
+  const { toast } = useToast();
+  const [changePassword, { isLoading }] = useChangePasswordMutation();
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const form = useForm<ChangePasswordFormValues>({
+    resolver: zodResolver(changePasswordSchema),
+    defaultValues: {
+      currentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
+    },
+  });
+
+  const newPassword = form.watch('newPassword');
+  const passwordStrength = useMemo(() => {
+    if (!newPassword) return null;
+    return calculatePasswordStrength(newPassword);
+  }, [newPassword]);
+
+  const onSubmit = async (data: ChangePasswordFormValues) => {
+    try {
+      const result = await changePassword({
+        currentPassword: data.currentPassword,
+        newPassword: data.newPassword,
+      }).unwrap();
+
+      toast({
+        title: 'Password updated',
+        description: result.message,
+      });
+
+      form.reset();
+    } catch (error: any) {
+      let errorMessage = 'Failed to change password. Please try again.';
+
+      if (error?.data?.message) {
+        errorMessage = error.data.message;
+      }
+
+      toast({
+        title: 'Error',
+        description: errorMessage,
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Lock className="h-5 w-5" />
+          Change Password
+        </CardTitle>
+        <CardDescription>Update your account password</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="currentPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Current Password</FormLabel>
+                  <FormControl>
+                    <div className="relative">
+                      <Input
+                        type={showCurrentPassword ? 'text' : 'password'}
+                        placeholder="Enter your current password"
+                        autoComplete="current-password"
+                        {...field}
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                        onClick={() => setShowCurrentPassword(!showCurrentPassword)}
+                        aria-label={showCurrentPassword ? 'Hide password' : 'Show password'}
+                      >
+                        {showCurrentPassword ? (
+                          <EyeOff className="h-4 w-4 text-muted-foreground" />
+                        ) : (
+                          <Eye className="h-4 w-4 text-muted-foreground" />
+                        )}
+                      </Button>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="newPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>New Password</FormLabel>
+                  <FormControl>
+                    <div className="relative">
+                      <Input
+                        type={showNewPassword ? 'text' : 'password'}
+                        placeholder="Enter your new password"
+                        autoComplete="new-password"
+                        {...field}
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                        onClick={() => setShowNewPassword(!showNewPassword)}
+                        aria-label={showNewPassword ? 'Hide password' : 'Show password'}
+                      >
+                        {showNewPassword ? (
+                          <EyeOff className="h-4 w-4 text-muted-foreground" />
+                        ) : (
+                          <Eye className="h-4 w-4 text-muted-foreground" />
+                        )}
+                      </Button>
+                    </div>
+                  </FormControl>
+                  {passwordStrength && (
+                    <FormDescription className="space-y-2">
+                      <div className="flex items-center gap-2">
+                        <div className="flex-1 h-2 bg-muted rounded-full overflow-hidden">
+                          <div
+                            className={`h-full transition-all ${passwordStrength.color}`}
+                            style={{ width: `${(passwordStrength.score / 5) * 100}%` }}
+                          />
+                        </div>
+                        <span className="text-xs font-medium">{passwordStrength.label}</span>
+                      </div>
+                      <p className="text-xs">
+                        Use at least 8 characters with a mix of uppercase, lowercase, numbers, and
+                        symbols.
+                      </p>
+                    </FormDescription>
+                  )}
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="confirmPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Confirm New Password</FormLabel>
+                  <FormControl>
+                    <div className="relative">
+                      <Input
+                        type={showConfirmPassword ? 'text' : 'password'}
+                        placeholder="Confirm your new password"
+                        autoComplete="new-password"
+                        {...field}
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                        onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                        aria-label={showConfirmPassword ? 'Hide password' : 'Show password'}
+                      >
+                        {showConfirmPassword ? (
+                          <EyeOff className="h-4 w-4 text-muted-foreground" />
+                        ) : (
+                          <Eye className="h-4 w-4 text-muted-foreground" />
+                        )}
+                      </Button>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <Button type="submit" disabled={isLoading}>
+              {isLoading ? 'Updating password...' : 'Update Password'}
+            </Button>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/pages/UserSettingsPage.tsx
+++ b/apps/frontend/src/pages/UserSettingsPage.tsx
@@ -1,11 +1,12 @@
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { useGetSessionQuery } from '@/services/authApi';
+import { useGetSessionQuery, useGetLoginMethodsQuery } from '@/services/authApi';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { AlertCircle, ArrowLeft, User as UserIcon } from 'lucide-react';
 import { GlobalApiKeysTab } from '@/components/settings/GlobalApiKeysTab';
+import { ChangePasswordCard } from '@/components/settings/ChangePasswordCard';
 
 type TabValue = 'profile' | 'api-keys' | 'preferences';
 
@@ -21,6 +22,9 @@ export function UserSettingsPage() {
   // Fetch session data for user info (auth already verified by ProtectedRoute)
   const { data: sessionData } = useGetSessionQuery();
   const user = sessionData?.user;
+
+  // Fetch login methods to determine if change password should be shown
+  const { data: loginMethods } = useGetLoginMethodsQuery();
 
   // Members cannot access API keys
   const canAccessApiKeys = user?.role !== 'member';
@@ -116,6 +120,8 @@ export function UserSettingsPage() {
               </div>
             </CardContent>
           </Card>
+
+          {loginMethods?.hasPassword && <ChangePasswordCard />}
         </TabsContent>
 
         {/* API Keys Tab - Hidden for member role */}

--- a/apps/frontend/src/services/authApi.ts
+++ b/apps/frontend/src/services/authApi.ts
@@ -82,6 +82,19 @@ export interface VerifyEmailResponse {
   message: string;
 }
 
+export interface LoginMethodsResponse {
+  hasPassword: boolean;
+}
+
+export interface ChangePasswordDto {
+  currentPassword: string;
+  newPassword: string;
+}
+
+export interface ChangePasswordResponse {
+  message: string;
+}
+
 export const authApi = api.injectEndpoints({
   endpoints: (builder) => ({
     getSession: builder.query<SessionInfo, void>({
@@ -174,6 +187,18 @@ export const authApi = api.injectEndpoints({
       }),
       invalidatesTags: ['User'],
     }),
+
+    getLoginMethods: builder.query<LoginMethodsResponse, void>({
+      query: () => '/api/auth/login-methods',
+    }),
+
+    changePassword: builder.mutation<ChangePasswordResponse, ChangePasswordDto>({
+      query: (data) => ({
+        url: '/api/auth/change-password',
+        method: 'POST',
+        body: data,
+      }),
+    }),
   }),
 });
 
@@ -188,4 +213,6 @@ export const {
   useGetRegistrationStatusQuery,
   useSendVerificationEmailMutation,
   useVerifyEmailMutation,
+  useGetLoginMethodsQuery,
+  useChangePasswordMutation,
 } = authApi;


### PR DESCRIPTION
Add authenticated password change flow so users can update their password from the Settings page without needing the email-based forgot password flow.

Backend:
- GET /api/auth/login-methods — returns { hasPassword } by checking SuperTokens login methods (future-proofed for OAuth providers)
- POST /api/auth/change-password — verifies current password via EmailPassword.signIn() before updating, handles policy violations

Frontend:
- ChangePasswordCard component with password strength indicator, show/hide toggles, and zod validation (matches ResetPasswordPage UX)
- Settings page conditionally renders the card only when hasPassword is true