### PR TITLE
feat: Replicate AI pipeline handler

### DIFF
--- a/apps/backend/drizzle/0012_sweet_loki.sql
+++ b/apps/backend/drizzle/0012_sweet_loki.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "projects" ADD COLUMN "ai_services" text;

--- a/apps/backend/drizzle/meta/0012_snapshot.json
+++ b/apps/backend/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,4954 @@
+{
+  "id": "a3d4ddaf-343e-47c1-a168-a69f7ffe0312",
+  "prevId": "87422b3a-b79b-439e-b54b-e7e66a85da87",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_project_id_idx": {
+          "name": "api_keys_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_path": {
+          "name": "original_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_number": {
+          "name": "workflow_run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'commits'"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_project_id_idx": {
+          "name": "assets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_type_idx": {
+          "name": "assets_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_path_idx": {
+          "name": "assets_project_commit_path_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_branch_idx": {
+          "name": "assets_project_branch_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_idx": {
+          "name": "assets_project_commit_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_created_at_idx": {
+          "name": "assets_project_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_committed_at_idx": {
+          "name": "assets_project_committed_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_path_idx": {
+          "name": "assets_deployment_path_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_id_idx": {
+          "name": "assets_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_size_idx": {
+          "name": "assets_deployment_size_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_uploaded_by_users_id_fk": {
+          "name": "assets_uploaded_by_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cache_rules": {
+      "name": "cache_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_max_age": {
+          "name": "browser_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "cdn_max_age": {
+          "name": "cdn_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stale_while_revalidate": {
+          "name": "stale_while_revalidate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immutable": {
+          "name": "immutable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cacheability": {
+          "name": "cacheability",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cache_rules_project_pattern_unique": {
+          "name": "cache_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_id_idx": {
+          "name": "cache_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_priority_idx": {
+          "name": "cache_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cache_rules_project_id_projects_id_fk": {
+          "name": "cache_rules_project_id_projects_id_fk",
+          "tableFrom": "cache_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_aliases": {
+      "name": "deployment_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_preview": {
+          "name": "is_auto_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployment_aliases_project_alias_unique": {
+          "name": "deployment_aliases_project_alias_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_project_id_idx": {
+          "name": "deployment_aliases_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_alias_unique": {
+          "name": "deployment_aliases_repository_alias_unique",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_idx": {
+          "name": "deployment_aliases_repository_idx",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_commit_sha_idx": {
+          "name": "deployment_aliases_commit_sha_idx",
+          "columns": [
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_deployment_id_idx": {
+          "name": "deployment_aliases_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_aliases_project_id_projects_id_fk": {
+          "name": "deployment_aliases_project_id_projects_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_mappings": {
+      "name": "domain_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_type": {
+          "name": "domain_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ssl_expires_at": {
+          "name": "ssl_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_verified": {
+          "name": "dns_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dns_verified_at": {
+          "name": "dns_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_renew_ssl": {
+          "name": "auto_renew_ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_renewed_at": {
+          "name": "ssl_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_status": {
+          "name": "ssl_renewal_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_error": {
+          "name": "ssl_renewal_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sticky_sessions_enabled": {
+          "name": "sticky_sessions_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sticky_session_duration": {
+          "name": "sticky_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 86400
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_mappings_project_id_idx": {
+          "name": "domain_mappings_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_domain_idx": {
+          "name": "domain_mappings_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_is_active_idx": {
+          "name": "domain_mappings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_mappings_project_id_projects_id_fk": {
+          "name": "domain_mappings_project_id_projects_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_mappings_created_by_users_id_fk": {
+          "name": "domain_mappings_created_by_users_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_mappings_domain_unique": {
+          "name": "domain_mappings_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_redirects": {
+      "name": "domain_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_domain": {
+          "name": "source_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_domain_id": {
+          "name": "target_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_redirects_target_domain_id_idx": {
+          "name": "domain_redirects_target_domain_id_idx",
+          "columns": [
+            {
+              "expression": "target_domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_redirects_source_domain_idx": {
+          "name": "domain_redirects_source_domain_idx",
+          "columns": [
+            {
+              "expression": "source_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_redirects_target_domain_id_domain_mappings_id_fk": {
+          "name": "domain_redirects_target_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "target_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_redirects_created_by_users_id_fk": {
+          "name": "domain_redirects_created_by_users_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_redirects_source_domain_unique": {
+          "name": "domain_redirects_source_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_rules": {
+      "name": "domain_traffic_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_key": {
+          "name": "condition_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_value": {
+          "name": "condition_value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_rules_domain_id_idx": {
+          "name": "domain_traffic_rules_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_traffic_rules_domain_id_priority_idx": {
+          "name": "domain_traffic_rules_domain_id_priority_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_rules_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_rules_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_rules",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_weights": {
+      "name": "domain_traffic_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_weights_domain_id_idx": {
+          "name": "domain_traffic_weights_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_weights_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_weights_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_weights",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_traffic_weights_domain_alias_unique": {
+          "name": "domain_traffic_weights_domain_alias_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain_id",
+            "alias"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flags_key_idx": {
+          "name": "feature_flags_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rule_executions": {
+      "name": "onboarding_rule_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rule_executions_user_idx": {
+          "name": "onboarding_rule_executions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_rule_idx": {
+          "name": "onboarding_rule_executions_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_executed_at_idx": {
+          "name": "onboarding_rule_executions_executed_at_idx",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_status_idx": {
+          "name": "onboarding_rule_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rule_executions_rule_id_onboarding_rules_id_fk": {
+          "name": "onboarding_rule_executions_rule_id_onboarding_rules_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "onboarding_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "onboarding_rule_executions_user_id_users_id_fk": {
+          "name": "onboarding_rule_executions_user_id_users_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rules": {
+      "name": "onboarding_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_signup'"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rules_enabled_trigger_idx": {
+          "name": "onboarding_rules_enabled_trigger_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rules_priority_idx": {
+          "name": "onboarding_rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rules_created_by_users_id_fk": {
+          "name": "onboarding_rules_created_by_users_id_fk",
+          "tableFrom": "onboarding_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_preferences": {
+      "name": "path_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spa_mode": {
+          "name": "spa_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_path_preferences_project_id": {
+          "name": "idx_path_preferences_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_preferences_project_id_projects_id_fk": {
+          "name": "path_preferences_project_id_projects_id_fk",
+          "tableFrom": "path_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "path_preferences_project_filepath_unique": {
+          "name": "path_preferences_project_filepath_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "filepath"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_redirects": {
+      "name": "path_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'100'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "path_redirects_domain_mapping_id_idx": {
+          "name": "path_redirects_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "path_redirects_source_path_idx": {
+          "name": "path_redirects_source_path_idx",
+          "columns": [
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_redirects_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "path_redirects_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "path_redirects_created_by_users_id_fk": {
+          "name": "path_redirects_created_by_users_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_token": {
+          "name": "upload_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_token_idx": {
+          "name": "pending_uploads_token_idx",
+          "columns": [
+            {
+              "expression": "upload_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_project_idx": {
+          "name": "pending_uploads_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_project_id_projects_id_fk": {
+          "name": "pending_uploads_project_id_projects_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_uploaded_by_users_id_fk": {
+          "name": "pending_uploads_uploaded_by_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_uploads_upload_token_unique": {
+          "name": "pending_uploads_upload_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data": {
+      "name": "pipeline_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_project_id_idx": {
+          "name": "pipeline_data_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_schema_id_idx": {
+          "name": "pipeline_data_schema_id_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_created_at_idx": {
+          "name": "pipeline_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_project_id_projects_id_fk": {
+          "name": "pipeline_data_project_id_projects_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_created_by_users_id_fk": {
+          "name": "pipeline_data_created_by_users_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schemas": {
+      "name": "pipeline_schemas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schemas_project_id_idx": {
+          "name": "pipeline_schemas_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schemas_project_id_projects_id_fk": {
+          "name": "pipeline_schemas_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schemas",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pipeline_schemas_project_name_unique": {
+          "name": "pipeline_schemas_project_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.primary_content": {
+      "name": "primary_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "www_enabled": {
+          "name": "www_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'redirect-to-www'"
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "primary_content_project_id_projects_id_fk": {
+          "name": "primary_content_project_id_projects_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "primary_content_configured_by_users_id_fk": {
+          "name": "primary_content_configured_by_users_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_group_permissions": {
+      "name": "project_group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_group_permissions_project_idx": {
+          "name": "project_group_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_permissions_group_idx": {
+          "name": "project_group_permissions_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_permissions_project_id_projects_id_fk": {
+          "name": "project_group_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_group_id_user_groups_id_fk": {
+          "name": "project_group_permissions_group_id_user_groups_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_granted_by_users_id_fk": {
+          "name": "project_group_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_group_permissions_unique": {
+          "name": "project_group_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "group_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_permissions": {
+      "name": "project_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_permissions_project_idx": {
+          "name": "project_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_permissions_user_idx": {
+          "name": "project_permissions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_permissions_project_id_projects_id_fk": {
+          "name": "project_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_user_id_users_id_fk": {
+          "name": "project_permissions_user_id_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_granted_by_users_id_fk": {
+          "name": "project_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_permissions_unique": {
+          "name": "project_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_found'"
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authenticated'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_providers": {
+          "name": "ai_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_services": {
+          "name": "ai_services",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_proxy_rule_set_id": {
+          "name": "default_proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_created_by_idx": {
+          "name": "projects_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_owner_idx": {
+          "name": "projects_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_owner_name_unique": {
+          "name": "projects_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_sets": {
+      "name": "proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_sets_project_name_unique": {
+          "name": "proxy_rule_sets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_project_id_idx": {
+          "name": "proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_environment_idx": {
+          "name": "proxy_rule_sets_environment_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rules": {
+      "name": "proxy_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strip_prefix": {
+          "name": "strip_prefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "preserve_host": {
+          "name": "preserve_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forward_cookies": {
+          "name": "forward_cookies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "header_config": {
+          "name": "header_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_transform": {
+          "name": "auth_transform",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_rewrite": {
+          "name": "internal_rewrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proxy_type": {
+          "name": "proxy_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external_proxy'"
+        },
+        "email_handler_config": {
+          "name": "email_handler_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rules_rule_set_path_method_unique": {
+          "name": "proxy_rules_rule_set_path_method_unique",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_id_idx": {
+          "name": "proxy_rules_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_order_idx": {
+          "name": "proxy_rules_rule_set_order_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_proxy_type_idx": {
+          "name": "proxy_rules_proxy_type_idx",
+          "columns": [
+            {
+              "expression": "proxy_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rules_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rules_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rules",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_logs": {
+      "name": "retention_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_count": {
+          "name": "asset_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "freed_bytes": {
+          "name": "freed_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_partial": {
+          "name": "is_partial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_logs_project_id_idx": {
+          "name": "retention_logs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_rule_id_idx": {
+          "name": "retention_logs_rule_id_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_deleted_at_idx": {
+          "name": "retention_logs_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_project_deleted_at_idx": {
+          "name": "retention_logs_project_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_logs_project_id_projects_id_fk": {
+          "name": "retention_logs_project_id_projects_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retention_logs_rule_id_retention_rules_id_fk": {
+          "name": "retention_logs_rule_id_retention_rules_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "retention_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_rules": {
+      "name": "retention_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_pattern": {
+          "name": "branch_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_branches": {
+          "name": "exclude_branches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keep_with_alias": {
+          "name": "keep_with_alias",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "keep_minimum": {
+          "name": "keep_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "path_patterns": {
+          "name": "path_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_mode": {
+          "name": "path_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_summary": {
+          "name": "last_run_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_rules_project_id_idx": {
+          "name": "retention_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_next_run_idx": {
+          "name": "retention_rules_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_enabled_next_run_idx": {
+          "name": "retention_rules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_rules_project_id_projects_id_fk": {
+          "name": "retention_rules_project_id_projects_id_fk",
+          "tableFrom": "retention_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "share_links_project_id_idx": {
+          "name": "share_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_domain_mapping_id_idx": {
+          "name": "share_links_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_token_idx": {
+          "name": "share_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_is_active_idx": {
+          "name": "share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_project_id_projects_id_fk": {
+          "name": "share_links_project_id_projects_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "share_links_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_created_by_users_id_fk": {
+          "name": "share_links_created_by_users_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "share_links_token_unique": {
+          "name": "share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_challenges": {
+      "name": "ssl_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "base_domain": {
+          "name": "base_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_type": {
+          "name": "challenge_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_name": {
+          "name": "record_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_value": {
+          "name": "record_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_data": {
+          "name": "order_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authz_data": {
+          "name": "authz_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_authorization": {
+          "name": "key_authorization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_challenges_base_domain_idx": {
+          "name": "ssl_challenges_base_domain_idx",
+          "columns": [
+            {
+              "expression": "base_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_challenges_status_idx": {
+          "name": "ssl_challenges_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ssl_challenges_base_domain_unique": {
+          "name": "ssl_challenges_base_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "base_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_renewal_history": {
+      "name": "ssl_renewal_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_type": {
+          "name": "certificate_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_expires_at": {
+          "name": "new_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_renewal_history_domain_id_idx": {
+          "name": "ssl_renewal_history_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_renewal_history_created_at_idx": {
+          "name": "ssl_renewal_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssl_renewal_history_domain_id_domain_mappings_id_fk": {
+          "name": "ssl_renewal_history_domain_id_domain_mappings_id_fk",
+          "tableFrom": "ssl_renewal_history",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_settings": {
+      "name": "ssl_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_config": {
+      "name": "system_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_setup_complete": {
+          "name": "is_setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_config": {
+          "name": "storage_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_provider": {
+          "name": "email_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_config": {
+          "name": "email_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_configured": {
+          "name": "email_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "smtp_config": {
+          "name": "smtp_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_configured": {
+          "name": "smtp_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_config": {
+          "name": "cache_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwt_secret": {
+          "name": "jwt_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_salt": {
+          "name": "api_key_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_public_signups": {
+          "name": "allow_public_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_group_members": {
+      "name": "user_group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_members_group_idx": {
+          "name": "user_group_members_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_group_members_user_idx": {
+          "name": "user_group_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_group_members_group_id_user_groups_id_fk": {
+          "name": "user_group_members_group_id_user_groups_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_user_id_users_id_fk": {
+          "name": "user_group_members_user_id_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_added_by_users_id_fk": {
+          "name": "user_group_members_added_by_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_group_members_unique": {
+          "name": "user_group_members_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_groups_created_by_idx": {
+          "name": "user_groups_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_created_by_users_id_fk": {
+          "name": "user_groups_created_by_users_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_invitations_email": {
+          "name": "idx_workspace_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_invitations_token": {
+          "name": "idx_workspace_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invitations_invited_by_users_id_fk": {
+          "name": "workspace_invitations_invited_by_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_accepted_user_id_users_id_fk": {
+          "name": "workspace_invitations_accepted_user_id_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitations_token_unique": {
+          "name": "workspace_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1773796721155,
       "tag": "0011_sour_ego",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1774091692420,
+      "tag": "0012_sweet_loki",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/auth/guards/project-permission.guard.spec.ts
+++ b/apps/backend/src/auth/guards/project-permission.guard.spec.ts
@@ -32,6 +32,7 @@ describe('ProjectPermissionGuard', () => {
     settings: {},
     defaultProxyRuleSetId: null,
     aiProviders: null,
+    aiServices: null,
     createdBy: 'user-123',
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/apps/backend/src/db/schema/projects.schema.ts
+++ b/apps/backend/src/db/schema/projects.schema.ts
@@ -48,6 +48,13 @@ export const projects = pgTable(
     aiProviders: text('ai_providers'),
 
     /**
+     * AI Service Configuration (external ML services like Replicate)
+     * Each service is stored with its encrypted config in a JSON array
+     * Format: [{ service: 'replicate', config: '<encrypted>', createdAt: '...' }, ...]
+     */
+    aiServices: text('ai_services'),
+
+    /**
      * Default proxy rule set for this project.
      * Used as fallback when an alias doesn't have its own proxyRuleSetId.
      * NULL means no default proxy rules.

--- a/apps/backend/src/deployments/deployments.service.spec.ts
+++ b/apps/backend/src/deployments/deployments.service.spec.ts
@@ -61,6 +61,7 @@ describe('DeploymentsService', () => {
     settings: {},
     defaultProxyRuleSetId: null,
     aiProviders: null,
+    aiServices: null,
     createdBy: mockUserId,
     createdAt: new Date('2025-01-01'),
     updatedAt: new Date('2025-01-01'),

--- a/apps/backend/src/pipelines/execution/step-handler.interface.ts
+++ b/apps/backend/src/pipelines/execution/step-handler.interface.ts
@@ -559,6 +559,15 @@ export interface FileUploadHandlerConfig extends BaseHandlerConfig {
    * @default "file"
    */
   fileField?: string;
+
+  /**
+   * Download a file from a URL instead of reading from multipart form data.
+   * When set, the handler fetches this URL, stores the file, and creates records
+   * just like a regular upload. Useful for saving output files from external
+   * services (e.g., Replicate AI prediction results).
+   * Supports expressions (e.g., "steps.replicate_ai.output").
+   */
+  sourceUrl?: string;
 }
 
 /**
@@ -579,3 +588,28 @@ export interface FileServeHandlerConfig extends BaseHandlerConfig {
 
 // Backwards compatibility alias
 export type ChatHandlerConfig = AIHandlerConfig;
+
+/**
+ * Configuration for replicate handler (calls Replicate ML models)
+ */
+export interface ReplicateHandlerConfig extends BaseHandlerConfig {
+  /**
+   * Replicate model identifier (e.g., 'andreasjansson/clip-features')
+   */
+  model: string;
+
+  /**
+   * Pin a specific model version hash (optional)
+   */
+  version?: string;
+
+  /**
+   * Input field mappings: { modelInputName: "expression" }
+   */
+  input: Record<string, string>;
+
+  /**
+   * Extract a specific key from the prediction output (optional)
+   */
+  outputField?: string;
+}

--- a/apps/backend/src/pipelines/handlers/file-upload.handler.ts
+++ b/apps/backend/src/pipelines/handlers/file-upload.handler.ts
@@ -17,8 +17,12 @@ import { createHash } from 'crypto';
 /**
  * File Upload Handler
  *
- * Handles file uploads via multipart form data.
- * Stores files in the storage adapter and creates pipeline_data + asset records.
+ * Handles file uploads from two sources:
+ * 1. Multipart form data (default) — user uploads a file via form
+ * 2. URL download (sourceUrl) — fetches a file from a URL (e.g., Replicate output)
+ *
+ * In both cases, stores the file in the storage adapter and creates
+ * pipeline_data + asset records with the same output shape.
  */
 @Injectable()
 export class FileUploadHandler implements StepHandler<FileUploadHandlerConfig> {
@@ -62,38 +66,59 @@ export class FileUploadHandler implements StepHandler<FileUploadHandlerConfig> {
       );
     }
 
-    // Extract file from multer-parsed request
-    const file = (context.request as any).file as Express.Multer.File | undefined;
-    if (!file) {
-      return {
-        success: false,
-        error: {
-          code: 'NO_FILE',
-          message: 'No file uploaded. Send a multipart form with a "file" field.',
-        },
-      };
-    }
+    // Determine file source: URL download or multipart form upload
+    let fileBuffer: Buffer;
+    let mimeType: string;
+    let originalName: string;
 
-    // Validate MIME type
-    const allowedMimeTypes = config.allowedMimeTypes || ['*/*'];
-    if (!this.isMimeTypeAllowed(file.mimetype, allowedMimeTypes)) {
-      return {
-        success: false,
-        error: {
-          code: 'INVALID_MIME_TYPE',
-          message: `File type "${file.mimetype}" is not allowed. Allowed types: ${allowedMimeTypes.join(', ')}`,
-        },
-      };
+    if (config.sourceUrl) {
+      // URL download mode: fetch the file from a URL expression
+      const resolved = await this.resolveFileFromUrl(config.sourceUrl, context, stepName);
+      if (!resolved.success) {
+        return resolved.error!;
+      }
+      fileBuffer = resolved.buffer!;
+      mimeType = resolved.mimeType!;
+      originalName = resolved.filename!;
+    } else {
+      // Multipart form upload mode (original behavior)
+      const file = (context.request as any).file as Express.Multer.File | undefined;
+      if (!file) {
+        return {
+          success: false,
+          error: {
+            code: 'NO_FILE',
+            message: 'No file uploaded. Send a multipart form with a "file" field.',
+          },
+        };
+      }
+
+      // Validate MIME type
+      const allowedMimeTypes = config.allowedMimeTypes || ['*/*'];
+      if (!this.isMimeTypeAllowed(file.mimetype, allowedMimeTypes)) {
+        return {
+          success: false,
+          error: {
+            code: 'INVALID_MIME_TYPE',
+            message: `File type "${file.mimetype}" is not allowed. Allowed types: ${allowedMimeTypes.join(', ')}`,
+          },
+        };
+      }
+
+      fileBuffer = file.buffer;
+      mimeType = file.mimetype;
+      // Multer encodes originalname as Latin-1; decode to UTF-8 for proper unicode support
+      originalName = Buffer.from(file.originalname, 'latin1').toString('utf8');
     }
 
     // Validate file size
     const maxFileSize = config.maxFileSize || 10 * 1024 * 1024; // default 10MB
-    if (file.size > maxFileSize) {
+    if (fileBuffer.length > maxFileSize) {
       return {
         success: false,
         error: {
           code: 'FILE_TOO_LARGE',
-          message: `File size ${file.size} bytes exceeds maximum ${maxFileSize} bytes`,
+          message: `File size ${fileBuffer.length} bytes exceeds maximum ${maxFileSize} bytes`,
         },
       };
     }
@@ -109,9 +134,7 @@ export class FileUploadHandler implements StepHandler<FileUploadHandlerConfig> {
     }
 
     const uuid = randomUUID();
-    // Multer encodes originalname as Latin-1; decode to UTF-8 for proper unicode support
-    const decodedOriginalName = Buffer.from(file.originalname, 'latin1').toString('utf8');
-    const sanitizedFilename = decodedOriginalName.replace(/[^a-zA-Z0-9._-]/g, '_');
+    const sanitizedFilename = originalName.replace(/[^a-zA-Z0-9._-]/g, '_');
     let storageKey = `${owner}/${repo}/uploads/${config.subDir}`;
 
     if (config.dateBucket) {
@@ -122,26 +145,25 @@ export class FileUploadHandler implements StepHandler<FileUploadHandlerConfig> {
     storageKey += `/${uuid}-${sanitizedFilename}`;
 
     // Upload to storage
-    await this.storageAdapter.upload(file.buffer, storageKey, {
-      mimeType: file.mimetype,
+    await this.storageAdapter.upload(fileBuffer, storageKey, {
+      mimeType,
     });
 
     // Build the public URL path
-    const alias = context.deployment?.alias ?? 'production';
     const publicPath = `/api/uploads/${config.subDir}/${uuid}-${sanitizedFilename}`;
 
     // Compute content hash
-    const contentHash = createHash('md5').update(file.buffer).digest('hex');
+    const contentHash = createHash('md5').update(fileBuffer).digest('hex');
 
     // Create pipeline_data record with metadata
     const data: Record<string, unknown> = {
       filename: sanitizedFilename,
       storage_path: storageKey,
-      content_type: file.mimetype,
-      size: file.size,
+      content_type: mimeType,
+      size: fileBuffer.length,
       url: publicPath,
       sub_dir: config.subDir,
-      original_name: decodedOriginalName,
+      original_name: originalName,
     };
 
     // Evaluate extra field expressions and merge into data
@@ -168,10 +190,10 @@ export class FileUploadHandler implements StepHandler<FileUploadHandlerConfig> {
     try {
       await db.insert(assets).values({
         fileName: sanitizedFilename,
-        originalPath: file.originalname,
+        originalPath: originalName,
         storageKey,
-        mimeType: file.mimetype,
-        size: file.size,
+        mimeType,
+        size: fileBuffer.length,
         projectId: context.projectId,
         uploadedBy: context.user?.id || null,
         assetType: AssetType.UPLOADS,
@@ -194,11 +216,132 @@ export class FileUploadHandler implements StepHandler<FileUploadHandlerConfig> {
         filename: sanitizedFilename,
         url: publicPath,
         storage_path: storageKey,
-        content_type: file.mimetype,
-        size: file.size,
-        original_name: decodedOriginalName,
+        content_type: mimeType,
+        size: fileBuffer.length,
+        original_name: originalName,
       },
     };
+  }
+
+  /**
+   * Fetch a file from a URL (evaluated from an expression).
+   * Extracts filename from URL path or Content-Disposition header,
+   * and MIME type from Content-Type header.
+   */
+  private async resolveFileFromUrl(
+    sourceUrlExpression: string,
+    context: PipelineContext,
+    stepName: string,
+  ): Promise<{
+    success: boolean;
+    buffer?: Buffer;
+    mimeType?: string;
+    filename?: string;
+    error?: StepResult;
+  }> {
+    const url = this.expressionEvaluator.evaluateExpression(
+      sourceUrlExpression,
+      context,
+      stepName,
+    );
+
+    if (!url || typeof url !== 'string') {
+      return {
+        success: false,
+        error: {
+          success: false,
+          error: {
+            code: 'INVALID_SOURCE_URL',
+            message: `sourceUrl expression "${sourceUrlExpression}" resolved to ${url === null ? 'null' : typeof url}, expected a URL string`,
+          },
+        },
+      };
+    }
+
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      return {
+        success: false,
+        error: {
+          success: false,
+          error: {
+            code: 'INVALID_SOURCE_URL',
+            message: `sourceUrl must be an HTTP(S) URL, got: ${url.substring(0, 100)}`,
+          },
+        },
+      };
+    }
+
+    try {
+      this.logger.debug(`Downloading file from URL: ${url}`);
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        return {
+          success: false,
+          error: {
+            success: false,
+            error: {
+              code: 'SOURCE_URL_FETCH_FAILED',
+              message: `Failed to download file from URL (${response.status}): ${url}`,
+            },
+          },
+        };
+      }
+
+      const arrayBuffer = await response.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+
+      // Extract MIME type from Content-Type header
+      const contentType = response.headers.get('content-type');
+      const mimeType = contentType?.split(';')[0]?.trim() || 'application/octet-stream';
+
+      // Extract filename from Content-Disposition header or URL path
+      let filename = this.extractFilenameFromHeaders(response.headers);
+      if (!filename) {
+        filename = this.extractFilenameFromUrl(url);
+      }
+
+      return { success: true, buffer, mimeType, filename };
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          success: false,
+          error: {
+            code: 'SOURCE_URL_FETCH_FAILED',
+            message: `Failed to download file from URL: ${(error as Error).message}`,
+          },
+        },
+      };
+    }
+  }
+
+  /**
+   * Try to extract filename from Content-Disposition header.
+   */
+  private extractFilenameFromHeaders(headers: Headers): string | null {
+    const disposition = headers.get('content-disposition');
+    if (!disposition) return null;
+
+    // Match filename="..." or filename*=UTF-8''...
+    const match = disposition.match(/filename[*]?=(?:UTF-8''|"?)([^";]+)/i);
+    return match ? decodeURIComponent(match[1].replace(/"/g, '')) : null;
+  }
+
+  /**
+   * Extract filename from URL path as fallback.
+   */
+  private extractFilenameFromUrl(url: string): string {
+    try {
+      const pathname = new URL(url).pathname;
+      const lastSegment = pathname.split('/').pop();
+      if (lastSegment && lastSegment.includes('.')) {
+        return decodeURIComponent(lastSegment);
+      }
+    } catch {
+      // ignore URL parse errors
+    }
+    return `download-${randomUUID().substring(0, 8)}`;
   }
 
   /**

--- a/apps/backend/src/pipelines/handlers/index.ts
+++ b/apps/backend/src/pipelines/handlers/index.ts
@@ -10,3 +10,4 @@ export * from './function.handler';
 export * from './ai.handler';
 export * from './file-upload.handler';
 export * from './file-serve.handler';
+export * from './replicate.handler';

--- a/apps/backend/src/pipelines/handlers/replicate.handler.ts
+++ b/apps/backend/src/pipelines/handlers/replicate.handler.ts
@@ -1,0 +1,429 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { StepHandler, ReplicateHandlerConfig } from '../execution/step-handler.interface';
+import { StepHandlerRegistry } from '../execution/step-handler.registry';
+import { ExpressionEvaluator } from '../execution/expression-evaluator';
+import { PipelineContext, StepResult } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+import { ProjectAISettingsService } from '../../projects/project-ai-settings.service';
+import { IStorageAdapter, STORAGE_ADAPTER } from '../../storage/storage.interface';
+import { ConfigurationError } from '../errors';
+
+const REPLICATE_API_BASE = 'https://api.replicate.com/v1';
+const MAX_POLL_ATTEMPTS = 60;
+const POLL_INTERVAL_MS = 1000;
+
+/**
+ * Threshold for using Replicate Files API vs base64 data URI.
+ * Files <= 256KB are sent inline as data URIs (one fewer API call).
+ * Files > 256KB are uploaded via POST /v1/files to avoid base64 bloat
+ * and use Replicate's optimized delivery infrastructure.
+ * Uploaded files auto-expire after 24 hours (no cleanup needed).
+ */
+const DATA_URI_SIZE_THRESHOLD = 256 * 1024; // 256KB
+
+/**
+ * Replicate Handler
+ *
+ * Calls Replicate ML models (CLIP embeddings, image generation, PDF extraction, etc.)
+ * from pipeline steps. Uses the Replicate predictions API with sync mode (Prefer: wait).
+ *
+ * File handling: When an input value is a storage path (from a file_upload_handler step),
+ * the handler automatically reads the file from storage and sends it to Replicate.
+ * - Small files (<=256KB): inlined as base64 data URIs for simplicity
+ * - Larger files: uploaded via Replicate's Files API (POST /v1/files), which returns
+ *   a serving URL on replicate.delivery — no base64 overhead, optimized for their infra
+ *
+ * Reference `steps.<upload_step>.storage_path` for the file input.
+ */
+@Injectable()
+export class ReplicateHandler implements StepHandler<ReplicateHandlerConfig> {
+  readonly type = 'replicate' as const;
+  private readonly logger = new Logger(ReplicateHandler.name);
+
+  constructor(
+    private readonly registry: StepHandlerRegistry,
+    private readonly expressionEvaluator: ExpressionEvaluator,
+    private readonly projectAISettingsService: ProjectAISettingsService,
+    @Inject(STORAGE_ADAPTER) private readonly storageAdapter: IStorageAdapter,
+  ) {
+    this.registry.register(this);
+  }
+
+  validateConfig(config: ReplicateHandlerConfig): void {
+    if (!config.model) {
+      throw new ConfigurationError('model is required', 'replicate');
+    }
+
+    if (!config.input || Object.keys(config.input).length === 0) {
+      throw new ConfigurationError('input is required and must have at least one field', 'replicate');
+    }
+  }
+
+  async execute(context: PipelineContext, step: PipelineStep): Promise<StepResult> {
+    const config = step.config as ReplicateHandlerConfig;
+
+    // Get Replicate API token
+    const serviceConfig = await this.projectAISettingsService.getServiceConfig(
+      context.projectId,
+      'replicate',
+    );
+
+    if (!serviceConfig) {
+      return {
+        success: false,
+        error: {
+          code: 'REPLICATE_NOT_CONFIGURED',
+          message: 'Replicate API token is not configured. Add it in Settings > AI > AI Services.',
+        },
+      };
+    }
+
+    // Evaluate input expressions
+    const evaluatedInput: Record<string, unknown> = {};
+    for (const [key, expression] of Object.entries(config.input)) {
+      evaluatedInput[key] = this.expressionEvaluator.evaluateExpression(
+        expression,
+        context,
+      );
+    }
+
+    // Resolve file references: read from storage and upload to Replicate or inline as data URI
+    await this.resolveFileInputs(evaluatedInput, context, serviceConfig.apiToken);
+
+    try {
+      // Resolve the version to use
+      // The "version" field on POST /v1/predictions accepts:
+      //   "{owner}/{name}" — official models only
+      //   "{owner}/{name}:{version_hash}" — any model, pinned version
+      //   "{version_hash}" — just the 64-char hash
+      // Community models need a version hash. If the user didn't pin one,
+      // we look up the latest version via GET /v1/models/{owner}/{name}/versions.
+      let version = config.version;
+      if (!version) {
+        version = await this.resolveLatestVersion(config.model, serviceConfig.apiToken);
+      }
+
+      const payload: Record<string, unknown> = {
+        input: evaluatedInput,
+        version,
+      };
+
+      // Create prediction with Prefer: wait (sync mode, up to 60s)
+      const response = await fetch(`${REPLICATE_API_BASE}/predictions`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${serviceConfig.apiToken}`,
+          'Content-Type': 'application/json',
+          Prefer: 'wait',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        return {
+          success: false,
+          error: {
+            code: 'REPLICATE_API_ERROR',
+            message: `Replicate API error: ${(errorBody as Record<string, string>).detail || response.statusText}`,
+            details: errorBody,
+          },
+        };
+      }
+
+      let prediction = (await response.json()) as Record<string, unknown>;
+
+      // If not completed yet, poll until succeeded/failed
+      if (prediction.status !== 'succeeded' && prediction.status !== 'failed' && prediction.status !== 'canceled') {
+        prediction = await this.pollPrediction(
+          prediction.id as string,
+          serviceConfig.apiToken,
+        );
+      }
+
+      if (prediction.status === 'failed') {
+        return {
+          success: false,
+          error: {
+            code: 'REPLICATE_PREDICTION_FAILED',
+            message: `Prediction failed: ${prediction.error || 'Unknown error'}`,
+            details: { predictionId: prediction.id, model: config.model },
+          },
+        };
+      }
+
+      if (prediction.status === 'canceled') {
+        return {
+          success: false,
+          error: {
+            code: 'REPLICATE_PREDICTION_CANCELED',
+            message: 'Prediction was canceled',
+            details: { predictionId: prediction.id, model: config.model },
+          },
+        };
+      }
+
+      // Extract output
+      let output = prediction.output;
+      if (config.outputField && output && typeof output === 'object' && !Array.isArray(output)) {
+        output = (output as Record<string, unknown>)[config.outputField];
+      }
+
+      return {
+        success: true,
+        output: {
+          predictionId: prediction.id,
+          model: config.model,
+          status: prediction.status,
+          output,
+          metrics: prediction.metrics,
+        },
+      };
+    } catch (error) {
+      this.logger.error(`Replicate handler error for step ${step.name}:`, error);
+      return {
+        success: false,
+        error: {
+          code: 'REPLICATE_EXECUTION_ERROR',
+          message: `Replicate execution failed: ${(error as Error).message}`,
+        },
+      };
+    }
+  }
+
+  /**
+   * Resolve file inputs by reading from storage and making them available to Replicate.
+   *
+   * Detects two patterns:
+   * 1. Storage path (e.g., "owner/repo/uploads/images/uuid-file.png") — reads directly
+   * 2. Internal API URL (e.g., "/api/uploads/images/uuid-file.png") — converts to storage path
+   *
+   * For each resolved file:
+   * - <= 256KB: inlined as a base64 data URI (one fewer API call)
+   * - > 256KB: uploaded to Replicate's Files API, replaced with the serving URL
+   */
+  private async resolveFileInputs(
+    input: Record<string, unknown>,
+    context: PipelineContext,
+    apiToken: string,
+  ): Promise<void> {
+    for (const [key, value] of Object.entries(input)) {
+      if (typeof value !== 'string') continue;
+
+      // Skip if already a URL (http/https) or data URI
+      if (value.startsWith('http://') || value.startsWith('https://') || value.startsWith('data:')) {
+        continue;
+      }
+
+      let storagePath: string | null = null;
+
+      // Pattern 1: Storage path (contains "uploads/" with owner/repo prefix)
+      if (value.includes('/uploads/') && value.includes('/')) {
+        storagePath = value;
+      }
+
+      // Pattern 2: Internal API URL like "/api/uploads/sub_dir/uuid-file.png"
+      if (!storagePath && value.startsWith('/api/uploads/')) {
+        storagePath = this.resolveApiUrlToStoragePath(value, context);
+      }
+
+      if (!storagePath) continue;
+
+      const resolved = await this.resolveStorageFile(storagePath, context, apiToken);
+      if (resolved) {
+        input[key] = resolved;
+      }
+    }
+  }
+
+  /**
+   * Read a file from storage and return either a data URI (small files)
+   * or a Replicate Files API serving URL (larger files).
+   */
+  private async resolveStorageFile(
+    storagePath: string,
+    context: PipelineContext,
+    apiToken: string,
+  ): Promise<string | null> {
+    try {
+      const contentType = this.findContentTypeFromSteps(storagePath, context) ||
+        this.guessContentType(storagePath);
+      const filename = storagePath.split('/').pop() || 'file';
+
+      const buffer = await this.storageAdapter.download(storagePath);
+
+      if (buffer.length <= DATA_URI_SIZE_THRESHOLD) {
+        // Small file: inline as data URI (avoids extra API call)
+        this.logger.debug(`File ${filename} (${buffer.length} bytes) — using inline data URI`);
+        const base64 = buffer.toString('base64');
+        return `data:${contentType};base64,${base64}`;
+      }
+
+      // Large file: upload via Replicate Files API
+      this.logger.debug(`File ${filename} (${buffer.length} bytes) — uploading via Replicate Files API`);
+      return await this.uploadToReplicateFiles(buffer, contentType, filename, apiToken);
+    } catch (error) {
+      this.logger.warn(`Failed to resolve file for Replicate input: ${storagePath}`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Upload a file to Replicate's Files API (POST /v1/files).
+   * Returns the serving URL (urls.get) which can be passed directly as a prediction input.
+   * Files auto-expire after 24 hours — no cleanup needed.
+   */
+  private async uploadToReplicateFiles(
+    buffer: Buffer,
+    contentType: string,
+    filename: string,
+    apiToken: string,
+  ): Promise<string> {
+    const formData = new FormData();
+    const blob = new Blob([buffer as unknown as BlobPart], { type: contentType });
+    formData.append('content', blob, filename);
+
+    const response = await fetch(`${REPLICATE_API_BASE}/files`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+      },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => '');
+      throw new Error(`Replicate Files API upload failed (${response.status}): ${errorBody}`);
+    }
+
+    const result = (await response.json()) as { urls?: { get?: string }; id?: string };
+    const servingUrl = result.urls?.get;
+
+    if (!servingUrl) {
+      throw new Error('Replicate Files API response missing urls.get');
+    }
+
+    this.logger.debug(`Uploaded file to Replicate: ${servingUrl}`);
+    return servingUrl;
+  }
+
+  /**
+   * Convert an internal /api/uploads/... URL to a storage path using deployment context.
+   */
+  private resolveApiUrlToStoragePath(apiUrl: string, context: PipelineContext): string | null {
+    const owner = context.deployment?.owner;
+    const repo = context.deployment?.repo;
+    if (!owner || !repo) return null;
+
+    const pathAfterUploads = apiUrl.replace('/api/uploads/', '');
+    return `${owner}/${repo}/uploads/${pathAfterUploads}`;
+  }
+
+  /**
+   * Look through previous step outputs to find the content_type for a given storage_path.
+   */
+  private findContentTypeFromSteps(storagePath: string, context: PipelineContext): string | null {
+    for (const stepOutput of Object.values(context.stepOutputs)) {
+      if (stepOutput && typeof stepOutput === 'object') {
+        const output = stepOutput as Record<string, unknown>;
+        if (output.storage_path === storagePath && typeof output.content_type === 'string') {
+          return output.content_type;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Guess MIME type from file extension as fallback.
+   */
+  private guessContentType(path: string): string {
+    const ext = path.split('.').pop()?.toLowerCase();
+    const mimeTypes: Record<string, string> = {
+      png: 'image/png',
+      jpg: 'image/jpeg',
+      jpeg: 'image/jpeg',
+      gif: 'image/gif',
+      webp: 'image/webp',
+      svg: 'image/svg+xml',
+      pdf: 'application/pdf',
+      mp3: 'audio/mpeg',
+      wav: 'audio/wav',
+      mp4: 'video/mp4',
+      webm: 'video/webm',
+      txt: 'text/plain',
+      json: 'application/json',
+    };
+    return mimeTypes[ext || ''] || 'application/octet-stream';
+  }
+
+  /**
+   * Resolve a model identifier to its latest version hash.
+   * Tries the model as-is first (works for official models), then
+   * fetches the latest version from the API for community models.
+   */
+  private async resolveLatestVersion(model: string, apiToken: string): Promise<string> {
+    try {
+      const response = await fetch(
+        `${REPLICATE_API_BASE}/models/${model}/versions`,
+        {
+          headers: { Authorization: `Bearer ${apiToken}` },
+        },
+      );
+
+      if (!response.ok) {
+        // Fallback: try using the model identifier directly (works for official models)
+        this.logger.warn(`Could not fetch versions for ${model} (${response.status}), using model ID directly`);
+        return model;
+      }
+
+      const data = (await response.json()) as { results?: { id: string }[] };
+      const latestVersion = data.results?.[0]?.id;
+
+      if (!latestVersion) {
+        this.logger.warn(`No versions found for ${model}, using model ID directly`);
+        return model;
+      }
+
+      this.logger.debug(`Resolved ${model} to version ${latestVersion.substring(0, 12)}...`);
+      return latestVersion;
+    } catch (error) {
+      this.logger.warn(`Failed to resolve version for ${model}, using model ID directly`, error);
+      return model;
+    }
+  }
+
+  private async pollPrediction(
+    predictionId: string,
+    apiToken: string,
+  ): Promise<Record<string, unknown>> {
+    for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+
+      const response = await fetch(
+        `${REPLICATE_API_BASE}/predictions/${predictionId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${apiToken}`,
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`Failed to poll prediction: ${response.statusText}`);
+      }
+
+      const prediction = (await response.json()) as Record<string, unknown>;
+
+      if (
+        prediction.status === 'succeeded' ||
+        prediction.status === 'failed' ||
+        prediction.status === 'canceled'
+      ) {
+        return prediction;
+      }
+    }
+
+    throw new Error(`Prediction ${predictionId} timed out after ${MAX_POLL_ATTEMPTS} attempts`);
+  }
+}

--- a/apps/backend/src/pipelines/pipelines.module.ts
+++ b/apps/backend/src/pipelines/pipelines.module.ts
@@ -29,6 +29,7 @@ import {
   AIHandler,
   FileUploadHandler,
   FileServeHandler,
+  ReplicateHandler,
 } from './handlers';
 // Services
 import { FunctionRunnerService } from './function-runner.service';
@@ -82,6 +83,7 @@ import {
     AIHandler,
     FileUploadHandler,
     FileServeHandler,
+    ReplicateHandler,
     // Validators (auto-register on construction)
     AuthRequiredValidator,
     RateLimitValidator,

--- a/apps/backend/src/pipelines/types.ts
+++ b/apps/backend/src/pipelines/types.ts
@@ -68,7 +68,8 @@ export type HandlerType =
   | 'db_aggregate'
   | 'ai_handler'
   | 'file_upload_handler'
-  | 'file_serve_handler';
+  | 'file_serve_handler'
+  | 'replicate';
 
 /**
  * Pipeline step definition for execution.

--- a/apps/backend/src/projects/project-ai-settings.service.ts
+++ b/apps/backend/src/projects/project-ai-settings.service.ts
@@ -11,6 +11,11 @@ import * as crypto from 'crypto';
 export type AIProviderType = 'openai' | 'anthropic' | 'google';
 
 /**
+ * AI Service types (external ML services, separate from chat LLM providers)
+ */
+export type AIServiceType = 'replicate';
+
+/**
  * Model tier for pricing/capability categorization
  */
 export type ModelTier = 'economy' | 'balanced' | 'premium';
@@ -126,6 +131,34 @@ export interface TestAIResponse {
   error?: string;
   latencyMs?: number;
   model?: string;
+}
+
+/**
+ * Stored AI service configuration
+ */
+interface StoredServiceConfig {
+  service: AIServiceType;
+  config: string; // encrypted
+  createdAt: string;
+}
+
+/**
+ * Decrypted AI service configuration
+ */
+export interface AIServiceConfig {
+  service: AIServiceType;
+  apiToken: string;
+}
+
+/**
+ * AI Services status response (for frontend display)
+ */
+export interface AIServicesStatusResponse {
+  services: {
+    service: AIServiceType;
+    apiToken: string; // Masked
+    createdAt: string;
+  }[];
 }
 
 @Injectable()
@@ -479,6 +512,188 @@ export class ProjectAISettingsService {
       .where(eq(projects.id, projectId));
 
     this.logger.log(`Updated skillsPath for project ${projectId}: ${skillsPath}`);
+  }
+
+  // ===== AI Services (Replicate, etc.) =====
+
+  /**
+   * Get all configured AI services for a project (with masked tokens)
+   */
+  async getAIServicesStatus(projectId: string): Promise<AIServicesStatusResponse> {
+    try {
+      const stored = await this.getStoredServices(projectId);
+
+      return {
+        services: stored.map((s) => {
+          const config = JSON.parse(this.decryptData(s.config));
+          return {
+            service: s.service,
+            apiToken: this.maskApiKey(config.apiToken),
+            createdAt: s.createdAt,
+          };
+        }),
+      };
+    } catch (error) {
+      this.logger.error('Error getting AI services status:', error);
+      return { services: [] };
+    }
+  }
+
+  /**
+   * Add or update an AI service for a project
+   */
+  async addOrUpdateService(
+    projectId: string,
+    service: AIServiceType,
+    apiToken: string,
+  ): Promise<AIServicesStatusResponse> {
+    try {
+      const project = await this.getProject(projectId);
+      if (!project) {
+        throw new NotFoundException('Project not found');
+      }
+
+      const existing = await this.getStoredServices(projectId);
+      const existingIndex = existing.findIndex((s) => s.service === service);
+
+      const newConfig: StoredServiceConfig = {
+        service,
+        config: this.encryptData(JSON.stringify({ apiToken })),
+        createdAt: new Date().toISOString(),
+      };
+
+      if (existingIndex >= 0) {
+        existing[existingIndex] = { ...existing[existingIndex], config: newConfig.config };
+      } else {
+        existing.push(newConfig);
+      }
+
+      await db
+        .update(projects)
+        .set({
+          aiServices: JSON.stringify(existing),
+          updatedAt: new Date(),
+        })
+        .where(eq(projects.id, projectId));
+
+      this.logger.log(`AI service ${service} ${existingIndex >= 0 ? 'updated' : 'added'} for project ${projectId}`);
+      return this.getAIServicesStatus(projectId);
+    } catch (error) {
+      this.logger.error('Error adding/updating AI service:', error);
+      if (error instanceof NotFoundException) throw error;
+      throw new InternalServerErrorException('Failed to update AI service configuration');
+    }
+  }
+
+  /**
+   * Remove an AI service from a project
+   */
+  async removeService(projectId: string, service: AIServiceType): Promise<AIServicesStatusResponse> {
+    try {
+      const project = await this.getProject(projectId);
+      if (!project) {
+        throw new NotFoundException('Project not found');
+      }
+
+      const existing = await this.getStoredServices(projectId);
+      const serviceIndex = existing.findIndex((s) => s.service === service);
+
+      if (serviceIndex < 0) {
+        throw new NotFoundException(`Service ${service} not configured`);
+      }
+
+      existing.splice(serviceIndex, 1);
+
+      await db
+        .update(projects)
+        .set({
+          aiServices: JSON.stringify(existing),
+          updatedAt: new Date(),
+        })
+        .where(eq(projects.id, projectId));
+
+      this.logger.log(`AI service ${service} removed from project ${projectId}`);
+      return this.getAIServicesStatus(projectId);
+    } catch (error) {
+      this.logger.error('Error removing AI service:', error);
+      if (error instanceof NotFoundException) throw error;
+      throw new InternalServerErrorException('Failed to remove AI service');
+    }
+  }
+
+  /**
+   * Get decrypted service config (for use by handlers)
+   */
+  async getServiceConfig(projectId: string, service: AIServiceType): Promise<AIServiceConfig | null> {
+    try {
+      const stored = await this.getStoredServices(projectId);
+      const entry = stored.find((s) => s.service === service);
+
+      if (!entry) {
+        return null;
+      }
+
+      const config = JSON.parse(this.decryptData(entry.config));
+      return {
+        service: entry.service,
+        apiToken: config.apiToken,
+      };
+    } catch (error) {
+      this.logger.error('Failed to get AI service config:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Test Replicate API connection
+   */
+  async testReplicateConnection(apiToken: string): Promise<TestAIResponse> {
+    try {
+      const startTime = Date.now();
+      const response = await fetch('https://api.replicate.com/v1/models', {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+        },
+      });
+
+      const latencyMs = Date.now() - startTime;
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}));
+        return {
+          success: false,
+          message: 'Replicate API test failed',
+          error: (error as Record<string, string>).detail || `HTTP ${response.status}`,
+          latencyMs,
+        };
+      }
+
+      return {
+        success: true,
+        message: 'Replicate connection successful',
+        latencyMs,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message: 'Replicate connection failed',
+        error: (error as Error).message,
+      };
+    }
+  }
+
+  private async getStoredServices(projectId: string): Promise<StoredServiceConfig[]> {
+    const project = await this.getProject(projectId);
+    if (!project?.aiServices) {
+      return [];
+    }
+
+    try {
+      return JSON.parse(project.aiServices);
+    } catch {
+      return [];
+    }
   }
 
   // ===== Private methods =====

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -17,7 +17,7 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { ProjectsService } from './projects.service';
-import { ProjectAISettingsService, AIProviderType } from './project-ai-settings.service';
+import { ProjectAISettingsService, AIProviderType, AIServiceType } from './project-ai-settings.service';
 import { SessionAuthGuard } from '../auth/session-auth.guard';
 import { ProjectPermissionGuard } from '../auth/guards/project-permission.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -201,6 +201,59 @@ export class ProjectsController {
     );
 
     return { skills };
+  }
+
+  // ==========================================================================
+  // AI Services Endpoints (Replicate, etc.)
+  // NOTE: These MUST be defined BEFORE :owner/:name to avoid route conflicts
+  // ==========================================================================
+
+  @Get(':id/ai-services')
+  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @RequireProjectRole('admin')
+  @ApiOperation({ summary: 'Get AI services configured for this project' })
+  @ApiResponse({ status: 200, description: 'AI services status' })
+  async getAIServicesStatus(@Param('id') id: string) {
+    return this.aiSettingsService.getAIServicesStatus(id);
+  }
+
+  @Post(':id/ai-services')
+  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @RequireProjectRole('admin')
+  @ApiOperation({ summary: 'Add or update an AI service for this project' })
+  @ApiResponse({ status: 200, description: 'Service added/updated' })
+  async addOrUpdateAIService(
+    @Param('id') id: string,
+    @Body() body: { service: AIServiceType; apiToken: string },
+  ) {
+    return this.aiSettingsService.addOrUpdateService(id, body.service, body.apiToken);
+  }
+
+  @Delete(':id/ai-services/:service')
+  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @RequireProjectRole('admin')
+  @ApiOperation({ summary: 'Remove an AI service from this project' })
+  @ApiResponse({ status: 200, description: 'Service removed' })
+  async removeAIService(
+    @Param('id') id: string,
+    @Param('service') service: AIServiceType,
+  ) {
+    return this.aiSettingsService.removeService(id, service);
+  }
+
+  @Post(':id/ai-services/test')
+  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @RequireProjectRole('admin')
+  @ApiOperation({ summary: 'Test AI service connection' })
+  @ApiResponse({ status: 200, description: 'Test result' })
+  async testAIService(
+    @Param('id') _id: string,
+    @Body() body: { service: AIServiceType; apiToken: string },
+  ) {
+    if (body.service === 'replicate') {
+      return this.aiSettingsService.testReplicateConnection(body.apiToken);
+    }
+    return { success: false, message: `Unknown service: ${body.service}` };
   }
 
   // ==========================================================================

--- a/apps/backend/src/repo-browser/repo-browser.service.spec.ts
+++ b/apps/backend/src/repo-browser/repo-browser.service.spec.ts
@@ -33,6 +33,7 @@ describe('RepoBrowserService', () => {
     settings: {},
     defaultProxyRuleSetId: null,
     aiProviders: null,
+    aiServices: null,
     createdBy: 'user-123',
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/apps/frontend/src/components/pipelines/PipelineConfig.tsx
+++ b/apps/frontend/src/components/pipelines/PipelineConfig.tsx
@@ -65,6 +65,7 @@ const HANDLER_TYPES: HandlerType[] = [
   'ai_handler',
   'file_upload_handler',
   'file_serve_handler',
+  'replicate',
 ];
 
 function generateId(): string {

--- a/apps/frontend/src/components/pipelines/handlers/AvailableVariables.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/AvailableVariables.tsx
@@ -179,6 +179,9 @@ function getStepOutputDescription(handlerType: string, config?: Record<string, u
     response_handler: 'Response config (usually last step)',
     ai_handler: 'AI response with content and usage stats',
     chat_handler: 'AI response with content and usage stats',
+    file_upload_handler: 'Uploaded file metadata (path, URL, size, type)',
+    file_serve_handler: 'Served file info',
+    replicate: 'Replicate prediction result with model output',
   };
   return descriptions[handlerType] || 'Step output data';
 }
@@ -258,6 +261,22 @@ function getStepOutputExamples(
       fmt(`${stepPath}.content`),
       fmt(`${stepPath}.tokensUsed`),
       fmt(`${stepPath}.usage.inputTokens`),
+    ],
+    file_upload_handler: [
+      `${fmt(`${stepPath}.storage_path`)} — full storage key`,
+      `${fmt(`${stepPath}.url`)} — internal URL path`,
+      `${fmt(`${stepPath}.content_type`)} — MIME type`,
+      `${fmt(`${stepPath}.filename`)} — sanitized filename`,
+      `${fmt(`${stepPath}.size`)} — file size in bytes`,
+      `${fmt(`${stepPath}.original_name`)} — original filename`,
+      `${fmt(`${stepPath}.id`)} — record ID`,
+    ],
+    replicate: [
+      `${fmt(`${stepPath}.output`)} — model output (URL, array, object, etc.)`,
+      `${fmt(`${stepPath}.predictionId`)} — prediction ID`,
+      `${fmt(`${stepPath}.model`)} — model that was run`,
+      `${fmt(`${stepPath}.status`)} — succeeded/failed`,
+      `${fmt(`${stepPath}.metrics`)} — timing metrics`,
     ],
   };
 

--- a/apps/frontend/src/components/pipelines/handlers/ExpressionInput.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/ExpressionInput.tsx
@@ -101,6 +101,25 @@ export function ExpressionInput({
             });
           }
         }
+      } else if (step.handlerType === 'file_upload_handler') {
+        suggestions.push(
+          { value: `${stepPath}.storage_path`, description: 'Full storage key', category: 'Steps' },
+          { value: `${stepPath}.url`, description: 'Internal URL path', category: 'Steps' },
+          { value: `${stepPath}.content_type`, description: 'MIME type (e.g., image/png)', category: 'Steps' },
+          { value: `${stepPath}.filename`, description: 'Sanitized filename', category: 'Steps' },
+          { value: `${stepPath}.size`, description: 'File size in bytes', category: 'Steps' },
+          { value: `${stepPath}.original_name`, description: 'Original filename', category: 'Steps' },
+          { value: `${stepPath}.id`, description: 'Record ID', category: 'Steps' },
+        );
+      } else if (step.handlerType === 'replicate') {
+        suggestions.push(
+          { value: `${stepPath}.output`, description: 'Model output (URL, array, object, etc.)', category: 'Steps' },
+          { value: `${stepPath}.output[0]`, description: 'First output (for array results)', category: 'Steps' },
+          { value: `${stepPath}.predictionId`, description: 'Prediction ID', category: 'Steps' },
+          { value: `${stepPath}.model`, description: 'Model that was run', category: 'Steps' },
+          { value: `${stepPath}.status`, description: 'Prediction status', category: 'Steps' },
+          { value: `${stepPath}.metrics`, description: 'Timing metrics', category: 'Steps' },
+        );
       }
     }
 

--- a/apps/frontend/src/components/pipelines/handlers/FileUploadHandlerConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/FileUploadHandlerConfig.tsx
@@ -38,6 +38,7 @@ export function FileUploadHandlerConfig({ config, onChange, projectId, previousS
     (typedConfig.allowedMimeTypes || []).join(', '),
   );
   const [fileField, setFileField] = useState(typedConfig.fileField || '');
+  const [sourceUrl, setSourceUrl] = useState(typedConfig.sourceUrl || '');
   const [fieldMappings, setFieldMappings] = useState<FieldMapping[]>(() => {
     const existing = typedConfig.extraFields || {};
     const entries = Object.entries(existing);
@@ -81,8 +82,9 @@ export function FileUploadHandlerConfig({ config, onChange, projectId, previousS
         : undefined,
       extraFields: Object.keys(extraFields).length > 0 ? extraFields : undefined,
       fileField: fileField.trim() || undefined,
+      sourceUrl: sourceUrl.trim() || undefined,
     });
-  }, [schemaId, subDir, dateBucket, maxFileSize, allowedMimeTypes, fileField, fieldMappings, onChange]);
+  }, [schemaId, subDir, dateBucket, maxFileSize, allowedMimeTypes, fileField, sourceUrl, fieldMappings, onChange]);
 
   const handleSchemaChange = (newSchemaId: string) => {
     setSchemaId(newSchemaId);
@@ -125,17 +127,35 @@ export function FileUploadHandlerConfig({ config, onChange, projectId, previousS
         </p>
       </div>
 
+      {/* Source URL — download from URL instead of multipart */}
       <div className="space-y-2">
-        <Label>File Field Name</Label>
-        <Input
-          value={fileField}
-          onChange={(e) => setFileField(e.target.value)}
-          placeholder="file"
+        <Label>Source URL (optional)</Label>
+        <ExpressionInput
+          value={sourceUrl}
+          onChange={setSourceUrl}
+          placeholder="e.g., steps.replicate_ai.output"
+          previousSteps={previousSteps}
         />
         <p className="text-xs text-muted-foreground">
-          The multipart form field name for the uploaded file. Default: <code>file</code>
+          Download a file from a URL instead of reading from a multipart form upload.
+          Use an expression to reference a URL from a previous step (e.g., a Replicate AI output).
+          {sourceUrl && ' File Field Name below is ignored when Source URL is set.'}
         </p>
       </div>
+
+      {!sourceUrl && (
+        <div className="space-y-2">
+          <Label>File Field Name</Label>
+          <Input
+            value={fileField}
+            onChange={(e) => setFileField(e.target.value)}
+            placeholder="file"
+          />
+          <p className="text-xs text-muted-foreground">
+            The multipart form field name for the uploaded file. Default: <code>file</code>
+          </p>
+        </div>
+      )}
 
       <div className="flex items-center justify-between">
         <div className="space-y-0.5">
@@ -170,6 +190,29 @@ export function FileUploadHandlerConfig({ config, onChange, projectId, previousS
         <p className="text-xs text-muted-foreground">
           Comma-separated. Leave empty to allow all file types.
         </p>
+      </div>
+
+      {/* Step Output Reference */}
+      <div className="rounded-md border bg-muted/30 p-3 space-y-1.5">
+        <p className="text-xs font-medium text-muted-foreground">
+          Step output (available to subsequent steps)
+        </p>
+        <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-xs">
+          <code className="bg-muted px-1.5 py-0.5 rounded text-[11px]">storage_path</code>
+          <span className="text-muted-foreground">Full storage key</span>
+          <code className="bg-muted px-1.5 py-0.5 rounded text-[11px]">url</code>
+          <span className="text-muted-foreground">Internal API URL</span>
+          <code className="bg-muted px-1.5 py-0.5 rounded text-[11px]">content_type</code>
+          <span className="text-muted-foreground">MIME type (e.g., image/png)</span>
+          <code className="bg-muted px-1.5 py-0.5 rounded text-[11px]">filename</code>
+          <span className="text-muted-foreground">Sanitized filename</span>
+          <code className="bg-muted px-1.5 py-0.5 rounded text-[11px]">size</code>
+          <span className="text-muted-foreground">File size in bytes</span>
+          <code className="bg-muted px-1.5 py-0.5 rounded text-[11px]">original_name</code>
+          <span className="text-muted-foreground">Original upload name</span>
+          <code className="bg-muted px-1.5 py-0.5 rounded text-[11px]">id</code>
+          <span className="text-muted-foreground">Record ID</span>
+        </div>
       </div>
 
       {/* Extra Fields */}

--- a/apps/frontend/src/components/pipelines/handlers/HandlerConfigWrapper.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/HandlerConfigWrapper.tsx
@@ -12,6 +12,7 @@ import { FunctionHandlerConfig } from './FunctionHandlerConfig';
 import { AIHandlerConfig } from './AIHandlerConfig';
 import { FileUploadHandlerConfig } from './FileUploadHandlerConfig';
 import { FileServeHandlerConfig } from './FileServeHandlerConfig';
+import { ReplicateHandlerConfig } from './ReplicateHandlerConfig';
 import { AvailableVariables, type PreviousStep } from './AvailableVariables';
 import type { HandlerConfig } from './types';
 
@@ -206,6 +207,19 @@ export function HandlerConfigWrapper({
         />
       );
 
+    case 'replicate':
+      return (
+        <>
+          {renderVariablesPanel()}
+          <ReplicateHandlerConfig
+            config={config}
+            onChange={handleChange}
+            projectId={projectId}
+            previousSteps={previousSteps}
+          />
+        </>
+      );
+
     default:
       return (
         <div className="text-sm text-destructive p-4 bg-destructive/10 rounded-md">
@@ -233,6 +247,7 @@ export function getHandlerDisplayName(type: HandlerType): string {
     ai_handler: 'AI',
     file_upload_handler: 'File Upload',
     file_serve_handler: 'File Serve',
+    replicate: 'Replicate AI',
   };
   return names[type] || type;
 }
@@ -255,6 +270,7 @@ export function getHandlerDescription(type: HandlerType): string {
     ai_handler: 'Call an AI model for chat or text completion',
     file_upload_handler: 'Upload a file to storage and create a metadata record',
     file_serve_handler: 'Serve a file from storage with caching headers',
+    replicate: 'Call a Replicate ML model (embeddings, image gen, transcription, etc.)',
   };
   return descriptions[type] || '';
 }

--- a/apps/frontend/src/components/pipelines/handlers/ReplicateHandlerConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/ReplicateHandlerConfig.tsx
@@ -1,0 +1,453 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { ChevronsUpDown, Check, Plus, Trash2, Info, ExternalLink } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { ReplicateHandlerConfig as Config } from './types';
+import type { PreviousStep } from './AvailableVariables';
+import { ExpressionInput } from './ExpressionInput';
+
+interface Props {
+  config: Record<string, unknown>;
+  onChange: (config: Config) => void;
+  projectId: string;
+  previousSteps?: PreviousStep[];
+}
+
+interface ModelInput {
+  name: string;
+  type: 'file' | 'text' | 'number' | 'boolean';
+  required: boolean;
+  description: string;
+  defaultExpression?: string;
+}
+
+interface ModelPreset {
+  id: string;
+  label: string;
+  description: string;
+  inputs: ModelInput[];
+  /** Description of what .output contains */
+  outputDescription: string;
+  /** Example of the raw output shape */
+  outputExample: string;
+}
+
+const MODEL_PRESETS: ModelPreset[] = [
+  {
+    id: 'andreasjansson/clip-features',
+    label: 'CLIP Embeddings',
+    description: 'Generate CLIP feature vectors from text or images',
+    inputs: [
+      { name: 'inputs', type: 'text', required: true, description: 'Text string to embed', defaultExpression: 'request.body.text' },
+    ],
+    outputDescription: 'Array of objects with embedding vectors',
+    outputExample: '[{ embedding: [0.1, 0.2, ...], input: "text" }]',
+  },
+  {
+    id: 'beautyyuyanli/multilingual-e5-large',
+    label: 'Text Embeddings (E5)',
+    description: 'Multilingual text embeddings for semantic search',
+    inputs: [
+      { name: 'text', type: 'text', required: true, description: 'Text to generate embeddings for', defaultExpression: 'request.body.text' },
+    ],
+    outputDescription: 'Array of numbers (embedding vector)',
+    outputExample: '[0.013, -0.028, 0.051, ...]',
+  },
+  {
+    id: 'black-forest-labs/flux-schnell',
+    label: 'Image Generation (Flux)',
+    description: 'Fast high-quality image generation from text',
+    inputs: [
+      { name: 'prompt', type: 'text', required: true, description: 'Text description of the image to generate', defaultExpression: 'request.body.prompt' },
+      { name: 'num_outputs', type: 'number', required: false, description: 'Number of images (1-4)', defaultExpression: '1' },
+      { name: 'aspect_ratio', type: 'text', required: false, description: 'e.g., 1:1, 16:9, 4:3', defaultExpression: '1:1' },
+    ],
+    outputDescription: 'Array of image URLs (expire after 1 hour)',
+    outputExample: '["https://replicate.delivery/...png"]',
+  },
+  {
+    id: 'lucataco/remove-bg',
+    label: 'Background Removal',
+    description: 'Remove background from an image',
+    inputs: [
+      { name: 'image', type: 'file', required: true, description: 'Image file to process', defaultExpression: 'steps.upload.storage_path' },
+    ],
+    outputDescription: 'Image URL of the result (expires after 1 hour)',
+    outputExample: '"https://replicate.delivery/...png"',
+  },
+  {
+    id: 'datalab-to/marker',
+    label: 'PDF to Text',
+    description: 'Extract structured text from a PDF document',
+    inputs: [
+      { name: 'document', type: 'file', required: true, description: 'PDF document to extract', defaultExpression: 'steps.upload.storage_path' },
+    ],
+    outputDescription: 'Extracted text in markdown format',
+    outputExample: '"# Document Title\\n\\nParagraph text..."',
+  },
+  {
+    id: 'vaibhavs10/incredibly-fast-whisper',
+    label: 'Speech Transcription',
+    description: 'Transcribe speech from an audio file',
+    inputs: [
+      { name: 'audio', type: 'file', required: true, description: 'Audio file to transcribe', defaultExpression: 'steps.upload.storage_path' },
+      { name: 'task', type: 'text', required: false, description: '"transcribe" or "translate"', defaultExpression: 'transcribe' },
+    ],
+    outputDescription: 'Object with transcribed text and segments',
+    outputExample: '{ text: "Hello world", chunks: [...] }',
+  },
+];
+
+function getModelUrl(modelId: string): string {
+  return `https://replicate.com/${modelId}`;
+}
+
+export function ReplicateHandlerConfig({ config, onChange, previousSteps = [] }: Props) {
+  const typedConfig = config as unknown as Partial<Config>;
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  const [model, setModel] = useState(typedConfig.model || '');
+  const [version, setVersion] = useState(typedConfig.version || '');
+  const [inputEntries, setInputEntries] = useState<[string, string][]>(() => {
+    const input = typedConfig.input || {};
+    const entries = Object.entries(input);
+    return entries.length > 0 ? entries : [['', '']];
+  });
+  const [outputField, setOutputField] = useState(typedConfig.outputField || '');
+  const [modelOpen, setModelOpen] = useState(false);
+
+  // Sync to parent
+  useEffect(() => {
+    const input: Record<string, string> = {};
+    for (const [key, value] of inputEntries) {
+      if (key.trim()) {
+        input[key.trim()] = value;
+      }
+    }
+
+    const newConfig: Config = {
+      model,
+      input,
+      ...(version ? { version } : {}),
+      ...(outputField ? { outputField } : {}),
+    };
+
+    onChangeRef.current(newConfig);
+  }, [model, version, inputEntries, outputField]);
+
+  const selectPreset = useCallback((preset: ModelPreset) => {
+    setModel(preset.id);
+    // Pre-fill required inputs with their default expressions
+    const requiredInputs = preset.inputs.filter((i) => i.required);
+    setInputEntries(requiredInputs.map((i) => [i.name, i.defaultExpression || '']));
+    setModelOpen(false);
+  }, []);
+
+  const addInputEntry = () => {
+    setInputEntries((prev) => [...prev, ['', '']]);
+  };
+
+  const removeInputEntry = (index: number) => {
+    setInputEntries((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const updateInputKey = (index: number, key: string) => {
+    setInputEntries((prev) => prev.map((entry, i) => (i === index ? [key, entry[1]] : entry)));
+  };
+
+  const updateInputValue = (index: number, value: string) => {
+    setInputEntries((prev) => prev.map((entry, i) => (i === index ? [entry[0], value] : entry)));
+  };
+
+  const selectedPreset = MODEL_PRESETS.find((p) => p.id === model);
+  const hasFileInputs = selectedPreset?.inputs.some((i) => i.type === 'file') ?? false;
+
+  return (
+    <div className="space-y-4">
+      {/* Model Selection */}
+      <div className="space-y-2">
+        <Label>Model</Label>
+        <Popover open={modelOpen} onOpenChange={setModelOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              role="combobox"
+              aria-expanded={modelOpen}
+              className="w-full justify-between font-normal"
+            >
+              {model ? (
+                <span className="flex items-center gap-2">
+                  <span className="font-mono text-sm">{model}</span>
+                  {selectedPreset && (
+                    <span className="text-xs text-muted-foreground">
+                      ({selectedPreset.label})
+                    </span>
+                  )}
+                </span>
+              ) : (
+                <span className="text-muted-foreground">Select or type a model...</span>
+              )}
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-[500px] p-0" align="start">
+            <Command>
+              <CommandInput
+                placeholder="Search or type model name..."
+                value={model}
+                onValueChange={setModel}
+              />
+              <CommandList>
+                <CommandEmpty>
+                  <div className="py-2 text-sm text-muted-foreground">
+                    Using custom model: <span className="font-mono">{model}</span>
+                  </div>
+                </CommandEmpty>
+                <CommandGroup heading="Text Input Models">
+                  {MODEL_PRESETS.filter((p) => p.inputs.every((i) => i.type !== 'file')).map((preset) => (
+                    <CommandItem
+                      key={preset.id}
+                      value={preset.id}
+                      onSelect={() => selectPreset(preset)}
+                    >
+                      <Check
+                        className={cn(
+                          'mr-2 h-4 w-4 shrink-0',
+                          model === preset.id ? 'opacity-100' : 'opacity-0',
+                        )}
+                      />
+                      <div className="flex flex-col min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium text-sm">{preset.label}</span>
+                          <span className="text-xs text-muted-foreground font-mono truncate">{preset.id}</span>
+                        </div>
+                        <span className="text-xs text-muted-foreground">{preset.description}</span>
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+                <CommandGroup heading="File Input Models (pair with File Upload step)">
+                  {MODEL_PRESETS.filter((p) => p.inputs.some((i) => i.type === 'file')).map((preset) => (
+                    <CommandItem
+                      key={preset.id}
+                      value={preset.id}
+                      onSelect={() => selectPreset(preset)}
+                    >
+                      <Check
+                        className={cn(
+                          'mr-2 h-4 w-4 shrink-0',
+                          model === preset.id ? 'opacity-100' : 'opacity-0',
+                        )}
+                      />
+                      <div className="flex flex-col min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium text-sm">{preset.label}</span>
+                          <span className="text-xs text-muted-foreground font-mono truncate">{preset.id}</span>
+                        </div>
+                        <span className="text-xs text-muted-foreground">{preset.description}</span>
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          {model ? (
+            <a
+              href={getModelUrl(model)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-primary hover:underline"
+            >
+              View model on Replicate
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          ) : (
+            <span>
+              Select a preset or type any model from{' '}
+              <a
+                href="https://replicate.com/explore"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                replicate.com/explore
+              </a>
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Model reference (when a preset is selected) */}
+      {selectedPreset && (
+        <div className="rounded-md border bg-muted/30 p-3 space-y-3">
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">Inputs</p>
+            <div className="space-y-1">
+              {selectedPreset.inputs.map((input) => (
+                <div key={input.name} className="flex items-start gap-2 text-xs">
+                  <code className="px-1.5 py-0.5 rounded bg-muted font-mono shrink-0">
+                    {input.name}
+                  </code>
+                  <span className="text-muted-foreground">
+                    {input.description}
+                    {input.required && <span className="text-destructive ml-1">*</span>}
+                    {input.type === 'file' && (
+                      <span className="ml-1 text-blue-600 dark:text-blue-400">(file)</span>
+                    )}
+                  </span>
+                </div>
+              ))}
+            </div>
+            {selectedPreset.inputs.some((i) => !i.required) && (
+              <p className="text-xs text-muted-foreground italic">
+                Optional inputs can be added with "+ Add Field" below.{' '}
+                <a
+                  href={getModelUrl(selectedPreset.id)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline inline-flex items-center gap-0.5"
+                >
+                  See all inputs
+                  <ExternalLink className="h-2.5 w-2.5" />
+                </a>
+              </p>
+            )}
+          </div>
+          <div className="border-t pt-2 space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Output</p>
+            <p className="text-xs text-muted-foreground">{selectedPreset.outputDescription}</p>
+            <code className="block text-[11px] bg-muted px-2 py-1 rounded font-mono text-muted-foreground">
+              {selectedPreset.outputExample}
+            </code>
+          </div>
+        </div>
+      )}
+
+      {/* Version */}
+      <div className="space-y-2">
+        <Label>Version {!version && <span className="text-yellow-600 font-normal">(recommended)</span>}</Label>
+        <Input
+          value={version}
+          onChange={(e) => setVersion(e.target.value)}
+          placeholder="e.g., 95fcc2a26d3899cd6c2691c900465aaeff..."
+          className="font-mono text-sm"
+        />
+        <p className="text-xs text-muted-foreground">
+          Pin a version hash for deterministic results and faster execution.
+          {model && (
+            <>
+              {' '}Find versions on the{' '}
+              <a
+                href={`${getModelUrl(model)}/versions`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline inline-flex items-center gap-0.5"
+              >
+                model page
+                <ExternalLink className="h-2.5 w-2.5" />
+              </a>
+              .
+            </>
+          )}
+          {!version && ' Without a version, the latest is resolved on each run (extra API call).'}
+        </p>
+      </div>
+
+      {/* Input Mappings */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label>Input Mappings</Label>
+          <Button variant="ghost" size="sm" onClick={addInputEntry}>
+            <Plus className="h-4 w-4 mr-1" />
+            Add Field
+          </Button>
+        </div>
+        <div className="space-y-2">
+          {inputEntries.map(([key, value], index) => {
+            // Find matching preset input for this key to show description
+            const presetInput = selectedPreset?.inputs.find((i) => i.name === key);
+            return (
+              <div key={index} className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <Input
+                    value={key}
+                    onChange={(e) => updateInputKey(index, e.target.value)}
+                    placeholder="input name"
+                    className="flex-1 font-mono text-sm"
+                  />
+                  <span className="text-muted-foreground">=</span>
+                  <ExpressionInput
+                    value={value}
+                    onChange={(v) => updateInputValue(index, v)}
+                    placeholder={presetInput?.type === 'file' ? 'steps.upload.storage_path' : 'e.g., request.body.text'}
+                    previousSteps={previousSteps}
+                    className="flex-1"
+                  />
+                  {inputEntries.length > 1 && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => removeInputEntry(index)}
+                      className="text-destructive hover:text-destructive px-2"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+                {presetInput && (
+                  <p className="text-xs text-muted-foreground pl-1">
+                    {presetInput.description}
+                    {presetInput.type === 'file' && ' — automatically uploaded to Replicate from storage'}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+        {hasFileInputs && (
+          <div className="flex items-start gap-2 p-2.5 rounded-md bg-blue-50 dark:bg-blue-950/30 text-xs text-blue-700 dark:text-blue-300">
+            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>
+              File inputs: use{' '}
+              <code className="px-1 py-0.5 rounded bg-blue-100 dark:bg-blue-900/50 font-mono">steps.&lt;upload_step&gt;.storage_path</code>{' '}
+              to reference an uploaded file. It's automatically read from storage and uploaded to Replicate — no public URL needed.
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Output Field (optional) */}
+      <div className="space-y-2">
+        <Label>Output Field (optional)</Label>
+        <Input
+          value={outputField}
+          onChange={(e) => setOutputField(e.target.value)}
+          placeholder="e.g., embedding"
+          className="font-mono text-sm"
+        />
+        <p className="text-xs text-muted-foreground">
+          Extract a specific key from the model output. Leave empty to use the full output.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/pipelines/handlers/index.ts
+++ b/apps/frontend/src/components/pipelines/handlers/index.ts
@@ -12,6 +12,7 @@ export { ResponseHandlerConfig } from './ResponseHandlerConfig';
 export { ProxyForwardConfig } from './ProxyForwardConfig';
 export { DbAggregateConfig } from './DbAggregateConfig';
 export { FunctionHandlerConfig } from './FunctionHandlerConfig';
+export { ReplicateHandlerConfig } from './ReplicateHandlerConfig';
 
 // Function templates
 export * from './function-templates';

--- a/apps/frontend/src/components/pipelines/handlers/types.ts
+++ b/apps/frontend/src/components/pipelines/handlers/types.ts
@@ -218,11 +218,24 @@ export interface FileUploadHandlerConfig extends BaseHandlerConfig {
   allowedMimeTypes?: string[];
   extraFields?: Record<string, string>;
   fileField?: string;
+  /** Download a file from a URL instead of multipart form. Supports expressions (e.g., steps.replicate_ai.output). */
+  sourceUrl?: string;
 }
 
 export interface FileServeHandlerConfig extends BaseHandlerConfig {
   subDir: string;
   cacheMaxAge?: number;
+}
+
+export interface ReplicateHandlerConfig extends BaseHandlerConfig {
+  /** Replicate model identifier (e.g., 'andreasjansson/clip-features') */
+  model: string;
+  /** Pin a specific model version hash */
+  version?: string;
+  /** Input field mappings: { modelInputName: "expression" } */
+  input: Record<string, string>;
+  /** Extract a specific key from the prediction output */
+  outputField?: string;
 }
 
 export type HandlerConfig =
@@ -238,4 +251,5 @@ export type HandlerConfig =
   | FunctionHandlerConfig
   | AIHandlerConfig
   | FileUploadHandlerConfig
-  | FileServeHandlerConfig;
+  | FileServeHandlerConfig
+  | ReplicateHandlerConfig;

--- a/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
+++ b/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
@@ -6,7 +6,12 @@ import {
   useSetProjectDefaultAIProviderMutation,
   useTestProjectAIMutation,
   useGetAvailableAIProvidersQuery,
+  useGetProjectAIServicesQuery,
+  useAddProjectAIServiceMutation,
+  useRemoveProjectAIServiceMutation,
+  useTestProjectAIServiceMutation,
   AIProviderType,
+  AIServiceType,
   ConfiguredProvider,
   ModelInfo,
   ModelTier,
@@ -56,6 +61,260 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import { ProjectAIPluginsSection } from './ProjectAIPluginsSection';
+
+// AI Service display config
+const SERVICE_CONFIG: Record<string, { name: string; color: string; bgColor: string; description: string }> = {
+  replicate: {
+    name: 'Replicate',
+    color: 'text-indigo-600',
+    bgColor: 'bg-indigo-50',
+    description: 'Run ML models (CLIP embeddings, image generation, transcription, etc.)',
+  },
+};
+
+// AI Services section component
+function ProjectAIServicesSection({ project }: { project: Project }) {
+  const { data: servicesStatus } = useGetProjectAIServicesQuery(project.id);
+  const [addService, { isLoading: isAdding }] = useAddProjectAIServiceMutation();
+  const [removeService] = useRemoveProjectAIServiceMutation();
+  const [testService] = useTestProjectAIServiceMutation();
+
+  const [showAddDialog, setShowAddDialog] = useState(false);
+  const [addToken, setAddToken] = useState('');
+  const [addError, setAddError] = useState<string | null>(null);
+  const [removingService, setRemovingService] = useState<string | null>(null);
+  const [testingToken, setTestingToken] = useState('');
+  const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+
+  const configuredServices = servicesStatus?.services || [];
+  const hasReplicate = configuredServices.some((s) => s.service === 'replicate');
+
+  const handleAdd = async () => {
+    try {
+      setAddError(null);
+      await addService({
+        projectId: project.id,
+        service: 'replicate' as AIServiceType,
+        apiToken: addToken.trim(),
+      }).unwrap();
+      setShowAddDialog(false);
+      setAddToken('');
+    } catch (error: unknown) {
+      const err = error as { data?: { message?: string } };
+      setAddError(err.data?.message || 'Failed to add service');
+    }
+  };
+
+  const handleRemove = async (service: string) => {
+    try {
+      setRemovingService(service);
+      await removeService({
+        projectId: project.id,
+        service: service as AIServiceType,
+      }).unwrap();
+    } catch (error) {
+      console.error('Failed to remove service:', error);
+    } finally {
+      setRemovingService(null);
+    }
+  };
+
+  const handleTest = async () => {
+    if (!testingToken.trim()) return;
+    try {
+      setTestResult(null);
+      const result = await testService({
+        projectId: project.id,
+        service: 'replicate' as AIServiceType,
+        apiToken: testingToken.trim(),
+      }).unwrap();
+      setTestResult({
+        success: result.success,
+        message: result.message || (result.success ? 'Connection successful' : 'Connection failed'),
+      });
+    } catch (error: unknown) {
+      const err = error as { data?: { message?: string } };
+      setTestResult({
+        success: false,
+        message: err.data?.message || 'Test failed',
+      });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Zap className="h-5 w-5" />
+              AI Services
+            </CardTitle>
+            <CardDescription>
+              Configure external ML services for pipeline steps.
+            </CardDescription>
+          </div>
+          {!hasReplicate && (
+            <Button onClick={() => setShowAddDialog(true)}>
+              <Plus className="h-4 w-4 mr-2" />
+              Add Service
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {configuredServices.length > 0 ? (
+          <div className="space-y-3">
+            {configuredServices.map((svc) => {
+              const meta = SERVICE_CONFIG[svc.service] || { name: svc.service, color: 'text-gray-600', bgColor: 'bg-gray-50', description: '' };
+              return (
+                <div key={svc.service} className="border rounded-lg p-4">
+                  <div className="flex items-start justify-between">
+                    <div className="flex items-center gap-3">
+                      <div className={cn('p-2 rounded-lg', meta.bgColor)}>
+                        <Zap className={cn('w-5 h-5', meta.color)} />
+                      </div>
+                      <div>
+                        <h4 className="font-medium">{meta.name}</h4>
+                        <p className="text-sm text-muted-foreground">
+                          Token: <span className="font-mono text-xs">{svc.apiToken}</span>
+                        </p>
+                        <p className="text-xs text-muted-foreground mt-1">{meta.description}</p>
+                      </div>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleRemove(svc.service)}
+                      disabled={removingService === svc.service}
+                      className="text-destructive hover:text-destructive"
+                      title="Remove service"
+                    >
+                      {removingService === svc.service ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Trash2 className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="flex items-center text-sm">
+              <AlertTriangle className="h-4 w-4 text-yellow-500 mr-2" />
+              <span className="text-muted-foreground">No AI services configured</span>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Add an AI service to enable Replicate ML model pipelines.
+            </p>
+            <Button onClick={() => setShowAddDialog(true)}>
+              <Plus className="h-4 w-4 mr-2" />
+              Add Service
+            </Button>
+          </div>
+        )}
+      </CardContent>
+
+      <Dialog open={showAddDialog} onOpenChange={(open) => {
+        setShowAddDialog(open);
+        if (!open) {
+          setAddToken('');
+          setAddError(null);
+          setTestingToken('');
+          setTestResult(null);
+        }
+      }}>
+        <DialogContent className="sm:max-w-[450px]">
+          <DialogHeader>
+            <DialogTitle>Add Replicate</DialogTitle>
+            <DialogDescription>
+              Add your Replicate API token to enable ML model pipelines.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div>
+              <Label htmlFor="replicate-token">API Token</Label>
+              <Input
+                id="replicate-token"
+                type="password"
+                value={addToken}
+                onChange={(e) => {
+                  setAddToken(e.target.value);
+                  setTestingToken(e.target.value);
+                }}
+                placeholder="r8_..."
+                className="mt-1"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                Get your API token from{' '}
+                <a
+                  href="https://replicate.com/account/api-tokens"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  replicate.com/account/api-tokens
+                </a>
+              </p>
+            </div>
+
+            {addToken.trim() && (
+              <div>
+                <Button variant="outline" size="sm" onClick={handleTest}>
+                  <Zap className="h-4 w-4 mr-1" />
+                  Test Connection
+                </Button>
+                {testResult && (
+                  <div className={cn(
+                    'mt-2 p-2 rounded text-sm flex items-center gap-2',
+                    testResult.success ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700'
+                  )}>
+                    {testResult.success ? (
+                      <CheckCircle className="h-4 w-4" />
+                    ) : (
+                      <XCircle className="h-4 w-4" />
+                    )}
+                    {testResult.message}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {addError && (
+              <Alert variant="destructive">
+                <XCircle className="h-4 w-4" />
+                <AlertDescription>{addError}</AlertDescription>
+              </Alert>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowAddDialog(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleAdd}
+              disabled={!addToken.trim() || isAdding}
+            >
+              {isAdding ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Adding...
+                </>
+              ) : (
+                'Add Replicate'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}
 
 // Provider display config
 const PROVIDER_CONFIG: Record<string, { color: string; bgColor: string; displayName: string }> = {
@@ -662,6 +921,8 @@ export function ProjectAISettingsTab({ project }: ProjectAISettingsTabProps) {
       </Card>
 
       <ProjectAIPluginsSection project={project} />
+
+      <ProjectAIServicesSection project={project} />
 
       <AddProviderDialog
         open={showAddDialog}

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -198,6 +198,7 @@ export const api = createApi({
     'PipelineSchema',
     'PipelineData',
     'ProjectAI',
+    'ProjectAIServices',
     'ProjectPlugin',
   ],
   endpoints: () => ({}),

--- a/apps/frontend/src/services/pipelinesApi.ts
+++ b/apps/frontend/src/services/pipelinesApi.ts
@@ -42,7 +42,8 @@ export type HandlerType =
   | 'db_aggregate'
   | 'ai_handler'
   | 'file_upload_handler'
-  | 'file_serve_handler';
+  | 'file_serve_handler'
+  | 'replicate';
 
 export interface Pipeline {
   id: string;

--- a/apps/frontend/src/services/projectsApi.ts
+++ b/apps/frontend/src/services/projectsApi.ts
@@ -57,6 +57,17 @@ export interface AvailableProvider {
   models: ModelInfo[];
 }
 
+// AI Service types
+export type AIServiceType = 'replicate';
+
+export interface AIServicesStatus {
+  services: {
+    service: AIServiceType;
+    apiToken: string; // Masked
+    createdAt: string;
+  }[];
+}
+
 // Plugin types
 export interface PluginListItem {
   id: string;
@@ -343,6 +354,52 @@ export const projectsApi = api.injectEndpoints({
         `/api/projects/${projectId}/ai-plugins/google-calendar/calendars`,
     }),
 
+    // AI Services endpoints
+    getProjectAIServices: builder.query<AIServicesStatus, string>({
+      query: (projectId) => `/api/projects/${projectId}/ai-services`,
+      providesTags: (_result, _error, projectId) => [
+        { type: 'ProjectAIServices' as const, id: projectId },
+      ],
+    }),
+
+    addProjectAIService: builder.mutation<
+      AIServicesStatus,
+      { projectId: string; service: AIServiceType; apiToken: string }
+    >({
+      query: ({ projectId, service, apiToken }) => ({
+        url: `/api/projects/${projectId}/ai-services`,
+        method: 'POST',
+        body: { service, apiToken },
+      }),
+      invalidatesTags: (_result, _error, { projectId }) => [
+        { type: 'ProjectAIServices' as const, id: projectId },
+      ],
+    }),
+
+    removeProjectAIService: builder.mutation<
+      AIServicesStatus,
+      { projectId: string; service: AIServiceType }
+    >({
+      query: ({ projectId, service }) => ({
+        url: `/api/projects/${projectId}/ai-services/${service}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: (_result, _error, { projectId }) => [
+        { type: 'ProjectAIServices' as const, id: projectId },
+      ],
+    }),
+
+    testProjectAIService: builder.mutation<
+      TestAIResponse,
+      { projectId: string; service: AIServiceType; apiToken: string }
+    >({
+      query: ({ projectId, service, apiToken }) => ({
+        url: `/api/projects/${projectId}/ai-services/test`,
+        method: 'POST',
+        body: { service, apiToken },
+      }),
+    }),
+
     // Skills endpoint
     listProjectSkills: builder.query<
       { skills: SkillSummary[] },
@@ -383,6 +440,11 @@ export const {
   useCompletePluginOAuthMutation,
   useDisconnectPluginOAuthMutation,
   useListPluginCalendarsQuery,
+  // AI Services
+  useGetProjectAIServicesQuery,
+  useAddProjectAIServiceMutation,
+  useRemoveProjectAIServiceMutation,
+  useTestProjectAIServiceMutation,
   // Skills
   useListProjectSkillsQuery,
 } = projectsApi;


### PR DESCRIPTION
## Summary

- Add a new `replicate` pipeline handler for calling Replicate ML models (embeddings, image generation, background removal, PDF extraction, transcription) from pipeline steps
- Add "AI Services" settings section (separate from chat LLM providers) for managing Replicate API tokens per project
- Add `sourceUrl` option to file_upload_handler for downloading output files from URLs (e.g., saving Replicate results back to storage)
- Enhanced pipeline UI with model presets, input/output documentation, ExpressionInput typeahead for file upload fields, and step output reference cards

## Details

**Backend (7 modified + 1 new):**
- `replicate.handler.ts` — New handler with sync predictions, polling, file input auto-resolution (Replicate Files API for >256KB, base64 for smaller), version auto-resolution
- `projects.schema.ts` — New `aiServices` column + migration
- `project-ai-settings.service.ts` — AI services CRUD, encrypted token storage, test connection
- `projects.controller.ts` — 4 new endpoints for AI services management
- `file-upload.handler.ts` — New `sourceUrl` config for downloading files from URLs
- Handler registration in types, index, and module

**Frontend (6 modified + 1 new):**
- `ReplicateHandlerConfig.tsx` — Model presets with documented inputs/outputs, ExpressionInput typeahead, version field with Replicate links
- `ProjectAISettingsTab.tsx` — AI Services section with add/remove/test Replicate tokens
- `ExpressionInput.tsx` + `AvailableVariables.tsx` — Sub-field suggestions for file_upload_handler and replicate outputs
- `FileUploadHandlerConfig.tsx` — Source URL field + step output reference card
- RTK Query endpoints + tag types for AI services

## Test plan

- [ ] Settings > AI tab shows "AI Services" section
- [ ] Add Replicate API token, verify masked display, test connection
- [ ] Create pipeline: File Upload → Replicate AI (e.g., lucataco/remove-bg) → File Upload (sourceUrl)
- [ ] Verify model presets show correct inputs/outputs in dropdown
- [ ] Verify ExpressionInput typeahead shows `steps.upload.storage_path` etc.
- [ ] Run pipeline end-to-end: upload image → remove background → save result
- [ ] Existing tests pass: `cd ce/apps/backend && pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)