### PR TITLE
feat: add MCP server for CE admin API

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -48,6 +48,7 @@
     "@azure/identity": "^4.13.0",
     "@azure/storage-blob": "^12.29.1",
     "@google-cloud/storage": "^7.7.0",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@nestjs/common": "^10.3.0",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.3.0",
@@ -56,6 +57,7 @@
     "@nestjs/schedule": "^6.1.0",
     "@nestjs/swagger": "^7.1.17",
     "@nestjs/throttler": "^6.5.0",
+    "@rekog/mcp-nest": "^1.9.8",
     "@types/jsonwebtoken": "^9.0.10",
     "acme-client": "^5.4.0",
     "ai": "^6.0.116",
@@ -83,7 +85,8 @@
     "sharp": "^0.34.5",
     "supertokens-auth-react": "^0.39.0",
     "supertokens-node": "^17.0.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.2.1",

--- a/apps/backend/src/api-keys/api-keys.controller.ts
+++ b/apps/backend/src/api-keys/api-keys.controller.ts
@@ -13,7 +13,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
-import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { ApiKeyGuard } from '../auth/api-key.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
 import { ApiKeysService } from './api-keys.service';
@@ -31,7 +31,7 @@ import {
 @ApiTags('API Keys')
 @ApiBearerAuth()
 @Controller('api/api-keys')
-@UseGuards(SessionAuthGuard, RolesGuard)
+@UseGuards(ApiKeyGuard, RolesGuard)
 export class ApiKeysController {
   constructor(private readonly apiKeysService: ApiKeysService) {}
 

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -35,6 +35,9 @@ import { PlatformModule } from './platform/platform.module';
 import { StorageUsageModule } from './storage/storage-usage.module';
 import { OnboardingRulesModule } from './onboarding-rules/onboarding-rules.module';
 import { PipelinesModule } from './pipelines/pipelines.module';
+import { McpModule, McpTransportType } from '@rekog/mcp-nest';
+import { ApiKeyGuard } from './auth/api-key.guard';
+import { McpToolsModule } from './mcp/mcp-tools.module';
 
 @Module({
   imports: [
@@ -52,6 +55,16 @@ import { PipelinesModule } from './pipelines/pipelines.module';
     // Platform module provides L1 → L2 communication services (global)
     PlatformModule,
     AuthModule.forRoot(),
+    McpModule.forRoot({
+      name: 'bffless-ce',
+      version: '1.0.0',
+      transport: McpTransportType.STREAMABLE_HTTP,
+      guards: [ApiKeyGuard],
+      streamableHttp: {
+        enableJsonResponse: true,
+        statelessMode: true,
+      },
+    }),
     SetupModule,
     FeatureFlagsModule,
     CacheModule.forRootAsync({
@@ -148,6 +161,7 @@ import { PipelinesModule } from './pipelines/pipelines.module';
     InvitationsModule,
     StorageUsageModule,
     OnboardingRulesModule,
+    McpToolsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/backend/src/domains/domains.controller.ts
+++ b/apps/backend/src/domains/domains.controller.ts
@@ -36,7 +36,7 @@ import {
   UpdateTrafficRuleDto,
   TrafficRuleResponseDto,
 } from './dto/traffic-rule.dto';
-import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { ApiKeyGuard } from '../auth/api-key.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -44,7 +44,7 @@ import { FeatureFlagGuard, RequireFeatureFlags } from '../feature-flags';
 
 @ApiTags('Domains')
 @Controller('api/domains')
-@UseGuards(SessionAuthGuard, RolesGuard)
+@UseGuards(ApiKeyGuard, RolesGuard)
 @Roles('admin')
 export class DomainsController {
   constructor(

--- a/apps/backend/src/feature-flags/feature-flags.controller.ts
+++ b/apps/backend/src/feature-flags/feature-flags.controller.ts
@@ -12,7 +12,7 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
-import { SessionAuthGuard, RolesGuard, Roles } from '../auth';
+import { ApiKeyGuard, RolesGuard, Roles } from '../auth';
 import { FeatureFlagsService, ResolvedFlag } from './feature-flags.service';
 import { isValidFlagKey } from './feature-flags.definitions';
 import {
@@ -33,7 +33,7 @@ export class FeatureFlagsController {
   // ==========================================================================
 
   @Get('client')
-  @UseGuards(SessionAuthGuard)
+  @UseGuards(ApiKeyGuard)
   @ApiOperation({ summary: 'Get UI-exposed feature flags (allowlisted only)' })
   @ApiResponse({
     status: 200,
@@ -44,7 +44,7 @@ export class FeatureFlagsController {
   }
 
   @Get()
-  @UseGuards(SessionAuthGuard)
+  @UseGuards(ApiKeyGuard)
   @ApiOperation({ summary: 'Get all feature flags with resolved values' })
   @ApiResponse({
     status: 200,
@@ -57,7 +57,7 @@ export class FeatureFlagsController {
   }
 
   @Get('grouped')
-  @UseGuards(SessionAuthGuard)
+  @UseGuards(ApiKeyGuard)
   @ApiOperation({ summary: 'Get all feature flags grouped by category' })
   @ApiResponse({
     status: 200,
@@ -75,7 +75,7 @@ export class FeatureFlagsController {
   }
 
   @Get(':key')
-  @UseGuards(SessionAuthGuard)
+  @UseGuards(ApiKeyGuard)
   @ApiOperation({ summary: 'Get a single feature flag' })
   @ApiParam({ name: 'key', description: 'Feature flag key', example: 'ENABLE_CUSTOM_DOMAINS' })
   @ApiResponse({
@@ -90,7 +90,7 @@ export class FeatureFlagsController {
   }
 
   @Get(':key/sources')
-  @UseGuards(SessionAuthGuard, RolesGuard)
+  @UseGuards(ApiKeyGuard, RolesGuard)
   @Roles('admin')
   @ApiOperation({ summary: 'Get all source values for a feature flag (admin only)' })
   @ApiParam({ name: 'key', description: 'Feature flag key' })
@@ -109,7 +109,7 @@ export class FeatureFlagsController {
   // ==========================================================================
 
   @Put(':key')
-  @UseGuards(SessionAuthGuard, RolesGuard)
+  @UseGuards(ApiKeyGuard, RolesGuard)
   @Roles('admin')
   @ApiOperation({ summary: 'Set a feature flag value (creates database override)' })
   @ApiParam({ name: 'key', description: 'Feature flag key' })
@@ -130,7 +130,7 @@ export class FeatureFlagsController {
   }
 
   @Put()
-  @UseGuards(SessionAuthGuard, RolesGuard)
+  @UseGuards(ApiKeyGuard, RolesGuard)
   @Roles('admin')
   @ApiOperation({ summary: 'Set multiple feature flags at once' })
   @ApiResponse({
@@ -157,7 +157,7 @@ export class FeatureFlagsController {
   }
 
   @Delete(':key')
-  @UseGuards(SessionAuthGuard, RolesGuard)
+  @UseGuards(ApiKeyGuard, RolesGuard)
   @Roles('admin')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Delete a database override (reverts to file/env/default)' })
@@ -169,7 +169,7 @@ export class FeatureFlagsController {
   }
 
   @Post('refresh')
-  @UseGuards(SessionAuthGuard, RolesGuard)
+  @UseGuards(ApiKeyGuard, RolesGuard)
   @Roles('admin')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Refresh all caches (reload file and database)' })
@@ -179,7 +179,7 @@ export class FeatureFlagsController {
   }
 
   @Get('admin/overrides')
-  @UseGuards(SessionAuthGuard, RolesGuard)
+  @UseGuards(ApiKeyGuard, RolesGuard)
   @Roles('admin')
   @ApiOperation({ summary: 'Get all database overrides (admin only)' })
   @ApiResponse({

--- a/apps/backend/src/invitations/invitations.controller.ts
+++ b/apps/backend/src/invitations/invitations.controller.ts
@@ -17,7 +17,7 @@ import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@ne
 import { Request } from 'express';
 import { getUser } from 'supertokens-node';
 import { InvitationsService } from './invitations.service.js';
-import { SessionAuthGuard } from '../auth/session-auth.guard.js';
+import { ApiKeyGuard } from '../auth/api-key.guard.js';
 import { RolesGuard } from '../auth/roles.guard.js';
 import { Roles } from '../auth/decorators/roles.decorator.js';
 import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator.js';
@@ -67,7 +67,7 @@ export class InvitationsController {
   // ============================================================================
 
   @Post('admin/invitations')
-  @UseGuards(SessionAuthGuard, RolesGuard)
+  @UseGuards(ApiKeyGuard, RolesGuard)
   @Roles('admin')
   @ApiBearerAuth()
   @ApiOperation({
@@ -104,7 +104,7 @@ export class InvitationsController {
   }
 
   @Get('admin/invitations')
-  @UseGuards(SessionAuthGuard, RolesGuard)
+  @UseGuards(ApiKeyGuard, RolesGuard)
   @Roles('admin')
   @ApiBearerAuth()
   @ApiOperation({
@@ -124,7 +124,7 @@ export class InvitationsController {
   }
 
   @Get('admin/invitations/:id')
-  @UseGuards(SessionAuthGuard, RolesGuard)
+  @UseGuards(ApiKeyGuard, RolesGuard)
   @Roles('admin')
   @ApiBearerAuth()
   @ApiOperation({
@@ -145,7 +145,7 @@ export class InvitationsController {
   }
 
   @Post('admin/invitations/:id/resend')
-  @UseGuards(SessionAuthGuard, RolesGuard)
+  @UseGuards(ApiKeyGuard, RolesGuard)
   @Roles('admin')
   @ApiBearerAuth()
   @HttpCode(HttpStatus.OK)
@@ -182,7 +182,7 @@ export class InvitationsController {
   }
 
   @Delete('admin/invitations/:id')
-  @UseGuards(SessionAuthGuard, RolesGuard)
+  @UseGuards(ApiKeyGuard, RolesGuard)
   @Roles('admin')
   @ApiBearerAuth()
   @HttpCode(HttpStatus.OK)
@@ -228,7 +228,7 @@ export class InvitationsController {
   }
 
   @Post('invitations/:token/accept')
-  @UseGuards(SessionAuthGuard)
+  @UseGuards(ApiKeyGuard)
   @ApiBearerAuth()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({

--- a/apps/backend/src/mcp/helpers/user-context.helper.ts
+++ b/apps/backend/src/mcp/helpers/user-context.helper.ts
@@ -1,0 +1,33 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { AuthService } from '../../auth/auth.service';
+
+export interface McpUserContext {
+  id: string;
+  role: string;
+}
+
+/**
+ * Extract user from the HTTP request and look up actual DB role.
+ * ApiKeyGuard hardcodes role as 'user' (api-key.guard.ts:73),
+ * so we fetch the real role from DB (same pattern as RolesGuard).
+ */
+export async function getUserContext(
+  request: any,
+  authService: AuthService,
+): Promise<McpUserContext> {
+  const user = request?.user;
+  if (!user?.id) {
+    throw new UnauthorizedException('No authenticated user found');
+  }
+
+  // Look up the real role from DB since API key auth hardcodes 'user'
+  const dbUser = await authService.getUserById(user.id);
+  if (!dbUser) {
+    throw new UnauthorizedException('User not found');
+  }
+
+  return {
+    id: dbUser.id,
+    role: dbUser.role,
+  };
+}

--- a/apps/backend/src/mcp/mcp-tools.module.ts
+++ b/apps/backend/src/mcp/mcp-tools.module.ts
@@ -1,0 +1,49 @@
+import { Module } from '@nestjs/common';
+import { McpModule } from '@rekog/mcp-nest';
+import { ProjectsModule } from '../projects/projects.module';
+import { DeploymentsModule } from '../deployments/deployments.module';
+import { DomainsModule } from '../domains/domains.module';
+import { PipelinesModule } from '../pipelines/pipelines.module';
+import { SettingsModule } from '../settings/settings.module';
+import { UsersModule } from '../users/users.module';
+import { ApiKeysModule } from '../api-keys/api-keys.module';
+import { ProxyRulesModule } from '../proxy-rules/proxy-rules.module';
+import { CacheRulesModule } from '../cache-rules/cache-rules.module';
+import { ProjectTools } from './tools/project.tools';
+import { DeploymentTools } from './tools/deployment.tools';
+import { DomainTools } from './tools/domain.tools';
+import { PipelineTools } from './tools/pipeline.tools';
+import { SettingsTools } from './tools/settings.tools';
+import { UserTools } from './tools/user.tools';
+import { ApiKeyTools } from './tools/api-key.tools';
+import { ProxyRulesTools } from './tools/proxy-rules.tools';
+import { CacheRulesTools } from './tools/cache-rules.tools';
+
+const ALL_TOOLS = [
+  ProjectTools,
+  DeploymentTools,
+  DomainTools,
+  PipelineTools,
+  SettingsTools,
+  UserTools,
+  ApiKeyTools,
+  ProxyRulesTools,
+  CacheRulesTools,
+];
+
+@Module({
+  imports: [
+    ProjectsModule,
+    DeploymentsModule,
+    DomainsModule,
+    PipelinesModule,
+    SettingsModule,
+    UsersModule,
+    ApiKeysModule,
+    ProxyRulesModule,
+    CacheRulesModule,
+    McpModule.forFeature(ALL_TOOLS, 'bffless-ce'),
+  ],
+  providers: ALL_TOOLS,
+})
+export class McpToolsModule {}

--- a/apps/backend/src/mcp/tools/api-key.tools.ts
+++ b/apps/backend/src/mcp/tools/api-key.tools.ts
@@ -1,0 +1,84 @@
+import { Injectable } from '@nestjs/common';
+import { Tool, Context } from '@rekog/mcp-nest';
+import { z } from 'zod';
+import { Request } from 'express';
+import { ApiKeysService } from '../../api-keys/api-keys.service';
+import { AuthService } from '../../auth/auth.service';
+import { getUserContext } from '../helpers/user-context.helper';
+
+@Injectable()
+export class ApiKeyTools {
+  constructor(
+    private readonly apiKeysService: ApiKeysService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Tool({
+    name: 'list_api_keys',
+    description: 'List API keys for the current user with pagination.',
+    parameters: z.object({
+      page: z.number().optional().describe('Page number (default 1)'),
+      limit: z.number().optional().describe('Items per page (default 20)'),
+    }),
+  })
+  async listApiKeys(
+    args: { page?: number; limit?: number },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.apiKeysService.findAll(user.id, args);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'create_api_key',
+    description:
+      'Create a new API key. Returns the raw key only once. Global keys require admin role.',
+    parameters: z.object({
+      name: z.string().describe('Display name for the key'),
+      repository: z
+        .string()
+        .optional()
+        .describe('Scope to a repository in "owner/repo" format (omit for global)'),
+      isGlobal: z.boolean().optional().describe('Create a global key (admin only)'),
+      expiresAt: z.string().optional().describe('Expiration date (ISO 8601)'),
+    }),
+  })
+  async createApiKey(
+    args: { name: string; repository?: string; isGlobal?: boolean; expiresAt?: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.apiKeysService.create(
+      user.id,
+      {
+        name: args.name,
+        repository: args.repository,
+        isGlobal: args.isGlobal,
+        expiresAt: args.expiresAt,
+      },
+      user.role,
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'delete_api_key',
+    description: 'Delete an API key.',
+    parameters: z.object({
+      id: z.string().describe('API key ID to delete'),
+    }),
+    annotations: { destructiveHint: true },
+  })
+  async deleteApiKey(
+    { id }: { id: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    await this.apiKeysService.remove(id, user.id);
+    return JSON.stringify({ success: true, id });
+  }
+}

--- a/apps/backend/src/mcp/tools/cache-rules.tools.ts
+++ b/apps/backend/src/mcp/tools/cache-rules.tools.ts
@@ -1,0 +1,102 @@
+import { Injectable } from '@nestjs/common';
+import { Tool, Context } from '@rekog/mcp-nest';
+import { z } from 'zod';
+import { Request } from 'express';
+import { CacheRulesService } from '../../cache-rules/cache-rules.service';
+import { AuthService } from '../../auth/auth.service';
+import { getUserContext } from '../helpers/user-context.helper';
+
+@Injectable()
+export class CacheRulesTools {
+  constructor(
+    private readonly cacheRulesService: CacheRulesService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Tool({
+    name: 'list_cache_rules',
+    description: 'List all cache rules for a project.',
+    parameters: z.object({
+      projectId: z.string().describe('Project ID'),
+    }),
+  })
+  async listRules(
+    { projectId }: { projectId: string },
+    _context: Context,
+    _request: Request,
+  ) {
+    const result = await this.cacheRulesService.getRulesByProjectId(projectId);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'get_cache_rule',
+    description: 'Get a cache rule by ID.',
+    parameters: z.object({
+      id: z.string().describe('Cache rule ID'),
+    }),
+  })
+  async getRule({ id }: { id: string }, _context: Context, _request: Request) {
+    const result = await this.cacheRulesService.getRuleById(id);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'create_cache_rule',
+    description: 'Create a new cache rule for a project.',
+    parameters: z.object({
+      projectId: z.string().describe('Project ID'),
+      pathPattern: z.string().describe('Glob pattern to match paths (e.g. "*.js", "images/**")'),
+      name: z.string().optional().describe('Rule name'),
+      description: z.string().optional().describe('Rule description'),
+      browserMaxAge: z.number().optional().describe('Browser cache max-age in seconds'),
+      cdnMaxAge: z.number().optional().describe('CDN cache max-age in seconds'),
+      staleWhileRevalidate: z
+        .number()
+        .optional()
+        .describe('Stale-while-revalidate window in seconds'),
+      immutable: z.boolean().optional().describe('Mark assets as immutable'),
+      isEnabled: z.boolean().optional().describe('Whether the rule is enabled'),
+      priority: z.number().optional().describe('Rule priority (higher = evaluated first)'),
+    }),
+  })
+  async createRule(
+    args: {
+      projectId: string;
+      pathPattern: string;
+      name?: string;
+      description?: string;
+      browserMaxAge?: number;
+      cdnMaxAge?: number;
+      staleWhileRevalidate?: number;
+      immutable?: boolean;
+      isEnabled?: boolean;
+      priority?: number;
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const { projectId, ...dto } = args;
+    const result = await this.cacheRulesService.create(projectId, dto, user.id, user.role);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'delete_cache_rule',
+    description: 'Delete a cache rule.',
+    parameters: z.object({
+      id: z.string().describe('Cache rule ID to delete'),
+    }),
+    annotations: { destructiveHint: true },
+  })
+  async deleteRule(
+    { id }: { id: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    await this.cacheRulesService.delete(id, user.id, user.role);
+    return JSON.stringify({ success: true, id });
+  }
+}

--- a/apps/backend/src/mcp/tools/deployment.tools.ts
+++ b/apps/backend/src/mcp/tools/deployment.tools.ts
@@ -1,0 +1,188 @@
+import { Injectable } from '@nestjs/common';
+import { Tool, Context } from '@rekog/mcp-nest';
+import { z } from 'zod';
+import { Request } from 'express';
+import { DeploymentsService } from '../../deployments/deployments.service';
+import { AuthService } from '../../auth/auth.service';
+import { getUserContext } from '../helpers/user-context.helper';
+
+@Injectable()
+export class DeploymentTools {
+  constructor(
+    private readonly deploymentsService: DeploymentsService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Tool({
+    name: 'list_deployments',
+    description:
+      'List deployments with optional filters by repository (owner/name), branch, or commit SHA.',
+    parameters: z.object({
+      repository: z
+        .string()
+        .optional()
+        .describe('Filter by repository in "owner/name" format'),
+      branch: z.string().optional().describe('Filter by branch name'),
+      commitSha: z.string().optional().describe('Filter by commit SHA prefix'),
+      page: z.number().optional().describe('Page number (default 1)'),
+      limit: z.number().optional().describe('Items per page (default 20)'),
+    }),
+  })
+  async listDeployments(
+    args: {
+      repository?: string;
+      branch?: string;
+      commitSha?: string;
+      page?: number;
+      limit?: number;
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.deploymentsService.listDeployments(
+      {
+        repository: args.repository,
+        branch: args.branch,
+        commitSha: args.commitSha,
+        page: args.page,
+        limit: args.limit,
+      },
+      user.id,
+      user.role,
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'get_deployment',
+    description: 'Get detailed information about a specific deployment including files and aliases.',
+    parameters: z.object({
+      deploymentId: z.string().describe('Deployment ID (UUID)'),
+    }),
+  })
+  async getDeployment(
+    { deploymentId }: { deploymentId: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.deploymentsService.getDeployment(deploymentId, user.id, user.role);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'delete_deployment',
+    description: 'Delete a deployment and all its files from storage. This is irreversible.',
+    parameters: z.object({
+      deploymentId: z.string().describe('Deployment ID (UUID) to delete'),
+    }),
+    annotations: { destructiveHint: true },
+  })
+  async deleteDeployment(
+    { deploymentId }: { deploymentId: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    await this.deploymentsService.deleteDeployment(deploymentId, user.id, user.role);
+    return JSON.stringify({ success: true, deploymentId });
+  }
+
+  @Tool({
+    name: 'list_aliases',
+    description: 'List deployment aliases, optionally filtered by repository.',
+    parameters: z.object({
+      repository: z
+        .string()
+        .optional()
+        .describe('Filter by repository in "owner/name" format'),
+    }),
+  })
+  async listAliases(
+    args: { repository?: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.deploymentsService.listAliases(
+      { repository: args.repository },
+      user.id,
+      user.role,
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'create_alias',
+    description: 'Create or update a deployment alias (e.g. "production", "staging").',
+    parameters: z.object({
+      deploymentId: z.string().describe('Deployment ID to alias'),
+      alias: z.string().describe('Alias name (e.g. "production")'),
+      commitSha: z.string().describe('Commit SHA the deployment belongs to'),
+    }),
+  })
+  async createAlias(
+    args: { deploymentId: string; alias: string; commitSha: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.deploymentsService.createAlias(
+      args.deploymentId,
+      { alias: args.alias, commitSha: args.commitSha },
+      user.id,
+      user.role,
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'update_alias',
+    description: 'Update an alias to point to a different commit SHA.',
+    parameters: z.object({
+      repository: z.string().describe('Repository in "owner/name" format'),
+      alias: z.string().describe('Alias name to update'),
+      commitSha: z.string().describe('New commit SHA to point to'),
+    }),
+  })
+  async updateAlias(
+    args: { repository: string; alias: string; commitSha: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.deploymentsService.updateAlias(
+      args.repository,
+      args.alias,
+      { commitSha: args.commitSha },
+      user.id,
+      user.role,
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'delete_alias',
+    description: 'Delete a deployment alias.',
+    parameters: z.object({
+      repository: z.string().describe('Repository in "owner/name" format'),
+      alias: z.string().describe('Alias name to delete'),
+    }),
+    annotations: { destructiveHint: true },
+  })
+  async deleteAlias(
+    args: { repository: string; alias: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    await this.deploymentsService.deleteAlias(
+      args.repository,
+      args.alias,
+      user.id,
+      user.role,
+    );
+    return JSON.stringify({ success: true, alias: args.alias });
+  }
+}

--- a/apps/backend/src/mcp/tools/domain.tools.ts
+++ b/apps/backend/src/mcp/tools/domain.tools.ts
@@ -1,0 +1,128 @@
+import { Injectable } from '@nestjs/common';
+import { Tool, Context } from '@rekog/mcp-nest';
+import { z } from 'zod';
+import { Request } from 'express';
+import { DomainsService } from '../../domains/domains.service';
+import { AuthService } from '../../auth/auth.service';
+import { getUserContext } from '../helpers/user-context.helper';
+
+@Injectable()
+export class DomainTools {
+  constructor(
+    private readonly domainsService: DomainsService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Tool({
+    name: 'list_domains',
+    description: 'List all domain mappings, optionally filtered by project, type, or active status.',
+    parameters: z.object({
+      projectId: z.string().optional().describe('Filter by project ID'),
+      domainType: z
+        .string()
+        .optional()
+        .describe('Filter by type: "subdomain", "custom", or "redirect"'),
+      isActive: z.boolean().optional().describe('Filter by active status'),
+    }),
+  })
+  async listDomains(
+    args: { projectId?: string; domainType?: string; isActive?: boolean },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.domainsService.findAll(user.id, {
+      projectId: args.projectId,
+      domainType: args.domainType,
+      isActive: args.isActive,
+    });
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'get_domain',
+    description: 'Get details of a specific domain mapping by ID.',
+    parameters: z.object({
+      id: z.string().describe('Domain mapping ID (UUID)'),
+    }),
+  })
+  async getDomain(
+    { id }: { id: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.domainsService.findOne(id, user.id);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'create_domain',
+    description:
+      'Create a new domain mapping (subdomain, custom domain, or redirect). Requires admin role.',
+    parameters: z.object({
+      domain: z.string().describe('The domain name (e.g. "app.example.com")'),
+      domainType: z
+        .enum(['subdomain', 'custom', 'redirect'])
+        .describe('Type of domain mapping'),
+      projectId: z
+        .string()
+        .optional()
+        .describe('Project ID to map to (required for subdomain/custom)'),
+      alias: z
+        .string()
+        .optional()
+        .describe('Deployment alias to serve (e.g. "production")'),
+      path: z.string().optional().describe('Subdirectory path to serve'),
+      redirectTarget: z
+        .string()
+        .optional()
+        .describe('Target URL for redirect domains'),
+    }),
+  })
+  async createDomain(
+    args: {
+      domain: string;
+      domainType: 'subdomain' | 'custom' | 'redirect';
+      projectId?: string;
+      alias?: string;
+      path?: string;
+      redirectTarget?: string;
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.domainsService.create(
+      {
+        domain: args.domain,
+        domainType: args.domainType,
+        projectId: args.projectId,
+        alias: args.alias,
+        path: args.path,
+        redirectTarget: args.redirectTarget,
+      },
+      user.id,
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'delete_domain',
+    description:
+      'Delete a domain mapping. Removes nginx config and notifies control plane. Requires admin role.',
+    parameters: z.object({
+      id: z.string().describe('Domain mapping ID (UUID) to delete'),
+    }),
+    annotations: { destructiveHint: true },
+  })
+  async deleteDomain(
+    { id }: { id: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.domainsService.remove(id, user.id);
+    return JSON.stringify(result);
+  }
+}

--- a/apps/backend/src/mcp/tools/pipeline.tools.ts
+++ b/apps/backend/src/mcp/tools/pipeline.tools.ts
@@ -1,0 +1,236 @@
+import { Injectable } from '@nestjs/common';
+import { Tool, Context } from '@rekog/mcp-nest';
+import { z } from 'zod';
+import { Request } from 'express';
+import { PipelineSchemasService } from '../../pipelines/pipeline-schemas.service';
+import { PipelineDataService } from '../../pipelines/pipeline-data.service';
+import { SchemaFieldType } from '../../db/schema';
+import { AuthService } from '../../auth/auth.service';
+import { getUserContext } from '../helpers/user-context.helper';
+
+@Injectable()
+export class PipelineTools {
+  constructor(
+    private readonly schemasService: PipelineSchemasService,
+    private readonly dataService: PipelineDataService,
+    private readonly authService: AuthService,
+  ) {}
+
+  // =====================
+  // Schema Tools
+  // =====================
+
+  @Tool({
+    name: 'list_pipeline_schemas',
+    description: 'List all pipeline schemas for a project.',
+    parameters: z.object({
+      projectId: z.string().describe('Project ID'),
+    }),
+  })
+  async listSchemas(
+    { projectId }: { projectId: string },
+    _context: Context,
+    _request: Request,
+  ) {
+    const result = await this.schemasService.getByProjectId(projectId);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'get_pipeline_schema',
+    description: 'Get a pipeline schema by ID, including record count.',
+    parameters: z.object({
+      id: z.string().describe('Schema ID'),
+    }),
+  })
+  async getSchema({ id }: { id: string }, _context: Context, _request: Request) {
+    const result = await this.schemasService.getByIdWithCount(id);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'create_pipeline_schema',
+    description: 'Create a new pipeline schema with typed fields.',
+    parameters: z.object({
+      projectId: z.string().describe('Project ID'),
+      name: z.string().describe('Schema name'),
+      fields: z
+        .array(
+          z.object({
+            name: z.string(),
+            type: z
+              .enum(['string', 'number', 'boolean', 'email', 'text', 'datetime', 'json'])
+              .describe('Field type'),
+            required: z.boolean().optional(),
+            description: z.string().optional(),
+          }),
+        )
+        .describe('Schema field definitions'),
+    }),
+  })
+  async createSchema(
+    args: {
+      projectId: string;
+      name: string;
+      fields: Array<{
+        name: string;
+        type: SchemaFieldType;
+        required?: boolean;
+        description?: string;
+      }>;
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.schemasService.create(
+      {
+        projectId: args.projectId,
+        name: args.name,
+        fields: args.fields.map((f) => ({ name: f.name, type: f.type, required: f.required })),
+      },
+      user.id,
+      user.role,
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'delete_pipeline_schema',
+    description: 'Delete a pipeline schema and all its data records.',
+    parameters: z.object({
+      id: z.string().describe('Schema ID to delete'),
+    }),
+    annotations: { destructiveHint: true },
+  })
+  async deleteSchema(
+    { id }: { id: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    await this.schemasService.delete(id, user.id, user.role);
+    return JSON.stringify({ success: true, id });
+  }
+
+  // =====================
+  // Data Tools
+  // =====================
+
+  @Tool({
+    name: 'query_pipeline_data',
+    description:
+      'Query pipeline data records by schema ID with pagination, search, and filters.',
+    parameters: z.object({
+      schemaId: z.string().describe('Schema ID to query'),
+      page: z.number().optional().describe('Page number (default 1)'),
+      pageSize: z.number().optional().describe('Items per page (default 20)'),
+      search: z.string().optional().describe('Full-text search across text fields'),
+      sortBy: z.string().optional().describe('Field name to sort by'),
+      sortOrder: z.enum(['asc', 'desc']).optional().describe('Sort order'),
+    }),
+  })
+  async queryData(
+    args: {
+      schemaId: string;
+      page?: number;
+      pageSize?: number;
+      search?: string;
+      sortBy?: string;
+      sortOrder?: 'asc' | 'desc';
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.dataService.getBySchemaId(
+      args.schemaId,
+      args.page ?? 1,
+      args.pageSize ?? 20,
+      user.id,
+      user.role,
+      {
+        search: args.search,
+        sortBy: args.sortBy,
+        sortOrder: args.sortOrder,
+      },
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'get_pipeline_record',
+    description: 'Get a single pipeline data record by ID.',
+    parameters: z.object({
+      id: z.string().describe('Record ID'),
+    }),
+  })
+  async getRecord(
+    { id }: { id: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.dataService.getByIdWithAccess(id, user.id, user.role);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'create_pipeline_record',
+    description: 'Create a new pipeline data record.',
+    parameters: z.object({
+      schemaId: z.string().describe('Schema ID'),
+      data: z.record(z.string(), z.unknown()).describe('Record data matching the schema fields'),
+    }),
+  })
+  async createRecord(
+    args: { schemaId: string; data: Record<string, unknown> },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.dataService.createWithAccess(
+      args.schemaId,
+      args.data,
+      user.id,
+      user.role,
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'update_pipeline_record',
+    description: 'Update an existing pipeline data record.',
+    parameters: z.object({
+      id: z.string().describe('Record ID to update'),
+      data: z.record(z.string(), z.unknown()).describe('Updated record data'),
+    }),
+  })
+  async updateRecord(
+    args: { id: string; data: Record<string, unknown> },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.dataService.update(args.id, args.data, user.id, user.role);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'delete_pipeline_record',
+    description: 'Delete a pipeline data record.',
+    parameters: z.object({
+      id: z.string().describe('Record ID to delete'),
+    }),
+    annotations: { destructiveHint: true },
+  })
+  async deleteRecord(
+    { id }: { id: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    await this.dataService.delete(id, user.id, user.role);
+    return JSON.stringify({ success: true, id });
+  }
+}

--- a/apps/backend/src/mcp/tools/project.tools.ts
+++ b/apps/backend/src/mcp/tools/project.tools.ts
@@ -1,0 +1,127 @@
+import { Injectable } from '@nestjs/common';
+import { Tool, Context } from '@rekog/mcp-nest';
+import { z } from 'zod';
+import { Request } from 'express';
+import { ProjectsService } from '../../projects/projects.service';
+import { AuthService } from '../../auth/auth.service';
+import { getUserContext } from '../helpers/user-context.helper';
+
+@Injectable()
+export class ProjectTools {
+  constructor(
+    private readonly projectsService: ProjectsService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Tool({
+    name: 'list_projects',
+    description:
+      'List all projects accessible to the current user, with permission type and role for each.',
+    parameters: z.object({}),
+  })
+  async listProjects(_args: object, _context: Context, request: Request) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.projectsService.getMyRepositories(user.id, user.role);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'get_project',
+    description: 'Get a project by owner and name (e.g. owner="acme", name="website").',
+    parameters: z.object({
+      owner: z.string().describe('Project owner'),
+      name: z.string().describe('Project name'),
+    }),
+  })
+  async getProject(
+    { owner, name }: { owner: string; name: string },
+    _context: Context,
+    _request: Request,
+  ) {
+    const project = await this.projectsService.getProjectByOwnerName(owner, name);
+    return JSON.stringify(project);
+  }
+
+  @Tool({
+    name: 'create_project',
+    description: 'Create a new project.',
+    parameters: z.object({
+      owner: z.string().describe('Project owner'),
+      name: z.string().describe('Project name'),
+      displayName: z.string().optional().describe('Human-readable display name'),
+      description: z.string().optional().describe('Project description'),
+      isPublic: z.boolean().optional().describe('Whether the project is publicly accessible'),
+    }),
+    annotations: { destructiveHint: false },
+  })
+  async createProject(
+    args: {
+      owner: string;
+      name: string;
+      displayName?: string;
+      description?: string;
+      isPublic?: boolean;
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const project = await this.projectsService.createProject({
+      owner: args.owner,
+      name: args.name,
+      displayName: args.displayName ?? args.name,
+      description: args.description ?? null,
+      isPublic: args.isPublic ?? false,
+      settings: {},
+      createdBy: user.id,
+    });
+    return JSON.stringify(project);
+  }
+
+  @Tool({
+    name: 'update_project',
+    description: 'Update project settings (display name, description, visibility).',
+    parameters: z.object({
+      projectId: z.string().describe('Project ID (UUID)'),
+      displayName: z.string().optional().describe('New display name'),
+      description: z.string().optional().describe('New description'),
+      isPublic: z.boolean().optional().describe('New visibility setting'),
+    }),
+  })
+  async updateProject(
+    args: {
+      projectId: string;
+      displayName?: string;
+      description?: string;
+      isPublic?: boolean;
+    },
+    _context: Context,
+    _request: Request,
+  ) {
+    const updates: Record<string, any> = {};
+    if (args.displayName !== undefined) updates.displayName = args.displayName;
+    if (args.description !== undefined) updates.description = args.description;
+    if (args.isPublic !== undefined) updates.isPublic = args.isPublic;
+
+    const project = await this.projectsService.updateProject(args.projectId, updates);
+    return JSON.stringify(project);
+  }
+
+  @Tool({
+    name: 'delete_project',
+    description:
+      'Delete a project and all its deployments, aliases, and storage files. This is irreversible.',
+    parameters: z.object({
+      projectId: z.string().describe('Project ID (UUID) to delete'),
+    }),
+    annotations: { destructiveHint: true },
+  })
+  async deleteProject(
+    { projectId }: { projectId: string },
+    _context: Context,
+    _request: Request,
+  ) {
+    await this.projectsService.deleteProject(projectId);
+    return JSON.stringify({ success: true, projectId });
+  }
+}

--- a/apps/backend/src/mcp/tools/proxy-rules.tools.ts
+++ b/apps/backend/src/mcp/tools/proxy-rules.tools.ts
@@ -1,0 +1,307 @@
+import { Injectable } from '@nestjs/common';
+import { Tool, Context } from '@rekog/mcp-nest';
+import { z } from 'zod';
+import { Request } from 'express';
+import { ProxyRuleSetsService } from '../../proxy-rules/proxy-rule-sets.service';
+import { ProxyRulesService } from '../../proxy-rules/proxy-rules.service';
+import { AuthService } from '../../auth/auth.service';
+import { getUserContext } from '../helpers/user-context.helper';
+
+const pipelineStepSchema = z.object({
+  id: z.string().describe('Unique step ID'),
+  name: z.string().describe('Step name'),
+  handlerType: z
+    .string()
+    .describe(
+      'Handler type: form, response, data_create, data_query, data_update, data_delete, email, db_aggregate, function, ai, file_upload, file_serve, replicate, embed_store, vector_search, image_convert',
+    ),
+  config: z
+    .record(z.string(), z.unknown())
+    .describe(
+      `Handler-specific configuration object. Key configs by handler type:
+
+- form: { fields: { fieldName: { type: "string"|"number"|"email"|"boolean", required?: bool } } }
+- response: { body: "Handlebars template string producing valid JSON. Use \\"key\\": \\"{{expr}}\\" for strings, \\"key\\": {{expr}} for numbers, \\"key\\": {{{expr}}} for raw JSON objects. Keys must always be quoted.", status?: number, headers?: {}, contentType?: string }
+- data_create: { schemaId: "uuid", fields: { schemaField: "expression" } }
+- data_query: { schemaId: "uuid", filters?: {}, pageSize?: number }
+- data_update: { schemaId: "uuid", recordId: "expression", fields: { schemaField: "expression" } }
+- data_delete: { schemaId: "uuid", recordId: "expression" }
+- replicate: { model: "owner/name" (JUST the model, e.g. "stability-ai/sdxl"), version?: "64-char hash" (SEPARATE from model — pin for deterministic results), input: { inputName: "expression" }, outputField?: "key" }
+- file_upload: { schemaId: "uuid", subDir: "folder", sourceUrl?: "expression" (for downloading from URL e.g. "steps.replicate.output[0]"), extraFields?: { field: "expression" }, filename?: "expression", convertTo?: "png"|"jpeg"|"webp" }
+- ai: { provider: "anthropic"|"openai", model: "model-id", systemPrompt?: "text", userPrompt: "expression", temperature?: number }
+- email: { to: "expression", subject: "expression", body: "expression" }
+- db_aggregate: { schemaId: "uuid", operation: "sum"|"count"|"avg"|"min"|"max", field?: "name", filters?: {} }
+
+All configs support: condition?: "expression" (skip step if falsy), timeout?: number (ms).
+Expressions reference prior steps: "steps.stepName.fieldName" or request data: "request.body.field".`,
+    ),
+  isEnabled: z.boolean().optional().describe('Whether step is enabled (default true)'),
+});
+
+@Injectable()
+export class ProxyRulesTools {
+  constructor(
+    private readonly proxyRuleSetsService: ProxyRuleSetsService,
+    private readonly proxyRulesService: ProxyRulesService,
+    private readonly authService: AuthService,
+  ) {}
+
+  // =====================
+  // Rule Set Tools
+  // =====================
+
+  @Tool({
+    name: 'list_proxy_rule_sets',
+    description: 'List all proxy rule sets for a project.',
+    parameters: z.object({
+      projectId: z.string().describe('Project ID'),
+    }),
+  })
+  async listRuleSets(
+    { projectId }: { projectId: string },
+    _context: Context,
+    _request: Request,
+  ) {
+    const result = await this.proxyRuleSetsService.listByProject(projectId);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'get_proxy_rule_set',
+    description: 'Get a proxy rule set by ID, including all its rules.',
+    parameters: z.object({
+      id: z.string().describe('Rule set ID'),
+    }),
+  })
+  async getRuleSet({ id }: { id: string }, _context: Context, _request: Request) {
+    const result = await this.proxyRuleSetsService.getById(id);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'create_proxy_rule_set',
+    description: 'Create a new proxy rule set for a project.',
+    parameters: z.object({
+      projectId: z.string().describe('Project ID'),
+      name: z.string().describe('Rule set name'),
+      description: z.string().optional().describe('Rule set description'),
+      environment: z.string().optional().describe('Target environment'),
+    }),
+  })
+  async createRuleSet(
+    args: {
+      projectId: string;
+      name: string;
+      description?: string;
+      environment?: string;
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.proxyRuleSetsService.create(
+      args.projectId,
+      { name: args.name, description: args.description, environment: args.environment },
+      user.id,
+      user.role,
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'delete_proxy_rule_set',
+    description: 'Delete a proxy rule set and all its rules. Cannot delete the default rule set.',
+    parameters: z.object({
+      id: z.string().describe('Rule set ID to delete'),
+    }),
+    annotations: { destructiveHint: true },
+  })
+  async deleteRuleSet(
+    { id }: { id: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    await this.proxyRuleSetsService.delete(id, user.id, user.role);
+    return JSON.stringify({ success: true, id });
+  }
+
+  // =====================
+  // Individual Rule Tools
+  // =====================
+
+  @Tool({
+    name: 'get_proxy_rule',
+    description: 'Get a single proxy rule by ID.',
+    parameters: z.object({
+      id: z.string().describe('Proxy rule ID'),
+    }),
+  })
+  async getRule({ id }: { id: string }, _context: Context, _request: Request) {
+    const result = await this.proxyRulesService.getRuleById(id);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'create_proxy_rule',
+    description:
+      'Create a proxy rule within a rule set. Supports external proxy, internal rewrite, email form handler, and pipeline types. For pipelines, provide pipelineConfig with steps array.',
+    parameters: z.object({
+      ruleSetId: z.string().describe('Rule set ID to add the rule to'),
+      pathPattern: z
+        .string()
+        .describe('URL path pattern to match (e.g. "/api/contact", "/api/generate-image")'),
+      targetUrl: z
+        .string()
+        .describe(
+          'Target URL for external_proxy, or path for internal_rewrite. Use "pipeline" for pipeline type.',
+        ),
+      method: z
+        .enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'])
+        .optional()
+        .describe('HTTP method to match (omit for any method)'),
+      proxyType: z
+        .enum(['external_proxy', 'internal_rewrite', 'email_form_handler', 'pipeline'])
+        .optional()
+        .describe('Rule type (default: external_proxy)'),
+      description: z.string().optional().describe('Rule description'),
+      isEnabled: z.boolean().optional().describe('Whether rule is active (default true)'),
+      order: z.number().optional().describe('Evaluation order (auto-assigned if omitted)'),
+      stripPrefix: z.boolean().optional().describe('Remove matched prefix before forwarding (default true)'),
+      timeout: z.number().optional().describe('Request timeout in ms (default 30000, range 1000-60000)'),
+      preserveHost: z.boolean().optional().describe('Preserve original Host header'),
+      forwardCookies: z.boolean().optional().describe('Forward cookies to target'),
+      headerConfig: z
+        .object({
+          forward: z.array(z.string()).optional().describe('Headers to forward'),
+          strip: z.array(z.string()).optional().describe('Headers to remove'),
+          add: z
+            .record(z.string(), z.string())
+            .optional()
+            .describe('Headers to add (values encrypted at rest)'),
+        })
+        .optional()
+        .describe('Header manipulation config'),
+      emailHandlerConfig: z
+        .object({
+          destinationEmail: z.string().describe('Email address to send form submissions to'),
+          subject: z.string().optional().describe('Email subject line'),
+          successRedirect: z.string().optional().describe('URL to redirect to after success'),
+          corsOrigin: z.string().optional().describe('Allowed CORS origin'),
+          honeypotField: z.string().optional().describe('Honeypot field name for spam detection'),
+          replyToField: z.string().optional().describe('Form field to use as reply-to address'),
+          requireAuth: z.boolean().optional().describe('Require authentication'),
+        })
+        .optional()
+        .describe('Config for email_form_handler type'),
+      pipelineConfig: z
+        .object({
+          name: z.string().describe('Pipeline name'),
+          description: z.string().optional().describe('Pipeline description'),
+          steps: z.array(pipelineStepSchema).describe('Pipeline execution steps'),
+          postSteps: z.array(pipelineStepSchema).optional().describe('Steps to run after main steps'),
+          validators: z
+            .array(
+              z.object({
+                type: z.string().describe('Validator type (e.g. "auth_required", "rate_limit")'),
+                config: z.record(z.string(), z.unknown()).describe('Validator config'),
+              }),
+            )
+            .optional()
+            .describe('Request validators'),
+        })
+        .optional()
+        .describe('Config for pipeline type - defines multi-step request processing'),
+    }),
+  })
+  async createRule(
+    args: Record<string, unknown>,
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.proxyRulesService.create(args as any, user.id, user.role);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'update_proxy_rule',
+    description: 'Update an existing proxy rule. All fields are optional — only provided fields are updated.',
+    parameters: z.object({
+      id: z.string().describe('Proxy rule ID to update'),
+      pathPattern: z.string().optional().describe('New path pattern'),
+      targetUrl: z.string().optional().describe('New target URL'),
+      method: z
+        .enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'])
+        .optional()
+        .describe('New HTTP method'),
+      proxyType: z
+        .enum(['external_proxy', 'internal_rewrite', 'email_form_handler', 'pipeline'])
+        .optional(),
+      description: z.string().optional(),
+      isEnabled: z.boolean().optional(),
+      order: z.number().optional(),
+      stripPrefix: z.boolean().optional(),
+      timeout: z.number().optional(),
+      preserveHost: z.boolean().optional(),
+      forwardCookies: z.boolean().optional(),
+      headerConfig: z
+        .object({
+          forward: z.array(z.string()).optional(),
+          strip: z.array(z.string()).optional(),
+          add: z.record(z.string(), z.string()).optional(),
+        })
+        .optional(),
+      emailHandlerConfig: z
+        .object({
+          destinationEmail: z.string(),
+          subject: z.string().optional(),
+          successRedirect: z.string().optional(),
+          corsOrigin: z.string().optional(),
+          honeypotField: z.string().optional(),
+          replyToField: z.string().optional(),
+          requireAuth: z.boolean().optional(),
+        })
+        .optional(),
+      pipelineConfig: z
+        .object({
+          name: z.string(),
+          description: z.string().optional(),
+          steps: z.array(pipelineStepSchema),
+          postSteps: z.array(pipelineStepSchema).optional(),
+          validators: z
+            .array(z.object({ type: z.string(), config: z.record(z.string(), z.unknown()) }))
+            .optional(),
+        })
+        .optional(),
+    }),
+  })
+  async updateRule(
+    args: Record<string, unknown>,
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const { id, ...dto } = args;
+    const result = await this.proxyRulesService.update(id as string, dto as any, user.id, user.role);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'delete_proxy_rule',
+    description: 'Delete a proxy rule.',
+    parameters: z.object({
+      id: z.string().describe('Proxy rule ID to delete'),
+    }),
+    annotations: { destructiveHint: true },
+  })
+  async deleteRule(
+    { id }: { id: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    await this.proxyRulesService.delete(id, user.id, user.role);
+    return JSON.stringify({ success: true, id });
+  }
+}

--- a/apps/backend/src/mcp/tools/settings.tools.ts
+++ b/apps/backend/src/mcp/tools/settings.tools.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@nestjs/common';
+import { Tool, Context } from '@rekog/mcp-nest';
+import { z } from 'zod';
+import { Request } from 'express';
+import { PrimaryContentService } from '../../settings/primary-content.service';
+import { AuthService } from '../../auth/auth.service';
+import { getUserContext } from '../helpers/user-context.helper';
+
+@Injectable()
+export class SettingsTools {
+  constructor(
+    private readonly primaryContentService: PrimaryContentService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Tool({
+    name: 'get_primary_content_config',
+    description:
+      'Get the primary content configuration (which project/alias is served on the root domain).',
+    parameters: z.object({}),
+  })
+  async getConfig(_args: object, _context: Context, _request: Request) {
+    const result = await this.primaryContentService.getConfig();
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'update_primary_content_config',
+    description:
+      'Update primary content configuration. Controls which project/alias is served on the root domain. Requires admin role.',
+    parameters: z.object({
+      enabled: z.boolean().optional().describe('Enable/disable primary content'),
+      projectId: z.string().optional().describe('Project ID to serve'),
+      alias: z.string().optional().describe('Deployment alias to serve'),
+      path: z.string().optional().describe('Subdirectory path to serve'),
+      isSpa: z.boolean().optional().describe('Enable SPA fallback (serve index.html for all paths)'),
+      wwwBehavior: z
+        .enum(['redirect-to-www', 'redirect-to-root', 'serve-both'])
+        .optional()
+        .describe('How to handle www subdomain'),
+    }),
+  })
+  async updateConfig(
+    args: {
+      enabled?: boolean;
+      projectId?: string;
+      alias?: string;
+      path?: string;
+      isSpa?: boolean;
+      wwwBehavior?: 'redirect-to-www' | 'redirect-to-root' | 'serve-both';
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.primaryContentService.updateConfig(args, user.id);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'list_available_projects_for_primary_content',
+    description: 'List projects available for primary content configuration, with their aliases.',
+    parameters: z.object({}),
+  })
+  async listAvailableProjects(_args: object, _context: Context, _request: Request) {
+    const result = await this.primaryContentService.getAvailableProjects();
+    return JSON.stringify(result);
+  }
+}

--- a/apps/backend/src/mcp/tools/user.tools.ts
+++ b/apps/backend/src/mcp/tools/user.tools.ts
@@ -1,0 +1,89 @@
+import { Injectable, ForbiddenException } from '@nestjs/common';
+import { Tool, Context } from '@rekog/mcp-nest';
+import { z } from 'zod';
+import { Request } from 'express';
+import { UsersService } from '../../users/users.service';
+import { UserRole, UserSortField, ListUsersQueryDto } from '../../users/users.dto';
+import { AuthService } from '../../auth/auth.service';
+import { getUserContext } from '../helpers/user-context.helper';
+
+@Injectable()
+export class UserTools {
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Tool({
+    name: 'list_users',
+    description: 'List all users with pagination and search. Requires admin role.',
+    parameters: z.object({
+      page: z.number().optional().describe('Page number (default 1)'),
+      limit: z.number().optional().describe('Items per page (default 20)'),
+      search: z.string().optional().describe('Search by email'),
+      role: z.enum(['admin', 'user', 'member']).optional().describe('Filter by role'),
+      sortBy: z.enum(['createdAt', 'updatedAt', 'email']).optional().describe('Sort field'),
+      sortOrder: z.enum(['asc', 'desc']).optional(),
+    }),
+  })
+  async listUsers(
+    args: {
+      page?: number;
+      limit?: number;
+      search?: string;
+      role?: 'admin' | 'user' | 'member';
+      sortBy?: 'createdAt' | 'updatedAt' | 'email';
+      sortOrder?: 'asc' | 'desc';
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    if (user.role !== 'admin') {
+      throw new ForbiddenException('Admin role required');
+    }
+    const result = await this.usersService.findAll(args as ListUsersQueryDto);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'get_user',
+    description: 'Get user details by ID. Requires admin role.',
+    parameters: z.object({
+      id: z.string().describe('User ID'),
+    }),
+  })
+  async getUser(
+    { id }: { id: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    if (user.role !== 'admin') {
+      throw new ForbiddenException('Admin role required');
+    }
+    const result = await this.usersService.findById(id);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'update_user_role',
+    description: 'Update a user\'s role. Requires admin role.',
+    parameters: z.object({
+      id: z.string().describe('User ID'),
+      role: z.enum(['admin', 'user']).describe('New role'),
+    }),
+  })
+  async updateUserRole(
+    args: { id: string; role: 'admin' | 'user' },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    if (user.role !== 'admin') {
+      throw new ForbiddenException('Admin role required');
+    }
+    const result = await this.usersService.updateRole(args.id, { role: args.role as UserRole });
+    return JSON.stringify(result);
+  }
+}

--- a/apps/backend/src/onboarding-rules/onboarding-rules.controller.ts
+++ b/apps/backend/src/onboarding-rules/onboarding-rules.controller.ts
@@ -28,7 +28,7 @@ import {
   OnboardingRuleResponseDto,
   OnboardingRuleExecutionResponseDto,
 } from './dto';
-import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { ApiKeyGuard } from '../auth/api-key.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
@@ -36,7 +36,7 @@ import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.de
 @ApiTags('Onboarding Rules')
 @ApiBearerAuth()
 @Controller('api/onboarding-rules')
-@UseGuards(SessionAuthGuard, RolesGuard)
+@UseGuards(ApiKeyGuard, RolesGuard)
 @Roles('admin')
 export class OnboardingRulesController {
   constructor(private readonly onboardingRulesService: OnboardingRulesService) {}

--- a/apps/backend/src/permissions/permissions.controller.ts
+++ b/apps/backend/src/permissions/permissions.controller.ts
@@ -14,7 +14,7 @@ import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagg
 import { PermissionsService } from './permissions.service';
 import { ProjectsService } from '../projects/projects.service';
 import { UsersService } from '../users/users.service';
-import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { ApiKeyGuard } from '../auth/api-key.guard';
 import { ProjectPermissionGuard } from '../auth/guards/project-permission.guard';
 import { RequireProjectRole } from '../auth/decorators/project-permission.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -29,7 +29,7 @@ import {
 
 @ApiTags('Permissions')
 @Controller('api/projects/:owner/:repo/permissions')
-@UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+@UseGuards(ApiKeyGuard, ProjectPermissionGuard)
 @ApiBearerAuth()
 export class PermissionsController {
   constructor(

--- a/apps/backend/src/pipelines/execution/pipeline-context.interface.ts
+++ b/apps/backend/src/pipelines/execution/pipeline-context.interface.ts
@@ -91,6 +91,12 @@ export interface StepResult {
    * Useful for honeypot detection where we want to return fake success without processing.
    */
   terminates?: boolean;
+
+  /**
+   * Optional warning message when step succeeded but with a non-ideal outcome.
+   * Surfaced in debug UI to help users diagnose template/config issues.
+   */
+  warning?: string;
 }
 
 /**
@@ -153,6 +159,11 @@ export interface StepDebugInfo {
     message: string;
     details?: unknown;
   };
+
+  /**
+   * Warning message if step succeeded but with a non-ideal outcome
+   */
+  warning?: string;
 
   /**
    * Condition that was evaluated (if any)

--- a/apps/backend/src/pipelines/execution/pipeline-execution.service.ts
+++ b/apps/backend/src/pipelines/execution/pipeline-execution.service.ts
@@ -391,6 +391,7 @@ export class PipelineExecutionService {
         input: inputSnapshot,
         output: result.output,
         error: result.error,
+        warning: result.warning,
         condition: config.condition,
         conditionResult: conditionResult,
         result,

--- a/apps/backend/src/pipelines/handlers/response.handler.ts
+++ b/apps/backend/src/pipelines/handlers/response.handler.ts
@@ -77,9 +77,10 @@ export class ResponseHandler implements StepHandler<ResponseHandlerConfig> {
     const contentType = config.contentType || 'application/json';
 
     // Build the response object
+    const { body: formattedBody, warning } = this.formatBody(body, contentType);
     const response = {
       status: config.status || 200,
-      body: this.formatBody(body, contentType),
+      body: formattedBody,
       headers: {
         'Content-Type': contentType,
         ...headers,
@@ -90,6 +91,7 @@ export class ResponseHandler implements StepHandler<ResponseHandlerConfig> {
 
     return {
       success: true,
+      warning,
       output: {
         __isResponse: true,
         ...response,
@@ -97,7 +99,10 @@ export class ResponseHandler implements StepHandler<ResponseHandlerConfig> {
     };
   }
 
-  private formatBody(body: unknown, contentType: string): unknown {
+  private formatBody(
+    body: unknown,
+    contentType: string,
+  ): { body: unknown; warning?: string } {
     // For JSON content type, ensure body is properly formatted
     if (contentType.includes('application/json')) {
       if (typeof body === 'string') {
@@ -105,20 +110,33 @@ export class ResponseHandler implements StepHandler<ResponseHandlerConfig> {
         // This allows templates like { success: true, data: {{ steps.foo.value }} }
         // to work even though they produce non-strict JSON
         try {
-          return JSON5.parse(body);
-        } catch {
-          // If even JSON5 fails, wrap in an object
-          return { message: body };
+          return { body: JSON5.parse(body) };
+        } catch (err) {
+          // JSON5 parse failed - this usually means the rendered template has
+          // unquoted string values (e.g. { name: John Doe } instead of { name: "John Doe" }).
+          // Wrap {{expressions}} that produce strings in quotes: "{{steps.step.field}}"
+          // Use triple braces {{{expr}}} for objects/arrays (already valid JSON).
+          const parseError = err instanceof Error ? err.message : String(err);
+          const truncatedBody =
+            body.length > 200 ? body.substring(0, 200) + '...' : body;
+          const warning =
+            `Response body template produced invalid JSON and was wrapped in { "message": ... }. ` +
+            `Parse error: ${parseError}. ` +
+            `Rendered body: ${truncatedBody}. ` +
+            `Tip: Quote string expressions in your template, e.g. "{{steps.myStep.field}}". ` +
+            `Use triple braces {{{expr}}} for objects/arrays that are already valid JSON.`;
+          this.logger.warn(warning);
+          return { body: { message: body }, warning };
         }
       }
-      return body;
+      return { body };
     }
 
     // For HTML/text, convert to string if needed
     if (contentType.includes('text/') || contentType.includes('html')) {
-      return typeof body === 'string' ? body : JSON.stringify(body);
+      return { body: typeof body === 'string' ? body : JSON.stringify(body) };
     }
 
-    return body;
+    return { body };
   }
 }

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -18,7 +18,7 @@ import {
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { ProjectsService } from './projects.service';
 import { ProjectAISettingsService, AIProviderType, AIServiceType } from './project-ai-settings.service';
-import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { ApiKeyGuard } from '../auth/api-key.guard';
 import { ProjectPermissionGuard } from '../auth/guards/project-permission.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import {
@@ -53,7 +53,7 @@ export class ProjectsController {
   ) {}
 
   @Get()
-  @UseGuards(SessionAuthGuard)
+  @UseGuards(ApiKeyGuard)
   @ApiOperation({ summary: 'List all projects for the current user' })
   @ApiResponse({ status: 200, description: 'List of projects', type: [ProjectResponseDto] })
   async listUserProjects(@CurrentUser('id') userId: string): Promise<ProjectResponseDto[]> {
@@ -67,7 +67,7 @@ export class ProjectsController {
   // ==========================================================================
 
   @Get(':id/ai')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'Get AI providers configured for this project' })
   @ApiResponse({
@@ -80,7 +80,7 @@ export class ProjectsController {
   }
 
   @Post(':id/ai')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'Add or update an AI provider for this project' })
   @ApiResponse({
@@ -96,7 +96,7 @@ export class ProjectsController {
   }
 
   @Delete(':id/ai/:provider')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'Remove an AI provider from this project' })
   @ApiResponse({
@@ -112,7 +112,7 @@ export class ProjectsController {
   }
 
   @Post(':id/ai/default')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'Set default AI provider for this project' })
   @ApiResponse({
@@ -128,7 +128,7 @@ export class ProjectsController {
   }
 
   @Post(':id/ai/test')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'Test AI connection for this project' })
   @ApiResponse({ status: 200, description: 'AI test result', type: TestAIResponseDto })
@@ -140,7 +140,7 @@ export class ProjectsController {
   }
 
   @Get(':id/ai/providers')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'Get available AI providers with model suggestions' })
   @ApiResponse({
@@ -155,7 +155,7 @@ export class ProjectsController {
   }
 
   @Get(':id/ai/skills')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('contributor')
   @ApiOperation({ summary: 'List available AI skills for the project deployment' })
   @ApiResponse({
@@ -209,7 +209,7 @@ export class ProjectsController {
   // ==========================================================================
 
   @Get(':id/ai-services')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'Get AI services configured for this project' })
   @ApiResponse({ status: 200, description: 'AI services status' })
@@ -218,7 +218,7 @@ export class ProjectsController {
   }
 
   @Post(':id/ai-services')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'Add or update an AI service for this project' })
   @ApiResponse({ status: 200, description: 'Service added/updated' })
@@ -230,7 +230,7 @@ export class ProjectsController {
   }
 
   @Delete(':id/ai-services/:service')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'Remove an AI service from this project' })
   @ApiResponse({ status: 200, description: 'Service removed' })
@@ -242,7 +242,7 @@ export class ProjectsController {
   }
 
   @Post(':id/ai-services/test')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'Test AI service connection' })
   @ApiResponse({ status: 200, description: 'Test result' })
@@ -262,7 +262,7 @@ export class ProjectsController {
   // ==========================================================================
 
   @Get(':id/ai-plugins')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'List all plugins with enabled status for this project' })
   @ApiResponse({ status: 200, description: 'List of plugins' })
@@ -271,7 +271,7 @@ export class ProjectsController {
   }
 
   @Post(':id/ai-plugins/:pluginId')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'Enable a plugin for this project' })
   @ApiResponse({ status: 200, description: 'Plugin enabled' })
@@ -284,7 +284,7 @@ export class ProjectsController {
   }
 
   @Put(':id/ai-plugins/:pluginId')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'Update plugin configuration' })
   @ApiResponse({ status: 200, description: 'Plugin config updated' })
@@ -298,7 +298,7 @@ export class ProjectsController {
 
   @Delete(':id/ai-plugins/:pluginId')
   @HttpCode(HttpStatus.NO_CONTENT)
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'Disable a plugin for this project' })
   @ApiResponse({ status: 204, description: 'Plugin disabled' })
@@ -315,7 +315,7 @@ export class ProjectsController {
   // ==========================================================================
 
   @Get(':owner/:name')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('viewer')
   @AllowPublicAccess()
   @ApiOperation({ summary: 'Get project by owner and name' })
@@ -330,7 +330,7 @@ export class ProjectsController {
   }
 
   @Get(':id')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('viewer')
   @AllowPublicAccess()
   @ApiOperation({ summary: 'Get project by ID' })
@@ -342,7 +342,7 @@ export class ProjectsController {
   }
 
   @Post()
-  @UseGuards(SessionAuthGuard, RolesGuard)
+  @UseGuards(ApiKeyGuard, RolesGuard)
   @Roles('admin', 'user')
   @ApiOperation({ summary: 'Create a new project' })
   @ApiResponse({ status: 201, description: 'Project created', type: ProjectResponseDto })
@@ -359,7 +359,7 @@ export class ProjectsController {
   }
 
   @Patch(':id')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('admin')
   @ApiOperation({ summary: 'Update project settings' })
   @ApiResponse({ status: 200, description: 'Project updated', type: ProjectResponseDto })
@@ -373,7 +373,7 @@ export class ProjectsController {
   }
 
   @Delete(':id')
-  @UseGuards(SessionAuthGuard, ProjectPermissionGuard)
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
   @RequireProjectRole('owner')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Delete a project' })

--- a/apps/backend/src/settings/settings.controller.ts
+++ b/apps/backend/src/settings/settings.controller.ts
@@ -12,11 +12,11 @@ import {
   SendTestEmailDto,
   SendTestEmailResponseDto,
 } from './dto/email-settings.dto';
-import { SessionAuthGuard, RolesGuard, Roles, CurrentUser } from '../auth';
+import { ApiKeyGuard, RolesGuard, Roles, CurrentUser } from '../auth';
 
 @ApiTags('Settings')
 @Controller('api/settings')
-@UseGuards(SessionAuthGuard, RolesGuard)
+@UseGuards(ApiKeyGuard, RolesGuard)
 export class SettingsController {
   constructor(
     private readonly primaryContentService: PrimaryContentService,

--- a/apps/backend/src/storage/storage-usage.controller.ts
+++ b/apps/backend/src/storage/storage-usage.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, Param, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
-import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { ApiKeyGuard } from '../auth/api-key.guard';
 import { StorageUsageService, WorkspaceStorageUsage, ProjectUsage, BranchUsage } from './storage-usage.service';
 
 /**
@@ -11,7 +11,7 @@ import { StorageUsageService, WorkspaceStorageUsage, ProjectUsage, BranchUsage }
  */
 @ApiTags('Storage')
 @Controller('api/storage')
-@UseGuards(SessionAuthGuard)
+@UseGuards(ApiKeyGuard)
 @ApiBearerAuth()
 export class StorageUsageController {
   constructor(private readonly storageUsageService: StorageUsageService) {}

--- a/apps/backend/src/user-groups/user-groups.controller.ts
+++ b/apps/backend/src/user-groups/user-groups.controller.ts
@@ -11,7 +11,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
-import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { ApiKeyGuard } from '../auth/api-key.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -33,7 +33,7 @@ interface CurrentUserData {
 }
 
 @Controller('api/user-groups')
-@UseGuards(SessionAuthGuard, RolesGuard)
+@UseGuards(ApiKeyGuard, RolesGuard)
 @Roles('admin')
 @ApiTags('User Groups')
 @ApiBearerAuth()

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -15,7 +15,7 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { UsersService } from './users.service';
-import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { ApiKeyGuard } from '../auth/api-key.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
@@ -33,7 +33,7 @@ import {
 
 @ApiTags('Users')
 @Controller('api/users')
-@UseGuards(SessionAuthGuard, RolesGuard)
+@UseGuards(ApiKeyGuard, RolesGuard)
 @ApiBearerAuth()
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -63,7 +63,7 @@
     "shiki": "^3.15.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.25.76"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,13 +25,13 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.58
-        version: 3.0.58(zod@3.25.76)
+        version: 3.0.58(zod@4.3.6)
       '@ai-sdk/google':
         specifier: ^3.0.43
-        version: 3.0.43(zod@3.25.76)
+        version: 3.0.43(zod@4.3.6)
       '@ai-sdk/openai':
         specifier: ^3.0.41
-        version: 3.0.41(zod@3.25.76)
+        version: 3.0.41(zod@4.3.6)
       '@aws-sdk/client-s3':
         specifier: ^3.478.0
         version: 3.932.0
@@ -47,6 +47,9 @@ importers:
       '@google-cloud/storage':
         specifier: ^7.7.0
         version: 7.17.3
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.27.1
+        version: 1.27.1(zod@4.3.6)
       '@nestjs/common':
         specifier: ^10.3.0
         version: 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -71,6 +74,9 @@ importers:
       '@nestjs/throttler':
         specifier: ^6.5.0
         version: 6.5.0(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(reflect-metadata@0.2.2)
+      '@rekog/mcp-nest':
+        specifier: ^1.9.8
+        version: 1.9.8(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(@nestjs/jwt@11.0.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)))(@nestjs/passport@11.0.5(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0))(express@5.2.1)(reflect-metadata@0.2.2)(zod@4.3.6)
       '@types/jsonwebtoken':
         specifier: ^9.0.10
         version: 9.0.10
@@ -79,7 +85,7 @@ importers:
         version: 5.4.0
       ai:
         specifier: ^6.0.116
-        version: 6.0.116(zod@3.25.76)
+        version: 6.0.116(zod@4.3.6)
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1
@@ -155,6 +161,9 @@ importers:
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.2.1
@@ -382,8 +391,8 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.18(tsx@4.20.6))
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@playwright/test':
         specifier: ^1.57.0
@@ -1613,6 +1622,12 @@ packages:
     resolution: {integrity: sha512-gOnCAbFgAYKRozywLsxagdevTF7Gm+2Ncz5u5CQAuOv/2VCa0rdGJWvJFDOftPx1tc+q8TXiC2pEJfFKu+yeMQ==}
     engines: {node: '>=14'}
 
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hookform/resolvers@3.10.0':
     resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
     peerDependencies:
@@ -1936,6 +1951,16 @@ packages:
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
 
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@monaco-editor/loader@1.7.0':
     resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
 
@@ -1982,6 +2007,12 @@ packages:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
       rxjs: ^7.1.0
 
+  '@nestjs/config@4.0.3':
+    resolution: {integrity: sha512-FQ3M3Ohqfl+nHAn5tp7++wUQw0f2nAk+SFKe8EpNRnIifPqvfJP6JQxPKtFLMOHbyer4X646prFG4zSRYEssQQ==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      rxjs: ^7.1.0
+
   '@nestjs/core@10.4.20':
     resolution: {integrity: sha512-kRdtyKA3+Tu70N3RQ4JgmO1E3LzAMs/eppj7SfjabC7TgqNWoS4RLhWl4BqmsNVmjj6D5jgfPVtHtgYkU3AfpQ==}
     peerDependencies:
@@ -2005,6 +2036,11 @@ packages:
       '@nestjs/common': ^10.0.0 || ^11.0.0
       '@nestjs/core': ^10.0.0 || ^11.0.0
 
+  '@nestjs/jwt@11.0.2':
+    resolution: {integrity: sha512-rK8aE/3/Ma45gAWfCksAXUNbOoSOUudU0Kn3rT39htPF7wsYXtKfjALKeKKJbFrIWbLjsbqfXX5bIJNvgBugGA==}
+    peerDependencies:
+      '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+
   '@nestjs/mapped-types@2.0.5':
     resolution: {integrity: sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==}
     peerDependencies:
@@ -2017,6 +2053,12 @@ packages:
         optional: true
       class-validator:
         optional: true
+
+  '@nestjs/passport@11.0.5':
+    resolution: {integrity: sha512-ulQX6mbjlws92PIM15Naes4F4p2JoxGnIJuUsdXQPT+Oo2sqQmENEZXM7eYuimocfHnKlcfZOuyzbA33LwUlOQ==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      passport: ^0.5.0 || ^0.6.0 || ^0.7.0
 
   '@nestjs/platform-express@10.4.20':
     resolution: {integrity: sha512-rh97mX3rimyf4xLMLHuTOBKe6UD8LOJ14VlJ1F/PTd6C6ZK9Ak6EHuJvdaGcSFQhd3ZMBh3I6CuujKGW9pNdIg==}
@@ -2685,6 +2727,28 @@ packages:
       react:
         optional: true
       react-redux:
+        optional: true
+
+  '@rekog/mcp-nest@1.9.8':
+    resolution: {integrity: sha512-D+9RQDSiY7YF0PjWAa4uPnuqF6/sGwU5D7oUomuL9QyF6W30yCjJLZMCaHAFaMUDJJmjH3QKW/OqVwZdcBx9HQ==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.10.0'
+      '@nestjs/common': '>=9.0.0'
+      '@nestjs/core': '>=9.0.0'
+      '@nestjs/jwt': ^11.0.0
+      '@nestjs/passport': ^11.0.5
+      '@nestjs/platform-fastify': ^11.1.5
+      '@nestjs/typeorm': '>=9.0.0'
+      express: '>=4.0.0'
+      reflect-metadata: ^0.2.2
+      typeorm: '>=0.3.25'
+      zod: ^4.3.5
+    peerDependenciesMeta:
+      '@nestjs/platform-fastify':
+        optional: true
+      '@nestjs/typeorm':
+        optional: true
+      typeorm:
         optional: true
 
   '@remix-run/router@1.23.1':
@@ -3749,6 +3813,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acme-client@5.4.0:
     resolution: {integrity: sha512-mORqg60S8iML6XSmVjqjGHJkINrCGLMj2QvDmFzI9vIlv1RGlyjmw3nrzaINJjkNsYXC41XhhD5pfy7CtuGcbA==}
     engines: {node: '>= 16'}
@@ -3783,6 +3851,14 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -3969,6 +4045,10 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  base64url@3.0.1:
+    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
+    engines: {node: '>=6.0.0'}
+
   baseline-browser-mapping@2.8.28:
     resolution: {integrity: sha512-gYjt7OIqdM0PcttNYP2aVrr2G0bMALkBaoehD4BuRGjAOtipg0b6wHg1yNL+s5zSnLZZrGHOw4IrND8CD+3oIQ==}
     hasBin: true
@@ -4000,6 +4080,10 @@ packages:
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
 
   bowser@2.12.1:
     resolution: {integrity: sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==}
@@ -4272,6 +4356,10 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -4285,6 +4373,10 @@ packages:
 
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.4.0:
     resolution: {integrity: sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==}
@@ -4518,6 +4610,10 @@ packages:
 
   dotenv-expand@10.0.0:
     resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
+    engines: {node: '>=12'}
+
+  dotenv-expand@12.0.3:
+    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
     engines: {node: '>=12'}
 
   dotenv@16.4.5:
@@ -4842,6 +4938,10 @@ packages:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -4858,9 +4958,19 @@ packages:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  express-rate-limit@8.3.1:
+    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -4945,6 +5055,10 @@ packages:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -5005,6 +5119,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -5186,6 +5304,10 @@ packages:
     resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
     engines: {node: '>=18.0.0'}
 
+  hono@4.12.8:
+    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
+    engines: {node: '>=16.9.0'}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -5204,6 +5326,10 @@ packages:
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
   http-proxy-agent@5.0.0:
@@ -5232,6 +5358,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -5289,6 +5419,10 @@ packages:
   ioredis@5.8.2:
     resolution: {integrity: sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q==}
     engines: {node: '>=12.22.0'}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -5385,6 +5519,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -5591,6 +5728,9 @@ packages:
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -5641,6 +5781,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -5747,6 +5890,9 @@ packages:
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -5860,6 +6006,10 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
@@ -5872,6 +6022,10 @@ packages:
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -5955,9 +6109,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -6089,6 +6251,10 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -6148,6 +6314,12 @@ packages:
   npmlog@5.0.1:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
     deprecated: This package is no longer supported.
+
+  oauth@0.10.2:
+    resolution: {integrity: sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==}
+
+  oauth@0.9.15:
+    resolution: {integrity: sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -6242,6 +6414,37 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  passport-azure-ad-oauth2@0.0.4:
+    resolution: {integrity: sha512-yjwi0qXzGPIrR8yI5mBql2wO6tf/G5+HAFllkwwZ6f2EBCVvRv5z+6CwQeBvlrDbFh8RCXdj/IfB17r8LYDQQQ==}
+
+  passport-github@1.1.0:
+    resolution: {integrity: sha512-XARXJycE6fFh/dxF+Uut8OjlwbFEXgbPVj/+V+K7cvriRK7VcAOm+NgBmbiLM9Qv3SSxEAV+V6fIk89nYHXa8A==}
+    engines: {node: '>= 0.4.0'}
+
+  passport-google-oauth20@2.0.0:
+    resolution: {integrity: sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==}
+    engines: {node: '>= 0.4.0'}
+
+  passport-oauth1@1.3.0:
+    resolution: {integrity: sha512-8T/nX4gwKTw0PjxP1xfD0QhrydQNakzeOpZ6M5Uqdgz9/a/Ag62RmJxnZQ4LkbdXGrRehQHIAHNAu11rCP46Sw==}
+    engines: {node: '>= 0.4.0'}
+
+  passport-oauth2@1.8.0:
+    resolution: {integrity: sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==}
+    engines: {node: '>= 0.4.0'}
+
+  passport-oauth@1.0.0:
+    resolution: {integrity: sha512-4IZNVsZbN1dkBzmEbBqUxDG8oFOIK81jqdksE3HEb/vI3ib3FMjbiZZ6MTtooyYZzmKu0BfovjvT1pdGgIq+4Q==}
+    engines: {node: '>= 0.4.0'}
+
+  passport-strategy@1.0.0:
+    resolution: {integrity: sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==}
+    engines: {node: '>= 0.4.0'}
+
+  passport@0.7.0:
+    resolution: {integrity: sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==}
+    engines: {node: '>= 0.4.0'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -6270,6 +6473,9 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -6280,6 +6486,9 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  pause@0.0.1:
+    resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
 
   pg-cloudflare@1.2.7:
     resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
@@ -6340,6 +6549,10 @@ packages:
 
   pkce-challenge@3.1.0:
     resolution: {integrity: sha512-bQ/0XPZZ7eX+cdAkd61uYWpfMhakH3NeteUF1R8GNa+LMqX8QFAkbCLqq+AYAns1/ueACBu/BMWhrlKGrdvGZg==}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -6507,6 +6720,10 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
   query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
@@ -6527,6 +6744,10 @@ packages:
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
@@ -6784,6 +7005,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -6852,12 +7077,20 @@ packages:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -7415,6 +7648,10 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
@@ -7432,6 +7669,9 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+
+  uid2@0.0.4:
+    resolution: {integrity: sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==}
 
   uid@2.0.2:
     resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
@@ -7838,8 +8078,13 @@ packages:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -7850,37 +8095,37 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/anthropic@3.0.58(zod@3.25.76)':
+  '@ai-sdk/anthropic@3.0.58(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      zod: 4.3.6
 
-  '@ai-sdk/gateway@3.0.66(zod@3.25.76)':
+  '@ai-sdk/gateway@3.0.66(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
       '@vercel/oidc': 3.1.0
-      zod: 3.25.76
+      zod: 4.3.6
 
-  '@ai-sdk/google@3.0.43(zod@3.25.76)':
+  '@ai-sdk/google@3.0.43(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      zod: 4.3.6
 
-  '@ai-sdk/openai@3.0.41(zod@3.25.76)':
+  '@ai-sdk/openai@3.0.41(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      zod: 4.3.6
 
-  '@ai-sdk/provider-utils@4.0.19(zod@3.25.76)':
+  '@ai-sdk/provider-utils@4.0.19(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 3.25.76
+      zod: 4.3.6
 
   '@ai-sdk/provider@3.0.8':
     dependencies:
@@ -9455,6 +9700,10 @@ snapshots:
       - encoding
       - supports-color
 
+  '@hono/node-server@1.19.11(hono@4.12.8)':
+    dependencies:
+      hono: 4.12.8
+
   '@hookform/resolvers@3.10.0(react-hook-form@7.66.0(react@18.3.1))':
     dependencies:
       react-hook-form: 7.66.0(react@18.3.1)
@@ -9845,6 +10094,28 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.8)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.12.8
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+
   '@monaco-editor/loader@1.7.0':
     dependencies:
       state-local: 1.0.7
@@ -9913,6 +10184,14 @@ snapshots:
       lodash: 4.17.21
       rxjs: 7.8.2
 
+  '@nestjs/config@4.0.3(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      dotenv: 17.2.3
+      dotenv-expand: 12.0.3
+      lodash: 4.17.23
+      rxjs: 7.8.2
+
   '@nestjs/core@10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -9935,6 +10214,12 @@ snapshots:
       '@nestjs/core': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       eventemitter2: 6.4.9
 
+  '@nestjs/jwt@11.0.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))':
+    dependencies:
+      '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@types/jsonwebtoken': 9.0.10
+      jsonwebtoken: 9.0.3
+
   '@nestjs/mapped-types@2.0.5(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)':
     dependencies:
       '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -9942,6 +10227,11 @@ snapshots:
     optionalDependencies:
       class-transformer: 0.5.1
       class-validator: 0.14.2
+
+  '@nestjs/passport@11.0.5(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0)':
+    dependencies:
+      '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      passport: 0.7.0
 
   '@nestjs/platform-express@10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)':
     dependencies:
@@ -10702,6 +10992,26 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
       react-redux: 9.2.0(@types/react@18.3.26)(react@18.3.1)(redux@5.0.1)
+
+  '@rekog/mcp-nest@1.9.8(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(@nestjs/jwt@11.0.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)))(@nestjs/passport@11.0.5(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0))(express@5.2.1)(reflect-metadata@0.2.2)(zod@4.3.6)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
+      '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/config': 4.0.3(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
+      '@nestjs/core': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/jwt': 11.0.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))
+      '@nestjs/passport': 11.0.5(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0)
+      cookie-parser: 1.4.7
+      express: 5.2.1
+      multer: 2.0.2
+      passport: 0.7.0
+      passport-azure-ad-oauth2: 0.0.4
+      passport-github: 1.1.0
+      passport-google-oauth20: 2.0.0
+      path-to-regexp: 8.3.0
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      zod: 4.3.6
 
   '@remix-run/router@1.23.1': {}
 
@@ -12081,6 +12391,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acme-client@5.4.0:
     dependencies:
       '@peculiar/x509': 1.14.2
@@ -12109,19 +12424,23 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.116(zod@3.25.76):
+  ai@6.0.116(zod@4.3.6):
     dependencies:
-      '@ai-sdk/gateway': 3.0.66(zod@3.25.76)
+      '@ai-sdk/gateway': 3.0.66(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
-      zod: 3.25.76
+      zod: 4.3.6
 
   ajv-formats@2.1.1(ajv@8.12.0):
     optionalDependencies:
       ajv: 8.12.0
 
   ajv-formats@2.1.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
+  ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
 
@@ -12332,6 +12651,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  base64url@3.0.1: {}
+
   baseline-browser-mapping@2.8.28: {}
 
   bcrypt@5.1.1:
@@ -12381,6 +12702,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.0
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   bowser@2.12.1: {}
 
   brace-expansion@1.1.12:
@@ -12402,7 +12737,7 @@ snapshots:
 
   browser-tabs-lock@1.3.0:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   browserslist@4.28.0:
     dependencies:
@@ -12646,6 +12981,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.0.1: {}
+
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
@@ -12656,6 +12993,8 @@ snapshots:
       cookie-signature: 1.0.6
 
   cookie-signature@1.0.6: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.4.0: {}
 
@@ -12846,6 +13185,10 @@ snapshots:
       '@types/trusted-types': 2.0.7
 
   dotenv-expand@10.0.0: {}
+
+  dotenv-expand@12.0.3:
+    dependencies:
+      dotenv: 16.4.5
 
   dotenv@16.4.5: {}
 
@@ -13148,6 +13491,10 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -13171,6 +13518,11 @@ snapshots:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+
+  express-rate-limit@8.3.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
 
   express@4.21.2:
     dependencies:
@@ -13204,6 +13556,39 @@ snapshots:
       statuses: 2.0.1
       type-is: 1.6.18
       utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -13297,6 +13682,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -13374,6 +13770,8 @@ snapshots:
   fraction.js@5.3.4: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -13611,6 +14009,8 @@ snapshots:
 
   helmet@8.1.0: {}
 
+  hono@4.12.8: {}
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
@@ -13629,6 +14029,14 @@ snapshots:
       inherits: 2.0.4
       setprototypeof: 1.2.0
       statuses: 2.0.1
+      toidentifier: 1.0.1
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
       toidentifier: 1.0.1
 
   http-proxy-agent@5.0.0:
@@ -13667,6 +14075,10 @@ snapshots:
       safer-buffer: 2.1.2
 
   iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -13753,6 +14165,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ip-address@10.1.0: {}
+
   ipaddr.js@1.9.1: {}
 
   ipaddr.js@2.2.0: {}
@@ -13822,6 +14236,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -14226,6 +14642,8 @@ snapshots:
 
   jose@4.15.9: {}
 
+  jose@6.2.2: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -14285,6 +14703,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -14383,6 +14803,8 @@ snapshots:
   lodash.once@4.1.1: {}
 
   lodash@4.17.21: {}
+
+  lodash@4.17.23: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -14546,6 +14968,8 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.1.0
@@ -14557,6 +14981,8 @@ snapshots:
       map-or-similar: 1.5.0
 
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -14704,9 +15130,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -14847,6 +15279,8 @@ snapshots:
 
   negotiator@0.6.3: {}
 
+  negotiator@1.0.0: {}
+
   neo-async@2.6.2: {}
 
   node-abort-controller@3.1.1: {}
@@ -14889,6 +15323,10 @@ snapshots:
       console-control-strings: 1.1.0
       gauge: 3.0.2
       set-blocking: 2.0.0
+
+  oauth@0.10.2: {}
+
+  oauth@0.9.15: {}
 
   object-assign@4.1.1: {}
 
@@ -15001,6 +15439,45 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  passport-azure-ad-oauth2@0.0.4:
+    dependencies:
+      passport-oauth: 1.0.0
+
+  passport-github@1.1.0:
+    dependencies:
+      passport-oauth2: 1.8.0
+
+  passport-google-oauth20@2.0.0:
+    dependencies:
+      passport-oauth2: 1.8.0
+
+  passport-oauth1@1.3.0:
+    dependencies:
+      oauth: 0.9.15
+      passport-strategy: 1.0.0
+      utils-merge: 1.0.1
+
+  passport-oauth2@1.8.0:
+    dependencies:
+      base64url: 3.0.1
+      oauth: 0.10.2
+      passport-strategy: 1.0.0
+      uid2: 0.0.4
+      utils-merge: 1.0.1
+
+  passport-oauth@1.0.0:
+    dependencies:
+      passport-oauth1: 1.3.0
+      passport-oauth2: 1.8.0
+
+  passport-strategy@1.0.0: {}
+
+  passport@0.7.0:
+    dependencies:
+      passport-strategy: 1.0.0
+      pause: 0.0.1
+      utils-merge: 1.0.1
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -15020,11 +15497,15 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
+  path-to-regexp@8.3.0: {}
+
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  pause@0.0.1: {}
 
   pg-cloudflare@1.2.7:
     optional: true
@@ -15076,6 +15557,8 @@ snapshots:
   pkce-challenge@3.1.0:
     dependencies:
       crypto-js: 4.2.0
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@4.2.0:
     dependencies:
@@ -15213,6 +15696,10 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
   query-string@7.1.3:
     dependencies:
       decode-uri-component: 0.2.2
@@ -15235,6 +15722,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   react-docgen-typescript@2.4.0(typescript@5.9.3):
@@ -15530,6 +16024,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.53.2
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.1.0: {}
 
   run-async@2.4.1: {}
@@ -15607,6 +16111,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
@@ -15617,6 +16137,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -16238,6 +16767,12 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typedarray@0.0.6: {}
 
   typescript@5.7.2: {}
@@ -16246,6 +16781,8 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
+
+  uid2@0.0.4: {}
 
   uid@2.0.2:
     dependencies:
@@ -16617,6 +17154,10 @@ snapshots:
 
   yoctocolors-cjs@2.1.3: {}
 
-  zod@3.25.76: {}
+  zod-to-json-schema@3.25.1(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
+  zod@4.3.6: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

- Adds a Streamable HTTP MCP endpoint at `POST /mcp` using `@rekog/mcp-nest`, enabling LLMs (Claude Code, etc.) to manage the CE platform programmatically via `X-API-Key` auth
- Exposes ~39 MCP tools across 9 tool classes: projects, deployments/aliases, domains, pipelines/data, settings, users, API keys, proxy rule sets/rules, cache rules
- Switches 11 controllers from `SessionAuthGuard` → `ApiKeyGuard` (backwards-compatible — falls back to session auth)
- Upgrades zod v3 → v4 (zero code changes needed, required by `@rekog/mcp-nest` v1.9)

## Test plan

- [x] `tsc --noEmit` — clean compile
- [x] 903 backend tests pass, 0 failures
- [x] Verified `/mcp` endpoint returns 401 without auth
- [x] Tested MCP tool discovery and execution via Claude Code MCP client
- [ ] Verify session-based UI still works with ApiKeyGuard swap
- [ ] Test API key auth on previously session-only endpoints (domains, settings, users, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)