### PR TITLE
feat: per-step Stripe environment override

### DIFF
--- a/apps/backend/src/integrations/integrations.service.ts
+++ b/apps/backend/src/integrations/integrations.service.ts
@@ -186,17 +186,19 @@ export class IntegrationsService {
   async getActiveConfig(
     projectId: string,
     integrationId: string,
+    environmentOverride?: 'sandbox' | 'production',
   ): Promise<Record<string, unknown> | null> {
     const stored = await this.getStoredIntegration(projectId, integrationId);
     if (!stored?.enabled) return null;
 
-    const envConfig = stored[stored.activeEnvironment];
+    const env = environmentOverride || stored.activeEnvironment;
+    const envConfig = stored[env];
     if (!envConfig?.config) return null;
 
     try {
       return JSON.parse(this.decryptData(envConfig.config));
     } catch {
-      this.logger.warn(`Failed to decrypt ${stored.activeEnvironment} config for '${integrationId}'`);
+      this.logger.warn(`Failed to decrypt ${env} config for '${integrationId}'`);
       return null;
     }
   }

--- a/apps/backend/src/pipelines/handlers/stripe-checkout.handler.ts
+++ b/apps/backend/src/pipelines/handlers/stripe-checkout.handler.ts
@@ -27,6 +27,8 @@ export interface StripeCheckoutHandlerConfig extends BaseHandlerConfig {
   metadata?: Record<string, string>;
   /** Quantity (expression, default "1") */
   quantity?: string;
+  /** Override the project's active Stripe environment for this step */
+  environment?: 'sandbox' | 'production';
 }
 
 /**
@@ -75,6 +77,7 @@ export class StripeCheckoutHandler implements StepHandler<StripeCheckoutHandlerC
     const stripeConfig = await this.integrationsService.getActiveConfig(
       context.projectId,
       'stripe',
+      config.environment,
     );
 
     if (!stripeConfig?.secretKey) {

--- a/apps/backend/src/pipelines/handlers/stripe-webhook.handler.ts
+++ b/apps/backend/src/pipelines/handlers/stripe-webhook.handler.ts
@@ -16,6 +16,8 @@ export interface StripeWebhookHandlerConfig extends BaseHandlerConfig {
    * If omitted, all event types are accepted.
    */
   allowedEventTypes?: string[];
+  /** Override the project's active Stripe environment for this step */
+  environment?: 'sandbox' | 'production';
 }
 
 /**
@@ -90,6 +92,7 @@ export class StripeWebhookHandler implements StepHandler<StripeWebhookHandlerCon
     const stripeConfig = await this.integrationsService.getActiveConfig(
       context.projectId,
       'stripe',
+      config.environment,
     );
 
     if (!stripeConfig?.secretKey || !stripeConfig?.webhookSecret) {

--- a/apps/frontend/src/components/pipelines/handlers/StripeCheckoutConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/StripeCheckoutConfig.tsx
@@ -25,6 +25,7 @@ export function StripeCheckoutConfig({ config, onChange, previousSteps = [] }: S
   const [customerEmail, setCustomerEmail] = useState(config.customerEmail || '');
   const [clientReferenceId, setClientReferenceId] = useState(config.clientReferenceId || '');
   const [quantity, setQuantity] = useState(config.quantity || '1');
+  const [environment, setEnvironment] = useState<'sandbox' | 'production' | ''>(config.environment || '');
 
   useEffect(() => {
     onChange({
@@ -35,11 +36,29 @@ export function StripeCheckoutConfig({ config, onChange, previousSteps = [] }: S
       ...(customerEmail ? { customerEmail } : {}),
       ...(clientReferenceId ? { clientReferenceId } : {}),
       ...(quantity !== '1' ? { quantity } : {}),
+      ...(environment ? { environment } : {}),
     });
-  }, [priceId, mode, successUrl, cancelUrl, customerEmail, clientReferenceId, quantity]);
+  }, [priceId, mode, successUrl, cancelUrl, customerEmail, clientReferenceId, quantity, environment]);
 
   return (
     <div className="space-y-4">
+      <div className="space-y-2">
+        <Label>Stripe Environment</Label>
+        <Select value={environment || 'default'} onValueChange={(v) => setEnvironment(v === 'default' ? '' : v as 'sandbox' | 'production')}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="default">Use project default</SelectItem>
+            <SelectItem value="sandbox">Sandbox</SelectItem>
+            <SelectItem value="production">Production</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          Override the project's active Stripe environment for this step
+        </p>
+      </div>
+
       <div className="space-y-2">
         <Label>Price ID *</Label>
         <ExpressionInput

--- a/apps/frontend/src/components/pipelines/handlers/StripeWebhookConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/StripeWebhookConfig.tsx
@@ -4,6 +4,13 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Plus, Trash2 } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Info } from 'lucide-react';
 import type { StripeWebhookHandlerConfig } from './types';
 
@@ -14,12 +21,14 @@ interface StripeWebhookConfigProps {
 
 export function StripeWebhookConfig({ config, onChange }: StripeWebhookConfigProps) {
   const [eventTypes, setEventTypes] = useState<string[]>(config.allowedEventTypes || []);
+  const [environment, setEnvironment] = useState<'sandbox' | 'production' | ''>(config.environment || '');
 
   useEffect(() => {
     onChange({
       ...(eventTypes.length > 0 ? { allowedEventTypes: eventTypes } : {}),
+      ...(environment ? { environment } : {}),
     });
-  }, [eventTypes]);
+  }, [eventTypes, environment]);
 
   const addEventType = () => {
     setEventTypes([...eventTypes, 'checkout.session.completed']);
@@ -37,6 +46,23 @@ export function StripeWebhookConfig({ config, onChange }: StripeWebhookConfigPro
 
   return (
     <div className="space-y-4">
+      <div className="space-y-2">
+        <Label>Stripe Environment</Label>
+        <Select value={environment || 'default'} onValueChange={(v) => setEnvironment(v === 'default' ? '' : v as 'sandbox' | 'production')}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="default">Use project default</SelectItem>
+            <SelectItem value="sandbox">Sandbox</SelectItem>
+            <SelectItem value="production">Production</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          Override the project's active Stripe environment for this step
+        </p>
+      </div>
+
       <Alert>
         <Info className="h-4 w-4" />
         <AlertDescription>

--- a/apps/frontend/src/components/pipelines/handlers/types.ts
+++ b/apps/frontend/src/components/pipelines/handlers/types.ts
@@ -327,8 +327,10 @@ export interface StripeCheckoutHandlerConfig extends BaseHandlerConfig {
   clientReferenceId?: string;
   quantity?: string;
   metadata?: Record<string, string>;
+  environment?: 'sandbox' | 'production';
 }
 
 export interface StripeWebhookHandlerConfig extends BaseHandlerConfig {
   allowedEventTypes?: string[];
+  environment?: 'sandbox' | 'production';
 }


### PR DESCRIPTION
## Summary

- Adds optional `environment` field to `stripe_checkout` and `stripe_webhook` pipeline step configs
- When set to `sandbox` or `production`, overrides the project's active Stripe environment for that specific step
- Allows running sandbox and production Stripe pipelines side by side in the same project
- Defaults to "Use project default" when not set

## Test plan

- [ ] Verify existing pipelines without environment set still use project default
- [ ] Set environment to `sandbox` on a step, verify it uses sandbox keys
- [ ] Set environment to `production` on a different step, verify it uses production keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)