### PR TITLE
feat: RAG Search AI plugin

### DIFF
--- a/apps/backend/src/pipelines/ai-plugins/plugins/index.ts
+++ b/apps/backend/src/pipelines/ai-plugins/plugins/index.ts
@@ -1,3 +1,4 @@
 export * from './calculator.plugin';
 export * from './web-search.plugin';
 export * from './google-calendar.plugin';
+export * from './rag-search.plugin';

--- a/apps/backend/src/pipelines/ai-plugins/plugins/rag-search.plugin.ts
+++ b/apps/backend/src/pipelines/ai-plugins/plugins/rag-search.plugin.ts
@@ -47,6 +47,18 @@ export class RagSearchPlugin implements AIToolPlugin {
         .describe(
           'Replicate embedding model (e.g., beautyyuyanli/multilingual-e5-large)',
         ),
+      embeddingInputField: z
+        .string()
+        .optional()
+        .describe(
+          'Input field name for the embedding model (default: "text"). Some models use "texts", "input", "prompt", etc.',
+        ),
+      embeddingInputTemplate: z
+        .string()
+        .optional()
+        .describe(
+          'Value template with {{query}} placeholder (default: "{{query}}"). For models expecting a JSON array string, use: ["{{query}}"]',
+        ),
       schemaId: z.string().min(1).describe('Pipeline schema to search'),
       fieldName: z
         .string()
@@ -163,10 +175,14 @@ export class RagSearchPlugin implements AIToolPlugin {
 
     try {
       // Step 1: Generate embedding for the query text via Replicate
+      const inputField = (pipelineOptions?.embeddingInputField as string) || 'text';
+      const inputTemplate = (pipelineOptions?.embeddingInputTemplate as string) || '{{query}}';
       const queryVector = await this.generateEmbedding(
         query,
         embeddingModel,
         projectId,
+        inputField,
+        inputTemplate,
       );
 
       if (!queryVector) {
@@ -246,10 +262,14 @@ export class RagSearchPlugin implements AIToolPlugin {
       );
 
       // Step 2: Generate embedding
+      const inputField = (pipelineOptions?.embeddingInputField as string) || 'text';
+      const inputTemplate = (pipelineOptions?.embeddingInputTemplate as string) || '{{query}}';
       const embedding = await this.generateEmbedding(
         textToEmbed,
         embeddingModel,
         projectId,
+        inputField,
+        inputTemplate,
       );
 
       if (!embedding) {
@@ -289,6 +309,8 @@ export class RagSearchPlugin implements AIToolPlugin {
     text: string,
     model: string,
     projectId: string,
+    inputField: string = 'text',
+    inputTemplate: string = '{{query}}',
   ): Promise<number[] | null> {
     // Get Replicate API token from project settings
     const serviceConfig =
@@ -311,6 +333,10 @@ export class RagSearchPlugin implements AIToolPlugin {
         serviceConfig.apiToken,
       );
 
+      // Build input — replace {{query}} placeholder in the template
+      const inputValue = inputTemplate.replace(/\{\{query\}\}/g, text);
+      const input = { [inputField]: inputValue };
+
       // Create prediction
       const response = await fetch(`${REPLICATE_API_BASE}/predictions`, {
         method: 'POST',
@@ -321,7 +347,7 @@ export class RagSearchPlugin implements AIToolPlugin {
         },
         body: JSON.stringify({
           version,
-          input: { text },
+          input,
         }),
       });
 

--- a/apps/backend/src/pipelines/ai-plugins/plugins/rag-search.plugin.ts
+++ b/apps/backend/src/pipelines/ai-plugins/plugins/rag-search.plugin.ts
@@ -1,0 +1,441 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { z } from 'zod';
+import {
+  AIToolPlugin,
+  AIToolPluginMetadata,
+  AIToolDefinition,
+  AIToolContext,
+} from '../ai-tool-plugin.interface';
+import { AIToolPluginRegistry } from '../ai-tool-plugin.registry';
+import { PipelineEmbeddingsService } from '../../pipeline-embeddings.service';
+import { PipelineSchemasService } from '../../pipeline-schemas.service';
+import { PipelineDataService } from '../../pipeline-data.service';
+import { ProjectAISettingsService } from '../../../projects/project-ai-settings.service';
+
+const REPLICATE_API_BASE = 'https://api.replicate.com/v1';
+const MAX_POLL_ATTEMPTS = 60;
+const POLL_INTERVAL_MS = 1000;
+
+/**
+ * RAG Search plugin — gives the AI the ability to search pipeline data
+ * using semantic similarity (vector embeddings).
+ *
+ * Project-level: just enable the plugin (uses existing Replicate API token from AI Services)
+ * Pipeline-level: choose embedding model, schema, field, limits, etc.
+ *
+ * The AI gets two tools:
+ * - `search`: generate embedding from text query, then vector search
+ * - `save_note`: store a new note/record and embed it for future retrieval (opt-in)
+ */
+@Injectable()
+export class RagSearchPlugin implements AIToolPlugin {
+  private readonly logger = new Logger(RagSearchPlugin.name);
+
+  readonly metadata: AIToolPluginMetadata = {
+    id: 'rag-search',
+    name: 'RAG Search',
+    description:
+      'Search and store data using semantic similarity. Enables AI to look up context from your pipeline data using natural language queries and save new information for future retrieval. Requires Replicate in AI Services.',
+    category: 'information',
+    icon: 'database',
+    // No configSchema — uses Replicate API token from AI Services.
+    // Embedding model is configured per-pipeline so different chat handlers can use different models.
+    pipelineOptionsSchema: z.object({
+      embeddingModel: z
+        .string()
+        .min(1)
+        .describe(
+          'Replicate embedding model (e.g., beautyyuyanli/multilingual-e5-large)',
+        ),
+      schemaId: z.string().min(1).describe('Pipeline schema to search'),
+      fieldName: z
+        .string()
+        .min(1)
+        .describe('Embedding field name (must match embed_store fieldName)'),
+      limit: z
+        .number()
+        .min(1)
+        .max(50)
+        .optional()
+        .describe('Max results to return (default 5)'),
+      threshold: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe('Minimum similarity threshold (0-1)'),
+      enableSaveNote: z
+        .boolean()
+        .optional()
+        .describe('Enable the save_note tool for write-back'),
+    }),
+  };
+
+  constructor(
+    private readonly registry: AIToolPluginRegistry,
+    private readonly embeddingsService: PipelineEmbeddingsService,
+    private readonly schemasService: PipelineSchemasService,
+    private readonly dataService: PipelineDataService,
+    private readonly projectAISettingsService: ProjectAISettingsService,
+  ) {
+    this.registry.register(this);
+  }
+
+  getTools(_config: Record<string, unknown>): AIToolDefinition[] {
+    return [
+      {
+        name: 'search',
+        description:
+          'Search for relevant information using a natural language query. Returns matching records ranked by semantic similarity.',
+        inputSchema: z.object({
+          query: z
+            .string()
+            .describe(
+              'Natural language search query (e.g., a name, topic, or question)',
+            ),
+        }),
+        execute: async (
+          args: { query: string },
+          context: AIToolContext,
+        ) => {
+          return this.search(args.query, context);
+        },
+      },
+      {
+        name: 'save_note',
+        description:
+          'Save a new piece of information for future retrieval. Stores the data and generates an embedding so it can be found by semantic search later.',
+        inputSchema: z.object({
+          data: z
+            .record(z.string(), z.unknown())
+            .describe(
+              'The data fields to store (e.g., { "name": "Hannah", "notes": "Moving back in June" })',
+            ),
+          textToEmbed: z
+            .string()
+            .describe(
+              'The text to generate an embedding from. Should capture the key searchable content.',
+            ),
+        }),
+        execute: async (
+          args: { data: Record<string, unknown>; textToEmbed: string },
+          context: AIToolContext,
+        ) => {
+          // Check if save_note is enabled in pipeline options
+          if (!context.pipelineOptions?.enableSaveNote) {
+            return {
+              error:
+                'The save_note tool is not enabled for this pipeline. Enable it in pipeline options.',
+            };
+          }
+          return this.saveNote(args.data, args.textToEmbed, context);
+        },
+      },
+    ];
+  }
+
+  private async search(
+    query: string,
+    context: AIToolContext,
+  ): Promise<
+    | { results: Array<Record<string, unknown>> }
+    | { error: string }
+  > {
+    const { projectId, pipelineOptions } = context;
+    const schemaId = pipelineOptions?.schemaId as string;
+    const fieldName = pipelineOptions?.fieldName as string;
+    const limit = (pipelineOptions?.limit as number) || 5;
+    const threshold = pipelineOptions?.threshold as number | undefined;
+    const embeddingModel = pipelineOptions?.embeddingModel as string;
+
+    if (!schemaId || !fieldName || !embeddingModel) {
+      return {
+        error:
+          'RAG Search plugin requires embeddingModel, schemaId, and fieldName in pipeline options',
+      };
+    }
+
+    // Verify schema belongs to project
+    const schema = await this.schemasService.getById(schemaId);
+    if (!schema || schema.projectId !== projectId) {
+      return { error: 'Schema not found or does not belong to this project' };
+    }
+
+    try {
+      // Step 1: Generate embedding for the query text via Replicate
+      const queryVector = await this.generateEmbedding(
+        query,
+        embeddingModel,
+        projectId,
+      );
+
+      if (!queryVector) {
+        return {
+          error: 'Failed to generate embedding for query. Check Replicate API configuration.',
+        };
+      }
+
+      // Step 2: Vector search
+      const results = await this.embeddingsService.vectorSearch({
+        schemaId,
+        fieldName,
+        queryVector,
+        limit,
+        threshold,
+        projectId,
+      });
+
+      // Step 3: Format results — flatten data fields
+      const formatted = results.map((r) => {
+        const dataFields = (r.data ?? {}) as Record<string, unknown>;
+        return {
+          id: r.pipelineDataId,
+          similarity: Math.round(r.similarity * 1000) / 1000,
+          ...(r.chunkText != null ? { chunkText: r.chunkText } : {}),
+          ...(r.chunkIndex != null ? { chunkIndex: r.chunkIndex } : {}),
+          ...dataFields,
+        };
+      });
+
+      this.logger.debug(
+        `RAG search for "${query}" returned ${formatted.length} results`,
+      );
+
+      return { results: formatted };
+    } catch (error) {
+      this.logger.error(`RAG search failed: ${(error as Error).message}`);
+      return { error: `Search failed: ${(error as Error).message}` };
+    }
+  }
+
+  /**
+   * Save a new note/record to the schema and generate + store its embedding.
+   */
+  private async saveNote(
+    data: Record<string, unknown>,
+    textToEmbed: string,
+    context: AIToolContext,
+  ): Promise<{ success: boolean; id?: string; error?: string }> {
+    const { projectId, pipelineOptions } = context;
+    const schemaId = pipelineOptions?.schemaId as string;
+    const fieldName = pipelineOptions?.fieldName as string;
+    const embeddingModel = pipelineOptions?.embeddingModel as string;
+
+    if (!schemaId || !fieldName || !embeddingModel) {
+      return {
+        success: false,
+        error: 'RAG Search plugin requires embeddingModel, schemaId, and fieldName in pipeline options',
+      };
+    }
+
+    // Verify schema belongs to project
+    const schema = await this.schemasService.getById(schemaId);
+    if (!schema || schema.projectId !== projectId) {
+      return {
+        success: false,
+        error: 'Schema not found or does not belong to this project',
+      };
+    }
+
+    try {
+      // Step 1: Create the data record
+      const record = await this.dataService.create(
+        schemaId,
+        projectId,
+        data,
+      );
+
+      // Step 2: Generate embedding
+      const embedding = await this.generateEmbedding(
+        textToEmbed,
+        embeddingModel,
+        projectId,
+      );
+
+      if (!embedding) {
+        return {
+          success: true,
+          id: record.id,
+          error: 'Record saved but embedding generation failed. The record will not appear in search results until re-embedded.',
+        };
+      }
+
+      // Step 3: Store embedding
+      await this.embeddingsService.storeEmbedding({
+        pipelineDataId: record.id,
+        schemaId,
+        fieldName,
+        embedding,
+      });
+
+      this.logger.debug(
+        `Saved note and embedding for record ${record.id} in schema ${schemaId}`,
+      );
+
+      return { success: true, id: record.id };
+    } catch (error) {
+      this.logger.error(`Save note failed: ${(error as Error).message}`);
+      return {
+        success: false,
+        error: `Failed to save note: ${(error as Error).message}`,
+      };
+    }
+  }
+
+  /**
+   * Generate an embedding vector using a Replicate model.
+   */
+  private async generateEmbedding(
+    text: string,
+    model: string,
+    projectId: string,
+  ): Promise<number[] | null> {
+    // Get Replicate API token from project settings
+    const serviceConfig =
+      await this.projectAISettingsService.getServiceConfig(
+        projectId,
+        'replicate',
+      );
+
+    if (!serviceConfig) {
+      this.logger.warn(
+        'Replicate API token not configured for RAG Search embedding generation',
+      );
+      return null;
+    }
+
+    try {
+      // Resolve model version
+      const version = await this.resolveLatestVersion(
+        model,
+        serviceConfig.apiToken,
+      );
+
+      // Create prediction
+      const response = await fetch(`${REPLICATE_API_BASE}/predictions`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${serviceConfig.apiToken}`,
+          'Content-Type': 'application/json',
+          Prefer: 'wait',
+        },
+        body: JSON.stringify({
+          version,
+          input: { text },
+        }),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        this.logger.error(
+          `Replicate embedding API error: ${(errorBody as Record<string, string>).detail || response.statusText}`,
+        );
+        return null;
+      }
+
+      let prediction = (await response.json()) as Record<string, unknown>;
+
+      // Poll if not completed
+      if (
+        prediction.status !== 'succeeded' &&
+        prediction.status !== 'failed' &&
+        prediction.status !== 'canceled'
+      ) {
+        prediction = await this.pollPrediction(
+          prediction.id as string,
+          serviceConfig.apiToken,
+        );
+      }
+
+      if (prediction.status !== 'succeeded') {
+        this.logger.error(
+          `Embedding prediction failed: ${prediction.error || prediction.status}`,
+        );
+        return null;
+      }
+
+      // Extract embedding — unwrap nested arrays
+      let embedding = prediction.output as unknown;
+      if (Array.isArray(embedding) && Array.isArray(embedding[0])) {
+        embedding = embedding[0];
+      }
+
+      if (!Array.isArray(embedding) || typeof embedding[0] !== 'number') {
+        this.logger.error(
+          `Unexpected embedding output format: ${typeof embedding}`,
+        );
+        return null;
+      }
+
+      return embedding as number[];
+    } catch (error) {
+      this.logger.error(
+        `Embedding generation failed: ${(error as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  private async resolveLatestVersion(
+    model: string,
+    apiToken: string,
+  ): Promise<string> {
+    try {
+      const response = await fetch(
+        `${REPLICATE_API_BASE}/models/${model}/versions`,
+        {
+          headers: { Authorization: `Bearer ${apiToken}` },
+        },
+      );
+
+      if (!response.ok) {
+        return model;
+      }
+
+      const data = (await response.json()) as {
+        results?: { id: string }[];
+      };
+      const latestVersion = data.results?.[0]?.id;
+
+      return latestVersion || model;
+    } catch {
+      return model;
+    }
+  }
+
+  private async pollPrediction(
+    predictionId: string,
+    apiToken: string,
+  ): Promise<Record<string, unknown>> {
+    for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+
+      const response = await fetch(
+        `${REPLICATE_API_BASE}/predictions/${predictionId}`,
+        {
+          headers: { Authorization: `Bearer ${apiToken}` },
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to poll prediction: ${response.statusText}`,
+        );
+      }
+
+      const prediction = (await response.json()) as Record<string, unknown>;
+
+      if (
+        prediction.status === 'succeeded' ||
+        prediction.status === 'failed' ||
+        prediction.status === 'canceled'
+      ) {
+        return prediction;
+      }
+    }
+
+    throw new Error(
+      `Prediction ${predictionId} timed out after ${MAX_POLL_ATTEMPTS} attempts`,
+    );
+  }
+}

--- a/apps/backend/src/pipelines/pipelines.module.ts
+++ b/apps/backend/src/pipelines/pipelines.module.ts
@@ -57,6 +57,7 @@ import {
   CalculatorPlugin,
   WebSearchPlugin,
   GoogleCalendarPlugin,
+  RagSearchPlugin,
 } from './ai-plugins';
 
 @Module({
@@ -118,6 +119,7 @@ import {
     CalculatorPlugin,
     WebSearchPlugin,
     GoogleCalendarPlugin,
+    RagSearchPlugin,
   ],
   exports: [
     PipelineExecutionService,

--- a/apps/frontend/src/components/pipelines/handlers/PluginsConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/PluginsConfig.tsx
@@ -183,6 +183,32 @@ function RagSearchOptions({
         </p>
       </div>
       <div className="space-y-1">
+        <Label className="text-xs">Input Field Name</Label>
+        <Input
+          type="text"
+          className="h-8 text-xs w-40"
+          placeholder="text"
+          value={(options.embeddingInputField as string) || ''}
+          onChange={(e) => onChange({ ...options, embeddingInputField: e.target.value || undefined })}
+        />
+        <p className="text-xs text-muted-foreground">
+          The model&apos;s input parameter name (default: &quot;text&quot;). Some models use &quot;texts&quot;, &quot;input&quot;, &quot;prompt&quot;, etc.
+        </p>
+      </div>
+      <div className="space-y-1">
+        <Label className="text-xs">Input Value Template</Label>
+        <Input
+          type="text"
+          className="h-8 text-xs"
+          placeholder="{{query}}"
+          value={(options.embeddingInputTemplate as string) || ''}
+          onChange={(e) => onChange({ ...options, embeddingInputTemplate: e.target.value || undefined })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Use {'{{query}}'} as the placeholder for the search text. Default: {'{{query}}'}. For multilingual-e5-large use: [&quot;{'{{query}}'}&quot;]
+        </p>
+      </div>
+      <div className="space-y-1">
         <Label className="text-xs">Schema</Label>
         {isLoading ? (
           <Skeleton className="h-8 w-full" />

--- a/apps/frontend/src/components/pipelines/handlers/PluginsConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/PluginsConfig.tsx
@@ -1,4 +1,5 @@
 import { useListProjectPluginsQuery, useListPluginCalendarsQuery } from '@/services/projectsApi';
+import { useGetProjectSchemasQuery } from '@/services/pipelineSchemasApi';
 import { Label } from '@/components/ui/label';
 import {
   Select,
@@ -146,6 +147,139 @@ function GoogleCalendarOptions({
   );
 }
 
+function RagSearchOptions({
+  projectId,
+  options,
+  onChange,
+}: {
+  projectId: string;
+  options: Record<string, unknown>;
+  onChange: (opts: Record<string, unknown>) => void;
+}) {
+  const { data: schemasData, isLoading } = useGetProjectSchemasQuery(projectId);
+  const schemas = schemasData?.schemas || [];
+
+  return (
+    <div className="ml-7 mt-2 space-y-3 border-l-2 border-muted pl-3">
+      <div className="space-y-1">
+        <Label className="text-xs">Embedding Model</Label>
+        <Input
+          type="text"
+          className="h-8 text-xs"
+          placeholder="beautyyuyanli/multilingual-e5-large"
+          value={(options.embeddingModel as string) || ''}
+          onChange={(e) => onChange({ ...options, embeddingModel: e.target.value || undefined })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Replicate model for generating embeddings. Browse models at{' '}
+          <a
+            href="https://replicate.com/collections/embedding-models"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            replicate.com/collections/embedding-models
+          </a>
+        </p>
+      </div>
+      <div className="space-y-1">
+        <Label className="text-xs">Schema</Label>
+        {isLoading ? (
+          <Skeleton className="h-8 w-full" />
+        ) : schemas.length > 0 ? (
+          <Select
+            value={(options.schemaId as string) || ''}
+            onValueChange={(v) => onChange({ ...options, schemaId: v })}
+          >
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue placeholder="Select a schema..." />
+            </SelectTrigger>
+            <SelectContent>
+              {schemas.map((schema) => (
+                <SelectItem key={schema.id} value={schema.id}>
+                  {schema.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            No schemas found. Create a pipeline schema first.
+          </p>
+        )}
+        <p className="text-xs text-muted-foreground">
+          The schema containing your data records with embeddings
+        </p>
+      </div>
+      <div className="space-y-1">
+        <Label className="text-xs">Embedding Field Name</Label>
+        <Input
+          type="text"
+          className="h-8 text-xs"
+          placeholder="e.g., notes_embedding"
+          value={(options.fieldName as string) || ''}
+          onChange={(e) => onChange({ ...options, fieldName: e.target.value || undefined })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Must match the fieldName used when storing embeddings via embed_store
+        </p>
+      </div>
+      <div className="space-y-1">
+        <Label className="text-xs">Max Results</Label>
+        <Input
+          type="number"
+          min={1}
+          max={50}
+          className="h-8 text-xs w-24"
+          value={(options.limit as number) || 5}
+          onChange={(e) =>
+            onChange({ ...options, limit: parseInt(e.target.value) || 5 })
+          }
+        />
+        <p className="text-xs text-muted-foreground">
+          Maximum number of results to return (1-50, default 5)
+        </p>
+      </div>
+      <div className="space-y-1">
+        <Label className="text-xs">Similarity Threshold</Label>
+        <Input
+          type="number"
+          min={0}
+          max={1}
+          step={0.05}
+          className="h-8 text-xs w-24"
+          value={(options.threshold as number) ?? ''}
+          placeholder="None"
+          onChange={(e) => {
+            const val = parseFloat(e.target.value);
+            onChange({ ...options, threshold: val >= 0 && val <= 1 ? val : undefined });
+          }}
+        />
+        <p className="text-xs text-muted-foreground">
+          Minimum cosine similarity (0-1). Leave empty to return all results up to the limit.
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="rag-enable-save-note"
+          checked={(options.enableSaveNote as boolean) || false}
+          onCheckedChange={(checked) =>
+            onChange({ ...options, enableSaveNote: checked === true ? true : undefined })
+          }
+        />
+        <div>
+          <label htmlFor="rag-enable-save-note" className="text-xs font-medium cursor-pointer">
+            Enable save_note tool
+          </label>
+          <p className="text-xs text-muted-foreground">
+            Allow the AI to save new records and auto-generate embeddings for future retrieval
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function PluginsConfig({ config, onChange, projectId }: PluginsConfigProps) {
   const { data: plugins, isLoading } = useListProjectPluginsQuery(projectId);
   // Only show plugins that are enabled at the project level
@@ -161,6 +295,31 @@ export function PluginsConfig({ config, onChange, projectId }: PluginsConfigProp
       options: { ...(config.options || {}), [pluginId]: opts },
     });
   };
+
+  const renderPluginOptions = (pluginId: string) => {
+    if (pluginId === 'google-calendar') {
+      return (
+        <GoogleCalendarOptions
+          projectId={projectId}
+          options={getPluginOptions(pluginId)}
+          onChange={(opts) => setPluginOptions(pluginId, opts)}
+        />
+      );
+    }
+    if (pluginId === 'rag-search') {
+      return (
+        <RagSearchOptions
+          projectId={projectId}
+          options={getPluginOptions(pluginId)}
+          onChange={(opts) => setPluginOptions(pluginId, opts)}
+        />
+      );
+    }
+    return null;
+  };
+
+  // Plugins that have per-pipeline options
+  const pluginsWithOptions = ['google-calendar', 'rag-search'];
 
   return (
     <div className="space-y-4">
@@ -231,15 +390,8 @@ export function PluginsConfig({ config, onChange, projectId }: PluginsConfigProp
                       </p>
                     </div>
                   </div>
-                  {/* Per-plugin options for Google Calendar */}
-                  {plugin.id === 'google-calendar' &&
-                    config.enabled?.includes(plugin.id) && (
-                      <GoogleCalendarOptions
-                        projectId={projectId}
-                        options={getPluginOptions(plugin.id)}
-                        onChange={(opts) => setPluginOptions(plugin.id, opts)}
-                      />
-                    )}
+                  {/* Per-plugin options when selected */}
+                  {config.enabled?.includes(plugin.id) && renderPluginOptions(plugin.id)}
                 </div>
               ))}
             </div>
@@ -248,16 +400,14 @@ export function PluginsConfig({ config, onChange, projectId }: PluginsConfigProp
       )}
 
       {/* Show per-plugin options for "all" mode too */}
-      {config.mode === 'all' && !isLoading && enabledPlugins.some((p) => p.id === 'google-calendar') && (
-        <div className="space-y-2">
-          <Label>Google Calendar Options</Label>
-          <GoogleCalendarOptions
-            projectId={projectId}
-            options={getPluginOptions('google-calendar')}
-            onChange={(opts) => setPluginOptions('google-calendar', opts)}
-          />
-        </div>
-      )}
+      {config.mode === 'all' && !isLoading && enabledPlugins
+        .filter((p) => pluginsWithOptions.includes(p.id))
+        .map((plugin) => (
+          <div key={plugin.id} className="space-y-2">
+            <Label>{plugin.name} Options</Label>
+            {renderPluginOptions(plugin.id)}
+          </div>
+        ))}
 
       {config.mode !== 'none' && (
         <Alert className="border-blue-500/30 bg-blue-500/5">

--- a/apps/frontend/src/components/project/ProjectAIPluginsSection.tsx
+++ b/apps/frontend/src/components/project/ProjectAIPluginsSection.tsx
@@ -29,6 +29,7 @@ import {
   Calculator,
   Search,
   Calendar,
+  Database,
   Settings2,
   ExternalLink,
   Unplug,
@@ -42,6 +43,7 @@ const PLUGIN_ICONS: Record<string, React.ElementType> = {
   calculator: Calculator,
   search: Search,
   calendar: Calendar,
+  database: Database,
 };
 
 // Category display config


### PR DESCRIPTION
## Summary
- Adds a new **RAG Search** AI plugin that gives chat handlers semantic search and write-back capabilities over pipeline data
- AI gets two tools: `search` (vector similarity lookup via Replicate embeddings + pgvector) and `save_note` (create record + auto-embed for future retrieval)
- Embedding model is configured **per-pipeline step**, so different chat handlers can use different models and data sources
- Plugin requires Replicate API token in AI Services (no project-level config needed beyond toggling it on)
- Frontend pipeline options UI for schema, embedding field, model, max results, similarity threshold, and save_note toggle

## How it works
1. Admin creates a schema (e.g., `user_notes`) and builds an indexing pipeline to populate embeddings
2. On the chat pipeline, enable RAG Search plugin and configure: embedding model, schema, field name
3. When a user chats, the AI can call `rag-search_search` to find relevant context and `rag-search_save_note` to persist new information

## Test plan
- [ ] Enable RAG Search plugin in project settings
- [ ] Configure pipeline options on a chat AI handler (model, schema, field)
- [ ] Verify search tool returns results from embedded pipeline data
- [ ] Verify save_note tool creates records with embeddings when enabled
- [ ] Verify save_note is blocked when not enabled in pipeline options
- [ ] Test with different embedding models across different chat handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)