### PR TITLE
feat(api-keys): enforce project scope on api-key calls across services

### DIFF
--- a/apps/backend/src/assets/assets.service.spec.ts
+++ b/apps/backend/src/assets/assets.service.spec.ts
@@ -99,12 +99,49 @@ describe('AssetsService', () => {
       getProjectByOwnerName: jest.fn(),
     };
 
+    const fakeRoleHierarchy: Record<string, number> = {
+      owner: 4,
+      admin: 3,
+      contributor: 2,
+      viewer: 1,
+      guest: 0,
+    };
     mockPermissionsService = {
       getUserProjectRole: jest.fn().mockResolvedValue('contributor'),
       addUserToProject: jest.fn(),
       removeUserFromProject: jest.fn(),
       updateUserProjectRole: jest.fn(),
       getProjectMembers: jest.fn(),
+      requireProjectAccess: jest.fn(
+        async (
+          projectId: string,
+          userId: string,
+          userRole: string | undefined,
+          requiredRole: string = 'contributor',
+          apiKeyProjectId?: string | null,
+        ) => {
+          if (apiKeyProjectId !== undefined && apiKeyProjectId !== null) {
+            if (apiKeyProjectId !== projectId) {
+              throw new (require('@nestjs/common').ForbiddenException)(
+                'API key is not authorized for this project',
+              );
+            }
+            return;
+          }
+          if (userRole === 'admin') return;
+          const role = await mockPermissionsService.getUserProjectRole(userId, projectId);
+          if (!role) {
+            throw new (require('@nestjs/common').ForbiddenException)(
+              'You do not have access to this project',
+            );
+          }
+          if (fakeRoleHierarchy[role] < fakeRoleHierarchy[requiredRole]) {
+            throw new (require('@nestjs/common').ForbiddenException)(
+              `This action requires ${requiredRole} role or higher`,
+            );
+          }
+        },
+      ),
     };
 
     const mockUsageReporterService = {

--- a/apps/backend/src/assets/assets.service.ts
+++ b/apps/backend/src/assets/assets.service.ts
@@ -92,35 +92,13 @@ export class AssetsService implements OnModuleInit {
     requiredRole: 'viewer' | 'contributor' | 'admin' | 'owner' = 'contributor',
     apiKeyProjectId?: string | null,
   ): Promise<void> {
-    // Admin users have access to all projects
-    if (userRole === 'admin') {
-      return;
-    }
-
-    // API key with specific projectId - must match target project
-    if (apiKeyProjectId !== undefined && apiKeyProjectId !== null) {
-      if (apiKeyProjectId !== projectId) {
-        throw new ForbiddenException('API key is not authorized for this project');
-      }
-      // API key matches project - authorized
-      return;
-    }
-
-    // Global API key (projectId = null) or session auth - check user's project permissions
-    const role = await this.permissionsService.getUserProjectRole(userId, projectId);
-
-    if (!role) {
-      throw new ForbiddenException('You do not have access to this project');
-    }
-
-    // Check if user has required role level
-    const roleHierarchy = { viewer: 1, contributor: 2, admin: 3, owner: 4 };
-    const userLevel = roleHierarchy[role] || 0;
-    const requiredLevel = roleHierarchy[requiredRole] || 0;
-
-    if (userLevel < requiredLevel) {
-      throw new ForbiddenException(`This action requires ${requiredRole} role or higher`);
-    }
+    await this.permissionsService.requireProjectAccess(
+      projectId,
+      userId,
+      userRole,
+      requiredRole,
+      apiKeyProjectId,
+    );
   }
 
   /**

--- a/apps/backend/src/cache-rules/cache-rules.controller.ts
+++ b/apps/backend/src/cache-rules/cache-rules.controller.ts
@@ -50,8 +50,12 @@ export class CacheRulesController {
   })
   async getProjectRules(
     @Param('projectId', ParseUUIDPipe) projectId: string,
+    @CurrentUser() user: CurrentUserData,
   ): Promise<{ rules: CacheRuleResponseDto[] }> {
-    const rules = await this.cacheRulesService.getRulesByProjectId(projectId);
+    const rules = await this.cacheRulesService.getRulesByProjectId(
+      projectId,
+      user.apiKeyProjectId,
+    );
     return { rules: rules as CacheRuleResponseDto[] };
   }
 
@@ -80,6 +84,7 @@ export class CacheRulesController {
       dto,
       user.id,
       user.role || 'user',
+      user.apiKeyProjectId,
     ) as Promise<CacheRuleResponseDto>;
   }
 
@@ -107,6 +112,7 @@ export class CacheRulesController {
       dto,
       user.id,
       user.role || 'user',
+      user.apiKeyProjectId,
     );
     return { rules: rules as CacheRuleResponseDto[] };
   }
@@ -148,6 +154,7 @@ export class CacheRulesController {
       dto,
       user.id,
       user.role || 'user',
+      user.apiKeyProjectId,
     ) as Promise<CacheRuleResponseDto>;
   }
 
@@ -164,7 +171,7 @@ export class CacheRulesController {
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<{ success: boolean }> {
-    await this.cacheRulesService.delete(id, user.id, user.role || 'user');
+    await this.cacheRulesService.delete(id, user.id, user.role || 'user', user.apiKeyProjectId);
     return { success: true };
   }
 }

--- a/apps/backend/src/cache-rules/cache-rules.service.ts
+++ b/apps/backend/src/cache-rules/cache-rules.service.ts
@@ -3,7 +3,6 @@ import {
   BadRequestException,
   NotFoundException,
   ConflictException,
-  ForbiddenException,
   Logger,
   Inject,
   forwardRef,
@@ -28,7 +27,11 @@ export class CacheRulesService {
   /**
    * Get all cache rules for a project, ordered by priority
    */
-  async getRulesByProjectId(projectId: string): Promise<CacheRule[]> {
+  async getRulesByProjectId(
+    projectId: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<CacheRule[]> {
+    this.permissionsService.enforceApiKeyProjectScope(apiKeyProjectId, projectId);
     return db
       .select()
       .from(cacheRules)
@@ -64,6 +67,7 @@ export class CacheRulesService {
     dto: CreateCacheRuleDto,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<CacheRule> {
     // Verify project exists
     const [project] = await db.select().from(projects).where(eq(projects.id, projectId)).limit(1);
@@ -71,8 +75,13 @@ export class CacheRulesService {
       throw new NotFoundException(`Project ${projectId} not found`);
     }
 
-    // Check project access (need contributor or higher)
-    await this.checkProjectAccess(projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Check for duplicate path pattern within the project
     const existingRule = await this.findRuleByPattern(projectId, dto.pathPattern.trim());
@@ -118,14 +127,20 @@ export class CacheRulesService {
     dto: UpdateCacheRuleDto,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<CacheRule> {
     const existing = await this.getRuleById(id);
     if (!existing) {
       throw new NotFoundException(`Cache rule ${id} not found`);
     }
 
-    // Check project access
-    await this.checkProjectAccess(existing.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      existing.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Check for duplicate path pattern if changing
     if (dto.pathPattern && dto.pathPattern !== existing.pathPattern) {
@@ -169,14 +184,24 @@ export class CacheRulesService {
   /**
    * Delete a cache rule
    */
-  async delete(id: string, userId: string, userRole: string): Promise<void> {
+  async delete(
+    id: string,
+    userId: string,
+    userRole: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<void> {
     const existing = await this.getRuleById(id);
     if (!existing) {
       throw new NotFoundException(`Cache rule ${id} not found`);
     }
 
-    // Check project access
-    await this.checkProjectAccess(existing.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      existing.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     const projectId = existing.projectId;
 
@@ -196,6 +221,7 @@ export class CacheRulesService {
     dto: ReorderCacheRulesDto,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<CacheRule[]> {
     // Verify project exists
     const [project] = await db.select().from(projects).where(eq(projects.id, projectId)).limit(1);
@@ -203,8 +229,13 @@ export class CacheRulesService {
       throw new NotFoundException(`Project ${projectId} not found`);
     }
 
-    // Check project access
-    await this.checkProjectAccess(projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Verify all rules belong to the project
     const existingRules = await db
@@ -235,34 +266,6 @@ export class CacheRulesService {
   }
 
   // ==================== Helper Methods ====================
-
-  private async checkProjectAccess(
-    projectId: string,
-    userId: string,
-    userRole: string,
-    requiredRole: 'viewer' | 'contributor' | 'admin' | 'owner' = 'contributor',
-  ): Promise<void> {
-    // Admin users have access to all projects
-    if (userRole === 'admin') {
-      return;
-    }
-
-    // Check project permissions
-    const role = await this.permissionsService.getUserProjectRole(userId, projectId);
-
-    if (!role) {
-      throw new ForbiddenException('You do not have access to this project');
-    }
-
-    // Check if user has required role level
-    const roleHierarchy = { viewer: 1, contributor: 2, admin: 3, owner: 4 };
-    const userLevel = roleHierarchy[role] || 0;
-    const requiredLevel = roleHierarchy[requiredRole] || 0;
-
-    if (userLevel < requiredLevel) {
-      throw new ForbiddenException(`This action requires ${requiredRole} role or higher`);
-    }
-  }
 
   private async findRuleByPattern(projectId: string, pattern: string): Promise<CacheRule | null> {
     const [rule] = await db

--- a/apps/backend/src/domains/domains.controller.ts
+++ b/apps/backend/src/domains/domains.controller.ts
@@ -543,11 +543,17 @@ export class DomainsController {
   async create(
     @Body() createDomainDto: CreateDomainDto,
     @CurrentUser('id') userId: string,
+    @CurrentUser('apiKeyProjectId') apiKeyProjectId: string | null | undefined,
     @Req() request: Request,
   ): Promise<DomainResponseDto> {
     // Extract JWT from SuperTokens cookie for Control Plane auth
     const authToken = (request.cookies as Record<string, string>)?.sAccessToken;
-    const domain = await this.domainsService.create(createDomainDto, userId, authToken);
+    const domain = await this.domainsService.create(
+      createDomainDto,
+      userId,
+      authToken,
+      apiKeyProjectId,
+    );
     return this.toResponseDto(domain);
   }
 
@@ -556,15 +562,20 @@ export class DomainsController {
   @ApiResponse({ status: 200, type: [DomainResponseDto] })
   async findAll(
     @CurrentUser('id') userId: string,
+    @CurrentUser('apiKeyProjectId') apiKeyProjectId: string | null | undefined,
     @Query('projectId') projectId?: string,
     @Query('domainType') domainType?: string,
     @Query('isActive') isActive?: string,
   ): Promise<DomainResponseDto[]> {
-    const domains = await this.domainsService.findAll(userId, {
-      projectId,
-      domainType,
-      isActive: isActive ? isActive === 'true' : undefined,
-    });
+    const domains = await this.domainsService.findAll(
+      userId,
+      {
+        projectId,
+        domainType,
+        isActive: isActive ? isActive === 'true' : undefined,
+      },
+      apiKeyProjectId,
+    );
     return domains.map((d) => this.toResponseDto(d));
   }
 
@@ -574,8 +585,9 @@ export class DomainsController {
   async findOne(
     @Param('id') id: string,
     @CurrentUser('id') userId: string,
+    @CurrentUser('apiKeyProjectId') apiKeyProjectId: string | null | undefined,
   ): Promise<DomainResponseDto> {
-    const domain = await this.domainsService.findOne(id, userId);
+    const domain = await this.domainsService.findOne(id, userId, apiKeyProjectId);
     return this.toResponseDto(domain);
   }
 
@@ -586,8 +598,14 @@ export class DomainsController {
     @Param('id') id: string,
     @Body() updateDomainDto: UpdateDomainDto,
     @CurrentUser('id') userId: string,
+    @CurrentUser('apiKeyProjectId') apiKeyProjectId: string | null | undefined,
   ): Promise<DomainResponseDto> {
-    const domain = await this.domainsService.update(id, updateDomainDto, userId);
+    const domain = await this.domainsService.update(
+      id,
+      updateDomainDto,
+      userId,
+      apiKeyProjectId,
+    );
     return this.toResponseDto(domain);
   }
 
@@ -597,11 +615,12 @@ export class DomainsController {
   async remove(
     @Param('id') id: string,
     @CurrentUser('id') userId: string,
+    @CurrentUser('apiKeyProjectId') apiKeyProjectId: string | null | undefined,
     @Req() request: Request,
   ) {
     // Extract JWT from SuperTokens cookie for Control Plane auth
     const authToken = (request.cookies as Record<string, string>)?.sAccessToken;
-    return this.domainsService.remove(id, userId, authToken);
+    return this.domainsService.remove(id, userId, authToken, apiKeyProjectId);
   }
 
   /**

--- a/apps/backend/src/domains/domains.service.spec.ts
+++ b/apps/backend/src/domains/domains.service.spec.ts
@@ -10,6 +10,7 @@ import { SslInfoService } from './ssl-info.service';
 import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 import { ProxyRulesService } from '../proxy-rules/proxy-rules.service';
 import { VisibilityService } from './visibility.service';
+import { PermissionsService } from '../permissions/permissions.service';
 
 // Mock the database client
 jest.mock('../db/client', () => ({
@@ -168,6 +169,14 @@ describe('DomainsService', () => {
         { provide: FeatureFlagsService, useValue: mockFeatureFlagsService },
         { provide: ProxyRulesService, useValue: mockProxyRulesService },
         { provide: VisibilityService, useValue: mockVisibilityService },
+        {
+          provide: PermissionsService,
+          useValue: {
+            enforceApiKeyProjectScope: jest.fn(),
+            requireProjectAccess: jest.fn().mockResolvedValue(undefined),
+            getUserProjectRole: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/apps/backend/src/domains/domains.service.ts
+++ b/apps/backend/src/domains/domains.service.ts
@@ -22,6 +22,7 @@ import { SslInfoService, DomainSslInfo } from './ssl-info.service';
 import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 import { ProxyRulesService } from '../proxy-rules/proxy-rules.service';
 import { VisibilityService } from './visibility.service';
+import { PermissionsService } from '../permissions/permissions.service';
 
 const RESERVED_SUBDOMAINS = [
   'www',
@@ -94,6 +95,7 @@ export class DomainsService {
     private readonly featureFlagsService: FeatureFlagsService,
     private readonly proxyRulesService: ProxyRulesService,
     private readonly visibilityService: VisibilityService,
+    private readonly permissionsService: PermissionsService,
   ) {}
 
   /**
@@ -520,7 +522,22 @@ export class DomainsService {
     }
   }
 
-  async create(createDomainDto: CreateDomainDto, userId: string, authToken?: string) {
+  async create(
+    createDomainDto: CreateDomainDto,
+    userId: string,
+    authToken?: string,
+    apiKeyProjectId?: string | null,
+  ) {
+    if (createDomainDto.projectId) {
+      this.permissionsService.enforceApiKeyProjectScope(
+        apiKeyProjectId,
+        createDomainDto.projectId,
+      );
+    } else if (apiKeyProjectId !== undefined && apiKeyProjectId !== null) {
+      // Project-scoped key trying to create a domain with no project (e.g. redirect):
+      // forbid — a scoped key shouldn't create cross-project resources.
+      throw new ForbiddenException('API key is not authorized to create unscoped domains');
+    }
     const baseDomain = process.env.PRIMARY_DOMAIN || 'localhost';
 
     // Validate redirect domains have a target
@@ -785,9 +802,17 @@ export class DomainsService {
       domainType?: string;
       isActive?: boolean;
     },
+    apiKeyProjectId?: string | null,
   ) {
-    // Get user's accessible projects (owned + shared)
-    // For now, return all (will add permission filtering later)
+    // For a project-scoped api-key, narrow results to its project. If the caller
+    // also passed a projectId filter, both must match.
+    let effectiveProjectIdFilter = filters?.projectId;
+    if (apiKeyProjectId !== undefined && apiKeyProjectId !== null) {
+      if (effectiveProjectIdFilter && effectiveProjectIdFilter !== apiKeyProjectId) {
+        throw new ForbiddenException('API key is not authorized for this project');
+      }
+      effectiveProjectIdFilter = apiKeyProjectId;
+    }
 
     const query = db.select().from(domainMappings);
 
@@ -796,8 +821,8 @@ export class DomainsService {
     // Always exclude primary domains from the list - they're managed via Settings
     conditions.push(eq(domainMappings.isPrimary, false));
 
-    if (filters?.projectId) {
-      conditions.push(eq(domainMappings.projectId, filters.projectId));
+    if (effectiveProjectIdFilter) {
+      conditions.push(eq(domainMappings.projectId, effectiveProjectIdFilter));
     }
 
     if (filters?.domainType) {
@@ -822,7 +847,7 @@ export class DomainsService {
     return results;
   }
 
-  async findOne(id: string, _userId: string) {
+  async findOne(id: string, _userId: string, apiKeyProjectId?: string | null) {
     const [domainMapping] = await db
       .select()
       .from(domainMappings)
@@ -833,7 +858,11 @@ export class DomainsService {
       throw new NotFoundException(`Domain mapping with ID ${id} not found`);
     }
 
-    // TODO: Check user has permission to view this domain's project
+    if (domainMapping.projectId) {
+      this.permissionsService.enforceApiKeyProjectScope(apiKeyProjectId, domainMapping.projectId);
+    } else if (apiKeyProjectId !== undefined && apiKeyProjectId !== null) {
+      throw new ForbiddenException('API key is not authorized for this domain');
+    }
 
     // In platform mode, SSL is managed externally for subdomains — report as enabled
     if (this.isPlatformMode() && domainMapping.domainType === 'subdomain') {
@@ -843,9 +872,20 @@ export class DomainsService {
     return domainMapping;
   }
 
-  async update(id: string, updateDomainDto: UpdateDomainDto, userId: string) {
+  async update(
+    id: string,
+    updateDomainDto: UpdateDomainDto,
+    userId: string,
+    apiKeyProjectId?: string | null,
+  ) {
     // Check domain exists and get current data
     const existing = await this.findOne(id, userId);
+
+    if (existing.projectId) {
+      this.permissionsService.enforceApiKeyProjectScope(apiKeyProjectId, existing.projectId);
+    } else if (apiKeyProjectId !== undefined && apiKeyProjectId !== null) {
+      throw new ForbiddenException('API key is not authorized for this domain');
+    }
 
     // Validate path if provided (not applicable for redirect domains)
     if (updateDomainDto.path && existing.domainType !== 'redirect') {
@@ -1058,8 +1098,19 @@ export class DomainsService {
     return updated;
   }
 
-  async remove(id: string, userId: string, authToken?: string) {
+  async remove(
+    id: string,
+    userId: string,
+    authToken?: string,
+    apiKeyProjectId?: string | null,
+  ) {
     const existing = await this.findOne(id, userId);
+
+    if (existing.projectId) {
+      this.permissionsService.enforceApiKeyProjectScope(apiKeyProjectId, existing.projectId);
+    } else if (apiKeyProjectId !== undefined && apiKeyProjectId !== null) {
+      throw new ForbiddenException('API key is not authorized for this domain');
+    }
 
     // Delete from database
     await db.delete(domainMappings).where(eq(domainMappings.id, id));

--- a/apps/backend/src/mcp/helpers/user-context.helper.ts
+++ b/apps/backend/src/mcp/helpers/user-context.helper.ts
@@ -4,6 +4,13 @@ import { AuthService } from '../../auth/auth.service';
 export interface McpUserContext {
   id: string;
   role: string;
+  /**
+   * Project scope from the authenticating API key.
+   * - `undefined`: session auth, no api-key context
+   * - `null`: global (unscoped) api-key
+   * - string: api-key restricted to this project id
+   */
+  apiKeyProjectId?: string | null;
 }
 
 /**
@@ -29,5 +36,6 @@ export async function getUserContext(
   return {
     id: dbUser.id,
     role: dbUser.role,
+    apiKeyProjectId: user.apiKeyProjectId,
   };
 }

--- a/apps/backend/src/mcp/tools/cache-rules.tools.ts
+++ b/apps/backend/src/mcp/tools/cache-rules.tools.ts
@@ -23,9 +23,10 @@ export class CacheRulesTools {
   async listRules(
     { projectId }: { projectId: string },
     _context: Context,
-    _request: Request,
+    request: Request,
   ) {
-    const result = await this.cacheRulesService.getRulesByProjectId(projectId);
+    const apiKeyProjectId = (request as any)?.user?.apiKeyProjectId;
+    const result = await this.cacheRulesService.getRulesByProjectId(projectId, apiKeyProjectId);
     return JSON.stringify(result);
   }
 
@@ -36,8 +37,18 @@ export class CacheRulesTools {
       id: z.string().describe('Cache rule ID'),
     }),
   })
-  async getRule({ id }: { id: string }, _context: Context, _request: Request) {
+  async getRule({ id }: { id: string }, _context: Context, request: Request) {
+    const apiKeyProjectId = (request as any)?.user?.apiKeyProjectId;
     const result = await this.cacheRulesService.getRuleById(id);
+    if (
+      result &&
+      apiKeyProjectId !== undefined &&
+      apiKeyProjectId !== null &&
+      apiKeyProjectId !== result.projectId
+    ) {
+      // Don't leak existence — return null as if not found.
+      return JSON.stringify(null);
+    }
     return JSON.stringify(result);
   }
 
@@ -78,7 +89,13 @@ export class CacheRulesTools {
   ) {
     const user = await getUserContext(request, this.authService);
     const { projectId, ...dto } = args;
-    const result = await this.cacheRulesService.create(projectId, dto, user.id, user.role);
+    const result = await this.cacheRulesService.create(
+      projectId,
+      dto,
+      user.id,
+      user.role,
+      user.apiKeyProjectId,
+    );
     return JSON.stringify(result);
   }
 
@@ -96,7 +113,7 @@ export class CacheRulesTools {
     request: Request,
   ) {
     const user = await getUserContext(request, this.authService);
-    await this.cacheRulesService.delete(id, user.id, user.role);
+    await this.cacheRulesService.delete(id, user.id, user.role, user.apiKeyProjectId);
     return JSON.stringify({ success: true, id });
   }
 }

--- a/apps/backend/src/mcp/tools/domain.tools.ts
+++ b/apps/backend/src/mcp/tools/domain.tools.ts
@@ -31,11 +31,15 @@ export class DomainTools {
     request: Request,
   ) {
     const user = await getUserContext(request, this.authService);
-    const result = await this.domainsService.findAll(user.id, {
-      projectId: args.projectId,
-      domainType: args.domainType,
-      isActive: args.isActive,
-    });
+    const result = await this.domainsService.findAll(
+      user.id,
+      {
+        projectId: args.projectId,
+        domainType: args.domainType,
+        isActive: args.isActive,
+      },
+      user.apiKeyProjectId,
+    );
     return JSON.stringify(result);
   }
 
@@ -52,7 +56,7 @@ export class DomainTools {
     request: Request,
   ) {
     const user = await getUserContext(request, this.authService);
-    const result = await this.domainsService.findOne(id, user.id);
+    const result = await this.domainsService.findOne(id, user.id, user.apiKeyProjectId);
     return JSON.stringify(result);
   }
 
@@ -108,6 +112,8 @@ export class DomainTools {
         redirectTarget: args.redirectTarget,
       },
       user.id,
+      undefined,
+      user.apiKeyProjectId,
     );
     return JSON.stringify(result);
   }
@@ -155,7 +161,7 @@ export class DomainTools {
   ) {
     const user = await getUserContext(request, this.authService);
     const { id, ...dto } = args;
-    const result = await this.domainsService.update(id, dto, user.id);
+    const result = await this.domainsService.update(id, dto, user.id, user.apiKeyProjectId);
     return JSON.stringify(result);
   }
 
@@ -174,7 +180,7 @@ export class DomainTools {
     request: Request,
   ) {
     const user = await getUserContext(request, this.authService);
-    const result = await this.domainsService.remove(id, user.id);
+    const result = await this.domainsService.remove(id, user.id, undefined, user.apiKeyProjectId);
     return JSON.stringify(result);
   }
 }

--- a/apps/backend/src/mcp/tools/pipeline.tools.ts
+++ b/apps/backend/src/mcp/tools/pipeline.tools.ts
@@ -36,9 +36,10 @@ export class PipelineTools {
   async listSchemas(
     { projectId }: { projectId: string },
     _context: Context,
-    _request: Request,
+    request: Request,
   ) {
-    const result = await this.schemasService.getByProjectId(projectId);
+    const apiKeyProjectId = (request as any)?.user?.apiKeyProjectId;
+    const result = await this.schemasService.getByProjectId(projectId, apiKeyProjectId);
     return JSON.stringify(result);
   }
 
@@ -49,8 +50,9 @@ export class PipelineTools {
       id: z.string().describe('Schema ID'),
     }),
   })
-  async getSchema({ id }: { id: string }, _context: Context, _request: Request) {
-    const result = await this.schemasService.getByIdWithCount(id);
+  async getSchema({ id }: { id: string }, _context: Context, request: Request) {
+    const apiKeyProjectId = (request as any)?.user?.apiKeyProjectId;
+    const result = await this.schemasService.getByIdWithCount(id, apiKeyProjectId);
     return JSON.stringify(result);
   }
 
@@ -97,6 +99,7 @@ export class PipelineTools {
       },
       user.id,
       user.role,
+      user.apiKeyProjectId,
     );
     return JSON.stringify(result);
   }
@@ -115,7 +118,7 @@ export class PipelineTools {
     request: Request,
   ) {
     const user = await getUserContext(request, this.authService);
-    await this.schemasService.delete(id, user.id, user.role);
+    await this.schemasService.delete(id, user.id, user.role, user.apiKeyProjectId);
     return JSON.stringify({ success: true, id });
   }
 
@@ -160,7 +163,13 @@ export class PipelineTools {
     const updateDto: { name?: string; fields?: Array<{ name: string; type: SchemaFieldType; required?: boolean }> } = {};
     if (dto.name) updateDto.name = dto.name;
     if (dto.fields) updateDto.fields = dto.fields.map((f) => ({ name: f.name, type: f.type, required: f.required }));
-    const result = await this.schemasService.update(id, updateDto, user.id, user.role);
+    const result = await this.schemasService.update(
+      id,
+      updateDto,
+      user.id,
+      user.role,
+      user.apiKeyProjectId,
+    );
     return JSON.stringify(result);
   }
 
@@ -219,6 +228,7 @@ export class PipelineTools {
       args,
       user.id,
       user.role,
+      user.apiKeyProjectId,
     );
     return JSON.stringify(result);
   }
@@ -264,6 +274,7 @@ export class PipelineTools {
         sortBy: args.sortBy,
         sortOrder: args.sortOrder,
       },
+      user.apiKeyProjectId,
     );
     return JSON.stringify(result);
   }
@@ -281,7 +292,12 @@ export class PipelineTools {
     request: Request,
   ) {
     const user = await getUserContext(request, this.authService);
-    const result = await this.dataService.getByIdWithAccess(id, user.id, user.role);
+    const result = await this.dataService.getByIdWithAccess(
+      id,
+      user.id,
+      user.role,
+      user.apiKeyProjectId,
+    );
     return JSON.stringify(result);
   }
 
@@ -304,6 +320,7 @@ export class PipelineTools {
       args.data,
       user.id,
       user.role,
+      user.apiKeyProjectId,
     );
     return JSON.stringify(result);
   }
@@ -322,7 +339,13 @@ export class PipelineTools {
     request: Request,
   ) {
     const user = await getUserContext(request, this.authService);
-    const result = await this.dataService.update(args.id, args.data, user.id, user.role);
+    const result = await this.dataService.update(
+      args.id,
+      args.data,
+      user.id,
+      user.role,
+      user.apiKeyProjectId,
+    );
     return JSON.stringify(result);
   }
 
@@ -340,7 +363,7 @@ export class PipelineTools {
     request: Request,
   ) {
     const user = await getUserContext(request, this.authService);
-    await this.dataService.delete(id, user.id, user.role);
+    await this.dataService.delete(id, user.id, user.role, user.apiKeyProjectId);
     return JSON.stringify({ success: true, id });
   }
 

--- a/apps/backend/src/mcp/tools/proxy-rules.tools.ts
+++ b/apps/backend/src/mcp/tools/proxy-rules.tools.ts
@@ -96,9 +96,10 @@ export class ProxyRulesTools {
   async listRuleSets(
     { projectId }: { projectId: string },
     _context: Context,
-    _request: Request,
+    request: Request,
   ) {
-    const result = await this.proxyRuleSetsService.listByProject(projectId);
+    const apiKeyProjectId = (request as any)?.user?.apiKeyProjectId;
+    const result = await this.proxyRuleSetsService.listByProject(projectId, apiKeyProjectId);
     return JSON.stringify(result);
   }
 
@@ -109,8 +110,9 @@ export class ProxyRulesTools {
       id: z.string().describe('Rule set ID'),
     }),
   })
-  async getRuleSet({ id }: { id: string }, _context: Context, _request: Request) {
-    const result = await this.proxyRuleSetsService.getById(id);
+  async getRuleSet({ id }: { id: string }, _context: Context, request: Request) {
+    const apiKeyProjectId = (request as any)?.user?.apiKeyProjectId;
+    const result = await this.proxyRuleSetsService.getById(id, apiKeyProjectId);
     return JSON.stringify(result);
   }
 
@@ -140,6 +142,7 @@ export class ProxyRulesTools {
       { name: args.name, description: args.description, environment: args.environment },
       user.id,
       user.role,
+      user.apiKeyProjectId,
     );
     return JSON.stringify(result);
   }
@@ -158,7 +161,7 @@ export class ProxyRulesTools {
     request: Request,
   ) {
     const user = await getUserContext(request, this.authService);
-    await this.proxyRuleSetsService.delete(id, user.id, user.role);
+    await this.proxyRuleSetsService.delete(id, user.id, user.role, user.apiKeyProjectId);
     return JSON.stringify({ success: true, id });
   }
 
@@ -173,8 +176,17 @@ export class ProxyRulesTools {
       id: z.string().describe('Proxy rule ID'),
     }),
   })
-  async getRule({ id }: { id: string }, _context: Context, _request: Request) {
+  async getRule({ id }: { id: string }, _context: Context, request: Request) {
+    const apiKeyProjectId = (request as any)?.user?.apiKeyProjectId;
     const result = await this.proxyRulesService.getRuleById(id);
+    if (result && apiKeyProjectId !== undefined && apiKeyProjectId !== null) {
+      // Resolve owning project via the rule's rule set, then enforce scope
+      const ruleSet = await this.proxyRulesService.getRuleSetById(result.ruleSetId);
+      if (ruleSet) {
+        // throws if mismatch
+        await this.proxyRuleSetsService.getById(ruleSet.id, apiKeyProjectId);
+      }
+    }
     return JSON.stringify(result);
   }
 
@@ -256,7 +268,12 @@ export class ProxyRulesTools {
     request: Request,
   ) {
     const user = await getUserContext(request, this.authService);
-    const result = await this.proxyRulesService.create(args as any, user.id, user.role);
+    const result = await this.proxyRulesService.create(
+      args as any,
+      user.id,
+      user.role,
+      user.apiKeyProjectId,
+    );
     return JSON.stringify(result);
   }
 
@@ -319,7 +336,13 @@ export class ProxyRulesTools {
   ) {
     const user = await getUserContext(request, this.authService);
     const { id, ...dto } = args;
-    const result = await this.proxyRulesService.update(id as string, dto as any, user.id, user.role);
+    const result = await this.proxyRulesService.update(
+      id as string,
+      dto as any,
+      user.id,
+      user.role,
+      user.apiKeyProjectId,
+    );
     return JSON.stringify(result);
   }
 
@@ -337,7 +360,7 @@ export class ProxyRulesTools {
     request: Request,
   ) {
     const user = await getUserContext(request, this.authService);
-    await this.proxyRulesService.delete(id, user.id, user.role);
+    await this.proxyRulesService.delete(id, user.id, user.role, user.apiKeyProjectId);
     return JSON.stringify({ success: true, id });
   }
 }

--- a/apps/backend/src/permissions/permissions.service.spec.ts
+++ b/apps/backend/src/permissions/permissions.service.spec.ts
@@ -138,6 +138,98 @@ describe('PermissionsService', () => {
     });
   });
 
+  describe('enforceApiKeyProjectScope', () => {
+    const projectA = 'project-A';
+    const projectB = 'project-B';
+
+    it('is a no-op for session auth (apiKeyProjectId === undefined)', () => {
+      expect(() => service.enforceApiKeyProjectScope(undefined, projectA)).not.toThrow();
+    });
+
+    it('is a no-op for global api-keys (apiKeyProjectId === null)', () => {
+      expect(() => service.enforceApiKeyProjectScope(null, projectA)).not.toThrow();
+    });
+
+    it('allows when api-key scope matches the target project', () => {
+      expect(() => service.enforceApiKeyProjectScope(projectA, projectA)).not.toThrow();
+    });
+
+    it('throws ForbiddenException when api-key scope does not match', () => {
+      expect(() => service.enforceApiKeyProjectScope(projectA, projectB)).toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  describe('requireProjectAccess', () => {
+    const targetProject = mockProjectId;
+    const otherProject = 'other-project-999';
+
+    it('blocks an admin user when their api-key scope does not match (no admin shortcut on api-keys)', async () => {
+      const spy = jest.spyOn(service, 'getUserProjectRole');
+
+      await expect(
+        service.requireProjectAccess(targetProject, mockUserId, 'admin', 'contributor', otherProject),
+      ).rejects.toThrow(ForbiddenException);
+
+      // Important: scope check must reject before consulting role hierarchy.
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('allows when api-key scope matches the target project, regardless of role', async () => {
+      const spy = jest.spyOn(service, 'getUserProjectRole');
+
+      await expect(
+        service.requireProjectAccess(targetProject, mockUserId, 'user', 'contributor', targetProject),
+      ).resolves.toBeUndefined();
+
+      // Scope match short-circuits — no need to look up the user role.
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('falls through to role check for global api-keys (apiKeyProjectId === null)', async () => {
+      jest.spyOn(service, 'getUserProjectRole').mockResolvedValue('contributor');
+
+      await expect(
+        service.requireProjectAccess(targetProject, mockUserId, 'user', 'contributor', null),
+      ).resolves.toBeUndefined();
+    });
+
+    it('falls through to role check for session auth (apiKeyProjectId undefined)', async () => {
+      jest.spyOn(service, 'getUserProjectRole').mockResolvedValue('contributor');
+
+      await expect(
+        service.requireProjectAccess(targetProject, mockUserId, 'user', 'contributor'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('grants system admins access without looking up project role (when no api-key context)', async () => {
+      const spy = jest.spyOn(service, 'getUserProjectRole');
+
+      await expect(
+        service.requireProjectAccess(targetProject, mockUserId, 'admin', 'contributor'),
+      ).resolves.toBeUndefined();
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('rejects when user has no role on the project', async () => {
+      jest.spyOn(service, 'getUserProjectRole').mockResolvedValue(null);
+
+      await expect(
+        service.requireProjectAccess(targetProject, mockUserId, 'user', 'viewer'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('rejects when user role is below required role', async () => {
+      jest.spyOn(service, 'getUserProjectRole').mockResolvedValue('viewer');
+
+      await expect(
+        service.requireProjectAccess(targetProject, mockUserId, 'user', 'admin'),
+      ).rejects.toThrow(/admin role or higher/);
+    });
+  });
+
   describe('listUserProjects', () => {
     it('should return unique project IDs from direct and group permissions', async () => {
       const mockDirectPerms = [

--- a/apps/backend/src/permissions/permissions.service.ts
+++ b/apps/backend/src/permissions/permissions.service.ts
@@ -79,6 +79,75 @@ export class PermissionsService {
   }
 
   /**
+   * Enforce only the api-key project scope (no role check). Use this on paths
+   * where role authorization is already handled elsewhere (e.g. controller-level
+   * @Roles('admin')) and we just need to make sure a project-scoped api-key can
+   * only operate on its declared project.
+   *
+   * Throws ForbiddenException when the api-key is scoped to a different project.
+   * No-op for session auth (`undefined`) and global api-keys (`null`).
+   */
+  enforceApiKeyProjectScope(
+    apiKeyProjectId: string | null | undefined,
+    projectId: string,
+  ): void {
+    if (apiKeyProjectId !== undefined && apiKeyProjectId !== null && apiKeyProjectId !== projectId) {
+      throw new ForbiddenException('API key is not authorized for this project');
+    }
+  }
+
+  /**
+   * Authorize a request to operate on `projectId`. Throws ForbiddenException on denial.
+   *
+   * Resolution order is load-bearing:
+   *   1. Project-scoped API keys are enforced first, before any role shortcut. A
+   *      super-admin user whose API key was minted with `projectId = X` cannot
+   *      reach project Y through that key.
+   *   2. System admins bypass per-project role checks (only after the api-key
+   *      scope check above has passed).
+   *   3. Otherwise, look up the user's effective project role and compare to
+   *      the required role.
+   *
+   * @param apiKeyProjectId — `undefined` means session auth (no api-key context),
+   *   `null` means a global (unscoped) api-key, a string means a project-scoped key.
+   */
+  async requireProjectAccess(
+    projectId: string,
+    userId: string,
+    userRole: string | undefined,
+    requiredRole: Exclude<ProjectRole, 'guest'> = 'contributor',
+    apiKeyProjectId?: string | null,
+  ): Promise<void> {
+    if (apiKeyProjectId !== undefined && apiKeyProjectId !== null) {
+      if (apiKeyProjectId !== projectId) {
+        throw new ForbiddenException('API key is not authorized for this project');
+      }
+      return;
+    }
+
+    if (userRole === 'admin') {
+      return;
+    }
+
+    const role = await this.getUserProjectRole(userId, projectId);
+    if (!role) {
+      throw new ForbiddenException('You do not have access to this project');
+    }
+
+    const roleHierarchy: Record<ProjectRole, number> = {
+      owner: 4,
+      admin: 3,
+      contributor: 2,
+      viewer: 1,
+      guest: 0,
+    };
+
+    if (roleHierarchy[role] < roleHierarchy[requiredRole]) {
+      throw new ForbiddenException(`This action requires ${requiredRole} role or higher`);
+    }
+  }
+
+  /**
    * Check if a user's project role meets the required access control role
    * Used for private content access control (different from project permission checks)
    *

--- a/apps/backend/src/pipelines/chat-schema-generator.service.ts
+++ b/apps/backend/src/pipelines/chat-schema-generator.service.ts
@@ -39,9 +39,15 @@ export class ChatSchemaGeneratorService {
     dto: GenerateChatSchemaDto,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<GenerateChatSchemaResponseDto> {
-    // Check project access
-    await this.checkProjectAccess(dto.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      dto.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Get AI config from project settings to validate and get defaults
     const aiConfig = await this.projectAISettingsService.getProviderConfig(
@@ -356,31 +362,4 @@ export class ChatSchemaGeneratorService {
     };
   }
 
-  /**
-   * Check project access
-   */
-  private async checkProjectAccess(
-    projectId: string,
-    userId: string,
-    userRole: string,
-    requiredRole: 'viewer' | 'contributor' | 'admin' | 'owner' = 'contributor',
-  ): Promise<void> {
-    if (userRole === 'admin') {
-      return;
-    }
-
-    const role = await this.permissionsService.getUserProjectRole(userId, projectId);
-
-    if (!role) {
-      throw new Error('You do not have access to this project');
-    }
-
-    const roleHierarchy = { viewer: 1, contributor: 2, admin: 3, owner: 4 };
-    const userLevel = roleHierarchy[role] || 0;
-    const requiredLevel = roleHierarchy[requiredRole] || 0;
-
-    if (userLevel < requiredLevel) {
-      throw new Error(`This action requires ${requiredRole} role or higher`);
-    }
-  }
 }

--- a/apps/backend/src/pipelines/pipeline-data.controller.ts
+++ b/apps/backend/src/pipelines/pipeline-data.controller.ts
@@ -99,6 +99,7 @@ export class PipelineDataController {
         sortBy,
         sortOrder,
       },
+      user.apiKeyProjectId,
     );
   }
 
@@ -113,7 +114,13 @@ export class PipelineDataController {
     @Body() dto: CreatePipelineDataDto,
     @CurrentUser() user: CurrentUserData,
   ): Promise<PipelineDataResponseDto> {
-    return this.dataService.createWithAccess(schemaId, dto.data, user.id, user.role || 'user');
+    return this.dataService.createWithAccess(
+      schemaId,
+      dto.data,
+      user.id,
+      user.role || 'user',
+      user.apiKeyProjectId,
+    );
   }
 
   // Static routes MUST come before dynamic :recordId routes
@@ -129,7 +136,13 @@ export class PipelineDataController {
     @CurrentUser() user: CurrentUserData,
     @Res() res: Response,
   ): Promise<void> {
-    const data = await this.dataService.exportBySchemaId(schemaId, format, user.id, user.role || 'user');
+    const data = await this.dataService.exportBySchemaId(
+      schemaId,
+      format,
+      user.id,
+      user.role || 'user',
+      user.apiKeyProjectId,
+    );
 
     const contentType = format === 'csv' ? 'text/csv' : 'application/json';
     const extension = format === 'csv' ? 'csv' : 'json';
@@ -148,7 +161,12 @@ export class PipelineDataController {
     @Body() body: { ids: string[] },
     @CurrentUser() user: CurrentUserData,
   ): Promise<{ success: boolean; deleted: number }> {
-    const deleted = await this.dataService.deleteMany(body.ids, user.id, user.role || 'user');
+    const deleted = await this.dataService.deleteMany(
+      body.ids,
+      user.id,
+      user.role || 'user',
+      user.apiKeyProjectId,
+    );
     return { success: true, deleted };
   }
 
@@ -163,7 +181,12 @@ export class PipelineDataController {
     @Param('recordId', ParseUUIDPipe) recordId: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<PipelineDataResponseDto> {
-    return this.dataService.getByIdWithAccess(recordId, user.id, user.role || 'user');
+    return this.dataService.getByIdWithAccess(
+      recordId,
+      user.id,
+      user.role || 'user',
+      user.apiKeyProjectId,
+    );
   }
 
   @Put(':recordId')
@@ -178,7 +201,13 @@ export class PipelineDataController {
     @Body() dto: UpdatePipelineDataDto,
     @CurrentUser() user: CurrentUserData,
   ): Promise<PipelineDataResponseDto> {
-    return this.dataService.update(recordId, dto.data, user.id, user.role || 'user');
+    return this.dataService.update(
+      recordId,
+      dto.data,
+      user.id,
+      user.role || 'user',
+      user.apiKeyProjectId,
+    );
   }
 
   @Delete(':recordId')
@@ -192,7 +221,12 @@ export class PipelineDataController {
     @Param('recordId', ParseUUIDPipe) recordId: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<{ success: boolean }> {
-    await this.dataService.delete(recordId, user.id, user.role || 'user');
+    await this.dataService.delete(
+      recordId,
+      user.id,
+      user.role || 'user',
+      user.apiKeyProjectId,
+    );
     return { success: true };
   }
 }

--- a/apps/backend/src/pipelines/pipeline-data.service.spec.ts
+++ b/apps/backend/src/pipelines/pipeline-data.service.spec.ts
@@ -1,0 +1,100 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import { PipelineDataService } from './pipeline-data.service';
+import { PermissionsService } from '../permissions/permissions.service';
+import { db } from '../db/client';
+
+jest.mock('../db/client', () => ({
+  db: {
+    select: jest.fn(),
+    insert: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+describe('PipelineDataService — api-key project scoping', () => {
+  let service: PipelineDataService;
+  let permissionsService: PermissionsService;
+
+  const recordOwningProject = 'project-A';
+  const otherProject = 'project-B';
+  const recordId = 'record-1';
+  const userId = 'user-1';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PipelineDataService,
+        {
+          provide: PermissionsService,
+          useValue: {
+            requireProjectAccess: jest.fn(),
+            getUserProjectRole: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(PipelineDataService);
+    permissionsService = module.get(PermissionsService);
+    jest.clearAllMocks();
+  });
+
+  describe('update', () => {
+    beforeEach(() => {
+      // Stub: getById finds a record owned by `recordOwningProject`
+      (db.select as jest.Mock).mockReturnValue({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        limit: jest
+          .fn()
+          .mockResolvedValue([{ id: recordId, projectId: recordOwningProject, data: {} }]),
+      });
+      // Stub: db.update().set().where().returning() returns updated row
+      (db.update as jest.Mock).mockReturnValue({
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        returning: jest
+          .fn()
+          .mockResolvedValue([{ id: recordId, projectId: recordOwningProject, data: { x: 1 } }]),
+      });
+    });
+
+    it('passes the api-key scope through to PermissionsService.requireProjectAccess', async () => {
+      await service.update(recordId, { x: 1 }, userId, 'user', recordOwningProject);
+
+      expect(permissionsService.requireProjectAccess).toHaveBeenCalledWith(
+        recordOwningProject,
+        userId,
+        'user',
+        'contributor',
+        recordOwningProject,
+      );
+    });
+
+    it('rejects when the api-key is scoped to a different project (helper throws)', async () => {
+      (permissionsService.requireProjectAccess as jest.Mock).mockRejectedValueOnce(
+        new ForbiddenException('API key is not authorized for this project'),
+      );
+
+      await expect(
+        service.update(recordId, { x: 1 }, userId, 'admin', otherProject),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('proceeds normally when no api-key scope is present (session auth)', async () => {
+      await expect(
+        service.update(recordId, { x: 1 }, userId, 'user'),
+      ).resolves.toBeDefined();
+
+      expect(permissionsService.requireProjectAccess).toHaveBeenCalledWith(
+        recordOwningProject,
+        userId,
+        'user',
+        'contributor',
+        undefined,
+      );
+    });
+  });
+});

--- a/apps/backend/src/pipelines/pipeline-data.service.ts
+++ b/apps/backend/src/pipelines/pipeline-data.service.ts
@@ -1,9 +1,4 @@
-import {
-  Injectable,
-  NotFoundException,
-  ForbiddenException,
-  Logger,
-} from '@nestjs/common';
+import { Injectable, NotFoundException, Logger } from '@nestjs/common';
 import { eq, and, desc, asc, count, inArray, gte, lte, or, sql, SQL } from 'drizzle-orm';
 import { db } from '../db/client';
 import { pipelineSchemas, pipelineData, PipelineData, NewPipelineData } from '../db/schema';
@@ -44,6 +39,7 @@ export class PipelineDataService {
     userId: string,
     userRole: string,
     filterOptions?: DataFilterOptions,
+    apiKeyProjectId?: string | null,
   ): Promise<PaginatedDataResult> {
     // Get schema for project ID and access check
     const [schema] = await db
@@ -56,7 +52,13 @@ export class PipelineDataService {
       throw new NotFoundException(`Schema ${schemaId} not found`);
     }
 
-    await this.checkProjectAccess(schema.projectId, userId, userRole, 'viewer');
+    await this.permissionsService.requireProjectAccess(
+      schema.projectId,
+      userId,
+      userRole,
+      'viewer',
+      apiKeyProjectId,
+    );
 
     // Build filter conditions
     const conditions: SQL[] = [eq(pipelineData.schemaId, schemaId)];
@@ -225,6 +227,7 @@ export class PipelineDataService {
     data: Record<string, unknown>,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<PipelineData> {
     // Get schema for project ID and access check
     const [schema] = await db
@@ -237,7 +240,13 @@ export class PipelineDataService {
       throw new NotFoundException(`Schema ${schemaId} not found`);
     }
 
-    await this.checkProjectAccess(schema.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      schema.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     return this.create(schemaId, schema.projectId, data, userId, null, schema.version);
   }
@@ -250,13 +259,20 @@ export class PipelineDataService {
     data: Record<string, unknown>,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<PipelineData> {
     const record = await this.getById(id);
     if (!record) {
       throw new NotFoundException(`Record ${id} not found`);
     }
 
-    await this.checkProjectAccess(record.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      record.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     const [updated] = await db
       .update(pipelineData)
@@ -279,13 +295,20 @@ export class PipelineDataService {
     id: string,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<PipelineData> {
     const record = await this.getById(id);
     if (!record) {
       throw new NotFoundException(`Record ${id} not found`);
     }
 
-    await this.checkProjectAccess(record.projectId, userId, userRole, 'viewer');
+    await this.permissionsService.requireProjectAccess(
+      record.projectId,
+      userId,
+      userRole,
+      'viewer',
+      apiKeyProjectId,
+    );
 
     return record;
   }
@@ -293,13 +316,24 @@ export class PipelineDataService {
   /**
    * Delete a data record
    */
-  async delete(id: string, userId: string, userRole: string): Promise<void> {
+  async delete(
+    id: string,
+    userId: string,
+    userRole: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<void> {
     const record = await this.getById(id);
     if (!record) {
       throw new NotFoundException(`Record ${id} not found`);
     }
 
-    await this.checkProjectAccess(record.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      record.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     await db.delete(pipelineData).where(eq(pipelineData.id, id));
 
@@ -309,7 +343,12 @@ export class PipelineDataService {
   /**
    * Delete multiple data records
    */
-  async deleteMany(ids: string[], userId: string, userRole: string): Promise<number> {
+  async deleteMany(
+    ids: string[],
+    userId: string,
+    userRole: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<number> {
     if (ids.length === 0) {
       return 0;
     }
@@ -325,7 +364,13 @@ export class PipelineDataService {
       throw new NotFoundException(`Record ${ids[0]} not found`);
     }
 
-    await this.checkProjectAccess(record.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      record.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Delete all records that belong to the same project
     const result = await db
@@ -348,6 +393,7 @@ export class PipelineDataService {
     format: 'json' | 'csv',
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<string> {
     // Get schema for project ID and access check
     const [schema] = await db
@@ -360,7 +406,13 @@ export class PipelineDataService {
       throw new NotFoundException(`Schema ${schemaId} not found`);
     }
 
-    await this.checkProjectAccess(schema.projectId, userId, userRole, 'viewer');
+    await this.permissionsService.requireProjectAccess(
+      schema.projectId,
+      userId,
+      userRole,
+      'viewer',
+      apiKeyProjectId,
+    );
 
     // Get all records
     const records = await db
@@ -412,31 +464,6 @@ export class PipelineDataService {
   }
 
   // ==================== Helper Methods ====================
-
-  private async checkProjectAccess(
-    projectId: string,
-    userId: string,
-    userRole: string,
-    requiredRole: 'viewer' | 'contributor' | 'admin' | 'owner' = 'viewer',
-  ): Promise<void> {
-    if (userRole === 'admin') {
-      return;
-    }
-
-    const role = await this.permissionsService.getUserProjectRole(userId, projectId);
-
-    if (!role) {
-      throw new ForbiddenException('You do not have access to this project');
-    }
-
-    const roleHierarchy = { viewer: 1, contributor: 2, admin: 3, owner: 4 };
-    const userLevel = roleHierarchy[role] || 0;
-    const requiredLevel = roleHierarchy[requiredRole] || 0;
-
-    if (userLevel < requiredLevel) {
-      throw new ForbiddenException(`This action requires ${requiredRole} role or higher`);
-    }
-  }
 
   private escapeCSV(value: string): string {
     if (value.includes(',') || value.includes('"') || value.includes('\n')) {

--- a/apps/backend/src/pipelines/pipeline-schemas.controller.ts
+++ b/apps/backend/src/pipelines/pipeline-schemas.controller.ts
@@ -68,8 +68,9 @@ export class PipelineSchemasController {
   @ApiResponse({ status: 200, description: 'List of schemas', type: SchemasListResponseDto })
   async listByProject(
     @Param('projectId', ParseUUIDPipe) projectId: string,
+    @CurrentUser() user: CurrentUserData,
   ): Promise<SchemasListResponseDto> {
-    const schemas = await this.schemasService.getByProjectId(projectId);
+    const schemas = await this.schemasService.getByProjectId(projectId, user.apiKeyProjectId);
     return { schemas };
   }
 
@@ -83,7 +84,7 @@ export class PipelineSchemasController {
     @Body() dto: CreatePipelineSchemaDto,
     @CurrentUser() user: CurrentUserData,
   ): Promise<PipelineSchemaResponseDto> {
-    return this.schemasService.create(dto, user.id, user.role || 'user');
+    return this.schemasService.create(dto, user.id, user.role || 'user', user.apiKeyProjectId);
   }
 
   @Post('generate-state')
@@ -109,6 +110,7 @@ export class PipelineSchemasController {
       dto,
       user.id,
       user.role || 'user',
+      user.apiKeyProjectId,
     );
   }
 
@@ -135,6 +137,7 @@ export class PipelineSchemasController {
       dto,
       user.id,
       user.role || 'user',
+      user.apiKeyProjectId,
     );
   }
 
@@ -161,6 +164,7 @@ export class PipelineSchemasController {
       dto,
       user.id,
       user.role || 'user',
+      user.apiKeyProjectId,
     );
   }
 
@@ -171,8 +175,9 @@ export class PipelineSchemasController {
   @ApiResponse({ status: 404, description: 'Schema not found' })
   async getById(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: CurrentUserData,
   ): Promise<PipelineSchemaWithCountDto> {
-    const schema = await this.schemasService.getByIdWithCount(id);
+    const schema = await this.schemasService.getByIdWithCount(id, user.apiKeyProjectId);
     if (!schema) {
       throw new NotFoundException(`Schema ${id} not found`);
     }
@@ -192,7 +197,7 @@ export class PipelineSchemasController {
     @Body() dto: UpdatePipelineSchemaDto,
     @CurrentUser() user: CurrentUserData,
   ): Promise<PipelineSchemaResponseDto> {
-    return this.schemasService.update(id, dto, user.id, user.role || 'user');
+    return this.schemasService.update(id, dto, user.id, user.role || 'user', user.apiKeyProjectId);
   }
 
   @Delete(':id')
@@ -205,7 +210,7 @@ export class PipelineSchemasController {
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<{ success: boolean }> {
-    await this.schemasService.delete(id, user.id, user.role || 'user');
+    await this.schemasService.delete(id, user.id, user.role || 'user', user.apiKeyProjectId);
     return { success: true };
   }
 

--- a/apps/backend/src/pipelines/pipeline-schemas.service.ts
+++ b/apps/backend/src/pipelines/pipeline-schemas.service.ts
@@ -1,10 +1,4 @@
-import {
-  Injectable,
-  NotFoundException,
-  ConflictException,
-  ForbiddenException,
-  Logger,
-} from '@nestjs/common';
+import { Injectable, NotFoundException, ConflictException, Logger } from '@nestjs/common';
 import { eq, and, count } from 'drizzle-orm';
 import { db } from '../db/client';
 import { pipelineSchemas, pipelineData, PipelineSchema, NewPipelineSchema } from '../db/schema';
@@ -24,7 +18,11 @@ export class PipelineSchemasService {
   /**
    * Get all schemas for a project with record counts
    */
-  async getByProjectId(projectId: string): Promise<SchemaWithCount[]> {
+  async getByProjectId(
+    projectId: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<SchemaWithCount[]> {
+    this.permissionsService.enforceApiKeyProjectScope(apiKeyProjectId, projectId);
     const schemas = await db
       .select()
       .from(pipelineSchemas)
@@ -58,9 +56,14 @@ export class PipelineSchemasService {
   /**
    * Get a schema by ID with record count
    */
-  async getByIdWithCount(id: string): Promise<SchemaWithCount | null> {
+  async getByIdWithCount(
+    id: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<SchemaWithCount | null> {
     const schema = await this.getById(id);
     if (!schema) return null;
+
+    this.permissionsService.enforceApiKeyProjectScope(apiKeyProjectId, schema.projectId);
 
     const [countResult] = await db
       .select({ count: count() })
@@ -80,9 +83,15 @@ export class PipelineSchemasService {
     dto: CreatePipelineSchemaDto,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<PipelineSchema> {
-    // Check project access
-    await this.checkProjectAccess(dto.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      dto.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Check for duplicate name
     const existing = await this.findByName(dto.projectId, dto.name);
@@ -115,14 +124,20 @@ export class PipelineSchemasService {
     dto: UpdatePipelineSchemaDto,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<PipelineSchema> {
     const existing = await this.getById(id);
     if (!existing) {
       throw new NotFoundException(`Schema ${id} not found`);
     }
 
-    // Check project access
-    await this.checkProjectAccess(existing.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      existing.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Check for duplicate name if changing
     if (dto.name && dto.name !== existing.name) {
@@ -164,14 +179,24 @@ export class PipelineSchemasService {
   /**
    * Delete a schema (cascades to data records)
    */
-  async delete(id: string, userId: string, userRole: string): Promise<void> {
+  async delete(
+    id: string,
+    userId: string,
+    userRole: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<void> {
     const existing = await this.getById(id);
     if (!existing) {
       throw new NotFoundException(`Schema ${id} not found`);
     }
 
-    // Check project access
-    await this.checkProjectAccess(existing.projectId, userId, userRole, 'admin');
+    await this.permissionsService.requireProjectAccess(
+      existing.projectId,
+      userId,
+      userRole,
+      'admin',
+      apiKeyProjectId,
+    );
 
     await db.delete(pipelineSchemas).where(eq(pipelineSchemas.id, id));
 
@@ -179,31 +204,6 @@ export class PipelineSchemasService {
   }
 
   // ==================== Helper Methods ====================
-
-  private async checkProjectAccess(
-    projectId: string,
-    userId: string,
-    userRole: string,
-    requiredRole: 'viewer' | 'contributor' | 'admin' | 'owner' = 'contributor',
-  ): Promise<void> {
-    if (userRole === 'admin') {
-      return;
-    }
-
-    const role = await this.permissionsService.getUserProjectRole(userId, projectId);
-
-    if (!role) {
-      throw new ForbiddenException('You do not have access to this project');
-    }
-
-    const roleHierarchy = { viewer: 1, contributor: 2, admin: 3, owner: 4 };
-    const userLevel = roleHierarchy[role] || 0;
-    const requiredLevel = roleHierarchy[requiredRole] || 0;
-
-    if (userLevel < requiredLevel) {
-      throw new ForbiddenException(`This action requires ${requiredRole} role or higher`);
-    }
-  }
 
   private async findByName(projectId: string, name: string): Promise<PipelineSchema | null> {
     const [schema] = await db

--- a/apps/backend/src/pipelines/state-schema-generator.service.ts
+++ b/apps/backend/src/pipelines/state-schema-generator.service.ts
@@ -30,9 +30,15 @@ export class StateSchemaGeneratorService {
     dto: GenerateStateSchemaDto,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<GenerateStateSchemaResponseDto> {
-    // Check project access
-    await this.checkProjectAccess(dto.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      dto.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Check for existing schema with same name
     const [existingSchema] = await db
@@ -450,31 +456,4 @@ function handler({ user, request, steps }) {
     };
   }
 
-  /**
-   * Check project access
-   */
-  private async checkProjectAccess(
-    projectId: string,
-    userId: string,
-    userRole: string,
-    requiredRole: 'viewer' | 'contributor' | 'admin' | 'owner' = 'contributor',
-  ): Promise<void> {
-    if (userRole === 'admin') {
-      return;
-    }
-
-    const role = await this.permissionsService.getUserProjectRole(userId, projectId);
-
-    if (!role) {
-      throw new Error('You do not have access to this project');
-    }
-
-    const roleHierarchy = { viewer: 1, contributor: 2, admin: 3, owner: 4 };
-    const userLevel = roleHierarchy[role] || 0;
-    const requiredLevel = roleHierarchy[requiredRole] || 0;
-
-    if (userLevel < requiredLevel) {
-      throw new Error(`This action requires ${requiredRole} role or higher`);
-    }
-  }
 }

--- a/apps/backend/src/pipelines/upload-schema-generator.service.ts
+++ b/apps/backend/src/pipelines/upload-schema-generator.service.ts
@@ -34,9 +34,15 @@ export class UploadSchemaGeneratorService {
     dto: GenerateUploadSchemaDto,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<GenerateUploadSchemaResponseDto> {
-    // Check project access
-    await this.checkProjectAccess(dto.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      dto.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Check for existing schema with same name
     const [existingSchema] = await db
@@ -275,31 +281,4 @@ export class UploadSchemaGeneratorService {
     };
   }
 
-  /**
-   * Check project access
-   */
-  private async checkProjectAccess(
-    projectId: string,
-    userId: string,
-    userRole: string,
-    requiredRole: 'viewer' | 'contributor' | 'admin' | 'owner' = 'contributor',
-  ): Promise<void> {
-    if (userRole === 'admin') {
-      return;
-    }
-
-    const role = await this.permissionsService.getUserProjectRole(userId, projectId);
-
-    if (!role) {
-      throw new Error('You do not have access to this project');
-    }
-
-    const roleHierarchy = { viewer: 1, contributor: 2, admin: 3, owner: 4 };
-    const userLevel = roleHierarchy[role] || 0;
-    const requiredLevel = roleHierarchy[requiredRole] || 0;
-
-    if (userLevel < requiredLevel) {
-      throw new Error(`This action requires ${requiredRole} role or higher`);
-    }
-  }
 }

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.controller.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.controller.ts
@@ -59,8 +59,12 @@ export class ProxyRuleSetsController {
   @ApiResponse({ status: 200, description: 'List of rule sets', type: ProxyRuleSetsListResponseDto })
   async listByProject(
     @Param('projectId', ParseUUIDPipe) projectId: string,
+    @CurrentUser() user: CurrentUserData,
   ): Promise<ProxyRuleSetsListResponseDto> {
-    const ruleSets = await this.proxyRuleSetsService.listByProject(projectId);
+    const ruleSets = await this.proxyRuleSetsService.listByProject(
+      projectId,
+      user.apiKeyProjectId,
+    );
     return { ruleSets };
   }
 
@@ -76,7 +80,13 @@ export class ProxyRuleSetsController {
     @Body() dto: CreateProxyRuleSetDto,
     @CurrentUser() user: CurrentUserData,
   ): Promise<ProxyRuleSetResponseDto> {
-    return this.proxyRuleSetsService.create(projectId, dto, user.id, user.role || 'user');
+    return this.proxyRuleSetsService.create(
+      projectId,
+      dto,
+      user.id,
+      user.role || 'user',
+      user.apiKeyProjectId,
+    );
   }
 
   @Get(':id')
@@ -86,8 +96,9 @@ export class ProxyRuleSetsController {
   @ApiResponse({ status: 404, description: 'Rule set not found' })
   async getById(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: CurrentUserData,
   ): Promise<ProxyRuleSetWithRulesResponseDto> {
-    const ruleSet = await this.proxyRuleSetsService.getById(id);
+    const ruleSet = await this.proxyRuleSetsService.getById(id, user.apiKeyProjectId);
     if (!ruleSet) {
       throw new NotFoundException(`Rule set ${id} not found`);
     }
@@ -107,7 +118,13 @@ export class ProxyRuleSetsController {
     @Body() dto: UpdateProxyRuleSetDto,
     @CurrentUser() user: CurrentUserData,
   ): Promise<ProxyRuleSetResponseDto> {
-    return this.proxyRuleSetsService.update(id, dto, user.id, user.role || 'user');
+    return this.proxyRuleSetsService.update(
+      id,
+      dto,
+      user.id,
+      user.role || 'user',
+      user.apiKeyProjectId,
+    );
   }
 
   @Delete(':id')
@@ -121,7 +138,7 @@ export class ProxyRuleSetsController {
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<{ success: boolean }> {
-    await this.proxyRuleSetsService.delete(id, user.id, user.role || 'user');
+    await this.proxyRuleSetsService.delete(id, user.id, user.role || 'user', user.apiKeyProjectId);
     return { success: true };
   }
 
@@ -135,7 +152,7 @@ export class ProxyRuleSetsController {
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<ProxyRuleSetWithRulesResponseDto> {
-    return this.proxyRuleSetsService.copy(id, user.id, user.role || 'user');
+    return this.proxyRuleSetsService.copy(id, user.id, user.role || 'user', user.apiKeyProjectId);
   }
 
   // ==================== Rules within a Rule Set ====================
@@ -169,6 +186,7 @@ export class ProxyRuleSetsController {
       { ...dto, ruleSetId: id },
       user.id,
       user.role || 'user',
+      user.apiKeyProjectId,
     ) as Promise<ProxyRuleResponseDto>;
   }
 
@@ -184,7 +202,13 @@ export class ProxyRuleSetsController {
     @Body() dto: ReorderProxyRulesDto,
     @CurrentUser() user: CurrentUserData,
   ): Promise<ProxyRulesListResponseDto> {
-    const rules = await this.proxyRulesService.reorder(id, dto, user.id, user.role || 'user');
+    const rules = await this.proxyRulesService.reorder(
+      id,
+      dto,
+      user.id,
+      user.role || 'user',
+      user.apiKeyProjectId,
+    );
     return { rules: rules as ProxyRuleResponseDto[] };
   }
 }

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
@@ -2,7 +2,6 @@ import {
   Injectable,
   NotFoundException,
   ConflictException,
-  ForbiddenException,
   Logger,
   Inject,
   forwardRef,
@@ -34,7 +33,11 @@ export class ProxyRuleSetsService {
   /**
    * List all rule sets for a project
    */
-  async listByProject(projectId: string): Promise<ProxyRuleSetResponseDto[]> {
+  async listByProject(
+    projectId: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<ProxyRuleSetResponseDto[]> {
+    this.permissionsService.enforceApiKeyProjectScope(apiKeyProjectId, projectId);
     const ruleSets = await db
       .select()
       .from(proxyRuleSets)
@@ -46,7 +49,10 @@ export class ProxyRuleSetsService {
   /**
    * Get a rule set by ID with its rules
    */
-  async getById(id: string): Promise<ProxyRuleSetWithRulesResponseDto | null> {
+  async getById(
+    id: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<ProxyRuleSetWithRulesResponseDto | null> {
     const [ruleSet] = await db
       .select()
       .from(proxyRuleSets)
@@ -54,6 +60,8 @@ export class ProxyRuleSetsService {
       .limit(1);
 
     if (!ruleSet) return null;
+
+    this.permissionsService.enforceApiKeyProjectScope(apiKeyProjectId, ruleSet.projectId);
 
     const rules = await this.proxyRulesService.getRulesByRuleSetId(id);
 
@@ -71,6 +79,7 @@ export class ProxyRuleSetsService {
     dto: CreateProxyRuleSetDto,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<ProxyRuleSetResponseDto> {
     // Verify project exists
     const [project] = await db
@@ -83,8 +92,13 @@ export class ProxyRuleSetsService {
       throw new NotFoundException(`Project ${projectId} not found`);
     }
 
-    // Check project access (need contributor or higher)
-    await this.checkProjectAccess(projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Check for duplicate name within project
     const existing = await this.findByName(projectId, dto.name);
@@ -115,14 +129,20 @@ export class ProxyRuleSetsService {
     dto: UpdateProxyRuleSetDto,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<ProxyRuleSetResponseDto> {
     const existing = await this.findById(id);
     if (!existing) {
       throw new NotFoundException(`Rule set ${id} not found`);
     }
 
-    // Check project access
-    await this.checkProjectAccess(existing.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      existing.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Check for duplicate name if changing
     if (dto.name && dto.name !== existing.name) {
@@ -158,6 +178,7 @@ export class ProxyRuleSetsService {
     id: string,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<ProxyRuleSetWithRulesResponseDto> {
     // Get the existing rule set
     const existingRuleSet = await this.findById(id);
@@ -165,8 +186,13 @@ export class ProxyRuleSetsService {
       throw new NotFoundException(`Rule set ${id} not found`);
     }
 
-    // Check project access (need contributor or higher)
-    await this.checkProjectAccess(existingRuleSet.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      existingRuleSet.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Get the rules directly from database (with full schema type)
     const existingRules = await this.proxyRulesService.getRulesByRuleSetId(id);
@@ -229,14 +255,24 @@ export class ProxyRuleSetsService {
   /**
    * Delete a rule set (cascades to rules and join table rows)
    */
-  async delete(id: string, userId: string, userRole: string): Promise<void> {
+  async delete(
+    id: string,
+    userId: string,
+    userRole: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<void> {
     const existing = await this.findById(id);
     if (!existing) {
       throw new NotFoundException(`Rule set ${id} not found`);
     }
 
-    // Check project access
-    await this.checkProjectAccess(existing.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      existing.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Check if this rule set is being used as a default
     const [projectUsingDefault] = await db
@@ -300,34 +336,6 @@ export class ProxyRuleSetsService {
   }
 
   // ==================== Helper Methods ====================
-
-  private async checkProjectAccess(
-    projectId: string,
-    userId: string,
-    userRole: string,
-    requiredRole: 'viewer' | 'contributor' | 'admin' | 'owner' = 'contributor',
-  ): Promise<void> {
-    // Admin users have access to all projects
-    if (userRole === 'admin') {
-      return;
-    }
-
-    // Check project permissions
-    const role = await this.permissionsService.getUserProjectRole(userId, projectId);
-
-    if (!role) {
-      throw new ForbiddenException('You do not have access to this project');
-    }
-
-    // Check if user has required role level
-    const roleHierarchy = { viewer: 1, contributor: 2, admin: 3, owner: 4 };
-    const userLevel = roleHierarchy[role] || 0;
-    const requiredLevel = roleHierarchy[requiredRole] || 0;
-
-    if (userLevel < requiredLevel) {
-      throw new ForbiddenException(`This action requires ${requiredRole} role or higher`);
-    }
-  }
 
   private async findById(id: string) {
     const [ruleSet] = await db

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
@@ -123,6 +123,7 @@ describe('ProxyRulesController', () => {
         { targetUrl: 'https://new-api.example.com' },
         'user-1',
         'admin',
+        undefined,
       );
     });
   });
@@ -134,7 +135,12 @@ describe('ProxyRulesController', () => {
       const result = await controller.deleteRule('rule-1', mockUser);
 
       expect(result).toEqual({ success: true });
-      expect(mockProxyRulesService.delete).toHaveBeenCalledWith('rule-1', 'user-1', 'admin');
+      expect(mockProxyRulesService.delete).toHaveBeenCalledWith(
+        'rule-1',
+        'user-1',
+        'admin',
+        undefined,
+      );
     });
   });
 
@@ -156,6 +162,7 @@ describe('ProxyRulesController', () => {
         { isEnabled: false },
         'user-1',
         'user',
+        undefined,
       );
     });
   });

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.ts
@@ -86,6 +86,7 @@ export class ProxyRulesController {
       dto,
       user.id,
       user.role || 'user',
+      user.apiKeyProjectId,
     ) as Promise<ProxyRuleResponseDto>;
   }
 
@@ -99,7 +100,7 @@ export class ProxyRulesController {
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<{ success: boolean }> {
-    await this.proxyRulesService.delete(id, user.id, user.role || 'user');
+    await this.proxyRulesService.delete(id, user.id, user.role || 'user', user.apiKeyProjectId);
     return { success: true };
   }
 

--- a/apps/backend/src/proxy-rules/proxy-rules.service.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.service.spec.ts
@@ -69,6 +69,8 @@ describe('ProxyRulesService', () => {
 
   const mockPermissionsService = {
     getUserProjectRole: jest.fn(),
+    requireProjectAccess: jest.fn().mockResolvedValue(undefined),
+    enforceApiKeyProjectScope: jest.fn(),
   };
 
   const mockNginxRegenerationService = {
@@ -283,45 +285,8 @@ describe('ProxyRulesService', () => {
     });
   });
 
-  describe('checkProjectAccess', () => {
-    it('should allow admin users access to any project', async () => {
-      const result = await service['checkProjectAccess'](
-        'any-project',
-        'any-user',
-        'admin',
-        'admin',
-      );
-      expect(result).toBeUndefined();
-    });
-
-    it('should deny access for users without project role', async () => {
-      mockPermissionsService.getUserProjectRole.mockResolvedValue(null);
-
-      await expect(
-        service['checkProjectAccess']('project-id', 'user-id', 'user', 'contributor'),
-      ).rejects.toThrow(ForbiddenException);
-    });
-
-    it('should deny access for users with insufficient role', async () => {
-      mockPermissionsService.getUserProjectRole.mockResolvedValue('viewer');
-
-      await expect(
-        service['checkProjectAccess']('project-id', 'user-id', 'user', 'contributor'),
-      ).rejects.toThrow(ForbiddenException);
-    });
-
-    it('should allow access for users with sufficient role', async () => {
-      mockPermissionsService.getUserProjectRole.mockResolvedValue('contributor');
-
-      const result = await service['checkProjectAccess'](
-        'project-id',
-        'user-id',
-        'user',
-        'contributor',
-      );
-      expect(result).toBeUndefined();
-    });
-  });
+  // (Project access enforcement now lives in PermissionsService.requireProjectAccess
+  // and is covered by permissions.service.spec.ts.)
 
   describe('encryption', () => {
     it('should encrypt and decrypt header values correctly', () => {

--- a/apps/backend/src/proxy-rules/proxy-rules.service.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.service.ts
@@ -3,7 +3,6 @@ import {
   BadRequestException,
   NotFoundException,
   ConflictException,
-  ForbiddenException,
   Logger,
   Inject,
   forwardRef,
@@ -184,6 +183,7 @@ export class ProxyRulesService {
     dto: CreateProxyRuleDto,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<typeof proxyRules.$inferSelect> {
     // Get the rule set to find the project ID for permission checks
     const [ruleSet] = await db
@@ -196,8 +196,13 @@ export class ProxyRulesService {
       throw new NotFoundException(`Rule set ${dto.ruleSetId} not found`);
     }
 
-    // Check project access (need contributor or higher)
-    await this.checkProjectAccess(ruleSet.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      ruleSet.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Validate email form handler configuration
     if (dto.proxyType === 'email_form_handler') {
@@ -283,6 +288,7 @@ export class ProxyRulesService {
     dto: UpdateProxyRuleDto,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<typeof proxyRules.$inferSelect> {
     const existing = await this.findById(id);
     if (!existing) {
@@ -300,8 +306,13 @@ export class ProxyRulesService {
       throw new NotFoundException(`Rule set ${existing.ruleSetId} not found`);
     }
 
-    // Check project access
-    await this.checkProjectAccess(ruleSet.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      ruleSet.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Determine effective proxy type after update
     const effectiveProxyType = dto.proxyType ?? existing.proxyType ?? 'external_proxy';
@@ -420,7 +431,12 @@ export class ProxyRulesService {
   /**
    * Delete a proxy rule
    */
-  async delete(id: string, userId: string, userRole: string): Promise<void> {
+  async delete(
+    id: string,
+    userId: string,
+    userRole: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<void> {
     const existing = await this.findById(id);
     if (!existing) {
       throw new NotFoundException(`Proxy rule ${id} not found`);
@@ -437,8 +453,13 @@ export class ProxyRulesService {
       throw new NotFoundException(`Rule set ${existing.ruleSetId} not found`);
     }
 
-    // Check project access
-    await this.checkProjectAccess(ruleSet.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      ruleSet.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Store ruleSetId before deletion for regeneration
     const ruleSetId = existing.ruleSetId;
@@ -486,6 +507,7 @@ export class ProxyRulesService {
     dto: ReorderProxyRulesDto,
     userId: string,
     userRole: string,
+    apiKeyProjectId?: string | null,
   ): Promise<(typeof proxyRules.$inferSelect)[]> {
     // Get rule set for permission check
     const [ruleSet] = await db
@@ -498,8 +520,13 @@ export class ProxyRulesService {
       throw new NotFoundException(`Rule set ${ruleSetId} not found`);
     }
 
-    // Check project access
-    await this.checkProjectAccess(ruleSet.projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      ruleSet.projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     // Verify all rules belong to the rule set
     const existingRules = await db
@@ -547,34 +574,6 @@ export class ProxyRulesService {
   }
 
   // ==================== Helper Methods ====================
-
-  private async checkProjectAccess(
-    projectId: string,
-    userId: string,
-    userRole: string,
-    requiredRole: 'viewer' | 'contributor' | 'admin' | 'owner' = 'contributor',
-  ): Promise<void> {
-    // Admin users have access to all projects
-    if (userRole === 'admin') {
-      return;
-    }
-
-    // Check project permissions
-    const role = await this.permissionsService.getUserProjectRole(userId, projectId);
-
-    if (!role) {
-      throw new ForbiddenException('You do not have access to this project');
-    }
-
-    // Check if user has required role level
-    const roleHierarchy = { viewer: 1, contributor: 2, admin: 3, owner: 4 };
-    const userLevel = roleHierarchy[role] || 0;
-    const requiredLevel = roleHierarchy[requiredRole] || 0;
-
-    if (userLevel < requiredLevel) {
-      throw new ForbiddenException(`This action requires ${requiredRole} role or higher`);
-    }
-  }
 
   private async findById(id: string) {
     const [rule] = await db.select().from(proxyRules).where(eq(proxyRules.id, id)).limit(1);


### PR DESCRIPTION
## Summary

Project-scoped API keys (`api_keys.projectId IS NOT NULL`) are now restricted to their declared project across pipelines, proxy-rules, cache-rules, domains, and assets. Global keys and session auth retain prior behavior.

## Why

Today, an API key created with `repository: "owner/repo"` (i.e. project-scoped) inherits the creating user's identity but the scope itself is **not enforced server-side** outside of `assets/`. If `BFFLESS_KEY` is owned by a super-admin (which it is in production), any project-scoped key minted from it would still authenticate as that super-admin and be able to mutate _other_ projects' resources via REST or MCP.

The motivating use case: we want `claudbot` running in a per-site GitHub Action (`feedback.yml`) to use a project-scoped key for the BFFless MCP server — so a prompt-injected issue can't ask claudbot to "also update site-B's pipeline" and have it succeed.

A latent bug in the existing `assets.service.checkProjectAccess` was discovered while extending the pattern: the `userRole === 'admin'` shortcut returned **before** the api-key scope check, so an admin-owned project-scoped key would also escape its declared scope on assets paths reached via MCP. This is fixed.

## What changed

### New helpers in `PermissionsService`

- **`requireProjectAccess(projectId, userId, userRole, requiredRole, apiKeyProjectId)`** — full role-checked access, throws `ForbiddenException` on denial. **Critical ordering**: api-key scope is enforced first, then the admin shortcut, then the role-hierarchy check. This means an explicit narrowing on the API key always overrides the user's broader role.
- **`enforceApiKeyProjectScope(apiKeyProjectId, projectId)`** — scope-only check, no role logic. Used on paths where role authorization happens elsewhere (e.g. controller-level `@Roles('admin')`).

### Services hardened

| Service | Methods touched | Helper used |
|---|---|---|
| `assets/assets.service.ts` | switched private check to delegate to `requireProjectAccess` (also fixes the admin-shortcut bug) | `requireProjectAccess` |
| `pipelines/pipeline-schemas.service.ts` | `getByProjectId`, `getByIdWithCount`, `create`, `update`, `delete` | both |
| `pipelines/pipeline-data.service.ts` | `getBySchemaId`, `createWithAccess`, `update`, `getByIdWithAccess`, `delete`, `deleteMany`, `exportBySchemaId` | `requireProjectAccess` |
| `pipelines/upload-schema-generator.service.ts` | `generateUploadSchema` | `requireProjectAccess` |
| `pipelines/state-schema-generator.service.ts` | `generateStateSchema` | `requireProjectAccess` |
| `pipelines/chat-schema-generator.service.ts` | `generateChatSchema` | `requireProjectAccess` |
| `proxy-rules/proxy-rules.service.ts` | `create`, `update`, `delete`, `reorder` | `requireProjectAccess` |
| `proxy-rules/proxy-rule-sets.service.ts` | `listByProject`, `getById`, `create`, `update`, `copy`, `delete` | both |
| `cache-rules/cache-rules.service.ts` | `getRulesByProjectId`, `create`, `update`, `delete`, `reorder` | both |
| `domains/domains.service.ts` | `findAll`, `findOne`, `create`, `update`, `remove` | `enforceApiKeyProjectScope` (controller already gates via `@Roles('admin')`) |

Duplicated `private checkProjectAccess` methods deleted from each service.

### Callers wired

- **MCP tools**: `mcp/tools/{pipeline,proxy-rules,domain,cache-rules}.tools.ts` — `getUserContext` now exposes `apiKeyProjectId` from `request.user`; tools pass it into service calls.
- **REST controllers**: `pipelines/{pipeline-data,pipeline-schemas}.controller.ts`, `proxy-rules/{proxy-rules,proxy-rule-sets}.controller.ts`, `cache-rules/cache-rules.controller.ts`, `domains/domains.controller.ts` — pass `user.apiKeyProjectId` (via `@CurrentUser()` or `@CurrentUser('apiKeyProjectId')`).

## Backwards compatibility

- Global API keys (`apiKeyProjectId === null`) — **unchanged behavior**. The admin shortcut still fires for super-admin-owned keys.
- Session auth (`apiKeyProjectId === undefined`) — **unchanged behavior**.
- Project-scoped API keys — newly restricted to their declared project (this is the intended behavior).

## Tests

- 11 new unit tests on `PermissionsService` covering both helpers (admin-shortcut bypass blocked, scope-match short-circuit, fall-through to role check for global/session, role-hierarchy enforcement, scope mismatch).
- 3 new wiring tests on `pipeline-data.service` verifying the scope param threads through and that a scope-mismatch helper throw propagates.
- Updated mocks in `assets.service.spec.ts`, `proxy-rules.service.spec.ts`, `domains.service.spec.ts`, `proxy-rules.controller.spec.ts` to match new signatures.
- Removed redundant `checkProjectAccess` describe block in `proxy-rules.service.spec.ts` (logic now centrally tested in `permissions.service.spec.ts`).

**Backend test suite**: 911 passing, 0 failing. Type-check clean.

## Test plan

- [ ] Mint a project-scoped API key for project A via the MCP tool or REST API.
- [ ] Confirm it can read/write project A's pipelines, proxy rules, cache rules, domains.
- [ ] Confirm it gets `403 Forbidden` (or returns null for read-only `get_cache_rule`) when targeting project B's resources via any of: `mcp__bffless__update_pipeline_record`, `mcp__bffless__update_proxy_rule`, `mcp__bffless__update_cache_rule`, `mcp__bffless__update_domain`, REST `PUT /api/proxy-rules/:id`, REST `PATCH /api/domains/:id`.
- [ ] Confirm the existing global `BFFLESS_KEY` (super-admin, unscoped) continues to work for cross-project operations.
- [ ] Confirm session-authenticated admin users in the Console UI are unaffected.

## Follow-ups (not in this PR)

- Consider extending `enforceApiKeyProjectScope` to sibling domain services (`RedirectsService`, `PathRedirectsService`, `TrafficRulesService`) — currently only the main `DomainsService` surface is covered. They're admin-gated at the controller and not MCP-reachable, so the threat is lower but worth tightening.