### PR TITLE
perf(nginx): bulk-write configs at startup, single reload wait

### DIFF
--- a/apps/backend/src/domains/nginx-reload.service.spec.ts
+++ b/apps/backend/src/domains/nginx-reload.service.spec.ts
@@ -83,6 +83,47 @@ describe('NginxReloadService', () => {
     });
   });
 
+  describe('writeConfigOnly', () => {
+    it('copies the temp file to final, deletes temp, and does NOT wait for nginx', async () => {
+      const tempPath = '/tmp/domain-bulk.conf';
+      const finalPath = '/etc/nginx/sites-enabled/domain-bulk.conf';
+
+      const startTime = Date.now();
+      const result = await service.writeConfigOnly(tempPath, finalPath);
+      const elapsed = Date.now() - startTime;
+
+      expect(mockCopyFile).toHaveBeenCalledWith(tempPath, finalPath);
+      expect(mockUnlink).toHaveBeenCalledWith(tempPath);
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+      // Must return well before NGINX_RELOAD_WAIT_MS (100ms in test) — otherwise
+      // the bulk-write speedup at startup is defeated.
+      expect(elapsed).toBeLessThan(50);
+    });
+
+    it('returns failure on copyFile error without throwing', async () => {
+      mockCopyFile.mockRejectedValueOnce(new Error('disk full'));
+
+      const result = await service.writeConfigOnly('/tmp/x.conf', '/etc/nginx/x.conf');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('disk full');
+      // Temp file should NOT be unlinked when copy failed (would mask the original error)
+      expect(mockUnlink).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('waitForReload', () => {
+    it('waits for the configured NGINX_RELOAD_WAIT_MS', async () => {
+      const startTime = Date.now();
+      await service.waitForReload();
+      const elapsed = Date.now() - startTime;
+
+      // 100ms configured in beforeEach; allow 90ms threshold for timer imprecision
+      expect(elapsed).toBeGreaterThanOrEqual(90);
+    });
+  });
+
   describe('removeConfigAndReload', () => {
     it('should delete config file and return success', async () => {
       const configPath = '/etc/nginx/sites-enabled/domain-1.conf';

--- a/apps/backend/src/domains/nginx-reload.service.ts
+++ b/apps/backend/src/domains/nginx-reload.service.ts
@@ -80,10 +80,36 @@ export class NginxReloadService {
   }
 
   /**
-   * Wait for the nginx file watcher to process the config change.
-   * The watcher has a ~1s delay after detecting changes, plus validation time.
+   * Copy a config to its final location WITHOUT waiting for nginx to reload.
+   *
+   * Used by bulk regen paths (e.g. startup) that write many configs back-to-back.
+   * The nginx watcher debounces, so per-file waits would just stack up sleeps for
+   * a single coalesced reload. Callers MUST call `waitForReload` once after their
+   * batch completes to give the watcher time to validate and reload.
    */
-  private async waitForReload(): Promise<void> {
+  async writeConfigOnly(
+    tempConfigPath: string,
+    finalConfigPath: string,
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      await copyFile(tempConfigPath, finalConfigPath);
+      await unlink(tempConfigPath);
+      return { success: true };
+    } catch (error) {
+      this.logger.error('Failed to write config', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  /**
+   * Wait for the nginx file watcher to process config changes.
+   * The watcher has a ~1s delay after detecting changes, plus validation time.
+   * Public so bulk callers can do one wait after a batch of `writeConfigOnly` calls.
+   */
+  async waitForReload(): Promise<void> {
     const waitTime = parseInt(process.env.NGINX_RELOAD_WAIT_MS || '3000', 10);
     await new Promise((resolve) => setTimeout(resolve, waitTime));
   }

--- a/apps/backend/src/domains/nginx-startup.service.ts
+++ b/apps/backend/src/domains/nginx-startup.service.ts
@@ -52,7 +52,13 @@ export class NginxStartupService implements OnModuleInit {
   }
 
   /**
-   * Regenerates all nginx configs (domain mappings + redirects + primary content)
+   * Regenerates all nginx configs (domain mappings + redirects + primary content).
+   *
+   * Uses a bulk write strategy: every config is written to disk first, then a
+   * single `waitForReload()` lets the nginx watcher debounce and reload once.
+   * This collapses N × ~3s waits (N = total configs) into a single wait, which
+   * matters at startup where serialized waits previously pushed cold-start
+   * past the liveness probe budget on workspaces with many domains.
    */
   async regenerateAllConfigs(): Promise<void> {
     this.logger.log('Regenerating all nginx configs on startup...');
@@ -63,14 +69,19 @@ export class NginxStartupService implements OnModuleInit {
     // 0.5. Clean up stale primary domain mapping if PRIMARY_DOMAIN changed
     await this.cleanupStalePrimaryDomainMapping();
 
-    // 1. Regenerate all domain mapping configs
-    await this.regenerateDomainMappingConfigs();
+    // 1. Regenerate all domain mapping configs (write only, no per-file wait)
+    const domainCount = await this.regenerateDomainMappingConfigs();
 
-    // 2. Regenerate all redirect configs
-    await this.regenerateRedirectConfigs();
+    // 2. Regenerate all redirect configs (write only, no per-file wait)
+    const redirectCount = await this.regenerateRedirectConfigs();
 
-    // 3. Regenerate primary content config
-    await this.regeneratePrimaryContentConfig();
+    // 3. Regenerate primary content config (write only)
+    const primaryCount = await this.regeneratePrimaryContentConfig();
+
+    // 4. Single wait for the nginx watcher to debounce + reload all the writes.
+    if (domainCount + redirectCount + primaryCount > 0) {
+      await this.nginxReloadService.waitForReload();
+    }
 
     this.logger.log('Nginx config regeneration complete');
   }
@@ -411,14 +422,19 @@ export class NginxStartupService implements OnModuleInit {
   }
 
   /**
-   * Regenerates nginx configs for all active domain mappings
+   * Regenerates nginx configs for all active domain mappings.
+   *
+   * Writes each config to its final location WITHOUT waiting for nginx to reload
+   * — the caller (`regenerateAllConfigs`) does one final `waitForReload` after
+   * every config is on disk. Returns the number of configs written so the caller
+   * can decide whether to wait at all.
    */
-  private async regenerateDomainMappingConfigs(): Promise<void> {
+  private async regenerateDomainMappingConfigs(): Promise<number> {
     const domains = await db.select().from(domainMappings).where(eq(domainMappings.isActive, true));
 
     if (domains.length === 0) {
       this.logger.log('No active domain mappings found');
-      return;
+      return 0;
     }
 
     let successCount = 0;
@@ -449,7 +465,7 @@ export class NginxStartupService implements OnModuleInit {
           domain.id,
           config,
         );
-        await this.nginxReloadService.validateAndReload(tempPath, finalPath);
+        await this.nginxReloadService.writeConfigOnly(tempPath, finalPath);
         successCount++;
       } catch (error) {
         this.logger.error(`Failed to regenerate config for ${domain.domain}: ${error}`);
@@ -458,6 +474,7 @@ export class NginxStartupService implements OnModuleInit {
     }
 
     this.logger.log(`Regenerated ${successCount} domain mapping configs (${errorCount} errors)`);
+    return successCount;
   }
 
   /**
@@ -482,9 +499,12 @@ export class NginxStartupService implements OnModuleInit {
   }
 
   /**
-   * Regenerates nginx configs for all active redirects
+   * Regenerates nginx configs for all active redirects.
+   *
+   * Same bulk-write pattern as `regenerateDomainMappingConfigs` — caller does
+   * the single final wait. Returns the number of configs written.
    */
-  private async regenerateRedirectConfigs(): Promise<void> {
+  private async regenerateRedirectConfigs(): Promise<number> {
     const redirects = await db
       .select({
         redirect: domainRedirects,
@@ -496,7 +516,7 @@ export class NginxStartupService implements OnModuleInit {
 
     if (redirects.length === 0) {
       this.logger.log('No active redirects found');
-      return;
+      return 0;
     }
 
     let successCount = 0;
@@ -531,7 +551,7 @@ export class NginxStartupService implements OnModuleInit {
           redirect.id,
           config,
         );
-        await this.nginxReloadService.validateAndReload(tempPath, finalPath);
+        await this.nginxReloadService.writeConfigOnly(tempPath, finalPath);
         successCount++;
       } catch (error) {
         this.logger.error(
@@ -542,6 +562,7 @@ export class NginxStartupService implements OnModuleInit {
     }
 
     this.logger.log(`Regenerated ${successCount} redirect configs (${errorCount} errors)`);
+    return successCount;
   }
 
   /**
@@ -550,8 +571,11 @@ export class NginxStartupService implements OnModuleInit {
    * - If an ACTIVE primary domain mapping exists, it's already handled by regenerateDomainMappingConfigs()
    * - If an INACTIVE primary domain mapping exists, generate a welcome page
    * - If no primary domain mapping exists, generate a welcome page
+   *
+   * Same bulk-write pattern — caller does the single final wait. Returns the
+   * number of configs written (0 or 1).
    */
-  private async regeneratePrimaryContentConfig(): Promise<void> {
+  private async regeneratePrimaryContentConfig(): Promise<number> {
     // Check if a primary domain mapping exists (unified system)
     const [primaryDomainMapping] = await db
       .select()
@@ -566,25 +590,27 @@ export class NginxStartupService implements OnModuleInit {
       );
       // Clean up legacy primary-content.conf if it exists (avoid conflict)
       await this.cleanupLegacyPrimaryContentConfig();
-      return;
+      return 0;
     }
 
     // Either no primary domain mapping, or it's inactive - generate welcome page config
     try {
       const { tempPath, finalPath } = await this.nginxConfigService.generateWelcomePageConfig();
 
-      const result = await this.nginxReloadService.validateAndReload(tempPath, finalPath);
+      const result = await this.nginxReloadService.writeConfigOnly(tempPath, finalPath);
 
       if (result.success) {
         const reason = primaryDomainMapping
           ? 'primary domain disabled'
           : 'no primary domain configured';
         this.logger.log(`Regenerated welcome page config (${reason})`);
-      } else {
-        this.logger.error(`Failed to reload welcome page config: ${result.error}`);
+        return 1;
       }
+      this.logger.error(`Failed to write welcome page config: ${result.error}`);
+      return 0;
     } catch (error) {
       this.logger.error(`Failed to regenerate welcome page config: ${error}`);
+      return 0;
     }
   }
 


### PR DESCRIPTION
## Summary

`NginxStartupService.regenerateAllConfigs()` previously did a per-file `validateAndReload`, each of which sleeps `NGINX_RELOAD_WAIT_MS` (default 3000ms) waiting for the nginx watcher sidecar to detect and reload. With **N** domain mappings + redirects this stacked up to N × 3s of pure sleeping during cold start.

On the `sites` workspace (~14 domains) this pushed total backend startup past the 90s liveness probe budget and the deploy crashlooped — see today's incident where v0.1.14 wouldn't roll out and we had to (a) rollback to v0.1.13 and (b) ship a 5-minute `startupProbe` in the workspace Helm chart as a tactical fix.

This is the structural fix. The watcher already debounces — multiple writes in quick succession trigger a single reload. We can write every config without per-file waits, then do **one** `waitForReload` at the end.

## Changes

**`NginxReloadService`** gets two new methods:
- `writeConfigOnly(temp, final)` — copy without waiting
- `waitForReload()` — public version of the existing private wait (so bulk callers can do one wait after a batch)

The existing `validateAndReload` is unchanged — it's still the right API for runtime updates (a single domain edit via the dashboard still gets its own immediate reload).

**`NginxStartupService.regenerateAllConfigs`** uses the bulk pattern. Each per-category helper (`regenerateDomainMappingConfigs`, `regenerateRedirectConfigs`, `regeneratePrimaryContentConfig`) returns the number of configs written so the final wait is skipped entirely when the workspace is empty.

## Net effect

On the `sites` workspace (~14 domains): **~42s of sleeping → ~3s**. Cold start drops below the original 90s liveness budget; the chart's tactical 5-min `startupProbe` becomes belt-and-suspenders rather than load-bearing.

## Test plan

- [x] `pnpm --filter backend exec tsc --noEmit` — clean
- [x] `pnpm jest src/domains/nginx-reload.service.spec.ts` — 11 tests pass (8 original + 3 new for `writeConfigOnly` and public `waitForReload`)
- [ ] Manual: deploy to staging, verify backend starts in <30s with multi-domain workspaces and that nginx still serves all sites correctly after the single-reload window
- [ ] Manual: edit a single domain via the admin UI, verify it still picks up the new config within the usual ~3s (per-file path is unchanged)

## Related

- Workspace chart `startupProbe` (defense in depth): `bffless/platform@b973bb9..d6a47d6`
- Today's deploy incident: `sites` workspace, helm revision 24 timed out, rolled back to 23, fixed forward to 26 once chart had `startupProbe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)