### PR TITLE
fix(featureFlagsApi): include key in PUT body to match backend DTO

### DIFF
--- a/apps/frontend/src/services/featureFlagsApi.ts
+++ b/apps/frontend/src/services/featureFlagsApi.ts
@@ -61,7 +61,10 @@ export const featureFlagsApi = api.injectEndpoints({
       query: ({ key, value, enabled }) => ({
         url: `/api/feature-flags/${key}`,
         method: 'PUT',
-        body: { value, enabled: enabled ?? true },
+        // Backend's UpdateFeatureFlagDto requires `key` in the body in
+        // addition to the URL param — omitting it 400s with
+        // "key should not be empty".
+        body: { key, value, enabled: enabled ?? true },
       }),
       invalidatesTags: (_result, _error, { key }) => [
         'FeatureFlags',


### PR DESCRIPTION
## Summary

Hotfix for the admin AuthTab toggle shipped in #232. The new `useSetFeatureFlagMutation` 400s when invoked:

\`\`\`json
{
  "statusCode": 400,
  "error": "Bad Request",
  "message": ["key should not be empty", "key must be a string"],
  "path": "/api/feature-flags/REQUIRE_PROJECT_MEMBERSHIP"
}
\`\`\`

`UpdateFeatureFlagDto` requires `key` as a non-empty string in the body even though the URL `:key` param duplicates it. The mutation was sending only `{ value, enabled }`.

Fix: send `key` in the body too. Backend contract is unchanged.

## Test plan

- [x] `pnpm --filter frontend exec tsc --noEmit` — clean
- [ ] Manual: open `/admin/settings/auth` on a deployed CE, toggle "Require project membership for site authentication", confirm it persists across refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)