### PR TITLE
refactor(auth): namespace login-methods, split user-scoped to /me/login-methods

### DIFF
--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -24,6 +24,7 @@ import { DomainTokenService } from './domain-token.service';
 import { ProjectInviteLinksService } from '../project-invite-links/project-invite-links.service';
 import { ProjectResolverService } from './project-resolver.service';
 import { PermissionsService } from '../permissions/permissions.service';
+import { buildLoginMethodsResponse } from './login-methods.helper';
 import { CreateDomainTokenDto } from './dto/create-domain-token.dto';
 import { db } from '../db/client';
 import { workspaceInvitations, domainMappings } from '../db/schema';
@@ -1105,6 +1106,24 @@ export class AuthController {
   }
 
   @Get('login-methods')
+  @ApiOperation({
+    summary: 'Get site auth capabilities (workspace subdomain)',
+    description:
+      'Public endpoint. Returns which auth providers are enabled for this workspace, ' +
+      'and (when REQUIRE_PROJECT_MEMBERSHIP is on and the hostname maps to a project) ' +
+      'whether public signups are allowed for that project. Used by AuthDialog to decide ' +
+      'which tabs to render.',
+  })
+  async getSiteLoginMethods(@Req() req: Request) {
+    return buildLoginMethodsResponse({
+      featureFlagsService: this.featureFlagsService,
+      setupService: this.setupService,
+      projectResolver: this.projectResolver,
+      req,
+    });
+  }
+
+  @Get('me/login-methods')
   @UseGuards(SessionAuthGuard)
   @ApiOperation({
     summary: 'Get login methods for the current user',
@@ -1118,11 +1137,12 @@ export class AuthController {
       type: 'object',
       properties: {
         hasPassword: { type: 'boolean', description: 'Whether the user has email/password login' },
+        hasGoogle: { type: 'boolean', description: 'Whether the user has linked Google OAuth' },
       },
     },
   })
   @ApiResponse({ status: 401, description: 'Not authenticated' })
-  async getLoginMethods(@Req() req: Request & { session?: SessionContainer }) {
+  async getMyLoginMethods(@Req() req: Request & { session?: SessionContainer }) {
     if (!req.session) {
       throw new UnauthorizedException('No active session');
     }

--- a/apps/backend/src/auth/custom-domain-auth.controller.ts
+++ b/apps/backend/src/auth/custom-domain-auth.controller.ts
@@ -28,6 +28,7 @@ import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 import { EmailService } from '../email/email.service';
 import { ProjectResolverService } from './project-resolver.service';
 import { PermissionsService } from '../permissions/permissions.service';
+import { buildLoginMethodsResponse } from './login-methods.helper';
 import { Project } from '../db/schema';
 import { db } from '../db/client';
 import { users } from '../db/schema';
@@ -809,17 +810,20 @@ export class CustomDomainAuthController {
 
   @Get('login-methods')
   @ApiOperation({
-    summary: 'Get available login methods (in-page, custom domain)',
-    description: 'Public endpoint. Returns whether email/password and Google OAuth are enabled.',
+    summary: 'Get site auth capabilities (custom domain)',
+    description:
+      'Public endpoint. Returns which auth providers are enabled for this workspace, ' +
+      'and (when REQUIRE_PROJECT_MEMBERSHIP is on and the hostname maps to a project) ' +
+      'whether public signups are allowed for that project. Used by AuthDialog to decide ' +
+      'which tabs to render.',
   })
-  async getLoginMethods(): Promise<{ hasPassword: boolean; hasGoogle: boolean }> {
-    let hasGoogle = false;
-    try {
-      hasGoogle = await this.featureFlagsService.isEnabled('ENABLE_GOOGLE_OAUTH');
-    } catch {
-      hasGoogle = false;
-    }
-    return { hasPassword: true, hasGoogle };
+  async getLoginMethods(@Req() req: Request) {
+    return buildLoginMethodsResponse({
+      featureFlagsService: this.featureFlagsService,
+      setupService: this.setupService,
+      projectResolver: this.projectResolver,
+      req,
+    });
   }
 
   @Post('check-email')

--- a/apps/backend/src/auth/login-methods.helper.spec.ts
+++ b/apps/backend/src/auth/login-methods.helper.spec.ts
@@ -1,0 +1,138 @@
+import { Request } from 'express';
+import { buildLoginMethodsResponse } from './login-methods.helper';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import { SetupService } from '../setup/setup.service';
+import { ProjectResolverService } from './project-resolver.service';
+
+const reqStub = {} as Request;
+
+const makeFlags = (
+  values: Partial<Record<'ENABLE_GOOGLE_OAUTH' | 'REQUIRE_PROJECT_MEMBERSHIP', boolean>>,
+): FeatureFlagsService =>
+  ({
+    isEnabled: jest.fn(async (key: string) => values[key as keyof typeof values] ?? false),
+  }) as unknown as FeatureFlagsService;
+
+const makeSetup = (canPublicSignup: boolean): SetupService =>
+  ({
+    canPublicSignup: jest.fn(async () => canPublicSignup),
+  }) as unknown as SetupService;
+
+const makeResolver = (project: { id: string; allowPublicSignup: boolean } | null): ProjectResolverService =>
+  ({
+    resolveProjectFromRequest: jest.fn(async () => project),
+  }) as unknown as ProjectResolverService;
+
+describe('buildLoginMethodsResponse', () => {
+  describe('top-level back-compat fields', () => {
+    it('always returns hasPassword: true and hasGoogle from the workspace flag', async () => {
+      const res = await buildLoginMethodsResponse({
+        featureFlagsService: makeFlags({ ENABLE_GOOGLE_OAUTH: true }),
+        setupService: makeSetup(true),
+        projectResolver: makeResolver(null),
+        req: reqStub,
+      });
+
+      expect(res.hasPassword).toBe(true);
+      expect(res.hasGoogle).toBe(true);
+      // Same values are mirrored under workspace.* — old + new fields agree.
+      expect(res.workspace.hasPassword).toBe(true);
+      expect(res.workspace.hasGoogle).toBe(true);
+    });
+  });
+
+  describe('workspace namespace', () => {
+    it('reports allowSignup from setupService.canPublicSignup()', async () => {
+      const res = await buildLoginMethodsResponse({
+        featureFlagsService: makeFlags({}),
+        setupService: makeSetup(false),
+        projectResolver: makeResolver(null),
+        req: reqStub,
+      });
+
+      expect(res.workspace.allowSignup).toBe(false);
+    });
+
+    it('falls back to hasGoogle=false if the feature-flag lookup throws', async () => {
+      const flags = {
+        isEnabled: jest.fn(async () => {
+          throw new Error('flag service down');
+        }),
+      } as unknown as FeatureFlagsService;
+
+      const res = await buildLoginMethodsResponse({
+        featureFlagsService: flags,
+        setupService: makeSetup(true),
+        projectResolver: makeResolver(null),
+        req: reqStub,
+      });
+
+      expect(res.hasGoogle).toBe(false);
+      expect(res.workspace.hasGoogle).toBe(false);
+    });
+  });
+
+  describe('project namespace', () => {
+    it('omits the project key when REQUIRE_PROJECT_MEMBERSHIP is off', async () => {
+      const resolver = makeResolver({ id: 'p1', allowPublicSignup: false });
+
+      const res = await buildLoginMethodsResponse({
+        featureFlagsService: makeFlags({ REQUIRE_PROJECT_MEMBERSHIP: false }),
+        setupService: makeSetup(true),
+        projectResolver: resolver,
+        req: reqStub,
+      });
+
+      expect(res.project).toBeUndefined();
+      // Resolver should not even be consulted when the master switch is off.
+      expect(resolver.resolveProjectFromRequest).not.toHaveBeenCalled();
+    });
+
+    it('omits the project key when the resolver returns null (admin domain or unknown host)', async () => {
+      const res = await buildLoginMethodsResponse({
+        featureFlagsService: makeFlags({ REQUIRE_PROJECT_MEMBERSHIP: true }),
+        setupService: makeSetup(true),
+        projectResolver: makeResolver(null),
+        req: reqStub,
+      });
+
+      expect(res.project).toBeUndefined();
+    });
+
+    it('includes project.allowSignup=true when project allows it and master switch is on', async () => {
+      const res = await buildLoginMethodsResponse({
+        featureFlagsService: makeFlags({ REQUIRE_PROJECT_MEMBERSHIP: true }),
+        setupService: makeSetup(true),
+        projectResolver: makeResolver({ id: 'p1', allowPublicSignup: true }),
+        req: reqStub,
+      });
+
+      expect(res.project).toEqual({ allowSignup: true });
+    });
+
+    it('includes project.allowSignup=false when project forbids it and master switch is on', async () => {
+      const res = await buildLoginMethodsResponse({
+        featureFlagsService: makeFlags({ REQUIRE_PROJECT_MEMBERSHIP: true }),
+        setupService: makeSetup(true),
+        projectResolver: makeResolver({ id: 'p1', allowPublicSignup: false }),
+        req: reqStub,
+      });
+
+      expect(res.project).toEqual({ allowSignup: false });
+    });
+
+    it('reports project.allowSignup independently from workspace.allowSignup', async () => {
+      // Workspace allows signup but the specific project does not — AuthDialog
+      // must hide the Sign up tab on this project's site.
+      const res = await buildLoginMethodsResponse({
+        featureFlagsService: makeFlags({ REQUIRE_PROJECT_MEMBERSHIP: true }),
+        setupService: makeSetup(true),
+        projectResolver: makeResolver({ id: 'p1', allowPublicSignup: false }),
+        req: reqStub,
+      });
+
+      expect(res.workspace.allowSignup).toBe(true);
+      expect(res.project?.allowSignup).toBe(false);
+    });
+  });
+});

--- a/apps/backend/src/auth/login-methods.helper.ts
+++ b/apps/backend/src/auth/login-methods.helper.ts
@@ -1,0 +1,86 @@
+import { Request } from 'express';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import { SetupService } from '../setup/setup.service';
+import { ProjectResolverService } from './project-resolver.service';
+
+/**
+ * Public site-capability response shared by the workspace-subdomain
+ * (`/api/auth/login-methods`) and custom-domain (`/_bffless/auth/login-methods`)
+ * endpoints. Consumed by AuthDialog to decide which auth UI to render.
+ *
+ * Top-level `hasPassword`/`hasGoogle` are kept for backwards compatibility
+ * with older AuthDialog bundles. New code should read from `workspace.*` and
+ * the optional `project.*`.
+ */
+export interface LoginMethodsResponse {
+  /** @deprecated Use `workspace.hasPassword`. Kept for older AuthDialog versions. */
+  hasPassword: boolean;
+  /** @deprecated Use `workspace.hasGoogle`. Kept for older AuthDialog versions. */
+  hasGoogle: boolean;
+  workspace: {
+    hasPassword: boolean;
+    hasGoogle: boolean;
+    /**
+     * Whether this workspace accepts new public signups at all (admin kill
+     * switch + the `canPublicSignup` toggle). When false, no project can
+     * accept signups regardless of its own setting.
+     */
+    allowSignup: boolean;
+  };
+  /**
+   * Per-project signup gate. Present only when REQUIRE_PROJECT_MEMBERSHIP is
+   * on AND the request hostname resolves to a project. Absent on the admin
+   * domain or when the master switch is off.
+   */
+  project?: {
+    allowSignup: boolean;
+  };
+}
+
+interface BuildOpts {
+  featureFlagsService: FeatureFlagsService;
+  setupService: SetupService;
+  projectResolver: ProjectResolverService;
+  req: Request;
+}
+
+/**
+ * Build the public site-capability response. Pulls workspace-level
+ * provider/signup info from the existing services and consults the Phase A
+ * project resolver only when `REQUIRE_PROJECT_MEMBERSHIP` is enabled.
+ */
+export async function buildLoginMethodsResponse({
+  featureFlagsService,
+  setupService,
+  projectResolver,
+  req,
+}: BuildOpts): Promise<LoginMethodsResponse> {
+  const hasPassword = true; // Email/password is always available in CE.
+
+  const hasGoogle = await featureFlagsService
+    .isEnabled('ENABLE_GOOGLE_OAUTH')
+    .catch(() => false);
+
+  // canPublicSignup() already AND's isRegistrationFeatureEnabled internally
+  // (see setup.service.ts), so a single call captures the workspace gate.
+  const workspaceAllowSignup = await setupService.canPublicSignup().catch(() => false);
+
+  const membershipGateOn = await featureFlagsService
+    .isEnabled('REQUIRE_PROJECT_MEMBERSHIP')
+    .catch(() => false);
+
+  const project = membershipGateOn
+    ? await projectResolver.resolveProjectFromRequest(req)
+    : null;
+
+  return {
+    hasPassword,
+    hasGoogle,
+    workspace: {
+      hasPassword,
+      hasGoogle,
+      allowSignup: workspaceAllowSignup,
+    },
+    ...(project ? { project: { allowSignup: project.allowPublicSignup } } : {}),
+  };
+}

--- a/apps/frontend/src/services/authApi.ts
+++ b/apps/frontend/src/services/authApi.ts
@@ -215,7 +215,11 @@ export const authApi = api.injectEndpoints({
     }),
 
     getLoginMethods: builder.query<LoginMethodsResponse, void>({
-      query: () => '/api/auth/login-methods',
+      // User-scoped (returns the current user's linked methods, used by the
+      // change-password card). The site-capability endpoint at the same name
+      // moved here when /api/auth/login-methods was reclaimed for the public
+      // AuthDialog probe.
+      query: () => '/api/auth/me/login-methods',
     }),
 
     changePassword: builder.mutation<ChangePasswordResponse, ChangePasswordDto>({


### PR DESCRIPTION
## Summary

The `/login-methods` name was overloaded across the two auth controllers:
- `/api/auth/login-methods` was **authenticated** and returned the *current user's* linked auth methods (used by the change-password card in admin Settings).
- `/_bffless/auth/login-methods` was **public** and returned the *site's* auth capabilities (called by AuthDialog at boot).

Stacking the new per-project `allowSignup` field on either side was going to compound the confusion, so disambiguate first.

## Endpoint changes

| Path | Auth | Purpose |
|---|---|---|
| `/api/auth/me/login-methods` (renamed from `/api/auth/login-methods`) | Required | This user's `{ hasPassword, hasGoogle }`. Used by the change-password card. |
| `/api/auth/login-methods` (new) | Public | Site capabilities. Mirrors `/_bffless/auth/login-methods`. |
| `/_bffless/auth/login-methods` | Public | Site capabilities (existing endpoint, response shape extended). |

One frontend caller updated: `apps/frontend/src/services/authApi.ts:218` now calls `/api/auth/me/login-methods`. No other consumers.

## New response shape (both public endpoints)

```ts
{
  // @deprecated — kept for older AuthDialog bundles in the wild
  hasPassword: true,
  hasGoogle: false,

  workspace: {
    hasPassword: true,
    hasGoogle: false,
    allowSignup: true,         // setupService.canPublicSignup() — workspace kill switch
  },
  // Present ONLY when REQUIRE_PROJECT_MEMBERSHIP is on AND the hostname
  // maps to a project. Absent on admin domain or when master switch is off.
  project: {
    allowSignup: false,        // projects.allowPublicSignup
  },
}
```

Both controllers route through a shared `buildLoginMethodsResponse()` helper that owns all the resolution logic. Reuses the Phase A `ProjectResolverService`.

## Why namespace?

`hasPassword` and `hasGoogle` are workspace-level concepts. `allowSignup` exists at both layers (workspace kill switch + per-project toggle). A flat field named `allowSignup` would conflict the moment we expose the workspace-level value. Namespacing makes the layering explicit and gives a clear home to future per-layer fields (e.g. `project.allowedAuthProviders`).

## Companion components PR

[`bffless/components#fix/auth-dialog-signup-gate`](https://github.com/bffless/components/pull/new/fix/auth-dialog-signup-gate) consumes the new shape: AuthDialog hides the "switch to sign up" button and replaces the Sign up form with a friendly disabled panel when `canSignup` is false. Also maps the new `PUBLIC_SIGNUP_DISABLED` status / "Public signups are not enabled" message to a new `signup_disabled` error code. Without this PR, AuthDialog falls back to defaults (signup allowed) so consumer sites continue working.

## Test plan

- [x] `pnpm --filter backend exec tsc --noEmit` — clean
- [x] `pnpm --filter frontend exec tsc --noEmit` — clean
- [x] `pnpm jest src/auth/` — 65/65 pass (incl. 8 new helper cases)
- [ ] Manual: with `REQUIRE_PROJECT_MEMBERSHIP=true` and a project where `allowPublicSignup=false`, GET `/_bffless/auth/login-methods` from that project's hostname returns `project: { allowSignup: false }`
- [ ] Manual: GET from admin domain returns no `project` key
- [ ] Manual: with master switch off, GET from any hostname returns no `project` key
- [ ] Manual: admin Settings → "Change password" card still loads (uses the renamed `/me/login-methods`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)