### PR TITLE
feat(auth): project-membership gate for /session endpoints (Phase B)

### DIFF
--- a/apps/backend/src/auth/auth.controller.spec.ts
+++ b/apps/backend/src/auth/auth.controller.spec.ts
@@ -1,0 +1,170 @@
+import { Request } from 'express';
+import { UnauthorizedException } from '@nestjs/common';
+
+// Mock the database client used for the pending-invitation lookup branch.
+jest.mock('../db/client', () => ({
+  db: {
+    select: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockResolvedValue([]),
+  },
+}));
+
+// Mock the supertokens-node top-level imports used by getSession.
+jest.mock('supertokens-node', () => ({
+  __esModule: true,
+  getUser: jest.fn(),
+  listUsersByAccountInfo: jest.fn(),
+  RecipeUserId: jest.fn().mockImplementation((id: string) => ({ getAsString: () => id })),
+}));
+
+jest.mock('supertokens-node/recipe/emailverification', () => ({
+  __esModule: true,
+  default: {
+    isEmailVerified: jest.fn().mockResolvedValue(true),
+  },
+}));
+
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { SetupService } from '../setup/setup.service';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import { OnboardingExecutorService } from '../onboarding-rules/onboarding-executor.service';
+import { DomainTokenService } from './domain-token.service';
+import { ProjectInviteLinksService } from '../project-invite-links/project-invite-links.service';
+import { ProjectResolverService } from './project-resolver.service';
+import { PermissionsService } from '../permissions/permissions.service';
+
+const SESSION_USER_ID = 'user-1';
+const SESSION_HANDLE = 'session-handle-1';
+
+const reqWithSession = (): Request & { session: any } =>
+  ({
+    headers: { host: 'foo.sites.bffless.app' },
+    session: {
+      getUserId: () => SESSION_USER_ID,
+      getHandle: () => SESSION_HANDLE,
+    },
+  }) as unknown as Request & { session: any };
+
+describe('AuthController.getSession (project-membership gate, Phase B)', () => {
+  let controller: AuthController;
+  let authService: jest.Mocked<AuthService>;
+  let featureFlags: jest.Mocked<FeatureFlagsService>;
+  let projectResolver: jest.Mocked<ProjectResolverService>;
+  let permissions: jest.Mocked<PermissionsService>;
+
+  const dbUser = { id: SESSION_USER_ID, email: 'a@example.com', role: 'member' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    authService = {
+      getUserById: jest.fn().mockResolvedValue(dbUser),
+      getUserByEmail: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<AuthService>;
+
+    featureFlags = {
+      isEnabled: jest.fn().mockResolvedValue(false),
+    } as unknown as jest.Mocked<FeatureFlagsService>;
+
+    projectResolver = {
+      resolveProjectFromRequest: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<ProjectResolverService>;
+
+    permissions = {
+      getUserProjectRole: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<PermissionsService>;
+
+    controller = new AuthController(
+      authService,
+      {} as SetupService,
+      featureFlags,
+      {} as OnboardingExecutorService,
+      {} as DomainTokenService,
+      {} as ProjectInviteLinksService,
+      projectResolver,
+      permissions,
+    );
+  });
+
+  it('throws when there is no session', async () => {
+    await expect(
+      controller.getSession({ headers: {} } as unknown as Request & { session?: any }),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('returns the user normally when the master switch is OFF (no resolver call)', async () => {
+    featureFlags.isEnabled.mockResolvedValue(false);
+
+    const result: any = await controller.getSession(reqWithSession());
+
+    expect(result.user).toEqual({ id: dbUser.id, email: dbUser.email, role: dbUser.role });
+    expect(projectResolver.resolveProjectFromRequest).not.toHaveBeenCalled();
+    expect(permissions.getUserProjectRole).not.toHaveBeenCalled();
+  });
+
+  it('returns the user normally when admin domain (resolver returns null)', async () => {
+    featureFlags.isEnabled.mockResolvedValue(true);
+    projectResolver.resolveProjectFromRequest.mockResolvedValue(null);
+
+    const result: any = await controller.getSession(reqWithSession());
+
+    expect(result.user).toEqual({ id: dbUser.id, email: dbUser.email, role: dbUser.role });
+    expect(permissions.getUserProjectRole).not.toHaveBeenCalled();
+  });
+
+  it('returns { user: null } when project resolves and user has no membership', async () => {
+    featureFlags.isEnabled.mockResolvedValue(true);
+    projectResolver.resolveProjectFromRequest.mockResolvedValue({
+      id: 'proj-1',
+      allowPublicSignup: false,
+    } as any);
+    permissions.getUserProjectRole.mockResolvedValue(null);
+
+    const result: any = await controller.getSession(reqWithSession());
+
+    expect(result).toEqual({
+      session: { userId: SESSION_USER_ID, handle: SESSION_HANDLE },
+      user: null,
+      emailVerified: false,
+      emailVerificationRequired: false,
+    });
+    // Cheap-path optimisation: we should not have hit the DB for the user.
+    expect(authService.getUserById).not.toHaveBeenCalled();
+  });
+
+  it('returns the user when project resolves and user IS a member', async () => {
+    featureFlags.isEnabled.mockResolvedValue(true);
+    projectResolver.resolveProjectFromRequest.mockResolvedValue({
+      id: 'proj-1',
+      allowPublicSignup: false,
+    } as any);
+    permissions.getUserProjectRole.mockResolvedValue('guest');
+
+    const result: any = await controller.getSession(reqWithSession());
+
+    expect(result.user).toEqual({ id: dbUser.id, email: dbUser.email, role: dbUser.role });
+    expect(permissions.getUserProjectRole).toHaveBeenCalledWith(SESSION_USER_ID, 'proj-1');
+  });
+
+  it('uses the SuperTokens session userId for the membership check (works even if DB user is missing)', async () => {
+    // Pending-invitation-style scenario: signed-in via SuperTokens but no DB user yet.
+    // The gate must still trip before falling into the invitation branch when the
+    // request hits a project subdomain. The session userId is the unified ID.
+    featureFlags.isEnabled.mockResolvedValue(true);
+    projectResolver.resolveProjectFromRequest.mockResolvedValue({
+      id: 'proj-1',
+      allowPublicSignup: false,
+    } as any);
+    permissions.getUserProjectRole.mockResolvedValue(null);
+    authService.getUserById.mockResolvedValue(null);
+
+    const result: any = await controller.getSession(reqWithSession());
+
+    expect(result.user).toBeNull();
+    expect(permissions.getUserProjectRole).toHaveBeenCalledWith(SESSION_USER_ID, 'proj-1');
+    expect(authService.getUserById).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -570,6 +570,31 @@ export class AuthController {
       const userId = req.session.getUserId();
       const sessionHandle = req.session.getHandle();
 
+      // Project-membership gate (REQUIRE_PROJECT_MEMBERSHIP master switch).
+      // Closes the parent-domain cookie bleed across *.bffless.app: a user with
+      // a workspace SuperTokens cookie who lands on a sister site they have no
+      // membership in is reported as anonymous here. Cookie is intentionally
+      // NOT cleared — it may still be valid for sites where they ARE a member.
+      // Runs early so we short-circuit before the more expensive lookups.
+      // Admin domain (resolver returns null) and pending-invitation flow on
+      // admin domain are unaffected. A pending workspace invitation that
+      // somehow lands on a project subdomain is correctly treated as anonymous
+      // there (no project membership row exists).
+      if (await this.featureFlagsService.isEnabled('REQUIRE_PROJECT_MEMBERSHIP')) {
+        const project = await this.projectResolver.resolveProjectFromRequest(req);
+        if (project) {
+          const role = await this.permissions.getUserProjectRole(userId, project.id);
+          if (!role) {
+            return {
+              session: { userId, handle: sessionHandle },
+              user: null,
+              emailVerified: false,
+              emailVerificationRequired: false,
+            };
+          }
+        }
+      }
+
       // Look up user in our database by user ID
       let user = await this.authService.getUserById(userId);
 

--- a/apps/backend/src/auth/custom-domain-auth.controller.spec.ts
+++ b/apps/backend/src/auth/custom-domain-auth.controller.spec.ts
@@ -1,0 +1,181 @@
+import { Request, Response } from 'express';
+
+// Mock the database client used by trySupertokensSession's user lookup.
+const dbLimitMock = jest.fn();
+jest.mock('../db/client', () => ({
+  db: {
+    select: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    limit: () => dbLimitMock(),
+  },
+}));
+
+// Mock the SuperTokens fallback path used when no bffless_access cookie is present.
+const getSessionMock = jest.fn();
+jest.mock('supertokens-node/recipe/session', () => ({
+  __esModule: true,
+  getSession: (...args: any[]) => getSessionMock(...args),
+}));
+
+import { CustomDomainAuthController } from './custom-domain-auth.controller';
+import { CustomDomainAuthService } from './custom-domain-auth.service';
+import { DomainTokenService } from './domain-token.service';
+import { AuthService } from './auth.service';
+import { SetupService } from '../setup/setup.service';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import { EmailService } from '../email/email.service';
+import { ProjectResolverService } from './project-resolver.service';
+import { PermissionsService } from '../permissions/permissions.service';
+
+const HOST = 'foo.sites.bffless.app';
+
+const reqWithCookie = (accessToken?: string): Request =>
+  ({
+    headers: { host: HOST },
+    cookies: accessToken ? { [CustomDomainAuthService.ACCESS_COOKIE_NAME]: accessToken } : {},
+  }) as unknown as Request;
+
+const passthroughRes = (): Response =>
+  ({
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  }) as unknown as Response;
+
+describe('CustomDomainAuthController.session (project-membership gate, Phase B)', () => {
+  let controller: CustomDomainAuthController;
+  let customDomainAuthService: jest.Mocked<CustomDomainAuthService>;
+  let featureFlags: jest.Mocked<FeatureFlagsService>;
+  let projectResolver: jest.Mocked<ProjectResolverService>;
+  let permissions: jest.Mocked<PermissionsService>;
+
+  const validPayload = {
+    sub: 'user-1',
+    email: 'a@example.com',
+    role: 'member',
+    domain: HOST,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dbLimitMock.mockReset();
+
+    customDomainAuthService = {
+      validateAccessToken: jest.fn().mockReturnValue(validPayload),
+      isAccessTokenExpired: jest.fn().mockReturnValue(false),
+    } as unknown as jest.Mocked<CustomDomainAuthService>;
+
+    featureFlags = {
+      isEnabled: jest.fn().mockResolvedValue(false),
+    } as unknown as jest.Mocked<FeatureFlagsService>;
+
+    projectResolver = {
+      resolveProjectFromRequest: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<ProjectResolverService>;
+
+    permissions = {
+      getUserProjectRole: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<PermissionsService>;
+
+    controller = new CustomDomainAuthController(
+      {} as DomainTokenService,
+      customDomainAuthService,
+      {} as AuthService,
+      {} as SetupService,
+      featureFlags,
+      {} as EmailService,
+      projectResolver,
+      permissions,
+    );
+  });
+
+  describe('JWT cookie path (bffless_access)', () => {
+    it('returns authenticated when the master switch is OFF (no resolver call)', async () => {
+      featureFlags.isEnabled.mockResolvedValue(false);
+
+      const result = await controller.session(reqWithCookie('valid'), passthroughRes());
+
+      expect(result).toEqual({
+        authenticated: true,
+        user: { id: validPayload.sub, email: validPayload.email, role: validPayload.role },
+      });
+      expect(projectResolver.resolveProjectFromRequest).not.toHaveBeenCalled();
+    });
+
+    it('returns authenticated on admin domain (resolver returns null)', async () => {
+      featureFlags.isEnabled.mockResolvedValue(true);
+      projectResolver.resolveProjectFromRequest.mockResolvedValue(null);
+
+      const result = await controller.session(reqWithCookie('valid'), passthroughRes());
+
+      expect(result).toEqual({
+        authenticated: true,
+        user: { id: validPayload.sub, email: validPayload.email, role: validPayload.role },
+      });
+      expect(permissions.getUserProjectRole).not.toHaveBeenCalled();
+    });
+
+    it('returns { authenticated: false, user: null } when project resolves and user is not a member', async () => {
+      featureFlags.isEnabled.mockResolvedValue(true);
+      projectResolver.resolveProjectFromRequest.mockResolvedValue({ id: 'proj-1' } as any);
+      permissions.getUserProjectRole.mockResolvedValue(null);
+
+      const result = await controller.session(reqWithCookie('valid'), passthroughRes());
+
+      expect(result).toEqual({ authenticated: false, user: null });
+      expect(permissions.getUserProjectRole).toHaveBeenCalledWith(validPayload.sub, 'proj-1');
+    });
+
+    it('returns authenticated when project resolves and user IS a member', async () => {
+      featureFlags.isEnabled.mockResolvedValue(true);
+      projectResolver.resolveProjectFromRequest.mockResolvedValue({ id: 'proj-1' } as any);
+      permissions.getUserProjectRole.mockResolvedValue('guest');
+
+      const result = await controller.session(reqWithCookie('valid'), passthroughRes());
+
+      expect(result).toEqual({
+        authenticated: true,
+        user: { id: validPayload.sub, email: validPayload.email, role: validPayload.role },
+      });
+    });
+  });
+
+  describe('SuperTokens fallback path (no bffless_access cookie)', () => {
+    const stUser = { id: 'user-1', email: 'a@example.com', role: 'member' };
+
+    beforeEach(() => {
+      getSessionMock.mockResolvedValue({ getUserId: () => stUser.id });
+      dbLimitMock.mockResolvedValue([stUser]);
+    });
+
+    it('returns authenticated when the master switch is OFF', async () => {
+      featureFlags.isEnabled.mockResolvedValue(false);
+
+      const result = await controller.session(reqWithCookie(undefined), passthroughRes());
+
+      expect(result).toEqual({ authenticated: true, user: stUser });
+      expect(projectResolver.resolveProjectFromRequest).not.toHaveBeenCalled();
+    });
+
+    it('returns { authenticated: false, user: null } when project resolves and no membership', async () => {
+      featureFlags.isEnabled.mockResolvedValue(true);
+      projectResolver.resolveProjectFromRequest.mockResolvedValue({ id: 'proj-1' } as any);
+      permissions.getUserProjectRole.mockResolvedValue(null);
+
+      const result = await controller.session(reqWithCookie(undefined), passthroughRes());
+
+      expect(result).toEqual({ authenticated: false, user: null });
+      expect(permissions.getUserProjectRole).toHaveBeenCalledWith(stUser.id, 'proj-1');
+    });
+
+    it('returns authenticated when project resolves and user IS a member', async () => {
+      featureFlags.isEnabled.mockResolvedValue(true);
+      projectResolver.resolveProjectFromRequest.mockResolvedValue({ id: 'proj-1' } as any);
+      permissions.getUserProjectRole.mockResolvedValue('viewer');
+
+      const result = await controller.session(reqWithCookie(undefined), passthroughRes());
+
+      expect(result).toEqual({ authenticated: true, user: stUser });
+    });
+  });
+});

--- a/apps/backend/src/auth/custom-domain-auth.controller.ts
+++ b/apps/backend/src/auth/custom-domain-auth.controller.ts
@@ -80,6 +80,19 @@ export class CustomDomainAuthController {
     return this.projectResolver.resolveProjectFromRequest(req);
   }
 
+  /**
+   * True when the user passes the project-membership gate for this request.
+   * Returns true (pass) when the master switch is off OR the hostname doesn't
+   * resolve to a project (admin/legacy flow). Used by /session to refuse to
+   * expose a signed-in user on sites they have no membership in.
+   */
+  private async userHasProjectMembership(req: Request, userId: string): Promise<boolean> {
+    const project = await this.resolveGatedProject(req);
+    if (!project) return true;
+    const role = await this.permissions.getUserProjectRole(userId, project.id);
+    return Boolean(role);
+  }
+
   private getTenantId(): string {
     const isMultiTenant = process.env.SUPERTOKENS_MULTI_TENANT === 'true';
     return isMultiTenant
@@ -377,6 +390,10 @@ export class CustomDomainAuthController {
       }
     }
 
+    if (!(await this.userHasProjectMembership(req, payload.sub))) {
+      return { authenticated: false, user: null };
+    }
+
     return {
       authenticated: true,
       user: {
@@ -409,6 +426,10 @@ export class CustomDomainAuthController {
       const [user] = await db.select().from(users).where(eq(users.id, userId)).limit(1);
 
       if (!user) {
+        return { authenticated: false, user: null };
+      }
+
+      if (!(await this.userHasProjectMembership(req, user.id))) {
         return { authenticated: false, user: null };
       }
 


### PR DESCRIPTION
## Summary

Phase B of [project-membership-gated auth](../stories/backlog/phase-project-membership-auth/README.md) — closes the parent-domain cookie bleed across `*.bffless.app`.

A user with a workspace SuperTokens cookie who lands on a sister site they have no membership in is now reported as anonymous by `/session`. Cookie is left intact (it may still be valid on sites where they ARE a member). `AuthDialog` will render Sign in instead of treating them as logged in.

- **`AuthController.getSession`** — gate runs early on `req.session.getUserId()` and short-circuits before the DB user lookup. Uses the unified session ID so it also handles the pending-invitation path on a project subdomain.
- **`CustomDomainAuthController.session`** — new `userHasProjectMembership(req, userId)` helper called from both code paths: JWT cookie path (after `validateAccessToken`) and the SuperTokens fallback (after DB user lookup). Both return `{ authenticated: false, user: null }` on miss.
- Master switch (`REQUIRE_PROJECT_MEMBERSHIP`) and admin-domain bypass inherited from Phase A's `ProjectResolverService` — flag off / admin domain → zero behavior change.

Builds on Phase A (#232).

## Test plan

- [x] New `auth.controller.spec.ts` (6 cases) covers: flag-off bypass, admin-domain bypass, non-member → `{ user: null }`, member → user passes through, no-DB-user / pending-invitation interaction.
- [x] New `custom-domain-auth.controller.spec.ts` (7 cases) covers the same matrix on both the JWT cookie path and the SuperTokens fallback path.
- [x] All 78 auth specs pass; full backend suite (966 tests) green.
- [x] `tsc --noEmit` clean.
- [ ] Manual: with `REQUIRE_PROJECT_MEMBERSHIP=true`, sign in on `foo.sites.bffless.app`, navigate to `bar.sites.bffless.app` (where user is not a member) — `AuthDialog` should render Sign in, not signed-in state. Navigating back to `foo` should still show signed in.
- [ ] Manual: with `REQUIRE_PROJECT_MEMBERSHIP=false` (default), behavior unchanged across sister sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)