### PR TITLE
feat(auth): project-membership guard for data routes (Phase C)

### DIFF
--- a/apps/backend/src/auth/README.md
+++ b/apps/backend/src/auth/README.md
@@ -66,6 +66,20 @@ getAllUsers() {
 }
 ```
 
+#### ProjectMembershipGuard (global, default-on)
+
+Registered as `APP_GUARD`, runs after route-level auth guards. When the workspace feature flag `REQUIRE_PROJECT_MEMBERSHIP` is enabled and the inbound hostname resolves to a project, every authenticated request is required to hold a `project_permissions` row for that project — otherwise the guard throws `ForbiddenException`.
+
+The guard is a no-op when:
+
+- The workspace flag is off (legacy "any workspace user authenticates anywhere" behavior).
+- The route (or controller) is annotated with `@PublicProjectAccess()`.
+- The request is unauthenticated (`req.user` not populated).
+- The request authenticates via API key (`req.user.apiKeyId` set) — keys are CI/CD credentials and `ApiKeyGuard` already enforces project scope.
+- The hostname resolves to no project — admin domain, unknown hostname.
+
+If your new authenticated route should be reachable by any workspace user regardless of which project the hostname maps to (account management, cross-project dashboards, control-plane internal calls), annotate the controller method or class with `@PublicProjectAccess()`.
+
 ### Decorators
 
 #### @Public()
@@ -89,6 +103,19 @@ Specifies required roles for a route.
 @Delete('users/:id')
 deleteUser(@Param('id') id: string) {
   // Only admins and moderators can access
+}
+```
+
+#### @PublicProjectAccess()
+
+Bypasses the global `ProjectMembershipGuard`. Use on workspace-level admin endpoints, cross-project endpoints, or routes that already enforce membership inline (and would have their controlled error shape pre-empted by a generic 403).
+
+```typescript
+@PublicProjectAccess()
+@Controller('api/me/projects')
+export class MyProjectsController {
+  // Hit on any workspace subdomain — listing the user's memberships across
+  // projects is by definition cross-project, so the per-project gate is bypassed.
 }
 ```
 

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -24,6 +24,7 @@ import { DomainTokenService } from './domain-token.service';
 import { ProjectInviteLinksService } from '../project-invite-links/project-invite-links.service';
 import { ProjectResolverService } from './project-resolver.service';
 import { PermissionsService } from '../permissions/permissions.service';
+import { PublicProjectAccess } from './decorators/public-project-access.decorator';
 import { buildLoginMethodsResponse } from './login-methods.helper';
 import { CreateDomainTokenDto } from './dto/create-domain-token.dto';
 import { db } from '../db/client';
@@ -72,6 +73,10 @@ interface ChangePasswordDto {
 
 @ApiTags('Authentication')
 @Controller('api/auth')
+// AuthController routes enforce project membership inline (Phase A: signin/signup,
+// Phase B: getSession returns `{ user: null }`). Bypass the global Phase C guard
+// so those controlled response shapes aren't pre-empted by a 403.
+@PublicProjectAccess()
 export class AuthController {
   private readonly logger = new (require('@nestjs/common').Logger)(AuthController.name);
 

--- a/apps/backend/src/auth/auth.module.ts
+++ b/apps/backend/src/auth/auth.module.ts
@@ -11,6 +11,7 @@ import { ApiKeyGuard } from './api-key.guard';
 import { OptionalAuthGuard } from './optional-auth.guard';
 import { RolesGuard } from './roles.guard';
 import { EmailVerificationGuard } from './email-verification.guard';
+import { ProjectMembershipGuard } from './project-membership.guard';
 import { initSuperTokens, registerGoogleOAuthFromEnv } from './supertokens.config';
 import { SetupModule } from '../setup/setup.module';
 import { OnboardingRulesModule } from '../onboarding-rules/onboarding-rules.module';
@@ -53,11 +54,16 @@ export class AuthModule implements NestModule {
         OptionalAuthGuard,
         RolesGuard,
         EmailVerificationGuard,
+        ProjectMembershipGuard,
         VisibilityService, // Required for AuthMiddleware
         ProjectResolverService,
         {
           provide: APP_GUARD,
           useClass: EmailVerificationGuard,
+        },
+        {
+          provide: APP_GUARD,
+          useClass: ProjectMembershipGuard,
         },
       ],
       exports: [
@@ -69,6 +75,7 @@ export class AuthModule implements NestModule {
         OptionalAuthGuard,
         RolesGuard,
         EmailVerificationGuard,
+        ProjectMembershipGuard,
         ProjectResolverService,
       ],
     };

--- a/apps/backend/src/auth/custom-domain-auth.controller.ts
+++ b/apps/backend/src/auth/custom-domain-auth.controller.ts
@@ -28,6 +28,7 @@ import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 import { EmailService } from '../email/email.service';
 import { ProjectResolverService } from './project-resolver.service';
 import { PermissionsService } from '../permissions/permissions.service';
+import { PublicProjectAccess } from './decorators/public-project-access.decorator';
 import { buildLoginMethodsResponse } from './login-methods.helper';
 import { Project } from '../db/schema';
 import { db } from '../db/client';
@@ -53,6 +54,11 @@ import { users } from '../db/schema';
  */
 @ApiTags('Custom Domain Authentication')
 @Controller('_bffless/auth')
+// Routes here enforce project membership inline (Phase A: signin/signup,
+// Phase B: /session via `userHasProjectMembership`). Bypass the global Phase C
+// guard so those controlled response shapes (`{ authenticated: false, user: null }`,
+// 401 with the same message used for wrong credentials) survive.
+@PublicProjectAccess()
 export class CustomDomainAuthController {
   private readonly logger = new Logger(CustomDomainAuthController.name);
 

--- a/apps/backend/src/auth/decorators/public-project-access.decorator.ts
+++ b/apps/backend/src/auth/decorators/public-project-access.decorator.ts
@@ -1,0 +1,21 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const PUBLIC_PROJECT_ACCESS_KEY = 'publicProjectAccess';
+
+/**
+ * Mark a route (or controller) as bypassing the global ProjectMembershipGuard.
+ *
+ * Use for routes that legitimately serve any authenticated user regardless of
+ * which project the inbound hostname resolves to. Examples:
+ *
+ *   - Admin/workspace-wide endpoints (user management, billing, project list).
+ *   - Cross-project endpoints (e.g., a future `/api/me/projects` listing).
+ *   - Public-content controllers that intentionally serve sister-site visitors.
+ *   - Auth endpoints that already enforce membership inline (`AuthController`,
+ *     `CustomDomainAuthController` — see Phase A and Phase B), so the guard
+ *     would otherwise pre-empt their controlled response shapes.
+ *
+ * Greppable: `git grep '@PublicProjectAccess'` lists every cross-project
+ * endpoint that bypasses the membership gate.
+ */
+export const PublicProjectAccess = () => SetMetadata(PUBLIC_PROJECT_ACCESS_KEY, true);

--- a/apps/backend/src/auth/index.ts
+++ b/apps/backend/src/auth/index.ts
@@ -9,11 +9,13 @@ export { SessionAuthGuard } from './session-auth.guard';
 export { ApiKeyGuard } from './api-key.guard';
 export { RolesGuard } from './roles.guard';
 export { EmailVerificationGuard } from './email-verification.guard';
+export { ProjectMembershipGuard } from './project-membership.guard';
 
 // Decorators
 export { Roles } from './decorators/roles.decorator';
 export { Public } from './decorators/public.decorator';
 export { SkipEmailVerification } from './decorators/skip-email-verification.decorator';
+export { PublicProjectAccess } from './decorators/public-project-access.decorator';
 export { CurrentUser, CurrentUserData } from './decorators/current-user.decorator';
 
 // Middleware

--- a/apps/backend/src/auth/project-membership.guard.spec.ts
+++ b/apps/backend/src/auth/project-membership.guard.spec.ts
@@ -1,0 +1,122 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ProjectMembershipGuard } from './project-membership.guard';
+import { ProjectResolverService } from './project-resolver.service';
+import { PermissionsService } from '../permissions/permissions.service';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+
+describe('ProjectMembershipGuard', () => {
+  let guard: ProjectMembershipGuard;
+  let reflector: { getAllAndOverride: jest.Mock };
+  let featureFlags: { isEnabled: jest.Mock };
+  let projectResolver: { resolveProjectFromRequest: jest.Mock };
+  let permissions: { getUserProjectRole: jest.Mock };
+
+  const buildContext = (req: any): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => req,
+        getResponse: () => ({}),
+      }),
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(async () => {
+    reflector = { getAllAndOverride: jest.fn().mockReturnValue(false) };
+    featureFlags = { isEnabled: jest.fn().mockResolvedValue(true) };
+    projectResolver = { resolveProjectFromRequest: jest.fn() };
+    permissions = { getUserProjectRole: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProjectMembershipGuard,
+        { provide: Reflector, useValue: reflector },
+        { provide: FeatureFlagsService, useValue: featureFlags },
+        { provide: ProjectResolverService, useValue: projectResolver },
+        { provide: PermissionsService, useValue: permissions },
+      ],
+    }).compile();
+
+    guard = module.get(ProjectMembershipGuard);
+  });
+
+  it('passes when @PublicProjectAccess() is set on the route', async () => {
+    reflector.getAllAndOverride.mockReturnValue(true);
+
+    const ctx = buildContext({ user: { id: 'u1' }, headers: { host: 'foo.example.com' } });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(featureFlags.isEnabled).not.toHaveBeenCalled();
+    expect(projectResolver.resolveProjectFromRequest).not.toHaveBeenCalled();
+  });
+
+  it('passes when REQUIRE_PROJECT_MEMBERSHIP is off (legacy behavior)', async () => {
+    featureFlags.isEnabled.mockResolvedValue(false);
+
+    const ctx = buildContext({ user: { id: 'u1' }, headers: { host: 'foo.example.com' } });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(projectResolver.resolveProjectFromRequest).not.toHaveBeenCalled();
+  });
+
+  it('passes when no user is attached (anonymous request)', async () => {
+    const ctx = buildContext({ headers: { host: 'foo.example.com' } });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(projectResolver.resolveProjectFromRequest).not.toHaveBeenCalled();
+  });
+
+  it('passes when the request is authenticated via API key', async () => {
+    const ctx = buildContext({
+      user: { id: 'u1', apiKeyId: 'key-1' },
+      headers: { host: 'foo.example.com' },
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(projectResolver.resolveProjectFromRequest).not.toHaveBeenCalled();
+  });
+
+  it('passes when the hostname does not resolve to a project (admin/legacy)', async () => {
+    projectResolver.resolveProjectFromRequest.mockResolvedValue(null);
+
+    const ctx = buildContext({
+      user: { id: 'u1' },
+      headers: { host: 'admin.bffless.app' },
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(permissions.getUserProjectRole).not.toHaveBeenCalled();
+  });
+
+  it('passes when the user has a role on the resolved project', async () => {
+    projectResolver.resolveProjectFromRequest.mockResolvedValue({ id: 'p1' });
+    permissions.getUserProjectRole.mockResolvedValue('viewer');
+
+    const ctx = buildContext({
+      user: { id: 'u1' },
+      headers: { host: 'foo.bffless.app' },
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(permissions.getUserProjectRole).toHaveBeenCalledWith('u1', 'p1');
+  });
+
+  it('throws ForbiddenException when the user has no role on the resolved project', async () => {
+    projectResolver.resolveProjectFromRequest.mockResolvedValue({ id: 'p1' });
+    permissions.getUserProjectRole.mockResolvedValue(null);
+
+    const ctx = buildContext({
+      user: { id: 'u1' },
+      headers: { host: 'bar.bffless.app' },
+    });
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('checks the class-level decorator before the handler-level decorator', async () => {
+    // getAllAndOverride merges both; we rely on it returning the truthy override.
+    reflector.getAllAndOverride.mockReturnValue(true);
+
+    const ctx = buildContext({
+      user: { id: 'u1' },
+      headers: { host: 'bar.bffless.app' },
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(featureFlags.isEnabled).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/auth/project-membership.guard.ts
+++ b/apps/backend/src/auth/project-membership.guard.ts
@@ -1,0 +1,94 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import { ProjectResolverService } from './project-resolver.service';
+import { PermissionsService } from '../permissions/permissions.service';
+import { PUBLIC_PROJECT_ACCESS_KEY } from './decorators/public-project-access.decorator';
+
+/**
+ * Phase C: Defense-in-depth gate that prevents a user with a valid workspace
+ * session from interacting with project-scoped data routes on a sister site
+ * they have no membership in.
+ *
+ * Phase A blocks fresh signins by non-members. Phase B reports non-members as
+ * `{ user: null }` from `/session` so the AuthDialog UI hides personalized
+ * features. But the cookie is still valid: a malicious client could skip the
+ * UI and POST directly to a data route. This guard closes that gap on every
+ * route that authenticates a user, defaulting to deny when:
+ *
+ *   1. The workspace master switch `REQUIRE_PROJECT_MEMBERSHIP` is on,
+ *   2. The request hostname resolves to a project (not the admin domain),
+ *   3. A user is already attached to the request (an auth guard ran before
+ *      this one and populated `req.user`),
+ *   4. That user holds NO project_permissions row for the resolved project.
+ *
+ * Pass-through cases (return true without throwing):
+ *   - Master switch off (legacy "any workspace user authenticates anywhere"
+ *     behavior).
+ *   - Route opted out via `@PublicProjectAccess()`.
+ *   - No `req.user` — request is anonymous, or earlier auth guards rejected
+ *     it. `OptionalAuthGuard` populates `req.user` only on successful auth;
+ *     fully anonymous public requests are unaffected by this guard.
+ *   - API-key authenticated requests (`req.user.apiKeyId`). API keys are
+ *     CI/CD credentials minted by workspace admins; they are out of scope
+ *     for the project-membership gate and `ApiKeyGuard` already enforces
+ *     project scope when the key is project-scoped.
+ *   - The hostname resolves to no project (admin domain, unknown hostname).
+ *
+ * Registered via `APP_GUARD` so every route is gated by default. Adding a new
+ * authenticated route automatically inherits the check; routes that need to
+ * bypass it must opt out explicitly with `@PublicProjectAccess()`.
+ */
+@Injectable()
+export class ProjectMembershipGuard implements CanActivate {
+  private readonly logger = new Logger(ProjectMembershipGuard.name);
+
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly featureFlags: FeatureFlagsService,
+    private readonly projectResolver: ProjectResolverService,
+    private readonly permissions: PermissionsService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(
+      PUBLIC_PROJECT_ACCESS_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (isPublic) return true;
+
+    if (!(await this.featureFlags.isEnabled('REQUIRE_PROJECT_MEMBERSHIP'))) {
+      return true;
+    }
+
+    const req = context
+      .switchToHttp()
+      .getRequest<
+        Request & { user?: { id?: string; apiKeyId?: string } }
+      >();
+
+    const user = req.user;
+    if (!user?.id) return true;
+    if (user.apiKeyId) return true;
+
+    const project = await this.projectResolver.resolveProjectFromRequest(req);
+    if (!project) return true;
+
+    const role = await this.permissions.getUserProjectRole(user.id, project.id);
+    if (!role) {
+      this.logger.debug(
+        `Blocked: user ${user.id} has no membership on project ${project.id} (host: ${req.headers.host})`,
+      );
+      throw new ForbiddenException('You are not a member of this site');
+    }
+
+    return true;
+  }
+}

--- a/apps/backend/src/deployments/public.controller.ts
+++ b/apps/backend/src/deployments/public.controller.ts
@@ -23,6 +23,7 @@ import { IStorageAdapter, STORAGE_ADAPTER, DownloadResult } from '../storage/sto
 import { DeploymentsService } from './deployments.service';
 import { ProjectsService } from '../projects/projects.service';
 import { OptionalAuthGuard } from '../auth/optional-auth.guard';
+import { PublicProjectAccess } from '../auth/decorators/public-project-access.decorator';
 import { VisibilityService, AccessControlInfo } from '../domains/visibility.service';
 import { TrafficRoutingService, VariantSelectionResult } from '../domains/traffic-routing.service';
 import { PermissionsService, ProjectRole } from '../permissions/permissions.service';
@@ -85,6 +86,11 @@ const MIME_TYPES: Record<string, string> = {
 @Controller('public')
 @SkipThrottle()
 @UseGuards(OptionalAuthGuard)
+// Public-content serving runs on customer hostnames where a sister-site visitor
+// may carry a workspace SuperTokens cookie. We must keep static asset access
+// open even for non-members; per-route visibility/role gates are handled by
+// VisibilityService and the route handlers themselves.
+@PublicProjectAccess()
 export class PublicController {
   private readonly logger = new Logger(PublicController.name);
   private readonly svg404: string;


### PR DESCRIPTION
## Summary

- Adds `ProjectMembershipGuard` registered as a global `APP_GUARD`. When `REQUIRE_PROJECT_MEMBERSHIP` is on and the inbound hostname resolves to a project, every authenticated request must hold a `project_permissions` row for that project — otherwise the guard throws `ForbiddenException`. Closes the Phase B residual where a sister-site cookie holder could bypass the AuthDialog UI and POST directly to a data route.
- Adds `@PublicProjectAccess()` decorator (per the Phase C design decision — Option C: global default + explicit opt-out). New authenticated routes inherit the gate; routes that are legitimately cross-project (admin, control-plane, identity hub) opt out explicitly.
- Annotates the three controllers reachable on customer hostnames: `AuthController` and `CustomDomainAuthController` (Phase A & B already enforce membership inline with controlled response shapes), and `PublicController` (sister-site visitors must still load static assets). Other admin controllers are admin-domain-only — the resolver returns `null` there and the guard is a no-op.

Pass-through cases are documented in the guard's docstring: master switch off, `@PublicProjectAccess()`, anonymous request, API-key auth, hostname not bound to a project.

Story: `stories/backlog/phase-project-membership-auth/phases/C-data-endpoint-defense.md` (marked complete in this PR's parent story doc, off-tree).

## Out of scope (filed in story as a follow-up)

`ProxyMiddleware.getOptionalUser` runs before NestJS routing, so the guard does not gate customer-defined proxy rules / pipelines on **public** deployments. Private deployments already enforce `getUserProjectRole` in `checkVisibilityAndAuth`. Suggested follow-up: drop `req.user` for non-members in `getOptionalUser` so public-deployment pipelines can't be invoked under a sister-site identity.

## Test plan

- [x] `pnpm test -- project-membership` — 8 unit cases (decorator opt-out, master switch off, anonymous request, API-key bypass, admin-domain bypass, member allows, non-member 403, class-level opt-out)
- [x] `pnpm test -- src/auth` — 86 auth tests (78 prior + 8 new)
- [x] `pnpm test` — full backend suite (974 tests passing, 36 skipped, 0 failures)
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] Manual verification with `REQUIRE_PROJECT_MEMBERSHIP=true`:
  - Member of `foo` POSTs to `foo.sites.bffless.app/<protected route>` → 200
  - Same cookie POSTs to `bar.sites.bffless.app/<protected route>` → 403 ("You are not a member of this site")
  - Admin domain access unaffected
  - `/api/auth/session` and `/_bffless/auth/session` still return `{ user: null }` for non-members (Phase B shape preserved)
  - Static assets on a sister site still load with a sister-site cookie present

🤖 Generated with [Claude Code](https://claude.com/claude-code)