### PR TITLE
feat(auth): /account identity hub + My Sites + 403 link-back (Phase D)

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -20,6 +20,7 @@ import { RepoBrowserModule } from './repo-browser/repo-browser.module';
 import { ProjectsModule } from './projects/projects.module';
 import { UserGroupsModule } from './user-groups/user-groups.module';
 import { PermissionsModule } from './permissions/permissions.module';
+import { MeModule } from './me/me.module';
 import { DomainsModule } from './domains/domains.module';
 import { SettingsModule } from './settings/settings.module';
 import { ProxyRulesModule } from './proxy-rules/proxy-rules.module';
@@ -159,6 +160,7 @@ import { McpToolsModule } from './mcp/mcp-tools.module';
     ProjectsModule,
     UserGroupsModule,
     PermissionsModule,
+    MeModule,
     DomainsModule,
     SettingsModule,
     MigrationModule,

--- a/apps/backend/src/deployments/public.controller.ts
+++ b/apps/backend/src/deployments/public.controller.ts
@@ -295,6 +295,8 @@ export class PublicController {
             requiredRole: accessControl.requiredRole,
             currentRole: userRole,
             projectName: project.displayName || project.name,
+            userEmail: user.email,
+            req,
           });
         }
       }
@@ -563,6 +565,8 @@ export class PublicController {
             requiredRole: accessControl.requiredRole,
             currentRole: userRole,
             projectName: project.displayName || project.name,
+            userEmail: user.email,
+            req,
           });
         }
       }
@@ -1299,11 +1303,21 @@ export class PublicController {
   }
 
   /**
-   * Serve a styled 403 Forbidden page for authenticated users without sufficient role
+   * Serve a styled 403 Forbidden page for authenticated users without
+   * sufficient role. When the request carries a signed-in user, surfaces
+   * their email and a link to the central account hub
+   * (`<ADMIN_DOMAIN>/account` — falls back to `admin.<workspace-base>/account`)
+   * so they can manage their site memberships from one place.
    */
   private serve403Page(
     res: Response,
-    info: { requiredRole: string; currentRole: ProjectRole | null; projectName: string },
+    info: {
+      requiredRole: string;
+      currentRole: ProjectRole | null;
+      projectName: string;
+      userEmail?: string;
+      req?: Request;
+    },
   ): void {
     const roleLabels: Record<string, string> = {
       authenticated: 'Any authenticated user',
@@ -1315,6 +1329,20 @@ export class PublicController {
 
     const requiredLabel = roleLabels[info.requiredRole] || info.requiredRole;
     const currentLabel = info.currentRole ? roleLabels[info.currentRole] : 'None';
+    const accountHubUrl = info.req ? this.buildAccountHubUrl(info.req) : null;
+
+    const identityBlock =
+      info.userEmail && accountHubUrl
+        ? `
+        <p>You are signed in as <strong>${this.escapeHtml(info.userEmail)}</strong>, but you don't have access to this site.</p>`
+        : `
+        <p>You don't have permission to access this content.</p>`;
+
+    const accountHubLink = accountHubUrl
+      ? `
+        <a href="${this.escapeHtml(accountHubUrl)}" class="button" target="_blank" rel="noopener noreferrer">Manage your sites</a>`
+      : `
+        <a href="/" class="button">Go to Dashboard</a>`;
 
     const html = `<!DOCTYPE html>
 <html lang="en">
@@ -1391,8 +1419,7 @@ export class PublicController {
 <body>
     <div class="container">
         <div class="icon">&#128274;</div>
-        <h1>Access Denied</h1>
-        <p>You don't have permission to access this content.</p>
+        <h1>Access Denied</h1>${identityBlock}
 
         <div class="role-info">
             <div class="role-row">
@@ -1407,9 +1434,7 @@ export class PublicController {
                 <span class="role-label">Your role</span>
                 <span class="role-value">${currentLabel}</span>
             </div>
-        </div>
-
-        <a href="/" class="button">Go to Dashboard</a>
+        </div>${accountHubLink}
     </div>
 </body>
 </html>`;
@@ -1437,6 +1462,28 @@ export class PublicController {
     const path = originalUri || req.originalUrl;
 
     return `${protocol}://${host}${path}`;
+  }
+
+  /**
+   * Build the absolute URL of the central identity hub at `/account`. Used
+   * by `serve403Page` to link a stranded workspace user (signed-in but not a
+   * member of *this* site) back to the place where they can see and manage
+   * the sites they actually belong to.
+   *
+   * Mirrors `buildLoginUrl`'s host-resolution: prefer `ADMIN_DOMAIN`, fall
+   * back to `admin.<workspace-base>` derived from the inbound host.
+   */
+  private buildAccountHubUrl(req: Request): string {
+    const protocol = req.headers['x-forwarded-proto'] || req.protocol || 'https';
+
+    const adminDomain = this.configService.get<string>('ADMIN_DOMAIN');
+    if (adminDomain) {
+      return `${protocol}://${adminDomain}/account`;
+    }
+
+    const host = (req.headers['x-forwarded-host'] || req.get('host')) as string;
+    const workspaceBase = this.extractWorkspaceBase(host);
+    return `${protocol}://admin.${workspaceBase}/account`;
   }
 
   /**

--- a/apps/backend/src/me/me.controller.spec.ts
+++ b/apps/backend/src/me/me.controller.spec.ts
@@ -1,0 +1,102 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { MeController } from './me.controller';
+import {
+  MyProjectMembership,
+  PermissionsService,
+} from '../permissions/permissions.service';
+import { CurrentUserData } from '../auth';
+
+const makeUser = (id = 'user-1'): CurrentUserData => ({
+  id,
+  email: 'u@example.com',
+  role: 'member',
+  sessionHandle: 'sh-1',
+});
+
+describe('MeController', () => {
+  let controller: MeController;
+  let permissions: jest.Mocked<PermissionsService>;
+
+  beforeEach(() => {
+    permissions = {
+      listUserProjectMemberships: jest.fn(),
+      revokeSystemPermission: jest.fn(),
+    } as unknown as jest.Mocked<PermissionsService>;
+
+    controller = new MeController(permissions);
+  });
+
+  describe('GET /api/me/projects', () => {
+    it('returns memberships for the signed-in user', async () => {
+      const memberships: MyProjectMembership[] = [
+        {
+          projectId: 'p-1',
+          projectName: 'Bella Charlesworth Real Estate',
+          projectSlug: 'bffless/realestate-modern',
+          primaryUrl: 'https://www.bellacharlesworth.com',
+          role: 'guest',
+          joinedAt: '2026-04-30T00:00:00.000Z',
+          ownerEmail: 'james@example.com',
+        },
+      ];
+      permissions.listUserProjectMemberships.mockResolvedValue(memberships);
+
+      const result = await controller.listMyProjects(makeUser());
+
+      expect(permissions.listUserProjectMemberships).toHaveBeenCalledWith('user-1');
+      expect(result).toEqual(memberships);
+    });
+
+    it('returns empty array when user has no memberships', async () => {
+      permissions.listUserProjectMemberships.mockResolvedValue([]);
+      const result = await controller.listMyProjects(makeUser());
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('DELETE /api/me/projects/:projectId', () => {
+    it('revokes the caller’s membership when they are a non-owner member', async () => {
+      permissions.revokeSystemPermission.mockResolvedValue(undefined);
+
+      await expect(
+        controller.leaveProject(makeUser('user-1'), 'project-1'),
+      ).resolves.toBeUndefined();
+
+      expect(permissions.revokeSystemPermission).toHaveBeenCalledWith('project-1', 'user-1');
+    });
+
+    it('rewrites a ForbiddenException (owner) into a 400 with transfer-ownership guidance', async () => {
+      permissions.revokeSystemPermission.mockRejectedValue(
+        new ForbiddenException('Cannot revoke owner permission. Use transfer ownership instead.'),
+      );
+
+      await expect(
+        controller.leaveProject(makeUser('owner-1'), 'project-1'),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('returns 404 when the user is not a member', async () => {
+      permissions.revokeSystemPermission.mockRejectedValue(
+        new NotFoundException('Permission not found'),
+      );
+
+      await expect(
+        controller.leaveProject(makeUser('stranger-1'), 'project-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('rethrows unexpected errors unchanged', async () => {
+      const boom = new Error('db down');
+      permissions.revokeSystemPermission.mockRejectedValue(boom);
+
+      await expect(
+        controller.leaveProject(makeUser(), 'project-1'),
+      ).rejects.toBe(boom);
+    });
+  });
+});

--- a/apps/backend/src/me/me.controller.ts
+++ b/apps/backend/src/me/me.controller.ts
@@ -1,0 +1,88 @@
+import {
+  BadRequestException,
+  Controller,
+  Delete,
+  ForbiddenException,
+  Get,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Param,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { CurrentUserData } from '../auth';
+import { PublicProjectAccess } from '../auth/decorators/public-project-access.decorator';
+import {
+  MyProjectMembership,
+  PermissionsService,
+} from '../permissions/permissions.service';
+
+/**
+ * Cross-project endpoints for the signed-in user. Lives at `/api/me/*` and
+ * is the backend for the central "My Sites" account hub at
+ * `admin.sites.bffless.app/account` (Phase D of the project-membership-gated
+ * auth story).
+ *
+ * Routes here are inherently cross-project — a user's full membership list
+ * spans every project they belong to — so they bypass the global
+ * `ProjectMembershipGuard` via `@PublicProjectAccess()`. Authentication is
+ * still required (`SessionAuthGuard`); the bypass is for project-membership
+ * scoping, not auth.
+ */
+@ApiTags('Me')
+@Controller('api/me')
+@UseGuards(SessionAuthGuard)
+@PublicProjectAccess()
+@ApiBearerAuth()
+export class MeController {
+  constructor(private readonly permissions: PermissionsService) {}
+
+  @Get('projects')
+  @ApiOperation({
+    summary: 'List the authenticated user’s project memberships',
+    description:
+      'Returns one entry per project the user is a member of, with display name, primary URL, role, joined-at, and owner email. Used by the "My Sites" admin hub.',
+  })
+  @ApiResponse({ status: 200, description: 'Memberships listed successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async listMyProjects(
+    @CurrentUser() user: CurrentUserData,
+  ): Promise<MyProjectMembership[]> {
+    return this.permissions.listUserProjectMemberships(user.id);
+  }
+
+  @Delete('projects/:projectId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Leave a project the user is a member of',
+    description:
+      'Self-serve removal of the caller’s own membership on the given project. Owners cannot leave a project they own — they must transfer ownership first. Returns 404 if the user is not a member of the project.',
+  })
+  @ApiResponse({ status: 204, description: 'Membership revoked' })
+  @ApiResponse({ status: 400, description: 'Cannot leave a project you own' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Not a member of this project' })
+  async leaveProject(
+    @CurrentUser() user: CurrentUserData,
+    @Param('projectId') projectId: string,
+  ): Promise<void> {
+    try {
+      await this.permissions.revokeSystemPermission(projectId, user.id);
+    } catch (err) {
+      // Reframe the generic owner-block as a user-actionable 400, leaving the
+      // 404 (no membership) path untouched.
+      if (err instanceof ForbiddenException) {
+        throw new BadRequestException(
+          'You cannot leave a site you own. Transfer ownership first.',
+        );
+      }
+      if (err instanceof NotFoundException) {
+        throw new NotFoundException('You are not a member of this site');
+      }
+      throw err;
+    }
+  }
+}

--- a/apps/backend/src/me/me.module.ts
+++ b/apps/backend/src/me/me.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { MeController } from './me.controller';
+import { PermissionsModule } from '../permissions/permissions.module';
+
+@Module({
+  imports: [PermissionsModule],
+  controllers: [MeController],
+})
+export class MeModule {}

--- a/apps/backend/src/permissions/permissions.service.spec.ts
+++ b/apps/backend/src/permissions/permissions.service.spec.ts
@@ -625,4 +625,193 @@ describe('PermissionsService', () => {
       expect(result).toEqual(mockPermissions);
     });
   });
+
+  describe('revokeSystemPermission', () => {
+    it('deletes the membership row when present and not owner', async () => {
+      // Existence check
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockResolvedValue([
+          { projectId: mockProjectId, userId: mockUserId, role: 'guest' },
+        ]),
+      });
+
+      const deleteWhere = jest.fn().mockResolvedValue(undefined);
+      (db.delete as jest.Mock).mockReturnValue({ where: deleteWhere });
+
+      await service.revokeSystemPermission(mockProjectId, mockUserId);
+
+      expect(db.delete).toHaveBeenCalled();
+      expect(deleteWhere).toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when no membership exists', async () => {
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockResolvedValue([]),
+      });
+
+      await expect(
+        service.revokeSystemPermission(mockProjectId, mockUserId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ForbiddenException when target role is owner', async () => {
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockResolvedValue([
+          { projectId: mockProjectId, userId: mockUserId, role: 'owner' },
+        ]),
+      });
+
+      await expect(
+        service.revokeSystemPermission(mockProjectId, mockUserId),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('listUserProjectMemberships', () => {
+    it('aggregates direct + group memberships, picks the highest role per project', async () => {
+      const grantedAt = new Date('2026-04-30T00:00:00.000Z');
+
+      // 1. directRows query
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue([
+          { projectId: 'p-1', role: 'guest', grantedAt },
+        ]),
+      });
+
+      // 2. groupRows query (innerJoin chain)
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue([
+          { projectId: 'p-1', role: 'admin', grantedAt }, // higher than direct guest
+          { projectId: 'p-2', role: 'viewer', grantedAt },
+        ]),
+      });
+
+      // 3. projects in bulk
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue([
+          {
+            id: 'p-1',
+            owner: 'bffless',
+            name: 'realestate-modern',
+            displayName: 'Bella Charlesworth Real Estate',
+          },
+          {
+            id: 'p-2',
+            owner: 'bffless',
+            name: 'salon',
+            displayName: null,
+          },
+        ]),
+      });
+
+      // 4. domain mappings (active)
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue([
+          {
+            projectId: 'p-1',
+            domain: 'www.bellacharlesworth.com',
+            domainType: 'custom',
+            isPrimary: true,
+            isActive: true,
+            sslEnabled: true,
+          },
+          {
+            projectId: 'p-2',
+            domain: 'salon.sites.bffless.app',
+            domainType: 'subdomain',
+            isPrimary: false,
+            isActive: true,
+            sslEnabled: true,
+          },
+        ]),
+      });
+
+      // 5. owner emails in bulk
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue([
+          { projectId: 'p-1', email: 'james@example.com' },
+          { projectId: 'p-2', email: 'salonowner@example.com' },
+        ]),
+      });
+
+      const result = await service.listUserProjectMemberships(mockUserId);
+
+      expect(result).toHaveLength(2);
+      const p1 = result.find((m) => m.projectId === 'p-1')!;
+      const p2 = result.find((m) => m.projectId === 'p-2')!;
+
+      expect(p1.role).toBe('admin'); // group beat direct guest
+      expect(p1.projectName).toBe('Bella Charlesworth Real Estate');
+      expect(p1.projectSlug).toBe('bffless/realestate-modern');
+      expect(p1.primaryUrl).toBe('https://www.bellacharlesworth.com');
+      expect(p1.ownerEmail).toBe('james@example.com');
+
+      expect(p2.role).toBe('viewer');
+      expect(p2.projectName).toBe('salon'); // falls back to name when displayName null
+      expect(p2.primaryUrl).toBe('https://salon.sites.bffless.app');
+    });
+
+    it('returns empty array when user has no memberships anywhere', async () => {
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue([]),
+      });
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue([]),
+      });
+
+      const result = await service.listUserProjectMemberships(mockUserId);
+      expect(result).toEqual([]);
+    });
+
+    it('handles a project with no domain mappings (primaryUrl=null)', async () => {
+      const grantedAt = new Date();
+
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue([
+          { projectId: 'p-3', role: 'guest', grantedAt },
+        ]),
+      });
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue([]),
+      });
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue([
+          { id: 'p-3', owner: 'acme', name: 'unmapped', displayName: 'Unmapped' },
+        ]),
+      });
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue([]),
+      });
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue([]),
+      });
+
+      const [m] = await service.listUserProjectMemberships(mockUserId);
+      expect(m.primaryUrl).toBeNull();
+      expect(m.ownerEmail).toBeNull();
+    });
+  });
 });

--- a/apps/backend/src/permissions/permissions.service.ts
+++ b/apps/backend/src/permissions/permissions.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, ForbiddenException, NotFoundException } from '@nestjs/common';
-import { eq, and, sql } from 'drizzle-orm';
+import { eq, and, sql, inArray } from 'drizzle-orm';
 import { db } from '../db/client';
 import {
   projectPermissions,
@@ -7,10 +7,59 @@ import {
   userGroupMembers,
   users,
   userGroups,
+  projects,
+  domainMappings,
 } from '../db/schema';
 import { RequiredRole } from '../domains/visibility.service';
 
 export type ProjectRole = 'owner' | 'admin' | 'contributor' | 'viewer' | 'guest';
+
+/**
+ * Rich shape returned by `listUserProjectMemberships` for the "My Sites" hub.
+ * Distinct from `listUserProjects` (which returns bare project IDs) — this one
+ * carries everything the central account UI needs to render a project card
+ * without further per-project lookups.
+ */
+export interface MyProjectMembership {
+  projectId: string;
+  /** Display name (falls back to `name` when `displayName` is unset). */
+  projectName: string;
+  /** `${owner}/${name}` — best stable identifier we have for URL building. */
+  projectSlug: string;
+  /**
+   * Best public URL for this project — primary domain mapping if one is
+   * marked `isPrimary`, else first active custom domain, else first active
+   * subdomain. Null when the project has no active domain mappings (a
+   * synthesized workspace subdomain may still exist outside the DB; the UI
+   * decides how to render).
+   */
+  primaryUrl: string | null;
+  role: ProjectRole;
+  /** ISO timestamp of when this user's membership was granted. */
+  joinedAt: string;
+  /**
+   * Email of the project's owner (the unique `role='owner'` row in
+   * `project_permissions`). Null when no owner exists yet — should not happen
+   * in steady state but is possible mid-transfer or if the owner was deleted.
+   */
+  ownerEmail: string | null;
+}
+
+type DomainMappingRow = typeof domainMappings.$inferSelect;
+
+function pickPrimaryUrl(rows: DomainMappingRow[]): string | null {
+  if (rows.length === 0) return null;
+  const score = (r: DomainMappingRow): number => {
+    let s = 0;
+    if (r.isPrimary) s += 100;
+    if (r.domainType === 'custom') s += 10;
+    else if (r.domainType === 'subdomain') s += 5;
+    return s;
+  };
+  const best = [...rows].sort((a, b) => score(b) - score(a))[0];
+  const scheme = best.sslEnabled ? 'https' : 'http';
+  return `${scheme}://${best.domain}`;
+}
 
 @Injectable()
 export class PermissionsService {
@@ -229,6 +278,111 @@ export class PermissionsService {
   }
 
   /**
+   * List a user's project memberships with everything the "My Sites" admin
+   * page needs: display name, best public URL, role, joined-at, owner email.
+   *
+   * Aggregates direct memberships (`project_permissions`) and group-derived
+   * memberships (`project_group_permissions` via `user_group_members`),
+   * keeping the highest role per project. Per-project secondary lookups
+   * (project row, domain mappings, owner email) are batched with `inArray`
+   * so the cost is O(N) round-trips, not O(N × per-project queries).
+   */
+  async listUserProjectMemberships(userId: string): Promise<MyProjectMembership[]> {
+    const directRows = await db
+      .select({
+        projectId: projectPermissions.projectId,
+        role: projectPermissions.role,
+        grantedAt: projectPermissions.grantedAt,
+      })
+      .from(projectPermissions)
+      .where(eq(projectPermissions.userId, userId));
+
+    const groupRows = await db
+      .select({
+        projectId: projectGroupPermissions.projectId,
+        role: projectGroupPermissions.role,
+        grantedAt: projectGroupPermissions.grantedAt,
+      })
+      .from(projectGroupPermissions)
+      .innerJoin(userGroupMembers, eq(projectGroupPermissions.groupId, userGroupMembers.groupId))
+      .where(eq(userGroupMembers.userId, userId));
+
+    const roleHierarchy: Record<ProjectRole, number> = {
+      owner: 4,
+      admin: 3,
+      contributor: 2,
+      viewer: 1,
+      guest: 0,
+    };
+
+    const aggregated = new Map<string, { role: ProjectRole; grantedAt: Date }>();
+    for (const row of [...directRows, ...groupRows]) {
+      const role = row.role as ProjectRole;
+      const existing = aggregated.get(row.projectId);
+      if (!existing || roleHierarchy[role] > roleHierarchy[existing.role]) {
+        aggregated.set(row.projectId, { role, grantedAt: row.grantedAt });
+      }
+    }
+
+    if (aggregated.size === 0) return [];
+
+    const projectIds = Array.from(aggregated.keys());
+
+    const projectRows = await db
+      .select()
+      .from(projects)
+      .where(inArray(projects.id, projectIds));
+
+    const domainRows = await db
+      .select()
+      .from(domainMappings)
+      .where(
+        and(inArray(domainMappings.projectId, projectIds), eq(domainMappings.isActive, true)),
+      );
+
+    const ownerRows = await db
+      .select({ projectId: projectPermissions.projectId, email: users.email })
+      .from(projectPermissions)
+      .innerJoin(users, eq(users.id, projectPermissions.userId))
+      .where(
+        and(
+          inArray(projectPermissions.projectId, projectIds),
+          eq(projectPermissions.role, 'owner'),
+        ),
+      );
+
+    const ownerByProject = new Map(ownerRows.map((r) => [r.projectId, r.email]));
+
+    const domainsByProject = new Map<string, typeof domainRows>();
+    for (const dm of domainRows) {
+      if (!dm.projectId) continue;
+      const list = domainsByProject.get(dm.projectId) ?? [];
+      list.push(dm);
+      domainsByProject.set(dm.projectId, list);
+    }
+
+    const result: MyProjectMembership[] = [];
+    for (const project of projectRows) {
+      const membership = aggregated.get(project.id);
+      if (!membership) continue;
+      const projectDomains = domainsByProject.get(project.id) ?? [];
+      result.push({
+        projectId: project.id,
+        projectName: project.displayName ?? project.name,
+        projectSlug: `${project.owner}/${project.name}`,
+        primaryUrl: pickPrimaryUrl(projectDomains),
+        role: membership.role,
+        joinedAt: membership.grantedAt.toISOString(),
+        ownerEmail: ownerByProject.get(project.id) ?? null,
+      });
+    }
+
+    // Stable sort: most recently joined first.
+    result.sort((a, b) => (a.joinedAt < b.joinedAt ? 1 : -1));
+    return result;
+  }
+
+  /**
    * Grant permission to a user on a project
    */
   async grantPermission(
@@ -302,6 +456,45 @@ export class PermissionsService {
         grantedBy,
       });
     }
+  }
+
+  /**
+   * Revoke a project membership as a system action — used by self-serve
+   * "leave site" flows where there's no human revoker authorizing the
+   * removal. Mirror of `grantSystemPermission`: bypasses the
+   * revoker-must-be-admin check used by `revokePermission`. Owners cannot be
+   * removed this way (they must transfer ownership first); callers that
+   * receive a thrown ForbiddenException for an owner should surface a
+   * "transfer ownership first" message. Idempotent: throws NotFoundException
+   * when no membership row exists for the (projectId, userId) pair.
+   *
+   * Greppable: `git grep 'revokeSystemPermission'` lists every system-revoke
+   * site for audit.
+   */
+  async revokeSystemPermission(projectId: string, userId: string): Promise<void> {
+    const [permission] = await db
+      .select()
+      .from(projectPermissions)
+      .where(
+        and(eq(projectPermissions.projectId, projectId), eq(projectPermissions.userId, userId)),
+      )
+      .limit(1);
+
+    if (!permission) {
+      throw new NotFoundException('Permission not found');
+    }
+
+    if (permission.role === 'owner') {
+      throw new ForbiddenException(
+        'Cannot revoke owner permission. Use transfer ownership instead.',
+      );
+    }
+
+    await db
+      .delete(projectPermissions)
+      .where(
+        and(eq(projectPermissions.projectId, projectId), eq(projectPermissions.userId, userId)),
+      );
   }
 
   /**

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { UserGroupsPage } from '@/pages/UserGroupsPage';
 import { GroupDetailPage } from '@/pages/GroupDetailPage';
 import { UsersPage } from '@/pages/UsersPage';
 import { UserSettingsPage } from '@/pages/UserSettingsPage';
+import { AccountPage } from '@/pages/AccountPage';
 import { AdminSettingsPage } from '@/pages/AdminSettingsPage';
 import { GeneralTab } from '@/pages/admin-settings/GeneralTab';
 import { AuthTab } from '@/pages/admin-settings/AuthTab';
@@ -74,6 +75,9 @@ function App() {
 
         {/* User Settings route (requires auth) */}
         <Route path="/settings" element={<ProtectedRoute><UserSettingsPage /></ProtectedRoute>} />
+
+        {/* Identity hub: BFFless Auth account + "My Sites" memberships */}
+        <Route path="/account" element={<ProtectedRoute><AccountPage /></ProtectedRoute>} />
 
         {/* Admin Settings routes (requires admin, tabbed layout) */}
         <Route path="/admin/settings" element={<ProtectedRoute requireAdmin><AdminSettingsPage /></ProtectedRoute>}>

--- a/apps/frontend/src/components/account/MySitesSection.test.tsx
+++ b/apps/frontend/src/components/account/MySitesSection.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MySitesSection } from './MySitesSection';
+import type { MyProjectMembership } from '@/services/meApi';
+
+const mockUnwrap = vi.fn();
+const mockMutate = vi.fn(() => ({ unwrap: mockUnwrap }));
+let mockQueryResult: {
+  data?: MyProjectMembership[];
+  isLoading: boolean;
+  error?: unknown;
+} = { data: [], isLoading: false };
+
+vi.mock('@/services/meApi', () => ({
+  useListMyProjectsQuery: () => mockQueryResult,
+  useLeaveProjectMutation: () => [mockMutate, { isLoading: false }],
+}));
+
+// Radix AlertDialog uses a context scope (`createContextScope`) that hits
+// `useMemo` against a null React renderer in happy-dom. Stub the primitives so
+// the dialog is just a controlled fragment for assertion purposes — the
+// behavior we care about (open/close + button clicks) is preserved.
+vi.mock('@/components/ui/alert-dialog', () => {
+  type Props = { children?: React.ReactNode; [key: string]: unknown };
+  const Passthrough = ({ children }: Props) => <>{children}</>;
+  const Open = ({ open, children }: Props & { open?: boolean }) =>
+    open ? <div role="dialog">{children}</div> : null;
+  return {
+    AlertDialog: Open,
+    AlertDialogContent: Passthrough,
+    AlertDialogHeader: Passthrough,
+    AlertDialogFooter: Passthrough,
+    AlertDialogTitle: ({ children }: Props) => <h2>{children}</h2>,
+    AlertDialogDescription: ({ children }: Props) => <p>{children}</p>,
+    AlertDialogAction: ({ children, onClick, disabled }: Props & { onClick?: () => void; disabled?: boolean }) => (
+      <button type="button" onClick={onClick} disabled={disabled}>{children}</button>
+    ),
+    AlertDialogCancel: ({ children, disabled }: Props & { disabled?: boolean }) => (
+      <button type="button" disabled={disabled}>{children}</button>
+    ),
+  };
+});
+
+const mockToast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const guestMembership: MyProjectMembership = {
+  projectId: 'p-1',
+  projectName: 'Bella Real Estate',
+  projectSlug: 'bffless/realestate-modern',
+  primaryUrl: 'https://www.bellacharlesworth.com',
+  role: 'guest',
+  joinedAt: '2026-04-30T00:00:00.000Z',
+  ownerEmail: 'james@example.com',
+};
+
+const ownerMembership: MyProjectMembership = {
+  projectId: 'p-2',
+  projectName: 'My Own Site',
+  projectSlug: 'me/my-site',
+  primaryUrl: 'https://my-site.example.com',
+  role: 'owner',
+  joinedAt: '2026-01-01T00:00:00.000Z',
+  ownerEmail: 'me@example.com',
+};
+
+describe('MySitesSection', () => {
+  beforeEach(() => {
+    mockMutate.mockClear();
+    mockUnwrap.mockReset();
+    mockToast.mockClear();
+    mockQueryResult = { data: [], isLoading: false };
+  });
+
+  it('shows empty state when user has no memberships', () => {
+    mockQueryResult = { data: [], isLoading: false };
+    render(<MySitesSection />);
+    expect(screen.getByText(/not a member of any sites yet/i)).toBeInTheDocument();
+  });
+
+  it('renders membership cards with name, host, role, and owner email', () => {
+    mockQueryResult = { data: [guestMembership], isLoading: false };
+    render(<MySitesSection />);
+
+    expect(screen.getByText('Bella Real Estate')).toBeInTheDocument();
+    expect(screen.getByText('www.bellacharlesworth.com')).toBeInTheDocument();
+    expect(screen.getByText('guest')).toBeInTheDocument();
+    expect(screen.getByText(/Owner: james@example\.com/)).toBeInTheDocument();
+    const visit = screen.getByRole('link', { name: /visit/i });
+    expect(visit).toHaveAttribute('href', 'https://www.bellacharlesworth.com');
+  });
+
+  it('disables the Leave button for owners', () => {
+    mockQueryResult = { data: [ownerMembership], isLoading: false };
+    render(<MySitesSection />);
+    const leaveBtn = screen.getByRole('button', { name: /leave/i });
+    expect(leaveBtn).toBeDisabled();
+  });
+
+  it('opens the confirmation dialog and triggers the mutation on confirm', async () => {
+    mockUnwrap.mockResolvedValue(undefined);
+    mockQueryResult = { data: [guestMembership], isLoading: false };
+    render(<MySitesSection />);
+
+    fireEvent.click(screen.getByRole('button', { name: /leave/i }));
+    expect(await screen.findByText(/Leave Bella Real Estate\?/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /leave site/i }));
+
+    expect(mockMutate).toHaveBeenCalledWith({ projectId: 'p-1' });
+  });
+
+  it('shows an error toast when leaving fails', async () => {
+    mockUnwrap.mockRejectedValue({ data: { message: 'You cannot leave a site you own.' } });
+    mockQueryResult = { data: [guestMembership], isLoading: false };
+    render(<MySitesSection />);
+
+    fireEvent.click(screen.getByRole('button', { name: /leave/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /leave site/i }));
+
+    // Wait for the rejected promise to flush.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'destructive',
+        description: 'You cannot leave a site you own.',
+      }),
+    );
+  });
+});

--- a/apps/frontend/src/components/account/MySitesSection.tsx
+++ b/apps/frontend/src/components/account/MySitesSection.tsx
@@ -1,0 +1,191 @@
+import { useState } from 'react';
+import {
+  useListMyProjectsQuery,
+  useLeaveProjectMutation,
+  type MyProjectMembership,
+} from '@/services/meApi';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { ExternalLink, LogOut, Globe, AlertCircle } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+
+const ROLE_BADGE_VARIANT: Record<MyProjectMembership['role'], 'default' | 'secondary' | 'outline'> = {
+  owner: 'default',
+  admin: 'default',
+  contributor: 'secondary',
+  viewer: 'secondary',
+  guest: 'outline',
+};
+
+function formatJoinedAt(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function MembershipCard({
+  membership,
+  onLeaveClick,
+}: {
+  membership: MyProjectMembership;
+  onLeaveClick: (m: MyProjectMembership) => void;
+}) {
+  const isOwner = membership.role === 'owner';
+  const displayHost = membership.primaryUrl
+    ? membership.primaryUrl.replace(/^https?:\/\//, '')
+    : `${membership.projectSlug} (no domain)`;
+
+  return (
+    <Card>
+      <CardContent className="flex items-start justify-between gap-4 p-4">
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate text-base font-semibold">{membership.projectName}</h3>
+            <Badge variant={ROLE_BADGE_VARIANT[membership.role]} className="capitalize">
+              {membership.role}
+            </Badge>
+          </div>
+          <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <Globe className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">{displayHost}</span>
+          </div>
+          <div className="text-xs text-muted-foreground">
+            Joined {formatJoinedAt(membership.joinedAt)}
+            {membership.ownerEmail && ` · Owner: ${membership.ownerEmail}`}
+          </div>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          {membership.primaryUrl && (
+            <Button asChild size="sm" variant="outline">
+              <a href={membership.primaryUrl} target="_blank" rel="noopener noreferrer">
+                <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                Visit
+              </a>
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={isOwner}
+            onClick={() => onLeaveClick(membership)}
+            title={isOwner ? 'Transfer ownership before leaving' : undefined}
+          >
+            <LogOut className="mr-1.5 h-3.5 w-3.5" />
+            Leave
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * "My Sites" section for the central account hub at /account. Lists every
+ * project the signed-in user is a member of, with role badge, primary URL,
+ * Visit and Leave actions. Leave is disabled for owners (they must transfer
+ * ownership first).
+ */
+export function MySitesSection() {
+  const { toast } = useToast();
+  const { data, isLoading, error } = useListMyProjectsQuery();
+  const [leaveProject, { isLoading: isLeaving }] = useLeaveProjectMutation();
+
+  const [pendingLeave, setPendingLeave] = useState<MyProjectMembership | null>(null);
+
+  const onConfirmLeave = async () => {
+    if (!pendingLeave) return;
+    try {
+      await leaveProject({ projectId: pendingLeave.projectId }).unwrap();
+      toast({
+        title: 'Left site',
+        description: `You no longer have access to ${pendingLeave.projectName}.`,
+      });
+      setPendingLeave(null);
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'data' in err && err.data && typeof err.data === 'object'
+          ? (err.data as { message?: string }).message
+          : null;
+      toast({
+        title: 'Could not leave site',
+        description: message ?? 'Something went wrong. Please try again.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>My Sites{data ? ` (${data.length})` : ''}</CardTitle>
+        <CardDescription>
+          Sites where your BFFless Auth account is a member. You can leave any site you
+          don&apos;t own.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {isLoading && (
+          <>
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-20 w-full" />
+          </>
+        )}
+        {error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              Couldn&apos;t load your sites. Refresh the page or try again later.
+            </AlertDescription>
+          </Alert>
+        )}
+        {data && data.length === 0 && (
+          <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+            You&apos;re not a member of any sites yet. When a site owner adds you, it will show up
+            here.
+          </div>
+        )}
+        {data?.map((m) => (
+          <MembershipCard key={m.projectId} membership={m} onLeaveClick={setPendingLeave} />
+        ))}
+      </CardContent>
+
+      <AlertDialog
+        open={!!pendingLeave}
+        onOpenChange={(open) => !open && setPendingLeave(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Leave {pendingLeave?.projectName}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              You&apos;ll lose access to this site. The site owner can re-invite you any time.
+              Your BFFless Auth account stays active.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isLeaving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={onConfirmLeave} disabled={isLeaving}>
+              {isLeaving ? 'Leaving…' : 'Leave site'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/apps/frontend/src/pages/AccountPage.tsx
+++ b/apps/frontend/src/pages/AccountPage.tsx
@@ -1,0 +1,71 @@
+import { useNavigate } from 'react-router-dom';
+import { useGetSessionQuery, useGetLoginMethodsQuery } from '@/services/authApi';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft, User as UserIcon } from 'lucide-react';
+import { ChangePasswordCard } from '@/components/settings/ChangePasswordCard';
+import { MySitesSection } from '@/components/account/MySitesSection';
+
+/**
+ * The central identity hub. BFFless Auth is the identity provider; sites are
+ * SaaS that consume that identity. This page is where a user lands to:
+ *   - Confirm which account they're signed in as
+ *   - Change their password / manage credentials
+ *   - See every site their identity is a member of (My Sites)
+ *   - Leave any site they don't own
+ *
+ * Linked from `<AuthDialog.PoweredBy />` (consumer sites) and from the 403
+ * page when a workspace member hits a site they have no membership in.
+ *
+ * Distinct from `/settings`, which is the workspace-admin settings page
+ * (API keys, preferences). `/account` is identity-and-memberships only.
+ */
+export function AccountPage() {
+  const navigate = useNavigate();
+  const { data: sessionData } = useGetSessionQuery();
+  const { data: loginMethods } = useGetLoginMethodsQuery();
+  const user = sessionData?.user;
+
+  if (!user) return null;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="sm" onClick={() => navigate('/')}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back
+        </Button>
+        <div>
+          <h1 className="text-2xl font-bold">Account</h1>
+          <p className="text-sm text-muted-foreground">
+            Manage your BFFless Auth identity and the sites you&apos;re a member of.
+          </p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <UserIcon className="h-5 w-5" />
+            Signed in as
+          </CardTitle>
+          <CardDescription>
+            One identity, used across every site you&apos;re a member of.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div className="text-base">{user.email}</div>
+          <div className="text-xs font-mono text-muted-foreground">{user.id}</div>
+        </CardContent>
+      </Card>
+
+      {loginMethods?.hasPassword && <ChangePasswordCard />}
+
+      <MySitesSection />
+
+      <p className="text-center text-xs text-muted-foreground">
+        Powered by BFFless Auth — your identity provider for every site listed above.
+      </p>
+    </div>
+  );
+}

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -208,6 +208,7 @@ export const api = createApi({
     'Branding',
     'OAuthSettings',
     'ProjectInviteLink',
+    'MyProjects',
   ],
   endpoints: () => ({}),
 });

--- a/apps/frontend/src/services/meApi.ts
+++ b/apps/frontend/src/services/meApi.ts
@@ -1,0 +1,37 @@
+import { api } from './api';
+
+export type ProjectRole = 'owner' | 'admin' | 'contributor' | 'viewer' | 'guest';
+
+/**
+ * Mirror of `MyProjectMembership` from
+ * `ce/apps/backend/src/permissions/permissions.service.ts`. Powers the
+ * "My Sites" admin hub at `/account`.
+ */
+export interface MyProjectMembership {
+  projectId: string;
+  projectName: string;
+  projectSlug: string;
+  primaryUrl: string | null;
+  role: ProjectRole;
+  joinedAt: string;
+  ownerEmail: string | null;
+}
+
+export const meApi = api.injectEndpoints({
+  endpoints: (builder) => ({
+    listMyProjects: builder.query<MyProjectMembership[], void>({
+      query: () => '/api/me/projects',
+      providesTags: [{ type: 'MyProjects' as const, id: 'LIST' }],
+    }),
+
+    leaveProject: builder.mutation<void, { projectId: string }>({
+      query: ({ projectId }) => ({
+        url: `/api/me/projects/${projectId}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: [{ type: 'MyProjects' as const, id: 'LIST' }],
+    }),
+  }),
+});
+
+export const { useListMyProjectsQuery, useLeaveProjectMutation } = meApi;


### PR DESCRIPTION
## Summary

Phase D of the project-membership-gated auth story (`stories/backlog/phase-project-membership-auth/phases/D-identity-hub-ux.md`) — surfaces the BFFless-Auth-as-identity-provider model to end users.

- **Backend `/api/me/*`** — `MeController` with `GET projects` (rich `MyProjectMembership[]`) and `DELETE projects/:id` (self-serve leave). `permissions.listUserProjectMemberships` aggregates direct + group memberships and batches lookups; `permissions.revokeSystemPermission` mirrors `grantSystemPermission` for self-leave (rejects owners → 400, non-members → 404). Cross-project routes opt out of Phase C's `ProjectMembershipGuard` via `@PublicProjectAccess()`.
- **Admin UI `/account`** — `AccountPage` with identity card, Change Password, `<MySitesSection />` (role-badged cards, Visit/Leave actions, owner-disabled Leave with tooltip, AlertDialog confirmation, success + destructive-error toasts), and "Powered by BFFless Auth" footer. New `meApi` RTK Query service with `MyProjects` cache tag.
- **403 link-back** — `serve403Page` enriched with signed-in email and a "Manage your sites" link to `<ADMIN_DOMAIN>/account` (falls back to `admin.<workspace-base>/account`). New `buildAccountHubUrl` helper mirrors `buildLoginUrl`'s host resolution. Pure additive — falls back to old copy when email/req aren't passed.

Phase D's components-library work (`<AuthDialog.PoweredBy />`, smart "account exists" UX) lives in `web-templates/components` and ships separately. Public docs update is a `docs-public/` follow-up.

## Test plan

- [x] `pnpm --filter backend exec tsc --noEmit` — clean
- [x] `pnpm --filter frontend exec tsc --noEmit` — clean
- [x] `pnpm test -- me.controller.spec` — 6/6 pass
- [x] `pnpm test -- permissions.service.spec` — 44/44 pass (37 existing + 7 new for `revokeSystemPermission` and `listUserProjectMemberships`)
- [x] `pnpm test -- public.controller.spec` — 20/20 pass (no regression from 403 changes)
- [x] `pnpm test -- MySitesSection` — 5/5 pass (empty state, card render, owner-disabled, confirm-flow, error toast)
- [ ] Manual: sign in to `admin.<your-domain>`, visit `/account` — see identity, Change Password (when password auth enabled), My Sites cards
- [ ] Manual: with two test projects, Leave one as a guest → card disappears, can't re-leave
- [ ] Manual: try to Leave a project you own → button disabled with tooltip
- [ ] Manual: hit a private site as a non-member → 403 page shows your email + "Manage your sites" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)