### PR TITLE
fix(auth): backfill workspace user row on orphan signup via custom domain

### DIFF
--- a/apps/backend/src/auth/custom-domain-auth.controller.spec.ts
+++ b/apps/backend/src/auth/custom-domain-auth.controller.spec.ts
@@ -18,6 +18,17 @@ jest.mock('supertokens-node/recipe/session', () => ({
   getSession: (...args: any[]) => getSessionMock(...args),
 }));
 
+// Mock EmailPassword recipe used by signUp / signIn paths.
+const stSignUpMock = jest.fn();
+const stSignInMock = jest.fn();
+jest.mock('supertokens-node/recipe/emailpassword', () => ({
+  __esModule: true,
+  default: {
+    signUp: (...args: any[]) => stSignUpMock(...args),
+    signIn: (...args: any[]) => stSignInMock(...args),
+  },
+}));
+
 import { CustomDomainAuthController } from './custom-domain-auth.controller';
 import { CustomDomainAuthService } from './custom-domain-auth.service';
 import { DomainTokenService } from './domain-token.service';
@@ -177,5 +188,194 @@ describe('CustomDomainAuthController.session (project-membership gate, Phase B)'
 
       expect(result).toEqual({ authenticated: true, user: stUser });
     });
+  });
+});
+
+describe('CustomDomainAuthController.signUp (existing-email orphan re-create)', () => {
+  let controller: CustomDomainAuthController;
+  let customDomainAuthService: jest.Mocked<CustomDomainAuthService>;
+  let authService: jest.Mocked<AuthService>;
+  let setupService: jest.Mocked<SetupService>;
+  let featureFlags: jest.Mocked<FeatureFlagsService>;
+  let projectResolver: jest.Mocked<ProjectResolverService>;
+  let permissions: jest.Mocked<PermissionsService>;
+
+  const EMAIL = 'orphan@example.com';
+  const PASSWORD = 'correct-horse-battery';
+  const ST_USER_ID = 'st-user-123';
+  const PROJECT = { id: 'proj-1', allowPublicSignup: true } as any;
+
+  const reqForSignup = (): Request =>
+    ({
+      headers: { host: 'www.bellacharlesworth.com' },
+      cookies: {},
+    }) as unknown as Request;
+
+  const resForSignup = (): Response =>
+    ({
+      cookie: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    }) as unknown as Response;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stSignUpMock.mockReset();
+    stSignInMock.mockReset();
+
+    customDomainAuthService = {
+      createAccessToken: jest.fn().mockReturnValue('access-token'),
+      createRefreshToken: jest.fn().mockReturnValue('refresh-token'),
+      setAuthCookies: jest.fn(),
+    } as unknown as jest.Mocked<CustomDomainAuthService>;
+
+    authService = {
+      getUserByEmail: jest.fn(),
+      getUserById: jest.fn(),
+      createUser: jest.fn(),
+    } as unknown as jest.Mocked<AuthService>;
+
+    setupService = {
+      isRegistrationFeatureEnabled: jest.fn().mockResolvedValue(true),
+      canPublicSignup: jest.fn().mockResolvedValue(true),
+    } as unknown as jest.Mocked<SetupService>;
+
+    featureFlags = {
+      isEnabled: jest.fn().mockResolvedValue(true),
+    } as unknown as jest.Mocked<FeatureFlagsService>;
+
+    projectResolver = {
+      resolveProjectFromRequest: jest.fn().mockResolvedValue(PROJECT),
+    } as unknown as jest.Mocked<ProjectResolverService>;
+
+    permissions = {
+      grantSystemPermission: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<PermissionsService>;
+
+    controller = new CustomDomainAuthController(
+      {} as DomainTokenService,
+      customDomainAuthService,
+      authService,
+      setupService,
+      featureFlags,
+      {} as EmailService,
+      projectResolver,
+      permissions,
+    );
+  });
+
+  it('backfills the workspace user row when SuperTokens has the identity but the local users table does not', async () => {
+    stSignUpMock.mockResolvedValue({ status: 'EMAIL_ALREADY_EXISTS_ERROR' });
+    stSignInMock.mockResolvedValue({
+      status: 'OK',
+      recipeUserId: { getAsString: () => ST_USER_ID },
+    });
+    authService.getUserByEmail.mockResolvedValue(null);
+    authService.getUserById.mockResolvedValue(null);
+    const created = { id: ST_USER_ID, email: EMAIL, role: 'member', disabled: false } as any;
+    authService.createUser.mockResolvedValue(created);
+
+    const result = await controller.signUp(
+      { email: EMAIL, password: PASSWORD },
+      reqForSignup(),
+      resForSignup(),
+    );
+
+    expect(authService.createUser).toHaveBeenCalledWith(EMAIL, 'member', ST_USER_ID);
+    expect(permissions.grantSystemPermission).toHaveBeenCalledWith(PROJECT.id, ST_USER_ID, 'guest');
+    expect(customDomainAuthService.setAuthCookies).toHaveBeenCalled();
+    expect(result).toEqual({
+      status: 'OK',
+      user: { id: ST_USER_ID, email: EMAIL, role: 'member' },
+      emailVerificationRequired: false,
+    });
+  });
+
+  it('grants admin role to the orphan re-create when the email matches ADMIN_EMAIL', async () => {
+    const prevAdmin = process.env.ADMIN_EMAIL;
+    process.env.ADMIN_EMAIL = EMAIL;
+    try {
+      stSignUpMock.mockResolvedValue({ status: 'EMAIL_ALREADY_EXISTS_ERROR' });
+      stSignInMock.mockResolvedValue({
+        status: 'OK',
+        recipeUserId: { getAsString: () => ST_USER_ID },
+      });
+      authService.getUserByEmail.mockResolvedValue(null);
+      authService.getUserById.mockResolvedValue(null);
+      authService.createUser.mockResolvedValue({
+        id: ST_USER_ID,
+        email: EMAIL,
+        role: 'admin',
+        disabled: false,
+      } as any);
+
+      await controller.signUp(
+        { email: EMAIL, password: PASSWORD },
+        reqForSignup(),
+        resForSignup(),
+      );
+
+      expect(authService.createUser).toHaveBeenCalledWith(EMAIL, 'admin', ST_USER_ID);
+    } finally {
+      process.env.ADMIN_EMAIL = prevAdmin;
+    }
+  });
+
+  it('does not call createUser when the workspace user already exists (non-orphan)', async () => {
+    const existing = { id: ST_USER_ID, email: EMAIL, role: 'member', disabled: false } as any;
+    stSignUpMock.mockResolvedValue({ status: 'EMAIL_ALREADY_EXISTS_ERROR' });
+    stSignInMock.mockResolvedValue({
+      status: 'OK',
+      recipeUserId: { getAsString: () => ST_USER_ID },
+    });
+    authService.getUserByEmail.mockResolvedValue(existing);
+
+    const result = await controller.signUp(
+      { email: EMAIL, password: PASSWORD },
+      reqForSignup(),
+      resForSignup(),
+    );
+
+    expect(authService.createUser).not.toHaveBeenCalled();
+    expect(permissions.grantSystemPermission).toHaveBeenCalledWith(PROJECT.id, ST_USER_ID, 'guest');
+    expect(result).toEqual({
+      status: 'OK',
+      user: { id: ST_USER_ID, email: EMAIL, role: 'member' },
+      emailVerificationRequired: false,
+    });
+  });
+
+  it('still returns EMAIL_ALREADY_EXISTS_ERROR when the password is wrong (no orphan re-create)', async () => {
+    stSignUpMock.mockResolvedValue({ status: 'EMAIL_ALREADY_EXISTS_ERROR' });
+    stSignInMock.mockResolvedValue({ status: 'WRONG_CREDENTIALS_ERROR' });
+    authService.getUserByEmail.mockResolvedValue(null);
+    authService.getUserById.mockResolvedValue(null);
+
+    const result = await controller.signUp(
+      { email: EMAIL, password: 'wrong-but-long-enough' },
+      reqForSignup(),
+      resForSignup(),
+    );
+
+    expect(authService.createUser).not.toHaveBeenCalled();
+    expect(permissions.grantSystemPermission).not.toHaveBeenCalled();
+    expect(result).toEqual({ status: 'EMAIL_ALREADY_EXISTS_ERROR' });
+  });
+
+  it('does not orphan-re-create when the request resolves to no project (admin domain)', async () => {
+    projectResolver.resolveProjectFromRequest.mockResolvedValue(null);
+    stSignUpMock.mockResolvedValue({ status: 'EMAIL_ALREADY_EXISTS_ERROR' });
+    authService.getUserByEmail.mockResolvedValue(null);
+    authService.getUserById.mockResolvedValue(null);
+
+    const result = await controller.signUp(
+      { email: EMAIL, password: PASSWORD },
+      reqForSignup(),
+      resForSignup(),
+    );
+
+    expect(stSignInMock).not.toHaveBeenCalled();
+    expect(authService.createUser).not.toHaveBeenCalled();
+    expect(result).toEqual({ status: 'EMAIL_ALREADY_EXISTS_ERROR' });
   });
 });

--- a/apps/backend/src/auth/custom-domain-auth.controller.ts
+++ b/apps/backend/src/auth/custom-domain-auth.controller.ts
@@ -586,9 +586,21 @@ export class CustomDomainAuthController {
       if (project) {
         const verifyResponse = await EmailPassword.signIn(tenantId, email, password);
         if (verifyResponse.status === 'OK') {
+          const stUserId = verifyResponse.recipeUserId.getAsString();
           let user = await this.authService.getUserByEmail(email);
           if (!user) {
-            user = await this.authService.getUserById(verifyResponse.recipeUserId.getAsString());
+            user = await this.authService.getUserById(stUserId);
+          }
+          if (!user) {
+            // Orphan: SuperTokens has the identity but this workspace's `users`
+            // table doesn't. Happens when the email exists from another
+            // workspace sharing the same SuperTokens core, or the row was
+            // deleted app-side. Backfill using the verified SuperTokens id so
+            // the membership grant has something to point at. Mirrors the
+            // admin-side orphan re-create in auth.controller.ts:signUp.
+            const role: 'admin' | 'user' | 'member' =
+              email === process.env.ADMIN_EMAIL ? 'admin' : 'member';
+            user = await this.authService.createUser(email, role, stUserId);
           }
           if (user && !user.disabled) {
             await this.permissions.grantSystemPermission(project.id, user.id, 'guest');


### PR DESCRIPTION
## Summary

- Mirror the admin-controller orphan re-create pattern into `custom-domain-auth.controller.ts`'s signup. When SuperTokens has the identity but the workspace `users` table doesn't (and the password verifies), backfill the row before granting `guest` membership and minting cookies.
- Adds 5 unit tests covering the orphan branch, the `ADMIN_EMAIL` role variant, the non-orphan happy path, the wrong-password path, and the admin-domain bypass.

## Bug

On a custom domain, a user who exists in SuperTokens but not in the workspace's `users` table couldn't onboard:

- `POST /_bffless/auth/signin` → `401 "User not found"` (correct: opaque, member-only)
- `POST /_bffless/auth/signup` → `EMAIL_ALREADY_EXISTS_ERROR` even though `allowPublicSignup=true` and the password matched.

Happens whenever the email already exists in another workspace sharing the same SuperTokens core, or when the workspace `users` row was deleted while the SuperTokens identity remained. The admin controller `/api/auth/signup` already handles this (`auth.controller.ts:245-324`); the custom-domain controller (added in Phase A) was missing it.

## Test plan

- [x] `pnpm test -- custom-domain-auth.controller` — all 12 tests pass (5 new)
- [x] `pnpm --filter backend exec tsc --noEmit` — clean
- [ ] Manual: on `bellacharlesworth.com` (or any project with `allowPublicSignup=true`), use an email that exists in another workspace's SuperTokens. "Create account" should succeed and add the user to `users` + `project_permissions` as `guest`.
- [ ] Manual: same flow with the wrong password → `EMAIL_ALREADY_EXISTS_ERROR` (unchanged).
- [ ] Manual: `admin.sites.bffless.app` flow unchanged (no project resolves; admin's own orphan-recreate handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)