### PR TITLE
feat: generic scheduling component (Phase A: google-calendar integration)

### DIFF
--- a/apps/backend/src/integrations/google-calendar-oauth.service.spec.ts
+++ b/apps/backend/src/integrations/google-calendar-oauth.service.spec.ts
@@ -5,14 +5,22 @@ import { GoogleCalendarIntegrationKeys } from './google-calendar.interface';
 
 describe('GoogleCalendarOAuthService', () => {
   let service: GoogleCalendarOAuthService;
-  let integrationsService: { getActiveConfig: jest.Mock; setConfig: jest.Mock };
+  let integrationsService: {
+    getActiveConfig: jest.Mock;
+    setConfig: jest.Mock;
+    getStoredIntegration: jest.Mock;
+  };
   let originalFetch: typeof globalThis.fetch;
 
   beforeEach(async () => {
     integrationsService = {
       getActiveConfig: jest.fn(),
       setConfig: jest.fn().mockResolvedValue(undefined),
-    };
+      getStoredIntegration: jest.fn().mockResolvedValue({
+        enabled: true,
+        activeEnvironment: 'production',
+      }),
+    } as any;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -157,6 +165,32 @@ describe('GoogleCalendarOAuthService', () => {
         clientSecret: 'sec',
       });
       const tok = await service.getValidAccessToken('proj', 'production');
+      expect(tok).toBeNull();
+    });
+
+    it('falls back to active environment when env is omitted', async () => {
+      integrationsService.getStoredIntegration.mockResolvedValue({
+        enabled: true,
+        activeEnvironment: 'sandbox',
+      });
+      integrationsService.getActiveConfig.mockResolvedValue(baseConfig);
+
+      const tok = await service.getValidAccessToken('proj');
+      expect(tok).toBe('current-tok');
+      // resolved env should propagate to getActiveConfig
+      expect(integrationsService.getActiveConfig).toHaveBeenCalledWith(
+        'proj',
+        'google-calendar',
+        'sandbox',
+      );
+    });
+
+    it('returns null when integration is not enabled and env omitted', async () => {
+      integrationsService.getStoredIntegration.mockResolvedValue({
+        enabled: false,
+        activeEnvironment: 'production',
+      });
+      const tok = await service.getValidAccessToken('proj');
       expect(tok).toBeNull();
     });
   });

--- a/apps/backend/src/integrations/google-calendar-oauth.service.spec.ts
+++ b/apps/backend/src/integrations/google-calendar-oauth.service.spec.ts
@@ -1,0 +1,197 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GoogleCalendarOAuthService } from './google-calendar-oauth.service';
+import { IntegrationsService } from './integrations.service';
+import { GoogleCalendarIntegrationKeys } from './google-calendar.interface';
+
+describe('GoogleCalendarOAuthService', () => {
+  let service: GoogleCalendarOAuthService;
+  let integrationsService: { getActiveConfig: jest.Mock; setConfig: jest.Mock };
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(async () => {
+    integrationsService = {
+      getActiveConfig: jest.fn(),
+      setConfig: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GoogleCalendarOAuthService,
+        { provide: IntegrationsService, useValue: integrationsService },
+      ],
+    }).compile();
+
+    service = module.get(GoogleCalendarOAuthService);
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  const mockFetch = (impl: (url: string, init?: any) => Promise<{ ok: boolean; status?: number; body: any }>) => {
+    globalThis.fetch = jest.fn(async (url: any, init: any) => {
+      const r = await impl(String(url), init);
+      return {
+        ok: r.ok,
+        status: r.status ?? (r.ok ? 200 : 500),
+        json: async () => r.body,
+      } as any;
+    }) as any;
+  };
+
+  describe('buildAuthorizationUrl', () => {
+    it('includes the project clientId, scopes, and state', () => {
+      const url = service.buildAuthorizationUrl('cid.example', 'state-abc', 'https://site.test/cb');
+      expect(url).toContain('client_id=cid.example');
+      expect(url).toContain('redirect_uri=https%3A%2F%2Fsite.test%2Fcb');
+      expect(url).toContain('state=state-abc');
+      expect(url).toContain('access_type=offline');
+      expect(url).toContain('prompt=consent');
+      // calendar.events scope should appear in the encoded scope param
+      expect(url).toContain('calendar.events');
+    });
+  });
+
+  describe('refreshAccessTokenForCredentials', () => {
+    it('returns access token + absolute expiry on success', async () => {
+      mockFetch(async () => ({ ok: true, body: { access_token: 'new-tok', expires_in: 3600 } }));
+
+      const before = Date.now();
+      const result = await service.refreshAccessTokenForCredentials('cid', 'sec', 'rt');
+      const after = Date.now();
+
+      expect(result.accessToken).toBe('new-tok');
+      expect(result.tokenExpiry).toBeGreaterThanOrEqual(before + 3600 * 1000 - 50);
+      expect(result.tokenExpiry).toBeLessThanOrEqual(after + 3600 * 1000 + 50);
+    });
+
+    it('throws when Google returns non-2xx', async () => {
+      mockFetch(async () => ({ ok: false, status: 400, body: { error_description: 'invalid_grant' } }));
+
+      await expect(service.refreshAccessTokenForCredentials('cid', 'sec', 'rt')).rejects.toThrow(
+        'invalid_grant',
+      );
+    });
+  });
+
+  describe('listCalendarsForToken', () => {
+    it('parses items into the expected tuple shape with timezone fallback', async () => {
+      mockFetch(async () => ({
+        ok: true,
+        body: {
+          items: [
+            { id: 'a@x', summary: 'A', primary: true, timeZone: 'America/New_York' },
+            { id: 'b@x' /* missing summary + tz */ },
+          ],
+        },
+      }));
+
+      const cals = await service.listCalendarsForToken('access-tok');
+
+      expect(cals).toHaveLength(2);
+      expect(cals[0]).toEqual({ id: 'a@x', summary: 'A', primary: true, timeZone: 'America/New_York' });
+      expect(cals[1]).toEqual({ id: 'b@x', summary: 'b@x', primary: false, timeZone: 'UTC' });
+    });
+  });
+
+  describe('getValidAccessToken', () => {
+    const baseConfig: GoogleCalendarIntegrationKeys = {
+      clientId: 'cid',
+      clientSecret: 'sec',
+      accessToken: 'current-tok',
+      refreshToken: 'rt',
+      tokenExpiry: Date.now() + 5 * 60_000, // 5 min from now
+    };
+
+    it('returns the existing token when not within the 60s buffer', async () => {
+      integrationsService.getActiveConfig.mockResolvedValue(baseConfig);
+      const fetchSpy = jest.spyOn(globalThis, 'fetch' as any);
+
+      const tok = await service.getValidAccessToken('proj', 'production');
+      expect(tok).toBe('current-tok');
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(integrationsService.setConfig).not.toHaveBeenCalled();
+    });
+
+    it('refreshes and persists when within the 60s buffer', async () => {
+      integrationsService.getActiveConfig.mockResolvedValue({
+        ...baseConfig,
+        tokenExpiry: Date.now() + 30_000, // expires in 30s — inside buffer
+      });
+      mockFetch(async () => ({ ok: true, body: { access_token: 'fresh', expires_in: 3600 } }));
+
+      const tok = await service.getValidAccessToken('proj', 'production');
+
+      expect(tok).toBe('fresh');
+      expect(integrationsService.setConfig).toHaveBeenCalledWith(
+        'proj',
+        'google-calendar',
+        'production',
+        expect.objectContaining({ accessToken: 'fresh' }),
+      );
+    });
+
+    it('returns null without throwing when refresh fails', async () => {
+      integrationsService.getActiveConfig.mockResolvedValue({
+        ...baseConfig,
+        tokenExpiry: 0,
+      });
+      mockFetch(async () => ({ ok: false, status: 400, body: { error_description: 'invalid_grant' } }));
+
+      const tok = await service.getValidAccessToken('proj', 'production');
+      expect(tok).toBeNull();
+      expect(integrationsService.setConfig).not.toHaveBeenCalled();
+    });
+
+    it('returns null when integration is not configured', async () => {
+      integrationsService.getActiveConfig.mockResolvedValue(null);
+      const tok = await service.getValidAccessToken('proj', 'production');
+      expect(tok).toBeNull();
+    });
+
+    it('returns null when refreshToken is missing', async () => {
+      integrationsService.getActiveConfig.mockResolvedValue({
+        clientId: 'cid',
+        clientSecret: 'sec',
+      });
+      const tok = await service.getValidAccessToken('proj', 'production');
+      expect(tok).toBeNull();
+    });
+  });
+
+  describe('exchangeCodeForCredentials', () => {
+    it('exchanges code, fetches user email, returns absolute expiry', async () => {
+      const calls: string[] = [];
+      mockFetch(async (url) => {
+        calls.push(url);
+        if (url.includes('/token')) {
+          return { ok: true, body: { access_token: 'a', refresh_token: 'r', expires_in: 3600 } };
+        }
+        if (url.includes('userinfo')) {
+          return { ok: true, body: { email: 'owner@example.com' } };
+        }
+        return { ok: false, body: {} };
+      });
+
+      const result = await service.exchangeCodeForCredentials('cid', 'sec', 'auth-code', 'https://cb.test');
+      expect(result.accessToken).toBe('a');
+      expect(result.refreshToken).toBe('r');
+      expect(result.connectedEmail).toBe('owner@example.com');
+      expect(result.tokenExpiry).toBeGreaterThan(Date.now());
+    });
+
+    it('falls back to "unknown" email when userinfo fails', async () => {
+      mockFetch(async (url) => {
+        if (url.includes('/token')) {
+          return { ok: true, body: { access_token: 'a', refresh_token: 'r', expires_in: 3600 } };
+        }
+        return { ok: false, status: 500, body: {} };
+      });
+
+      const result = await service.exchangeCodeForCredentials('cid', 'sec', 'code', 'https://cb');
+      expect(result.connectedEmail).toBe('unknown');
+    });
+  });
+});

--- a/apps/backend/src/integrations/google-calendar-oauth.service.ts
+++ b/apps/backend/src/integrations/google-calendar-oauth.service.ts
@@ -1,0 +1,320 @@
+import { Inject, Injectable, Logger, forwardRef } from '@nestjs/common';
+import { IntegrationsService } from './integrations.service';
+import { GoogleCalendarIntegrationKeys } from './google-calendar.interface';
+
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
+const GOOGLE_REVOKE_URL = 'https://oauth2.googleapis.com/revoke';
+const GOOGLE_CALENDAR_LIST_URL = 'https://www.googleapis.com/calendar/v3/users/me/calendarList';
+
+const SCOPES = [
+  'https://www.googleapis.com/auth/calendar.freebusy',
+  'https://www.googleapis.com/auth/calendar.events',
+  'https://www.googleapis.com/auth/calendar.readonly',
+  'https://www.googleapis.com/auth/userinfo.email',
+];
+
+/**
+ * Token-refresh response surface. `tokenExpiry` is unix ms.
+ */
+export interface RefreshedTokens {
+  accessToken: string;
+  tokenExpiry: number;
+}
+
+/**
+ * OAuth-exchange response surface (refresh token included).
+ */
+export interface ExchangedTokens extends RefreshedTokens {
+  refreshToken: string;
+  connectedEmail: string;
+}
+
+export interface CalendarSummary {
+  id: string;
+  summary: string;
+  primary?: boolean;
+  timeZone: string;
+}
+
+/**
+ * Shared Google Calendar OAuth service.
+ *
+ * Two flavors of helper:
+ *   - `*ForCredentials(clientId, clientSecret, …)` — pure HTTP. Used by callers
+ *     that already have decrypted credentials in hand (e.g. the AI-plugin
+ *     `GoogleOAuthService` that stores creds in its own `settings.aiPlugins`
+ *     namespace).
+ *   - `*ForProject(projectId, env, …)` — fetches creds from
+ *     `IntegrationsService` (the `'google-calendar'` integration) and calls the
+ *     `ForCredentials` variant. Used by Phase B's `google_calendar` step
+ *     handler and the scheduling pipelines.
+ *
+ * Token storage: only the `*ForProject` variants persist refreshed tokens back
+ * via `IntegrationsService.setConfig`. The AI-plugin path does its own
+ * persistence.
+ */
+@Injectable()
+export class GoogleCalendarOAuthService {
+  private readonly logger = new Logger(GoogleCalendarOAuthService.name);
+  static readonly SCOPES = SCOPES;
+
+  constructor(
+    @Inject(forwardRef(() => IntegrationsService))
+    private readonly integrationsService: IntegrationsService,
+  ) {}
+
+  // ===== ForCredentials (pure HTTP) =====
+
+  /**
+   * Build the consent URL given an explicit clientId. The caller is responsible
+   * for opaque `state` (encryption / signing / replay protection).
+   */
+  buildAuthorizationUrl(clientId: string, state: string, redirectUri: string): string {
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: 'code',
+      scope: SCOPES.join(' '),
+      access_type: 'offline',
+      prompt: 'consent',
+      state,
+    });
+    return `${GOOGLE_AUTH_URL}?${params.toString()}`;
+  }
+
+  /** Exchange an auth code for tokens using the supplied credentials. */
+  async exchangeCodeForCredentials(
+    clientId: string,
+    clientSecret: string,
+    code: string,
+    redirectUri: string,
+  ): Promise<ExchangedTokens> {
+    const tokenResponse = await fetch(GOOGLE_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        code,
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uri: redirectUri,
+        grant_type: 'authorization_code',
+      }),
+    });
+
+    if (!tokenResponse.ok) {
+      const error = await tokenResponse.json().catch(() => ({}));
+      this.logger.error(`Token exchange failed: ${JSON.stringify(error)}`);
+      throw new Error(error.error_description || `Token exchange failed (HTTP ${tokenResponse.status})`);
+    }
+
+    const tokens = await tokenResponse.json();
+
+    // Best-effort fetch of the user's email for owner display
+    let connectedEmail = 'unknown';
+    try {
+      const userInfo = await fetch(GOOGLE_USERINFO_URL, {
+        headers: { Authorization: `Bearer ${tokens.access_token}` },
+      });
+      if (userInfo.ok) {
+        const data = await userInfo.json();
+        connectedEmail = data.email || 'unknown';
+      }
+    } catch (err: any) {
+      this.logger.warn(`Failed to fetch userinfo after token exchange: ${err.message}`);
+    }
+
+    return {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      tokenExpiry: Date.now() + tokens.expires_in * 1000,
+      connectedEmail,
+    };
+  }
+
+  /** Refresh an access token using the supplied credentials. */
+  async refreshAccessTokenForCredentials(
+    clientId: string,
+    clientSecret: string,
+    refreshToken: string,
+  ): Promise<RefreshedTokens> {
+    const response = await fetch(GOOGLE_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: refreshToken,
+        grant_type: 'refresh_token',
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(error.error_description || `Refresh failed (HTTP ${response.status})`);
+    }
+
+    const data = await response.json();
+    return {
+      accessToken: data.access_token,
+      tokenExpiry: Date.now() + data.expires_in * 1000,
+    };
+  }
+
+  /** GET calendarList. Used at OAuth callback and the admin "list_calendars" pipeline. */
+  async listCalendarsForToken(accessToken: string): Promise<CalendarSummary[]> {
+    const response = await fetch(GOOGLE_CALENDAR_LIST_URL, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(error.error?.message || `calendarList failed (HTTP ${response.status})`);
+    }
+    const data = await response.json();
+    return (data.items || []).map((item: any) => ({
+      id: item.id,
+      summary: item.summary || item.id,
+      primary: item.primary || false,
+      timeZone: item.timeZone || 'UTC',
+    }));
+  }
+
+  /** Best-effort revoke. */
+  async revokeToken(refreshToken: string): Promise<void> {
+    try {
+      await fetch(`${GOOGLE_REVOKE_URL}?token=${encodeURIComponent(refreshToken)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      });
+    } catch (err: any) {
+      this.logger.warn(`Token revocation failed: ${err.message}`);
+    }
+  }
+
+  // ===== ForProject (IntegrationsService-backed) =====
+
+  /**
+   * Build the consent URL using the project's stored clientId.
+   * Returns null if the integration isn't configured.
+   */
+  async getAuthorizationUrlForProject(
+    projectId: string,
+    env: 'sandbox' | 'production',
+    state: string,
+    redirectUri: string,
+  ): Promise<string | null> {
+    const config = await this.getProjectConfig(projectId, env);
+    if (!config?.clientId) return null;
+    return this.buildAuthorizationUrl(config.clientId, state, redirectUri);
+  }
+
+  /**
+   * Exchange auth code for tokens using the project's stored credentials and
+   * persist tokens + connectedEmail back into the integration config.
+   */
+  async exchangeCodeForProject(
+    projectId: string,
+    env: 'sandbox' | 'production',
+    code: string,
+    redirectUri: string,
+  ): Promise<ExchangedTokens> {
+    const config = await this.getProjectConfig(projectId, env);
+    if (!config?.clientId || !config?.clientSecret) {
+      throw new Error('Google Calendar integration not configured');
+    }
+    const tokens = await this.exchangeCodeForCredentials(
+      config.clientId,
+      config.clientSecret,
+      code,
+      redirectUri,
+    );
+
+    // Persist tokens + email. Refresh availableCalendars snapshot too.
+    let availableCalendars: CalendarSummary[] | undefined;
+    try {
+      availableCalendars = await this.listCalendarsForToken(tokens.accessToken);
+    } catch (err: any) {
+      this.logger.warn(`Could not fetch calendarList after exchange: ${err.message}`);
+    }
+
+    await this.integrationsService.setConfig(projectId, 'google-calendar', env, {
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      tokenExpiry: tokens.tokenExpiry,
+      connectedEmail: tokens.connectedEmail,
+      ...(availableCalendars ? { availableCalendars } : {}),
+    });
+
+    return tokens;
+  }
+
+  /**
+   * Get a valid access token for a project, refreshing if within 60s of expiry.
+   * Persists the refreshed token back to the integration config.
+   * Returns null if the integration isn't configured or refresh fails.
+   */
+  async getValidAccessToken(
+    projectId: string,
+    env: 'sandbox' | 'production',
+  ): Promise<string | null> {
+    const config = await this.getProjectConfig(projectId, env);
+    if (!config?.clientId || !config?.clientSecret || !config?.refreshToken) {
+      return null;
+    }
+
+    const expiry = config.tokenExpiry ?? 0;
+    if (config.accessToken && expiry > Date.now() + 60_000) {
+      return config.accessToken;
+    }
+
+    try {
+      const refreshed = await this.refreshAccessTokenForCredentials(
+        config.clientId,
+        config.clientSecret,
+        config.refreshToken,
+      );
+      await this.integrationsService.setConfig(projectId, 'google-calendar', env, {
+        accessToken: refreshed.accessToken,
+        tokenExpiry: refreshed.tokenExpiry,
+      });
+      return refreshed.accessToken;
+    } catch (err: any) {
+      this.logger.warn(`Token refresh failed for project ${projectId}: ${err.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * List calendars for the connected project account.
+   * Refreshes the token if needed and updates `availableCalendars`.
+   */
+  async listCalendarsForProject(
+    projectId: string,
+    env: 'sandbox' | 'production',
+  ): Promise<CalendarSummary[]> {
+    const accessToken = await this.getValidAccessToken(projectId, env);
+    if (!accessToken) {
+      throw new Error('Google Calendar not connected');
+    }
+    const calendars = await this.listCalendarsForToken(accessToken);
+    await this.integrationsService.setConfig(projectId, 'google-calendar', env, {
+      availableCalendars: calendars,
+    });
+    return calendars;
+  }
+
+  // ===== Internal =====
+
+  private async getProjectConfig(
+    projectId: string,
+    env: 'sandbox' | 'production',
+  ): Promise<GoogleCalendarIntegrationKeys | null> {
+    const config = await this.integrationsService.getActiveConfig(
+      projectId,
+      'google-calendar',
+      env,
+    );
+    return (config as GoogleCalendarIntegrationKeys | null) ?? null;
+  }
+}

--- a/apps/backend/src/integrations/google-calendar-oauth.service.ts
+++ b/apps/backend/src/integrations/google-calendar-oauth.service.ts
@@ -200,11 +200,13 @@ export class GoogleCalendarOAuthService {
    */
   async getAuthorizationUrlForProject(
     projectId: string,
-    env: 'sandbox' | 'production',
+    env: 'sandbox' | 'production' | undefined,
     state: string,
     redirectUri: string,
   ): Promise<string | null> {
-    const config = await this.getProjectConfig(projectId, env);
+    const resolvedEnv = await this.resolveActiveEnv(projectId, env);
+    if (!resolvedEnv) return null;
+    const config = await this.getProjectConfig(projectId, resolvedEnv);
     if (!config?.clientId) return null;
     return this.buildAuthorizationUrl(config.clientId, state, redirectUri);
   }
@@ -215,11 +217,15 @@ export class GoogleCalendarOAuthService {
    */
   async exchangeCodeForProject(
     projectId: string,
-    env: 'sandbox' | 'production',
+    env: 'sandbox' | 'production' | undefined,
     code: string,
     redirectUri: string,
   ): Promise<ExchangedTokens> {
-    const config = await this.getProjectConfig(projectId, env);
+    const resolvedEnv = await this.resolveActiveEnv(projectId, env);
+    if (!resolvedEnv) {
+      throw new Error('Google Calendar integration not configured');
+    }
+    const config = await this.getProjectConfig(projectId, resolvedEnv);
     if (!config?.clientId || !config?.clientSecret) {
       throw new Error('Google Calendar integration not configured');
     }
@@ -238,7 +244,7 @@ export class GoogleCalendarOAuthService {
       this.logger.warn(`Could not fetch calendarList after exchange: ${err.message}`);
     }
 
-    await this.integrationsService.setConfig(projectId, 'google-calendar', env, {
+    await this.integrationsService.setConfig(projectId, 'google-calendar', resolvedEnv, {
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken,
       tokenExpiry: tokens.tokenExpiry,
@@ -253,12 +259,18 @@ export class GoogleCalendarOAuthService {
    * Get a valid access token for a project, refreshing if within 60s of expiry.
    * Persists the refreshed token back to the integration config.
    * Returns null if the integration isn't configured or refresh fails.
+   *
+   * `env` is optional — when omitted, resolves to the project's active
+   * environment (matches `IntegrationsService.getActiveConfig` behaviour).
    */
   async getValidAccessToken(
     projectId: string,
-    env: 'sandbox' | 'production',
+    env?: 'sandbox' | 'production',
   ): Promise<string | null> {
-    const config = await this.getProjectConfig(projectId, env);
+    const resolvedEnv = await this.resolveActiveEnv(projectId, env);
+    if (!resolvedEnv) return null;
+
+    const config = await this.getProjectConfig(projectId, resolvedEnv);
     if (!config?.clientId || !config?.clientSecret || !config?.refreshToken) {
       return null;
     }
@@ -274,7 +286,7 @@ export class GoogleCalendarOAuthService {
         config.clientSecret,
         config.refreshToken,
       );
-      await this.integrationsService.setConfig(projectId, 'google-calendar', env, {
+      await this.integrationsService.setConfig(projectId, 'google-calendar', resolvedEnv, {
         accessToken: refreshed.accessToken,
         tokenExpiry: refreshed.tokenExpiry,
       });
@@ -291,14 +303,18 @@ export class GoogleCalendarOAuthService {
    */
   async listCalendarsForProject(
     projectId: string,
-    env: 'sandbox' | 'production',
+    env?: 'sandbox' | 'production',
   ): Promise<CalendarSummary[]> {
-    const accessToken = await this.getValidAccessToken(projectId, env);
+    const resolvedEnv = await this.resolveActiveEnv(projectId, env);
+    if (!resolvedEnv) {
+      throw new Error('Google Calendar not connected');
+    }
+    const accessToken = await this.getValidAccessToken(projectId, resolvedEnv);
     if (!accessToken) {
       throw new Error('Google Calendar not connected');
     }
     const calendars = await this.listCalendarsForToken(accessToken);
-    await this.integrationsService.setConfig(projectId, 'google-calendar', env, {
+    await this.integrationsService.setConfig(projectId, 'google-calendar', resolvedEnv, {
       availableCalendars: calendars,
     });
     return calendars;
@@ -316,5 +332,24 @@ export class GoogleCalendarOAuthService {
       env,
     );
     return (config as GoogleCalendarIntegrationKeys | null) ?? null;
+  }
+
+  /**
+   * Resolve the environment to use for token reads/writes. When `env` is
+   * supplied, returns it. Otherwise looks up the project's stored
+   * `activeEnvironment` for `'google-calendar'`. Returns null if the
+   * integration isn't enabled.
+   */
+  private async resolveActiveEnv(
+    projectId: string,
+    env: 'sandbox' | 'production' | undefined,
+  ): Promise<'sandbox' | 'production' | null> {
+    if (env) return env;
+    const stored = await this.integrationsService.getStoredIntegration(
+      projectId,
+      'google-calendar',
+    );
+    if (!stored?.enabled) return null;
+    return stored.activeEnvironment;
   }
 }

--- a/apps/backend/src/integrations/google-calendar.interface.ts
+++ b/apps/backend/src/integrations/google-calendar.interface.ts
@@ -1,0 +1,32 @@
+/**
+ * Decrypted Google Calendar integration config stored per-project in
+ * `settings.integrations['google-calendar']`.
+ *
+ * Each project registers its own Google OAuth client (clientId + clientSecret)
+ * for tenant isolation. The site owner then completes the consent flow which
+ * populates the token fields and the `availableCalendars` snapshot.
+ *
+ * NEVER expose `clientSecret`, `accessToken`, or `refreshToken` through
+ * `IntegrationsService.getPublicConfig` — see `PUBLIC_CONFIG_FIELDS`.
+ */
+export interface GoogleCalendarIntegrationKeys {
+  /** Per-project Google OAuth Client ID (e.g. `xxxxx.apps.googleusercontent.com`). */
+  clientId: string;
+  /** Per-project Google OAuth Client Secret. */
+  clientSecret: string;
+  /** Current OAuth access token (short-lived). Empty until OAuth flow completes. */
+  accessToken?: string;
+  /** Long-lived refresh token issued by Google. Empty until OAuth flow completes. */
+  refreshToken?: string;
+  /** Unix ms; `getValidAccessToken` refreshes when within 60s. */
+  tokenExpiry?: number;
+  /** Email address of the Google account that authorized — for owner display. */
+  connectedEmail?: string;
+  /** Snapshot of sub-calendars on the connected account. Refreshed at OAuth callback. */
+  availableCalendars?: Array<{
+    id: string;
+    summary: string;
+    primary?: boolean;
+    timeZone: string;
+  }>;
+}

--- a/apps/backend/src/integrations/integrations.module.ts
+++ b/apps/backend/src/integrations/integrations.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { IntegrationsService } from './integrations.service';
+import { GoogleCalendarOAuthService } from './google-calendar-oauth.service';
 
 @Module({
-  providers: [IntegrationsService],
-  exports: [IntegrationsService],
+  providers: [IntegrationsService, GoogleCalendarOAuthService],
+  exports: [IntegrationsService, GoogleCalendarOAuthService],
 })
 export class IntegrationsModule {}

--- a/apps/backend/src/integrations/integrations.service.spec.ts
+++ b/apps/backend/src/integrations/integrations.service.spec.ts
@@ -1,0 +1,179 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { IntegrationsService, StoredIntegrationConfig } from './integrations.service';
+import { GoogleCalendarOAuthService } from './google-calendar-oauth.service';
+import { GoogleCalendarIntegrationKeys } from './google-calendar.interface';
+
+// In-memory project settings store, keyed by projectId
+const settingsStore = new Map<string, Record<string, unknown>>();
+
+jest.mock('../db/client', () => {
+  return {
+    db: {
+      // SELECT { settings } FROM projects WHERE id = ? LIMIT 1
+      select: jest.fn(() => ({
+        from: jest.fn(() => ({
+          where: jest.fn((cond: any) => ({
+            limit: jest.fn(async () => {
+              const projectId: string = cond?._projectId ?? 'unknown';
+              const settings = settingsStore.get(projectId);
+              return settings ? [{ settings }] : [];
+            }),
+          })),
+        })),
+      })),
+
+      // UPDATE projects SET settings = ?, updatedAt = ? WHERE id = ?
+      update: jest.fn(() => ({
+        set: jest.fn((vals: { settings: Record<string, unknown> }) => ({
+          where: jest.fn(async (cond: any) => {
+            const projectId: string = cond?._projectId ?? 'unknown';
+            settingsStore.set(projectId, vals.settings);
+          }),
+        })),
+      })),
+    },
+  };
+});
+
+// drizzle-orm `eq` returns an object that survives through `where(...)`. Replace
+// it with a tagged shape carrying the projectId so the mocked db can identify
+// which row is being queried.
+jest.mock('drizzle-orm', () => {
+  const actual = jest.requireActual('drizzle-orm');
+  return {
+    ...actual,
+    eq: (_col: any, value: any) => ({ _projectId: value }),
+  };
+});
+
+describe('IntegrationsService — google-calendar', () => {
+  let service: IntegrationsService;
+  const projectId = 'proj-1';
+
+  beforeEach(async () => {
+    settingsStore.clear();
+    settingsStore.set(projectId, {});
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IntegrationsService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              if (key === 'ENCRYPTION_KEY') {
+                // 32 bytes, base64-encoded
+                return Buffer.alloc(32, 7).toString('base64');
+              }
+              return undefined;
+            },
+          },
+        },
+        // GoogleCalendarOAuthService is forwardRef'd into IntegrationsService.
+        // For this spec we only exercise setConfig / getActiveConfig / getPublicConfig
+        // which never touch the OAuth service, so a stub is enough.
+        {
+          provide: GoogleCalendarOAuthService,
+          useValue: { getValidAccessToken: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(IntegrationsService);
+  });
+
+  it('round-trips a GoogleCalendarIntegrationKeys config through setConfig → getActiveConfig', async () => {
+    const config: GoogleCalendarIntegrationKeys = {
+      clientId: 'client-abc.apps.googleusercontent.com',
+      clientSecret: 'shhh',
+      accessToken: 'tok',
+      refreshToken: 'rt',
+      tokenExpiry: 1_700_000_000_000,
+      connectedEmail: 'owner@example.com',
+      availableCalendars: [
+        { id: 'primary@x', summary: 'Primary', primary: true, timeZone: 'America/New_York' },
+      ],
+    };
+
+    await service.setConfig(projectId, 'google-calendar', 'production', { ...config });
+    const decrypted = (await service.getActiveConfig(
+      projectId,
+      'google-calendar',
+      'production',
+    )) as unknown as GoogleCalendarIntegrationKeys;
+
+    expect(decrypted).toEqual(config);
+
+    // Plaintext should not appear in stored settings
+    const stored = settingsStore.get(projectId)!;
+    const integrations = stored.integrations as Record<string, StoredIntegrationConfig>;
+    const cipher = integrations['google-calendar'].production!.config;
+    expect(cipher).not.toContain('shhh');
+    expect(cipher).not.toContain('client-abc');
+    expect(cipher.split(':')).toHaveLength(3); // iv:authTag:encrypted
+  });
+
+  it('exposes only PUBLIC_CONFIG_FIELDS via listIntegrations.publicConfig — never tokens or clientSecret', async () => {
+    const config: GoogleCalendarIntegrationKeys = {
+      clientId: 'cid',
+      clientSecret: 'super-secret',
+      accessToken: 'token-must-not-leak',
+      refreshToken: 'rt-must-not-leak',
+      tokenExpiry: 1_700_000_000_000,
+      connectedEmail: 'owner@example.com',
+      availableCalendars: [
+        { id: 'primary@x', summary: 'Primary', primary: true, timeZone: 'UTC' },
+      ],
+    };
+
+    await service.setConfig(projectId, 'google-calendar', 'production', { ...config });
+
+    const integrations = await service.listIntegrations(projectId);
+    const gc = integrations.find((i) => i.id === 'google-calendar');
+    expect(gc).toBeDefined();
+    expect(gc!.publicConfig).toEqual({
+      connectedEmail: 'owner@example.com',
+      availableCalendars: config.availableCalendars,
+    });
+
+    const json = JSON.stringify(gc);
+    expect(json).not.toContain('super-secret');
+    expect(json).not.toContain('token-must-not-leak');
+    expect(json).not.toContain('rt-must-not-leak');
+  });
+
+  it('listIntegrations returns google-calendar in the supported set', async () => {
+    const integrations = await service.listIntegrations(projectId);
+    const ids = integrations.map((i) => i.id);
+    expect(ids).toEqual(expect.arrayContaining(['stripe', 'github', 'google-calendar']));
+  });
+
+  it('setConfig merges with existing config (refresh-only writes do not wipe credentials)', async () => {
+    await service.setConfig(projectId, 'google-calendar', 'production', {
+      clientId: 'cid',
+      clientSecret: 'sec',
+      refreshToken: 'rt',
+      accessToken: 'old',
+      tokenExpiry: 1,
+    });
+
+    // Simulate the refresh write — only the rotating fields
+    await service.setConfig(projectId, 'google-calendar', 'production', {
+      accessToken: 'fresh',
+      tokenExpiry: 9_999_999_999_999,
+    });
+
+    const merged = (await service.getActiveConfig(
+      projectId,
+      'google-calendar',
+      'production',
+    )) as unknown as GoogleCalendarIntegrationKeys;
+
+    expect(merged.accessToken).toBe('fresh');
+    expect(merged.tokenExpiry).toBe(9_999_999_999_999);
+    expect(merged.clientId).toBe('cid');
+    expect(merged.clientSecret).toBe('sec');
+    expect(merged.refreshToken).toBe('rt');
+  });
+});

--- a/apps/backend/src/integrations/integrations.service.ts
+++ b/apps/backend/src/integrations/integrations.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable, Logger, NotFoundException, forwardRef } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { db } from '../db/client';
 import { projects } from '../db/schema';
 import { eq } from 'drizzle-orm';
 import * as crypto from 'crypto';
+import { GoogleCalendarOAuthService } from './google-calendar-oauth.service';
 
 /**
  * Stored integration config shape in projects.settings.integrations
@@ -63,7 +64,11 @@ export class IntegrationsService {
   private readonly ENCRYPTION_KEY: Buffer;
   private readonly ENCRYPTION_ALGORITHM = 'aes-256-gcm';
 
-  constructor(private configService: ConfigService) {
+  constructor(
+    private configService: ConfigService,
+    @Inject(forwardRef(() => GoogleCalendarOAuthService))
+    private readonly googleCalendarOAuthService: GoogleCalendarOAuthService,
+  ) {
     const encryptionKey = this.configService.get<string>('ENCRYPTION_KEY');
     if (encryptionKey) {
       this.ENCRYPTION_KEY = Buffer.from(encryptionKey, 'base64');
@@ -73,9 +78,13 @@ export class IntegrationsService {
     }
   }
 
+  /** Supported integration ids (returned by `listIntegrations`). */
+  private static readonly SUPPORTED_INTEGRATIONS = ['stripe', 'github', 'google-calendar'] as const;
+
   /** Fields that are safe to expose in the API response (per integration) */
   private static readonly PUBLIC_CONFIG_FIELDS: Record<string, string[]> = {
     github: ['defaultOrg'],
+    'google-calendar': ['connectedEmail', 'availableCalendars'],
   };
 
   /**
@@ -91,9 +100,9 @@ export class IntegrationsService {
    */
   async listIntegrations(projectId: string): Promise<IntegrationInfo[]> {
     const allIntegrations = await this.getAllStoredIntegrations(projectId);
-    const supported = ['stripe', 'github'];
-
-    return supported.map((id) => this.toIntegrationInfo(id, allIntegrations[id]));
+    return IntegrationsService.SUPPORTED_INTEGRATIONS.map((id) =>
+      this.toIntegrationInfo(id, allIntegrations[id]),
+    );
   }
 
   private toIntegrationInfo(id: string, stored?: StoredIntegrationConfig | null): IntegrationInfo {
@@ -303,6 +312,25 @@ export class IntegrationsService {
           return { success: false, error: body.message || `HTTP ${response.status}` };
         }
 
+        return { success: true };
+      }
+
+      if (integrationId === 'google-calendar') {
+        const token = await this.googleCalendarOAuthService.getValidAccessToken(projectId, env);
+        if (!token) {
+          return { success: false, error: 'Google Calendar not connected (complete OAuth flow first)' };
+        }
+        const response = await fetch(
+          'https://www.googleapis.com/calendar/v3/users/me/calendarList',
+          { headers: { Authorization: `Bearer ${token}` } },
+        );
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({}));
+          return {
+            success: false,
+            error: body.error?.message || `Google API HTTP ${response.status}`,
+          };
+        }
         return { success: true };
       }
 

--- a/apps/backend/src/pipelines/ai-plugins/google-oauth.service.ts
+++ b/apps/backend/src/pipelines/ai-plugins/google-oauth.service.ts
@@ -1,22 +1,24 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, forwardRef } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as crypto from 'crypto';
 import { AIToolPluginService } from './ai-tool-plugin.service';
-
-const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
-const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
-const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
-const GOOGLE_REVOKE_URL = 'https://oauth2.googleapis.com/revoke';
-
-const SCOPES = [
-  'https://www.googleapis.com/auth/calendar.freebusy',
-  'https://www.googleapis.com/auth/calendar.events',
-  'https://www.googleapis.com/auth/calendar.readonly',
-  'https://www.googleapis.com/auth/userinfo.email',
-];
+import { GoogleCalendarOAuthService } from '../../integrations/google-calendar-oauth.service';
 
 const STATE_EXPIRY_MS = 10 * 60 * 1000; // 10 minutes
 
+/**
+ * AI-chat Google Calendar OAuth.
+ *
+ * The HTTP plumbing (auth URL build, code exchange, refresh, calendar list,
+ * revoke) is delegated to `GoogleCalendarOAuthService`. What stays here:
+ *   - state-token encryption / replay protection bound to this AI plugin
+ *   - storage in `settings.aiPlugins['google-calendar']` via `AIToolPluginService`
+ *
+ * The new scheduling integration uses `settings.integrations['google-calendar']`
+ * instead. Both store per-project clientId/clientSecret + tokens; they share the
+ * same OAuth client model but live in different `settings` namespaces so the
+ * AI-chat path keeps working without migration.
+ */
 @Injectable()
 export class GoogleOAuthService {
   private readonly logger = new Logger(GoogleOAuthService.name);
@@ -26,6 +28,8 @@ export class GoogleOAuthService {
   constructor(
     private readonly pluginService: AIToolPluginService,
     private readonly configService: ConfigService,
+    @Inject(forwardRef(() => GoogleCalendarOAuthService))
+    private readonly googleCalendarOAuthService: GoogleCalendarOAuthService,
   ) {
     const encryptionKey = this.configService.get<string>('ENCRYPTION_KEY');
     if (encryptionKey) {
@@ -56,17 +60,13 @@ export class GoogleOAuthService {
       timestamp: Date.now(),
     });
 
-    const params = new URLSearchParams({
-      client_id: config.clientId as string,
-      redirect_uri: redirectUri,
-      response_type: 'code',
-      scope: SCOPES.join(' '),
-      access_type: 'offline',
-      prompt: 'consent',
+    const authUrl = this.googleCalendarOAuthService.buildAuthorizationUrl(
+      config.clientId as string,
       state,
-    });
+      redirectUri,
+    );
 
-    return { authUrl: `${GOOGLE_AUTH_URL}?${params.toString()}` };
+    return { authUrl };
   }
 
   /**
@@ -79,7 +79,6 @@ export class GoogleOAuthService {
     state: string,
     redirectUri: string,
   ): Promise<{ connectedEmail: string }> {
-    // Validate state
     const stateData = this.decryptState(state);
     if (stateData.projectId !== projectId || stateData.pluginId !== pluginId) {
       throw new Error('Invalid OAuth state: project/plugin mismatch');
@@ -88,103 +87,55 @@ export class GoogleOAuthService {
       throw new Error('OAuth state expired');
     }
 
-    // Get client credentials from stored config
     const config = await this.pluginService.getDecryptedPluginConfig(projectId, pluginId);
     if (!config?.clientId || !config?.clientSecret) {
       throw new Error('Google OAuth credentials not configured');
     }
 
-    // Exchange code for tokens
-    const tokenResponse = await fetch(GOOGLE_TOKEN_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        code,
-        client_id: config.clientId as string,
-        client_secret: config.clientSecret as string,
-        redirect_uri: redirectUri,
-        grant_type: 'authorization_code',
-      }),
-    });
+    const tokens = await this.googleCalendarOAuthService.exchangeCodeForCredentials(
+      config.clientId as string,
+      config.clientSecret as string,
+      code,
+      redirectUri,
+    );
 
-    if (!tokenResponse.ok) {
-      const error = await tokenResponse.json();
-      this.logger.error(`Token exchange failed: ${JSON.stringify(error)}`);
-      throw new Error(error.error_description || 'Failed to exchange authorization code');
-    }
-
-    const tokens = await tokenResponse.json();
-
-    // Fetch user email
-    const userInfoResponse = await fetch(GOOGLE_USERINFO_URL, {
-      headers: { Authorization: `Bearer ${tokens.access_token}` },
-    });
-
-    let connectedEmail = 'unknown';
-    if (userInfoResponse.ok) {
-      const userInfo = await userInfoResponse.json();
-      connectedEmail = userInfo.email || 'unknown';
-    }
-
-    // Merge tokens into existing plugin config
-    const updatedConfig = {
+    await this.pluginService.updatePluginConfig(projectId, pluginId, {
       ...config,
-      accessToken: tokens.access_token,
-      refreshToken: tokens.refresh_token,
-      tokenExpiry: Date.now() + tokens.expires_in * 1000,
-      connectedEmail,
-    };
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      tokenExpiry: tokens.tokenExpiry,
+      connectedEmail: tokens.connectedEmail,
+    });
+    this.logger.log(`Google OAuth connected for project ${projectId}: ${tokens.connectedEmail}`);
 
-    await this.pluginService.updatePluginConfig(projectId, pluginId, updatedConfig);
-    this.logger.log(`Google OAuth connected for project ${projectId}: ${connectedEmail}`);
-
-    return { connectedEmail };
+    return { connectedEmail: tokens.connectedEmail };
   }
 
   /**
-   * Refresh an expired access token.
+   * Refresh an expired access token. Returns the raw shape the AI plugin
+   * already expects (`expiresIn` seconds rather than absolute expiry).
    */
   async refreshAccessToken(
     clientId: string,
     clientSecret: string,
     refreshToken: string,
   ): Promise<{ accessToken: string; expiresIn: number }> {
-    const response = await fetch(GOOGLE_TOKEN_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        client_id: clientId,
-        client_secret: clientSecret,
-        refresh_token: refreshToken,
-        grant_type: 'refresh_token',
-      }),
-    });
-
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.error_description || 'Failed to refresh access token');
-    }
-
-    const data = await response.json();
+    const refreshed = await this.googleCalendarOAuthService.refreshAccessTokenForCredentials(
+      clientId,
+      clientSecret,
+      refreshToken,
+    );
     return {
-      accessToken: data.access_token,
-      expiresIn: data.expires_in,
+      accessToken: refreshed.accessToken,
+      expiresIn: Math.max(0, Math.floor((refreshed.tokenExpiry - Date.now()) / 1000)),
     };
   }
 
   /**
-   * Revoke a refresh token.
+   * Revoke a refresh token (best-effort).
    */
   async revokeToken(refreshToken: string): Promise<void> {
-    try {
-      await fetch(`${GOOGLE_REVOKE_URL}?token=${refreshToken}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      });
-    } catch (error) {
-      this.logger.warn(`Token revocation failed: ${error.message}`);
-      // Continue — revoking is best-effort
-    }
+    await this.googleCalendarOAuthService.revokeToken(refreshToken);
   }
 
   /**
@@ -200,22 +151,11 @@ export class GoogleOAuthService {
     }
 
     const accessToken = await this.getValidAccessToken(projectId, pluginId, config);
-
-    const response = await fetch(
-      'https://www.googleapis.com/calendar/v3/users/me/calendarList',
-      { headers: { Authorization: `Bearer ${accessToken}` } },
-    );
-
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.error?.message || 'Failed to list calendars');
-    }
-
-    const data = await response.json();
-    return (data.items || []).map((item: any) => ({
-      id: item.id,
-      summary: item.summary || item.id,
-      primary: item.primary || false,
+    const calendars = await this.googleCalendarOAuthService.listCalendarsForToken(accessToken);
+    return calendars.map((c) => ({
+      id: c.id,
+      summary: c.summary,
+      primary: c.primary || false,
     }));
   }
 
@@ -234,22 +174,19 @@ export class GoogleOAuthService {
       return config.accessToken as string;
     }
 
-    // Refresh
-    const { accessToken, expiresIn } = await this.refreshAccessToken(
+    const refreshed = await this.googleCalendarOAuthService.refreshAccessTokenForCredentials(
       config.clientId as string,
       config.clientSecret as string,
       config.refreshToken as string,
     );
 
-    // Update stored config with new token
-    const updatedConfig = {
+    await this.pluginService.updatePluginConfig(projectId, pluginId, {
       ...config,
-      accessToken,
-      tokenExpiry: Date.now() + expiresIn * 1000,
-    };
-    await this.pluginService.updatePluginConfig(projectId, pluginId, updatedConfig);
+      accessToken: refreshed.accessToken,
+      tokenExpiry: refreshed.tokenExpiry,
+    });
 
-    return accessToken;
+    return refreshed.accessToken;
   }
 
   // ===== State encryption helpers =====

--- a/apps/backend/src/pipelines/handlers/google-calendar.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/google-calendar.handler.spec.ts
@@ -1,0 +1,457 @@
+import { Request } from 'express';
+import {
+  GoogleCalendarHandler,
+  GoogleCalendarHandlerConfig,
+} from './google-calendar.handler';
+import { StepHandlerRegistry } from '../execution/step-handler.registry';
+import { ExpressionEvaluator } from '../execution/expression-evaluator';
+import { GoogleCalendarOAuthService } from '../../integrations/google-calendar-oauth.service';
+import { PipelineContext } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+import { ConfigurationError } from '../errors';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function makeFetchResponse(opts: {
+  status: number;
+  body?: unknown;
+}): Response {
+  const { status, body = {} } = opts;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function makeContext(overrides: Partial<PipelineContext> = {}): PipelineContext {
+  return {
+    request: { headers: {} } as unknown as Request,
+    stepOutputs: {},
+    projectId: 'proj-1',
+    pipelineId: 'pl-1',
+    metadata: {
+      path: '/',
+      method: 'POST',
+      headers: {},
+      query: {},
+      body: {},
+    },
+    ...overrides,
+  };
+}
+
+function makeStep(config: Record<string, unknown>): PipelineStep {
+  return {
+    id: 'step-1',
+    pipelineId: 'pl-1',
+    name: 'gc',
+    handlerType: 'google_calendar',
+    config: config as PipelineStep['config'],
+    order: 0,
+    isEnabled: true,
+  };
+}
+
+describe('GoogleCalendarHandler', () => {
+  let handler: GoogleCalendarHandler;
+  let oauthService: { getValidAccessToken: jest.Mock };
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    const registry = { register: jest.fn() } as unknown as StepHandlerRegistry;
+    const evaluator = new ExpressionEvaluator();
+    oauthService = { getValidAccessToken: jest.fn().mockResolvedValue('access-tok') };
+    handler = new GoogleCalendarHandler(
+      registry,
+      evaluator,
+      oauthService as unknown as GoogleCalendarOAuthService,
+    );
+  });
+
+  // ===== validateConfig =====
+
+  describe('validateConfig', () => {
+    it('requires action', () => {
+      expect(() => handler.validateConfig({} as GoogleCalendarHandlerConfig)).toThrow(
+        ConfigurationError,
+      );
+    });
+
+    it('list_calendars has no required fields', () => {
+      expect(() => handler.validateConfig({ action: 'list_calendars' })).not.toThrow();
+    });
+
+    it('freebusy requires calendarIds + timeMin + timeMax', () => {
+      expect(() => handler.validateConfig({ action: 'freebusy' })).toThrow(/calendarIds/);
+      expect(() =>
+        handler.validateConfig({
+          action: 'freebusy',
+          calendarIds: ['primary'],
+        }),
+      ).toThrow(/timeMin and timeMax/);
+    });
+
+    it('create_event requires calendarId, summary, startTime, endTime', () => {
+      expect(() => handler.validateConfig({ action: 'create_event' })).toThrow(/calendarId/);
+      expect(() =>
+        handler.validateConfig({ action: 'create_event', calendarId: 'c' }),
+      ).toThrow(/summary/);
+      expect(() =>
+        handler.validateConfig({
+          action: 'create_event',
+          calendarId: 'c',
+          summary: 's',
+        }),
+      ).toThrow(/startTime and endTime/);
+    });
+
+    it('update_event requires calendarId + eventId', () => {
+      expect(() => handler.validateConfig({ action: 'update_event' })).toThrow(/calendarId/);
+      expect(() =>
+        handler.validateConfig({ action: 'update_event', calendarId: 'c' }),
+      ).toThrow(/eventId/);
+    });
+
+    it('delete_event requires calendarId + eventId', () => {
+      expect(() => handler.validateConfig({ action: 'delete_event' })).toThrow(/calendarId/);
+      expect(() =>
+        handler.validateConfig({ action: 'delete_event', calendarId: 'c' }),
+      ).toThrow(/eventId/);
+    });
+
+    it('list_events requires calendarId', () => {
+      expect(() => handler.validateConfig({ action: 'list_events' })).toThrow(/calendarId/);
+    });
+  });
+
+  // ===== execute — token gating =====
+
+  describe('execute — auth gating', () => {
+    it('short-circuits with NOT_CONFIGURED when no access token', async () => {
+      oauthService.getValidAccessToken.mockResolvedValueOnce(null);
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({ action: 'list_calendars' }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('GOOGLE_CALENDAR_NOT_CONFIGURED');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===== Per-action =====
+
+  describe('list_calendars', () => {
+    it('GETs calendarList and unwraps items', async () => {
+      mockFetch.mockResolvedValue(
+        makeFetchResponse({
+          status: 200,
+          body: {
+            items: [
+              { id: 'a@x', summary: 'A', primary: true, timeZone: 'America/New_York' },
+              { id: 'b@x', summary: 'B', timeZone: 'UTC' },
+            ],
+          },
+        }),
+      );
+
+      const result = await handler.execute(makeContext(), makeStep({ action: 'list_calendars' }));
+
+      expect(result.success).toBe(true);
+      expect((result.output as any).calendars).toHaveLength(2);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://www.googleapis.com/calendar/v3/users/me/calendarList',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer access-tok' }),
+        }),
+      );
+    });
+  });
+
+  describe('freebusy', () => {
+    it('POSTs freeBusy with resolved calendar ids and timeMin/timeMax', async () => {
+      mockFetch.mockResolvedValue(
+        makeFetchResponse({
+          status: 200,
+          body: { calendars: { 'primary': { busy: [{ start: 's', end: 'e' }] } } },
+        }),
+      );
+
+      // Simulate template evaluation through request.body
+      const ctx = makeContext({
+        metadata: {
+          path: '/',
+          method: 'POST',
+          headers: {},
+          query: {},
+          body: { from: '2026-05-04T00:00:00Z', to: '2026-05-05T00:00:00Z' },
+        },
+      });
+
+      const result = await handler.execute(
+        ctx,
+        makeStep({
+          action: 'freebusy',
+          calendarIds: ['primary'],
+          timeMin: 'request.body.from',
+          timeMax: 'request.body.to',
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://www.googleapis.com/calendar/v3/freeBusy');
+      expect(init.method).toBe('POST');
+      const sentBody = JSON.parse(init.body as string);
+      expect(sentBody).toMatchObject({
+        timeMin: '2026-05-04T00:00:00Z',
+        timeMax: '2026-05-05T00:00:00Z',
+        items: [{ id: 'primary' }],
+      });
+    });
+  });
+
+  describe('list_events', () => {
+    it('GETs events with default params and URL-encoded calendarId', async () => {
+      mockFetch.mockResolvedValue(
+        makeFetchResponse({
+          status: 200,
+          body: { items: [{ id: 'e1', summary: 'meeting', start: { dateTime: 's' } }] },
+        }),
+      );
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({
+          action: 'list_events',
+          calendarId: 'cal+with+plus@group.calendar.google.com',
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('cal%2Bwith%2Bplus%40group.calendar.google.com');
+      expect(url).toContain('singleEvents=true');
+      expect(url).toContain('orderBy=startTime');
+      expect((result.output as any).events).toHaveLength(1);
+    });
+  });
+
+  describe('create_event', () => {
+    it('POSTs event with templated summary + attendee email expressions', async () => {
+      mockFetch.mockResolvedValue(
+        makeFetchResponse({
+          status: 200,
+          body: {
+            id: 'evt-1',
+            summary: 'Haircut — Alice',
+            htmlLink: 'https://cal/evt-1',
+            start: { dateTime: '2026-05-04T10:00:00Z' },
+            end: { dateTime: '2026-05-04T11:00:00Z' },
+          },
+        }),
+      );
+
+      const ctx = makeContext({
+        metadata: {
+          path: '/',
+          method: 'POST',
+          headers: {},
+          query: {},
+          body: {
+            customer_name: 'Alice',
+            customer_email: 'alice@example.com',
+            start_time: '2026-05-04T10:00:00Z',
+            end_time: '2026-05-04T11:00:00Z',
+          },
+        },
+      });
+
+      const result = await handler.execute(
+        ctx,
+        makeStep({
+          action: 'create_event',
+          calendarId: 'primary',
+          summary: 'Haircut — {{request.body.customer_name}}',
+          startTime: 'request.body.start_time',
+          endTime: 'request.body.end_time',
+          attendees: [{ email: 'request.body.customer_email' }],
+          sendUpdates: 'all',
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe(
+        'https://www.googleapis.com/calendar/v3/calendars/primary/events?sendUpdates=all',
+      );
+      const sent = JSON.parse(init.body as string);
+      expect(sent.summary).toBe('Haircut — Alice');
+      expect(sent.start.dateTime).toBe('2026-05-04T10:00:00Z');
+      expect(sent.end.dateTime).toBe('2026-05-04T11:00:00Z');
+      expect(sent.attendees).toEqual([{ email: 'alice@example.com' }]);
+      expect((result.output as any).event.id).toBe('evt-1');
+    });
+  });
+
+  describe('update_event', () => {
+    it('PATCHes only supplied fields', async () => {
+      mockFetch.mockResolvedValue(
+        makeFetchResponse({
+          status: 200,
+          body: { id: 'evt-1', summary: 'Updated' },
+        }),
+      );
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({
+          action: 'update_event',
+          calendarId: 'primary',
+          eventId: 'evt-1',
+          summary: 'Updated',
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(init.method).toBe('PATCH');
+      expect(url).toBe('https://www.googleapis.com/calendar/v3/calendars/primary/events/evt-1');
+      const sent = JSON.parse(init.body as string);
+      expect(sent.summary).toBe('Updated');
+      expect(sent.start).toBeUndefined();
+      expect(sent.end).toBeUndefined();
+    });
+  });
+
+  describe('delete_event', () => {
+    it('DELETEs and treats 204 as success', async () => {
+      mockFetch.mockResolvedValue(makeFetchResponse({ status: 204 }));
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({
+          action: 'delete_event',
+          calendarId: 'primary',
+          eventId: 'evt-1',
+          sendUpdates: 'none',
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect((result.output as any).deleted).toBe(true);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(init.method).toBe('DELETE');
+      expect(url).toContain('sendUpdates=none');
+    });
+
+    it('treats 404 (already gone) as success', async () => {
+      mockFetch.mockResolvedValue(makeFetchResponse({ status: 404, body: {} }));
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({
+          action: 'delete_event',
+          calendarId: 'primary',
+          eventId: 'evt-gone',
+        }),
+      );
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // ===== Error mapping + 401 retry =====
+
+  describe('error mapping', () => {
+    it('maps 404 to NOT_FOUND (non-delete action)', async () => {
+      mockFetch.mockResolvedValue(
+        makeFetchResponse({ status: 404, body: { error: { message: 'Calendar not found' } } }),
+      );
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({ action: 'list_events', calendarId: 'gone@x' }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('GOOGLE_CALENDAR_NOT_FOUND');
+    });
+
+    it('maps 429 to RATE_LIMITED', async () => {
+      mockFetch.mockResolvedValue(
+        makeFetchResponse({ status: 429, body: { error: { message: 'rate' } } }),
+      );
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({ action: 'list_calendars' }),
+      );
+
+      expect(result.error?.code).toBe('GOOGLE_CALENDAR_RATE_LIMITED');
+    });
+
+    it('maps 5xx to API_ERROR', async () => {
+      mockFetch.mockResolvedValue(
+        makeFetchResponse({ status: 500, body: { error: { message: 'internal' } } }),
+      );
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({ action: 'list_calendars' }),
+      );
+
+      expect(result.error?.code).toBe('GOOGLE_CALENDAR_API_ERROR');
+    });
+  });
+
+  describe('401 retry', () => {
+    it('forces token refresh and retries once on 401, succeeds on retry', async () => {
+      // First call returns 401, second call returns 200
+      mockFetch
+        .mockResolvedValueOnce(makeFetchResponse({ status: 401, body: {} }))
+        .mockResolvedValueOnce(
+          makeFetchResponse({ status: 200, body: { items: [] } }),
+        );
+
+      // First getValidAccessToken (initial) returns the stale token; second
+      // returns the fresh one for the retry.
+      oauthService.getValidAccessToken
+        .mockResolvedValueOnce('stale-tok')
+        .mockResolvedValueOnce('fresh-tok');
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({ action: 'list_calendars' }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      // The retry should use the fresh token
+      const [, retryInit] = mockFetch.mock.calls[1];
+      expect((retryInit.headers as any).Authorization).toBe('Bearer fresh-tok');
+    });
+
+    it('falls through to AUTH_FAILED if refresh also fails', async () => {
+      mockFetch.mockResolvedValueOnce(makeFetchResponse({ status: 401, body: {} }));
+
+      oauthService.getValidAccessToken
+        .mockResolvedValueOnce('stale-tok')
+        .mockResolvedValueOnce(null); // refresh failed
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({ action: 'list_calendars' }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('GOOGLE_CALENDAR_AUTH_FAILED');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/backend/src/pipelines/handlers/google-calendar.handler.ts
+++ b/apps/backend/src/pipelines/handlers/google-calendar.handler.ts
@@ -1,0 +1,558 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { StepHandler, BaseHandlerConfig } from '../execution/step-handler.interface';
+import { StepHandlerRegistry } from '../execution/step-handler.registry';
+import { ExpressionEvaluator } from '../execution/expression-evaluator';
+import { PipelineContext, StepResult } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+import { ConfigurationError } from '../errors';
+import { GoogleCalendarOAuthService } from '../../integrations/google-calendar-oauth.service';
+
+const GOOGLE_CALENDAR_BASE = 'https://www.googleapis.com/calendar/v3';
+
+export type GoogleCalendarAction =
+  | 'list_calendars'
+  | 'freebusy'
+  | 'list_events'
+  | 'create_event'
+  | 'update_event'
+  | 'delete_event';
+
+export interface GoogleCalendarHandlerConfig extends BaseHandlerConfig {
+  /** Calendar API action to perform. */
+  action: GoogleCalendarAction;
+
+  // ---- freebusy ----
+  /** Single calendar id or array of ids (expression-evaluated). */
+  calendarIds?: string | string[];
+  /** ISO 8601 expression — start of the freeBusy / list_events window. */
+  timeMin?: string;
+  /** ISO 8601 expression — end of the freeBusy / list_events window. */
+  timeMax?: string;
+  /** IANA timezone (e.g. "America/New_York"). */
+  timezone?: string;
+
+  // ---- list_events / create_event / update_event / delete_event ----
+  /** Calendar id (expression-evaluated). For list/create/update/delete. */
+  calendarId?: string;
+  /** Event id (expression-evaluated). For update/delete. */
+  eventId?: string;
+  /** Max events to return (list_events). Default 250. */
+  maxResults?: number;
+  /** Expand recurring events into instances (list_events). Default true. */
+  singleEvents?: boolean;
+  /** Sort order for list_events. Default 'startTime'. */
+  orderBy?: 'startTime' | 'updated';
+
+  // ---- create_event / update_event ----
+  /** Event summary/title (template). */
+  summary?: string;
+  /** Event description (template). */
+  description?: string;
+  /** Event location (template). */
+  location?: string;
+  /** Start time, ISO 8601 (expression). */
+  startTime?: string;
+  /** End time, ISO 8601 (expression). */
+  endTime?: string;
+  /** Attendee email entries. Each `email` is expression-evaluated. */
+  attendees?: Array<{ email: string }>;
+  /** Whether Google sends notifications. Defaults to 'none' for safety. */
+  sendUpdates?: 'all' | 'externalOnly' | 'none';
+}
+
+const ERROR_CODES = {
+  NOT_CONFIGURED: 'GOOGLE_CALENDAR_NOT_CONFIGURED',
+  AUTH_FAILED: 'GOOGLE_CALENDAR_AUTH_FAILED',
+  NOT_FOUND: 'GOOGLE_CALENDAR_NOT_FOUND',
+  RATE_LIMITED: 'GOOGLE_CALENDAR_RATE_LIMITED',
+  API_ERROR: 'GOOGLE_CALENDAR_API_ERROR',
+} as const;
+
+/**
+ * Google Calendar pipeline step handler.
+ *
+ * One handler, six actions: list_calendars, freebusy, list_events,
+ * create_event, update_event, delete_event. OAuth refresh is handled by
+ * `GoogleCalendarOAuthService`; on a 401 from Google we force a refresh and
+ * retry the call once before mapping to AUTH_FAILED.
+ *
+ * Requires the `google-calendar` integration to be configured on the project
+ * (see `IntegrationsService` and Phase A).
+ */
+@Injectable()
+export class GoogleCalendarHandler implements StepHandler<GoogleCalendarHandlerConfig> {
+  readonly type = 'google_calendar' as const;
+  private readonly logger = new Logger(GoogleCalendarHandler.name);
+
+  constructor(
+    private readonly registry: StepHandlerRegistry,
+    private readonly expressionEvaluator: ExpressionEvaluator,
+    private readonly googleCalendarOAuthService: GoogleCalendarOAuthService,
+  ) {
+    this.registry.register(this);
+  }
+
+  validateConfig(config: GoogleCalendarHandlerConfig): void {
+    if (!config.action) {
+      throw new ConfigurationError('action is required', 'google_calendar');
+    }
+
+    switch (config.action) {
+      case 'list_calendars':
+        // No required fields
+        return;
+
+      case 'freebusy':
+        if (!config.calendarIds) {
+          throw new ConfigurationError('calendarIds is required for freebusy', 'google_calendar');
+        }
+        if (!config.timeMin || !config.timeMax) {
+          throw new ConfigurationError(
+            'timeMin and timeMax are required for freebusy',
+            'google_calendar',
+          );
+        }
+        return;
+
+      case 'list_events':
+        if (!config.calendarId) {
+          throw new ConfigurationError('calendarId is required for list_events', 'google_calendar');
+        }
+        return;
+
+      case 'create_event':
+        if (!config.calendarId) {
+          throw new ConfigurationError('calendarId is required for create_event', 'google_calendar');
+        }
+        if (!config.summary) {
+          throw new ConfigurationError('summary is required for create_event', 'google_calendar');
+        }
+        if (!config.startTime || !config.endTime) {
+          throw new ConfigurationError(
+            'startTime and endTime are required for create_event',
+            'google_calendar',
+          );
+        }
+        return;
+
+      case 'update_event':
+        if (!config.calendarId) {
+          throw new ConfigurationError('calendarId is required for update_event', 'google_calendar');
+        }
+        if (!config.eventId) {
+          throw new ConfigurationError('eventId is required for update_event', 'google_calendar');
+        }
+        return;
+
+      case 'delete_event':
+        if (!config.calendarId) {
+          throw new ConfigurationError('calendarId is required for delete_event', 'google_calendar');
+        }
+        if (!config.eventId) {
+          throw new ConfigurationError('eventId is required for delete_event', 'google_calendar');
+        }
+        return;
+
+      default: {
+        // Exhaustiveness guard — TypeScript catches missing actions at compile time
+        const _exhaustive: never = config.action;
+        throw new ConfigurationError(
+          `Unknown action '${_exhaustive}'. Supported: list_calendars, freebusy, list_events, create_event, update_event, delete_event`,
+          'google_calendar',
+        );
+      }
+    }
+  }
+
+  async execute(context: PipelineContext, step: PipelineStep): Promise<StepResult> {
+    const config = step.config as GoogleCalendarHandlerConfig;
+
+    const token = await this.googleCalendarOAuthService.getValidAccessToken(context.projectId);
+    if (!token) {
+      return {
+        success: false,
+        error: {
+          code: ERROR_CODES.NOT_CONFIGURED,
+          message:
+            'Google Calendar integration is not configured (or OAuth not completed) for this project.',
+        },
+      };
+    }
+
+    try {
+      switch (config.action) {
+        case 'list_calendars':
+          return await this.listCalendars(context, token);
+        case 'freebusy':
+          return await this.freeBusy(config, context, step, token);
+        case 'list_events':
+          return await this.listEvents(config, context, step, token);
+        case 'create_event':
+          return await this.createEvent(config, context, step, token);
+        case 'update_event':
+          return await this.updateEvent(config, context, step, token);
+        case 'delete_event':
+          return await this.deleteEvent(config, context, step, token);
+        default: {
+          const _exhaustive: never = config.action;
+          return {
+            success: false,
+            error: {
+              code: ERROR_CODES.API_ERROR,
+              message: `Unknown google_calendar action: ${String(_exhaustive)}`,
+            },
+          };
+        }
+      }
+    } catch (error: any) {
+      this.logger.error(
+        `google_calendar request failed for step '${step.name}': ${error.message}`,
+      );
+      return {
+        success: false,
+        error: {
+          code: ERROR_CODES.API_ERROR,
+          message: `Google Calendar request failed: ${error.message}`,
+        },
+      };
+    }
+  }
+
+  // ===== Actions =====
+
+  private async listCalendars(context: PipelineContext, token: string): Promise<StepResult> {
+    const r = await this.fetchWith401Retry(
+      context,
+      `${GOOGLE_CALENDAR_BASE}/users/me/calendarList`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (!r.ok) return await this.httpErrorResult(r);
+    const body = await r.json();
+    return {
+      success: true,
+      output: {
+        calendars: (body.items ?? []).map((c: any) => ({
+          id: c.id,
+          summary: c.summary,
+          primary: !!c.primary,
+          timeZone: c.timeZone,
+        })),
+      },
+    };
+  }
+
+  private async freeBusy(
+    config: GoogleCalendarHandlerConfig,
+    context: PipelineContext,
+    step: PipelineStep,
+    token: string,
+  ): Promise<StepResult> {
+    const calendarIds = this.resolveCalendarIds(config.calendarIds!, context, step);
+    const timeMin = String(
+      this.expressionEvaluator.evaluateExpression(config.timeMin!, context, step.name),
+    );
+    const timeMax = String(
+      this.expressionEvaluator.evaluateExpression(config.timeMax!, context, step.name),
+    );
+
+    const requestBody: Record<string, unknown> = {
+      timeMin,
+      timeMax,
+      items: calendarIds.map((id) => ({ id })),
+    };
+    if (config.timezone) requestBody.timeZone = config.timezone;
+
+    const r = await this.fetchWith401Retry(context, `${GOOGLE_CALENDAR_BASE}/freeBusy`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+    });
+    if (!r.ok) return await this.httpErrorResult(r);
+    const body = await r.json();
+    return {
+      success: true,
+      output: { calendars: body.calendars ?? {}, timeMin, timeMax },
+    };
+  }
+
+  private async listEvents(
+    config: GoogleCalendarHandlerConfig,
+    context: PipelineContext,
+    step: PipelineStep,
+    token: string,
+  ): Promise<StepResult> {
+    const calendarId = String(
+      this.expressionEvaluator.evaluateExpression(config.calendarId!, context, step.name),
+    );
+
+    const params = new URLSearchParams();
+    if (config.timeMin) {
+      params.set(
+        'timeMin',
+        String(this.expressionEvaluator.evaluateExpression(config.timeMin, context, step.name)),
+      );
+    }
+    if (config.timeMax) {
+      params.set(
+        'timeMax',
+        String(this.expressionEvaluator.evaluateExpression(config.timeMax, context, step.name)),
+      );
+    }
+    params.set('maxResults', String(config.maxResults ?? 250));
+    params.set('singleEvents', String(config.singleEvents ?? true));
+    params.set('orderBy', config.orderBy ?? 'startTime');
+
+    const url = `${GOOGLE_CALENDAR_BASE}/calendars/${encodeURIComponent(calendarId)}/events?${params.toString()}`;
+
+    const r = await this.fetchWith401Retry(context, url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!r.ok) return await this.httpErrorResult(r);
+    const body = await r.json();
+    return {
+      success: true,
+      output: {
+        events: (body.items ?? []).map((e: any) => this.summarizeEvent(e)),
+        nextPageToken: body.nextPageToken ?? null,
+      },
+    };
+  }
+
+  private async createEvent(
+    config: GoogleCalendarHandlerConfig,
+    context: PipelineContext,
+    step: PipelineStep,
+    token: string,
+  ): Promise<StepResult> {
+    const calendarId = String(
+      this.expressionEvaluator.evaluateExpression(config.calendarId!, context, step.name),
+    );
+
+    const eventBody = this.buildEventBody(config, context, step, /* requireTimes */ true);
+
+    const url = new URL(
+      `${GOOGLE_CALENDAR_BASE}/calendars/${encodeURIComponent(calendarId)}/events`,
+    );
+    if (config.sendUpdates) url.searchParams.set('sendUpdates', config.sendUpdates);
+
+    const r = await this.fetchWith401Retry(context, url.toString(), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(eventBody),
+    });
+    if (!r.ok) return await this.httpErrorResult(r);
+    const event = await r.json();
+    this.logger.log(`Created event ${event.id} on calendar ${calendarId}`);
+    return { success: true, output: { event: this.summarizeEvent(event) } };
+  }
+
+  private async updateEvent(
+    config: GoogleCalendarHandlerConfig,
+    context: PipelineContext,
+    step: PipelineStep,
+    token: string,
+  ): Promise<StepResult> {
+    const calendarId = String(
+      this.expressionEvaluator.evaluateExpression(config.calendarId!, context, step.name),
+    );
+    const eventId = String(
+      this.expressionEvaluator.evaluateExpression(config.eventId!, context, step.name),
+    );
+
+    const eventBody = this.buildEventBody(config, context, step, /* requireTimes */ false);
+
+    const url = new URL(
+      `${GOOGLE_CALENDAR_BASE}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
+    );
+    if (config.sendUpdates) url.searchParams.set('sendUpdates', config.sendUpdates);
+
+    const r = await this.fetchWith401Retry(context, url.toString(), {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(eventBody),
+    });
+    if (!r.ok) return await this.httpErrorResult(r);
+    const event = await r.json();
+    this.logger.log(`Updated event ${event.id} on calendar ${calendarId}`);
+    return { success: true, output: { event: this.summarizeEvent(event) } };
+  }
+
+  private async deleteEvent(
+    config: GoogleCalendarHandlerConfig,
+    context: PipelineContext,
+    step: PipelineStep,
+    token: string,
+  ): Promise<StepResult> {
+    const calendarId = String(
+      this.expressionEvaluator.evaluateExpression(config.calendarId!, context, step.name),
+    );
+    const eventId = String(
+      this.expressionEvaluator.evaluateExpression(config.eventId!, context, step.name),
+    );
+
+    const url = new URL(
+      `${GOOGLE_CALENDAR_BASE}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
+    );
+    if (config.sendUpdates) url.searchParams.set('sendUpdates', config.sendUpdates);
+
+    const r = await this.fetchWith401Retry(context, url.toString(), {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    // 204 = deleted, 410/404 = already gone — both treated as success
+    if (r.ok || r.status === 404 || r.status === 410) {
+      this.logger.log(`Deleted event ${eventId} on calendar ${calendarId} (status ${r.status})`);
+      return { success: true, output: { eventId, calendarId, deleted: true } };
+    }
+    return await this.httpErrorResult(r);
+  }
+
+  // ===== Helpers =====
+
+  /** Resolve calendarIds (string or array) — each entry runs through the expression evaluator. */
+  private resolveCalendarIds(
+    raw: string | string[],
+    context: PipelineContext,
+    step: PipelineStep,
+  ): string[] {
+    const list = Array.isArray(raw) ? raw : [raw];
+    return list.map((id) =>
+      String(this.expressionEvaluator.evaluateExpression(id, context, step.name)),
+    );
+  }
+
+  /** Build a Google Calendar event body from config, applying templates / expressions. */
+  private buildEventBody(
+    config: GoogleCalendarHandlerConfig,
+    context: PipelineContext,
+    step: PipelineStep,
+    requireTimes: boolean,
+  ): Record<string, unknown> {
+    const body: Record<string, unknown> = {};
+
+    if (config.summary) {
+      body.summary = this.expressionEvaluator.evaluateTemplate(config.summary, context, step.name);
+    }
+    if (config.description) {
+      body.description = this.expressionEvaluator.evaluateTemplate(
+        config.description,
+        context,
+        step.name,
+      );
+    }
+    if (config.location) {
+      body.location = this.expressionEvaluator.evaluateTemplate(
+        config.location,
+        context,
+        step.name,
+      );
+    }
+
+    if (requireTimes || config.startTime) {
+      body.start = {
+        dateTime: String(
+          this.expressionEvaluator.evaluateExpression(config.startTime!, context, step.name),
+        ),
+        ...(config.timezone ? { timeZone: config.timezone } : {}),
+      };
+    }
+    if (requireTimes || config.endTime) {
+      body.end = {
+        dateTime: String(
+          this.expressionEvaluator.evaluateExpression(config.endTime!, context, step.name),
+        ),
+        ...(config.timezone ? { timeZone: config.timezone } : {}),
+      };
+    }
+
+    if (config.attendees && config.attendees.length > 0) {
+      body.attendees = config.attendees.map((a) => ({
+        email: String(
+          this.expressionEvaluator.evaluateExpression(a.email, context, step.name),
+        ),
+      }));
+    }
+
+    return body;
+  }
+
+  /** Stable shape returned from create/update/list. */
+  private summarizeEvent(event: any) {
+    return {
+      id: event.id,
+      summary: event.summary,
+      description: event.description,
+      location: event.location,
+      start: event.start?.dateTime || event.start?.date || null,
+      end: event.end?.dateTime || event.end?.date || null,
+      attendees: (event.attendees ?? []).map((a: any) => ({
+        email: a.email,
+        responseStatus: a.responseStatus,
+      })),
+      htmlLink: event.htmlLink,
+      status: event.status,
+    };
+  }
+
+  /**
+   * Fetch with one-shot 401 retry. `getValidAccessToken` already refreshes when
+   * within 60s of expiry, but a token can still expire between that check and
+   * the actual API call (rare on long-running pipelines, but real). On 401 we
+   * force a fresh token via `getValidAccessToken` and retry once.
+   */
+  private async fetchWith401Retry(
+    context: PipelineContext,
+    url: string,
+    init: RequestInit,
+  ): Promise<Response> {
+    let response = await fetch(url, init);
+    if (response.status !== 401) return response;
+
+    const fresh = await this.googleCalendarOAuthService.getValidAccessToken(context.projectId);
+    if (!fresh) return response; // refresh failed — let httpErrorResult map the original 401
+
+    const headers = { ...(init.headers as Record<string, string>), Authorization: `Bearer ${fresh}` };
+    return fetch(url, { ...init, headers });
+  }
+
+  private async httpErrorResult(response: Response): Promise<StepResult> {
+    let detail: any = {};
+    try {
+      detail = await response.json();
+    } catch {
+      // body wasn't JSON
+    }
+    const message = detail?.error?.message || `HTTP ${response.status}`;
+    const code = (() => {
+      switch (response.status) {
+        case 401:
+        case 403:
+          return ERROR_CODES.AUTH_FAILED;
+        case 404:
+          return ERROR_CODES.NOT_FOUND;
+        case 429:
+          return ERROR_CODES.RATE_LIMITED;
+        default:
+          return ERROR_CODES.API_ERROR;
+      }
+    })();
+    this.logger.error(`Google Calendar API ${response.status}: ${message}`);
+    return {
+      success: false,
+      error: {
+        code,
+        message: `Google Calendar API error (${response.status}): ${message}`,
+        details: { status: response.status, ...(detail?.error ? { google: detail.error } : {}) },
+      },
+    };
+  }
+}

--- a/apps/backend/src/pipelines/handlers/index.ts
+++ b/apps/backend/src/pipelines/handlers/index.ts
@@ -19,3 +19,4 @@ export * from './stripe-checkout.handler';
 export * from './stripe-webhook.handler';
 export * from './signed-url.handler';
 export * from './github-api.handler';
+export * from './google-calendar.handler';

--- a/apps/backend/src/pipelines/pipelines.module.ts
+++ b/apps/backend/src/pipelines/pipelines.module.ts
@@ -39,6 +39,7 @@ import {
   StripeWebhookHandler,
   SignedUrlHandler,
   GitHubApiHandler,
+  GoogleCalendarHandler,
 } from './handlers';
 import { IntegrationsModule } from '../integrations/integrations.module';
 // Embeddings service
@@ -112,6 +113,7 @@ import {
     StripeWebhookHandler,
     SignedUrlHandler,
     GitHubApiHandler,
+    GoogleCalendarHandler,
     // Validators (auto-register on construction)
     AuthRequiredValidator,
     RateLimitValidator,

--- a/apps/backend/src/pipelines/types.ts
+++ b/apps/backend/src/pipelines/types.ts
@@ -77,7 +77,8 @@ export type HandlerType =
   | 'stripe_checkout'
   | 'stripe_webhook'
   | 'signed_url'
-  | 'github_api';
+  | 'github_api'
+  | 'google_calendar';
 
 /**
  * Pipeline step definition for execution.


### PR DESCRIPTION
## Summary

Foundation for the generic scheduling component
([story 0044](../tree/main/../stories/backlog/0044-generic-scheduling)).
This PR accumulates commits as Phases A through F land.

### Phase A — Google Calendar Integration (CE backend)

Promotes Google Calendar from an AI-chat-only `AIToolPlugin` to a
first-class `IntegrationsService` integration alongside Stripe and
GitHub, so any pipeline (not just the AI handler) can read/write
calendars.

- New `GoogleCalendarIntegrationKeys` interface (per-project
  `clientId`/`clientSecret` + optional OAuth tokens).
- New `GoogleCalendarOAuthService` with two helper flavors:
  - `*ForCredentials(...)` — pure HTTP, used by the existing AI-plugin
    OAuth service which already has decrypted creds in hand.
  - `*ForProject(projectId, env, ...)` — `IntegrationsService`-backed,
    refreshes and persists tokens. `env` is optional and defaults to
    the project's active environment.
- `IntegrationsService` extended for `'google-calendar'`:
  added to supported list, `PUBLIC_CONFIG_FIELDS` exposes only
  `connectedEmail` + `availableCalendars`, `testConnection` case added.
- `IntegrationsModule` provides + exports the new service.
- AI-chat `GoogleOAuthService` refactored to delegate HTTP plumbing —
  storage in `settings.aiPlugins` namespace preserved, no migration
  needed for existing AI-chat projects.

**Why per-project credentials**: each project stores its own Google
OAuth client (clientId + clientSecret) for tenant isolation and
per-project consent-screen branding ("Salon Luxe wants access" rather
than a generic "BFFless wants access"). Same pattern Stripe / GitHub
already use on `IntegrationsService`. Documented in
[design-decisions §11](../tree/main/../stories/backlog/0044-generic-scheduling/reference/design-decisions.md).

### Phase B — `google_calendar` step handler (CE backend)

One handler, six actions: `list_calendars`, `freebusy`, `list_events`,
`create_event`, `update_event`, `delete_event`. Pipeline JSON consumers
can call Google Calendar declaratively without `external_proxy` + bespoke
OAuth — matches the `github_api` action-dispatch precedent.

- Per-action runtime validation throws `ConfigurationError`.
- All string-typed inputs run through the expression evaluator
  (`evaluateExpression` for raw fields, `evaluateTemplate` for
  human-facing summary/description/location). `calendarId` and
  `eventId` URL-encoded before path interpolation.
- Stable error codes: `GOOGLE_CALENDAR_NOT_CONFIGURED`, `_AUTH_FAILED`,
  `_NOT_FOUND`, `_RATE_LIMITED`, `_API_ERROR`.
- `delete_event` treats `204`, `404`, `410` as success.
- `fetchWith401Retry` forces a fresh token via `getValidAccessToken` and
  retries once on 401 (handles the rare race where a token is valid at
  resolve-time but expires before Google sees it).

### What's user-visible

Nothing yet. Phases A and B are pure backend plumbing — the new handler
has no consumer in this PR. AI-chat behaviour is unchanged. End-to-end
UI surfaces land in Phase E (demo wiring) and Phase F (template port).

## Test plan

- [x] Unit tests for `GoogleCalendarOAuthService` (13 tests covering
      build URL, token refresh paths including failure, calendar list
      parsing, exchangeCodeForCredentials, getValidAccessToken with 60s
      buffer + active-env fallback)
- [x] `IntegrationsService` round-trip tests (4 tests: encrypt/decrypt,
      public-config field-filtering, supported-list membership,
      refresh-merge semantics)
- [x] Unit tests for `GoogleCalendarHandler` (20 tests: per-action
      happy paths, validation, error code mapping for 404 / 429 / 5xx,
      401 retry success path, 401-then-refresh-fail path, URL encoding,
      expression evaluation through templates)
- [x] Full backend Jest suite green (61 suites / 1028 tests, no
      regressions)
- [x] `tsc --noEmit` clean
- [ ] Manual AI-chat smoke: prompt "what's on my calendar tomorrow?"
      against a project with the existing AI-plugin Google Calendar
      integration — to be verified before merge
- [ ] Manual handler smoke: hit a test pipeline with action `freebusy`
      against a real Google calendar (after Phase C exposes a pipeline
      that uses it)

## Phases landing on this PR

- [x] Phase A — Google Calendar Integration
- [x] Phase B — `google_calendar` step handler
- [ ] Phase C — Per-site scheduling schemas + pipelines
- [ ] Phase D — `@bffless/components` hooks + headless primitives
- [ ] Phase E — Demo wiring in salon-luxe-salon-luxe
- [ ] Phase F — Template port back to `web-templates/templates/salon-luxe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)