### PR TITLE
feat: scheduling component (Phase C-1: google-calendar OAuth UX in CE Settings)

### DIFF
--- a/apps/backend/src/integrations/google-calendar-integration.controller.spec.ts
+++ b/apps/backend/src/integrations/google-calendar-integration.controller.spec.ts
@@ -1,0 +1,221 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GoogleCalendarIntegrationController } from './google-calendar-integration.controller';
+import { IntegrationsService } from './integrations.service';
+import { GoogleCalendarOAuthService } from './google-calendar-oauth.service';
+
+function makeController(): {
+  controller: GoogleCalendarIntegrationController;
+  integrationsService: any;
+  oauthService: any;
+} {
+  const integrationsService = {
+    getActiveConfig: jest.fn(),
+    setConfig: jest.fn().mockResolvedValue(undefined),
+    getStoredIntegration: jest.fn(),
+  };
+  const oauthService = {
+    buildAuthorizationUrl: jest.fn().mockReturnValue('https://accounts.google.com/o/oauth2/v2/auth?…'),
+    exchangeCodeForProject: jest.fn().mockResolvedValue({
+      accessToken: 'a',
+      refreshToken: 'r',
+      tokenExpiry: Date.now() + 3600_000,
+      connectedEmail: 'owner@example.com',
+    }),
+    listCalendarsForProject: jest.fn().mockResolvedValue([
+      { id: 'primary@x', summary: 'Primary', primary: true, timeZone: 'UTC' },
+    ]),
+    revokeToken: jest.fn().mockResolvedValue(undefined),
+  };
+  const configService = {
+    get: (key: string) => (key === 'ENCRYPTION_KEY' ? Buffer.alloc(32, 7).toString('base64') : undefined),
+  } as unknown as ConfigService;
+
+  const controller = new GoogleCalendarIntegrationController(
+    integrationsService as unknown as IntegrationsService,
+    oauthService as unknown as GoogleCalendarOAuthService,
+    configService,
+  );
+  return { controller, integrationsService, oauthService };
+}
+
+describe('GoogleCalendarIntegrationController', () => {
+  describe('initiateOAuth', () => {
+    it('rejects when redirectUri is missing', async () => {
+      const { controller } = makeController();
+      await expect(controller.initiateOAuth('proj-1', '')).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects when clientId is not configured', async () => {
+      const { controller, integrationsService } = makeController();
+      integrationsService.getActiveConfig.mockResolvedValueOnce(null);
+      await expect(controller.initiateOAuth('proj-1', 'https://cb')).rejects.toThrow(/Client ID/);
+    });
+
+    it('returns authUrl from the oauth service', async () => {
+      const { controller, integrationsService, oauthService } = makeController();
+      integrationsService.getActiveConfig.mockResolvedValueOnce({ clientId: 'cid', clientSecret: 'sec' });
+
+      const result = await controller.initiateOAuth('proj-1', 'https://cb');
+
+      expect(result.authUrl).toContain('accounts.google.com');
+      expect(oauthService.buildAuthorizationUrl).toHaveBeenCalledWith(
+        'cid',
+        expect.any(String), // encrypted state
+        'https://cb',
+      );
+      // State should be a 3-segment AES-GCM payload (iv:tag:cipher)
+      const stateArg = oauthService.buildAuthorizationUrl.mock.calls[0][1];
+      expect(stateArg.split(':')).toHaveLength(3);
+    });
+  });
+
+  describe('completeOAuth', () => {
+    it('rejects missing fields', async () => {
+      const { controller } = makeController();
+      await expect(
+        controller.completeOAuth('proj-1', { code: '', state: '', redirectUri: '' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects tampered state token', async () => {
+      const { controller } = makeController();
+      await expect(
+        controller.completeOAuth('proj-1', {
+          code: 'c',
+          state: 'not:a:valid:token',
+          redirectUri: 'https://cb',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects projectId mismatch', async () => {
+      const { controller, integrationsService } = makeController();
+      // First initiate to get a state token bound to proj-A
+      integrationsService.getActiveConfig.mockResolvedValueOnce({ clientId: 'cid', clientSecret: 'sec' });
+      await controller.initiateOAuth('proj-A', 'https://cb');
+      const oauth = (controller as any).googleCalendarOAuthService;
+      const state = oauth.buildAuthorizationUrl.mock.calls[0][1];
+
+      // Then attempt completion as proj-B
+      await expect(
+        controller.completeOAuth('proj-B', { code: 'c', state, redirectUri: 'https://cb' }),
+      ).rejects.toThrow(/state mismatch/);
+    });
+
+    it('rejects expired state token', async () => {
+      const { controller, integrationsService, oauthService } = makeController();
+      integrationsService.getActiveConfig.mockResolvedValueOnce({ clientId: 'cid', clientSecret: 'sec' });
+
+      // Freeze "now" 11 minutes in the past for state generation
+      const realNow = Date.now;
+      Date.now = () => realNow() - 11 * 60 * 1000;
+      await controller.initiateOAuth('proj-1', 'https://cb');
+      Date.now = realNow;
+
+      const state = oauthService.buildAuthorizationUrl.mock.calls[0][1];
+      await expect(
+        controller.completeOAuth('proj-1', { code: 'c', state, redirectUri: 'https://cb' }),
+      ).rejects.toThrow(/expired/);
+    });
+
+    it('exchanges code and returns connectedEmail on valid state', async () => {
+      const { controller, integrationsService, oauthService } = makeController();
+      integrationsService.getActiveConfig.mockResolvedValueOnce({ clientId: 'cid', clientSecret: 'sec' });
+      await controller.initiateOAuth('proj-1', 'https://cb');
+      const state = oauthService.buildAuthorizationUrl.mock.calls[0][1];
+
+      const result = await controller.completeOAuth('proj-1', {
+        code: 'auth-code',
+        state,
+        redirectUri: 'https://cb',
+      });
+
+      expect(result).toEqual({ success: true, connectedEmail: 'owner@example.com' });
+      expect(oauthService.exchangeCodeForProject).toHaveBeenCalledWith(
+        'proj-1',
+        undefined, // env auto-resolves
+        'auth-code',
+        'https://cb',
+      );
+    });
+  });
+
+  describe('disconnectOAuth', () => {
+    it('throws when integration is not enabled', async () => {
+      const { controller, integrationsService } = makeController();
+      integrationsService.getStoredIntegration.mockResolvedValueOnce({ enabled: false });
+      await expect(controller.disconnectOAuth('proj-1')).rejects.toThrow(NotFoundException);
+    });
+
+    it('revokes refresh token, clears tokens, keeps clientId/clientSecret', async () => {
+      const { controller, integrationsService, oauthService } = makeController();
+      integrationsService.getStoredIntegration.mockResolvedValueOnce({
+        enabled: true,
+        activeEnvironment: 'production',
+      });
+      integrationsService.getActiveConfig.mockResolvedValueOnce({
+        clientId: 'cid',
+        clientSecret: 'sec',
+        accessToken: 'a',
+        refreshToken: 'r-token',
+        tokenExpiry: 9999999,
+        connectedEmail: 'owner@example.com',
+      });
+
+      await controller.disconnectOAuth('proj-1');
+
+      expect(oauthService.revokeToken).toHaveBeenCalledWith('r-token');
+      expect(integrationsService.setConfig).toHaveBeenCalledWith(
+        'proj-1',
+        'google-calendar',
+        'production',
+        expect.objectContaining({
+          accessToken: '',
+          refreshToken: '',
+          tokenExpiry: 0,
+          connectedEmail: '',
+          availableCalendars: [],
+        }),
+      );
+      // Did NOT pass clientId / clientSecret in the clear payload — setConfig merges
+      // and existing creds are preserved
+      const cleared = integrationsService.setConfig.mock.calls[0][3];
+      expect(cleared.clientId).toBeUndefined();
+      expect(cleared.clientSecret).toBeUndefined();
+    });
+
+    it('handles disconnect when no refresh token is present (silently)', async () => {
+      const { controller, integrationsService, oauthService } = makeController();
+      integrationsService.getStoredIntegration.mockResolvedValueOnce({
+        enabled: true,
+        activeEnvironment: 'production',
+      });
+      integrationsService.getActiveConfig.mockResolvedValueOnce({
+        clientId: 'cid',
+        clientSecret: 'sec',
+      });
+
+      await controller.disconnectOAuth('proj-1');
+      expect(oauthService.revokeToken).not.toHaveBeenCalled();
+      expect(integrationsService.setConfig).toHaveBeenCalled();
+    });
+  });
+
+  describe('listCalendars', () => {
+    it('delegates to listCalendarsForProject and returns wrapped response', async () => {
+      const { controller, oauthService } = makeController();
+
+      const result = await controller.listCalendars('proj-1');
+
+      expect(oauthService.listCalendarsForProject).toHaveBeenCalledWith('proj-1');
+      expect(result.calendars).toHaveLength(1);
+      expect(result.calendars[0]).toEqual({
+        id: 'primary@x',
+        summary: 'Primary',
+        primary: true,
+        timeZone: 'UTC',
+      });
+    });
+  });
+});

--- a/apps/backend/src/integrations/google-calendar-integration.controller.ts
+++ b/apps/backend/src/integrations/google-calendar-integration.controller.ts
@@ -1,0 +1,211 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import * as crypto from 'crypto';
+import { ApiKeyGuard } from '../auth/api-key.guard';
+import { ProjectPermissionGuard } from '../auth/guards/project-permission.guard';
+import { RequireProjectRole } from '../auth/decorators/project-permission.decorator';
+import { IntegrationsService } from './integrations.service';
+import { GoogleCalendarOAuthService } from './google-calendar-oauth.service';
+import { GoogleCalendarIntegrationKeys } from './google-calendar.interface';
+
+const STATE_EXPIRY_MS = 10 * 60 * 1000; // 10 minutes
+
+interface OAuthStatePayload {
+  projectId: string;
+  integrationId: 'google-calendar';
+  timestamp: number;
+}
+
+/**
+ * REST API for the per-project Google Calendar integration OAuth flow.
+ *
+ * Routes are nested under /api/projects/:projectId/integrations/google-calendar
+ * to match the existing IntegrationsService surface (Stripe / GitHub) and the
+ * AI-plugin OAuth precedent (`/api/projects/:projectId/ai-plugins/...`).
+ *
+ * State tokens are AES-256-GCM with the platform `ENCRYPTION_KEY` and bind
+ * `{projectId, integrationId, timestamp}` so a callback can't be substituted
+ * across projects or replayed past expiry.
+ */
+@ApiTags('integrations')
+@Controller('api/projects/:projectId/integrations/google-calendar')
+@UseGuards(ApiKeyGuard, ProjectPermissionGuard)
+@RequireProjectRole('admin')
+export class GoogleCalendarIntegrationController {
+  private readonly logger = new Logger(GoogleCalendarIntegrationController.name);
+  private readonly ENCRYPTION_KEY: Buffer;
+  private readonly ENCRYPTION_ALGORITHM = 'aes-256-gcm';
+
+  constructor(
+    private readonly integrationsService: IntegrationsService,
+    private readonly googleCalendarOAuthService: GoogleCalendarOAuthService,
+    configService: ConfigService,
+  ) {
+    const encryptionKey = configService.get<string>('ENCRYPTION_KEY');
+    if (encryptionKey) {
+      this.ENCRYPTION_KEY = Buffer.from(encryptionKey, 'base64');
+    } else {
+      this.ENCRYPTION_KEY = crypto.randomBytes(32);
+      this.logger.warn('No ENCRYPTION_KEY found. Generated temporary key.');
+    }
+  }
+
+  @Get('oauth/initiate')
+  @ApiOperation({ summary: 'Initiate Google Calendar OAuth flow' })
+  @ApiParam({ name: 'projectId', description: 'Project UUID' })
+  async initiateOAuth(
+    @Param('projectId') projectId: string,
+    @Query('redirectUri') redirectUri: string,
+  ): Promise<{ authUrl: string }> {
+    if (!redirectUri) {
+      throw new BadRequestException('redirectUri is required');
+    }
+
+    const config = (await this.integrationsService.getActiveConfig(
+      projectId,
+      'google-calendar',
+    )) as GoogleCalendarIntegrationKeys | null;
+    if (!config?.clientId) {
+      throw new BadRequestException(
+        'Google OAuth Client ID not configured. Save clientId/clientSecret first.',
+      );
+    }
+
+    const state = this.encryptState({
+      projectId,
+      integrationId: 'google-calendar',
+      timestamp: Date.now(),
+    });
+
+    const authUrl = this.googleCalendarOAuthService.buildAuthorizationUrl(
+      config.clientId,
+      state,
+      redirectUri,
+    );
+    return { authUrl };
+  }
+
+  @Post('oauth/callback')
+  @ApiOperation({ summary: 'Complete Google Calendar OAuth flow with authorization code' })
+  @ApiParam({ name: 'projectId', description: 'Project UUID' })
+  async completeOAuth(
+    @Param('projectId') projectId: string,
+    @Body() body: { code: string; state: string; redirectUri: string },
+  ): Promise<{ success: boolean; connectedEmail: string }> {
+    const { code, state, redirectUri } = body;
+    if (!code || !state || !redirectUri) {
+      throw new BadRequestException('code, state, and redirectUri are required');
+    }
+
+    let payload: OAuthStatePayload;
+    try {
+      payload = this.decryptState(state);
+    } catch {
+      throw new BadRequestException('Invalid OAuth state token');
+    }
+
+    if (payload.projectId !== projectId || payload.integrationId !== 'google-calendar') {
+      throw new BadRequestException('OAuth state mismatch (project/integration)');
+    }
+    if (Date.now() - payload.timestamp > STATE_EXPIRY_MS) {
+      throw new BadRequestException('OAuth state expired');
+    }
+
+    const result = await this.googleCalendarOAuthService.exchangeCodeForProject(
+      projectId,
+      undefined,
+      code,
+      redirectUri,
+    );
+    this.logger.log(
+      `Google Calendar connected for project ${projectId}: ${result.connectedEmail}`,
+    );
+    return { success: true, connectedEmail: result.connectedEmail };
+  }
+
+  @Delete('oauth')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Disconnect Google Calendar (revoke tokens, keep clientId/clientSecret)' })
+  @ApiParam({ name: 'projectId', description: 'Project UUID' })
+  async disconnectOAuth(@Param('projectId') projectId: string): Promise<void> {
+    const stored = await this.integrationsService.getStoredIntegration(
+      projectId,
+      'google-calendar',
+    );
+    if (!stored?.enabled) {
+      throw new NotFoundException('Google Calendar integration is not configured');
+    }
+
+    const env = stored.activeEnvironment;
+    const config = (await this.integrationsService.getActiveConfig(
+      projectId,
+      'google-calendar',
+      env,
+    )) as GoogleCalendarIntegrationKeys | null;
+
+    if (config?.refreshToken) {
+      await this.googleCalendarOAuthService.revokeToken(config.refreshToken);
+    }
+
+    // Keep clientId / clientSecret; clear OAuth state.
+    await this.integrationsService.setConfig(projectId, 'google-calendar', env, {
+      accessToken: '',
+      refreshToken: '',
+      tokenExpiry: 0,
+      connectedEmail: '',
+      availableCalendars: [],
+    });
+  }
+
+  @Get('calendars')
+  @ApiOperation({ summary: 'List sub-calendars on the connected Google account' })
+  @ApiParam({ name: 'projectId', description: 'Project UUID' })
+  async listCalendars(
+    @Param('projectId') projectId: string,
+  ): Promise<{
+    calendars: Array<{ id: string; summary: string; primary?: boolean; timeZone: string }>;
+  }> {
+    const calendars = await this.googleCalendarOAuthService.listCalendarsForProject(projectId);
+    return { calendars };
+  }
+
+  // ===== State encryption =====
+
+  private encryptState(payload: OAuthStatePayload): string {
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv(this.ENCRYPTION_ALGORITHM, this.ENCRYPTION_KEY, iv);
+    let encrypted = cipher.update(JSON.stringify(payload), 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+    const authTag = cipher.getAuthTag();
+    return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`;
+  }
+
+  private decryptState(state: string): OAuthStatePayload {
+    const [ivHex, authTagHex, encrypted] = state.split(':');
+    if (!ivHex || !authTagHex || !encrypted) {
+      throw new Error('Malformed state token');
+    }
+    const iv = Buffer.from(ivHex, 'hex');
+    const authTag = Buffer.from(authTagHex, 'hex');
+    const decipher = crypto.createDecipheriv(this.ENCRYPTION_ALGORITHM, this.ENCRYPTION_KEY, iv);
+    decipher.setAuthTag(authTag);
+    let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+    return JSON.parse(decrypted) as OAuthStatePayload;
+  }
+}

--- a/apps/backend/src/integrations/integrations.module.ts
+++ b/apps/backend/src/integrations/integrations.module.ts
@@ -1,9 +1,16 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { IntegrationsService } from './integrations.service';
 import { GoogleCalendarOAuthService } from './google-calendar-oauth.service';
 import { GoogleCalendarIntegrationController } from './google-calendar-integration.controller';
+import { PermissionsModule } from '../permissions/permissions.module';
+import { ProjectsModule } from '../projects/projects.module';
 
 @Module({
+  // PermissionsModule + ProjectsModule are needed by ProjectPermissionGuard
+  // (the guard takes Reflector, PermissionsService, ProjectsService).
+  // ProjectsModule already imports IntegrationsModule, so the cycle is broken
+  // with forwardRef on this side. Same pattern PipelinesModule uses.
+  imports: [PermissionsModule, forwardRef(() => ProjectsModule)],
   controllers: [GoogleCalendarIntegrationController],
   providers: [IntegrationsService, GoogleCalendarOAuthService],
   exports: [IntegrationsService, GoogleCalendarOAuthService],

--- a/apps/backend/src/integrations/integrations.module.ts
+++ b/apps/backend/src/integrations/integrations.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { IntegrationsService } from './integrations.service';
 import { GoogleCalendarOAuthService } from './google-calendar-oauth.service';
+import { GoogleCalendarIntegrationController } from './google-calendar-integration.controller';
 
 @Module({
+  controllers: [GoogleCalendarIntegrationController],
   providers: [IntegrationsService, GoogleCalendarOAuthService],
   exports: [IntegrationsService, GoogleCalendarOAuthService],
 })

--- a/apps/frontend/src/components/project/GoogleCalendarIntegrationDialog.tsx
+++ b/apps/frontend/src/components/project/GoogleCalendarIntegrationDialog.tsx
@@ -1,0 +1,333 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  useSetIntegrationConfigMutation,
+  useTestIntegrationConnectionMutation,
+  useLazyInitiateGoogleCalendarOAuthQuery,
+  useDisconnectGoogleCalendarOAuthMutation,
+  useListGoogleCalendarCalendarsQuery,
+  type IntegrationInfo,
+  type CalendarSummary,
+} from '@/services/integrationsApi';
+import { useToast } from '@/hooks/use-toast';
+import { CheckCircle, XCircle, Loader2, ExternalLink, Unlink } from 'lucide-react';
+
+interface GoogleCalendarIntegrationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  projectOwner: string;
+  projectName: string;
+  integration: IntegrationInfo;
+}
+
+export function GoogleCalendarIntegrationDialog({
+  open,
+  onOpenChange,
+  projectId,
+  projectOwner,
+  projectName,
+  integration,
+}: GoogleCalendarIntegrationDialogProps) {
+  const { toast } = useToast();
+
+  const [clientId, setClientId] = useState('');
+  const [clientSecret, setClientSecret] = useState('');
+  const [testResult, setTestResult] = useState<{ success: boolean; error?: string } | null>(null);
+
+  const [setConfig, { isLoading: isSaving }] = useSetIntegrationConfigMutation();
+  const [testConnection, { isLoading: isTesting }] = useTestIntegrationConnectionMutation();
+  const [initiateOAuth, { isFetching: isInitiating }] = useLazyInitiateGoogleCalendarOAuthQuery();
+  const [disconnectOAuth, { isLoading: isDisconnecting }] = useDisconnectGoogleCalendarOAuthMutation();
+
+  const connectedEmail = integration.publicConfig?.connectedEmail as string | undefined;
+  const availableCalendars =
+    (integration.publicConfig?.availableCalendars as CalendarSummary[] | undefined) || [];
+  const hasCredentials = integration.hasProductionConfig;
+  const isConnected = !!connectedEmail;
+
+  // Only fetch fresh calendar list when already connected — avoid 4xx noise
+  // before OAuth completion.
+  const { data: calendarsData, isFetching: isFetchingCalendars } =
+    useListGoogleCalendarCalendarsQuery(projectId, {
+      skip: !isConnected,
+    });
+
+  const calendars =
+    (calendarsData?.calendars && calendarsData.calendars.length > 0
+      ? calendarsData.calendars
+      : availableCalendars) || [];
+
+  const handleSaveCredentials = async () => {
+    if (!hasCredentials && (!clientId || !clientSecret)) {
+      toast({
+        title: 'Error',
+        description: 'Both Client ID and Client Secret are required',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      const config: Record<string, string> = {};
+      if (clientId) config.clientId = clientId;
+      if (clientSecret) config.clientSecret = clientSecret;
+
+      await setConfig({
+        projectId,
+        integrationId: 'google-calendar',
+        environment: 'production',
+        config,
+      }).unwrap();
+
+      toast({
+        title: 'Saved',
+        description: 'Google Calendar credentials saved. Click "Connect Google" to authorize.',
+      });
+      setClientId('');
+      setClientSecret('');
+    } catch (error: any) {
+      toast({
+        title: 'Error',
+        description: error?.data?.message || 'Failed to save credentials',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleConnect = async () => {
+    try {
+      const redirectUri = window.location.origin + '/oauth/callback';
+      sessionStorage.setItem(
+        'oauth_integration_context',
+        JSON.stringify({
+          projectId,
+          integrationId: 'google-calendar',
+          owner: projectOwner,
+          repo: projectName,
+        }),
+      );
+      const result = await initiateOAuth({ projectId, redirectUri }).unwrap();
+      window.location.href = result.authUrl;
+    } catch (error: any) {
+      toast({
+        title: 'Error',
+        description: error?.data?.message || 'Failed to start OAuth flow',
+        variant: 'destructive',
+      });
+      sessionStorage.removeItem('oauth_integration_context');
+    }
+  };
+
+  const handleDisconnect = async () => {
+    try {
+      await disconnectOAuth({ projectId }).unwrap();
+      toast({ title: 'Google Calendar disconnected' });
+    } catch (error: any) {
+      toast({
+        title: 'Error',
+        description: error?.data?.message || 'Failed to disconnect',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleTestConnection = async () => {
+    setTestResult(null);
+    try {
+      const result = await testConnection({
+        projectId,
+        integrationId: 'google-calendar',
+        environment: 'production',
+      }).unwrap();
+      setTestResult(result);
+    } catch (error: any) {
+      setTestResult({
+        success: false,
+        error: error?.data?.message || 'Connection test failed',
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[520px]">
+        <DialogHeader>
+          <DialogTitle>Configure Google Calendar Integration</DialogTitle>
+          <DialogDescription>
+            Connect a Google account so pipelines can read free/busy information and create
+            calendar events. Each project owns its own OAuth client (configured in
+            Google Cloud Console) so credentials never leave this project.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Step 1 — credentials */}
+          {!isConnected && (
+            <div className="space-y-3">
+              {hasCredentials && (
+                <Alert>
+                  <CheckCircle className="h-4 w-4" />
+                  <AlertDescription>
+                    OAuth credentials saved. Click "Connect Google" to authorize.
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              <div className="space-y-2">
+                <Label>Client ID *</Label>
+                <Input
+                  type="text"
+                  placeholder={
+                    hasCredentials
+                      ? '••••••••••.apps.googleusercontent.com'
+                      : 'xxxxx.apps.googleusercontent.com'
+                  }
+                  value={clientId}
+                  onChange={(e) => setClientId(e.target.value)}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label>Client Secret *</Label>
+                <Input
+                  type="password"
+                  placeholder={hasCredentials ? '••••••••••••••••' : 'GOCSPX-...'}
+                  value={clientSecret}
+                  onChange={(e) => setClientSecret(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Create at{' '}
+                  <a
+                    href="https://console.cloud.google.com/apis/credentials"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline inline-flex items-center gap-1"
+                  >
+                    console.cloud.google.com/apis/credentials
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                  . Add{' '}
+                  <code>{`${typeof window !== 'undefined' ? window.location.origin : ''}/oauth/callback`}</code>{' '}
+                  as an authorized redirect URI.
+                </p>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  onClick={handleSaveCredentials}
+                  disabled={isSaving || (!hasCredentials && (!clientId || !clientSecret))}
+                >
+                  {isSaving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
+                  Save Credentials
+                </Button>
+
+                {hasCredentials && (
+                  <Button onClick={handleConnect} variant="default" disabled={isInitiating}>
+                    {isInitiating ? (
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    ) : (
+                      <ExternalLink className="h-4 w-4 mr-2" />
+                    )}
+                    Connect Google
+                  </Button>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Step 2 — connected state */}
+          {isConnected && (
+            <div className="space-y-3">
+              <Alert>
+                <CheckCircle className="h-4 w-4" />
+                <AlertDescription>
+                  Connected as <strong>{connectedEmail}</strong>
+                </AlertDescription>
+              </Alert>
+
+              <div className="space-y-2">
+                <Label>Available calendars</Label>
+                {isFetchingCalendars ? (
+                  <p className="text-sm text-muted-foreground">Loading calendars…</p>
+                ) : calendars.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    No calendars returned. The connected account may not have any sub-calendars yet.
+                  </p>
+                ) : (
+                  <ul className="text-sm border rounded-md divide-y">
+                    {calendars.map((c) => (
+                      <li key={c.id} className="flex items-center justify-between px-3 py-2">
+                        <div>
+                          <div className="font-medium">{c.summary}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {c.id} · {c.timeZone}
+                          </div>
+                        </div>
+                        {c.primary && (
+                          <span className="text-xs px-2 py-0.5 rounded-full bg-muted">primary</span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <Button variant="outline" onClick={handleTestConnection} disabled={isTesting}>
+                  {isTesting ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
+                  Test Connection
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={handleDisconnect}
+                  disabled={isDisconnecting}
+                  className="text-destructive hover:text-destructive"
+                >
+                  {isDisconnecting ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <Unlink className="h-4 w-4 mr-2" />
+                  )}
+                  Disconnect
+                </Button>
+              </div>
+
+              {testResult && (
+                <Alert variant={testResult.success ? 'default' : 'destructive'}>
+                  {testResult.success ? (
+                    <CheckCircle className="h-4 w-4" />
+                  ) : (
+                    <XCircle className="h-4 w-4" />
+                  )}
+                  <AlertDescription>
+                    {testResult.success
+                      ? 'Successfully reached Google Calendar.'
+                      : `Connection failed: ${testResult.error}`}
+                  </AlertDescription>
+                </Alert>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/project/ProjectIntegrationsTab.tsx
+++ b/apps/frontend/src/components/project/ProjectIntegrationsTab.tsx
@@ -10,7 +10,8 @@ import {
 import { useToast } from '@/hooks/use-toast';
 import { StripeIntegrationDialog } from './StripeIntegrationDialog';
 import { GitHubIntegrationDialog } from './GitHubIntegrationDialog';
-import { Settings, Trash2, CreditCard, Github } from 'lucide-react';
+import { GoogleCalendarIntegrationDialog } from './GoogleCalendarIntegrationDialog';
+import { Settings, Trash2, CreditCard, Github, Calendar } from 'lucide-react';
 
 interface Project {
   id: string;
@@ -35,6 +36,11 @@ const INTEGRATION_META: Record<
     name: 'GitHub',
     description: 'Create repositories from templates and interact with the GitHub API from pipeline steps.',
     icon: Github,
+  },
+  'google-calendar': {
+    name: 'Google Calendar',
+    description: 'Mirror bookings to Google Calendar and read free/busy from connected sub-calendars.',
+    icon: Calendar,
   },
 };
 
@@ -112,7 +118,9 @@ export function ProjectIntegrationsTab({ project }: ProjectIntegrationsTabProps)
                     <div>
                       <div className="flex items-center gap-2">
                         <h4 className="font-medium">{meta.name}</h4>
-                        {integration.enabled && integration.id !== 'github' && (
+                        {integration.enabled &&
+                          integration.id !== 'github' &&
+                          integration.id !== 'google-calendar' && (
                           <Badge
                             variant={
                               integration.activeEnvironment === 'production'
@@ -190,6 +198,20 @@ export function ProjectIntegrationsTab({ project }: ProjectIntegrationsTabProps)
             if (!open) setConfigDialogId(null);
           }}
           projectId={project.id}
+          integration={configIntegration}
+        />
+      )}
+
+      {/* Google Calendar Dialog */}
+      {configDialogId === 'google-calendar' && configIntegration && (
+        <GoogleCalendarIntegrationDialog
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) setConfigDialogId(null);
+          }}
+          projectId={project.id}
+          projectOwner={project.owner}
+          projectName={project.name}
           integration={configIntegration}
         />
       )}

--- a/apps/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/apps/frontend/src/pages/OAuthCallbackPage.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useCompletePluginOAuthMutation } from '@/services/projectsApi';
+import { useCompleteGoogleCalendarOAuthMutation } from '@/services/integrationsApi';
 import { Loader2, CheckCircle2, XCircle } from 'lucide-react';
 
 export function OAuthCallbackPage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const [completeOAuth] = useCompletePluginOAuthMutation();
+  const [completePluginOAuth] = useCompletePluginOAuthMutation();
+  const [completeIntegrationOAuth] = useCompleteGoogleCalendarOAuthMutation();
   const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
   const [errorMessage, setErrorMessage] = useState('');
   const [connectedEmail, setConnectedEmail] = useState('');
@@ -32,39 +34,74 @@ export function OAuthCallbackPage() {
       return;
     }
 
-    // Read stored context from sessionStorage
-    const storedData = sessionStorage.getItem('oauth_plugin_context');
-    if (!storedData) {
-      setStatus('error');
-      setErrorMessage('OAuth session expired. Please try connecting again.');
+    // Two callers, two sessionStorage keys. Integration takes precedence
+    // because the new google-calendar entry under Project Settings is the
+    // intended path going forward; AI-plugin OAuth is the legacy path.
+    const integrationContext = sessionStorage.getItem('oauth_integration_context');
+    const pluginContext = sessionStorage.getItem('oauth_plugin_context');
+
+    if (integrationContext) {
+      sessionStorage.removeItem('oauth_integration_context');
+      const { projectId, integrationId, owner, repo } = JSON.parse(integrationContext);
+      const redirectUri = window.location.origin + '/oauth/callback';
+
+      if (integrationId !== 'google-calendar') {
+        setStatus('error');
+        setErrorMessage(`Unsupported integration: ${integrationId}`);
+        return;
+      }
+
+      completeIntegrationOAuth({ projectId, code, state, redirectUri })
+        .unwrap()
+        .then((result) => {
+          setConnectedEmail(result.connectedEmail);
+          setStatus('success');
+          setTimeout(() => {
+            if (owner && repo) {
+              navigate(`/repo/${owner}/${repo}/settings?tab=integrations`);
+            } else {
+              navigate('/');
+            }
+          }, 2000);
+        })
+        .catch((err) => {
+          setStatus('error');
+          setErrorMessage(
+            err.data?.message || 'Failed to complete OAuth connection. Please try again.',
+          );
+        });
       return;
     }
 
-    const { projectId, pluginId, owner, repo } = JSON.parse(storedData);
-    sessionStorage.removeItem('oauth_plugin_context');
+    if (pluginContext) {
+      sessionStorage.removeItem('oauth_plugin_context');
+      const { projectId, pluginId, owner, repo } = JSON.parse(pluginContext);
+      const redirectUri = window.location.origin + '/oauth/callback';
 
-    const redirectUri = window.location.origin + '/oauth/callback';
+      completePluginOAuth({ projectId, pluginId, code, state, redirectUri })
+        .unwrap()
+        .then((result) => {
+          setConnectedEmail(result.connectedEmail);
+          setStatus('success');
+          setTimeout(() => {
+            if (owner && repo) {
+              navigate(`/repo/${owner}/${repo}/settings?tab=ai`);
+            } else {
+              navigate('/');
+            }
+          }, 2000);
+        })
+        .catch((err) => {
+          setStatus('error');
+          setErrorMessage(
+            err.data?.message || 'Failed to complete OAuth connection. Please try again.',
+          );
+        });
+      return;
+    }
 
-    completeOAuth({ projectId, pluginId, code, state, redirectUri })
-      .unwrap()
-      .then((result) => {
-        setConnectedEmail(result.connectedEmail);
-        setStatus('success');
-        // Redirect to project settings after a brief delay
-        setTimeout(() => {
-          if (owner && repo) {
-            navigate(`/repo/${owner}/${repo}/settings?tab=ai`);
-          } else {
-            navigate('/');
-          }
-        }, 2000);
-      })
-      .catch((err) => {
-        setStatus('error');
-        setErrorMessage(
-          err.data?.message || 'Failed to complete OAuth connection. Please try again.',
-        );
-      });
+    setStatus('error');
+    setErrorMessage('OAuth session expired. Please try connecting again.');
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (

--- a/apps/frontend/src/services/integrationsApi.ts
+++ b/apps/frontend/src/services/integrationsApi.ts
@@ -9,6 +9,13 @@ export interface IntegrationInfo {
   publicConfig?: Record<string, unknown>;
 }
 
+export interface CalendarSummary {
+  id: string;
+  summary: string;
+  primary?: boolean;
+  timeZone: string;
+}
+
 export const integrationsApi = api.injectEndpoints({
   endpoints: (builder) => ({
     getProjectIntegrations: builder.query<IntegrationInfo[], string>({
@@ -85,6 +92,48 @@ export const integrationsApi = api.injectEndpoints({
         body: { environment },
       }),
     }),
+
+    // ===== Google Calendar OAuth =====
+
+    initiateGoogleCalendarOAuth: builder.query<
+      { authUrl: string },
+      { projectId: string; redirectUri: string }
+    >({
+      query: ({ projectId, redirectUri }) =>
+        `/api/projects/${projectId}/integrations/google-calendar/oauth/initiate?redirectUri=${encodeURIComponent(redirectUri)}`,
+    }),
+
+    completeGoogleCalendarOAuth: builder.mutation<
+      { success: boolean; connectedEmail: string },
+      { projectId: string; code: string; state: string; redirectUri: string }
+    >({
+      query: ({ projectId, code, state, redirectUri }) => ({
+        url: `/api/projects/${projectId}/integrations/google-calendar/oauth/callback`,
+        method: 'POST',
+        body: { code, state, redirectUri },
+      }),
+      invalidatesTags: (_result, _error, { projectId }) => [
+        { type: 'Integration' as const, id: projectId },
+      ],
+    }),
+
+    disconnectGoogleCalendarOAuth: builder.mutation<void, { projectId: string }>({
+      query: ({ projectId }) => ({
+        url: `/api/projects/${projectId}/integrations/google-calendar/oauth`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: (_result, _error, { projectId }) => [
+        { type: 'Integration' as const, id: projectId },
+      ],
+    }),
+
+    listGoogleCalendarCalendars: builder.query<{ calendars: CalendarSummary[] }, string>({
+      query: (projectId) =>
+        `/api/projects/${projectId}/integrations/google-calendar/calendars`,
+      providesTags: (_result, _error, projectId) => [
+        { type: 'Integration' as const, id: projectId },
+      ],
+    }),
   }),
 });
 
@@ -95,4 +144,8 @@ export const {
   useSwitchIntegrationEnvironmentMutation,
   useDeleteIntegrationMutation,
   useTestIntegrationConnectionMutation,
+  useLazyInitiateGoogleCalendarOAuthQuery,
+  useCompleteGoogleCalendarOAuthMutation,
+  useDisconnectGoogleCalendarOAuthMutation,
+  useListGoogleCalendarCalendarsQuery,
 } = integrationsApi;


### PR DESCRIPTION
## Summary

Phase C-1 of [story 0044](../tree/main/../stories/backlog/0044-generic-scheduling).
Closes the Phase A gap: `'google-calendar'` was registered in the
supported list but had no OAuth controller routes and no frontend card.
The auto-rendered tile's "Set Up" button was a no-op until this PR.

This PR is the natural successor to PR #249 (Phases A + B). When this is
merged, deploy and verify the OAuth round-trip end-to-end in CE Settings.
Phase C-2 (per-site scheduling schemas + pipelines + the `optional: true`
handler amendment) follows on its own branch / PR.

## What changed

### Backend
- New `GoogleCalendarIntegrationController` mounted at
  `/api/projects/:projectId/integrations/google-calendar/oauth/{initiate,callback}`
  + DELETE + `/calendars`. State tokens are AES-256-GCM with the platform
  `ENCRYPTION_KEY`, bind `{projectId, integrationId, timestamp}`, and
  expire after 10 minutes.
- All routes guarded by `ApiKeyGuard` + `ProjectPermissionGuard`
  (`admin` role).
- Tokens persisted via `IntegrationsService.setConfig` (merge semantics);
  disconnect clears tokens but keeps clientId/clientSecret so re-connect
  doesn't require re-entering credentials.

### Frontend
- `GoogleCalendarIntegrationDialog` — three-state flow: enter creds →
  "Connect Google" → connected (shows email + sub-calendar list +
  test-connection + disconnect).
- `INTEGRATION_META.google-calendar` entry with `Calendar` icon. Badge
  suppressed for single-env integration (matches existing GitHub
  exception).
- `OAuthCallbackPage` extended to dispatch on
  `oauth_integration_context` vs `oauth_plugin_context` so the existing
  `/oauth/callback` route handles both flows. Navigates back to
  `?tab=integrations` for the new integration path.
- New RTK Query endpoints in `integrationsApi.ts`:
  `initiateGoogleCalendarOAuth` (lazy), `completeGoogleCalendarOAuth`,
  `disconnectGoogleCalendarOAuth`, `listGoogleCalendarCalendars`.

### Why per-project credentials (recap from Phase A)

Each project stores its own `clientId` + `clientSecret` (encrypted at
rest in `IntegrationsService`). Tenant isolation: project A and project
B have separate Google OAuth clients, separate consent screens
(branding), separate token rows. Credentials never leak across projects
and aren't in env vars. See
[design-decisions §11](../tree/main/../stories/backlog/0044-generic-scheduling/reference/design-decisions.md).

## Test plan

- [x] Backend unit tests: 12 controller specs covering state token
      encrypt/decrypt round-trip, projectId-mismatch rejection, expired
      state rejection, disconnect with/without refresh token,
      listCalendars delegation
- [x] Full backend Jest suite: 62 suites / 1040 tests green (+12 from
      this PR)
- [x] Frontend type check (`tsc --noEmit`) clean
- [x] Frontend vitest: 19 files / 364 tests green
- [x] Backend `nest build` clean
- [x] Frontend `vite build` clean
- [ ] Manual: deploy → CE Settings → Integrations → Google Calendar
      card has proper name + Calendar icon + description
- [ ] Manual: enter clientId/clientSecret → Save → "Connect Google"
      becomes enabled
- [ ] Manual: Connect Google → consent screen → redirected back →
      `connectedEmail` shown
- [ ] Manual: sub-calendar list populated
- [ ] Manual: Disconnect → tokens cleared, clientId/clientSecret
      retained, "Connect Google" reappears
- [ ] Manual: AI-chat regression — existing AI-plugin OAuth flow still
      works (different sessionStorage key, separate code path)

## Phases on the parent story

- [x] Phase A — Google Calendar Integration (PR #249)
- [x] Phase B — `google_calendar` step handler (PR #249)
- [x] Phase C-1 — google-calendar OAuth UX in CE Project Settings (this PR)
- [ ] Phase C-2 — `optional` handler flag + scheduling schemas + pipelines
- [ ] Phase D — `@bffless/components` hooks + headless primitives
- [ ] Phase E — Demo wiring in salon-luxe-salon-luxe
- [ ] Phase F — Template port back to `web-templates/templates/salon-luxe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)