### PR TITLE
fix(integrations): prevent long calendar ids overflowing the dialog

### DIFF
--- a/apps/frontend/src/components/project/GoogleCalendarIntegrationDialog.tsx
+++ b/apps/frontend/src/components/project/GoogleCalendarIntegrationDialog.tsx
@@ -268,15 +268,17 @@ export function GoogleCalendarIntegrationDialog({
                 ) : (
                   <ul className="text-sm border rounded-md divide-y">
                     {calendars.map((c) => (
-                      <li key={c.id} className="flex items-center justify-between px-3 py-2">
-                        <div>
-                          <div className="font-medium">{c.summary}</div>
-                          <div className="text-xs text-muted-foreground">
+                      <li key={c.id} className="flex items-start justify-between gap-2 px-3 py-2">
+                        <div className="min-w-0 flex-1">
+                          <div className="font-medium truncate">{c.summary}</div>
+                          <div className="text-xs text-muted-foreground break-all">
                             {c.id} · {c.timeZone}
                           </div>
                         </div>
                         {c.primary && (
-                          <span className="text-xs px-2 py-0.5 rounded-full bg-muted">primary</span>
+                          <span className="text-xs px-2 py-0.5 rounded-full bg-muted shrink-0">
+                            primary
+                          </span>
                         )}
                       </li>
                     ))}


### PR DESCRIPTION
## Summary

Long Google calendar ids (no spaces, e.g.
`a6088a065487b50f0fc62293f100cabae89ce989784936bc695ebc32515e11b684@group.calendar.google.com`)
were pushing past the right edge of the Google Calendar integration
dialog, bleeding into the page background.

Three CSS fixes:
- `min-w-0` + `flex-1` on the text container so it can shrink inside its flex parent
- `break-all` on the id line so the unbreakable string wraps
- `shrink-0` on the "primary" badge so it stays pinned to the right
- `truncate` on the calendar name (defense-in-depth for unusually long names)

## Test plan

- [x] Frontend `tsc --noEmit` clean
- [ ] Visual: dialog no longer overflows when calendar ids are long

🤖 Generated with [Claude Code](https://claude.com/claude-code)