### PR TITLE
feat: optional flag on google_calendar handler (Phase C-2 prep)

### DIFF
--- a/apps/backend/src/mcp/tools/proxy-rules.tools.ts
+++ b/apps/backend/src/mcp/tools/proxy-rules.tools.ts
@@ -33,6 +33,7 @@ const pipelineStepSchema = z.object({
       'stripe_webhook',
       'signed_url',
       'github_api',
+      'google_calendar',
     ])
     .describe(
       'IMPORTANT: Use exact handler type strings. Some have _handler suffix, some do not. The enum values are the only valid options.',
@@ -67,6 +68,13 @@ const pipelineStepSchema = z.object({
   - action "close_pull_request": { action: "close_pull_request", owner: "expression", repo: "expression", issueNumber: "expression" }. Closes a PR. Output: { number, state, html_url }.
   - action "merge_pull_request": { action: "merge_pull_request", owner: "expression", repo: "expression", issueNumber: "expression", mergeMethod?: "expression" (default "merge") }. Merges a PR. Output: { sha, merged, message }.
   - action "list_pull_requests": { action: "list_pull_requests", owner: "expression", repo: "expression", state?: "expression" (default "open") }. Lists PRs. Output: [{ number, title, state, html_url, head_ref, body }].
+- google_calendar: Read free/busy and read/write events on Google Calendar via the project's Google Calendar integration (per-project clientId/clientSecret stored encrypted in IntegrationsService). Supports multiple actions via the "action" field. Token refresh + 401 retry are handled internally; pass calendar IDs and event IDs as expressions where useful. Set optional?: true to soft-fail (NOT_CONFIGURED / AUTH_FAILED / NOT_FOUND become success-with-warning, output: { skipped: true, reason }) so the integration can be a layered enhancement on top of DB-only flows. Transient failures (5xx, 429) still error regardless of optional. All string-typed inputs run through the expression evaluator.
+  - action "list_calendars": { action: "list_calendars" }. Lists sub-calendars on the connected account. Output: { calendars: [{ id, summary, primary, timeZone }] }.
+  - action "freebusy": { action: "freebusy", calendarIds: ["expression" | string[]], timeMin: "expression (ISO 8601)", timeMax: "expression (ISO 8601)", timezone?: "IANA tz" }. Output: { calendars: { [calId]: { busy: [{ start, end }] } }, timeMin, timeMax }.
+  - action "list_events": { action: "list_events", calendarId: "expression", timeMin?: "expression", timeMax?: "expression", maxResults?: number, singleEvents?: boolean, orderBy?: "startTime"|"updated" }. Output: { events: [{ id, summary, start, end, ... }], nextPageToken }.
+  - action "create_event": { action: "create_event", calendarId: "expression", summary: "template", description?: "template", location?: "template", startTime: "expression (ISO 8601)", endTime: "expression (ISO 8601)", attendees?: [{ email: "expression" }], timezone?: "IANA tz", sendUpdates?: "all"|"externalOnly"|"none" }. Output: { event: { id, summary, start, end, htmlLink, ... } }.
+  - action "update_event": { action: "update_event", calendarId: "expression", eventId: "expression", summary?: "template", description?: "template", location?: "template", startTime?: "expression", endTime?: "expression", sendUpdates?: "all"|"externalOnly"|"none" }. Output: { event: { ... } }.
+  - action "delete_event": { action: "delete_event", calendarId: "expression", eventId: "expression", sendUpdates?: "all"|"externalOnly"|"none" }. Treats 204/404/410 as success. Output: { eventId, calendarId, deleted: true }.
 
 All configs support: condition?: "expression" (skip step if falsy), timeout?: number (ms).
 Expressions reference prior steps by step NAME (not id): "steps.stepName.field" or request data: "request.body.field". Use bracket notation for names with spaces: "steps['Step Name'].field". Use simple names without spaces to keep expressions clean.`,

--- a/apps/backend/src/pipelines/handlers/google-calendar.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/google-calendar.handler.spec.ts
@@ -454,4 +454,98 @@ describe('GoogleCalendarHandler', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
+
+  // ===== Soft-fail (optional: true) =====
+
+  describe('optional flag', () => {
+    it('NOT_CONFIGURED → success with skipped=not_configured + warning', async () => {
+      oauthService.getValidAccessToken.mockResolvedValueOnce(null);
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({ action: 'create_event', optional: true, calendarId: 'primary' }),
+      );
+
+      expect(result.success).toBe(true);
+      expect((result.output as any).skipped).toBe(true);
+      expect((result.output as any).reason).toBe('not_configured');
+      expect(result.warning).toBeDefined();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('AUTH_FAILED (401 + refresh fail) → success with skipped=auth_failed', async () => {
+      mockFetch.mockResolvedValueOnce(makeFetchResponse({ status: 401, body: {} }));
+      oauthService.getValidAccessToken
+        .mockResolvedValueOnce('stale-tok')
+        .mockResolvedValueOnce(null);
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({ action: 'list_calendars', optional: true }),
+      );
+
+      expect(result.success).toBe(true);
+      expect((result.output as any).skipped).toBe(true);
+      expect((result.output as any).reason).toBe('auth_failed');
+    });
+
+    it('NOT_FOUND on a non-delete action → success with skipped=not_found', async () => {
+      mockFetch.mockResolvedValue(
+        makeFetchResponse({ status: 404, body: { error: { message: 'Calendar not found' } } }),
+      );
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({
+          action: 'list_events',
+          calendarId: 'gone@x',
+          optional: true,
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect((result.output as any).skipped).toBe(true);
+      expect((result.output as any).reason).toBe('not_found');
+    });
+
+    it('RATE_LIMITED (429) is NOT soft-failed even with optional: true', async () => {
+      mockFetch.mockResolvedValue(
+        makeFetchResponse({ status: 429, body: { error: { message: 'rate' } } }),
+      );
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({ action: 'list_calendars', optional: true }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('GOOGLE_CALENDAR_RATE_LIMITED');
+    });
+
+    it('5xx (API_ERROR) is NOT soft-failed even with optional: true', async () => {
+      mockFetch.mockResolvedValue(
+        makeFetchResponse({ status: 500, body: { error: { message: 'internal' } } }),
+      );
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({ action: 'list_calendars', optional: true }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('GOOGLE_CALENDAR_API_ERROR');
+    });
+
+    it('default (optional: false) keeps the existing error behavior', async () => {
+      oauthService.getValidAccessToken.mockResolvedValueOnce(null);
+
+      const result = await handler.execute(
+        makeContext(),
+        makeStep({ action: 'create_event', calendarId: 'primary' }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('GOOGLE_CALENDAR_NOT_CONFIGURED');
+    });
+  });
 });

--- a/apps/backend/src/pipelines/handlers/google-calendar.handler.ts
+++ b/apps/backend/src/pipelines/handlers/google-calendar.handler.ts
@@ -58,6 +58,38 @@ export interface GoogleCalendarHandlerConfig extends BaseHandlerConfig {
   attendees?: Array<{ email: string }>;
   /** Whether Google sends notifications. Defaults to 'none' for safety. */
   sendUpdates?: 'all' | 'externalOnly' | 'none';
+
+  /**
+   * When true, downstream "Google not available" failures (NOT_CONFIGURED /
+   * AUTH_FAILED / NOT_FOUND) return success with `output: { skipped: true,
+   * reason }` instead of erroring out. Lets pipelines treat the integration
+   * as a soft, layered enhancement on top of a DB-as-truth booking flow
+   * (see scheduling design decisions §12). Transient failures (rate limits,
+   * 5xx, network errors) still bubble up — they're recoverable, the others
+   * aren't.
+   * @default false
+   */
+  optional?: boolean;
+}
+
+/** Soft-failable error codes when `optional: true`. */
+const SOFT_FAIL_CODES = new Set<string>([
+  'GOOGLE_CALENDAR_NOT_CONFIGURED',
+  'GOOGLE_CALENDAR_AUTH_FAILED',
+  'GOOGLE_CALENDAR_NOT_FOUND',
+]);
+
+function softFailReason(code: string): 'not_configured' | 'auth_failed' | 'not_found' {
+  switch (code) {
+    case 'GOOGLE_CALENDAR_NOT_CONFIGURED':
+      return 'not_configured';
+    case 'GOOGLE_CALENDAR_AUTH_FAILED':
+      return 'auth_failed';
+    case 'GOOGLE_CALENDAR_NOT_FOUND':
+      return 'not_found';
+    default:
+      return 'not_configured'; // unreachable — guarded by SOFT_FAIL_CODES
+  }
 }
 
 const ERROR_CODES = {
@@ -166,7 +198,20 @@ export class GoogleCalendarHandler implements StepHandler<GoogleCalendarHandlerC
 
   async execute(context: PipelineContext, step: PipelineStep): Promise<StepResult> {
     const config = step.config as GoogleCalendarHandlerConfig;
+    const result = await this.executeInner(context, step, config);
+    return this.maybeSoftFail(result, config);
+  }
 
+  /**
+   * Pre-soft-fail dispatch — same shape as the original execute. The wrapper
+   * above filters the result through the soft-fail policy when `optional`
+   * is set.
+   */
+  private async executeInner(
+    context: PipelineContext,
+    step: PipelineStep,
+    config: GoogleCalendarHandlerConfig,
+  ): Promise<StepResult> {
     const token = await this.googleCalendarOAuthService.getValidAccessToken(context.projectId);
     if (!token) {
       return {
@@ -216,6 +261,28 @@ export class GoogleCalendarHandler implements StepHandler<GoogleCalendarHandlerC
         },
       };
     }
+  }
+
+  /**
+   * If `config.optional === true` and the result is a soft-failable error,
+   * convert to success-with-warning. Hard errors (5xx, rate-limit, network)
+   * pass through unchanged because they're transient — pipelines should
+   * surface them, not pretend nothing happened.
+   */
+  private maybeSoftFail(
+    result: StepResult,
+    config: GoogleCalendarHandlerConfig,
+  ): StepResult {
+    if (result.success) return result;
+    if (!config.optional) return result;
+    const code = result.error?.code;
+    if (!code || !SOFT_FAIL_CODES.has(code)) return result;
+    const reason = softFailReason(code);
+    return {
+      success: true,
+      output: { skipped: true, reason },
+      warning: result.error?.message ?? `Google Calendar step skipped: ${reason}`,
+    };
   }
 
   // ===== Actions =====


### PR DESCRIPTION
## Summary

Phase B amendment for Phase C-2's soft-dependency design (see
[story 0044 design decisions §12](../tree/main/../stories/backlog/0044-generic-scheduling/reference/design-decisions.md)).

When `config.optional === true` on a `google_calendar` step, three
"Google not available" failure modes return success-with-warning
(`output: { skipped, reason }`) instead of erroring out:

| Failure | reason |
| --- | --- |
| `GOOGLE_CALENDAR_NOT_CONFIGURED` | `not_configured` |
| `GOOGLE_CALENDAR_AUTH_FAILED` | `auth_failed` |
| `GOOGLE_CALENDAR_NOT_FOUND` | `not_found` |

Transient failures stay errors regardless of the flag — rate limits and
5xx are recoverable, the pipeline should surface them not pretend
nothing happened.

Default is `false`; existing pipelines and the AI-chat path keep their
current behavior. Implementation is a small wrapper around `execute()`
that filters the result through the soft-fail policy when `optional`
is set — the action methods themselves are unchanged.

Lets the upcoming scheduling pipelines (Phase C-2) compose the handler
as a soft, layered enhancement: bookings work end-to-end against
DB-only when the project hasn't connected Google, when a resource has
no `google_calendar_id` mapped, or when auth has expired and refresh
failed.

## Test plan

- [x] 6 new tests covering each soft-fail code → success+skipped+reason,
      each transient code still errors with `optional: true`, default
      behavior preserved
- [x] Full handler suite: 26 tests green (was 20)
- [x] `tsc --noEmit` clean
- [ ] Manual: deploy and use from a scheduling pipeline (Phase C-2 in
      progress — already validated public read pipelines in the live
      demo without the calendar step; calendar augmentation will land
      once MCP tool enum catches up)

## Phase C-2 progress (out of scope for this PR but for context)

- [x] Handler `optional` flag (this PR)
- [x] 7 `scheduling_*` schemas provisioned to the salon-luxe demo
- [x] Public read pipelines (services, resources, availability) live —
      DB-only path validated
- [ ] Booking pipelines (POST /bookings, /bookings/manage)
- [ ] Admin CRUD pipelines (6 schemas)
- [ ] `google_calendar` step injection once MCP enum catches up

🤖 Generated with [Claude Code](https://claude.com/claude-code)