### PR TITLE
fix(frontend): teach pipeline editor about google_calendar handler

### DIFF
--- a/apps/frontend/src/components/pipelines/PipelineConfig.tsx
+++ b/apps/frontend/src/components/pipelines/PipelineConfig.tsx
@@ -64,7 +64,7 @@ const HANDLER_GROUPS: { label: string; types: HandlerType[] }[] = [
   { label: 'Files', types: ['file_upload_handler', 'file_serve_handler', 'image_convert_handler', 'signed_url'] },
   { label: 'AI & ML', types: ['ai_handler', 'replicate', 'embed_store', 'vector_search'] },
   { label: 'Payments', types: ['stripe_checkout', 'stripe_webhook'] },
-  { label: 'Integrations', types: ['github_api'] },
+  { label: 'Integrations', types: ['github_api', 'google_calendar'] },
   { label: 'Other', types: ['email_handler', 'function_handler', 'http_request'] },
 ];
 

--- a/apps/frontend/src/components/pipelines/handlers/GoogleCalendarConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/GoogleCalendarConfig.tsx
@@ -1,0 +1,316 @@
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
+import { ExpressionInput } from './ExpressionInput';
+import type { PreviousStep } from './AvailableVariables';
+
+interface GoogleCalendarConfigProps {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+  previousSteps: PreviousStep[];
+}
+
+export function GoogleCalendarConfig({ config, onChange, previousSteps }: GoogleCalendarConfigProps) {
+  const action = (config.action as string) || 'freebusy';
+
+  const calendarIdsValue = Array.isArray(config.calendarIds)
+    ? (config.calendarIds as string[]).join(', ')
+    : (config.calendarIds as string) || '';
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label>Action</Label>
+        <Select
+          value={action}
+          onValueChange={(value) => onChange({ ...config, action: value })}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="list_calendars">List Calendars</SelectItem>
+            <SelectItem value="freebusy">Free/Busy</SelectItem>
+            <SelectItem value="list_events">List Events</SelectItem>
+            <SelectItem value="create_event">Create Event</SelectItem>
+            <SelectItem value="update_event">Update Event</SelectItem>
+            <SelectItem value="delete_event">Delete Event</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          Requires the Google Calendar integration to be configured in Project Settings → Integrations.
+        </p>
+      </div>
+
+      {action === 'freebusy' && (
+        <>
+          <div className="space-y-2">
+            <Label>Calendar IDs *</Label>
+            <ExpressionInput
+              value={calendarIdsValue}
+              onChange={(value) =>
+                onChange({
+                  ...config,
+                  calendarIds: value.split(',').map((s: string) => s.trim()).filter(Boolean),
+                })
+              }
+              placeholder="primary, steps.resource.google_calendar_id"
+              previousSteps={previousSteps}
+            />
+            <p className="text-xs text-muted-foreground">
+              Comma-separated calendar IDs (or single expression that resolves to one).
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label>Time Min *</Label>
+            <ExpressionInput
+              value={(config.timeMin as string) || ''}
+              onChange={(value) => onChange({ ...config, timeMin: value })}
+              placeholder="request.query.from"
+              previousSteps={previousSteps}
+            />
+            <p className="text-xs text-muted-foreground">ISO 8601 start of window.</p>
+          </div>
+          <div className="space-y-2">
+            <Label>Time Max *</Label>
+            <ExpressionInput
+              value={(config.timeMax as string) || ''}
+              onChange={(value) => onChange({ ...config, timeMax: value })}
+              placeholder="request.query.to"
+              previousSteps={previousSteps}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Timezone</Label>
+            <Input
+              value={(config.timezone as string) || ''}
+              onChange={(e) => onChange({ ...config, timezone: e.target.value })}
+              placeholder="America/New_York"
+            />
+            <p className="text-xs text-muted-foreground">IANA timezone (optional).</p>
+          </div>
+        </>
+      )}
+
+      {action === 'list_events' && (
+        <>
+          <div className="space-y-2">
+            <Label>Calendar ID *</Label>
+            <ExpressionInput
+              value={(config.calendarId as string) || ''}
+              onChange={(value) => onChange({ ...config, calendarId: value })}
+              placeholder="primary"
+              previousSteps={previousSteps}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Time Min</Label>
+            <ExpressionInput
+              value={(config.timeMin as string) || ''}
+              onChange={(value) => onChange({ ...config, timeMin: value })}
+              placeholder="request.query.from"
+              previousSteps={previousSteps}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Time Max</Label>
+            <ExpressionInput
+              value={(config.timeMax as string) || ''}
+              onChange={(value) => onChange({ ...config, timeMax: value })}
+              placeholder="request.query.to"
+              previousSteps={previousSteps}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Max Results</Label>
+            <Input
+              type="number"
+              value={(config.maxResults as number) || ''}
+              onChange={(e) =>
+                onChange({ ...config, maxResults: e.target.value ? Number(e.target.value) : undefined })
+              }
+              placeholder="250"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch
+              checked={config.singleEvents !== false}
+              onCheckedChange={(checked) => onChange({ ...config, singleEvents: checked })}
+            />
+            <Label>Expand recurring events into instances</Label>
+          </div>
+          <div className="space-y-2">
+            <Label>Order By</Label>
+            <Select
+              value={(config.orderBy as string) || 'startTime'}
+              onValueChange={(value) => onChange({ ...config, orderBy: value })}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="startTime">startTime</SelectItem>
+                <SelectItem value="updated">updated</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </>
+      )}
+
+      {(action === 'create_event' || action === 'update_event') && (
+        <>
+          <div className="space-y-2">
+            <Label>Calendar ID *</Label>
+            <ExpressionInput
+              value={(config.calendarId as string) || ''}
+              onChange={(value) => onChange({ ...config, calendarId: value })}
+              placeholder="steps.resource.google_calendar_id"
+              previousSteps={previousSteps}
+            />
+          </div>
+
+          {action === 'update_event' && (
+            <div className="space-y-2">
+              <Label>Event ID *</Label>
+              <ExpressionInput
+                value={(config.eventId as string) || ''}
+                onChange={(value) => onChange({ ...config, eventId: value })}
+                placeholder="steps.lookup.0.google_event_id"
+                previousSteps={previousSteps}
+              />
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label>{action === 'create_event' ? 'Summary *' : 'Summary'}</Label>
+            <ExpressionInput
+              value={(config.summary as string) || ''}
+              onChange={(value) => onChange({ ...config, summary: value })}
+              placeholder="{{steps.service.name}} — {{steps.parse.customer_name}}"
+              previousSteps={previousSteps}
+            />
+            <p className="text-xs text-muted-foreground">
+              Handlebars template (use {`{{...}}`} for interpolation).
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Description</Label>
+            <ExpressionInput
+              value={(config.description as string) || ''}
+              onChange={(value) => onChange({ ...config, description: value })}
+              placeholder="Notes: {{steps.parse.notes}}"
+              previousSteps={previousSteps}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Location</Label>
+            <ExpressionInput
+              value={(config.location as string) || ''}
+              onChange={(value) => onChange({ ...config, location: value })}
+              placeholder="123 Linden Ave, Asheville NC"
+              previousSteps={previousSteps}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>{action === 'create_event' ? 'Start Time *' : 'Start Time'}</Label>
+            <ExpressionInput
+              value={(config.startTime as string) || ''}
+              onChange={(value) => onChange({ ...config, startTime: value })}
+              placeholder="steps.parse.starts_at"
+              previousSteps={previousSteps}
+            />
+            <p className="text-xs text-muted-foreground">ISO 8601 expression.</p>
+          </div>
+
+          <div className="space-y-2">
+            <Label>{action === 'create_event' ? 'End Time *' : 'End Time'}</Label>
+            <ExpressionInput
+              value={(config.endTime as string) || ''}
+              onChange={(value) => onChange({ ...config, endTime: value })}
+              placeholder="steps.parse.ends_at"
+              previousSteps={previousSteps}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Send Updates</Label>
+            <Select
+              value={(config.sendUpdates as string) || 'none'}
+              onValueChange={(value) => onChange({ ...config, sendUpdates: value })}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">none</SelectItem>
+                <SelectItem value="all">all</SelectItem>
+                <SelectItem value="externalOnly">externalOnly</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Whether Google notifies attendees by email.
+            </p>
+          </div>
+        </>
+      )}
+
+      {action === 'delete_event' && (
+        <>
+          <div className="space-y-2">
+            <Label>Calendar ID *</Label>
+            <ExpressionInput
+              value={(config.calendarId as string) || ''}
+              onChange={(value) => onChange({ ...config, calendarId: value })}
+              placeholder="steps.resource.google_calendar_id"
+              previousSteps={previousSteps}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Event ID *</Label>
+            <ExpressionInput
+              value={(config.eventId as string) || ''}
+              onChange={(value) => onChange({ ...config, eventId: value })}
+              placeholder="steps.lookup.0.google_event_id"
+              previousSteps={previousSteps}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Send Updates</Label>
+            <Select
+              value={(config.sendUpdates as string) || 'none'}
+              onValueChange={(value) => onChange({ ...config, sendUpdates: value })}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">none</SelectItem>
+                <SelectItem value="all">all</SelectItem>
+                <SelectItem value="externalOnly">externalOnly</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </>
+      )}
+
+      <div className="flex items-center gap-2 pt-2 border-t">
+        <Switch
+          checked={!!config.optional}
+          onCheckedChange={(checked) => onChange({ ...config, optional: checked })}
+        />
+        <div>
+          <Label>Optional (soft-fail)</Label>
+          <p className="text-xs text-muted-foreground">
+            When on, NOT_CONFIGURED / AUTH_FAILED / NOT_FOUND return success with{' '}
+            <code>{`{ skipped: true, reason }`}</code> instead of erroring. Transient errors
+            (rate-limit, 5xx) still surface.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/pipelines/handlers/HandlerConfigWrapper.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/HandlerConfigWrapper.tsx
@@ -21,6 +21,7 @@ import { StripeCheckoutConfig } from './StripeCheckoutConfig';
 import { StripeWebhookConfig } from './StripeWebhookConfig';
 import { SignedUrlHandlerConfig } from './SignedUrlHandlerConfig';
 import { GitHubApiConfig } from './GitHubApiConfig';
+import { GoogleCalendarConfig } from './GoogleCalendarConfig';
 import { AvailableVariables, type PreviousStep } from './AvailableVariables';
 import type { HandlerConfig } from './types';
 
@@ -322,6 +323,18 @@ export function HandlerConfigWrapper({
         </>
       );
 
+    case 'google_calendar':
+      return (
+        <>
+          {renderVariablesPanel()}
+          <GoogleCalendarConfig
+            config={config}
+            onChange={handleChange}
+            previousSteps={previousSteps}
+          />
+        </>
+      );
+
     default:
       return (
         <div className="text-sm text-destructive p-4 bg-destructive/10 rounded-md">
@@ -358,6 +371,7 @@ export function getHandlerDisplayName(type: HandlerType): string {
     stripe_webhook: 'Stripe Webhook',
     signed_url: 'Signed URL',
     github_api: 'GitHub API',
+    google_calendar: 'Google Calendar',
   };
   return names[type] || type;
 }
@@ -389,6 +403,7 @@ export function getHandlerDescription(type: HandlerType): string {
     stripe_webhook: 'Verify Stripe webhook signature and parse the event',
     signed_url: 'Generate a time-limited presigned URL for a file in storage',
     github_api: 'Create repositories from templates and call the GitHub API',
+    google_calendar: 'Read free/busy and read/write events on Google Calendar',
   };
   return descriptions[type] || '';
 }

--- a/apps/frontend/src/services/pipelinesApi.ts
+++ b/apps/frontend/src/services/pipelinesApi.ts
@@ -51,7 +51,8 @@ export type HandlerType =
   | 'stripe_checkout'
   | 'stripe_webhook'
   | 'signed_url'
-  | 'github_api';
+  | 'github_api'
+  | 'google_calendar';
 
 export interface Pipeline {
   id: string;


### PR DESCRIPTION
## Summary

Pipelines using the new `google_calendar` step handler rendered with a
red **"Unknown handler type: google_calendar"** error in the BFFless
console pipeline editor. The handler runs fine — both the runtime
registry (PR #251) and the MCP tool's Zod enum (PR #255) include it —
but the **frontend** was a third hardcoded place that needed updating.


## Changes

Four files updated:

- **`pipelinesApi.ts`** — adds `'google_calendar'` to the `HandlerType`
  union (so other components type-check it).
- **`HandlerConfigWrapper.tsx`** — switch case dispatches to a new
  `GoogleCalendarConfig` component; display name "Google Calendar";
  description.
- **`GoogleCalendarConfig.tsx`** *(new)* — mirrors `GitHubApiConfig`
  pattern: Action select (list_calendars / freebusy / list_events /
  create_event / update_event / delete_event) → per-action field set →
  trailing "Optional (soft-fail)" switch tied to `config.optional`.
- **`PipelineConfig.tsx`** — adds `google_calendar` to the
  "Integrations" group in the new-step dropdown.

## Why this wasn't part of PR #255

PR #255 caught the MCP enum gate but not the frontend dropdown — both
are silent until you actually try to render a pipeline that uses the
handler. Discovered while completing Phase C-2 of the scheduling
component: the salon-luxe demo's availability/booking pipelines had
`google_calendar` steps injected via MCP, and clicking "Edit" in the
console showed the red error.

Memory updated: `feedback_new_handler_two_places.md` should now read
"three places" — runtime registry, MCP enum, and frontend
HandlerType union + dispatcher + dropdown group.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Pipelines using `google_calendar` already running in production
      (salon-luxe demo) — runtime side proven
- [ ] After merge: open the salon-luxe `scheduling_availability` /
      `scheduling_booking_create` / `scheduling_booking_manage`
      pipelines in the console editor. The `google_calendar` steps
      should render the new config form (Action picker + per-action
      fields + Optional switch) instead of "Unknown handler type".

🤖 Generated with [Claude Code](https://claude.com/claude-code)