### PR TITLE
fix: include redirectType in domain response DTO and SSL renewal regen

### DIFF
--- a/apps/backend/src/domains/domains.controller.ts
+++ b/apps/backend/src/domains/domains.controller.ts
@@ -642,6 +642,7 @@ export class DomainsController {
       isSpa: domain.isSpa, // SPA mode for client-side routing
       wwwBehavior: domain.wwwBehavior, // WWW/apex redirect behavior
       redirectTarget: domain.redirectTarget, // Target for redirect domains
+      redirectType: domain.redirectType, // HTTP status code for redirect domains (301/302)
       sslEnabled: domain.sslEnabled,
       sslExpiresAt: domain.sslExpiresAt,
       dnsVerified: domain.dnsVerified,

--- a/apps/backend/src/domains/ssl-renewal.service.ts
+++ b/apps/backend/src/domains/ssl-renewal.service.ts
@@ -217,6 +217,7 @@ export class SslRenewalService {
                 id: domain.id,
                 domain: domain.domain,
                 redirectTarget: domain.redirectTarget!,
+                redirectType: domain.redirectType,
                 sslEnabled: domain.sslEnabled,
               });
             } else if (domain.projectId) {


### PR DESCRIPTION
## Summary

Follow-up to #283. The redirect-type field was being **persisted** correctly but stripped from every API response, so saving 302 in the Edit dialog appeared to have no effect — the dialog reopened showing 301 because RTK Query's cache held a response missing the field.

- `domains.controller.ts:toResponseDto` is a hand-written field-by-field mapper; #283 added `redirectType` to `DomainResponseDto` but not to this mapper.
- `ssl-renewal.service.ts:219` also calls `generateRedirectDomainConfig` and was missing `redirectType`, which would silently rewrite a 302 mapping back to 301 on every cert renewal.

## Test plan

- [x] `pnpm --filter backend exec tsc --noEmit` — clean
- [ ] Manual: set a redirect domain to 302 in the Edit dialog, save, reopen — should now stay 302; badge in list also reflects 302
- [ ] Manual: `curl -I https://<source>/` returns `HTTP/1.1 302 Found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)