### PR TITLE
fix: surface storage migration errors and add force-switch recovery path

### DIFF
--- a/apps/backend/src/storage/migration/migration.controller.ts
+++ b/apps/backend/src/storage/migration/migration.controller.ts
@@ -63,9 +63,15 @@ export class MigrationController {
     });
 
     // Test target connection
-    const connected = await targetAdapter.testConnection();
-    if (!connected) {
-      throw new BadRequestException('Cannot connect to target storage provider');
+    try {
+      const connected = await targetAdapter.testConnection();
+      if (!connected) {
+        throw new BadRequestException('Cannot connect to target storage provider');
+      }
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new BadRequestException(`Cannot connect to target storage provider: ${reason}`);
     }
 
     // Get current storage provider name
@@ -150,6 +156,41 @@ export class MigrationController {
     });
 
     await this.migrationService.resumeMigration(this.currentStorage, targetAdapter);
+    return { success: true };
+  }
+
+  @Post('force-switch')
+  @ApiOperation({
+    summary: 'Switch storage provider without migrating data (recovery path)',
+    description:
+      'For situations where the current storage backend is unreachable (e.g. deleted bucket, revoked credentials) and the user just needs to repoint to a new provider. Validates the target, persists config, and swaps the runtime adapter. Does NOT copy any files.',
+  })
+  @ApiResponse({ status: 200, description: 'Provider switched without data migration' })
+  async forceSwitchProvider(@Body() dto: CompleteMigrationDto): Promise<{ success: boolean }> {
+    const targetAdapter = StorageModule.createAdapter({
+      storageType: dto.provider,
+      config: dto.config,
+    });
+
+    try {
+      const connected = await targetAdapter.testConnection();
+      if (!connected) {
+        throw new BadRequestException('Cannot connect to target storage provider');
+      }
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new BadRequestException(`Cannot connect to target storage provider: ${reason}`);
+    }
+
+    await this.saveStorageConfig(dto.provider, dto.config);
+    this.dynamicStorage.setAdapter(targetAdapter);
+    this.migrationService.clearMigrationJob();
+
+    this.logger.warn(
+      `Storage provider FORCE-SWITCHED to ${dto.provider} (no data migration performed)`,
+    );
+
     return { success: true };
   }
 

--- a/apps/backend/src/storage/migration/migration.interface.ts
+++ b/apps/backend/src/storage/migration/migration.interface.ts
@@ -128,6 +128,10 @@ export interface MigrationScope {
   totalBytes: number;
   formattedSize: string;
   estimatedDuration: string;
+  // Set when the current (source) storage adapter could not be reached.
+  // The wizard uses this to offer a "switch without migrating data" recovery path
+  // instead of blocking the user with a 500.
+  sourceError?: string;
 }
 
 /**

--- a/apps/backend/src/storage/migration/migration.service.spec.ts
+++ b/apps/backend/src/storage/migration/migration.service.spec.ts
@@ -202,6 +202,19 @@ describe('StorageMigrationService', () => {
 
       expect(scope.estimatedDuration).toBe('1 minutes');
     });
+
+    it('should return sourceError instead of throwing when source is unreachable', async () => {
+      mockSource.listKeys.mockReset();
+      mockSource.listKeys.mockRejectedValueOnce(
+        new Error('bucket does not exist or is not accessible'),
+      );
+
+      const scope = await service.calculateScope(mockSource);
+
+      expect(scope.sourceError).toBe('bucket does not exist or is not accessible');
+      expect(scope.fileCount).toBe(0);
+      expect(scope.totalBytes).toBe(0);
+    });
   });
 
   describe('file migration', () => {

--- a/apps/backend/src/storage/migration/migration.service.ts
+++ b/apps/backend/src/storage/migration/migration.service.ts
@@ -329,9 +329,24 @@ export class StorageMigrationService {
    * Calculate migration scope without starting
    */
   async calculateScope(source: IStorageAdapter, filterPrefix?: string): Promise<MigrationScope> {
-    const keys = await source.listKeys(filterPrefix);
-    let totalBytes = 0;
+    let keys: string[];
+    try {
+      keys = await source.listKeys(filterPrefix);
+    } catch (err) {
+      // Source storage is unreachable (deleted bucket, revoked credentials,
+      // network outage, etc). Return a degraded scope so the wizard can render
+      // a recovery option instead of bubbling a 500.
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        fileCount: 0,
+        totalBytes: 0,
+        formattedSize: '0 B',
+        estimatedDuration: 'unknown',
+        sourceError: message,
+      };
+    }
 
+    let totalBytes = 0;
     for (const key of keys) {
       try {
         const metadata = await source.getMetadata(key);

--- a/apps/frontend/src/components/storage/MigrationWizard.tsx
+++ b/apps/frontend/src/components/storage/MigrationWizard.tsx
@@ -19,6 +19,7 @@ import {
   useLazyCalculateMigrationScopeQuery,
   useStartMigrationMutation,
   useCompleteMigrationMutation,
+  useForceSwitchProviderMutation,
   useGetMigrationJobQuery,
   type MigrationOptions,
 } from '@/services/migrationApi';
@@ -98,6 +99,7 @@ export function MigrationWizard({ currentProvider, onComplete, onCancel }: Migra
   const [calculateScope, { data: scope, isLoading: isCalculating }] = useLazyCalculateMigrationScopeQuery();
   const [startMigration, { isLoading: isStarting }] = useStartMigrationMutation();
   const [completeMigration, { isLoading: isCompleting }] = useCompleteMigrationMutation();
+  const [forceSwitchProvider, { isLoading: isForceSwitching }] = useForceSwitchProviderMutation();
   // Always check for active migration on mount and during progress step
   const { data: currentJob } = useGetMigrationJobQuery(undefined, {
     pollingInterval: step === 'progress' || step === 'select' ? 1000 : undefined,
@@ -246,6 +248,23 @@ export function MigrationWizard({ currentProvider, onComplete, onCancel }: Migra
 
   const handleMigrationComplete = () => {
     setStep('complete');
+  };
+
+  const handleForceSwitch = async () => {
+    if (!targetProvider) return;
+
+    try {
+      setError(null);
+      await forceSwitchProvider({
+        provider: targetProvider,
+        config: getConfig(),
+      }).unwrap();
+
+      onComplete?.();
+    } catch (err: unknown) {
+      const e = err as { data?: { message?: string } };
+      setError(e.data?.message || 'Failed to switch provider');
+    }
   };
 
   const handleFinish = async () => {
@@ -849,33 +868,57 @@ export function MigrationWizard({ currentProvider, onComplete, onCancel }: Migra
       {step === 'confirm' && scope && (
         <Card>
           <CardHeader>
-            <CardTitle>Confirm Migration</CardTitle>
-            <CardDescription>Review the migration details before starting</CardDescription>
+            <CardTitle>{scope.sourceError ? 'Source Storage Unreachable' : 'Confirm Migration'}</CardTitle>
+            <CardDescription>
+              {scope.sourceError
+                ? `BFFless could not list files from ${currentProvider}. You can still switch providers, but no data will be copied.`
+                : 'Review the migration details before starting'}
+            </CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
-            <Alert>
-              <AlertTriangle className="h-4 w-4" />
-              <AlertDescription>
-                Migration will copy all files from {currentProvider} to {targetProvider}. This process
-                may take a while for large datasets.
-              </AlertDescription>
-            </Alert>
+            {scope.sourceError ? (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>
+                  <p className="font-medium mb-1">
+                    Cannot read from {currentProvider}:
+                  </p>
+                  <p className="font-mono text-xs break-all">{scope.sourceError}</p>
+                  <p className="mt-3">
+                    This usually means the bucket was deleted, credentials were revoked,
+                    or the storage backend is unreachable. Use{' '}
+                    <strong>Switch Without Migrating</strong> below to repoint BFFless to
+                    {' '}{targetProvider} without copying data.
+                  </p>
+                </AlertDescription>
+              </Alert>
+            ) : (
+              <>
+                <Alert>
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertDescription>
+                    Migration will copy all files from {currentProvider} to {targetProvider}. This process
+                    may take a while for large datasets.
+                  </AlertDescription>
+                </Alert>
 
-            <div className="grid grid-cols-2 gap-4">
-              <div className="p-4 bg-muted rounded-lg">
-                <p className="text-sm text-muted-foreground">Files to migrate</p>
-                <p className="text-2xl font-bold">{scope.fileCount.toLocaleString()}</p>
-              </div>
-              <div className="p-4 bg-muted rounded-lg">
-                <p className="text-sm text-muted-foreground">Total size</p>
-                <p className="text-2xl font-bold">{scope.formattedSize}</p>
-              </div>
-            </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="p-4 bg-muted rounded-lg">
+                    <p className="text-sm text-muted-foreground">Files to migrate</p>
+                    <p className="text-2xl font-bold">{scope.fileCount.toLocaleString()}</p>
+                  </div>
+                  <div className="p-4 bg-muted rounded-lg">
+                    <p className="text-sm text-muted-foreground">Total size</p>
+                    <p className="text-2xl font-bold">{scope.formattedSize}</p>
+                  </div>
+                </div>
 
-            <div className="p-4 border rounded-lg">
-              <p className="text-sm text-muted-foreground">Estimated duration</p>
-              <p className="text-lg font-semibold">{scope.estimatedDuration}</p>
-            </div>
+                <div className="p-4 border rounded-lg">
+                  <p className="text-sm text-muted-foreground">Estimated duration</p>
+                  <p className="text-lg font-semibold">{scope.estimatedDuration}</p>
+                </div>
+              </>
+            )}
 
             {error && (
               <Alert variant="destructive">
@@ -894,16 +937,33 @@ export function MigrationWizard({ currentProvider, onComplete, onCancel }: Migra
                 <Button variant="outline" onClick={() => setStep('configure')}>
                   Back
                 </Button>
-                <Button onClick={handleStartMigration} disabled={isStarting}>
-                  {isStarting ? (
-                    <>
-                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                      Starting...
-                    </>
-                  ) : (
-                    'Start Migration'
-                  )}
-                </Button>
+                {scope.sourceError ? (
+                  <Button
+                    variant="destructive"
+                    onClick={handleForceSwitch}
+                    disabled={isForceSwitching}
+                  >
+                    {isForceSwitching ? (
+                      <>
+                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        Switching...
+                      </>
+                    ) : (
+                      'Switch Without Migrating'
+                    )}
+                  </Button>
+                ) : (
+                  <Button onClick={handleStartMigration} disabled={isStarting}>
+                    {isStarting ? (
+                      <>
+                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        Starting...
+                      </>
+                    ) : (
+                      'Start Migration'
+                    )}
+                  </Button>
+                )}
               </div>
             </div>
           </CardContent>

--- a/apps/frontend/src/services/migrationApi.ts
+++ b/apps/frontend/src/services/migrationApi.ts
@@ -41,6 +41,9 @@ export interface MigrationScope {
   totalBytes: number;
   formattedSize: string;
   estimatedDuration: string;
+  // Set when the current (source) storage adapter could not be reached.
+  // Wizard uses this to offer a "switch without migrating data" recovery option.
+  sourceError?: string;
 }
 
 // Migration options
@@ -142,6 +145,17 @@ export const migrationApi = api.injectEndpoints({
       }),
       invalidatesTags: ['Setup'],
     }),
+
+    // Switch storage provider without copying data (recovery path for
+    // when the current source is unreachable, e.g. deleted bucket).
+    forceSwitchProvider: builder.mutation<{ success: boolean }, CompleteMigrationRequest>({
+      query: (body) => ({
+        url: '/api/storage/migration/force-switch',
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: ['Setup'],
+    }),
   }),
 });
 
@@ -154,4 +168,5 @@ export const {
   useCancelMigrationMutation,
   useResumeMigrationMutation,
   useCompleteMigrationMutation,
+  useForceSwitchProviderMutation,
 } = migrationApi;


### PR DESCRIPTION
## Summary

When the configured storage backend becomes unreachable (deleted bucket, revoked credentials, network outage), the Storage Migration wizard previously 500'd on its initial scope call and locked the admin out of switching providers. Provider connection errors during migration start were also returned as opaque \"Internal server error\" 500s because the `GlobalExceptionFilter` strips raw `Error` messages in production.

This PR makes the wizard resilient and adds a documented recovery path.

- **`migration.service.calculateScope`**: catches `listKeys` failures from the source adapter and returns a degraded scope with a new `sourceError` field instead of throwing. `GET /api/storage/migration/scope` no longer 500s.
- **`migration.controller.startMigration`**: wraps the target `testConnection()` call so provider errors surface as `400 BadRequestException` with the real cause (e.g. `does not have storage.buckets.get access`) instead of getting stripped to `Internal server error`.
- **New `POST /api/storage/migration/force-switch`** endpoint — validates the target, persists the new provider config, and swaps the runtime adapter without copying any data. This is the recovery path when the source is dead and the user just needs to repoint BFFless.
- **Frontend wizard** detects `scope.sourceError` on the confirm step, renders a destructive alert with the actual error message, and replaces \"Start Migration\" with a clearly-labeled **\"Switch Without Migrating\"** button wired to the new endpoint.

## Why this matters

Came out of real destructive testing: user migrated to GCS, deleted the GCS bucket, then could not return to local storage because every screen depended on the dead adapter. The migration UI is supposed to be the recovery surface — it has to keep working even when the configured backend doesn't.

## Test plan

- [x] `pnpm test -- migration.service.spec` — 26/26 pass, including a new regression test asserting `sourceError` is set when `listKeys` throws
- [x] Backend `tsc --noEmit` — clean
- [x] Frontend `tsc --noEmit` — clean
- [ ] Manual: GCS-configured workspace, delete bucket in GCP console, hit Storage Migration → confirm wizard loads with destructive alert + Switch Without Migrating button
- [ ] Manual: provide bad GCS credentials to a fresh migration → confirm the real GCS error message appears in the UI (not \"Internal server error\")
- [ ] Manual: happy-path migration (local → S3) still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)