### PR TITLE
feat(deployments): accept multiple proxy rule sets on deploy

### DIFF
--- a/apps/backend/src/deployments/deployments.controller.ts
+++ b/apps/backend/src/deployments/deployments.controller.ts
@@ -320,6 +320,14 @@ export class DeploymentsController {
       });
     }
 
+    // Resolve proxy rule sets: prefer values from the finalize body (authoritative),
+    // fall back to the singular value persisted in pending_uploads on prepare.
+    const finalizeProxyOverride =
+      (dto.proxyRuleSetIds && dto.proxyRuleSetIds.length > 0) ||
+      (dto.proxyRuleSetNames && dto.proxyRuleSetNames.length > 0) ||
+      dto.proxyRuleSetId ||
+      dto.proxyRuleSetName;
+
     // Create asset records from manifest
     const result = await this.deploymentsService.createAssetsFromManifest(
       {
@@ -332,7 +340,12 @@ export class DeploymentsController {
           typeof pendingUpload.tags === 'string'
             ? pendingUpload.tags
             : JSON.stringify(pendingUpload.tags),
-        proxyRuleSetId: pendingUpload.proxyRuleSetId ?? undefined,
+        proxyRuleSetId: finalizeProxyOverride
+          ? dto.proxyRuleSetId
+          : (pendingUpload.proxyRuleSetId ?? undefined),
+        proxyRuleSetName: finalizeProxyOverride ? dto.proxyRuleSetName : undefined,
+        proxyRuleSetIds: finalizeProxyOverride ? dto.proxyRuleSetIds : undefined,
+        proxyRuleSetNames: finalizeProxyOverride ? dto.proxyRuleSetNames : undefined,
         alias: pendingUpload.alias ?? undefined,
         basePath: pendingUpload.basePath ?? undefined,
         files: pendingUpload.files,

--- a/apps/backend/src/deployments/deployments.dto.ts
+++ b/apps/backend/src/deployments/deployments.dto.ts
@@ -107,7 +107,7 @@ export class CreateDeploymentDto {
   basePath?: string;
 
   @ApiPropertyOptional({
-    description: 'Proxy rule set name to apply to auto-preview aliases. Takes precedence over proxyRuleSetId. If neither specified, uses project default.',
+    description: 'Proxy rule set name to apply to auto-preview aliases. Legacy — prefer proxyRuleSetNames.',
     example: 'api-backend',
   })
   @IsOptional()
@@ -115,12 +115,32 @@ export class CreateDeploymentDto {
   proxyRuleSetName?: string;
 
   @ApiPropertyOptional({
-    description: 'Proxy rule set ID to apply to auto-preview aliases. Use proxyRuleSetName for a more human-friendly option.',
+    description: 'Proxy rule set ID to apply to auto-preview aliases. Legacy — prefer proxyRuleSetIds.',
     example: '550e8400-e29b-41d4-a716-446655440000',
   })
   @IsOptional()
   @IsUUID()
   proxyRuleSetId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Ordered list of proxy rule set names to attach to auto-preview aliases. Appended idempotently to any rule sets already on the alias. Overrides proxyRuleSetName when provided.',
+    example: ['stripe-webhook', 'ai-proxy'],
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  proxyRuleSetNames?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Ordered list of proxy rule set IDs to attach to auto-preview aliases. Appended idempotently to any rule sets already on the alias. Overrides proxyRuleSetId when provided.',
+    example: ['550e8400-e29b-41d4-a716-446655440000'],
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  proxyRuleSetIds?: string[];
 }
 
 export class CreateDeploymentZipDto {
@@ -213,7 +233,7 @@ export class CreateDeploymentZipDto {
   basePath?: string;
 
   @ApiPropertyOptional({
-    description: 'Proxy rule set name to apply to auto-preview aliases. Takes precedence over proxyRuleSetId. If neither specified, uses project default.',
+    description: 'Proxy rule set name to apply to auto-preview aliases. Legacy — prefer proxyRuleSetNames.',
     example: 'api-backend',
   })
   @IsOptional()
@@ -221,12 +241,32 @@ export class CreateDeploymentZipDto {
   proxyRuleSetName?: string;
 
   @ApiPropertyOptional({
-    description: 'Proxy rule set ID to apply to auto-preview aliases. Use proxyRuleSetName for a more human-friendly option.',
+    description: 'Proxy rule set ID to apply to auto-preview aliases. Legacy — prefer proxyRuleSetIds.',
     example: '550e8400-e29b-41d4-a716-446655440000',
   })
   @IsOptional()
   @IsUUID()
   proxyRuleSetId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Ordered list of proxy rule set names to attach to auto-preview aliases. Appended idempotently to any rule sets already on the alias. Overrides proxyRuleSetName when provided.',
+    example: ['stripe-webhook', 'ai-proxy'],
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  proxyRuleSetNames?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Ordered list of proxy rule set IDs to attach to auto-preview aliases. Appended idempotently to any rule sets already on the alias. Overrides proxyRuleSetId when provided.',
+    example: ['550e8400-e29b-41d4-a716-446655440000'],
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  proxyRuleSetIds?: string[];
 
   @ApiPropertyOptional({
     description: 'Origin of the deployment. Defaults to "github" for upload-artifact GitHub Action; the admin UI sends "manual".',
@@ -736,7 +776,7 @@ export class PrepareBatchUploadDto {
   tags?: string;
 
   @ApiPropertyOptional({
-    description: 'Proxy rule set name to apply to auto-preview aliases',
+    description: 'Proxy rule set name to apply to auto-preview aliases. Legacy — prefer proxyRuleSetNames.',
     example: 'api-backend',
   })
   @IsOptional()
@@ -744,12 +784,32 @@ export class PrepareBatchUploadDto {
   proxyRuleSetName?: string;
 
   @ApiPropertyOptional({
-    description: 'Proxy rule set ID to apply to auto-preview aliases',
+    description: 'Proxy rule set ID to apply to auto-preview aliases. Legacy — prefer proxyRuleSetIds.',
     example: '550e8400-e29b-41d4-a716-446655440000',
   })
   @IsOptional()
   @IsUUID()
   proxyRuleSetId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Ordered list of proxy rule set names. Echoed on finalize-upload — the values used there are authoritative.',
+    example: ['stripe-webhook', 'ai-proxy'],
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  proxyRuleSetNames?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Ordered list of proxy rule set IDs. Echoed on finalize-upload — the values used there are authoritative.',
+    example: ['550e8400-e29b-41d4-a716-446655440000'],
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  proxyRuleSetIds?: string[];
 
   @ApiProperty({
     description: 'Array of files to upload',
@@ -816,6 +876,42 @@ export class FinalizeUploadDto {
   @ApiProperty({ description: 'Upload token from prepare-batch-upload response' })
   @IsString()
   uploadToken: string;
+
+  @ApiPropertyOptional({
+    description: 'Proxy rule set name to apply to auto-preview aliases. Legacy — prefer proxyRuleSetNames.',
+    example: 'api-backend',
+  })
+  @IsOptional()
+  @IsString()
+  proxyRuleSetName?: string;
+
+  @ApiPropertyOptional({
+    description: 'Proxy rule set ID to apply to auto-preview aliases. Legacy — prefer proxyRuleSetIds.',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsOptional()
+  @IsUUID()
+  proxyRuleSetId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Ordered list of proxy rule set names to attach to auto-preview aliases. Appended idempotently. Overrides any value carried over from prepare-batch-upload.',
+    example: ['stripe-webhook', 'ai-proxy'],
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  proxyRuleSetNames?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Ordered list of proxy rule set IDs to attach to auto-preview aliases. Appended idempotently. Overrides any value carried over from prepare-batch-upload.',
+    example: ['550e8400-e29b-41d4-a716-446655440000'],
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  proxyRuleSetIds?: string[];
 }
 
 /**

--- a/apps/backend/src/deployments/deployments.service.spec.ts
+++ b/apps/backend/src/deployments/deployments.service.spec.ts
@@ -388,6 +388,74 @@ describe('DeploymentsService', () => {
     });
   });
 
+  describe('resolveProxyRuleSetIds (plural resolver)', () => {
+    // Private method — invoked via cast for direct unit coverage
+    const callResolve = (input: Record<string, unknown>) =>
+      (service as unknown as {
+        resolveProxyRuleSetIds: (projectId: string, input: unknown) => Promise<string[]>;
+      }).resolveProxyRuleSetIds(mockProjectId, input);
+
+    it('returns empty array when nothing provided', async () => {
+      const result = await callResolve({});
+      expect(result).toEqual([]);
+    });
+
+    it('returns plural ids unchanged when only proxyRuleSetIds provided', async () => {
+      const ids = ['id-a', 'id-b', 'id-c'];
+      const result = await callResolve({ proxyRuleSetIds: ids });
+      expect(result).toEqual(ids);
+    });
+
+    it('resolves plural names + ids, names first in caller order', async () => {
+      setupMockChain([
+        [
+          { id: 'id-stripe', name: 'stripe-webhook' },
+          { id: 'id-ai', name: 'ai-proxy' },
+        ],
+      ]);
+      const result = await callResolve({
+        proxyRuleSetNames: ['stripe-webhook', 'ai-proxy'],
+        proxyRuleSetIds: ['id-extra'],
+      });
+      expect(result).toEqual(['id-stripe', 'id-ai', 'id-extra']);
+    });
+
+    it('falls back to singular proxyRuleSetId when no plural provided', async () => {
+      const result = await callResolve({ proxyRuleSetId: 'id-legacy' });
+      expect(result).toEqual(['id-legacy']);
+    });
+
+    it('falls back to singular proxyRuleSetName when no plural provided', async () => {
+      setupMockChain([[{ id: 'id-from-name', name: 'legacy-set' }]]);
+      const result = await callResolve({ proxyRuleSetName: 'legacy-set' });
+      expect(result).toEqual(['id-from-name']);
+    });
+
+    it('ignores singular when plural is provided', async () => {
+      const result = await callResolve({
+        proxyRuleSetIds: ['id-plural'],
+        proxyRuleSetId: 'id-singular-ignored',
+      });
+      expect(result).toEqual(['id-plural']);
+    });
+
+    it('dedupes preserving first occurrence', async () => {
+      setupMockChain([[{ id: 'id-shared', name: 'shared-set' }]]);
+      const result = await callResolve({
+        proxyRuleSetNames: ['shared-set'],
+        proxyRuleSetIds: ['id-shared', 'id-unique'],
+      });
+      expect(result).toEqual(['id-shared', 'id-unique']);
+    });
+
+    it('throws BadRequestException when a plural name does not resolve', async () => {
+      setupMockChain([[{ id: 'id-known', name: 'known-set' }]]);
+      await expect(
+        callResolve({ proxyRuleSetNames: ['known-set', 'unknown-set'] }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
   describe('resolveAlias', () => {
     it('should resolve alias to commit SHA', async () => {
       setupMockChain([[mockAlias]]);

--- a/apps/backend/src/deployments/deployments.service.ts
+++ b/apps/backend/src/deployments/deployments.service.ts
@@ -115,6 +115,71 @@ export class DeploymentsService {
   }
 
   /**
+   * Resolve proxy rule set names + IDs to an ordered, deduped array of IDs.
+   * Plural inputs win over singular; singular only applies as a back-compat
+   * fallback when neither plural array is provided.
+   * Returns [] when nothing is requested.
+   */
+  private async resolveProxyRuleSetIds(
+    projectId: string,
+    input: {
+      proxyRuleSetNames?: string[];
+      proxyRuleSetIds?: string[];
+      proxyRuleSetName?: string;
+      proxyRuleSetId?: string;
+    },
+  ): Promise<string[]> {
+    const usePlural =
+      (input.proxyRuleSetNames && input.proxyRuleSetNames.length > 0) ||
+      (input.proxyRuleSetIds && input.proxyRuleSetIds.length > 0);
+
+    const namesToResolve = usePlural
+      ? (input.proxyRuleSetNames ?? [])
+      : input.proxyRuleSetName
+        ? [input.proxyRuleSetName]
+        : [];
+
+    const directIds = usePlural
+      ? (input.proxyRuleSetIds ?? [])
+      : input.proxyRuleSetId
+        ? [input.proxyRuleSetId]
+        : [];
+
+    // Resolve names to IDs in a single query
+    const resolvedNameIds: string[] = [];
+    if (namesToResolve.length > 0) {
+      const rows = await db
+        .select({ id: proxyRuleSets.id, name: proxyRuleSets.name })
+        .from(proxyRuleSets)
+        .where(
+          and(eq(proxyRuleSets.projectId, projectId), inArray(proxyRuleSets.name, namesToResolve)),
+        );
+
+      const byName = new Map(rows.map((r) => [r.name, r.id]));
+      for (const name of namesToResolve) {
+        const id = byName.get(name);
+        if (!id) {
+          throw new BadRequestException(
+            `Proxy rule set "${name}" not found for this project`,
+          );
+        }
+        resolvedNameIds.push(id);
+      }
+    }
+
+    // Names first, then explicit IDs, in caller order — dedupe preserving first occurrence
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const id of [...resolvedNameIds, ...directIds]) {
+      if (!seen.has(id)) {
+        seen.add(id);
+        result.push(id);
+      }
+    }
+    return result;
+  }
+
+  /**
    * Create a new deployment from a zip file
    */
   async createDeploymentFromZip(
@@ -164,12 +229,13 @@ export class DeploymentsService {
     // Parse tags if provided
     const tags = this.parseTags(dto.tags);
 
-    // Resolve proxy rule set name to ID if provided
-    const resolvedProxyRuleSetId = await this.resolveProxyRuleSetId(
-      project.id,
-      dto.proxyRuleSetName,
-      dto.proxyRuleSetId,
-    );
+    // Resolve proxy rule set names/IDs to a deduped ordered array
+    const resolvedProxyRuleSetIds = await this.resolveProxyRuleSetIds(project.id, {
+      proxyRuleSetNames: dto.proxyRuleSetNames,
+      proxyRuleSetIds: dto.proxyRuleSetIds,
+      proxyRuleSetName: dto.proxyRuleSetName,
+      proxyRuleSetId: dto.proxyRuleSetId,
+    });
 
     try {
       // Parse zip with fflate (async, non-blocking - better CPU performance)
@@ -321,7 +387,7 @@ export class DeploymentsService {
       if (dto.alias) {
         try {
           await this.createOrUpdateAlias(dto.repository, dto.alias, dto.commitSha, deploymentId, {
-            proxyRuleSetId: resolvedProxyRuleSetId,
+            proxyRuleSetIdsToAppend: resolvedProxyRuleSetIds,
           });
           aliases.push(dto.alias);
         } catch (error) {
@@ -346,7 +412,7 @@ export class DeploymentsService {
           {
             isAutoPreview: true,
             basePath: effectiveBasePath,
-            proxyRuleSetId: resolvedProxyRuleSetId,
+            proxyRuleSetIdsToAppend: resolvedProxyRuleSetIds,
           },
         );
         aliases.push(previewAliasName);
@@ -453,12 +519,13 @@ export class DeploymentsService {
     // Parse tags if provided
     const tags = this.parseTags(dto.tags);
 
-    // Resolve proxy rule set name to ID if provided
-    const resolvedProxyRuleSetId = await this.resolveProxyRuleSetId(
-      project.id,
-      dto.proxyRuleSetName,
-      dto.proxyRuleSetId,
-    );
+    // Resolve proxy rule set names/IDs to a deduped ordered array
+    const resolvedProxyRuleSetIds = await this.resolveProxyRuleSetIds(project.id, {
+      proxyRuleSetNames: dto.proxyRuleSetNames,
+      proxyRuleSetIds: dto.proxyRuleSetIds,
+      proxyRuleSetName: dto.proxyRuleSetName,
+      proxyRuleSetId: dto.proxyRuleSetId,
+    });
 
     // Upload each file
     for (let i = 0; i < files.length; i++) {
@@ -556,7 +623,9 @@ export class DeploymentsService {
     const aliases: string[] = [];
     if (dto.alias) {
       try {
-        await this.createOrUpdateAlias(dto.repository, dto.alias, dto.commitSha, deploymentId);
+        await this.createOrUpdateAlias(dto.repository, dto.alias, dto.commitSha, deploymentId, {
+          proxyRuleSetIdsToAppend: resolvedProxyRuleSetIds,
+        });
         aliases.push(dto.alias);
       } catch (error) {
         // Alias creation failure is non-critical
@@ -580,7 +649,7 @@ export class DeploymentsService {
         {
           isAutoPreview: true,
           basePath: effectiveBasePath,
-          proxyRuleSetId: resolvedProxyRuleSetId,
+          proxyRuleSetIdsToAppend: resolvedProxyRuleSetIds,
         },
       );
       aliases.push(previewAliasName);
@@ -1101,7 +1170,13 @@ export class DeploymentsService {
     alias: string,
     commitSha: string,
     deploymentId: string,
-    options?: { isAutoPreview?: boolean; basePath?: string; proxyRuleSetId?: string; proxyRuleSetIds?: string[] },
+    options?: {
+      isAutoPreview?: boolean;
+      basePath?: string;
+      proxyRuleSetId?: string;
+      proxyRuleSetIds?: string[];
+      proxyRuleSetIdsToAppend?: string[];
+    },
   ): Promise<AliasResponseDto> {
     // Phase 3H: Convert repository string to projectId
     const [owner, name] = repository.split('/');
@@ -1117,10 +1192,12 @@ export class DeploymentsService {
       .where(and(eq(deploymentAliases.projectId, project.id), eq(deploymentAliases.alias, alias)))
       .limit(1);
 
-    // Determine the rule set IDs to write
-    // When proxyRuleSetIds (array) is provided, it's an explicit full replacement (e.g. from update_alias API).
-    // When only proxyRuleSetId (singular) is provided, merge it into existing rule sets (e.g. from deploy).
-    // This prevents deploys from overwriting rule sets that were added separately (admin-toolbar, uploads, etc.).
+    // Determine the rule set IDs to write. Three modes, in precedence order:
+    //   1. proxyRuleSetIds (array)  — explicit full replacement (update_alias API).
+    //   2. proxyRuleSetIdsToAppend  — append each id to existing rule sets, dedupe (deploy with plural).
+    //   3. proxyRuleSetId           — single-id back-compat append (legacy deploy).
+    // Append-mode (2 & 3) preserves rule sets that were added separately
+    // (admin-toolbar, uploads, etc.) so deploys never silently drop them.
     let ruleSetIds: string[] | undefined;
     let ruleSetChanged = false;
 
@@ -1128,6 +1205,37 @@ export class DeploymentsService {
       // Explicit array = full replacement
       ruleSetIds = options.proxyRuleSetIds;
       ruleSetChanged = true;
+    } else if (options?.proxyRuleSetIdsToAppend && options.proxyRuleSetIdsToAppend.length > 0) {
+      // Array of ids to append idempotently
+      const toAppend = options.proxyRuleSetIdsToAppend;
+      if (existingAlias) {
+        const existingIds = await this.getAliasProxyRuleSetIds(existingAlias.id);
+        const seen = new Set(existingIds);
+        const merged = [...existingIds];
+        for (const id of toAppend) {
+          if (!seen.has(id)) {
+            seen.add(id);
+            merged.push(id);
+          }
+        }
+        if (merged.length !== existingIds.length) {
+          ruleSetIds = merged;
+          ruleSetChanged = true;
+        }
+        // All ids already present → no change
+      } else {
+        // New alias — dedupe the incoming list and write as-is
+        const seen = new Set<string>();
+        const initial: string[] = [];
+        for (const id of toAppend) {
+          if (!seen.has(id)) {
+            seen.add(id);
+            initial.push(id);
+          }
+        }
+        ruleSetIds = initial;
+        ruleSetChanged = true;
+      }
     } else if (options?.proxyRuleSetId) {
       // Single ID = merge with existing (for deploys)
       if (existingAlias) {
@@ -1691,6 +1799,9 @@ export class DeploymentsService {
       description?: string;
       tags?: string;
       proxyRuleSetId?: string;
+      proxyRuleSetName?: string;
+      proxyRuleSetIds?: string[];
+      proxyRuleSetNames?: string[];
       alias?: string;
       basePath?: string;
       files: Array<{
@@ -1717,6 +1828,14 @@ export class DeploymentsService {
 
     // Parse tags if provided
     const tags = this.parseTags(params.tags);
+
+    // Resolve proxy rule set names/IDs to a deduped ordered array
+    const resolvedProxyRuleSetIds = await this.resolveProxyRuleSetIds(params.projectId, {
+      proxyRuleSetNames: params.proxyRuleSetNames,
+      proxyRuleSetIds: params.proxyRuleSetIds,
+      proxyRuleSetName: params.proxyRuleSetName,
+      proxyRuleSetId: params.proxyRuleSetId,
+    });
 
     for (const file of params.files) {
       try {
@@ -1803,7 +1922,7 @@ export class DeploymentsService {
           params.commitSha,
           deploymentId,
           {
-            proxyRuleSetId: params.proxyRuleSetId,
+            proxyRuleSetIdsToAppend: resolvedProxyRuleSetIds,
           },
         );
         aliases.push(params.alias);
@@ -1828,7 +1947,7 @@ export class DeploymentsService {
         {
           isAutoPreview: true,
           basePath: effectiveBasePath,
-          proxyRuleSetId: params.proxyRuleSetId,
+          proxyRuleSetIdsToAppend: resolvedProxyRuleSetIds,
         },
       );
       aliases.push(previewAliasName);


### PR DESCRIPTION
## Summary

Deploys can now attach multiple proxy rule sets to the auto-preview alias in a single request — closes the gap that forced callers to deploy with one rule set and then make a second `update_alias` call with the merged array (racey, since the alias briefly serves with only one rule set in between).

- New plural fields on `CreateDeploymentDto`, `CreateDeploymentZipDto`, `PrepareBatchUploadDto`, `FinalizeUploadDto`: `proxyRuleSetIds: string[]` and `proxyRuleSetNames: string[]`. Singular fields stay as a back-compat shim and are now marked legacy in OpenAPI.
- New `resolveProxyRuleSetIds()` resolves names → ids in a single query, falls back to the singular shim, dedupes preserving caller-supplied order.
- New `proxyRuleSetIdsToAppend` option on `createOrUpdateAlias` appends each id only if it is not already attached — append + idempotent, matching today's singular behavior. Replacement semantics on `update_alias` are untouched.
- `finalizeUpload` treats its body as authoritative: plural values sent by the action override the singular value carried in the `pending_uploads` row. No schema migration needed.

## Test plan

- [x] Unit tests for `resolveProxyRuleSetIds` (8 cases — plural-only, names+ids ordering, singular fallback, dedupe, unknown name → 400)
- [x] Full `deployments.service.spec.ts` still green (45/45)
- [x] Full backend `tsc --noEmit` clean
- [ ] Manual: deploy through the upload-artifact action (next PR) against the sandbox workspace with `proxy-rule-set-names=a,b`; verify the alias ends up with `[a, b]`. Re-deploy with the same list → no change. Re-deploy with `[b, c]` → alias becomes `[a, b, c]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)