### PR TITLE
fix(permissions): enforce role lanes when granting project permissions

### DIFF
--- a/apps/backend/src/permissions/permissions.service.spec.ts
+++ b/apps/backend/src/permissions/permissions.service.spec.ts
@@ -286,14 +286,30 @@ describe('PermissionsService', () => {
   });
 
   describe('grantPermission', () => {
+    // Two-stage select mock: first call (target-user lookup) returns the supplied
+    // user row, every subsequent call (existing-permission lookup, etc.) returns
+    // the supplied existing row (or []). Implemented with mockImplementation so
+    // state is contained to the current test — mockReturnValueOnce queues survive
+    // jest.clearAllMocks() and would leak into neighbouring tests.
+    const mockSelectChain = (
+      targetUser: { role: string; email: string } | null,
+      existing: { role: string }[] = [],
+    ) => {
+      let call = 0;
+      (db.select as jest.Mock).mockImplementation(() => {
+        call += 1;
+        const result = call === 1 ? (targetUser ? [targetUser] : []) : existing;
+        return {
+          from: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          limit: jest.fn().mockResolvedValue(result),
+        };
+      });
+    };
+
     it('should grant permission if granter is admin', async () => {
       jest.spyOn(service, 'getUserProjectRole').mockResolvedValue('admin');
-
-      (db.select as jest.Mock).mockReturnValue({
-        from: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockResolvedValue([]), // No existing permission
-      });
+      mockSelectChain({ role: 'user', email: 'target@example.com' });
 
       (db.insert as jest.Mock).mockReturnValue({
         values: jest.fn().mockResolvedValue(undefined),
@@ -322,14 +338,7 @@ describe('PermissionsService', () => {
 
     it('should update existing permission if already exists', async () => {
       jest.spyOn(service, 'getUserProjectRole').mockResolvedValue('admin');
-
-      const mockExisting = { role: 'viewer' };
-
-      (db.select as jest.Mock).mockReturnValue({
-        from: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockResolvedValue([mockExisting]),
-      });
+      mockSelectChain({ role: 'user', email: 'target@example.com' }, [{ role: 'viewer' }]);
 
       (db.update as jest.Mock).mockReturnValue({
         set: jest.fn().mockReturnThis(),
@@ -339,6 +348,73 @@ describe('PermissionsService', () => {
       await service.grantPermission(mockProjectId, mockUserId, 'admin', mockGrantedBy);
 
       expect(db.update).toHaveBeenCalled();
+    });
+
+    describe('role lanes', () => {
+      it('rejects granting project admin to a global member', async () => {
+        jest.spyOn(service, 'getUserProjectRole').mockResolvedValue('admin');
+        mockSelectChain({ role: 'member', email: 'member@example.com' });
+
+        await expect(
+          service.grantPermission(mockProjectId, mockUserId, 'admin', mockGrantedBy),
+        ).rejects.toThrow(
+          /global 'member' role and cannot be granted the project 'admin' role/,
+        );
+      });
+
+      it('rejects granting project contributor to a global member', async () => {
+        jest.spyOn(service, 'getUserProjectRole').mockResolvedValue('admin');
+        mockSelectChain({ role: 'member', email: 'member@example.com' });
+
+        await expect(
+          service.grantPermission(mockProjectId, mockUserId, 'contributor', mockGrantedBy),
+        ).rejects.toThrow(ForbiddenException);
+      });
+
+      it('allows granting project viewer to a global member', async () => {
+        jest.spyOn(service, 'getUserProjectRole').mockResolvedValue('admin');
+        mockSelectChain({ role: 'member', email: 'member@example.com' });
+        (db.insert as jest.Mock).mockReturnValue({
+          values: jest.fn().mockResolvedValue(undefined),
+        });
+
+        await service.grantPermission(mockProjectId, mockUserId, 'viewer', mockGrantedBy);
+
+        expect(db.insert).toHaveBeenCalled();
+      });
+
+      it('allows granting project guest to a global member', async () => {
+        jest.spyOn(service, 'getUserProjectRole').mockResolvedValue('admin');
+        mockSelectChain({ role: 'member', email: 'member@example.com' });
+        (db.insert as jest.Mock).mockReturnValue({
+          values: jest.fn().mockResolvedValue(undefined),
+        });
+
+        await service.grantPermission(mockProjectId, mockUserId, 'guest', mockGrantedBy);
+
+        expect(db.insert).toHaveBeenCalled();
+      });
+
+      it('allows granting project admin to a global user', async () => {
+        jest.spyOn(service, 'getUserProjectRole').mockResolvedValue('admin');
+        mockSelectChain({ role: 'user', email: 'user@example.com' });
+        (db.insert as jest.Mock).mockReturnValue({
+          values: jest.fn().mockResolvedValue(undefined),
+        });
+
+        await service.grantPermission(mockProjectId, mockUserId, 'admin', mockGrantedBy);
+
+        expect(db.insert).toHaveBeenCalled();
+      });
+
+      it('throws NotFoundException if the target user does not exist', async () => {
+        jest.spyOn(service, 'getUserProjectRole').mockResolvedValue('admin');
+        mockSelectChain(null);
+
+        await expect(
+          service.grantPermission(mockProjectId, mockUserId, 'viewer', mockGrantedBy),
+        ).rejects.toThrow(/User not found/);
+      });
     });
   });
 

--- a/apps/backend/src/permissions/permissions.service.ts
+++ b/apps/backend/src/permissions/permissions.service.ts
@@ -13,6 +13,28 @@ import {
 import { RequiredRole } from '../domains/visibility.service';
 
 export type ProjectRole = 'owner' | 'admin' | 'contributor' | 'viewer' | 'guest';
+export type GlobalRole = 'admin' | 'user' | 'member';
+
+/**
+ * Project roles a user with the given global role is allowed to receive.
+ * Global Admins act as project Owners everywhere (see ProjectPermissionGuard)
+ * and don't need explicit grants — listed here only so the helper is total.
+ * Members are workspace participants who cannot create projects, so they
+ * cannot be granted project-admin or contributor authority without first
+ * being promoted to 'user' at the workspace level.
+ */
+const PROJECT_ROLES_BY_GLOBAL_ROLE: Record<GlobalRole, ProjectRole[]> = {
+  admin: ['owner', 'admin', 'contributor', 'viewer', 'guest'],
+  user: ['admin', 'contributor', 'viewer', 'guest'],
+  member: ['viewer', 'guest'],
+};
+
+export function isProjectRoleAllowedForGlobalRole(
+  globalRole: GlobalRole,
+  projectRole: ProjectRole,
+): boolean {
+  return PROJECT_ROLES_BY_GLOBAL_ROLE[globalRole].includes(projectRole);
+}
 
 /**
  * Rich shape returned by `listUserProjectMemberships` for the "My Sites" hub.
@@ -402,6 +424,25 @@ export class PermissionsService {
       throw new ForbiddenException('Cannot grant owner role. Use transfer ownership instead.');
     }
 
+    // Project role must stay in lane with the target's workspace-level role:
+    // a global Member cannot be granted project Admin/Contributor without
+    // first being promoted to Global User.
+    const [targetUser] = await db
+      .select({ role: users.role, email: users.email })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+    if (!targetUser) {
+      throw new NotFoundException('User not found');
+    }
+    const targetGlobalRole = targetUser.role as GlobalRole;
+    if (!isProjectRoleAllowedForGlobalRole(targetGlobalRole, role)) {
+      throw new ForbiddenException(
+        `${targetUser.email} has the global '${targetGlobalRole}' role and cannot be granted the project '${role}' role. ` +
+          `Promote the user to 'user' in the Users tab first, then re-grant.`,
+      );
+    }
+
     await this.upsertProjectPermission(projectId, userId, role, grantedBy);
   }
 
@@ -638,6 +679,7 @@ export class PermissionsService {
           id: users.id,
           email: users.email,
           name: sql<string | null>`NULL`, // Users table doesn't have a name field yet
+          role: users.role,
         },
       })
       .from(projectPermissions)

--- a/apps/frontend/src/components/project/ProjectMembersTab.tsx
+++ b/apps/frontend/src/components/project/ProjectMembersTab.tsx
@@ -3,7 +3,9 @@ import {
   useGetProjectPermissionsQuery,
   useGrantUserPermissionMutation,
   useRevokeUserPermissionMutation,
+  isProjectRoleAllowedForGlobalRole,
   type ProjectRole,
+  type GlobalRole,
 } from '@/services/permissionsApi';
 import {
   useGetProjectQuery,
@@ -78,6 +80,17 @@ export function ProjectMembersTab({ owner, repo }: ProjectMembersTabProps) {
   const [newUserEmail, setNewUserEmail] = useState('');
   const [newUserRole, setNewUserRole] = useState<ProjectRole>('guest');
   const [editRole, setEditRole] = useState<ProjectRole>('viewer');
+
+  // Project roles available given the target member's global (workspace) role.
+  // Mirrors backend enforcement: global Members can only hold viewer/guest.
+  const allowedRolesFor = (globalRole: GlobalRole | undefined): ProjectRole[] => {
+    if (!globalRole) {
+      return ['admin', 'contributor', 'viewer', 'guest'];
+    }
+    return (['admin', 'contributor', 'viewer', 'guest'] as ProjectRole[]).filter((r) =>
+      isProjectRoleAllowedForGlobalRole(globalRole, r),
+    );
+  };
 
   // Fetch permissions
   const { data, isLoading, error } = useGetProjectPermissionsQuery({ owner, repo });
@@ -312,6 +325,13 @@ export function ProjectMembersTab({ owner, repo }: ProjectMembersTabProps) {
                       <SelectItem value="admin">Admin - Can manage settings</SelectItem>
                     </SelectContent>
                   </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Contributor and Admin require the target to have the global{' '}
+                    <code className="font-mono">user</code> or{' '}
+                    <code className="font-mono">admin</code> role. Members can only be granted
+                    Viewer or Guest — promote them in the{' '}
+                    <a href="/users" className="underline">Users tab</a> first if needed.
+                  </p>
                 </div>
               </div>
               <DialogFooter>
@@ -400,16 +420,34 @@ export function ProjectMembersTab({ owner, repo }: ProjectMembersTabProps) {
                                       <SelectValue />
                                     </SelectTrigger>
                                     <SelectContent>
-                                      <SelectItem value="guest">Guest - Site access only</SelectItem>
-                                      <SelectItem value="viewer">Viewer - Read only admin</SelectItem>
-                                      <SelectItem value="contributor">
-                                        Contributor - Can deploy
-                                      </SelectItem>
-                                      <SelectItem value="admin">
-                                        Admin - Can manage settings
-                                      </SelectItem>
+                                      {allowedRolesFor(permission.user.role).includes('guest') && (
+                                        <SelectItem value="guest">Guest - Site access only</SelectItem>
+                                      )}
+                                      {allowedRolesFor(permission.user.role).includes('viewer') && (
+                                        <SelectItem value="viewer">Viewer - Read only admin</SelectItem>
+                                      )}
+                                      {allowedRolesFor(permission.user.role).includes('contributor') && (
+                                        <SelectItem value="contributor">
+                                          Contributor - Can deploy
+                                        </SelectItem>
+                                      )}
+                                      {allowedRolesFor(permission.user.role).includes('admin') && (
+                                        <SelectItem value="admin">
+                                          Admin - Can manage settings
+                                        </SelectItem>
+                                      )}
                                     </SelectContent>
                                   </Select>
+                                  {permission.user.role === 'member' && (
+                                    <p className="text-xs text-muted-foreground">
+                                      {permission.user.email} has the global{' '}
+                                      <code className="font-mono">member</code> role, so only
+                                      Viewer or Guest can be granted here. Promote them to{' '}
+                                      <code className="font-mono">user</code> in the{' '}
+                                      <a href="/users" className="underline">Users tab</a>{' '}
+                                      first to grant Contributor or Admin.
+                                    </p>
+                                  )}
                                 </div>
                               </div>
                               <DialogFooter>

--- a/apps/frontend/src/services/permissionsApi.ts
+++ b/apps/frontend/src/services/permissionsApi.ts
@@ -2,6 +2,23 @@ import { api } from './api';
 
 export type ProjectRole = 'owner' | 'admin' | 'contributor' | 'viewer' | 'guest';
 export type ProjectGroupRole = 'admin' | 'contributor' | 'viewer' | 'guest';
+export type GlobalRole = 'admin' | 'user' | 'member';
+
+// Mirrors PROJECT_ROLES_BY_GLOBAL_ROLE in the backend's permissions.service.ts.
+// Global Members can only hold viewer/guest at the project level; promotion to
+// 'user' is required before they can be a project Admin or Contributor.
+export const PROJECT_ROLES_BY_GLOBAL_ROLE: Record<GlobalRole, ProjectRole[]> = {
+  admin: ['owner', 'admin', 'contributor', 'viewer', 'guest'],
+  user: ['admin', 'contributor', 'viewer', 'guest'],
+  member: ['viewer', 'guest'],
+};
+
+export function isProjectRoleAllowedForGlobalRole(
+  globalRole: GlobalRole,
+  projectRole: ProjectRole,
+): boolean {
+  return PROJECT_ROLES_BY_GLOBAL_ROLE[globalRole].includes(projectRole);
+}
 
 export interface UserPermission {
   id: string;
@@ -14,6 +31,7 @@ export interface UserPermission {
     id: string;
     email: string;
     name: string | null;
+    role: GlobalRole;
   };
 }
 


### PR DESCRIPTION
## Summary
A workspace Member could be granted project Admin/Contributor directly, contradicting the docs which scope Members to Viewer/Guest. `permissions.service.ts:grantPermission` only checked the *granter's* authority, never the *target's* global role — so a global Member could receive any project role short of Owner.

## Changes

### Backend
- **`apps/backend/src/permissions/permissions.service.ts`**
  - `grantPermission` now looks up the target user's global role and rejects mismatched combinations:
    - Global **Admin** → can be granted any project role (rarely needed — admins already act as project Owners on every project after #292)
    - Global **User** → admin, contributor, viewer, guest
    - Global **Member** → viewer, guest only
  - Owner remains rejected (still only via project creation or transfer-ownership; Members can't reach Owner because they can't create projects).
  - Error message tells the granter how to fix it: `"… has the global 'member' role and cannot be granted the project 'admin' role. Promote the user to 'user' in the Users tab first, then re-grant."`
  - Exports a shared helper `isProjectRoleAllowedForGlobalRole(globalRole, projectRole)` and lookup table `PROJECT_ROLES_BY_GLOBAL_ROLE` so the frontend mirrors the constraint exactly with one source of truth.
  - `getProjectUserPermissions` now selects `users.role` so the response includes each member's global role.

### Frontend
- **`apps/frontend/src/services/permissionsApi.ts`** — exports `GlobalRole`, `PROJECT_ROLES_BY_GLOBAL_ROLE`, and `isProjectRoleAllowedForGlobalRole`; adds `user.role` to `UserPermission`.
- **`apps/frontend/src/components/project/ProjectMembersTab.tsx`**
  - **Edit Role** dialog hides Admin and Contributor options when the target is a global Member, and shows an inline hint linking to /users with the promote-first workflow.
  - **Add Member** dialog shows the same hint above the role picker as a heads-up (target's global role isn't known until backend resolves the email — backend still enforces and the toast surfaces the clear error message).

### Tests
6 new unit tests in `permissions.service.spec.ts`:
- rejects project admin → global member
- rejects project contributor → global member
- allows project viewer → global member
- allows project guest → global member
- allows project admin → global user
- throws NotFoundException when target user doesn't exist

Existing tests refactored to use a stateful `mockSelectChain` helper (avoids `mockReturnValueOnce` queues leaking across tests).

## Why explicit promotion vs. auto-promote
Considered three options:
- ✅ **Require explicit promotion** (this PR): an admin must deliberately bump the target's workspace role before granting elevated project rights.
- ❌ Auto-promote: bumps global role implicitly — less deliberate, harder to audit.
- ❌ Loosen docs: gives up the design intent that global role is a privilege ceiling.

User picked explicit promotion to keep "roles in their lanes."

## Test plan
- [x] `jest src/permissions/permissions.service.spec.ts` — 50/50 passing
- [x] `tsc --noEmit` backend + frontend clean
- [ ] Manual: as workspace Owner, open Members tab, try changing a global-Member project Viewer to Admin → option hidden, hint visible
- [ ] Manual: same, try Add Member with a Member's email + Admin → backend returns the promote-first message in toast
- [ ] Manual: promote that Member to User in Users tab → re-try the same grant → succeeds
- [ ] Manual: API `curl POST /api/projects/{owner}/{repo}/permissions/users` with member target + admin role → 403 with promote-first message

Companion docs PR will land in `bffless/docs-public`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)