### PR TITLE
fix(authz): hide Create Deployment for viewers and make rule rows non-clickable

### DIFF
--- a/apps/frontend/src/components/proxy-rules/RulesList.tsx
+++ b/apps/frontend/src/components/proxy-rules/RulesList.tsx
@@ -146,10 +146,10 @@ export function RulesList({
         {sortedRules.map((rule) => (
           <div
             key={rule.id}
-            onClick={() => onRuleClick(rule)}
-            className={`flex items-center gap-3 p-3 border rounded-md bg-background transition-colors cursor-pointer hover:bg-accent ${
-              !rule.isEnabled ? 'opacity-50' : ''
-            }`}
+            onClick={canEdit ? () => onRuleClick(rule) : undefined}
+            className={`flex items-center gap-3 p-3 border rounded-md bg-background transition-colors ${
+              canEdit ? 'cursor-pointer hover:bg-accent' : ''
+            } ${!rule.isEnabled ? 'opacity-50' : ''}`}
           >
             <div
               className="flex items-center justify-center w-6 h-6 rounded bg-muted text-xs font-mono flex-shrink-0"

--- a/apps/frontend/src/components/repo/DeploymentsList.tsx
+++ b/apps/frontend/src/components/repo/DeploymentsList.tsx
@@ -35,6 +35,7 @@ import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Input } from '@/components/ui/input';
 import { CreateDeploymentDialog } from './CreateDeploymentDialog';
+import { useProjectRole } from '@/hooks/useProjectRole';
 
 interface DeploymentsListProps {
   owner: string;
@@ -48,6 +49,7 @@ interface DeploymentsListProps {
 export function DeploymentsList({ owner, repo }: DeploymentsListProps) {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
+  const { canEdit } = useProjectRole(owner, repo);
   const { selectedBranch, currentPage, sortBy, sortOrder, searchQuery } = useAppSelector(
     (state) => state.repoOverview,
   );
@@ -204,10 +206,12 @@ export function DeploymentsList({ owner, repo }: DeploymentsListProps) {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between">
             <CardTitle>Deployments</CardTitle>
-            <Button onClick={() => setCreateOpen(true)} className="gap-2">
-              <Plus className="h-4 w-4" />
-              Create Deployment
-            </Button>
+            {canEdit && (
+              <Button onClick={() => setCreateOpen(true)} className="gap-2">
+                <Plus className="h-4 w-4" />
+                Create Deployment
+              </Button>
+            )}
           </CardHeader>
           <CardContent className="p-8 text-center">
             <Package className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
@@ -322,10 +326,12 @@ export function DeploymentsList({ owner, repo }: DeploymentsListProps) {
           </Button>
 
           {/* Create Deployment */}
-          <Button onClick={() => setCreateOpen(true)} size="sm" className="gap-2 ml-auto">
-            <Plus className="h-4 w-4" aria-hidden="true" />
-            Create Deployment
-          </Button>
+          {canEdit && (
+            <Button onClick={() => setCreateOpen(true)} size="sm" className="gap-2 ml-auto">
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Create Deployment
+            </Button>
+          )}
         </div>
 
         {/* Empty Search Results */}


### PR DESCRIPTION
## Summary
Two more viewer-role UI gaps surfaced after #294 merged. These commits originally sat on the `fix/role-lanes-grant-permission` branch but got cut from the squash-merge of #294, so they're re-stacked here on top of `main`.

## Changes
- **`apps/frontend/src/components/repo/DeploymentsList.tsx`** — gate the Create Deployment button (both the empty-state header and the populated-list toolbar) on `canEdit` from `useProjectRole`. Viewers/guests no longer see the button — the API would reject the call anyway.
- **`apps/frontend/src/components/proxy-rules/RulesList.tsx`** — when `canEdit` is false, drop the row `onClick` handler and the `cursor-pointer`/`hover:bg-accent` styles. Previously the row click navigated to the rule editor, but the editor has no read-only mode — viewers landed on a "You do not have permission to edit proxy rules" dead-end. Static rows are clearer.

This reverses the earlier "let viewers open editor read-only" call from PR #292's review thread — the editor page doesn't actually have a read-only mode, so the click goes nowhere useful.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Manual: sign in as a project viewer, open Deployments tab — Create Deployment button is hidden in both empty and populated states.
- [ ] Manual: same user, open a rule set with rules — rows show no hover/cursor effect and clicking does nothing.
- [ ] Manual: sign in as a project admin or contributor — buttons and clickable rows still work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)