### PR TITLE
fix(pipelines): serve string response bodies verbatim instead of JSON-encoding

### DIFF
--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -1129,7 +1129,12 @@ export class ProxyMiddleware implements NestMiddleware {
             res.setHeader(key, value);
           }
         }
-        res.status(result.response.status).json(result.response.body);
+        // Use res.send (not res.json): for string bodies (text/plain, text/html,
+        // application/x-sh, etc.) res.json would JSON.stringify the string and
+        // produce `"#!/bin/sh\n..."` instead of the raw script. res.send writes
+        // strings verbatim, calls res.json for objects/arrays, and respects the
+        // Content-Type header we already set above.
+        res.status(result.response.status).send(result.response.body);
       } else {
         // Pipeline failed - map error codes to appropriate HTTP status codes
         const errorCode = result.error?.code;


### PR DESCRIPTION
## Summary

`proxy.middleware.ts` unconditionally calls `res.json(body)` when a pipeline returns successfully, which JSON.stringifies string bodies regardless of the Content-Type the `response_handler` set. A `response_handler` with `contentType: "text/plain"` and a body fed from an `http_request` step (e.g. a bash script fetched from GitHub raw) lands on the wire as `"#!/bin/sh\n# ..."` — quoted, backslash-escaped newlines — instead of the raw script. That breaks `sh -c "$(curl -fsSL …)"` because bash sees a quoted string literal instead of a shell program.

This swaps the one call site to `res.send(body)`:

- String bodies: written verbatim, honouring the Content-Type header we already set on the previous line.
- Object/array bodies: `res.send` internally routes through `res.json`, so every existing form-handler / data-query / default-response pipeline produces the same wire output as before.

Use case driving the fix: serving `bffless.app/install.sh` through a pipeline that (a) reverse-proxies `raw.githubusercontent.com/bffless/ce/main/install.sh` via `http_request`, (b) returns it as `text/plain`, and (c) logs every download to a tracking schema in `postSteps`. Before this fix the script reached `curl` as a JSON-encoded blob and `sh -c` could not execute it.

## Test plan

- [ ] Existing JSON pipelines on the landing page (`/api/pricing-form`, `/api/feedback-form`, `/api/demo`, `/api/hits`) still return the same JSON shape and Content-Type
- [ ] After deploy, `curl -fsSL https://bffless.app/install.sh | diff - <(curl -fsSL https://raw.githubusercontent.com/bffless/ce/main/install.sh)` is empty (byte-equivalent)
- [ ] After deploy, `INSTALL_DIR=/tmp/ce-smoke sh -c "$(curl -fsSL https://bffless.app/install.sh)"` actually clones and runs setup
- [ ] After deploy, a row appears in the `install_downloads` pipeline schema with `tag: "install.sh"`, non-empty `ip`, and a `curl/x.y.z` user_agent for each download

🤖 Generated with [Claude Code](https://claude.com/claude-code)