### PR TITLE
fix: serve /auth via SPA fallback instead of proxying to backend

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -53,18 +53,10 @@ server {
         proxy_cache_bypass $http_upgrade;
     }
 
-    # Proxy auth requests to backend
-    location /auth {
-        proxy_pass http://backend:3000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass $http_upgrade;
-    }
+    # NOTE: /auth is SuperTokens' websiteBasePath (client-side SPA routes).
+    # The auth API lives at /api/auth (see location /api), so /auth* must NOT
+    # be proxied to the backend — it falls through to the SPA fallback below
+    # so hard-reloads of /auth routes render client-side.
 
     # Proxy public asset requests to backend
     location /public {


### PR DESCRIPTION
## Problem

Hard-reloading `https://www.j5s.dev/auth` (and any `/auth*` route) returns an **nginx 404**, not the React SPA — even though SPA mode is enabled and other paths fall back correctly.

## Root cause

`docker/nginx.conf` had a `location /auth` block that proxied every `/auth*` request to the backend:

```nginx
location /auth {
    proxy_pass http://backend:3000;
    ...
}
```

But the backend has **no route at `/auth`**. SuperTokens' `apiBasePath` is `/api/auth` (`apps/backend/src/auth/supertokens.config.ts`), which is already handled by the `location /api` block. `websiteBasePath: '/auth'` is a *client-side* concept — the SuperTokens backend SDK serves nothing at `/auth`. So the proxy forwarded to a nonexistent route → 404.

This is stale config from when `apiBasePath` was presumably `/auth`.

## Fix

Remove the `/auth` proxy block so `/auth*` falls through to the SPA fallback (`try_files $uri $uri/ /index.html`) and renders client-side, like every other front-end route.

`location /api` continues to handle all real SuperTokens API traffic (`/api/auth/*`) — nothing depended on the `/auth` proxy.

## Testing

After deploy, hard-reload `/auth` → should render the SPA instead of an nginx 404. API auth flows (`/api/auth/*`) are unaffected.

> Note: the equivalent fix for the K8s workspace nginx config (`platform/adapters/.../configmap-nginx.yaml`) is raised in a separate PR on the platform repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)