### PR TITLE
fix: don't match bare /prefix for /prefix/* proxy rules

### DIFF
--- a/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
@@ -169,7 +169,12 @@ describe('ProxyMiddleware', () => {
       expect((middleware as any).matchesPattern('/api/*', '/api/users')).toBe(true);
       expect((middleware as any).matchesPattern('/api/*', '/api/users/123')).toBe(true);
       expect((middleware as any).matchesPattern('/api/*', '/api/')).toBe(true);
-      expect((middleware as any).matchesPattern('/api/*', '/api')).toBe(true);
+      // The wildcard requires a path separator: '/prefix/*' must NOT match the
+      // bare '/prefix', so a same-named SPA route (e.g. '/auth') falls through
+      // to the SPA fallback instead of being proxied.
+      expect((middleware as any).matchesPattern('/api/*', '/api')).toBe(false);
+      expect((middleware as any).matchesPattern('/auth/*', '/auth')).toBe(false);
+      expect((middleware as any).matchesPattern('/auth/*', '/auth/signin')).toBe(true);
       expect((middleware as any).matchesPattern('/api/*', '/graphql')).toBe(false);
     });
 

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -1438,8 +1438,11 @@ export class ProxyMiddleware implements NestMiddleware {
     if (pattern === path) return true;
     if (!pattern.includes('*')) return false;
 
-    // Backward-compat: '/prefix/*' also matches the bare '/prefix' (no trailing slash).
-    if (pattern.endsWith('/*') && path === pattern.slice(0, -2)) return true;
+    // Note: '/prefix/*' matches '/prefix/' and '/prefix/<sub>' but NOT the bare
+    // '/prefix' — the wildcard requires a path separator. This lets a same-named
+    // client-side SPA route (e.g. bare '/auth') fall through to the SPA fallback
+    // while subpaths (e.g. '/auth/signin') are still proxied. To also match the
+    // bare prefix, use '/prefix*' or add an explicit '/prefix' rule.
 
     // Glob → regex: escape regex metacharacters (but not '*'), then replace
     // '*' with '.*' and anchor. Handles trailing, leading, and middle wildcards.


### PR DESCRIPTION
## Problem

On a CE deployment serving an SPA at the primary domain, hard-reloading `/auth` returns a **404** while other routes fall back to the SPA correctly.

Diagnostic signature (same domain, same alias):

| Path | Result |
|------|--------|
| `/auth` | ❌ 404 |
| `/auth/` | ❌ 404 |
| `/randomxyz` | ✅ 200 (SPA fallback) |
| `/authfoo` | ✅ 200 |
| `/foo/auth` | ✅ 200 |

Only the *exact* bare `/auth` (and `/auth/`) breaks.

## Root cause

The deployment has an intentional proxy rule `/auth/*` → upstream (reverse-proxying SuperTokens auth subpaths like `/auth/signin`). Proxy rules are matched in `ProxyMiddleware` against the `X-Original-URI` header and run **before** the nginx SPA fallback (`location /` → `@spa_fallback` → `index.html`). A matched rule is terminal, so its upstream 404 is returned raw — the SPA fallback never fires.

`matchesPattern` had a backward-compat shortcut that made `/prefix/*` also match the bare `/prefix`:

```ts
// Backward-compat: '/prefix/*' also matches the bare '/prefix' (no trailing slash).
if (pattern.endsWith('/*') && path === pattern.slice(0, -2)) return true;
```

So `/auth/*` matched bare `/auth`, the rule proxied the SPA's login page to the auth upstream (404), and nginx fell to its static 404 page. `/authfoo` and `/foo/auth` don't match `/auth/*`, which is why they fell through to the SPA and worked.

## Fix

Remove the bare-prefix shortcut so `/prefix/*` requires a path separator:

- `/auth/*` vs `/auth` → **false** (falls through to SPA fallback)
- `/auth/*` vs `/auth/` → true
- `/auth/*` vs `/auth/signin` → true

A path prefix can't simultaneously mean "proxy everything here including the bare segment" and "let the bare segment render as an SPA route." Standard glob semantics (wildcard needs a separator) resolve it in favor of the SPA, and real subpaths still proxy.

## ⚠️ Breaking change

Any rule that relied on `/x/*` also matching the bare `/x` must now use `/x*` or add an explicit `/x` rule. The `matchesPattern` spec asserting `/api/*` matches `/api` is updated accordingly.

## Tests

`proxy.middleware.spec.ts` updated: `/api/*` ✗ `/api`, plus explicit `/auth/*` ✗ `/auth` / ✓ `/auth/signin` regression cases. Full `proxy.middleware.spec` suite passes (21/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)