### PR TITLE
fix: proxy /_bffless/auth/* on primary domain nginx config

### DIFF
--- a/apps/backend/src/domains/nginx-config.service.ts
+++ b/apps/backend/src/domains/nginx-config.service.ts
@@ -1048,6 +1048,17 @@ ${httpServerBlock}${httpsServerBlock}
     const locationBlock = `
 ${proxyLocations}
 
+    # BFFless auth relay endpoints (login relay, session, callback, refresh, logout)
+    location /_bffless/auth/ {
+        proxy_pass http://${backendHost}:${backendPort}/_bffless/auth/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+    }
+
     # Main location - serves static content
     location / {
         rewrite ^/(.*)$ ${internalPath}/$1 break;
@@ -1231,6 +1242,17 @@ ${serverBlocks}`;
 
     const locationBlock = `
 ${proxyLocations}
+
+    # BFFless auth relay endpoints (login relay, session, callback, refresh, logout)
+    location /_bffless/auth/ {
+        proxy_pass http://${backendHost}:${backendPort}/_bffless/auth/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+    }
 
     location / {
         rewrite ^/(.*)$ ${internalPath}/$1 break;


### PR DESCRIPTION
## Problem

On a primary-domain CE site (e.g. the apex `www.j5s.dev` content), the BFFless auth-relay endpoints under `/_bffless/auth/*` are **not reverse-proxied** to the backend — they fall through to the SPA and get served `index.html`.

Symptom: a static site using the admin login relay always shows "not signed in" because `/_bffless/auth/session` returns `text/html` (the SPA shell) instead of the JSON session payload.

Confirmed on a live deployment:

```
PUBLIC  /_bffless/auth/session  -> 200 text/html      (serving index.html via SPA fallback)
BACKEND /_bffless/auth/session  -> 200 application/json (backend handles it fine when proxied)
grep -c "_bffless/auth" <primary-domain config>  -> 0   (the location block is missing)
```

## Root cause

The primary-domain nginx generators — `generateCEPrimaryDomainConfig` and `generatePlatformPrimaryDomainConfig` in `nginx-config.service.ts` — never emitted a `location /_bffless/auth/` proxy block. So `/_bffless/auth/*` matched `location /`, got rewritten to `/public/.../<path>`, 404'd at the backend, and (in SPA mode) fell through to `index.html`.

The **subdomain** and **custom-domain** generators already include this block — it was added in `64e054e` ("add _bffless/auth proxy to subdomain/wildcard nginx configs") but the two primary-domain generators were missed.

## Fix

Add the same `location /_bffless/auth/` proxy block to both primary-domain generators, ahead of `location /` (the longer prefix wins in nginx, so it takes precedence over the content rewrite). Block matches the existing subdomain/custom-domain templates verbatim.

## Effect

`/_bffless/auth/session` (and `/callback`, `/refresh`, `/logout`) on a primary domain now reverse-proxy to the backend and return JSON, so the login relay / session check works. Regenerated on next config write (or toggle/save of the primary content domain).

## Tests

`nginx-config.service.spec.ts` passes (16/16). No behavior change for subdomain/custom-domain configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)