### PR TITLE
fix: route primary domain mappings to the primary generator on regeneration

### DIFF
--- a/apps/backend/src/domains/nginx-config.service.spec.ts
+++ b/apps/backend/src/domains/nginx-config.service.spec.ts
@@ -448,6 +448,56 @@ server {
 
       expect(config).toContain('latest');
     });
+
+    it('routes isPrimary mappings to the primary-domain generator (SPA + www + auth relay survive regeneration)', async () => {
+      // Regression: regeneration paths (startup, proxy-rule changes) funnel
+      // primary mappings through generateConfig. Without an isPrimary branch they
+      // fell through to the custom-domain template, dropping SPA mode + www
+      // handling until the next explicit domain save.
+      const domainMapping = {
+        id: 'domain-primary',
+        projectId: 'proj-1',
+        domain: 'example.com',
+        domainType: 'custom' as const,
+        alias: 'production',
+        path: '/dist',
+        sslEnabled: true,
+        isActive: true,
+        isPublic: null,
+        unauthorizedBehavior: null,
+        requiredRole: null,
+        dnsVerified: true,
+        createdBy: 'user-1',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        sslExpiresAt: null,
+        dnsVerifiedAt: null,
+        nginxConfigPath: null,
+        autoRenewSsl: true,
+        sslRenewedAt: null,
+        sslRenewalStatus: null,
+        sslRenewalError: null,
+        stickySessionsEnabled: true,
+        stickySessionDuration: 86400,
+        isSpa: true,
+        isPrimary: true,
+        wwwBehavior: 'serve-both' as const,
+        redirectTarget: null,
+        redirectType: '301' as const,
+      };
+
+      const config = await service.generateConfig(domainMapping, mockProject);
+
+      // Primary-domain generator output, not the custom-domain template
+      expect(config).toContain('Primary Domain Configuration');
+      // www handling preserved (serve-both → "server_name <base> www.<base>").
+      // server_name comes from getBaseDomain(), not domainMapping.domain.
+      expect(config).toContain('www.');
+      // SPA fallback present because isSpa is true
+      expect(config).toContain('@spa_fallback');
+      // BFFless auth relay proxied (not swallowed by SPA fallback)
+      expect(config).toContain('location /_bffless/auth/');
+    });
   });
 
   describe('generateRedirectDomainConfig', () => {

--- a/apps/backend/src/domains/nginx-config.service.ts
+++ b/apps/backend/src/domains/nginx-config.service.ts
@@ -163,6 +163,30 @@ export class NginxConfigService implements OnModuleInit {
       });
     }
 
+    // Primary domain mappings have a dedicated generator that handles wwwBehavior
+    // (serve-both / redirect), SPA fallback, and the /_bffless/auth relay. Without
+    // this branch, regeneration paths that funnel through generateConfig — startup
+    // (regenerateDomainMappingConfigs) and proxy-rule changes (regenerateForAlias)
+    // — would fall through to the custom-domain/subdomain template and silently
+    // drop SPA mode + www handling, until the next explicit domain save re-ran the
+    // primary generator. Mirrors the isPrimary branch in DomainsService.
+    if (domainMapping.isPrimary) {
+      const primaryConfig: PrimaryDomainConfig = {
+        id: domainMapping.id,
+        owner: project.owner,
+        repo: project.name,
+        alias: domainMapping.alias || 'latest',
+        path: domainMapping.path || '',
+        wwwBehavior: domainMapping.wwwBehavior as PrimaryDomainConfig['wwwBehavior'],
+        isSpa: domainMapping.isSpa,
+        proxyRules,
+      };
+      const baseDomain = this.getBaseDomain();
+      return this.shouldNginxHandleSsl()
+        ? this.generateCEPrimaryDomainConfig(primaryConfig, baseDomain)
+        : this.generatePlatformPrimaryDomainConfig(primaryConfig, baseDomain);
+    }
+
     // Determine SSL mode for subdomains.
     // Two ways a subdomain can serve HTTPS:
     //   1. Let's Encrypt wildcard cert at /etc/nginx/ssl/wildcard.<baseDomain>.crt


### PR DESCRIPTION
## Problem

On a primary-domain SPA site, a **backend restart/upgrade** (or a **proxy-rule edit**) causes client-side routes to start returning the backend's 404 page ("File not found: dist/<route>") instead of `index.html` — even though SPA mode is enabled. Toggling SPA off/on in the domain settings fixes it, until the next restart.

## Root cause

The primary-domain nginx config has **two generation paths that diverged**:

- **`DomainsService` create/update** branches on `isPrimary` and calls `generatePrimaryDomainConfig` — the correct generator (handles `wwwBehavior` serve-both/redirect, SPA fallback, and the `/_bffless/auth` relay).
- **Regeneration paths** — startup (`NginxStartupService.regenerateDomainMappingConfigs`) and proxy-rule changes (`NginxRegenerationService.regenerateForAlias → regenerateDomainConfig`) — call `generateConfig`, which had **no `isPrimary` branch**. The primary mapping fell through to the custom-domain/subdomain Handlebars template, producing a different config that dropped the serve-both `www` server block and SPA wiring.

So any regeneration silently overwrote the primary domain's config with a non-primary one. A domain **save** restored it (different code path), which is why toggling SPA "fixed" it.

This also explains the earlier "SPA setting got overwritten when I changed a pipeline" report — editing a proxy rule triggers `regenerateForAlias`, same buggy path.

## Fix

Add the `isPrimary` branch to `generateConfig` so **every** regeneration path delegates to the primary generator (`generateCEPrimaryDomainConfig` / `generatePlatformPrimaryDomainConfig`), exactly as `DomainsService` does on save.

`DomainsService` keeps its own `isPrimary` branch and never reaches this code for primary mappings, so only the (buggy) regeneration paths change behavior.

## Tests

Adds a regression test: `generateConfig` on an `isPrimary` mapping must produce the primary-domain config with the `Primary Domain Configuration` header, `www` server handling, `@spa_fallback`, and the `location /_bffless/auth/` block — i.e. SPA + www + auth relay survive regeneration. Full `nginx-config.service.spec` passes (17/17); `tsc` clean.

## Related

Builds on #308 (which added the `/_bffless/auth/` block to the primary generators). Together: #308 makes the primary generator emit the auth relay; this PR makes regeneration actually use the primary generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)