### PR TITLE
feat: custom response headers via UI editor + MCP tools

### DIFF
--- a/apps/backend/src/mcp/mcp-tools.module.ts
+++ b/apps/backend/src/mcp/mcp-tools.module.ts
@@ -9,6 +9,7 @@ import { UsersModule } from '../users/users.module';
 import { ApiKeysModule } from '../api-keys/api-keys.module';
 import { ProxyRulesModule } from '../proxy-rules/proxy-rules.module';
 import { CacheRulesModule } from '../cache-rules/cache-rules.module';
+import { ResponseHeaderRulesModule } from '../response-header-rules/response-header-rules.module';
 import { ProjectTools } from './tools/project.tools';
 import { DeploymentTools } from './tools/deployment.tools';
 import { DomainTools } from './tools/domain.tools';
@@ -18,6 +19,7 @@ import { UserTools } from './tools/user.tools';
 import { ApiKeyTools } from './tools/api-key.tools';
 import { ProxyRulesTools } from './tools/proxy-rules.tools';
 import { CacheRulesTools } from './tools/cache-rules.tools';
+import { ResponseHeaderRulesTools } from './tools/response-header-rules.tools';
 import { StorageTools } from './tools/storage.tools';
 
 const ALL_TOOLS = [
@@ -30,6 +32,7 @@ const ALL_TOOLS = [
   ApiKeyTools,
   ProxyRulesTools,
   CacheRulesTools,
+  ResponseHeaderRulesTools,
   StorageTools,
 ];
 
@@ -48,6 +51,7 @@ const ALL_TOOLS = [
     ApiKeysModule,
     ProxyRulesModule,
     CacheRulesModule,
+    ResponseHeaderRulesModule,
     McpModule.forFeature(ALL_TOOLS, 'bffless-ce'),
   ],
   providers: ALL_TOOLS,

--- a/apps/backend/src/mcp/tools/response-header-rules.tools.ts
+++ b/apps/backend/src/mcp/tools/response-header-rules.tools.ts
@@ -1,0 +1,180 @@
+import { Injectable } from '@nestjs/common';
+import { Tool, Context } from '@rekog/mcp-nest';
+import { z } from 'zod';
+import { Request } from 'express';
+import { ResponseHeaderRulesService } from '../../response-header-rules/response-header-rules.service';
+import { AuthService } from '../../auth/auth.service';
+import { getUserContext } from '../helpers/user-context.helper';
+
+const framePolicySchema = z
+  .enum(['sameorigin', 'allow', 'deny'])
+  .describe(
+    'Frame embedding policy. "sameorigin" = same-origin framing only (default), "allow" = allow the origins in allowedOrigins, "deny" = block all framing.',
+  );
+
+const allowedOriginsSchema = z
+  .array(z.string())
+  .describe(
+    'Full origins allowed to iframe the content when framePolicy is "allow", e.g. ["https://example.com"]. Leave empty to allow all origins.',
+  );
+
+const customHeadersSchema = z
+  .record(z.string(), z.string().nullable())
+  .describe(
+    'Arbitrary response headers to set on matching files, as { "Header-Name": "value" }. ' +
+      'Set a value to null to REMOVE a default header. ' +
+      'Use this for headers unrelated to framing, e.g. cross-origin isolation: ' +
+      '{ "Cross-Origin-Opener-Policy": "same-origin", "Cross-Origin-Embedder-Policy": "credentialless" }.',
+  );
+
+@Injectable()
+export class ResponseHeaderRulesTools {
+  constructor(
+    private readonly responseHeaderRulesService: ResponseHeaderRulesService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Tool({
+    name: 'list_response_header_rules',
+    description:
+      'List all response header rules for a project. Rules control iframe embedding (CSP frame-ancestors / X-Frame-Options) and arbitrary custom response headers per path pattern, evaluated in priority order (first match wins).',
+    parameters: z.object({
+      projectId: z.string().describe('Project ID'),
+    }),
+  })
+  async listRules(
+    { projectId }: { projectId: string },
+    _context: Context,
+    _request: Request,
+  ) {
+    const result =
+      await this.responseHeaderRulesService.getRulesByProjectId(projectId);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'get_response_header_rule',
+    description: 'Get a single response header rule by ID.',
+    parameters: z.object({
+      id: z.string().describe('Response header rule ID'),
+    }),
+  })
+  async getRule({ id }: { id: string }, _context: Context, _request: Request) {
+    const result = await this.responseHeaderRulesService.getRuleById(id);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'create_response_header_rule',
+    description:
+      'Create a response header rule for a project. Matches files by glob pattern and applies frame-embedding policy and/or arbitrary custom response headers. ' +
+      'For cross-origin isolation (SharedArrayBuffer / multithreaded WASM), set pathPattern "**" and customHeaders { "Cross-Origin-Opener-Policy": "same-origin", "Cross-Origin-Embedder-Policy": "credentialless" }.',
+    parameters: z.object({
+      projectId: z.string().describe('Project ID'),
+      pathPattern: z
+        .string()
+        .describe(
+          'Glob pattern matched against the deployment file path, e.g. "embed/**", "*.html", "**" (all files).',
+        ),
+      framePolicy: framePolicySchema.optional(),
+      allowedOrigins: allowedOriginsSchema.optional(),
+      customHeaders: customHeadersSchema.optional(),
+      priority: z
+        .number()
+        .optional()
+        .describe('Rule priority. Lower = evaluated first. Auto-assigned if omitted.'),
+      isEnabled: z
+        .boolean()
+        .optional()
+        .describe('Whether the rule is active (default true).'),
+      name: z.string().optional().describe('Human-readable rule name.'),
+      description: z.string().optional().describe("Explanation of the rule's purpose."),
+    }),
+  })
+  async createRule(
+    args: {
+      projectId: string;
+      pathPattern: string;
+      framePolicy?: 'sameorigin' | 'allow' | 'deny';
+      allowedOrigins?: string[];
+      customHeaders?: Record<string, string | null>;
+      priority?: number;
+      isEnabled?: boolean;
+      name?: string;
+      description?: string;
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const { projectId, ...dto } = args;
+    const result = await this.responseHeaderRulesService.create(
+      projectId,
+      dto,
+      user.id,
+      user.role,
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'update_response_header_rule',
+    description:
+      'Update a response header rule. Only provided fields are changed. ' +
+      'NOTE: customHeaders REPLACES the existing custom headers object entirely — read the current rule first and merge if doing a partial update.',
+    parameters: z.object({
+      id: z.string().describe('Response header rule ID to update'),
+      pathPattern: z.string().optional().describe('New glob path pattern.'),
+      framePolicy: framePolicySchema.optional(),
+      allowedOrigins: allowedOriginsSchema.optional(),
+      customHeaders: customHeadersSchema.optional(),
+      priority: z.number().optional().describe('New priority (lower = evaluated first).'),
+      isEnabled: z.boolean().optional().describe('Enable or disable the rule.'),
+      name: z.string().optional().describe('New rule name.'),
+      description: z.string().optional().describe('New description.'),
+    }),
+  })
+  async updateRule(
+    args: {
+      id: string;
+      pathPattern?: string;
+      framePolicy?: 'sameorigin' | 'allow' | 'deny';
+      allowedOrigins?: string[];
+      customHeaders?: Record<string, string | null>;
+      priority?: number;
+      isEnabled?: boolean;
+      name?: string;
+      description?: string;
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const { id, ...dto } = args;
+    const result = await this.responseHeaderRulesService.update(
+      id,
+      dto,
+      user.id,
+      user.role,
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'delete_response_header_rule',
+    description: 'Delete a response header rule.',
+    parameters: z.object({
+      id: z.string().describe('Response header rule ID to delete'),
+    }),
+    annotations: { destructiveHint: true },
+  })
+  async deleteRule(
+    { id }: { id: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    await this.responseHeaderRulesService.delete(id, user.id, user.role);
+    return JSON.stringify({ success: true, id });
+  }
+}

--- a/apps/frontend/src/components/project/ProjectResponseHeaderRulesTab.tsx
+++ b/apps/frontend/src/components/project/ProjectResponseHeaderRulesTab.tsx
@@ -127,6 +127,9 @@ export function ProjectResponseHeaderRulesTab({ project }: ProjectResponseHeader
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [ruleToDelete, setRuleToDelete] = useState<ResponseHeaderRule | null>(null);
   const [originsText, setOriginsText] = useState('');
+  const [customHeaderRows, setCustomHeaderRows] = useState<
+    { name: string; value: string }[]
+  >([]);
 
   const {
     data: rules,
@@ -142,6 +145,7 @@ export function ProjectResponseHeaderRulesTab({ project }: ProjectResponseHeader
     setEditingRule(null);
     setRuleForm(defaultRuleForm);
     setOriginsText('');
+    setCustomHeaderRows([]);
     setShowRuleDialog(true);
   };
 
@@ -155,6 +159,7 @@ export function ProjectResponseHeaderRulesTab({ project }: ProjectResponseHeader
       description: preset.description,
     });
     setOriginsText(preset.allowedOrigins.join('\n'));
+    setCustomHeaderRows([]);
   };
 
   const handleEditRule = (rule: ResponseHeaderRule) => {
@@ -170,8 +175,29 @@ export function ProjectResponseHeaderRulesTab({ project }: ProjectResponseHeader
       description: rule.description || '',
     });
     setOriginsText(origins.join('\n'));
+    setCustomHeaderRows(
+      Object.entries(rule.customHeaders || {}).map(([name, value]) => ({
+        name,
+        value: value ?? '',
+      })),
+    );
     setShowRuleDialog(true);
   };
+
+  const addCustomHeaderRow = () =>
+    setCustomHeaderRows((rows) => [...rows, { name: '', value: '' }]);
+
+  const updateCustomHeaderRow = (
+    index: number,
+    field: 'name' | 'value',
+    next: string,
+  ) =>
+    setCustomHeaderRows((rows) =>
+      rows.map((row, i) => (i === index ? { ...row, [field]: next } : row)),
+    );
+
+  const removeCustomHeaderRow = (index: number) =>
+    setCustomHeaderRows((rows) => rows.filter((_, i) => i !== index));
 
   const handleSaveRule = async () => {
     // Parse origins from textarea
@@ -180,9 +206,23 @@ export function ProjectResponseHeaderRulesTab({ project }: ProjectResponseHeader
       .map((s) => s.trim())
       .filter(Boolean);
 
+    // Build custom headers from key/value rows.
+    // Blank value => null, which removes a default header on matching responses.
+    const customHeaders = customHeaderRows.reduce<Record<string, string | null>>(
+      (acc, { name, value }) => {
+        const headerName = name.trim();
+        if (!headerName) return acc;
+        const trimmedValue = value.trim();
+        acc[headerName] = trimmedValue === '' ? null : trimmedValue;
+        return acc;
+      },
+      {},
+    );
+
     const formData = {
       ...ruleForm,
       allowedOrigins: origins,
+      customHeaders,
     };
 
     try {
@@ -204,6 +244,7 @@ export function ProjectResponseHeaderRulesTab({ project }: ProjectResponseHeader
       setEditingRule(null);
       setRuleForm(defaultRuleForm);
       setOriginsText('');
+      setCustomHeaderRows([]);
     } catch (err: any) {
       toast({
         title: 'Error',
@@ -321,6 +362,13 @@ export function ProjectResponseHeaderRulesTab({ project }: ProjectResponseHeader
                         {rule.name && (
                           <span className="text-xs text-muted-foreground">{rule.name}</span>
                         )}
+                        {rule.customHeaders &&
+                          Object.keys(rule.customHeaders).length > 0 && (
+                            <span className="text-xs text-muted-foreground">
+                              {Object.keys(rule.customHeaders).length} custom header
+                              {Object.keys(rule.customHeaders).length === 1 ? '' : 's'}
+                            </span>
+                          )}
                       </div>
                     </TableCell>
                     <TableCell>
@@ -487,6 +535,52 @@ export function ProjectResponseHeaderRulesTab({ project }: ProjectResponseHeader
                 </p>
               </div>
             )}
+
+            {/* Custom Headers */}
+            <div className="space-y-2">
+              <Label>Custom Headers (optional)</Label>
+              <div className="space-y-2">
+                {customHeaderRows.map((row, index) => (
+                  <div key={index} className="flex items-center gap-2">
+                    <Input
+                      value={row.name}
+                      onChange={(e) =>
+                        updateCustomHeaderRow(index, 'name', e.target.value)
+                      }
+                      placeholder="Header-Name"
+                      className="font-mono text-sm"
+                    />
+                    <Input
+                      value={row.value}
+                      onChange={(e) =>
+                        updateCustomHeaderRow(index, 'value', e.target.value)
+                      }
+                      placeholder="value"
+                      className="font-mono text-sm"
+                    />
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => removeCustomHeaderRow(index)}
+                      aria-label="Remove header"
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+              <Button variant="outline" size="sm" onClick={addCustomHeaderRow}>
+                <Plus className="h-4 w-4 mr-2" />
+                Add header
+              </Button>
+              <p className="text-xs text-muted-foreground">
+                Arbitrary response headers applied to matching files (e.g.{' '}
+                <code className="text-xs bg-muted px-1 rounded">
+                  Cross-Origin-Opener-Policy
+                </code>
+                ). Leave the value blank to remove a default header.
+              </p>
+            </div>
 
             {/* Priority */}
             <div className="space-y-2">


### PR DESCRIPTION
## Summary

Generalizes **Response Header Rules** so any HTTP response header can be configured — not just frame-embedding ones — and exposes the feature over MCP. Motivated by needing `Cross-Origin-Opener-Policy` / `Cross-Origin-Embedder-Policy` on a hosted SPA to unlock `SharedArrayBuffer` / multithreaded WASM.

**No schema change / no migration.** The persistence was already general — `response_header_rules.custom_headers` (JSONB) and `applyHeaders()` already set/removed arbitrary headers (`null` = remove). The coupling lived only in the two *surfaces*, which this PR fixes.

## Changes

**Frontend** (`ProjectResponseHeaderRulesTab.tsx`)
- New "Custom Headers (optional)" key/value editor in the create/edit dialog (add row, name + value, remove; blank value = remove a default header).
- Frame-embedding fields untouched; the rules table shows a per-rule custom-header count.
- RTK Query types already carried `customHeaders`, so no API-layer change.

**Backend** (`mcp/tools/response-header-rules.tools.ts` + `mcp-tools.module.ts`)
- New `ResponseHeaderRulesTools`: `list` / `get` / `create` / `update` / `delete`, wired into `McpToolsModule` (import, `ALL_TOOLS`, module `imports`).
- `create`/`update` expose `customHeaders`; tool descriptions document the COOP/COEP cross-origin-isolation recipe and warn that `customHeaders` **replaces** the whole object on update (read-then-merge for partial updates).

## Backwards compatibility

`framePolicy` / `allowedOrigins` and all existing rules behave identically; `customHeaders` is purely additive.

## Example (COOP/COEP)

```
create_response_header_rule(
  projectId: "<id>",
  pathPattern: "**",
  customHeaders: {
    "Cross-Origin-Opener-Policy": "same-origin",
    "Cross-Origin-Embedder-Policy": "credentialless"
  }
)
```

## Testing

- `tsc --noEmit` passes for both backend and frontend.
- DI: `ResponseHeaderRulesModule` exports the service and is imported by `McpToolsModule`; `AuthService` is global via `AuthModule.forRoot()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)