### PR TITLE
fix: stream only requested byte range in file_serve_handler

### DIFF
--- a/apps/backend/src/pipelines/handlers/file-serve.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/file-serve.handler.spec.ts
@@ -1,0 +1,118 @@
+import { FileServeHandler } from './file-serve.handler';
+import { StepHandlerRegistry } from '../execution/step-handler.registry';
+import { IStorageAdapter } from '../../storage/storage.interface';
+import { CacheConfigService } from '../../cache-rules/cache-config.service';
+import { PipelineContext } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+
+describe('FileServeHandler — streaming & range', () => {
+  const makeRes = () => {
+    const res: any = {
+      headersSent: false,
+      writableEnded: false,
+      setHeader: jest.fn(),
+      end: jest.fn(),
+      on: jest.fn(),
+      json: jest.fn(),
+    };
+    res.status = jest.fn(() => res);
+    return res;
+  };
+
+  const makeStream = () => ({ pipe: jest.fn(), on: jest.fn(), destroy: jest.fn() });
+
+  const buildHandler = (storage: Partial<IStorageAdapter>) => {
+    const registry = { register: jest.fn() } as unknown as StepHandlerRegistry;
+    const cacheConfigService = {
+      getCacheConfig: jest.fn().mockResolvedValue({ source: 'default' }),
+      buildCacheControlHeader: jest.fn(),
+    } as unknown as CacheConfigService;
+    return new FileServeHandler(registry, storage as IStorageAdapter, cacheConfigService);
+  };
+
+  const step = {
+    id: 'serve',
+    name: 'serve',
+    handlerType: 'file_serve_handler',
+    config: { subDir: 'export' },
+  } as unknown as PipelineStep;
+
+  const buildContext = (res: any, headers: Record<string, unknown>): PipelineContext =>
+    ({
+      projectId: 'p1',
+      deployment: { owner: 'o', repo: 'r', commitSha: 'sha' },
+      metadata: { path: '/api/uploads/export/video.mp4', headers },
+      request: { res },
+    }) as unknown as PipelineContext;
+
+  const STORAGE_KEY = 'o/r/uploads/export/video.mp4';
+
+  it('serves a range request by fetching only the requested bytes and piping (206)', async () => {
+    const stream = makeStream();
+    const storage = {
+      downloadStream: jest.fn().mockResolvedValue({ stream, size: 10000, etag: 'abc' }),
+      getMetadata: jest.fn().mockResolvedValue({ key: STORAGE_KEY, size: 10000, etag: 'abc' }),
+    };
+    const handler = buildHandler(storage);
+    const res = makeRes();
+
+    await handler.execute(buildContext(res, { range: 'bytes=0-1023' }), step);
+
+    // Only the requested range is fetched from storage.
+    expect(storage.downloadStream).toHaveBeenCalledWith(STORAGE_KEY, { start: 0, end: 1023 });
+    expect(res.status).toHaveBeenCalledWith(206);
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Range', 'bytes 0-1023/10000');
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Length', 1024);
+    expect(res.setHeader).toHaveBeenCalledWith('Accept-Ranges', 'bytes');
+    expect(stream.pipe).toHaveBeenCalledWith(res);
+  });
+
+  it('treats an open-ended range (bytes=0-) as through end of file', async () => {
+    const stream = makeStream();
+    const storage = {
+      downloadStream: jest.fn().mockResolvedValue({ stream, size: 10000, etag: 'abc' }),
+      getMetadata: jest.fn().mockResolvedValue({ key: STORAGE_KEY, size: 10000, etag: 'abc' }),
+    };
+    const handler = buildHandler(storage);
+    const res = makeRes();
+
+    await handler.execute(buildContext(res, { range: 'bytes=0-' }), step);
+
+    expect(storage.downloadStream).toHaveBeenCalledWith(STORAGE_KEY, { start: 0, end: 9999 });
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Range', 'bytes 0-9999/10000');
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Length', 10000);
+  });
+
+  it('streams the whole object with no range options when there is no Range header (200)', async () => {
+    const stream = makeStream();
+    const storage = {
+      downloadStream: jest.fn().mockResolvedValue({ stream, size: 10000, etag: 'abc' }),
+      getMetadata: jest.fn(),
+    };
+    const handler = buildHandler(storage);
+    const res = makeRes();
+
+    await handler.execute(buildContext(res, {}), step);
+
+    expect(storage.downloadStream).toHaveBeenCalledWith(STORAGE_KEY);
+    expect(storage.getMetadata).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Length', 10000);
+    expect(stream.pipe).toHaveBeenCalledWith(res);
+  });
+
+  it('returns 416 for an unsatisfiable range without touching storage data', async () => {
+    const storage = {
+      downloadStream: jest.fn(),
+      getMetadata: jest.fn().mockResolvedValue({ key: STORAGE_KEY, size: 1000, etag: 'abc' }),
+    };
+    const handler = buildHandler(storage);
+    const res = makeRes();
+
+    await handler.execute(buildContext(res, { range: 'bytes=2000-3000' }), step);
+
+    expect(res.status).toHaveBeenCalledWith(416);
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Range', 'bytes */1000');
+    expect(storage.downloadStream).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/pipelines/handlers/file-serve.handler.ts
+++ b/apps/backend/src/pipelines/handlers/file-serve.handler.ts
@@ -180,6 +180,11 @@ export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
   /**
    * Stream file directly from storage to response.
    * Supports HTTP Range requests for video/audio seeking.
+   *
+   * For range requests, only the requested byte range is fetched from storage
+   * (via downloadStream's range options) and piped straight to the response so
+   * backpressure is honored — never buffering the whole object in memory or
+   * pulling the full file from storage for a partial request.
    */
   private async serveWithStream(
     storageKey: string,
@@ -188,29 +193,50 @@ export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
     context: PipelineContext,
     res: any,
   ): Promise<StepResult> {
-    const result = await this.storageAdapter.downloadStream!(storageKey);
-    const fileSize = result.size;
     const rangeHeader = context.metadata.headers['range'] as string | undefined;
 
-    // Common headers for all responses
+    // Mix cache-control into ETag so CDN refetches when cache rules change
+    const setEtag = (etag?: string) => {
+      if (!etag) return;
+      const combined = crypto
+        .createHash('md5')
+        .update(`${etag.replace(/"/g, '')}:${cacheControlHeader}`)
+        .digest('hex');
+      res.setHeader('ETag', `"${combined}"`);
+    };
+
+    // Pipe a storage stream to the response with backpressure + cleanup.
+    const pipeStream = (stream: NodeJS.ReadableStream) => {
+      stream.pipe(res);
+      stream.on('error', (err: Error) => {
+        this.logger.error(`Stream error during serve: ${err.message}`);
+        if (!res.headersSent) {
+          res.status(500).json({ error: 'Stream error' });
+        } else if (!res.writableEnded) {
+          res.end();
+        }
+      });
+      // If the client disconnects mid-stream (common when scrubbing video,
+      // which cancels in-flight range requests), stop pulling from storage.
+      res.on('close', () => {
+        if (!res.writableEnded && typeof (stream as any).destroy === 'function') {
+          (stream as any).destroy();
+        }
+      });
+    };
+
     res.setHeader('Accept-Ranges', 'bytes');
     res.setHeader('Cache-Control', cacheControlHeader);
-    if (result.etag) {
-      // Mix cache-control into ETag so CDN refetches when cache rules change
-      const combined = crypto.createHash('md5').update(`${result.etag.replace(/"/g, '')}:${cacheControlHeader}`).digest('hex');
-      res.setHeader('ETag', `"${combined}"`);
-    }
 
     if (rangeHeader) {
-      // Parse Range header (e.g., "bytes=0-1023")
+      // Need the total object size to validate the range and build Content-Range.
+      const meta = await this.storageAdapter.getMetadata(storageKey);
+      const fileSize = meta.size;
+
       const match = rangeHeader.match(/bytes=(\d*)-(\d*)/);
       if (!match) {
         res.status(416).setHeader('Content-Range', `bytes */${fileSize}`);
         res.end();
-        // Destroy the unused stream to prevent resource leaks
-        if (typeof (result.stream as any).destroy === 'function') {
-          (result.stream as any).destroy();
-        }
         return { success: true, terminates: true };
       }
 
@@ -220,76 +246,29 @@ export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
       if (start >= fileSize || end >= fileSize || start > end) {
         res.status(416).setHeader('Content-Range', `bytes */${fileSize}`);
         res.end();
-        if (typeof (result.stream as any).destroy === 'function') {
-          (result.stream as any).destroy();
-        }
         return { success: true, terminates: true };
       }
 
-      const chunkSize = end - start + 1;
+      // Fetch ONLY the requested range from storage.
+      const { stream } = await this.storageAdapter.downloadStream!(storageKey, { start, end });
 
       res.setHeader('Content-Type', contentType);
-      res.setHeader('Content-Length', chunkSize);
+      res.setHeader('Content-Length', end - start + 1);
       res.setHeader('Content-Range', `bytes ${start}-${end}/${fileSize}`);
+      setEtag(meta.etag);
       res.status(206);
 
-      // For range requests, we need to slice the stream
-      // Pipe through and track bytes to only send the requested range
-      let bytesRead = 0;
-      const stream = result.stream;
-
-      stream.on('data', (chunk: Buffer) => {
-        const chunkStart = bytesRead;
-        const chunkEnd = bytesRead + chunk.length;
-        bytesRead += chunk.length;
-
-        // Calculate overlap between this chunk and the requested range
-        const overlapStart = Math.max(chunkStart, start);
-        const overlapEnd = Math.min(chunkEnd, end + 1);
-
-        if (overlapStart < overlapEnd) {
-          const slice = chunk.slice(overlapStart - chunkStart, overlapEnd - chunkStart);
-          res.write(slice);
-        }
-
-        // If we've read past the end, we can stop
-        if (bytesRead > end) {
-          if (typeof (stream as any).destroy === 'function') {
-            (stream as any).destroy();
-          }
-          res.end();
-        }
-      });
-
-      stream.on('end', () => {
-        if (!res.writableEnded) {
-          res.end();
-        }
-      });
-
-      stream.on('error', (err: Error) => {
-        this.logger.error(`Stream error during range serve: ${err.message}`);
-        if (!res.headersSent) {
-          res.status(500).json({ error: 'Stream error' });
-        } else if (!res.writableEnded) {
-          res.end();
-        }
-      });
+      pipeStream(stream);
     } else {
-      // Full file response — stream directly
+      // Full file response — stream directly.
+      const result = await this.storageAdapter.downloadStream!(storageKey);
+
       res.setHeader('Content-Type', contentType);
-      res.setHeader('Content-Length', fileSize);
+      res.setHeader('Content-Length', result.size);
+      setEtag(result.etag);
       res.status(200);
 
-      const stream = result.stream;
-      stream.pipe(res);
-
-      stream.on('error', (err: Error) => {
-        this.logger.error(`Stream error during full serve: ${err.message}`);
-        if (!res.writableEnded) {
-          res.end();
-        }
-      });
+      pipeStream(result.stream);
     }
 
     return {

--- a/apps/backend/src/storage/azure.adapter.ts
+++ b/apps/backend/src/storage/azure.adapter.ts
@@ -8,7 +8,12 @@ import {
   SASProtocol,
 } from '@azure/storage-blob';
 import { DefaultAzureCredential, ManagedIdentityCredential } from '@azure/identity';
-import { IStorageAdapter, FileMetadata, StreamDownloadResult } from './storage.interface';
+import {
+  IStorageAdapter,
+  FileMetadata,
+  StreamDownloadResult,
+  DownloadStreamOptions,
+} from './storage.interface';
 import { AzureBlobStorageConfig, validateAzureConfig } from './azure.config';
 
 /**
@@ -149,14 +154,21 @@ export class AzureBlobStorageAdapter implements IStorageAdapter {
   /**
    * Download a file as a stream without buffering into memory
    */
-  async downloadStream(key: string): Promise<StreamDownloadResult> {
+  async downloadStream(
+    key: string,
+    opts?: DownloadStreamOptions,
+  ): Promise<StreamDownloadResult> {
     const sanitizedKey = this.sanitizeKey(key);
     const storageKey = this.prefixKey(sanitizedKey);
     const blockBlobClient = this.containerClient.getBlockBlobClient(storageKey);
 
     try {
       const properties = await blockBlobClient.getProperties();
-      const downloadResponse = await blockBlobClient.download(0);
+      // download(offset, count): count undefined reads to end. Bounds inclusive
+      // (HTTP Range), so count = end - start + 1.
+      const offset = opts?.start ?? 0;
+      const count = opts?.end !== undefined ? opts.end - offset + 1 : undefined;
+      const downloadResponse = await blockBlobClient.download(offset, count);
 
       if (!downloadResponse.readableStreamBody) {
         throw new Error('Empty response body');

--- a/apps/backend/src/storage/cache/caching-storage.adapter.ts
+++ b/apps/backend/src/storage/cache/caching-storage.adapter.ts
@@ -1,5 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { IStorageAdapter, FileMetadata, DownloadResult, StreamDownloadResult } from '../storage.interface';
+import {
+  IStorageAdapter,
+  FileMetadata,
+  DownloadResult,
+  StreamDownloadResult,
+  DownloadStreamOptions,
+} from '../storage.interface';
 import { ICacheAdapter, CacheConfig } from './cache.interface';
 
 /**
@@ -176,11 +182,14 @@ export class CachingStorageAdapter implements IStorageAdapter {
    * Large files (video/audio) should not be cached in the application layer.
    * CDN and browser caching via Cache-Control/ETag headers handle repeat requests.
    */
-  async downloadStream(key: string): Promise<StreamDownloadResult> {
+  async downloadStream(
+    key: string,
+    opts?: DownloadStreamOptions,
+  ): Promise<StreamDownloadResult> {
     if (!this.storage.downloadStream) {
       throw new Error('Underlying storage adapter does not support streaming');
     }
-    return this.storage.downloadStream(key);
+    return this.storage.downloadStream(key, opts);
   }
 
   /**

--- a/apps/backend/src/storage/gcs.adapter.ts
+++ b/apps/backend/src/storage/gcs.adapter.ts
@@ -1,6 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Storage, Bucket, GetSignedUrlConfig } from '@google-cloud/storage';
-import { IStorageAdapter, FileMetadata, StreamDownloadResult } from './storage.interface';
+import {
+  IStorageAdapter,
+  FileMetadata,
+  StreamDownloadResult,
+  DownloadStreamOptions,
+} from './storage.interface';
 import { GcsStorageConfig, validateGcsConfig } from './gcs.config';
 
 /**
@@ -119,14 +124,14 @@ export class GcsStorageAdapter implements IStorageAdapter {
   /**
    * Download a file as a stream without buffering into memory
    */
-  async downloadStream(key: string): Promise<StreamDownloadResult> {
+  async downloadStream(key: string, opts?: DownloadStreamOptions): Promise<StreamDownloadResult> {
     const sanitizedKey = this.sanitizeKey(key);
     const storageKey = this.prefixKey(sanitizedKey);
     const blob = this.bucket.file(storageKey);
 
     try {
       const [metadata] = await blob.getMetadata();
-      const stream = blob.createReadStream();
+      const stream = blob.createReadStream({ start: opts?.start, end: opts?.end });
 
       return {
         stream,

--- a/apps/backend/src/storage/local.adapter.ts
+++ b/apps/backend/src/storage/local.adapter.ts
@@ -1,5 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { IStorageAdapter, FileMetadata, StreamDownloadResult } from './storage.interface';
+import {
+  IStorageAdapter,
+  FileMetadata,
+  StreamDownloadResult,
+  DownloadStreamOptions,
+} from './storage.interface';
 import * as fs from 'fs/promises';
 import * as fsSync from 'fs';
 import * as path from 'path';
@@ -93,14 +98,21 @@ export class LocalStorageAdapter implements IStorageAdapter {
   /**
    * Download a file as a stream without buffering into memory
    */
-  async downloadStream(key: string): Promise<StreamDownloadResult> {
+  async downloadStream(
+    key: string,
+    opts?: DownloadStreamOptions,
+  ): Promise<StreamDownloadResult> {
     const sanitizedKey = this.sanitizeKey(key);
     const storageKey = this.prefixKey(sanitizedKey);
     const fullPath = path.join(this.basePath, storageKey);
 
     try {
       const stats = await fs.stat(fullPath);
-      const stream = fsSync.createReadStream(fullPath);
+      // fs.createReadStream start/end are inclusive byte offsets (HTTP Range).
+      const hasRange = opts?.start !== undefined || opts?.end !== undefined;
+      const stream = hasRange
+        ? fsSync.createReadStream(fullPath, { start: opts?.start ?? 0, end: opts?.end })
+        : fsSync.createReadStream(fullPath);
       const mimeType = this.guessMimeType(sanitizedKey);
 
       return {

--- a/apps/backend/src/storage/minio.adapter.ts
+++ b/apps/backend/src/storage/minio.adapter.ts
@@ -1,5 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { IStorageAdapter, FileMetadata, StreamDownloadResult } from './storage.interface';
+import {
+  IStorageAdapter,
+  FileMetadata,
+  StreamDownloadResult,
+  DownloadStreamOptions,
+} from './storage.interface';
 import * as Minio from 'minio';
 
 export interface MinioConfig {
@@ -132,13 +137,25 @@ export class MinioStorageAdapter implements IStorageAdapter {
   /**
    * Download a file as a stream without buffering into memory
    */
-  async downloadStream(key: string): Promise<StreamDownloadResult> {
+  async downloadStream(
+    key: string,
+    opts?: DownloadStreamOptions,
+  ): Promise<StreamDownloadResult> {
     const sanitizedKey = this.sanitizeKey(key);
     const storageKey = this.prefixKey(sanitizedKey);
 
     try {
       const stat = await this.client.statObject(this.bucket, storageKey);
-      const stream = await this.client.getObject(this.bucket, storageKey);
+
+      // When a byte range is requested, fetch only that range from storage via
+      // getPartialObject so large videos/audio are never pulled in full.
+      // length 0 means "to end of object". Bounds are inclusive (HTTP Range).
+      const hasRange = opts?.start !== undefined || opts?.end !== undefined;
+      const offset = opts?.start ?? 0;
+      const length = opts?.end !== undefined ? opts.end - offset + 1 : 0;
+      const stream = hasRange
+        ? await this.client.getPartialObject(this.bucket, storageKey, offset, length)
+        : await this.client.getObject(this.bucket, storageKey);
 
       return {
         stream,

--- a/apps/backend/src/storage/storage.interface.ts
+++ b/apps/backend/src/storage/storage.interface.ts
@@ -55,10 +55,21 @@ export interface DownloadResult {
 }
 
 /**
+ * Byte range for downloadStream (both bounds inclusive, like HTTP Range)
+ */
+export interface DownloadStreamOptions {
+  /** First byte to read (inclusive). Defaults to 0. */
+  start?: number;
+  /** Last byte to read (inclusive). Defaults to end of file. */
+  end?: number;
+}
+
+/**
  * Result from downloadStream for streaming file access
  */
 export interface StreamDownloadResult {
   stream: NodeJS.ReadableStream;
+  /** Total object size in bytes (not the range length) */
   size: number;
   etag?: string;
   mimeType?: string;
@@ -162,7 +173,10 @@ export interface IStorageAdapter {
    * Returns the stream along with metadata (size, etag, etc.)
    * Essential for serving large files (videos, images) without OOM.
    * @param key - Storage key/path
+   * @param opts - Optional byte range (inclusive bounds); the stream then
+   *               yields only the requested range, but `size` is still the
+   *               total object size (for Content-Range headers)
    * @returns Stream and metadata
    */
-  downloadStream?(key: string): Promise<StreamDownloadResult>;
+  downloadStream?(key: string, opts?: DownloadStreamOptions): Promise<StreamDownloadResult>;
 }


### PR DESCRIPTION
## Problem

Serving a large video through `file_serve_handler` (e.g. `/api/uploads/export/*`) spiked memory and errored in the browser. Browsers fetch media via HTTP `Range` requests, and the range branch of `serveWithStream` had two compounding bugs:

1. **Whole-object fetch per range request** — `downloadStream(key)` was called with no range, so Minio/S3 (`getObject`) and GCS streamed the **entire** object on every seek/scrub, then discarded everything outside the requested range. j5s.dev runs on Minio/S3 (`S3StorageAdapter extends MinioStorageAdapter`).
2. **No backpressure** — it pumped `stream.on('data') -> res.write(slice)` ignoring `res.write()`'s return value and never pausing the source, so a slow client caused unbounded buffering in the response socket.

Together: the full file was pulled from storage **and** buffered in memory faster than the client could drain it.

## Fix

**Storage layer** — `downloadStream(key, { start, end })` now fetches only the requested byte range (inclusive bounds, HTTP Range semantics):

| Adapter | Ranged read |
|---|---|
| Minio / S3 | `getPartialObject(bucket, key, offset, length)` |
| GCS | `createReadStream({ start, end })` |
| Local | `fs.createReadStream(path, { start, end })` |
| Azure | `download(offset, count)` |
| Caching wrapper | forwards `opts` through (previously dropped) |

**Handler** — `serveWithStream`'s range branch now fetches only `[start, end]` and `stream.pipe(res)` (honors backpressure), replacing the manual chunk-slicing pump. Range validation/`Content-Range` uses `getMetadata` for the total size, and a client disconnect destroys the storage stream (no leaks when scrubbing cancels in-flight requests).

## Tests

`file-serve.handler.spec` covers: 206 ranged read fetches only the requested bytes and pipes; open-ended `bytes=0-`; full 200 with no range options; 416 unsatisfiable range without touching storage data. Backend typecheck clean.

## Notes

This supersedes and completes the earlier WIP that added range support to only the GCS adapter + interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)