### PR TITLE
feat: fetch Anthropic models live from /v1/models

### DIFF
--- a/apps/backend/src/projects/project-ai-settings.service.ts
+++ b/apps/backend/src/projects/project-ai-settings.service.ts
@@ -167,6 +167,14 @@ export class ProjectAISettingsService {
   private readonly ENCRYPTION_KEY: Buffer;
   private readonly ENCRYPTION_ALGORITHM = 'aes-256-gcm';
 
+  /**
+   * In-memory cache of live model lists keyed by a hash of the API key.
+   * Model catalogs change rarely (a few times a year), so a long TTL avoids
+   * hitting the provider's /v1/models endpoint on every status fetch.
+   */
+  private readonly modelsCache = new Map<string, { models: ModelInfo[]; expires: number }>();
+  private readonly MODELS_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
   constructor(private configService: ConfigService) {
     const encryptionKey = this.configService.get<string>('ENCRYPTION_KEY');
     if (encryptionKey) {
@@ -432,19 +440,29 @@ export class ProjectAISettingsService {
     try {
       const stored = await this.getStoredProviders(projectId);
 
-      return stored.map((p) => {
-        const config = JSON.parse(this.decryptData(p.config));
-        const meta = AI_PROVIDER_METADATA[p.provider];
+      return await Promise.all(
+        stored.map(async (p) => {
+          const config = JSON.parse(this.decryptData(p.config));
+          const meta = AI_PROVIDER_METADATA[p.provider];
 
-        return {
-          provider: p.provider,
-          providerName: meta?.name || p.provider,
-          apiKey: config.apiKey,
-          defaultModel: config.defaultModel,
-          isDefault: p.isDefault,
-          suggestedModels: meta?.models || [],
-        };
-      });
+          // For Anthropic, pull the live model list from the provider's API so
+          // newly released models show up without a redeploy. Falls back to the
+          // hardcoded metadata if the fetch fails.
+          const suggestedModels =
+            p.provider === 'anthropic'
+              ? await this.fetchAnthropicModels(config.apiKey)
+              : meta?.models || [];
+
+          return {
+            provider: p.provider,
+            providerName: meta?.name || p.provider,
+            apiKey: config.apiKey,
+            defaultModel: config.defaultModel,
+            isDefault: p.isDefault,
+            suggestedModels,
+          };
+        }),
+      );
     } catch (error) {
       this.logger.error('Failed to get AI providers:', error);
       return [];
@@ -474,6 +492,119 @@ export class ProjectAISettingsService {
       description: meta.description,
       models: meta.models,
     }));
+  }
+
+  /**
+   * Preview the live model list for a provider using a caller-supplied API key.
+   *
+   * Used by the "Add Provider" dialog so the default-model picker reflects the
+   * models the typed key can actually access, before the provider is saved.
+   * Falls back to the hardcoded metadata list (no key, unsupported provider, or
+   * a failed fetch) so the picker is never empty.
+   */
+  async previewProviderModels(provider: AIProviderType, apiKey: string): Promise<ModelInfo[]> {
+    const fallback = AI_PROVIDER_METADATA[provider]?.models || [];
+    if (!apiKey?.trim()) {
+      return fallback;
+    }
+
+    if (provider === 'anthropic') {
+      return this.fetchAnthropicModels(apiKey.trim());
+    }
+
+    // OpenAI/Google live listing not implemented yet — return the static catalog.
+    return fallback;
+  }
+
+  /**
+   * Fetch the live Anthropic model list via GET /v1/models.
+   *
+   * The API returns model IDs + display names only (no tier/description), so we
+   * classify each into a tier locally. Results are cached per-key with a long
+   * TTL, and any failure falls back to the hardcoded catalog so the UI never
+   * ends up with an empty model list.
+   */
+  private async fetchAnthropicModels(apiKey: string): Promise<ModelInfo[]> {
+    const fallback = AI_PROVIDER_METADATA.anthropic.models;
+    if (!apiKey) {
+      return fallback;
+    }
+
+    const cacheKey = crypto.createHash('sha256').update(apiKey).digest('hex');
+    const cached = this.modelsCache.get(cacheKey);
+    if (cached && cached.expires > Date.now()) {
+      return cached.models;
+    }
+
+    try {
+      const response = await fetch('https://api.anthropic.com/v1/models?limit=100', {
+        method: 'GET',
+        headers: {
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+      });
+
+      if (!response.ok) {
+        this.logger.warn(
+          `Anthropic models fetch failed (HTTP ${response.status}); using fallback list`,
+        );
+        return fallback;
+      }
+
+      const data = (await response.json()) as {
+        data?: Array<{ id?: string; display_name?: string }>;
+      };
+      const models = (data.data ?? [])
+        .filter((m): m is { id: string; display_name?: string } => Boolean(m.id))
+        .map((m) => this.toAnthropicModelInfo(m.id, m.display_name));
+
+      if (models.length === 0) {
+        return fallback;
+      }
+
+      this.modelsCache.set(cacheKey, {
+        models,
+        expires: Date.now() + this.MODELS_CACHE_TTL_MS,
+      });
+      return models;
+    } catch (error) {
+      this.logger.warn(
+        `Anthropic models fetch error; using fallback list: ${(error as Error)?.message}`,
+      );
+      return fallback;
+    }
+  }
+
+  /**
+   * Map a live Anthropic model id + display name into our tiered ModelInfo.
+   * Tier is derived from the model family so new releases slot in automatically.
+   */
+  private toAnthropicModelInfo(id: string, displayName?: string): ModelInfo {
+    const tier = this.anthropicTierFor(id);
+    const descriptions: Record<ModelTier, string> = {
+      premium: 'Most intelligent for agents and coding',
+      balanced: 'Best balance of speed and intelligence',
+      economy: 'Fastest with near-frontier intelligence',
+    };
+    return {
+      id,
+      name: displayName || id,
+      tier,
+      description: descriptions[tier],
+    };
+  }
+
+  /**
+   * Classify an Anthropic model id into a pricing/capability tier by family.
+   * Unknown families default to 'balanced' so they remain selectable.
+   */
+  private anthropicTierFor(id: string): ModelTier {
+    const lower = id.toLowerCase();
+    if (lower.includes('opus') || lower.includes('fable')) return 'premium';
+    if (lower.includes('haiku')) return 'economy';
+    if (lower.includes('sonnet')) return 'balanced';
+    return 'balanced';
   }
 
   // ===== Skills Path Settings =====

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -36,6 +36,7 @@ import {
   TestAIResponseDto,
   AIProvidersResponseDto,
   AIProviderEnum,
+  ModelInfoDto,
 } from '../settings/dto/ai-settings.dto';
 import { SkillsService, SkillSummary } from '../pipelines/skills.service';
 import { AIToolPluginService, PluginListItem } from '../pipelines/ai-plugins/ai-tool-plugin.service';
@@ -156,6 +157,28 @@ export class ProjectsController {
     return {
       providers: this.aiSettingsService.getAvailableProviders(),
     };
+  }
+
+  @Post(':id/ai/providers/:provider/models')
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
+  @RequireProjectRole('admin')
+  @ApiOperation({
+    summary: 'Preview live model list for a provider using a supplied API key',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Live (or fallback) model suggestions for the provider',
+    type: [ModelInfoDto],
+  })
+  async previewProviderModels(
+    @Param('provider') provider: AIProviderEnum,
+    @Body() body: { apiKey?: string },
+  ): Promise<{ models: ModelInfoDto[] }> {
+    const models = await this.aiSettingsService.previewProviderModels(
+      provider as AIProviderType,
+      body?.apiKey ?? '',
+    );
+    return { models };
   }
 
   @Get(':id/ai/skills')

--- a/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
+++ b/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import {
   useGetProjectAIStatusQuery,
   useAddProjectAIProviderMutation,
@@ -6,6 +6,7 @@ import {
   useSetProjectDefaultAIProviderMutation,
   useTestProjectAIMutation,
   useGetAvailableAIProvidersQuery,
+  usePreviewProviderModelsMutation,
   useGetProjectAIServicesQuery,
   useAddProjectAIServiceMutation,
   useRemoveProjectAIServiceMutation,
@@ -555,6 +556,7 @@ function ProviderCard({
 function AddProviderDialog({
   open,
   onOpenChange,
+  projectId,
   availableProviders,
   onAdd,
   isAdding,
@@ -563,6 +565,7 @@ function AddProviderDialog({
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  projectId: string;
   availableProviders: { provider: AIProviderType; displayName: string; models: ModelInfo[] }[];
   onAdd: (provider: AIProviderType, apiKey: string, defaultModel: string, isDefault: boolean) => void;
   isAdding: boolean;
@@ -574,8 +577,37 @@ function AddProviderDialog({
   const [defaultModel, setDefaultModel] = useState('');
   // First provider is always default
   const [isDefault, setIsDefault] = useState(isFirstProvider);
+  // Live model list fetched with the entered key (overrides the static catalog)
+  const [liveModels, setLiveModels] = useState<ModelInfo[] | null>(null);
+
+  const [previewModels, { isLoading: isLoadingModels }] = usePreviewProviderModelsMutation();
 
   const selectedProviderInfo = availableProviders.find((p) => p.provider === selectedProvider);
+
+  // When a plausible key is entered, fetch the live model list (debounced) so the
+  // default-model picker reflects models that key can actually access.
+  useEffect(() => {
+    if (!selectedProvider || apiKey.trim().length < 8) {
+      setLiveModels(null);
+      return;
+    }
+    const handle = setTimeout(async () => {
+      try {
+        const result = await previewModels({
+          projectId,
+          provider: selectedProvider,
+          apiKey: apiKey.trim(),
+        }).unwrap();
+        setLiveModels(result.models?.length ? result.models : null);
+      } catch {
+        setLiveModels(null); // fall back to the static catalog
+      }
+    }, 500);
+    return () => clearTimeout(handle);
+  }, [apiKey, selectedProvider, projectId, previewModels]);
+
+  // Prefer live models when available, otherwise the static catalog
+  const modelOptions = liveModels ?? selectedProviderInfo?.models ?? [];
 
   const handleSubmit = () => {
     if (selectedProvider && apiKey.trim()) {
@@ -587,6 +619,7 @@ function AddProviderDialog({
     setSelectedProvider(null);
     setApiKey('');
     setDefaultModel('');
+    setLiveModels(null);
     setIsDefault(isFirstProvider); // Reset to true for first provider
     onOpenChange(false);
   };
@@ -676,11 +709,15 @@ function AddProviderDialog({
                   <ModelSelector
                     value={defaultModel}
                     onChange={setDefaultModel}
-                    suggestedModels={selectedProviderInfo.models}
+                    suggestedModels={modelOptions}
                   />
                 </div>
                 <p className="mt-1 text-xs text-muted-foreground">
-                  Choose a suggested model or type any model ID. Can be overridden per-pipeline.
+                  {isLoadingModels
+                    ? 'Fetching available models for this key…'
+                    : liveModels
+                      ? 'Showing models available to this API key. You can also type any model ID.'
+                      : 'Choose a suggested model or type any model ID. Can be overridden per-pipeline.'}
                 </p>
               </div>
 
@@ -930,6 +967,7 @@ export function ProjectAISettingsTab({ project }: ProjectAISettingsTabProps) {
       <AddProviderDialog
         open={showAddDialog}
         onOpenChange={setShowAddDialog}
+        projectId={project.id}
         availableProviders={availableToAdd}
         onAdd={handleAddProvider}
         isAdding={isAdding}

--- a/apps/frontend/src/services/projectsApi.ts
+++ b/apps/frontend/src/services/projectsApi.ts
@@ -277,6 +277,17 @@ export const projectsApi = api.injectEndpoints({
       query: (projectId) => `/api/projects/${projectId}/ai/providers`,
     }),
 
+    previewProviderModels: builder.mutation<
+      { models: ModelInfo[] },
+      { projectId: string; provider: AIProviderType; apiKey: string }
+    >({
+      query: ({ projectId, provider, apiKey }) => ({
+        url: `/api/projects/${projectId}/ai/providers/${provider}/models`,
+        method: 'POST',
+        body: { apiKey },
+      }),
+    }),
+
     // AI Plugin endpoints
     listProjectPlugins: builder.query<PluginListItem[], string>({
       query: (id) => `/api/projects/${id}/ai-plugins`,
@@ -505,6 +516,7 @@ export const {
   useSetProjectDefaultAIProviderMutation,
   useTestProjectAIMutation,
   useGetAvailableAIProvidersQuery,
+  usePreviewProviderModelsMutation,
   // Plugins
   useListProjectPluginsQuery,
   useEnableProjectPluginMutation,


### PR DESCRIPTION
## Summary

The Anthropic model list was hardcoded in `project-ai-settings.service.ts`, so every new model release required a redeploy to surface in the UI. This pulls the list live from Anthropic's [Models API](https://docs.anthropic.com/en/api/models-list) instead, mirroring the dynamic-fetch pattern already used for OpenAI/Google connection tests.

Both model-picker surfaces are now dynamic:

| Screen | Source | Auth |
|---|---|---|
| Per-pipeline **AI Handler** dropdown | `getAIStatus` → `getAllProviders().suggestedModels` | stored key |
| **AI Settings → Add Provider** default-model picker | new preview endpoint | key being typed |

## Changes

**Backend**
- `fetchAnthropicModels(apiKey)` — `GET /v1/models?limit=100` with `x-api-key` + `anthropic-version: 2023-06-01`; maps `id`/`display_name` → `ModelInfo`, classifies tier by family (opus/fable → premium, sonnet → balanced, haiku → economy, unknown → balanced). Cached per-key (SHA-256, 1h TTL) and **falls back to the hardcoded catalog** on any failure/empty result.
- `getAllProviders()` serves live models for Anthropic.
- `previewProviderModels()` + `POST :id/ai/providers/:provider/models` (admin) for the keyless add flow.

**Frontend**
- `usePreviewProviderModelsMutation`.
- `AddProviderDialog` debounce-fetches live models 500ms after a key (≥8 chars) is entered, prefers them over the static list, and falls back when unavailable.

## Notes
- Tier/description are derived locally — Anthropic's API returns `id`/`display_name`/`created_at` only.
- The per-pipeline dropdown reflects exactly the models each workspace's own key can access.
- OpenAI/Google keep the static catalog (live listing not implemented).

## Testing
- `tsc --noEmit` passes for both backend and frontend.
- No existing tests touch the changed paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)