### PR TITLE
fix: send literal AI handler message text instead of treating it as a field name

### DIFF
--- a/apps/backend/src/pipelines/handlers/ai.handler.ts
+++ b/apps/backend/src/pipelines/handlers/ai.handler.ts
@@ -234,20 +234,22 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
           context,
           stepName,
         );
-      } else if (messageFieldConfig.includes('.')) {
-        // Full expression: request.body.message, steps.form.data
+      } else if (/^[\w.]+$/.test(messageFieldConfig.trim())) {
+        // Field/expression reference (no spaces): a dotted path like
+        // "request.body.message" / "steps.form.data", or a bare field name
+        // "message" → request.body.message.
+        const expression = messageFieldConfig.includes('.')
+          ? messageFieldConfig
+          : `request.body.${messageFieldConfig}`;
         userMessage = this.expressionEvaluator.evaluateExpression(
-          messageFieldConfig,
+          expression,
           context,
           stepName,
         ) as string;
       } else {
-        // Simple field name: "message" → request.body.message
-        userMessage = this.expressionEvaluator.evaluateExpression(
-          `request.body.${messageFieldConfig}`,
-          context,
-          stepName,
-        ) as string;
+        // Literal message text (contains spaces/punctuation, no {{ }} vars):
+        // send it to the model as-is.
+        userMessage = messageFieldConfig;
       }
 
       if (!userMessage || typeof userMessage !== 'string') {


### PR DESCRIPTION
## Problem

Testing an `ai_handler` step in **completion** mode with a literal prompt (e.g. `this is a test`) fails with:

```
MISSING_MESSAGE — Missing or invalid message. Config: 'this is a test'
```

The "Message" box is presented in the UI as a literal template (*"The message to send to the AI. Use template variables like `{{steps.form.message}}`"*), but the handler only treated a value as literal when it contained `{{`. A plain prompt with no `{{` and no `.` fell through to the legacy **bare field-name** branch → `request.body.this is a test` → `undefined` → `MISSING_MESSAGE`.

## Fix

`ai.handler.ts` now resolves `messageField` as a field/expression reference **only when it looks like one** — a bare identifier or dotted path (no spaces). Prose containing spaces is an unambiguous literal message and is sent as-is.

| Input | Treated as | Result |
|---|---|---|
| `this is a test` | literal (has spaces) | sent as-is ✓ (was `MISSING_MESSAGE`) |
| `message` | bare field name | `request.body.message` (legacy, unchanged) |
| `request.body.prompt` | dotted expression | resolved (unchanged) |
| `Summarize: {{request.body.text}}` | template | interpolated (unchanged) |

## Testing
- `tsc --noEmit` passes for backend.
- No existing tests touch this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)