### PR TITLE
fix: normalize live Anthropic model ids to alias form

### DIFF
--- a/apps/backend/src/projects/project-ai-settings.service.ts
+++ b/apps/backend/src/projects/project-ai-settings.service.ts
@@ -555,9 +555,18 @@ export class ProjectAISettingsService {
       const data = (await response.json()) as {
         data?: Array<{ id?: string; display_name?: string }>;
       };
+      // Normalize current models to their stable alias form (e.g. drop the
+      // dated suffix on claude-haiku-4-5-20251001) so the list is consistent —
+      // some entries come back aliased, others dated — then dedupe.
+      const seen = new Set<string>();
       const models = (data.data ?? [])
         .filter((m): m is { id: string; display_name?: string } => Boolean(m.id))
-        .map((m) => this.toAnthropicModelInfo(m.id, m.display_name));
+        .map((m) => this.toAnthropicModelInfo(this.normalizeAnthropicModelId(m.id), m.display_name))
+        .filter((m) => {
+          if (seen.has(m.id)) return false;
+          seen.add(m.id);
+          return true;
+        });
 
       if (models.length === 0) {
         return fallback;
@@ -574,6 +583,20 @@ export class ProjectAISettingsService {
       );
       return fallback;
     }
+  }
+
+  /**
+   * Prefer the stable alias form for current Claude models by dropping the
+   * trailing dated-snapshot suffix (e.g. claude-haiku-4-5-20251001 →
+   * claude-haiku-4-5), so the picker is consistent regardless of whether the
+   * API returns the aliased or dated id.
+   *
+   * Restricted to the modern "family-major-minor-date" shape: older 3.x ids
+   * (e.g. claude-3-5-sonnet-20241022), whose stripped form is NOT a valid
+   * alias, and single-segment ids (claude-opus-4-20250514) are left untouched.
+   */
+  private normalizeAnthropicModelId(id: string): string {
+    return id.replace(/^(claude-(?:opus|sonnet|haiku|fable)-\d+-\d+)-20\d{6}$/, '$1');
   }
 
   /**


### PR DESCRIPTION
Follow-up to #326 (live Anthropic model list).

## Problem

The live `GET /v1/models` list returns a **mix** of aliased and dated model ids, so the picker is inconsistent: Haiku only offered the dated snapshot `claude-haiku-4-5-20251001`, while Sonnet showed the clean alias `claude-sonnet-4-6`.

## Fix

Normalize current models to their stable alias by stripping the trailing dated-snapshot suffix, then dedupe.

| Live API id | Shown as |
|---|---|
| `claude-haiku-4-5-20251001` | `claude-haiku-4-5` |
| `claude-sonnet-4-5-20250929` | `claude-sonnet-4-5` |
| `claude-opus-4-1-20250805` | `claude-opus-4-1` |
| `claude-sonnet-4-6` | `claude-sonnet-4-6` (unchanged) |

The regex is restricted to the modern `family-major-minor-date` shape, so ids whose stripped form is **not** a valid alias are left untouched:
- `claude-opus-4-20250514` (4.0, single segment) → unchanged
- `claude-3-5-sonnet-20241022` (3.x) → unchanged

Aliases resolve to the latest snapshot on Anthropic's side, so selection/invocation is unaffected.

## Testing
- `tsc --noEmit` passes for backend.
- Regex verified against the id forms above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)