### PR TITLE
feat: export and import proxy rule sets from the admin UI

### DIFF
--- a/apps/backend/src/proxy-rules/dto/import-proxy-rule-set.dto.ts
+++ b/apps/backend/src/proxy-rules/dto/import-proxy-rule-set.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsArray, IsInt, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { CreateProxyRuleSetDto } from './proxy-rule-set.dto';
+import { CreateProxyRuleInSetDto } from './create-proxy-rule.dto';
+
+/**
+ * DTO for importing a rule set from an exported JSON definition.
+ *
+ * Mirrors the envelope produced by the admin UI's "Export" action. The
+ * top-level metadata fields (`version`, `exportedAt`, `kind`) are accepted but
+ * ignored — they exist so a raw export file can be POSTed without stripping.
+ */
+export class ImportProxyRuleSetDto {
+  @ApiPropertyOptional({ description: 'Export format version', example: 1 })
+  @IsOptional()
+  @IsInt()
+  version?: number;
+
+  @ApiPropertyOptional({ description: 'ISO timestamp the export was created' })
+  @IsOptional()
+  @IsString()
+  exportedAt?: string;
+
+  @ApiPropertyOptional({ description: 'Export kind discriminator' })
+  @IsOptional()
+  @IsString()
+  kind?: string;
+
+  @ApiProperty({ type: CreateProxyRuleSetDto, description: 'Rule set metadata' })
+  @ValidateNested()
+  @Type(() => CreateProxyRuleSetDto)
+  ruleSet: CreateProxyRuleSetDto;
+
+  @ApiProperty({ type: [CreateProxyRuleInSetDto], description: 'Rules to import into the set' })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateProxyRuleInSetDto)
+  rules: CreateProxyRuleInSetDto[];
+}

--- a/apps/backend/src/proxy-rules/dto/index.ts
+++ b/apps/backend/src/proxy-rules/dto/index.ts
@@ -3,3 +3,4 @@ export * from './update-proxy-rule.dto';
 export * from './reorder-proxy-rules.dto';
 export * from './proxy-rule-response.dto';
 export * from './proxy-rule-set.dto';
+export * from './import-proxy-rule-set.dto';

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.controller.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.controller.ts
@@ -31,6 +31,7 @@ import {
   ReorderProxyRulesDto,
   ProxyRuleResponseDto,
   ProxyRulesListResponseDto,
+  ImportProxyRuleSetDto,
 } from './dto';
 import { ApiKeyGuard } from '../auth/api-key.guard';
 import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
@@ -81,6 +82,26 @@ export class ProxyRuleSetsController {
     @CurrentUser() user: CurrentUserData,
   ): Promise<ProxyRuleSetResponseDto> {
     return this.proxyRuleSetsService.create(
+      projectId,
+      dto,
+      user.id,
+      user.role || 'user',
+      user.apiKeyProjectId,
+    );
+  }
+
+  @Post('project/:projectId/import')
+  @ApiOperation({ summary: 'Import a rule set (with rules) from an exported JSON definition' })
+  @ApiParam({ name: 'projectId', type: 'string' })
+  @ApiResponse({ status: 201, description: 'Imported rule set with rules', type: ProxyRuleSetWithRulesResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid import payload' })
+  @ApiResponse({ status: 403, description: 'Not authorized' })
+  async import(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Body() dto: ImportProxyRuleSetDto,
+    @CurrentUser() user: CurrentUserData,
+  ): Promise<ProxyRuleSetWithRulesResponseDto> {
+    return this.proxyRuleSetsService.importRuleSet(
       projectId,
       dto,
       user.id,

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
@@ -16,7 +16,9 @@ import {
   UpdateProxyRuleSetDto,
   ProxyRuleSetResponseDto,
   ProxyRuleSetWithRulesResponseDto,
+  ImportProxyRuleSetDto,
 } from './dto';
+import type { PipelineConfig, ProxyType } from '../db/schema/proxy-rules.schema';
 import { ProxyRulesService } from './proxy-rules.service';
 
 @Injectable()
@@ -249,6 +251,102 @@ export class ProxyRuleSetsService {
     return {
       ...newRuleSet,
       rules: copiedRules as ProxyRuleSetWithRulesResponseDto['rules'],
+    };
+  }
+
+  /**
+   * Import a rule set (and all its rules) from an exported JSON definition.
+   *
+   * Mirrors copy() — rules are inserted directly rather than going through
+   * ProxyRulesService.create(), so there is no per-rule nginx regeneration
+   * (a freshly imported set is not yet attached to any alias) and no
+   * email-service / SSRF re-validation beyond the DTO validation already
+   * performed at the controller boundary. Header `add` values are encrypted
+   * before storage so they round-trip correctly with the rest of the system.
+   */
+  async importRuleSet(
+    projectId: string,
+    dto: ImportProxyRuleSetDto,
+    userId: string,
+    userRole: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<ProxyRuleSetWithRulesResponseDto> {
+    // Verify project exists
+    const [project] = await db
+      .select()
+      .from(projects)
+      .where(eq(projects.id, projectId))
+      .limit(1);
+
+    if (!project) {
+      throw new NotFoundException(`Project ${projectId} not found`);
+    }
+
+    await this.permissionsService.requireProjectAccess(
+      projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
+
+    // Generate a unique name, appending "(Imported)" on collision
+    const baseName = dto.ruleSet.name?.trim() || 'Imported Rule Set';
+    let name = baseName;
+    if (await this.findByName(projectId, name)) {
+      name = `${baseName} (Imported)`;
+      let importIndex = 1;
+      while (await this.findByName(projectId, name)) {
+        importIndex++;
+        name = `${baseName} (Imported ${importIndex})`;
+      }
+    }
+
+    const [newRuleSet] = await db
+      .insert(proxyRuleSets)
+      .values({
+        projectId,
+        name,
+        description: dto.ruleSet.description,
+        environment: dto.ruleSet.environment,
+      })
+      .returning();
+
+    // Insert rules in their declared order so evaluation order is preserved
+    const rules = [...(dto.rules ?? [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    for (let i = 0; i < rules.length; i++) {
+      const rule = rules[i];
+      await db.insert(proxyRules).values({
+        ruleSetId: newRuleSet.id,
+        pathPattern: rule.pathPattern,
+        method: rule.method ?? null,
+        targetUrl: rule.targetUrl ?? '',
+        stripPrefix: rule.stripPrefix ?? true,
+        order: rule.order ?? i,
+        timeout: rule.timeout ?? 30000,
+        preserveHost: rule.preserveHost ?? false,
+        forwardCookies: rule.forwardCookies ?? false,
+        headerConfig: this.proxyRulesService.encryptHeaderConfigForStorage(rule.headerConfig),
+        authTransform: rule.authTransform ?? null,
+        internalRewrite: rule.internalRewrite ?? false,
+        proxyType: (rule.proxyType as ProxyType) ?? 'external_proxy',
+        emailHandlerConfig: rule.emailHandlerConfig ?? null,
+        pipelineConfig: (rule.pipelineConfig as PipelineConfig) ?? null,
+        isEnabled: rule.isEnabled ?? true,
+        debugEnabled: rule.debugEnabled ?? false,
+        description: rule.description,
+      });
+    }
+
+    this.logger.log(
+      `Imported proxy rule set "${name}" (${rules.length} rules) for project ${projectId}`,
+    );
+
+    const insertedRules = await this.proxyRulesService.getRulesByRuleSetId(newRuleSet.id);
+
+    return {
+      ...newRuleSet,
+      rules: insertedRules as ProxyRuleSetWithRulesResponseDto['rules'],
     };
   }
 

--- a/apps/backend/src/proxy-rules/proxy-rules.service.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.service.ts
@@ -728,6 +728,18 @@ export class ProxyRulesService {
   }
 
   /**
+   * Encrypt header config 'add' values for storage. Public wrapper around the
+   * internal encryption used when persisting rules directly (e.g. import/copy),
+   * bypassing the create()/update() paths.
+   */
+  encryptHeaderConfigForStorage(
+    config: ProxyHeaderConfig | null | undefined,
+  ): ProxyHeaderConfig | null {
+    if (!config) return null;
+    return this.encryptHeaderConfig(config);
+  }
+
+  /**
    * Encrypt sensitive header values
    */
   private encryptHeaderConfig(config: ProxyHeaderConfig): ProxyHeaderConfig {

--- a/apps/frontend/src/components/proxy-rules/ProxyRuleSetsTab.tsx
+++ b/apps/frontend/src/components/proxy-rules/ProxyRuleSetsTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -19,11 +19,27 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { Plus, MoreHorizontal, Edit2, Trash2, Settings, Layers, CopyPlus } from 'lucide-react';
+import {
+  Plus,
+  MoreHorizontal,
+  Edit2,
+  Trash2,
+  Settings,
+  Layers,
+  CopyPlus,
+  Download,
+  Upload,
+} from 'lucide-react';
 import {
   useGetProjectRuleSetsQuery,
   useDeleteRuleSetMutation,
   useCopyRuleSetMutation,
+  useLazyGetRuleSetQuery,
+  useImportRuleSetMutation,
+  type ProxyRuleSetExport,
+  type ExportedProxyRule,
+  type ProxyRuleSetWithRules,
+  type HeaderConfig,
 } from '@/services/proxyRulesApi';
 import { useGetProjectQuery } from '@/services/projectsApi';
 import { useProjectRole } from '@/hooks/useProjectRole';
@@ -34,6 +50,22 @@ import { RuleSetEditorDialog } from './RuleSetEditorDialog';
 interface ProxyRuleSetsTabProps {
   owner: string;
   repo: string;
+}
+
+/**
+ * Header `add` values can hold secrets (API keys, bearer tokens). We deliberately
+ * do NOT export their values — exports keep the header names but blank the values,
+ * so the user re-enters secrets after import. This is a known export/import gap
+ * until inline secrets move to project-level `secrets.<name>` references
+ * (see stories/tasks/migrate-inline-pipeline-secrets-to-project-secrets.md).
+ */
+function sanitizeHeaderConfigForExport(headerConfig: HeaderConfig | null): HeaderConfig | null {
+  if (!headerConfig?.add) return headerConfig;
+  const blankedAdd: Record<string, string> = {};
+  for (const key of Object.keys(headerConfig.add)) {
+    blankedAdd[key] = '';
+  }
+  return { ...headerConfig, add: blankedAdd };
 }
 
 /**
@@ -70,6 +102,127 @@ export function ProxyRuleSetsTab({ owner, repo }: ProxyRuleSetsTabProps) {
 
   // Copy mutation
   const [copyRuleSet, { isLoading: isCopying }] = useCopyRuleSetMutation();
+
+  // Export / import
+  const [fetchRuleSet, { isFetching: isExporting }] = useLazyGetRuleSetQuery();
+  const [importRuleSet, { isLoading: isImporting }] = useImportRuleSetMutation();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleExport = async (ruleSetId: string) => {
+    try {
+      const ruleSet = await fetchRuleSet(ruleSetId).unwrap();
+      const exportData: ProxyRuleSetExport = {
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        kind: 'bffless-proxy-rule-set',
+        ruleSet: {
+          name: ruleSet.name,
+          description: ruleSet.description,
+          environment: ruleSet.environment,
+        },
+        // Strip server-managed fields; keep only portable rule config
+        rules: ruleSet.rules.map(
+          (rule): ExportedProxyRule => ({
+            pathPattern: rule.pathPattern,
+            method: rule.method,
+            targetUrl: rule.targetUrl,
+            stripPrefix: rule.stripPrefix,
+            order: rule.order,
+            timeout: rule.timeout,
+            preserveHost: rule.preserveHost,
+            forwardCookies: rule.forwardCookies,
+            headerConfig: sanitizeHeaderConfigForExport(rule.headerConfig),
+            authTransform: rule.authTransform,
+            internalRewrite: rule.internalRewrite,
+            proxyType: rule.proxyType,
+            emailHandlerConfig: rule.emailHandlerConfig,
+            pipelineConfig: rule.pipelineConfig,
+            isEnabled: rule.isEnabled,
+            debugEnabled: rule.debugEnabled,
+            description: rule.description,
+          }),
+        ),
+      };
+
+      const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      const safeName = ruleSet.name.replace(/[^a-zA-Z0-9-_]+/g, '-').replace(/^-+|-+$/g, '');
+      link.href = url;
+      link.download = `${safeName || 'proxy-rule-set'}.proxy-rules.json`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+
+      const hadSecrets = ruleSet.rules.some(
+        (rule) => rule.headerConfig?.add && Object.keys(rule.headerConfig.add).length > 0,
+      );
+      toast({
+        title: 'Rule set exported',
+        description:
+          `Exported "${ruleSet.name}" with ${ruleSet.rules.length} rule${ruleSet.rules.length !== 1 ? 's' : ''}.` +
+          (hadSecrets ? ' Added-header secret values were not included.' : ''),
+      });
+    } catch {
+      toast({
+        title: 'Export failed',
+        description: 'Could not export the rule set. Please try again.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImportFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    // Reset the input so selecting the same file again re-triggers onChange
+    event.target.value = '';
+    if (!file || !project?.id) return;
+
+    let parsed: ProxyRuleSetExport;
+    try {
+      parsed = JSON.parse(await file.text());
+    } catch {
+      toast({
+        title: 'Invalid file',
+        description: 'The selected file is not valid JSON.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (!parsed?.ruleSet?.name || !Array.isArray(parsed.rules)) {
+      toast({
+        title: 'Invalid file',
+        description: 'This file is not a valid proxy rule set export.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      const imported = (await importRuleSet({
+        projectId: project.id,
+        data: parsed,
+      }).unwrap()) as ProxyRuleSetWithRules;
+      toast({
+        title: 'Rule set imported',
+        description: `Created "${imported.name}" with ${imported.rules.length} rule${imported.rules.length !== 1 ? 's' : ''}.`,
+      });
+    } catch (err: unknown) {
+      const errorMessage =
+        (err as { data?: { message?: string } })?.data?.message || 'Failed to import rule set';
+      toast({
+        title: 'Import failed',
+        description: errorMessage,
+        variant: 'destructive',
+      });
+    }
+  };
 
   const handleCopy = async (ruleSetId: string) => {
     try {
@@ -110,6 +263,37 @@ export function ProxyRuleSetsTab({ owner, repo }: ProxyRuleSetsTabProps) {
   };
 
   const isLoading = isLoadingProject || isLoadingRuleSets;
+
+  // Shared header action buttons (Import + Create), reused across states
+  const headerActions = canEdit ? (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-2"
+        onClick={handleImportClick}
+        disabled={isImporting || !project?.id}
+      >
+        <Upload className="h-4 w-4" />
+        {isImporting ? 'Importing...' : 'Import'}
+      </Button>
+      <Button size="sm" className="gap-2" onClick={() => setIsCreateDialogOpen(true)}>
+        <Plus className="h-4 w-4" />
+        Create Rule Set
+      </Button>
+    </div>
+  ) : null;
+
+  // Hidden file input used by the Import button
+  const importFileInput = (
+    <input
+      ref={fileInputRef}
+      type="file"
+      accept="application/json,.json"
+      className="hidden"
+      onChange={handleImportFile}
+    />
+  );
 
   // Loading state
   if (isLoading) {
@@ -161,6 +345,7 @@ export function ProxyRuleSetsTab({ owner, repo }: ProxyRuleSetsTabProps) {
   if (ruleSets.length === 0) {
     return (
       <>
+        {importFileInput}
         <Card>
           <CardHeader className="flex flex-row items-center justify-between">
             <div>
@@ -198,18 +383,14 @@ export function ProxyRuleSetsTab({ owner, repo }: ProxyRuleSetsTabProps) {
 
   return (
     <>
+      {importFileInput}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <div>
             <CardTitle>Proxy Rule Sets</CardTitle>
             <CardDescription>Manage reusable proxy rule configurations</CardDescription>
           </div>
-          {canEdit && (
-            <Button size="sm" className="gap-2" onClick={() => setIsCreateDialogOpen(true)}>
-              <Plus className="h-4 w-4" />
-              Create Rule Set
-            </Button>
-          )}
+          {headerActions}
         </CardHeader>
         <CardContent>
           {/* Rule Sets List */}
@@ -265,6 +446,13 @@ export function ProxyRuleSetsTab({ owner, repo }: ProxyRuleSetsTabProps) {
                         >
                           <CopyPlus className="h-4 w-4 mr-2" />
                           {isCopying ? 'Duplicating...' : 'Duplicate'}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => handleExport(ruleSet.id)}
+                          disabled={isExporting}
+                        >
+                          <Download className="h-4 w-4 mr-2" />
+                          {isExporting ? 'Exporting...' : 'Export'}
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onClick={() => setDeletingRuleSet({ id: ruleSet.id, name: ruleSet.name })}

--- a/apps/frontend/src/services/proxyRulesApi.ts
+++ b/apps/frontend/src/services/proxyRulesApi.ts
@@ -144,6 +144,25 @@ export interface UpdateProxyRuleDto {
   debugEnabled?: boolean;
 }
 
+// A single proxy rule as represented in an export file (no server-managed fields)
+export type ExportedProxyRule = Omit<
+  ProxyRule,
+  'id' | 'ruleSetId' | 'createdAt' | 'updatedAt'
+>;
+
+// Portable export envelope for a proxy rule set and its rules
+export interface ProxyRuleSetExport {
+  version: number;
+  exportedAt: string;
+  kind: 'bffless-proxy-rule-set';
+  ruleSet: {
+    name: string;
+    description?: string | null;
+    environment?: string | null;
+  };
+  rules: ExportedProxyRule[];
+}
+
 // Pipeline execution log summary (list view)
 export interface PipelineExecutionLogSummary {
   id: string;
@@ -302,6 +321,22 @@ export const proxyRulesApi = api.injectEndpoints({
       invalidatesTags: ['ProxyRuleSet', 'ProxyRule'],
     }),
 
+    // Import a rule set (with rules) from an exported JSON definition
+    importRuleSet: builder.mutation<
+      ProxyRuleSetWithRules,
+      { projectId: string; data: ProxyRuleSetExport }
+    >({
+      query: ({ projectId, data }) => ({
+        url: `/api/proxy-rule-sets/project/${projectId}/import`,
+        method: 'POST',
+        body: data,
+      }),
+      invalidatesTags: (_result, _error, { projectId }) => [
+        { type: 'ProxyRuleSet' as const, id: `project-${projectId}` },
+        'ProxyRuleSet',
+      ],
+    }),
+
     // ==================== Rules within a Rule Set ====================
 
     // List rules in a rule set
@@ -441,9 +476,11 @@ export const {
   useGetProjectRuleSetsQuery,
   useCreateRuleSetMutation,
   useGetRuleSetQuery,
+  useLazyGetRuleSetQuery,
   useUpdateRuleSetMutation,
   useDeleteRuleSetMutation,
   useCopyRuleSetMutation,
+  useImportRuleSetMutation,
   // Rules within a Rule Set
   useGetRuleSetRulesQuery,
   useCreateRuleInSetMutation,


### PR DESCRIPTION
## What

Adds export/import for proxy rule sets in the admin UI (Proxy Rules tab).

- **Export** — new "Export" item in each rule set's `…` menu. Downloads a portable `{name}.proxy-rules.json` containing the set metadata and all its rules (server-managed fields like `id`/`ruleSetId`/timestamps stripped).
- **Import** — new "Import" button beside "Create Rule Set" (in both the populated and empty states). Picks a file, validates the JSON shape client-side, and POSTs it to a new backend endpoint that creates a new set with all its rules.

## Backend

- `POST /api/proxy-rule-sets/project/:projectId/import` + `ImportProxyRuleSetDto` (reuses `CreateProxyRuleSetDto` / `CreateProxyRuleInSetDto` for full class-validator coverage; top-level `version`/`exportedAt`/`kind` are accepted-but-ignored so a raw export file posts directly).
- `ProxyRuleSetsService.importRuleSet()` mirrors the existing `copy()` — direct inserts, contributor-permission check, `(Imported)`/`(Imported N)` name de-dup, no per-rule nginx regen (a fresh set isn't attached to any alias).
- Re-encrypts `headerConfig.add` before storage via a new public `ProxyRulesService.encryptHeaderConfigForStorage()` (the API decrypts on read, so values must be re-encrypted on the way back in).

## Secrets handling

Export **deliberately omits added-header secret values** — it keeps the header names but blanks the values (`sanitizeHeaderConfigForExport`), so export files never contain live credentials. The export toast notes when secret values were excluded.

This leaves inline secrets as a known export/import gap, tracked in `stories/tasks/migrate-inline-pipeline-secrets-to-project-secrets.md`: once secrets move to project-level `secrets.<name>` references, exports can carry the reference and the blanking can be removed.

## Verification

- `tsc --noEmit` clean for backend and frontend
- ESLint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)