### PR TITLE
feat: bundle schema dependencies in proxy rule set export/import

### DIFF
--- a/apps/backend/src/proxy-rules/dto/import-proxy-rule-set.dto.ts
+++ b/apps/backend/src/proxy-rules/dto/import-proxy-rule-set.dto.ts
@@ -1,8 +1,52 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsArray, IsInt, IsOptional, IsString, ValidateNested } from 'class-validator';
+import {
+  IsArray,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 import { CreateProxyRuleSetDto } from './proxy-rule-set.dto';
 import { CreateProxyRuleInSetDto } from './create-proxy-rule.dto';
+import { SchemaFieldDto } from '../../pipelines/dto/create-pipeline-schema.dto';
+
+/**
+ * Resolution for one schema dependency bundled in the export. The pipeline rules
+ * still carry the original (source) schema id; the import remaps them to the
+ * resolved target schema id (an existing one, or a freshly created one).
+ */
+export class ImportSchemaResolutionDto {
+  @ApiProperty({ description: 'Original schema id as referenced in the exported rules' })
+  @IsUUID()
+  sourceId: string;
+
+  @ApiProperty({ description: 'Schema name from the export' })
+  @IsString()
+  @MaxLength(255)
+  name: string;
+
+  @ApiProperty({ type: [SchemaFieldDto], description: 'Schema field definitions from the export' })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SchemaFieldDto)
+  fields: SchemaFieldDto[];
+
+  @ApiProperty({
+    description: 'Reuse an existing schema in the target project, or create a fresh one',
+    enum: ['reuse', 'create'],
+  })
+  @IsIn(['reuse', 'create'])
+  action: 'reuse' | 'create';
+
+  @ApiPropertyOptional({ description: 'Target schema id to map to (required when action=reuse)' })
+  @IsOptional()
+  @IsUUID()
+  targetSchemaId?: string;
+}
 
 /**
  * DTO for importing a rule set from an exported JSON definition.
@@ -37,4 +81,14 @@ export class ImportProxyRuleSetDto {
   @ValidateNested({ each: true })
   @Type(() => CreateProxyRuleInSetDto)
   rules: CreateProxyRuleInSetDto[];
+
+  @ApiPropertyOptional({
+    type: [ImportSchemaResolutionDto],
+    description: 'Schema dependencies bundled in the export, with how to resolve each in the target project',
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ImportSchemaResolutionDto)
+  schemas?: ImportSchemaResolutionDto[];
 }

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   ConflictException,
+  BadRequestException,
   Logger,
   Inject,
   forwardRef,
@@ -11,6 +12,7 @@ import { db } from '../db/client';
 import { proxyRuleSets, proxyRules, projects, aliasProxyRuleSets, deploymentAliases } from '../db/schema';
 import { PermissionsService } from '../permissions/permissions.service';
 import { NginxRegenerationService } from '../domains/nginx-regeneration.service';
+import { PipelineSchemasService } from '../pipelines/pipeline-schemas.service';
 import {
   CreateProxyRuleSetDto,
   UpdateProxyRuleSetDto,
@@ -20,6 +22,7 @@ import {
 } from './dto';
 import type { PipelineConfig, ProxyType } from '../db/schema/proxy-rules.schema';
 import { ProxyRulesService } from './proxy-rules.service';
+import { remapSchemaIds } from './schema-refs.util';
 
 @Injectable()
 export class ProxyRuleSetsService {
@@ -30,6 +33,8 @@ export class ProxyRuleSetsService {
     private readonly proxyRulesService: ProxyRulesService,
     @Inject(forwardRef(() => NginxRegenerationService))
     private readonly nginxRegenerationService: NginxRegenerationService,
+    @Inject(forwardRef(() => PipelineSchemasService))
+    private readonly pipelineSchemasService: PipelineSchemasService,
   ) {}
 
   /**
@@ -290,6 +295,52 @@ export class ProxyRuleSetsService {
       apiKeyProjectId,
     );
 
+    // Resolve bundled schema dependencies to target-project schema ids.
+    // Pipeline rules carry the original (source) schema ids; we build a map and
+    // remap every schema reference in the pipeline configs before insert.
+    const idMap = new Map<string, string>();
+    const schemaResolutions = dto.schemas ?? [];
+    if (schemaResolutions.length > 0) {
+      const existingSchemas = await this.pipelineSchemasService.getByProjectId(
+        projectId,
+        apiKeyProjectId,
+      );
+      const existingNames = new Set(existingSchemas.map((s) => s.name));
+
+      for (const res of schemaResolutions) {
+        if (res.action === 'reuse') {
+          if (!res.targetSchemaId) {
+            throw new BadRequestException(
+              `Schema "${res.name}" is set to reuse but no targetSchemaId was provided`,
+            );
+          }
+          const target = await this.pipelineSchemasService.getById(res.targetSchemaId);
+          if (!target || target.projectId !== projectId) {
+            throw new BadRequestException(
+              `Target schema ${res.targetSchemaId} not found in this project`,
+            );
+          }
+          idMap.set(res.sourceId, target.id);
+        } else {
+          // create — auto-suffix on name conflict so import never hard-fails
+          let schemaName = res.name;
+          if (existingNames.has(schemaName)) {
+            let suffix = 2;
+            while (existingNames.has(`${res.name} (${suffix})`)) suffix++;
+            schemaName = `${res.name} (${suffix})`;
+          }
+          existingNames.add(schemaName);
+          const created = await this.pipelineSchemasService.create(
+            { projectId, name: schemaName, fields: res.fields },
+            userId,
+            userRole,
+            apiKeyProjectId,
+          );
+          idMap.set(res.sourceId, created.id);
+        }
+      }
+    }
+
     // Generate a unique name, appending "(Imported)" on collision
     const baseName = dto.ruleSet.name?.trim() || 'Imported Rule Set';
     let name = baseName;
@@ -312,8 +363,10 @@ export class ProxyRuleSetsService {
       })
       .returning();
 
-    // Insert rules in their declared order so evaluation order is preserved
-    const rules = [...(dto.rules ?? [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    // Remap schema references to the resolved target-project ids, then insert
+    // rules in their declared order so evaluation order is preserved
+    const sourceRules = idMap.size > 0 ? remapSchemaIds(dto.rules ?? [], idMap) : dto.rules ?? [];
+    const rules = [...sourceRules].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
     for (let i = 0; i < rules.length; i++) {
       const rule = rules[i];
       await db.insert(proxyRules).values({

--- a/apps/backend/src/proxy-rules/schema-refs.util.spec.ts
+++ b/apps/backend/src/proxy-rules/schema-refs.util.spec.ts
@@ -1,0 +1,78 @@
+import { collectSchemaIds, remapSchemaIds } from './schema-refs.util';
+
+describe('schema-refs.util', () => {
+  // A rule shaped like an exported pipeline rule, exercising steps, postSteps,
+  // and the ai handler's non-`schemaId` reference keys.
+  const rules = [
+    {
+      pathPattern: '/api/*',
+      proxyType: 'pipeline',
+      pipelineConfig: {
+        name: 'p',
+        steps: [
+          { name: 'q', handlerType: 'data_query', config: { schemaId: 'A', pageSize: 10 } },
+          { name: 'u', handlerType: 'file_upload', config: { schemaId: 'B', subDir: 'x' } },
+          {
+            name: 'chat',
+            handlerType: 'ai',
+            config: { persistMessagesSchemaId: 'C', persistConversationsSchemaId: 'A' },
+          },
+        ],
+        postSteps: [
+          { name: 'c', handlerType: 'data_create', config: { schemaId: 'A', fields: {} } },
+        ],
+      },
+    },
+    {
+      pathPattern: '/static',
+      proxyType: 'external_proxy',
+      targetUrl: 'https://example.com',
+      pipelineConfig: null,
+    },
+  ];
+
+  describe('collectSchemaIds', () => {
+    it('collects distinct ids across steps, postSteps, and ai handler keys', () => {
+      expect(collectSchemaIds(rules)).toEqual(new Set(['A', 'B', 'C']));
+    });
+
+    it('ignores empty/non-string values and non-pipeline rules', () => {
+      expect(collectSchemaIds([{ pipelineConfig: null }, { config: { schemaId: '' } }])).toEqual(
+        new Set(),
+      );
+    });
+  });
+
+  describe('remapSchemaIds', () => {
+    it('rewrites mapped ids in every schema-ref key and leaves the rest untouched', () => {
+      const idMap = new Map([
+        ['A', 'A2'],
+        ['B', 'B2'],
+        ['C', 'C2'],
+      ]);
+      const out = remapSchemaIds(rules, idMap);
+
+      const cfg = out[0].pipelineConfig!;
+      expect(cfg.steps[0].config.schemaId).toBe('A2');
+      expect(cfg.steps[0].config.pageSize).toBe(10); // non-ref field preserved
+      expect(cfg.steps[1].config.schemaId).toBe('B2');
+      expect(cfg.steps[2].config.persistMessagesSchemaId).toBe('C2');
+      expect(cfg.steps[2].config.persistConversationsSchemaId).toBe('A2');
+      expect(cfg.postSteps[0].config.schemaId).toBe('A2');
+      expect(out[1].targetUrl).toBe('https://example.com'); // untouched rule
+    });
+
+    it('leaves ids absent from the map unchanged (e.g. unbundled refs)', () => {
+      const out = remapSchemaIds(rules, new Map([['A', 'A2']]));
+      const cfg = out[0].pipelineConfig!;
+      expect(cfg.steps[0].config.schemaId).toBe('A2');
+      expect(cfg.steps[1].config.schemaId).toBe('B'); // not in map → unchanged
+    });
+
+    it('does not mutate the input', () => {
+      const out = remapSchemaIds(rules, new Map([['A', 'A2']]));
+      expect(rules[0].pipelineConfig!.steps[0].config.schemaId).toBe('A');
+      expect(out).not.toBe(rules);
+    });
+  });
+});

--- a/apps/backend/src/proxy-rules/schema-refs.util.ts
+++ b/apps/backend/src/proxy-rules/schema-refs.util.ts
@@ -1,0 +1,60 @@
+/**
+ * Keys inside a pipeline rule's `pipelineConfig` (step/postStep `config` objects)
+ * that hold a reference to a `pipeline_schemas` row id. These are project-scoped,
+ * so they must be remapped when a rule set is imported into another project.
+ *
+ * - `schemaId`: data_create, data_query, data_update, data_delete, db_aggregate,
+ *   file_upload, embed_store, vector_search
+ * - `persist*SchemaId` / deprecated `conversationsSchemaId` / `messagesSchemaId`: ai handler
+ */
+export const SCHEMA_REF_KEYS = [
+  'schemaId',
+  'persistMessagesSchemaId',
+  'persistConversationsSchemaId',
+  'conversationsSchemaId',
+  'messagesSchemaId',
+] as const;
+
+const SCHEMA_REF_KEY_SET = new Set<string>(SCHEMA_REF_KEYS);
+
+/**
+ * Recursively collect every schema-id reference value found under any
+ * SCHEMA_REF_KEYS key. Generic key-based walk so new schema-bearing handlers
+ * are covered automatically.
+ */
+export function collectSchemaIds(node: unknown, out = new Set<string>()): Set<string> {
+  if (Array.isArray(node)) {
+    for (const item of node) collectSchemaIds(item, out);
+  } else if (node && typeof node === 'object') {
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (SCHEMA_REF_KEY_SET.has(key) && typeof value === 'string' && value) {
+        out.add(value);
+      }
+      collectSchemaIds(value, out);
+    }
+  }
+  return out;
+}
+
+/**
+ * Return a deep clone of `node` with any schema-id reference value replaced via
+ * `idMap`. References not present in the map are left untouched (e.g. a v1 export
+ * with no bundled schemas, or a ref the user chose not to remap).
+ */
+export function remapSchemaIds<T>(node: T, idMap: Map<string, string>): T {
+  if (Array.isArray(node)) {
+    return node.map((item) => remapSchemaIds(item, idMap)) as unknown as T;
+  }
+  if (node && typeof node === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (SCHEMA_REF_KEY_SET.has(key) && typeof value === 'string' && idMap.has(value)) {
+        result[key] = idMap.get(value);
+      } else {
+        result[key] = remapSchemaIds(value, idMap);
+      }
+    }
+    return result as T;
+  }
+  return node;
+}

--- a/apps/frontend/src/components/proxy-rules/ImportRuleSetDialog.tsx
+++ b/apps/frontend/src/components/proxy-rules/ImportRuleSetDialog.tsx
@@ -1,0 +1,283 @@
+import { useRef, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Upload, FileJson, AlertTriangle } from 'lucide-react';
+import {
+  useImportRuleSetMutation,
+  type ProxyRuleSetExport,
+  type ImportSchemaResolution,
+} from '@/services/proxyRulesApi';
+import { useGetProjectSchemasQuery } from '@/services/pipelineSchemasApi';
+import { collectSchemaIds } from '@/utils/proxyRuleSchemaRefs';
+import { useToast } from '@/hooks/use-toast';
+
+interface ImportRuleSetDialogProps {
+  projectId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+// Sentinel for the "create a fresh schema" option in the resolution selects
+const CREATE = '__create__';
+
+/**
+ * ImportRuleSetDialog - imports a proxy rule set from an exported JSON file.
+ *
+ * When the export bundles schema dependencies (v2 exports), the user resolves
+ * each one against the target project: reuse an existing schema or create a
+ * fresh one. Defaults: match by id (same-project backup), else by name, else
+ * create. The chosen resolutions are sent to the backend, which remaps every
+ * schema reference in the pipeline configs before insert.
+ */
+export function ImportRuleSetDialog({ projectId, open, onOpenChange }: ImportRuleSetDialogProps) {
+  const { toast } = useToast();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [parsed, setParsed] = useState<ProxyRuleSetExport | null>(null);
+  const [fileName, setFileName] = useState('');
+  // sourceSchemaId -> targetSchemaId | CREATE (user overrides; defaults computed below)
+  const [resolutions, setResolutions] = useState<Record<string, string>>({});
+
+  const { data: schemasData } = useGetProjectSchemasQuery(projectId, {
+    skip: !projectId || !open,
+  });
+  const existingSchemas = schemasData?.schemas ?? [];
+
+  const [importRuleSet, { isLoading: isImporting }] = useImportRuleSetMutation();
+
+  const bundledSchemas = parsed?.schemas ?? [];
+
+  // Default resolution for a bundled schema: match by id, then by name, else create
+  const defaultFor = (sourceId: string, name: string): string => {
+    const byId = existingSchemas.find((s) => s.id === sourceId);
+    if (byId) return byId.id;
+    const byName = existingSchemas.find((s) => s.name === name);
+    if (byName) return byName.id;
+    return CREATE;
+  };
+  const chosenFor = (sourceId: string, name: string): string =>
+    resolutions[sourceId] ?? defaultFor(sourceId, name);
+
+  // Schema ids referenced by the rules but not bundled (e.g. a v1 export) — these
+  // cannot be remapped and will stay pointing at the source project's schemas.
+  const unbundledRefCount = parsed
+    ? (() => {
+        const bundledIds = new Set(bundledSchemas.map((s) => s.id));
+        return [...collectSchemaIds(parsed.rules)].filter((id) => !bundledIds.has(id)).length;
+      })()
+    : 0;
+
+  const resetState = () => {
+    setParsed(null);
+    setFileName('');
+    setResolutions({});
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) resetState();
+    onOpenChange(next);
+  };
+
+  const handleFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+
+    let data: ProxyRuleSetExport;
+    try {
+      data = JSON.parse(await file.text());
+    } catch {
+      toast({
+        title: 'Invalid file',
+        description: 'The selected file is not valid JSON.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (!data?.ruleSet?.name || !Array.isArray(data.rules)) {
+      toast({
+        title: 'Invalid file',
+        description: 'This file is not a valid proxy rule set export.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setParsed(data);
+    setFileName(file.name);
+    setResolutions({});
+  };
+
+  const handleImport = async () => {
+    if (!parsed || !projectId) return;
+
+    const schemaResolutions: ImportSchemaResolution[] = bundledSchemas.map((s) => {
+      const target = chosenFor(s.id, s.name);
+      return target === CREATE
+        ? { sourceId: s.id, name: s.name, fields: s.fields, action: 'create' }
+        : { sourceId: s.id, name: s.name, fields: s.fields, action: 'reuse', targetSchemaId: target };
+    });
+
+    try {
+      // Rebuild the envelope, replacing the bundled schemas (ExportedSchema[])
+      // with the per-schema resolutions the backend expects
+      const imported = await importRuleSet({
+        projectId,
+        data: {
+          version: parsed.version,
+          exportedAt: parsed.exportedAt,
+          kind: parsed.kind,
+          ruleSet: parsed.ruleSet,
+          rules: parsed.rules,
+          schemas: schemaResolutions.length > 0 ? schemaResolutions : undefined,
+        },
+      }).unwrap();
+
+      const createdCount = schemaResolutions.filter((r) => r.action === 'create').length;
+      toast({
+        title: 'Rule set imported',
+        description:
+          `Created "${imported.name}" with ${imported.rules.length} rule${imported.rules.length !== 1 ? 's' : ''}.` +
+          (createdCount > 0
+            ? ` ${createdCount} new schema${createdCount !== 1 ? 's' : ''} created.`
+            : ''),
+      });
+      handleOpenChange(false);
+    } catch (err: unknown) {
+      const errorMessage =
+        (err as { data?: { message?: string } })?.data?.message || 'Failed to import rule set';
+      toast({
+        title: 'Import failed',
+        description: errorMessage,
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Import Rule Set</DialogTitle>
+          <DialogDescription>
+            Import a proxy rule set from an exported JSON file. If it depends on schemas, choose how
+            to resolve each one in this project.
+          </DialogDescription>
+        </DialogHeader>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json,.json"
+          className="hidden"
+          onChange={handleFile}
+        />
+
+        {!parsed ? (
+          <div className="rounded border border-dashed p-8 text-center">
+            <FileJson className="h-10 w-10 mx-auto text-muted-foreground mb-3" />
+            <p className="text-sm text-muted-foreground mb-4">
+              Select a <code>.proxy-rules.json</code> export file to import.
+            </p>
+            <Button variant="outline" className="gap-2" onClick={() => fileInputRef.current?.click()}>
+              <Upload className="h-4 w-4" />
+              Select file
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between rounded border p-3 text-sm">
+              <div>
+                <div className="font-medium">{parsed.ruleSet.name}</div>
+                <div className="text-muted-foreground">
+                  {parsed.rules.length} rule{parsed.rules.length !== 1 ? 's' : ''}
+                  {bundledSchemas.length > 0 &&
+                    ` · ${bundledSchemas.length} schema${bundledSchemas.length !== 1 ? 's' : ''}`}
+                  {fileName ? ` · ${fileName}` : ''}
+                </div>
+              </div>
+              <Button variant="ghost" size="sm" onClick={() => fileInputRef.current?.click()}>
+                Change
+              </Button>
+            </div>
+
+            {bundledSchemas.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-sm font-medium">Schema dependencies</p>
+                <p className="text-xs text-muted-foreground">
+                  Reuse an existing schema in this project, or create a fresh one. References in the
+                  pipelines are remapped automatically.
+                </p>
+                <div className="space-y-2">
+                  {bundledSchemas.map((s) => (
+                    <div
+                      key={s.id}
+                      className="flex items-center justify-between gap-3 rounded border p-3"
+                    >
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium truncate">{s.name}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {s.fields.length} field{s.fields.length !== 1 ? 's' : ''}
+                        </div>
+                      </div>
+                      <Select
+                        value={chosenFor(s.id, s.name)}
+                        onValueChange={(v) => setResolutions((prev) => ({ ...prev, [s.id]: v }))}
+                      >
+                        <SelectTrigger className="w-52">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={CREATE}>Create new schema</SelectItem>
+                          {existingSchemas.map((e) => (
+                            <SelectItem key={e.id} value={e.id}>
+                              Reuse: {e.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {unbundledRefCount > 0 && (
+              <div className="flex items-start gap-2 rounded border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-400">
+                <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                <span>
+                  {unbundledRefCount} schema reference{unbundledRefCount !== 1 ? 's' : ''} in this
+                  export {unbundledRefCount !== 1 ? 'are' : 'is'} not bundled and will keep pointing
+                  at the original project. Pipelines using {unbundledRefCount !== 1 ? 'them' : 'it'}{' '}
+                  may not work here.
+                </span>
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleImport} disabled={isImporting}>
+                {isImporting ? 'Importing...' : 'Import'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/pages/ProxyRuleSetsPage.tsx
+++ b/apps/frontend/src/pages/ProxyRuleSetsPage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -25,16 +25,18 @@ import {
   useDeleteRuleSetMutation,
   useCopyRuleSetMutation,
   useLazyGetRuleSetQuery,
-  useImportRuleSetMutation,
   type ProxyRuleSetExport,
   type ExportedProxyRule,
-  type ProxyRuleSetWithRules,
+  type ExportedSchema,
   type HeaderConfig,
 } from '@/services/proxyRulesApi';
+import { useLazyGetSchemaQuery } from '@/services/pipelineSchemasApi';
 import { useGetProjectQuery } from '@/services/projectsApi';
 import { useProjectRole } from '@/hooks/useProjectRole';
 import { useToast } from '@/hooks/use-toast';
+import { collectSchemaIds } from '@/utils/proxyRuleSchemaRefs';
 import { CreateRuleSetDialog } from '@/components/proxy-rules/CreateRuleSetDialog';
+import { ImportRuleSetDialog } from '@/components/proxy-rules/ImportRuleSetDialog';
 import { RuleSetCard } from '@/components/proxy-rules/RuleSetCard';
 import { routes } from '@/utils/routes';
 
@@ -92,14 +94,28 @@ export function ProxyRuleSetsPage() {
 
   // Export / import
   const [fetchRuleSet, { isFetching: isExporting }] = useLazyGetRuleSetQuery();
-  const [importRuleSet, { isLoading: isImporting }] = useImportRuleSetMutation();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [fetchSchema] = useLazyGetSchemaQuery();
+  const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
 
   const handleExport = async (ruleSetId: string) => {
     try {
       const ruleSet = await fetchRuleSet(ruleSetId).unwrap();
+
+      // Bundle the schema definitions the pipelines depend on so the export is
+      // portable across projects. Definitions only (name + fields), no data rows.
+      const schemaIds = [...collectSchemaIds(ruleSet.rules)];
+      const schemas: ExportedSchema[] = [];
+      for (const id of schemaIds) {
+        try {
+          const schema = await fetchSchema(id).unwrap();
+          schemas.push({ id: schema.id, name: schema.name, fields: schema.fields });
+        } catch {
+          // Schema missing/inaccessible — leave it as an unbundled reference
+        }
+      }
+
       const exportData: ProxyRuleSetExport = {
-        version: 1,
+        version: 2,
         exportedAt: new Date().toISOString(),
         kind: 'bffless-proxy-rule-set',
         ruleSet: {
@@ -129,6 +145,7 @@ export function ProxyRuleSetsPage() {
             description: rule.description,
           }),
         ),
+        schemas: schemas.length > 0 ? schemas : undefined,
       };
 
       const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
@@ -148,64 +165,16 @@ export function ProxyRuleSetsPage() {
       toast({
         title: 'Rule set exported',
         description:
-          `Exported "${ruleSet.name}" with ${ruleSet.rules.length} rule${ruleSet.rules.length !== 1 ? 's' : ''}.` +
+          `Exported "${ruleSet.name}" with ${ruleSet.rules.length} rule${ruleSet.rules.length !== 1 ? 's' : ''}` +
+          (schemas.length > 0
+            ? ` and ${schemas.length} schema${schemas.length !== 1 ? 's' : ''}.`
+            : '.') +
           (hadSecrets ? ' Added-header secret values were not included.' : ''),
       });
     } catch {
       toast({
         title: 'Export failed',
         description: 'Could not export the rule set. Please try again.',
-        variant: 'destructive',
-      });
-    }
-  };
-
-  const handleImportClick = () => {
-    fileInputRef.current?.click();
-  };
-
-  const handleImportFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    // Reset the input so selecting the same file again re-triggers onChange
-    event.target.value = '';
-    if (!file || !project?.id) return;
-
-    let parsed: ProxyRuleSetExport;
-    try {
-      parsed = JSON.parse(await file.text());
-    } catch {
-      toast({
-        title: 'Invalid file',
-        description: 'The selected file is not valid JSON.',
-        variant: 'destructive',
-      });
-      return;
-    }
-
-    if (!parsed?.ruleSet?.name || !Array.isArray(parsed.rules)) {
-      toast({
-        title: 'Invalid file',
-        description: 'This file is not a valid proxy rule set export.',
-        variant: 'destructive',
-      });
-      return;
-    }
-
-    try {
-      const imported = (await importRuleSet({
-        projectId: project.id,
-        data: parsed,
-      }).unwrap()) as ProxyRuleSetWithRules;
-      toast({
-        title: 'Rule set imported',
-        description: `Created "${imported.name}" with ${imported.rules.length} rule${imported.rules.length !== 1 ? 's' : ''}.`,
-      });
-    } catch (err: unknown) {
-      const errorMessage =
-        (err as { data?: { message?: string } })?.data?.message || 'Failed to import rule set';
-      toast({
-        title: 'Import failed',
-        description: errorMessage,
         variant: 'destructive',
       });
     }
@@ -298,13 +267,6 @@ export function ProxyRuleSetsPage() {
 
   return (
     <>
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="application/json,.json"
-        className="hidden"
-        onChange={handleImportFile}
-      />
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <div>
@@ -317,11 +279,11 @@ export function ProxyRuleSetsPage() {
                 variant="outline"
                 size="sm"
                 className="gap-2"
-                onClick={handleImportClick}
-                disabled={isImporting || !project?.id}
+                onClick={() => setIsImportDialogOpen(true)}
+                disabled={!project?.id}
               >
                 <Upload className="h-4 w-4" />
-                {isImporting ? 'Importing...' : 'Import'}
+                Import
               </Button>
               <Button size="sm" className="gap-2" onClick={() => setIsCreateDialogOpen(true)}>
                 <Plus className="h-4 w-4" />
@@ -413,6 +375,15 @@ export function ProxyRuleSetsPage() {
           projectId={project?.id || ''}
           open={isCreateDialogOpen}
           onOpenChange={setIsCreateDialogOpen}
+        />
+      )}
+
+      {/* Import Dialog */}
+      {canEdit && (
+        <ImportRuleSetDialog
+          projectId={project?.id || ''}
+          open={isImportDialogOpen}
+          onOpenChange={setIsImportDialogOpen}
         />
       )}
 

--- a/apps/frontend/src/services/pipelineSchemasApi.ts
+++ b/apps/frontend/src/services/pipelineSchemasApi.ts
@@ -340,6 +340,7 @@ export const {
   // Schemas
   useGetProjectSchemasQuery,
   useGetSchemaQuery,
+  useLazyGetSchemaQuery,
   useCreateSchemaMutation,
   useUpdateSchemaMutation,
   useDeleteSchemaMutation,

--- a/apps/frontend/src/services/proxyRulesApi.ts
+++ b/apps/frontend/src/services/proxyRulesApi.ts
@@ -1,5 +1,6 @@
 import { api } from './api';
 import type { HandlerType, TestPipelineDto, TestPipelineResult, ValidatorConfig } from './pipelinesApi';
+import type { SchemaField } from './pipelineSchemasApi';
 
 // Header configuration for proxy rules
 export interface HeaderConfig {
@@ -150,7 +151,16 @@ export type ExportedProxyRule = Omit<
   'id' | 'ruleSetId' | 'createdAt' | 'updatedAt'
 >;
 
-// Portable export envelope for a proxy rule set and its rules
+// A schema dependency bundled in an export (definitions only — name + fields).
+// `id` is the original (source-project) schema id as referenced in the rules.
+export interface ExportedSchema {
+  id: string;
+  name: string;
+  fields: SchemaField[];
+}
+
+// Portable export envelope for a proxy rule set, its rules, and schema deps.
+// version 1: no `schemas`. version 2: bundles referenced schema definitions.
 export interface ProxyRuleSetExport {
   version: number;
   exportedAt: string;
@@ -161,7 +171,22 @@ export interface ProxyRuleSetExport {
     environment?: string | null;
   };
   rules: ExportedProxyRule[];
+  schemas?: ExportedSchema[];
 }
+
+// How to resolve one bundled schema in the target project on import
+export interface ImportSchemaResolution {
+  sourceId: string;
+  name: string;
+  fields: SchemaField[];
+  action: 'reuse' | 'create';
+  targetSchemaId?: string;
+}
+
+// Import payload: the export envelope, with `schemas` carrying per-schema resolutions
+export type ImportRuleSetPayload = Omit<ProxyRuleSetExport, 'schemas'> & {
+  schemas?: ImportSchemaResolution[];
+};
 
 // Pipeline execution log summary (list view)
 export interface PipelineExecutionLogSummary {
@@ -324,7 +349,7 @@ export const proxyRulesApi = api.injectEndpoints({
     // Import a rule set (with rules) from an exported JSON definition
     importRuleSet: builder.mutation<
       ProxyRuleSetWithRules,
-      { projectId: string; data: ProxyRuleSetExport }
+      { projectId: string; data: ImportRuleSetPayload }
     >({
       query: ({ projectId, data }) => ({
         url: `/api/proxy-rule-sets/project/${projectId}/import`,

--- a/apps/frontend/src/utils/proxyRuleSchemaRefs.ts
+++ b/apps/frontend/src/utils/proxyRuleSchemaRefs.ts
@@ -1,0 +1,35 @@
+/**
+ * Keys inside a pipeline rule's `pipelineConfig` (step/postStep `config` objects)
+ * that hold a reference to a pipeline schema id. These are project-scoped, so an
+ * export must bundle the referenced schemas and an import must remap them.
+ *
+ * Mirrors SCHEMA_REF_KEYS in the backend (apps/backend/src/proxy-rules/schema-refs.util.ts).
+ */
+export const SCHEMA_REF_KEYS = [
+  'schemaId',
+  'persistMessagesSchemaId',
+  'persistConversationsSchemaId',
+  'conversationsSchemaId',
+  'messagesSchemaId',
+] as const;
+
+const SCHEMA_REF_KEY_SET = new Set<string>(SCHEMA_REF_KEYS);
+
+/**
+ * Recursively collect every schema-id reference value found under any
+ * SCHEMA_REF_KEYS key. Generic key-based walk so new schema-bearing handlers
+ * are covered automatically.
+ */
+export function collectSchemaIds(node: unknown, out = new Set<string>()): Set<string> {
+  if (Array.isArray(node)) {
+    for (const item of node) collectSchemaIds(item, out);
+  } else if (node && typeof node === 'object') {
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (SCHEMA_REF_KEY_SET.has(key) && typeof value === 'string' && value) {
+        out.add(value);
+      }
+      collectSchemaIds(value, out);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Problem

A real export (`studio.proxy-rules.json`, 39 rules) carries **29 `schemaId` references across 4 schemas**. Pipeline rules embed schema references (`data_create/query/update/delete`, `db_aggregate`, `file_upload`, `embed_store`, `vector_search`, and the `ai` handler's `persistMessagesSchemaId`/`persistConversationsSchemaId`) that point at the **source project's** `pipeline_schemas`. Importing into another project produced pipelines referencing schemas that don't exist there — silently broken.

## Approach (confirmed with product owner)

- Export **always bundles** the referenced schema definitions (name + fields, **no data rows**) → one file works for both backup and cross-project.
- Import shows a dialog to resolve each schema in the target project: **Reuse existing** or **Create new**. Defaults: match by id (same-project backup → reuse), else by name (→ reuse), else create.
- The backend **remaps every schema reference** in the pipeline configs to the resolved ids before insert.

## Changes

**Shared** — `SCHEMA_REF_KEYS` + a generic key-based recursive walker (covers new schema-bearing handlers automatically), mirrored on both sides:
- `apps/backend/src/proxy-rules/schema-refs.util.ts` (`collectSchemaIds`, `remapSchemaIds`) + unit tests
- `apps/frontend/src/utils/proxyRuleSchemaRefs.ts` (`collectSchemaIds`)

**Backend**
- `ImportProxyRuleSetDto` gains optional `schemas` resolutions (`{ sourceId, name, fields, action: 'reuse'|'create', targetSchemaId? }`).
- `ProxyRuleSetsService.importRuleSet` injects `PipelineSchemasService` (no module change — `PipelinesModule` already imported & exports it), creates/reuses schemas (auto-suffixes name on conflict), builds an id map, and `remapSchemaIds` before inserting rules.

**Frontend**
- Export bumps the envelope to **v2** with a `schemas[]` of definitions (v1 still imports — backward compatible).
- New `ImportRuleSetDialog`: file pick → per-schema Reuse/Create selects (smart defaults) → warns about any schema refs not bundled (e.g. v1 files) → imports.

## Verification

- Backend `tsc` clean; `jest proxy-rules` (69) + new `schema-refs.util.spec` (5) pass.
- Frontend `tsc` + ESLint clean; built bundle contains the new strings.
- Manual: export `studio` → file has 4 schema defs; import into a **different** project with "Create new" → schemas created and all pipeline refs remapped; re-import into the **original** project → defaults to reuse, no duplicates; v1 files still import.

## Out of scope
Copying schema data rows; remapping non-schema refs (plugin ids/skills); the `/settings` Proxy Rules surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)