### PR TITLE
feat: let users pin which deployment alias AI skills load from

### DIFF
--- a/apps/backend/src/deployments/deployments.service.ts
+++ b/apps/backend/src/deployments/deployments.service.ts
@@ -1655,6 +1655,22 @@ export class DeploymentsService {
     return project.isPublic ? latestAsset?.commitSha || null : null;
   }
 
+  /**
+   * Get the commit SHA of the most recent deployment for a project,
+   * regardless of visibility or alias. Used as a fallback when no
+   * conventional alias (e.g. 'production') exists.
+   */
+  async getLatestDeploymentSha(projectId: string): Promise<string | null> {
+    const [latestAsset] = await db
+      .select({ commitSha: assets.commitSha })
+      .from(assets)
+      .where(eq(assets.projectId, projectId))
+      .orderBy(desc(assets.createdAt))
+      .limit(1);
+
+    return latestAsset?.commitSha || null;
+  }
+
   // Helper methods
 
   /**

--- a/apps/backend/src/pipelines/handlers/ai.handler.ts
+++ b/apps/backend/src/pipelines/handlers/ai.handler.ts
@@ -277,9 +277,18 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
     );
 
     if (config.skills?.mode !== 'none' && context.deployment) {
-      const { owner, repo, commitSha } = context.deployment;
+      const { owner, repo } = context.deployment;
+      // Use the project's configured skills alias if set; otherwise load skills
+      // from the deployment serving this request.
+      const commitSha =
+        (await this.projectAISettingsService.resolveSkillsCommitSha(
+          context.projectId,
+          context.deployment.commitSha,
+        )) ?? context.deployment.commitSha;
       const skillsPath = await this.projectAISettingsService.getSkillsPath(context.projectId);
-      this.logger.debug(`Skills path for project ${context.projectId}: ${skillsPath}`);
+      this.logger.debug(
+        `Skills source for project ${context.projectId}: ${commitSha?.substring(0, 8)} (path: ${skillsPath})`,
+      );
 
       try {
         const allSkills = await this.skillsService.listSkills(owner, repo, commitSha, skillsPath);

--- a/apps/backend/src/projects/project-ai-settings.service.ts
+++ b/apps/backend/src/projects/project-ai-settings.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { db } from '../db/client';
-import { projects } from '../db/schema';
-import { eq } from 'drizzle-orm';
+import { projects, deploymentAliases } from '../db/schema';
+import { eq, and } from 'drizzle-orm';
 import * as crypto from 'crypto';
 
 /**
@@ -666,6 +666,82 @@ export class ProjectAISettingsService {
       .where(eq(projects.id, projectId));
 
     this.logger.log(`Updated skillsPath for project ${projectId}: ${skillsPath}`);
+  }
+
+  // ===== Skills Alias Settings =====
+
+  /**
+   * Get the alias that skills are loaded from for a project.
+   * Returns null when unset (callers should fall back to the serving
+   * deployment at runtime, or the latest deployment in the config UI).
+   */
+  async getSkillsAlias(projectId: string): Promise<string | null> {
+    const project = await this.getProject(projectId);
+    if (!project?.settings) {
+      return null;
+    }
+
+    const settings = project.settings as Record<string, unknown>;
+    const alias = settings.skillsAlias as string | undefined;
+    return alias && alias.trim() ? alias : null;
+  }
+
+  /**
+   * Set (or clear, when given an empty value) the alias skills are loaded from.
+   */
+  async setSkillsAlias(projectId: string, alias: string | null): Promise<void> {
+    const project = await this.getProject(projectId);
+    if (!project) {
+      throw new NotFoundException('Project not found');
+    }
+
+    const settings = (project.settings || {}) as Record<string, unknown>;
+    if (alias && alias.trim()) {
+      settings.skillsAlias = alias.trim();
+    } else {
+      delete settings.skillsAlias;
+    }
+
+    await db
+      .update(projects)
+      .set({
+        settings,
+        updatedAt: new Date(),
+      })
+      .where(eq(projects.id, projectId));
+
+    this.logger.log(
+      `Updated skillsAlias for project ${projectId}: ${alias?.trim() || '(cleared)'}`,
+    );
+  }
+
+  /**
+   * Resolve the commit SHA that skills should be loaded from for a project.
+   * If a skills alias is configured and resolves to a deployment, that SHA is
+   * returned; otherwise the provided fallback (e.g. the serving deployment's
+   * SHA at runtime) is returned.
+   */
+  async resolveSkillsCommitSha(
+    projectId: string,
+    fallbackCommitSha?: string,
+  ): Promise<string | undefined> {
+    const alias = await this.getSkillsAlias(projectId);
+    if (alias) {
+      const [record] = await db
+        .select({ commitSha: deploymentAliases.commitSha })
+        .from(deploymentAliases)
+        .where(
+          and(
+            eq(deploymentAliases.projectId, projectId),
+            eq(deploymentAliases.alias, alias),
+          ),
+        )
+        .limit(1);
+      if (record?.commitSha) {
+        return record.commitSha;
+      }
+    }
+    return fallbackCommitSha;
   }
 
   // ===== AI Services (Replicate, etc.) =====

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -199,8 +199,18 @@ export class ProjectsController {
       throw new NotFoundException('Project not found');
     }
 
-    // Resolve commitSha: use provided, or try to get from production alias
+    // Resolve commitSha in priority order:
+    //   1. explicit ?commitSha query param
+    //   2. the project's configured skills alias (settings.skillsAlias)
+    //   3. the 'production' alias
+    //   4. the most recent deployment
+    // Steps 3-4 are sensible defaults for when no skills alias is configured;
+    // they matter because deployments may be aliased something other than
+    // 'production' (e.g. 'studio').
     let sha = commitSha;
+    if (!sha) {
+      sha = await this.aiSettingsService.resolveSkillsCommitSha(projectId);
+    }
     if (!sha) {
       try {
         const alias = await this.deploymentsService.getAlias(
@@ -211,8 +221,13 @@ export class ProjectsController {
         );
         sha = alias?.commitSha;
       } catch {
-        // No production alias - that's OK
+        // No production alias - that's OK, fall through to latest deployment
       }
+    }
+    if (!sha) {
+      sha =
+        (await this.deploymentsService.getLatestDeploymentSha(projectId)) ??
+        undefined;
     }
 
     if (!sha) {
@@ -253,6 +268,32 @@ export class ProjectsController {
   ): Promise<{ skillsPath: string }> {
     await this.aiSettingsService.setSkillsPath(projectId, body.skillsPath);
     return { skillsPath: body.skillsPath };
+  }
+
+  @Get(':id/ai/skills-alias')
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
+  @RequireProjectRole('admin')
+  @ApiOperation({ summary: 'Get the alias skills are loaded from for a project' })
+  @ApiResponse({ status: 200, description: 'Skills alias configuration' })
+  async getSkillsAlias(
+    @Param('id') projectId: string,
+  ): Promise<{ skillsAlias: string | null }> {
+    const skillsAlias = await this.aiSettingsService.getSkillsAlias(projectId);
+    return { skillsAlias };
+  }
+
+  @Put(':id/ai/skills-alias')
+  @UseGuards(ApiKeyGuard, ProjectPermissionGuard)
+  @RequireProjectRole('admin')
+  @ApiOperation({ summary: 'Set the alias skills are loaded from for a project' })
+  @ApiResponse({ status: 200, description: 'Skills alias updated' })
+  async setSkillsAlias(
+    @Param('id') projectId: string,
+    @Body() body: { skillsAlias: string | null },
+  ): Promise<{ skillsAlias: string | null }> {
+    await this.aiSettingsService.setSkillsAlias(projectId, body.skillsAlias);
+    const skillsAlias = await this.aiSettingsService.getSkillsAlias(projectId);
+    return { skillsAlias };
   }
 
   // ==========================================================================

--- a/apps/frontend/src/components/pipelines/handlers/SkillsConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/SkillsConfig.tsx
@@ -1,5 +1,13 @@
 import { useState, useEffect } from 'react';
-import { useListProjectSkillsQuery, useGetProjectSkillsPathQuery, useSetProjectSkillsPathMutation } from '@/services/projectsApi';
+import {
+  useListProjectSkillsQuery,
+  useGetProjectSkillsPathQuery,
+  useSetProjectSkillsPathMutation,
+  useGetProjectByIdQuery,
+  useGetProjectSkillsAliasQuery,
+  useSetProjectSkillsAliasMutation,
+} from '@/services/projectsApi';
+import { useListAliasesQuery } from '@/services/repoApi';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -33,6 +41,25 @@ export function SkillsConfig({ config, onChange, projectId }: SkillsConfigProps)
   const [localPath, setLocalPath] = useState('');
   const [saved, setSaved] = useState(false);
   const skills = data?.skills ?? [];
+
+  // Skills alias: which deployment alias to load skills from
+  const { data: project } = useGetProjectByIdQuery(projectId);
+  const { data: aliasesData } = useListAliasesQuery(
+    { owner: project?.owner ?? '', repo: project?.name ?? '' },
+    { skip: !project?.owner || !project?.name },
+  );
+  const { data: aliasData } = useGetProjectSkillsAliasQuery({ projectId });
+  const [setSkillsAlias] = useSetProjectSkillsAliasMutation();
+  const aliases = aliasesData?.aliases ?? [];
+  const AUTO = '__auto__';
+  const selectedAlias = aliasData?.skillsAlias || AUTO;
+
+  const handleAliasChange = async (value: string) => {
+    await setSkillsAlias({
+      projectId,
+      skillsAlias: value === AUTO ? null : value,
+    });
+  };
 
   useEffect(() => {
     if (pathData?.skillsPath) {
@@ -74,6 +101,30 @@ export function SkillsConfig({ config, onChange, projectId }: SkillsConfigProps)
           {config.mode === 'selected' && 'Choose specific skills to enable.'}
         </p>
       </div>
+
+      {config.mode !== 'none' && (
+        <div className="space-y-2">
+          <Label>Skills Source (Alias)</Label>
+          <Select value={selectedAlias} onValueChange={handleAliasChange}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={AUTO}>Auto (serving deployment)</SelectItem>
+              {aliases.map((a) => (
+                <SelectItem key={a.name} value={a.name}>
+                  {a.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Which deployment alias to load <code className="bg-muted px-1 rounded">SKILL.md</code> files
+            from. <strong>Auto</strong> uses whichever deployment serves the request at runtime; pick a
+            specific alias to always load skills from there (e.g. a dedicated skills deployment).
+          </p>
+        </div>
+      )}
 
       {config.mode !== 'none' && (
         <div className="space-y-2">

--- a/apps/frontend/src/services/projectsApi.ts
+++ b/apps/frontend/src/services/projectsApi.ts
@@ -499,6 +499,30 @@ export const projectsApi = api.injectEndpoints({
         { type: 'ProjectAI' as const, id: `${projectId}-skills` },
       ],
     }),
+    // Skills alias (which deployment alias skills are loaded from)
+    getProjectSkillsAlias: builder.query<
+      { skillsAlias: string | null },
+      { projectId: string }
+    >({
+      query: ({ projectId }) => `/api/projects/${projectId}/ai/skills-alias`,
+      providesTags: (_result, _error, { projectId }) => [
+        { type: 'ProjectAI' as const, id: `${projectId}-skills-alias` },
+      ],
+    }),
+    setProjectSkillsAlias: builder.mutation<
+      { skillsAlias: string | null },
+      { projectId: string; skillsAlias: string | null }
+    >({
+      query: ({ projectId, skillsAlias }) => ({
+        url: `/api/projects/${projectId}/ai/skills-alias`,
+        method: 'PUT',
+        body: { skillsAlias },
+      }),
+      invalidatesTags: (_result, _error, { projectId }) => [
+        { type: 'ProjectAI' as const, id: `${projectId}-skills-alias` },
+        { type: 'ProjectAI' as const, id: `${projectId}-skills` },
+      ],
+    }),
   }),
 });
 
@@ -540,4 +564,6 @@ export const {
   useListProjectSkillsQuery,
   useGetProjectSkillsPathQuery,
   useSetProjectSkillsPathMutation,
+  useGetProjectSkillsAliasQuery,
+  useSetProjectSkillsAliasMutation,
 } = projectsApi;


### PR DESCRIPTION
## Problem

The ai_handler **Skills** config screen showed "No skills found" even when `SKILL.md` files existed in the deployment. The listing endpoint resolved which deployment to scan **only from the `production` alias**, so any project aliased something else (e.g. `studio`) found nothing — even though skills loaded fine at runtime, which uses the *serving* deployment's commitSha. The config UI and runtime also disagreed on which deployment they looked at.

## Change

Add a per-project **skills alias** setting so users explicitly pick which deployment alias skills load from, pinned across **both** the config UI and runtime.

- **`ProjectAISettingsService`** — `getSkillsAlias` / `setSkillsAlias` (persisted in `settings.skillsAlias`) and `resolveSkillsCommitSha(projectId, fallbackSha?)`. Resolution lives here (already injected in both the handler and the controller) to avoid a circular DI of `DeploymentsService` into a pipeline handler.
- **`projects.controller`** — new `GET`/`PUT /:id/ai/skills-alias`; `listSkills` now resolves the SHA as `?commitSha` → skills alias → `production` → latest deployment (`DeploymentsService.getLatestDeploymentSha`, added because `getDefaultAlias` only returns for public projects but the admin UI is authenticated).
- **`ai.handler`** (runtime) — uses `resolveSkillsCommitSha(projectId, servingDeploymentSha)`, so a pinned alias wins, otherwise falls back to the serving deployment as before.
- **Frontend `SkillsConfig`** — new "Skills Source (Alias)" dropdown ("Auto (serving deployment)" + every project alias), saved immediately and re-lists skills on change.

## Behavior

- Unset → unchanged for existing users (runtime: serving deployment; UI: production → latest).
- Set → skills always load from that alias's commitSha everywhere.

## Testing

- `tsc --noEmit` clean for backend and frontend.
- No unit specs exist for the touched files (`ai.handler`, `project-ai-settings`), so none were affected; additive `DeploymentsService` method doesn't change existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)