### PR TITLE
fix: raise request body limit above body-parser's 100kb default

### DIFF
--- a/apps/backend/src/common/filters/http-exception.filter.ts
+++ b/apps/backend/src/common/filters/http-exception.filter.ts
@@ -75,8 +75,13 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       message = this.isProduction ? 'Internal server error' : exception.message;
       error = 'Internal Server Error';
 
-      // Check for specific database errors
-      if (this.isDatabaseConnectionError(exception)) {
+      // Body-parser rejects oversized request bodies with a plain Error;
+      // surface it as a proper 413 instead of a generic 500.
+      if (this.isPayloadTooLargeError(exception)) {
+        status = HttpStatus.PAYLOAD_TOO_LARGE;
+        error = 'Payload Too Large';
+        message = 'Request body is too large.';
+      } else if (this.isDatabaseConnectionError(exception)) {
         status = HttpStatus.SERVICE_UNAVAILABLE;
         error = 'Service Unavailable';
         message = 'Service temporarily unavailable. Please try again later.';
@@ -116,11 +121,22 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       [HttpStatus.NOT_FOUND]: 'Not Found',
       [HttpStatus.CONFLICT]: 'Conflict',
       [HttpStatus.UNPROCESSABLE_ENTITY]: 'Unprocessable Entity',
+      [HttpStatus.PAYLOAD_TOO_LARGE]: 'Payload Too Large',
       [HttpStatus.TOO_MANY_REQUESTS]: 'Too Many Requests',
       [HttpStatus.INTERNAL_SERVER_ERROR]: 'Internal Server Error',
       [HttpStatus.SERVICE_UNAVAILABLE]: 'Service Unavailable',
     };
     return errorNames[status] || 'Error';
+  }
+
+  /**
+   * Check if exception is a body-parser "request entity too large" error.
+   */
+  private isPayloadTooLargeError(exception: Error): boolean {
+    return (
+      exception.name === 'PayloadTooLargeError' ||
+      (exception as { type?: string }).type === 'entity.too.large'
+    );
   }
 
   /**

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,14 +1,23 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe, LogLevel } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, {
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     logger: (process.env.LOG_LEVEL?.split(',') as LogLevel[]) || ['error', 'warn', 'log'],
     rawBody: true, // Needed for Stripe webhook signature verification
   });
+
+  // Raise the request body limit above body-parser's 100kb default. Pipeline
+  // endpoints (e.g. studio's /api/projects/save) POST large JSON documents that
+  // otherwise fail with PayloadTooLargeError -> 500. Re-registering the parsers
+  // here keeps the rawBody capture enabled above.
+  const bodyLimit = process.env.BODY_LIMIT || '10mb';
+  app.useBodyParser('json', { limit: bodyLimit });
+  app.useBodyParser('urlencoded', { extended: true, limit: bodyLimit });
 
   // Parse cookies (populates req.cookies)
   app.use(cookieParser());


### PR DESCRIPTION
## Problem

Large pipeline POST payloads were failing with a **500**. Studio's `/api/projects/save` sends the full project state (~136 KB of JSON), which exceeds body-parser's **100 KB** JSON default. The thrown `PayloadTooLargeError` was rendered by the global exception filter as a generic 500 (no pipeline execution log, since it fails during body parsing — before the pipeline runs).

Confirmed in production logs:
```
ERROR [GlobalExceptionFilter] [POST] /public/bffless/apps/alias/studio/.../api/projects/save - 500
ERROR [GlobalExceptionFilter] PayloadTooLargeError: request entity too large
    at readStream (.../raw-body/index.js:163:17)
    at jsonParser (.../body-parser/lib/types/json.js:138:5)
```

## Changes

1. **Raise the body limit** (`main.ts`) — re-register the json/urlencoded parsers with a **10 MB** limit (overridable via `BODY_LIMIT`). Uses `app.useBodyParser(...)` on a typed `NestExpressApplication`, preserving the existing `rawBody: true` capture needed for Stripe webhook signature verification.
2. **Correct status for oversized bodies** (`http-exception.filter.ts`) — `PayloadTooLargeError` is a plain `Error` (not an `HttpException`), so it previously fell through to 500. Detect it (by `name` or `type === 'entity.too.large'`) and surface a proper **413 Payload Too Large**.

## Testing

- `tsc --noEmit` clean (backend).

## Notes

- Takes effect after the backend is redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)