### PR TITLE
fix: support absolute external URLs as path redirect targets

### DIFF
--- a/apps/backend/src/domains/dto/create-path-redirect.dto.ts
+++ b/apps/backend/src/domains/dto/create-path-redirect.dto.ts
@@ -12,12 +12,15 @@ export class CreatePathRedirectDto {
   sourcePath: string;
 
   @ApiProperty({
-    description: 'Target path to redirect to (/new-page or /blog/$1 for wildcard replacement)',
+    description:
+      'Target to redirect to: a path on this domain (/new-page or /blog/$1 for wildcard replacement) or an absolute URL (https://example.com)',
     example: '/new-page',
   })
   @IsString()
   @Length(1, 500)
-  @Matches(/^\//, { message: 'Target path must start with /' })
+  @Matches(/^(https?:\/\/|\/)/, {
+    message: 'Target must start with / or be an absolute http(s) URL',
+  })
   targetPath: string;
 
   @ApiPropertyOptional({

--- a/apps/backend/src/domains/dto/update-path-redirect.dto.ts
+++ b/apps/backend/src/domains/dto/update-path-redirect.dto.ts
@@ -13,13 +13,16 @@ export class UpdatePathRedirectDto {
   sourcePath?: string;
 
   @ApiPropertyOptional({
-    description: 'Target path to redirect to (/new-page or /blog/$1 for wildcard replacement)',
+    description:
+      'Target to redirect to: a path on this domain (/new-page or /blog/$1 for wildcard replacement) or an absolute URL (https://example.com)',
     example: '/new-page',
   })
   @IsOptional()
   @IsString()
   @Length(1, 500)
-  @Matches(/^\//, { message: 'Target path must start with /' })
+  @Matches(/^(https?:\/\/|\/)/, {
+    message: 'Target must start with / or be an absolute http(s) URL',
+  })
   targetPath?: string;
 
   @ApiPropertyOptional({

--- a/apps/backend/src/domains/nginx-config.service.spec.ts
+++ b/apps/backend/src/domains/nginx-config.service.spec.ts
@@ -215,6 +215,65 @@ server {
       expect(config).toContain('/apps/frontend/coverage');
     });
 
+    // Regression: redirect targets that are absolute external URLs must be emitted
+    // verbatim. Previously they were forced to start with "/", so nginx produced
+    // `return 302 /https://discord.gg/...`, which the browser resolved relative to
+    // the host (-> example.com/https://discord.gg/...) instead of redirecting out.
+    it('should emit absolute external URL redirect targets without a leading slash', async () => {
+      const domainMapping = {
+        id: 'domain-redir',
+        projectId: 'proj-1',
+        domain: 'app.example.com',
+        domainType: 'subdomain' as const,
+        alias: 'production',
+        path: null,
+        sslEnabled: false,
+        isActive: true,
+        isPublic: null,
+        unauthorizedBehavior: null,
+        requiredRole: null,
+        dnsVerified: true,
+        createdBy: 'user-1',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        sslExpiresAt: null,
+        dnsVerifiedAt: null,
+        nginxConfigPath: null,
+        autoRenewSsl: true,
+        sslRenewedAt: null,
+        sslRenewalStatus: null,
+        sslRenewalError: null,
+        stickySessionsEnabled: true,
+        stickySessionDuration: 86400,
+        isSpa: false,
+        isPrimary: false,
+        wwwBehavior: null,
+        redirectTarget: null,
+        redirectType: '301' as const,
+      };
+
+      const config = await service.generateConfig(domainMapping, mockProject, undefined, [
+        {
+          sourcePath: '/discord',
+          targetPath: 'https://discord.gg/CaRsVzuE',
+          redirectType: '302' as const,
+          priority: '100',
+        },
+        {
+          sourcePath: '/old-page',
+          targetPath: '/new-page',
+          redirectType: '301' as const,
+          priority: '100',
+        },
+      ]);
+
+      // Absolute URL passes through untouched (redirects off-site).
+      expect(config).toContain('return 302 https://discord.gg/CaRsVzuE;');
+      expect(config).not.toContain('return 302 /https://discord.gg/CaRsVzuE');
+      // Relative same-domain targets still work as before.
+      expect(config).toContain('return 301 /new-page;');
+    });
+
     it('should generate custom domain config', async () => {
       const domainMapping = {
         id: 'domain-2',

--- a/apps/frontend/src/components/domains/RedirectsTab.tsx
+++ b/apps/frontend/src/components/domains/RedirectsTab.tsx
@@ -53,9 +53,16 @@ export function RedirectsTab({ domainId, targetDomain }: RedirectsTabProps) {
       return;
     }
 
-    // Ensure paths start with /
+    // Source is always a path on this domain, so ensure it starts with /.
     const sourcePath = newSourcePath.startsWith('/') ? newSourcePath : `/${newSourcePath}`;
-    const targetPath = newTargetPath.startsWith('/') ? newTargetPath : `/${newTargetPath}`;
+    // Target can be an absolute external URL (http(s)://...) or a path on this
+    // domain. Only prepend / for relative paths — never mangle an absolute URL.
+    const trimmedTarget = newTargetPath.trim();
+    const targetPath = /^https?:\/\//i.test(trimmedTarget)
+      ? trimmedTarget
+      : trimmedTarget.startsWith('/')
+        ? trimmedTarget
+        : `/${trimmedTarget}`;
 
     try {
       await createPathRedirect({
@@ -224,7 +231,7 @@ export function RedirectsTab({ domainId, targetDomain }: RedirectsTabProps) {
             <ArrowRight className="h-4 w-4 text-muted-foreground flex-shrink-0" />
             <div className="flex-1">
               <Input
-                placeholder="/new-page"
+                placeholder="/new-page or https://example.com"
                 value={newTargetPath}
                 onChange={(e) => setNewTargetPath(e.target.value)}
                 className="font-mono text-sm"
@@ -267,6 +274,7 @@ export function RedirectsTab({ domainId, targetDomain }: RedirectsTabProps) {
           <strong>301</strong> = Permanent redirect (recommended for SEO),{' '}
           <strong>302</strong> = Temporary redirect.
           Use <code className="bg-muted px-1 rounded">*</code> for wildcards (e.g., <code className="bg-muted px-1 rounded">/old-blog/*</code>).
+          Targets can be a path on this domain or an absolute URL (e.g., <code className="bg-muted px-1 rounded">https://discord.gg/…</code>).
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Problem

Creating a domain path redirect to an external site (e.g. `/discord` → `https://discord.gg/CaRsVzuE`) sent visitors to `example.com/https://discord.gg/CaRsVzuE` instead of Discord.

**Root cause:** path redirects were built assuming every target is a relative path on the same domain, so both the frontend and the DTO validation forced a leading `/`. The external URL became `/https://discord.gg/CaRsVzuE`, nginx emitted `return 302 /https://discord.gg/CaRsVzuE;`, and the browser resolved that leading-slash path against the current host. (nginx handles absolute URLs in `return` correctly, so no nginx change was needed — only the forced `/`.)

## Changes

- **Frontend** (`RedirectsTab.tsx`): only prepend `/` to relative targets; pass `http(s)://` URLs through untouched. Updated the input placeholder and helper text so the capability is discoverable.
- **Backend DTOs** (`create-/update-path-redirect.dto.ts`): relaxed target validation to `/^(https?:\/\/|\/)/`. Source paths still require a leading `/`.
- **Test** (`nginx-config.service.spec.ts`): regression test asserting an absolute target produces `return 302 https://discord.gg/CaRsVzuE;` (not the leading-slash form) while relative same-domain targets still work.

## Testing

- `nginx-config.service.spec` — 18/18 pass (incl. new regression test)
- Frontend + backend `tsc --noEmit` clean

## Note on existing data

Redirects created before this fix are stored with the broken `/https://…` target. After deploy, delete and re-add them with the bare `https://…` URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)