### PR TITLE
docs: point Discord links at bffless.app/discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See the [claude-skills repo](https://github.com/bffless/claude-skills) for full 
 
 ## Community
 
-Join our [Discord](https://discord.gg/BAYKm5Kv) for support, feature discussions, and updates.
+Join our [Discord](https://bffless.app/discord) for support, feature discussions, and updates.
 
 ## Contributing
 
@@ -97,4 +97,4 @@ O'Saasy License - see [LICENSE](./LICENSE) for details.
 
 ---
 
-[Documentation](https://docs.bffless.app) | [Discord](https://discord.gg/BAYKm5Kv) | [Changelog](./CHANGELOG.md) | [Issues](https://github.com/bffless/ce/issues)
+[Documentation](https://docs.bffless.app) | [Discord](https://bffless.app/discord) | [Changelog](./CHANGELOG.md) | [Issues](https://github.com/bffless/ce/issues)


### PR DESCRIPTION
Replaces the raw `discord.gg` invite with the reverse-proxied `https://bffless.app/discord` in the README community links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)