### PR TITLE
fix: show correct permission badge for global admins on repo cards

### DIFF
--- a/apps/frontend/src/components/repositories/RepositoryCard.test.tsx
+++ b/apps/frontend/src/components/repositories/RepositoryCard.test.tsx
@@ -184,6 +184,28 @@ describe('RepositoryCard', () => {
     expect(screen.getByText('Admin')).toBeInTheDocument();
   });
 
+  it('displays Owner badge for global admin (permissionType admin, role owner)', () => {
+    // Global admins act as owner on every project: the feed returns
+    // permissionType 'admin' with role 'owner'. This must not fall through
+    // to the Viewer default.
+    const globalAdminRepository: FeedRepository = {
+      ...mockRepository,
+      id: 'repo-global-admin',
+      name: 'global-admin-repo',
+      permissionType: 'admin',
+      role: 'owner',
+    };
+
+    render(
+      <RouterWrapper>
+        <RepositoryCard repository={globalAdminRepository} />
+      </RouterWrapper>
+    );
+
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+    expect(screen.queryByText('Viewer')).not.toBeInTheDocument();
+  });
+
   it('does not display permission badge for public repos', () => {
     render(
       <RouterWrapper>

--- a/apps/frontend/src/components/repositories/RepositoryCard.tsx
+++ b/apps/frontend/src/components/repositories/RepositoryCard.tsx
@@ -17,16 +17,21 @@ interface RepositoryCardProps {
 export function RepositoryCard({ repository }: RepositoryCardProps) {
   // Map permission type and role to PermissionLevel
   const getPermissionLevel = (): PermissionLevel | null => {
-    if (repository.permissionType === 'owner') return 'owner';
     if (repository.permissionType === 'public') return null; // No permission badge for public repos
 
-    // For direct and group permissions, map role to permission level
+    // The effective role is the source of truth. Owners and global admins
+    // (permissionType 'admin', who act as owner on every project) both have
+    // role 'owner'; direct/group grants carry their own role.
     const role = repository.role?.toLowerCase();
+    if (role === 'owner') return 'owner';
     if (role === 'admin') return 'admin';
     if (role === 'contributor') return 'contributor';
     if (role === 'viewer') return 'viewer';
 
-    // Default to viewer if role is not recognized
+    // Fall back to permissionType when role is missing/unrecognized.
+    if (repository.permissionType === 'owner') return 'owner';
+    if (repository.permissionType === 'admin') return 'admin';
+
     return 'viewer';
   };
 


### PR DESCRIPTION
## Problem

Signed in as the owner/global admin, every repository card on `/repo` showed a **Viewer** badge — in both the docs and j5s installs. The access itself is fine; only the badge was wrong.

## Root cause

The backend feed (`projects.service.ts`) returns, for a **global admin**, `permissionType: 'admin'` with `role: 'owner'` ("global admin acts as owner on every project"). Repos you simply own return `permissionType: 'owner'`, `role: 'owner'`.

`RepositoryCard.getPermissionLevel()` only special-cased `permissionType === 'owner'`/`'public'`, then matched `role` against `admin`/`contributor`/`viewer`. Since the global-admin `role` is `'owner'` (unhandled) and `permissionType` is `'admin'` (unhandled), every card fell through to the `return 'viewer'` default.

## Fix

Drive the badge off the effective `role` (`owner`/`admin`/`contributor`/`viewer`), with `permissionType` as a fallback. Global admins and owners now correctly show the **Owner** badge.

## Tests

- All existing frontend tests pass (365).
- Added a regression test covering the global-admin case (`permissionType: 'admin'`, `role: 'owner'` → Owner, not Viewer).

UI display fix only — no backend/auth changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)