### PR TITLE
feat(pipelines): expose crypto utils to function_handler sandbox

### DIFF
--- a/apps/backend/src/pipelines/__tests__/function-runner.service.spec.ts
+++ b/apps/backend/src/pipelines/__tests__/function-runner.service.spec.ts
@@ -404,5 +404,96 @@ describe('FunctionRunnerService', () => {
         expect(result.executionTime).toBeGreaterThanOrEqual(0);
       });
     });
+
+    describe('utils crypto helpers', () => {
+      it('exposes utils on the handler argument and as a global', async () => {
+        const viaArg = await service.run(
+          'function handler({ utils }) { return typeof utils.sign; }',
+          {},
+        );
+        expect(viaArg.success).toBe(true);
+        expect(viaArg.output).toBe('function');
+
+        const viaGlobal = await service.run(
+          'function handler() { return typeof utils.sign; }',
+          {},
+        );
+        expect(viaGlobal.success).toBe(true);
+        expect(viaGlobal.output).toBe('function');
+      });
+
+      it('sha256 returns a stable lowercase hex digest', async () => {
+        const result = await service.run(
+          'function handler({ utils }) { return utils.sha256("hello"); }',
+          {},
+        );
+        expect(result.success).toBe(true);
+        // Known SHA-256 of "hello"
+        expect(result.output).toBe(
+          '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+        );
+      });
+
+      it('sign + verify round-trips and rejects tampering', async () => {
+        const result = await service.run(
+          `function handler({ utils }) {
+            var sig = utils.sign('folder:abc|user:42');
+            return {
+              ok: utils.verify('folder:abc|user:42', sig),
+              tampered: utils.verify('folder:abc|user:99', sig),
+              wrongSig: utils.verify('folder:abc|user:42', 'deadbeef'),
+            };
+          }`,
+          {},
+        );
+        expect(result.success).toBe(true);
+        expect(result.output).toEqual({
+          ok: true,
+          tampered: false,
+          wrongSig: false,
+        });
+      });
+
+      it('the same message always signs to the same value (stable key)', async () => {
+        const a = await service.run(
+          'function handler({ utils }) { return utils.sign("x"); }',
+          {},
+        );
+        const b = await service.run(
+          'function handler({ utils }) { return utils.sign("x"); }',
+          {},
+        );
+        expect(a.output).toBe(b.output);
+        expect(typeof a.output).toBe('string');
+      });
+
+      it('randomToken returns distinct hex tokens of the requested length', async () => {
+        const result = await service.run(
+          `function handler({ utils }) {
+            var a = utils.randomToken(16);
+            var b = utils.randomToken(16);
+            return { len: a.length, distinct: a !== b, hex: /^[0-9a-f]+$/.test(a) };
+          }`,
+          {},
+        );
+        expect(result.success).toBe(true);
+        expect(result.output).toEqual({ len: 32, distinct: true, hex: true });
+      });
+
+      it('base64url encode/decode round-trips without padding', async () => {
+        const result = await service.run(
+          `function handler({ utils }) {
+            var enc = utils.base64urlEncode('{"f":"abc","u":"42"}');
+            return { dec: utils.base64urlDecode(enc), padless: enc.indexOf('=') === -1 };
+          }`,
+          {},
+        );
+        expect(result.success).toBe(true);
+        expect(result.output).toEqual({
+          dec: '{"f":"abc","u":"42"}',
+          padless: true,
+        });
+      });
+    });
   });
 });

--- a/apps/backend/src/pipelines/function-runner.service.ts
+++ b/apps/backend/src/pipelines/function-runner.service.ts
@@ -1,5 +1,42 @@
 import { Injectable, Logger } from '@nestjs/common';
 import * as vm from 'vm';
+import {
+  createHash,
+  createHmac,
+  randomBytes,
+  randomUUID,
+  timingSafeEqual,
+} from 'crypto';
+
+/**
+ * Crypto helpers exposed to pipeline function handlers as the global `utils`
+ * (also passed on the handler argument, so both `utils.sign(...)` and
+ * `function handler({ utils }) { ... }` work).
+ *
+ * These are pure string -> string|boolean helpers backed by Node's crypto at
+ * the host level. `sign`/`verify` use a server-held pipeline signing key that
+ * is NEVER exposed to the sandbox, so handlers can mint/validate tamper-proof
+ * tokens (e.g. a short-lived, folder-scoped access cookie) without handling the
+ * raw secret.
+ */
+export interface PipelineFunctionUtils {
+  /** Lowercase hex SHA-256 of `message`. */
+  sha256(message: string): string;
+  /** Lowercase hex HMAC-SHA256 of `message` with the caller-supplied `key`. */
+  hmacSha256(message: string, key: string): string;
+  /** Hex HMAC-SHA256 of `message` using the server pipeline signing key. */
+  sign(message: string): string;
+  /** Timing-safe check that `signature` matches `sign(message)`. */
+  verify(message: string, signature: string): boolean;
+  /** Crypto-strong random hex token of `bytes` length (default 18 → 36 hex chars). */
+  randomToken(bytes?: number): string;
+  /** RFC4122 v4 UUID. */
+  randomUUID(): string;
+  /** Base64url-encode a UTF-8 string (no padding). */
+  base64urlEncode(value: string): string;
+  /** Decode a base64url string back to a UTF-8 string ('' on malformed input). */
+  base64urlDecode(value: string): string;
+}
 
 /**
  * Options for function execution
@@ -79,6 +116,65 @@ const PROHIBITED_PATTERNS = [
 export class FunctionRunnerService {
   private readonly logger = new Logger(FunctionRunnerService.name);
 
+  /** Cached server-side signing key for `utils.sign` / `utils.verify`. */
+  private signingKeyCache: Buffer | null = null;
+
+  /**
+   * Derive the pipeline signing key once, from a dedicated env var when set,
+   * otherwise from the (required, stable) ENCRYPTION_KEY so signatures survive
+   * restarts without extra configuration. Never exposed to the sandbox.
+   */
+  private getSigningKey(): Buffer {
+    if (!this.signingKeyCache) {
+      const base =
+        process.env.PIPELINE_SIGNING_SECRET ||
+        process.env.ENCRYPTION_KEY ||
+        'bffless-pipeline-dev-signing-secret';
+      this.signingKeyCache = createHash('sha256')
+        .update(`${base}|pipeline-fn-sign`)
+        .digest();
+    }
+    return this.signingKeyCache;
+  }
+
+  /**
+   * Build the `utils` crypto bag injected into every function sandbox. All
+   * helpers coerce their inputs with String() and never throw on bad input.
+   */
+  private buildUtils(): PipelineFunctionUtils {
+    const signingKey = this.getSigningKey();
+    const hmacHex = (message: string, key: Buffer | string): string =>
+      createHmac('sha256', key).update(String(message)).digest('hex');
+
+    return {
+      sha256: (message) =>
+        createHash('sha256').update(String(message)).digest('hex'),
+      hmacSha256: (message, key) => hmacHex(message, String(key)),
+      sign: (message) => hmacHex(message, signingKey),
+      verify: (message, signature) => {
+        const expected = hmacHex(message, signingKey);
+        const a = Buffer.from(expected, 'utf8');
+        const b = Buffer.from(String(signature), 'utf8');
+        if (a.length !== b.length) return false;
+        return timingSafeEqual(a, b);
+      },
+      randomToken: (bytes = 18) => {
+        const n = Math.min(Math.max(Math.floor(Number(bytes) || 18), 1), 64);
+        return randomBytes(n).toString('hex');
+      },
+      randomUUID: () => randomUUID(),
+      base64urlEncode: (value) =>
+        Buffer.from(String(value), 'utf8').toString('base64url'),
+      base64urlDecode: (value) => {
+        try {
+          return Buffer.from(String(value), 'base64url').toString('utf8');
+        } catch {
+          return '';
+        }
+      },
+    };
+  }
+
   /**
    * Validate user code before execution.
    * Checks for prohibited patterns that could be used to escape the sandbox.
@@ -146,10 +242,17 @@ export class FunctionRunnerService {
       // Create a frozen copy of data to prevent modifications
       const frozenData = this.deepFreeze(structuredClone(data));
 
+      // Crypto helpers exposed to the handler. Built per-run; functions are not
+      // structured-cloneable, so utils is attached AFTER the freeze/clone above.
+      const utils = this.buildUtils();
+
       // Create a minimal sandbox context with safe built-ins
       const sandbox: vm.Context = {
-        // User data (frozen)
-        data: frozenData,
+        // User data (frozen) + crypto helpers on the handler argument
+        data: { ...frozenData, utils },
+
+        // Crypto helpers also available as a bare global (`utils.sign(...)`)
+        utils,
 
         // Safe built-ins
         Math,
@@ -207,8 +310,9 @@ export class FunctionRunnerService {
       // Create the context
       vm.createContext(sandbox);
 
-      // Wrap user code: user defines a handler({ input, user, request, steps }) function, we call it
-      // This matches the serverless function pattern (AWS Lambda, Cloud Functions, etc.)
+      // Wrap user code: user defines a handler({ user, request, steps, deployment, utils }) function, we call it
+      // (`utils` is also available as a bare global). This matches the serverless
+      // function pattern (AWS Lambda, Cloud Functions, etc.)
       const wrappedCode = `
         (async function() {
           try {


### PR DESCRIPTION
## What

Adds a `utils` crypto helper bag to the pipeline `function_handler` sandbox. It's available both as a bare global and on the handler argument:

```js
function handler({ request, steps, utils }) {
  var token = utils.base64urlEncode(JSON.stringify({ f: folderId, u: userId, exp: now + 300000 }))
  var sig = utils.sign(token)                 // HMAC-SHA256 with a server key the sandbox never sees
  // ... later request:
  if (utils.verify(token, sig)) { /* trusted */ }
}
```

### API
- `sha256(message)` / `hmacSha256(message, key)` — lowercase hex digests
- `sign(message)` / `verify(message, signature)` — HMAC-SHA256 using a **server-held** pipeline signing key (never exposed to the sandbox); `verify` is timing-safe
- `randomToken(bytes = 18)` / `randomUUID()` — crypto-strong randomness
- `base64urlEncode(str)` / `base64urlDecode(str)` — compact, URL-safe payloads

### Signing key
Derived once from `PIPELINE_SIGNING_SECRET` if set, else the existing required `ENCRYPTION_KEY`, so signatures are stable across restarts with **no new required config**.

## Why
Function handlers had only `Math/Date/JSON/...` — no crypto. This blocks tamper-proof server-minted tokens, e.g. a short-lived, folder-scoped access cookie for per-folder ACL enforcement (an app building a permissioned file server on BFFless). `sign`/`verify` keep the raw secret out of the sandbox, so handlers can mint/validate tokens without handling key material.

## Safety
- Helpers are pure `string -> string | boolean`, coerce inputs with `String()`, and never throw.
- The signing key lives in the host; the sandbox only ever sees signatures.
- Consistent with the existing trust model — function code is authored by project owners, and host functions (e.g. captured `console`) are already injected into the vm context.

## Tests
`apps/backend/src/pipelines/__tests__/function-runner.service.spec.ts` — 6 new cases: `utils` exposure (arg + global), known SHA-256 digest, sign/verify round-trip + tamper rejection, stable signing across runs, distinct hex `randomToken`, base64url round-trip without padding. Full suite: **47/47 pass**; backend `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Ae6sEbZTbNf2r1ZA8Vb7a