### PR TITLE
feat(mcp): expose cacheability on create_cache_rule tool

### DIFF
--- a/apps/backend/src/mcp/tools/cache-rules.tools.spec.ts
+++ b/apps/backend/src/mcp/tools/cache-rules.tools.spec.ts
@@ -1,0 +1,82 @@
+import { createCacheRuleParameters, CacheRulesTools } from './cache-rules.tools';
+
+describe('create_cache_rule MCP tool', () => {
+  describe('parameters schema', () => {
+    it('accepts and preserves a cacheability override (the field the MCP framework forwards)', () => {
+      const parsed = createCacheRuleParameters.parse({
+        projectId: 'p1',
+        pathPattern: 'api/uploads/content/**',
+        cacheability: 'private',
+        browserMaxAge: 0,
+      });
+      // The framework strips any field not declared in the schema before it
+      // reaches the service, so this must round-trip for `private` to take effect.
+      expect(parsed.cacheability).toBe('private');
+    });
+
+    it('allows public and null, and omitting it', () => {
+      expect(
+        createCacheRuleParameters.parse({
+          projectId: 'p1',
+          pathPattern: '*.js',
+          cacheability: 'public',
+        }).cacheability,
+      ).toBe('public');
+      expect(
+        createCacheRuleParameters.parse({
+          projectId: 'p1',
+          pathPattern: '*.js',
+          cacheability: null,
+        }).cacheability,
+      ).toBeNull();
+      expect(
+        createCacheRuleParameters.parse({ projectId: 'p1', pathPattern: '*.js' }).cacheability,
+      ).toBeUndefined();
+    });
+
+    it('rejects an invalid cacheability value', () => {
+      expect(() =>
+        createCacheRuleParameters.parse({
+          projectId: 'p1',
+          pathPattern: '*.js',
+          cacheability: 'sometimes',
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe('createRule', () => {
+    it('forwards cacheability through to the cache-rules service', async () => {
+      const create = jest.fn().mockResolvedValue({ id: 'r1', cacheability: 'private' });
+      const tools = new CacheRulesTools({ create } as any, {} as any);
+      // getUserContext reads auth from the request; stub a resolved user.
+      const request = { user: { id: 'u1', role: 'admin', apiKeyProjectId: null } } as any;
+      jest
+        .spyOn(
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          require('../helpers/user-context.helper'),
+          'getUserContext',
+        )
+        .mockResolvedValue({ id: 'u1', role: 'admin', apiKeyProjectId: null });
+
+      await tools.createRule(
+        {
+          projectId: 'p1',
+          pathPattern: 'api/uploads/content/**',
+          cacheability: 'private',
+          browserMaxAge: 0,
+        } as any,
+        {} as any,
+        request,
+      );
+
+      expect(create).toHaveBeenCalledWith(
+        'p1',
+        expect.objectContaining({ cacheability: 'private', browserMaxAge: 0 }),
+        'u1',
+        'admin',
+        null,
+      );
+    });
+  });
+});

--- a/apps/backend/src/mcp/tools/cache-rules.tools.ts
+++ b/apps/backend/src/mcp/tools/cache-rules.tools.ts
@@ -6,6 +6,31 @@ import { CacheRulesService } from '../../cache-rules/cache-rules.service';
 import { AuthService } from '../../auth/auth.service';
 import { getUserContext } from '../helpers/user-context.helper';
 
+/**
+ * Parameters for the `create_cache_rule` tool. Exported so the schema (and the
+ * fields it forwards to the service) can be asserted in tests — the MCP
+ * framework strips any field not declared here before it reaches the service.
+ */
+export const createCacheRuleParameters = z.object({
+  projectId: z.string().describe('Project ID'),
+  pathPattern: z.string().describe('Glob pattern to match paths (e.g. "*.js", "images/**")'),
+  name: z.string().optional().describe('Rule name'),
+  description: z.string().optional().describe('Rule description'),
+  browserMaxAge: z.number().optional().describe('Browser cache max-age in seconds'),
+  cdnMaxAge: z.number().optional().describe('CDN cache max-age in seconds'),
+  staleWhileRevalidate: z.number().optional().describe('Stale-while-revalidate window in seconds'),
+  immutable: z.boolean().optional().describe('Mark assets as immutable'),
+  cacheability: z
+    .enum(['public', 'private'])
+    .nullable()
+    .optional()
+    .describe(
+      'Cache directive: "public" (CDNs can cache) or "private" (browser only, not shared/CDN caches). Null = inherit from project visibility.',
+    ),
+  isEnabled: z.boolean().optional().describe('Whether the rule is enabled'),
+  priority: z.number().optional().describe('Rule priority (lower number = evaluated first)'),
+});
+
 @Injectable()
 export class CacheRulesTools {
   constructor(
@@ -55,35 +80,10 @@ export class CacheRulesTools {
   @Tool({
     name: 'create_cache_rule',
     description: 'Create a new cache rule for a project.',
-    parameters: z.object({
-      projectId: z.string().describe('Project ID'),
-      pathPattern: z.string().describe('Glob pattern to match paths (e.g. "*.js", "images/**")'),
-      name: z.string().optional().describe('Rule name'),
-      description: z.string().optional().describe('Rule description'),
-      browserMaxAge: z.number().optional().describe('Browser cache max-age in seconds'),
-      cdnMaxAge: z.number().optional().describe('CDN cache max-age in seconds'),
-      staleWhileRevalidate: z
-        .number()
-        .optional()
-        .describe('Stale-while-revalidate window in seconds'),
-      immutable: z.boolean().optional().describe('Mark assets as immutable'),
-      isEnabled: z.boolean().optional().describe('Whether the rule is enabled'),
-      priority: z.number().optional().describe('Rule priority (higher = evaluated first)'),
-    }),
+    parameters: createCacheRuleParameters,
   })
   async createRule(
-    args: {
-      projectId: string;
-      pathPattern: string;
-      name?: string;
-      description?: string;
-      browserMaxAge?: number;
-      cdnMaxAge?: number;
-      staleWhileRevalidate?: number;
-      immutable?: boolean;
-      isEnabled?: boolean;
-      priority?: number;
-    },
+    args: z.infer<typeof createCacheRuleParameters>,
     _context: Context,
     request: Request,
   ) {


### PR DESCRIPTION
## What

Expose `cacheability` on the `create_cache_rule` MCP tool.

The tool's zod parameter schema omitted `cacheability`, and the MCP framework strips any field not declared in the schema before it reaches the service. So an agent calling `create_cache_rule` could **not** create a `private` (browser-only, non-CDN-cacheable) rule — even though `CreateCacheRuleDto`, `CacheRulesService`, the REST API, and the dashboard UI all already support it.

## Why it matters

For ACL-gated content served through a pipeline `file_serve_handler`, the served 200 currently defaults to `Cache-Control: public, max-age=3600`. A shared cache (CDN) will then store and serve those bytes to anyone, bypassing the app's access gate. Being able to author a `cacheability: 'private'` rule is the agent-side lever to mark such paths non-shared-cacheable.

## Changes

- Add `cacheability` (`'public' | 'private' | null`) to the `create_cache_rule` tool params.
- Extract params into an exported `createCacheRuleParameters` zod schema; derive the handler arg type via `z.infer` (schema + type stay in sync, and the forwarded fields become unit-testable).
- Fix the misleading `priority` description (`higher` → `lower number = evaluated first`, matching the DB schema/service semantics).
- Add `cache-rules.tools.spec.ts` (4 tests): schema round-trips `cacheability`, accepts public/null/omitted, rejects invalid values, and forwards it to the service.

## Verification

- `pnpm test -- cache-rules.tools` → 4/4 pass (added TDD red→green).
- `tsc --noEmit` (backend) → clean.
- ESLint on changed additions → clean.

## Notes / follow-ups (not in this PR)

- No `update_cache_rule` MCP tool exists, so `cacheability` can be set at creation but not changed later via MCP — easy follow-up if wanted.
- The deeper fix — `file_serve_handler` not defaulting ACL-gated content to `public` — is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
