### PR TITLE
fix(pipelines): default file_serve_handler to private caching

### DIFF
--- a/apps/backend/src/pipelines/execution/step-handler.interface.ts
+++ b/apps/backend/src/pipelines/execution/step-handler.interface.ts
@@ -642,6 +642,18 @@ export interface FileServeHandlerConfig extends BaseHandlerConfig {
    * @default 3600
    */
   cacheMaxAge?: number;
+
+  /**
+   * Cache directive for the served bytes: `'public'` (shared caches / CDNs may
+   * store and reuse the response) or `'private'` (browser-only; never a shared
+   * cache). Pipeline-served files are usually behind app-defined access control
+   * that this handler cannot see, so the default is `'private'` to avoid a CDN
+   * serving ACL-gated content to other users. Set `'public'` only for content
+   * that is genuinely public. A matching cache rule's `cacheability` overrides
+   * this.
+   * @default 'private'
+   */
+  cacheability?: 'public' | 'private';
 }
 
 /**

--- a/apps/backend/src/pipelines/handlers/file-serve.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/file-serve.handler.spec.ts
@@ -115,4 +115,44 @@ describe('FileServeHandler — streaming & range', () => {
     expect(res.setHeader).toHaveBeenCalledWith('Content-Range', 'bytes */1000');
     expect(storage.downloadStream).not.toHaveBeenCalled();
   });
+
+  // Pipeline-served files are typically behind app-defined access control
+  // (e.g. an ACL gate), but this handler can't see that. Defaulting to `public`
+  // lets a CDN cache and serve gated bytes to anyone — so the safe default is
+  // `private` (browser-only, never a shared/CDN cache). Public is opt-in.
+  it('defaults Cache-Control to private when there is no rule and no override', async () => {
+    const stream = makeStream();
+    const storage = {
+      downloadStream: jest.fn().mockResolvedValue({ stream, size: 10000, etag: 'abc' }),
+      getMetadata: jest.fn(),
+    };
+    const handler = buildHandler(storage);
+    const res = makeRes();
+
+    await handler.execute(buildContext(res, {}), step);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'private, max-age=3600');
+    expect(res.setHeader).not.toHaveBeenCalledWith(
+      'Cache-Control',
+      expect.stringContaining('public'),
+    );
+  });
+
+  it('serves public only when the step opts in via cacheability: "public"', async () => {
+    const stream = makeStream();
+    const storage = {
+      downloadStream: jest.fn().mockResolvedValue({ stream, size: 10000, etag: 'abc' }),
+      getMetadata: jest.fn(),
+    };
+    const handler = buildHandler(storage);
+    const res = makeRes();
+    const publicStep = {
+      ...step,
+      config: { subDir: 'export', cacheability: 'public' },
+    } as unknown as PipelineStep;
+
+    await handler.execute(buildContext(res, {}), publicStep);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'public, max-age=3600');
+  });
 });

--- a/apps/backend/src/pipelines/handlers/file-serve.handler.ts
+++ b/apps/backend/src/pipelines/handlers/file-serve.handler.ts
@@ -123,7 +123,12 @@ export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
     const ext = path.extname(sanitized).toLowerCase();
     const contentType = MIME_TYPES[ext] || 'application/octet-stream';
 
-    // Resolve cache headers: check cache rules first, fall back to config/default
+    // Resolve cache headers: check cache rules first, fall back to config/default.
+    // Files served through a pipeline are typically behind app-defined access
+    // control this handler can't see, so the safe default is `private` (never a
+    // shared/CDN cache) — `public` is opt-in via the step config. A matching
+    // cache rule's own `cacheability` still wins over this default.
+    const isPublicContent = config.cacheability === 'public';
     let cacheControlHeader: string;
     const cacheConfig = await this.cacheConfigService.getCacheConfig(
       context.projectId,
@@ -131,10 +136,13 @@ export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
       false,
     );
     if (cacheConfig.source === 'rule') {
-      cacheControlHeader = this.cacheConfigService.buildCacheControlHeader(cacheConfig, true);
+      cacheControlHeader = this.cacheConfigService.buildCacheControlHeader(
+        cacheConfig,
+        isPublicContent,
+      );
     } else {
       const cacheMaxAge = config.cacheMaxAge ?? 3600;
-      cacheControlHeader = `public, max-age=${cacheMaxAge}`;
+      cacheControlHeader = `${isPublicContent ? 'public' : 'private'}, max-age=${cacheMaxAge}`;
     }
 
     const res = context.request.res;


### PR DESCRIPTION
> **Draft** — root-cause fix for the private-content-via-CDN class of bug. Opening for review of the **default-behavior change** (see Migration impact). Related: GHSA advisory in `bffless/apps`; enabler PR #353 (expose `cacheability` on the `create_cache_rule` MCP tool).

## Problem

`file_serve_handler` (pipeline-based file serving) tagged its responses **`Cache-Control: public`**:
- No matching cache rule → hardcoded `public, max-age=3600`.
- Matching rule → `buildCacheControlHeader(cacheConfig, /* isPublicContent */ true)` — hardcoded `true`.

Files served through a pipeline are typically behind **app-defined access control** (an ACL gate step) that this handler can't see — its own comment says *"Access control is handled by pipeline validators, not this handler."* A `public` directive lets a shared cache / CDN (e.g. Cloudflare) **store and serve ACL-gated bytes to unauthenticated users**, bypassing the app's gate. (Observed live: a permitted user warms a CDN edge, then anonymous requests to that edge get `cf-cache-status: HIT` and the private bytes.)

## Change

Default to **`private`** (browser-only; never a shared/CDN cache). `public` becomes **opt-in**.

- New `cacheability?: 'public' | 'private'` on `FileServeHandlerConfig` (`@default 'private'`).
- No-rule branch: `private` (or `public` when the step opts in) instead of hardcoded `public`.
- Rule branch: passes real visibility (`config.cacheability === 'public'`) into `buildCacheControlHeader` instead of hardcoded `true` — so a rule's explicit `cacheability` wins, and absent that it inherits the safe default.
- `cacheMaxAge` semantics unchanged.

## Verification

- `pnpm test -- file-serve.handler` → 6/6 (added TDD red→green: default is `private`; `public` only when opted in).
- `tsc --noEmit` (backend) → clean.

## Migration impact (the thing to review)

This flips the **default** for pipeline-served files from `public` → `private`. Apps that serve **genuinely public** content via `file_serve_handler` (incl. the GET pipeline auto-generated by `generate_upload_schema`) will stop being CDN-cached until they either:
- set `cacheability: 'public'` on the serve step, or
- add a cache rule with `cacheability: 'public'` for those paths.

No correctness regression (content still serves) — only reduced CDN caching / more origin hits for public assets. This is the intended safe-by-default tradeoff; flagging it explicitly for the default decision.

## Open questions for review

- Should `generate_upload_schema` set `cacheability: 'public'` on its generated serve step to preserve prior behavior for general (often-public) uploads, leaving gated apps to override to `private`? Or keep the safe `private` default everywhere?
- Do we also want a true `no-store` option (the cache-rule model + this config currently express `private`, not `no-store`)? `private` already prevents shared/CDN caching, so it's sufficient for the security issue; `no-store` would be a stricter follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
