### PR TITLE
fix(frontend): keep file_serve/file_delete config mode toggle switchable

### DIFF
--- a/apps/frontend/src/components/pipelines/handlers/FileDeleteHandlerConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/FileDeleteHandlerConfig.test.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FileDeleteHandlerConfig } from './FileDeleteHandlerConfig';
+
+// Controlled harness: mirrors how the real editor feeds config back in, so the
+// mode toggle's behavior across the full onChange round-trip is exercised.
+function Harness({ initial = {} }: { initial?: Record<string, unknown> }) {
+  const [config, setConfig] = useState<Record<string, unknown>>(initial);
+  return (
+    <FileDeleteHandlerConfig
+      config={config}
+      onChange={(c) => setConfig(c as Record<string, unknown>)}
+    />
+  );
+}
+
+describe('FileDeleteHandlerConfig', () => {
+  it('can switch key → prefix → key and back to the key field', async () => {
+    render(<Harness initial={{ key: 'projects/abc/file.mov' }} />);
+
+    expect(screen.getByDisplayValue('projects/abc/file.mov')).toBeInTheDocument();
+
+    // Key → Prefix (clears the key).
+    await userEvent.click(screen.getByRole('button', { name: /prefix/i }));
+    expect(
+      screen.getByPlaceholderText('e.g., projects/{{request.body.projectId}}/'),
+    ).toBeInTheDocument();
+
+    // Prefix → Key: the key input must come back even though key is empty.
+    await userEvent.click(screen.getByRole('button', { name: /single key/i }));
+    expect(
+      screen.getByPlaceholderText('e.g., projects/abc123/source/uuid-file.mov'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText('e.g., projects/{{request.body.projectId}}/'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/FileDeleteHandlerConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/FileDeleteHandlerConfig.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { ExpressionInput } from './ExpressionInput';
@@ -20,15 +21,20 @@ interface Props {
 export function FileDeleteHandlerConfig({ config, onChange, previousSteps = [] }: Props) {
   const typedConfig = config as unknown as Partial<Config>;
 
-  // Default to prefix mode unless an explicit key is already set.
-  const mode: 'prefix' | 'key' =
-    typeof typedConfig.key === 'string' && typedConfig.key.length > 0 ? 'key' : 'prefix';
+  // Track the selected mode in local state. Deriving it from whether `key` has
+  // content would strand the user in prefix mode: switching to Key while the key
+  // is still empty would leave the derived mode at 'prefix', so the Key field
+  // could never appear. Seed from the existing config (key present → key).
+  const [mode, setMode] = useState<'prefix' | 'key'>(
+    typeof typedConfig.key === 'string' && typedConfig.key.length > 0 ? 'key' : 'prefix',
+  );
 
   const update = (partial: Partial<Config>) => {
     onChange({ ...typedConfig, ...partial } as Config);
   };
 
-  const setMode = (next: 'prefix' | 'key') => {
+  const switchMode = (next: 'prefix' | 'key') => {
+    setMode(next);
     // Keep only the field for the selected mode so exactly one is sent.
     if (next === 'prefix') {
       onChange({ ...typedConfig, key: undefined } as Config);
@@ -49,7 +55,7 @@ export function FileDeleteHandlerConfig({ config, onChange, previousSteps = [] }
         <div className="flex gap-2">
           <button
             type="button"
-            onClick={() => setMode('prefix')}
+            onClick={() => switchMode('prefix')}
             className={`rounded border px-3 py-1.5 text-sm ${
               mode === 'prefix' ? 'border-primary bg-primary/10 font-medium' : 'border-input'
             }`}
@@ -58,7 +64,7 @@ export function FileDeleteHandlerConfig({ config, onChange, previousSteps = [] }
           </button>
           <button
             type="button"
-            onClick={() => setMode('key')}
+            onClick={() => switchMode('key')}
             className={`rounded border px-3 py-1.5 text-sm ${
               mode === 'key' ? 'border-primary bg-primary/10 font-medium' : 'border-input'
             }`}

--- a/apps/frontend/src/components/pipelines/handlers/FileServeHandlerConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/FileServeHandlerConfig.test.tsx
@@ -1,7 +1,20 @@
+import { useState } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FileServeHandlerConfig } from './FileServeHandlerConfig';
+
+// Controlled harness: mirrors how the real editor feeds config back in, so the
+// mode toggle's behavior across the full onChange round-trip is exercised.
+function Harness({ initial = {} }: { initial?: Record<string, unknown> }) {
+  const [config, setConfig] = useState<Record<string, unknown>>(initial);
+  return (
+    <FileServeHandlerConfig
+      config={config}
+      onChange={(c) => setConfig(c as Record<string, unknown>)}
+    />
+  );
+}
 
 describe('FileServeHandlerConfig', () => {
   it('defaults to sub-directory mode and edits subDir', async () => {
@@ -33,5 +46,21 @@ describe('FileServeHandlerConfig', () => {
     await userEvent.click(screen.getByRole('button', { name: /key/i }));
 
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ subDir: undefined }));
+  });
+
+  it('can switch key → sub-directory → key and back to the key field', async () => {
+    render(<Harness initial={{ key: 'content/x.css' }} />);
+
+    // Start in key mode.
+    expect(screen.getByDisplayValue('content/x.css')).toBeInTheDocument();
+
+    // Key → Sub-directory (clears the key).
+    await userEvent.click(screen.getByRole('button', { name: /sub-directory/i }));
+    expect(screen.getByPlaceholderText('e.g., images, documents')).toBeInTheDocument();
+
+    // Sub-directory → Key: the key input must come back even though key is empty.
+    await userEvent.click(screen.getByRole('button', { name: /^key$/i }));
+    expect(screen.getByPlaceholderText('e.g., content/{{steps.resolve.serveKey}}')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('e.g., images, documents')).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/pipelines/handlers/FileServeHandlerConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/FileServeHandlerConfig.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { ExpressionInput } from './ExpressionInput';
@@ -23,15 +24,20 @@ interface Props {
 export function FileServeHandlerConfig({ config, onChange, previousSteps = [] }: Props) {
   const typedConfig = config as unknown as Partial<Config>;
 
-  // Default to sub-directory mode unless an explicit key is already set.
-  const mode: 'subDir' | 'key' =
-    typeof typedConfig.key === 'string' && typedConfig.key.length > 0 ? 'key' : 'subDir';
+  // Track the selected mode in local state. Deriving it from whether `key` has
+  // content would strand the user in sub-directory mode: switching to Key while
+  // the key is still empty would leave the derived mode at 'subDir', so the Key
+  // field could never appear. Seed from the existing config (key present → key).
+  const [mode, setMode] = useState<'subDir' | 'key'>(
+    typeof typedConfig.key === 'string' && typedConfig.key.length > 0 ? 'key' : 'subDir',
+  );
 
   const update = (partial: Partial<Config>) => {
     onChange({ ...typedConfig, ...partial } as Config);
   };
 
-  const setMode = (next: 'subDir' | 'key') => {
+  const switchMode = (next: 'subDir' | 'key') => {
+    setMode(next);
     // Keep only the field for the selected mode so exactly one is sent.
     if (next === 'subDir') {
       onChange({ ...typedConfig, key: undefined } as Config);
@@ -47,7 +53,7 @@ export function FileServeHandlerConfig({ config, onChange, previousSteps = [] }:
         <div className="flex gap-2">
           <button
             type="button"
-            onClick={() => setMode('subDir')}
+            onClick={() => switchMode('subDir')}
             className={`rounded border px-3 py-1.5 text-sm ${
               mode === 'subDir' ? 'border-primary bg-primary/10 font-medium' : 'border-input'
             }`}
@@ -56,7 +62,7 @@ export function FileServeHandlerConfig({ config, onChange, previousSteps = [] }:
           </button>
           <button
             type="button"
-            onClick={() => setMode('key')}
+            onClick={() => switchMode('key')}
             className={`rounded border px-3 py-1.5 text-sm ${
               mode === 'key' ? 'border-primary bg-primary/10 font-medium' : 'border-input'
             }`}


### PR DESCRIPTION
## Bug

In the pipeline step-config editor, the `file_serve_handler` **Source** toggle (Sub-directory / Key) — and the `file_delete` **Mode** toggle (Prefix / Single key) — got stuck after one round-trip: once you switched **away** from Key, you couldn't switch **back**.

## Cause

The mode was *derived* from whether `key` had content:

```ts
const mode = typeof key === 'string' && key.length > 0 ? 'key' : 'subDir';
```

Switching to Sub-directory clears `key` to `undefined`. Clicking **Key** then cleared `subDir`, but `key` was still empty — so the derived mode stayed `subDir` and the Key field never reappeared.

## Fix

Track the selected mode in local `useState` (seeded from the config), so the toggle reflects the user's choice regardless of whether the field has content yet. Applied to both `FileServeHandlerConfig` and `FileDeleteHandlerConfig` (same pattern, same latent bug).

## Tests

Test-first (RED→GREEN). Added round-trip component tests using a controlled harness (mirrors the real onChange loop):
- file_serve: key → sub-directory → key shows the Key field again
- file_delete: key → prefix → key shows the Key field again

All 21 frontend test files pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)