### PR TITLE
feat(pipelines): file_delete keys accepts a runtime array expression

### DIFF
--- a/apps/backend/src/pipelines/execution/step-handler.interface.ts
+++ b/apps/backend/src/pipelines/execution/step-handler.interface.ts
@@ -697,8 +697,17 @@ export interface FileDeleteHandlerConfig extends BaseHandlerConfig {
    * each expression-interpolated and guarded exactly like `key`. Use this to
    * purge objects that share no common prefix (e.g. a Site manifest's assets).
    * Mutually exclusive with both `prefix` and `key`.
+   *
+   * Two forms:
+   *   - a **static array** of key templates (`["a/b", "content/{{hash}}"]`) when
+   *     the set is known at authoring time, or
+   *   - a **single expression string** (e.g. `"steps.siteKeys.list"`) that
+   *     resolves AT RUNTIME to an array of string keys. Use this when the set is
+   *     dynamic and variable-length — a prior step computes it (e.g. parsing a
+   *     Site manifest into its object keys). A resolved empty array is a no-op
+   *     (`{ deleted: 0 }`), not an error.
    */
-  keys?: string[];
+  keys?: string[] | string;
 
   /**
    * When true, list and report what WOULD be deleted but delete nothing.

--- a/apps/backend/src/pipelines/handlers/file-delete.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/file-delete.handler.spec.ts
@@ -10,13 +10,17 @@ describe('FileDeleteHandler', () => {
   const UPLOADS_ROOT = 'o/r/uploads/';
 
   // evaluateTemplate is a pass-through by default; individual tests can override.
+  // resolveExpr backs evaluateExpression — used by the `keys`-as-expression mode
+  // to resolve a single expression to its runtime value (e.g. an array).
   const buildHandler = (
     storage: Partial<IStorageAdapter>,
     evaluate: (expr: string) => string = (expr) => expr,
+    resolveExpr: (expr: string) => unknown = (expr) => expr,
   ) => {
     const registry = { register: jest.fn() } as unknown as StepHandlerRegistry;
     const expressionEvaluator = {
       evaluateTemplate: jest.fn((expr: string) => evaluate(expr)),
+      evaluateExpression: jest.fn((expr: string) => resolveExpr(expr)),
     } as unknown as ExpressionEvaluator;
     const uploadRecords = {
       resolveOwnerRepo: jest.fn().mockResolvedValue({ owner: 'o', repo: 'r' }),
@@ -53,6 +57,23 @@ describe('FileDeleteHandler', () => {
     it('accepts a non-empty keys array', () => {
       const handler = buildHandler({});
       expect(() => handler.validateConfig({ keys: ['a/b', 'c/d'] })).not.toThrow();
+    });
+
+    it('accepts keys as an expression string (resolved at runtime)', () => {
+      const handler = buildHandler({});
+      expect(() => handler.validateConfig({ keys: 'steps.siteKeys.list' })).not.toThrow();
+    });
+
+    it('rejects a blank keys expression string', () => {
+      const handler = buildHandler({});
+      expect(() => handler.validateConfig({ keys: '   ' })).toThrow(/non-empty/i);
+    });
+
+    it('rejects keys that is neither an array nor a string', () => {
+      const handler = buildHandler({});
+      expect(() =>
+        handler.validateConfig({ keys: { not: 'valid' } as unknown as string[] }),
+      ).toThrow(/array of strings or an expression string/i);
     });
 
     it('rejects keys combined with key', () => {
@@ -321,6 +342,80 @@ describe('FileDeleteHandler', () => {
       await expect(
         handler.execute(context, step({ keys: ['projects/abc/ok', '{{blank}}'] })),
       ).rejects.toThrow(/empty/i);
+      expect(exists).not.toHaveBeenCalled();
+      expect(del).not.toHaveBeenCalled();
+    });
+  });
+
+  // `keys` given as a SINGLE expression string that resolves to an array at
+  // runtime — the dynamic, variable-length case a static array can't express
+  // (e.g. a Site manifest's object keys, computed by a prior step).
+  describe('keys expression mode', () => {
+    const KEYS_EXPR = 'steps.siteKeys.list';
+
+    it('resolves the expression to an array and deletes each key', async () => {
+      const exists = jest.fn().mockResolvedValue(true);
+      const del = jest.fn().mockResolvedValue(undefined);
+      const resolved = ['content/aaa', 'content/bbb', 'content/ccc'];
+      const handler = buildHandler(
+        { exists, delete: del },
+        (expr) => expr,
+        (expr) => (expr === KEYS_EXPR ? resolved : expr),
+      );
+
+      const result = await handler.execute(context, step({ keys: KEYS_EXPR }));
+
+      resolved.forEach((k) => expect(del).toHaveBeenCalledWith(`${UPLOADS_ROOT}${k}`));
+      expect(del).toHaveBeenCalledTimes(3);
+      expect(result).toEqual({
+        success: true,
+        output: { deleted: 3, keys: resolved, dryRun: false },
+      });
+    });
+
+    it('treats a resolved empty array as a no-op (deleted: 0, no storage calls)', async () => {
+      const exists = jest.fn();
+      const del = jest.fn();
+      const handler = buildHandler(
+        { exists, delete: del },
+        (expr) => expr,
+        () => [],
+      );
+
+      const result = await handler.execute(context, step({ keys: KEYS_EXPR }));
+
+      expect(exists).not.toHaveBeenCalled();
+      expect(del).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: true,
+        output: { deleted: 0, keys: [], dryRun: false },
+      });
+    });
+
+    it('throws when the expression resolves to a non-array', async () => {
+      const handler = buildHandler({ exists: jest.fn(), delete: jest.fn() }, (expr) => expr, () => 'not-an-array');
+      await expect(handler.execute(context, step({ keys: KEYS_EXPR }))).rejects.toThrow(/must resolve to an array/i);
+    });
+
+    it('throws when the resolved array contains a non-string entry', async () => {
+      const handler = buildHandler(
+        { exists: jest.fn(), delete: jest.fn() },
+        (expr) => expr,
+        () => ['content/ok', 42],
+      );
+      await expect(handler.execute(context, step({ keys: KEYS_EXPR }))).rejects.toThrow(/array of strings/i);
+    });
+
+    it('still guards each resolved key against traversal before any storage call', async () => {
+      const exists = jest.fn();
+      const del = jest.fn();
+      const handler = buildHandler(
+        { exists, delete: del },
+        (expr) => expr,
+        () => ['content/ok', '../../secret.env'],
+      );
+
+      await expect(handler.execute(context, step({ keys: KEYS_EXPR }))).rejects.toThrow(/traversal/i);
       expect(exists).not.toHaveBeenCalled();
       expect(del).not.toHaveBeenCalled();
     });

--- a/apps/backend/src/pipelines/handlers/file-delete.handler.ts
+++ b/apps/backend/src/pipelines/handlers/file-delete.handler.ts
@@ -21,6 +21,11 @@ import { UploadRecordService } from '../upload-record.service';
  *   - key:    delete a single object at <uploadsRoot>/<key>.
  *   - keys:   delete an explicit set of objects that share no common prefix
  *             (e.g. a Site manifest's assets), each at <uploadsRoot>/<entry>.
+ *             `keys` is either a static array of key templates, or a single
+ *             expression STRING that resolves at runtime to an array of keys —
+ *             the dynamic, variable-length case (e.g. a Site manifest mapped to
+ *             its object keys) that a static array can't express. A resolved
+ *             empty array is a no-op (`{ deleted: 0 }`), not an error.
  *
  * `prefix`, `key`, and every entry of `keys` are relative to the uploads root
  * and are expression-interpolated before use. This is a destructive handler, so it
@@ -63,12 +68,28 @@ export class FileDeleteHandler implements StepHandler<FileDeleteHandlerConfig> {
     }
 
     if (hasKeys) {
-      if (!Array.isArray(config.keys) || config.keys.length === 0) {
-        throw new ConfigurationError('"keys" must be a non-empty array', 'file_delete');
-      }
-      if (!config.keys.every((k) => typeof k === 'string' && k.length > 0)) {
+      // `keys` may be a static array of key templates, OR a single expression
+      // string that resolves to an array at runtime (validated when it runs).
+      if (typeof config.keys === 'string') {
+        if (config.keys.trim().length === 0) {
+          throw new ConfigurationError(
+            '"keys" expression must be a non-empty string',
+            'file_delete',
+          );
+        }
+      } else if (Array.isArray(config.keys)) {
+        if (config.keys.length === 0) {
+          throw new ConfigurationError('"keys" must be a non-empty array', 'file_delete');
+        }
+        if (!config.keys.every((k) => typeof k === 'string' && k.length > 0)) {
+          throw new ConfigurationError(
+            'Every entry in "keys" must be a non-empty string',
+            'file_delete',
+          );
+        }
+      } else {
         throw new ConfigurationError(
-          'Every entry in "keys" must be a non-empty string',
+          '"keys" must be an array of strings or an expression string',
           'file_delete',
         );
       }
@@ -83,11 +104,12 @@ export class FileDeleteHandler implements StepHandler<FileDeleteHandlerConfig> {
     const { owner, repo } = await this.uploadRecords.resolveOwnerRepo(context, stepName);
     const uploadsRoot = `${owner}/${repo}/uploads/`;
 
-    const isKeysMode = Array.isArray(config.keys) && config.keys.length > 0;
+    const isKeysMode = config.keys !== undefined;
     if (isKeysMode) {
+      const keyList = this.resolveKeyList(config.keys!, context, stepName);
       // Resolve and guard EVERY entry before any storage call, so a single bad
       // entry aborts the whole step without partially deleting the good ones.
-      const targets = config.keys!.map((expr) => {
+      const targets = keyList.map((expr) => {
         const relKey = this.resolveAndGuard(expr, context, stepName, 'key');
         const fullKey = this.confineToRoot(uploadsRoot, relKey, stepName);
         return { relKey, fullKey };
@@ -106,6 +128,41 @@ export class FileDeleteHandler implements StepHandler<FileDeleteHandlerConfig> {
     const relPrefix = this.resolveAndGuard(config.prefix!, context, stepName, 'prefix');
     const fullPrefix = this.confineToRoot(uploadsRoot, relPrefix, stepName);
     return this.deletePrefix(fullPrefix, relPrefix, dryRun, stepName);
+  }
+
+  /**
+   * Produce the list of key expressions for `keys` mode.
+   *
+   *   - Array form: a static list of key templates, used as-is (each is still
+   *     interpolated + guarded downstream).
+   *   - String form: a single expression that must resolve to an array of
+   *     strings at runtime — the dynamic, variable-length case (e.g. a prior
+   *     step parsing a Site manifest into its object keys). A resolved empty
+   *     array is allowed (it makes the whole step a no-op).
+   */
+  private resolveKeyList(
+    keys: string[] | string,
+    context: PipelineContext,
+    stepName: string,
+  ): string[] {
+    if (Array.isArray(keys)) {
+      return keys;
+    }
+
+    const resolved = this.expressionEvaluator.evaluateExpression(keys, context, stepName);
+    if (!Array.isArray(resolved)) {
+      throw new ConfigurationError(
+        `"keys" expression "${keys}" must resolve to an array, but resolved to ${typeof resolved}`,
+        stepName,
+      );
+    }
+    if (!resolved.every((k) => typeof k === 'string')) {
+      throw new ConfigurationError(
+        `"keys" expression "${keys}" must resolve to an array of strings`,
+        stepName,
+      );
+    }
+    return resolved as string[];
   }
 
   /**


### PR DESCRIPTION
## Why

`file_delete`'s `keys` mode (added in #362 / ce#361) takes a **static, authoring-time array** of key templates. That can't express a **dynamic, variable-length** set of objects discovered at request time.

The motivating case is the Handoff app's Site delete (**bffless/apps#35**). A Site's assets are many `content/<hash>` objects referenced only by its `manifest` — **no shared prefix** and an **arbitrary count** — so a static pipeline can't enumerate them as a fixed array, and key-mode deletes one object per call.

## What

`keys` now also accepts a **single expression string** (e.g. `"steps.siteKeys.list"`) that resolves **at runtime** to an array of string keys:

- A prior step computes the array (e.g. a `function_handler` parsing a Site manifest into its object keys), and `file_delete` purges each one.
- Each resolved key is still **confined to the uploads root** and **guarded against traversal / blank** exactly like the array form.
- A resolved **empty array is a no-op** (`{ deleted: 0 }`), not an error — a Site with no assets deletes cleanly.
- The existing **array / `key` / `prefix` modes are unchanged** — fully backward-compatible (`keys?: string[]` → `keys?: string[] | string`).

```jsonc
// before — static, fixed length only
{ "keys": ["content/a1b2", "content/c3d4"] }

// now — also a runtime expression resolving to string[]
{ "keys": "steps.siteKeys.list" }
```

## Tests

`file-delete.handler.spec.ts` (+7): validateConfig accepts an expression string / rejects blank / rejects non-array-non-string; execute resolves to an array and deletes each, treats an empty resolution as a no-op, throws on a non-array or non-string resolution, and still rejects a traversal key before any storage call. **34/34 pass**; backend `tsc --noEmit` clean.

## Follow-up

Unblocks **bffless/apps#35** (purge a Handoff Site's manifest assets on delete). That wiring lands in `bffless/apps` once this is released and deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)