### PR TITLE
feat(users): member-accessible user directory endpoint

### DIFF
--- a/apps/backend/src/users/users.controller.spec.ts
+++ b/apps/backend/src/users/users.controller.spec.ts
@@ -54,6 +54,9 @@ describe('UsersController', () => {
 
   const mockUsersService = {
     findAll: jest.fn().mockResolvedValue(mockPaginatedResponse),
+    searchDirectory: jest.fn().mockResolvedValue({
+      users: [{ id: mockUser.id, email: mockUser.email }],
+    }),
     findById: jest.fn().mockResolvedValue(mockUser),
     findByEmail: jest.fn().mockResolvedValue(mockUser),
     update: jest.fn().mockResolvedValue(mockUser),
@@ -94,6 +97,15 @@ describe('UsersController', () => {
 
       expect(result).toEqual(mockPaginatedResponse);
       expect(usersService.findAll).toHaveBeenCalledWith({ page: 1, limit: 10 });
+    });
+  });
+
+  describe('searchDirectory', () => {
+    it('should delegate to the service and return matching users', async () => {
+      const result = await controller.searchDirectory({ search: 'test', limit: 10 });
+
+      expect(result).toEqual({ users: [{ id: mockUser.id, email: mockUser.email }] });
+      expect(usersService.searchDirectory).toHaveBeenCalledWith('test', 10);
     });
   });
 

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -21,11 +21,13 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
 import {
   ListUsersQueryDto,
+  SearchDirectoryQueryDto,
   CreateUserDto,
   UpdateUserDto,
   UpdateUserRoleDto,
   UserResponseDto,
   PaginatedUsersResponseDto,
+  DirectoryResponseDto,
   CreateUserResponseDto,
   UpdateUserResponseDto,
   DeleteUserResponseDto,
@@ -68,6 +70,25 @@ export class UsersController {
   @ApiResponse({ status: 401, description: 'Not authenticated' })
   async getCurrentUser(@CurrentUser() user: CurrentUserData): Promise<UserResponseDto> {
     return this.usersService.findById(user.id);
+  }
+
+  @Get('directory')
+  @ApiOperation({
+    summary: 'Search the user directory',
+    description:
+      'Search users by email for people-pickers / autocomplete. Available to any ' +
+      'authenticated user (session or API key) — NOT admin-only — so a content owner ' +
+      'can resolve a colleague by email. Returns only id + email, requires a non-empty ' +
+      'search term, excludes disabled accounts, and caps the result count.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Matching users',
+    type: DirectoryResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Not authenticated' })
+  async searchDirectory(@Query() query: SearchDirectoryQueryDto): Promise<DirectoryResponseDto> {
+    return this.usersService.searchDirectory(query.search, query.limit);
   }
 
   @Get('by-email/:email')

--- a/apps/backend/src/users/users.dto.ts
+++ b/apps/backend/src/users/users.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsEmail, IsOptional, IsEnum, IsInt, Min, Max } from 'class-validator';
+import { IsString, IsEmail, IsOptional, IsEnum, IsInt, IsNotEmpty, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
 
 // Enums
@@ -98,7 +98,45 @@ export class ListUsersQueryDto {
   sortOrder?: SortOrder = SortOrder.DESC;
 }
 
+export class SearchDirectoryQueryDto {
+  @ApiProperty({
+    description: 'Email substring to search for (required)',
+    example: 'jane',
+  })
+  @IsString()
+  @IsNotEmpty()
+  search: string;
+
+  @ApiPropertyOptional({
+    description: 'Maximum number of results to return (1-25)',
+    example: 10,
+    default: 10,
+  })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(25)
+  @IsOptional()
+  limit?: number = 10;
+}
+
 // Response DTOs
+export class DirectoryUserDto {
+  @ApiProperty({ description: 'User ID', example: '550e8400-e29b-41d4-a716-446655440000' })
+  id: string;
+
+  @ApiProperty({ description: 'User email', example: 'user@example.com' })
+  email: string;
+}
+
+export class DirectoryResponseDto {
+  @ApiProperty({
+    description: 'Matching users — id and email only',
+    type: [DirectoryUserDto],
+  })
+  users: DirectoryUserDto[];
+}
+
 export class UserResponseDto {
   @ApiProperty({ description: 'User ID', example: '550e8400-e29b-41d4-a716-446655440000' })
   id: string;

--- a/apps/backend/src/users/users.service.spec.ts
+++ b/apps/backend/src/users/users.service.spec.ts
@@ -179,6 +179,53 @@ describe('UsersService', () => {
     });
   });
 
+  describe('searchDirectory', () => {
+    it('should return id + email projections for matching users', async () => {
+      const limitMock = jest.fn().mockResolvedValue([
+        { id: mockUser.id, email: mockUser.email },
+        { id: mockAdminUser.id, email: mockAdminUser.email },
+      ]);
+      mockDb.select.mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            orderBy: jest.fn().mockReturnValue({ limit: limitMock }),
+          }),
+        }),
+      });
+
+      const result = await service.searchDirectory('example');
+
+      expect(result.users).toEqual([
+        { id: mockUser.id, email: mockUser.email },
+        { id: mockAdminUser.id, email: mockAdminUser.email },
+      ]);
+      // Default limit applied.
+      expect(limitMock).toHaveBeenCalledWith(10);
+    });
+
+    it('should return an empty list for a blank search without querying the db', async () => {
+      const result = await service.searchDirectory('   ');
+
+      expect(result).toEqual({ users: [] });
+      expect(mockDb.select).not.toHaveBeenCalled();
+    });
+
+    it('should cap the result limit to prevent bulk export', async () => {
+      const limitMock = jest.fn().mockResolvedValue([]);
+      mockDb.select.mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            orderBy: jest.fn().mockReturnValue({ limit: limitMock }),
+          }),
+        }),
+      });
+
+      await service.searchDirectory('a', 9999);
+
+      expect(limitMock).toHaveBeenCalledWith(25);
+    });
+  });
+
   describe('findById', () => {
     it('should return a user by ID', async () => {
       mockDb.select.mockReturnValueOnce({

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -18,7 +18,11 @@ import {
   SortOrder,
   PaginatedUsersResponseDto,
   UserResponseDto,
+  DirectoryResponseDto,
 } from './users.dto';
+
+/** Hard cap on directory search results, so the member-facing picker can't bulk-export users. */
+const DIRECTORY_MAX_LIMIT = 25;
 
 @Injectable()
 export class UsersService {
@@ -92,6 +96,35 @@ export class UsersService {
         hasPreviousPage: page > 1,
       },
     };
+  }
+
+  /**
+   * Search users by email for people-pickers / autocomplete.
+   *
+   * Unlike findAll (admin-only, full user records), this is member-accessible and
+   * deliberately minimal: it requires a non-empty search term, returns only id +
+   * email (never role/status), skips disabled accounts, and caps the result count —
+   * so an authenticated member can resolve an email to a user without being able to
+   * enumerate or bulk-export the whole directory.
+   */
+  async searchDirectory(search: string, limit = 10): Promise<DirectoryResponseDto> {
+    const term = (search ?? '').trim();
+
+    // A blank term must not return the entire user table.
+    if (term.length === 0) {
+      return { users: [] };
+    }
+
+    const capped = Math.min(Math.max(Math.trunc(limit) || 10, 1), DIRECTORY_MAX_LIMIT);
+
+    const rows = await db
+      .select({ id: users.id, email: users.email })
+      .from(users)
+      .where(and(like(users.email, `%${term}%`), eq(users.disabled, false)))
+      .orderBy(asc(users.email))
+      .limit(capped);
+
+    return { users: rows.map((row) => ({ id: row.id, email: row.email })) };
   }
 
   /**


### PR DESCRIPTION
## Why

CE only exposes user listing via `GET /api/users`, which is `@Roles('admin')`. Any BFFless app that wants an **email-autocomplete people-picker** (to grant another user access to something) therefore has no member-safe way to resolve an email → user — it has to borrow an admin API key or be admin-only.

This came up fixing the **Handoff** app's "Manage access" picker (bffless/apps#11): the typeahead was fully built on the frontend but had no backend to call, so it always showed "No people found."

## What

New `GET /api/users/directory` — a read-only, **member-accessible** user search:

- Available to **any authenticated user** (`ApiKeyGuard`, no `@Roles('admin')`).
- Returns only `{ users: [{ id, email }] }` — never role/status.
- **Requires a non-empty `search`** (a blank term returns `[]` without hitting the DB).
- **Caps results** (max 25) and **excludes disabled accounts** — so a member can resolve an email to a user without bulk-exporting the directory.
- Declared before `@Get(':id')` so the literal route isn't shadowed by the UUID param.

## Tests

- 3 new `UsersService.searchDirectory` specs: id+email projection, blank-search short-circuit (no DB call), and limit cap.
- A controller delegation spec.
- Backend `tsc --noEmit` clean.

> Note: the `users.controller.spec.ts` suite can't load in some local envs because `bcrypt`'s native binding isn't compiled (pre-existing, unrelated to this change — fails identically on `main`). CI builds bcrypt and runs it.

## Consumer

Pairs with bffless/apps — Handoff adds a plain `/api/directory` proxy rule that forwards (with the requester's session cookie, **no admin key**) to this endpoint. Returns the exact shape the picker already expects, so no client changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZcDQFqeuKJYFRvUbbM2AM