### PR TITLE
fix(nginx): enlarge proxy header buffers for SuperTokens session refresh

### DIFF
--- a/apps/backend/templates/nginx/custom-domain.conf.hbs
+++ b/apps/backend/templates/nginx/custom-domain.conf.hbs
@@ -60,6 +60,14 @@ server {
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
 
+        # Header buffers must hold SuperTokens' session-refresh response, which
+        # sets several large Set-Cookie/token headers. The nginx default (8k)
+        # overflows on a successful /api/auth/session/refresh (502 "upstream
+        # sent too big header").
+        proxy_buffer_size 16k;
+        proxy_buffers 8 16k;
+        proxy_busy_buffers_size 32k;
+
 {{#if isSpa}}
         # SPA mode: intercept 404s to fallback to index.html for client-side routing
         proxy_intercept_errors on;
@@ -169,6 +177,14 @@ server {
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
+
+        # Header buffers must hold SuperTokens' session-refresh response, which
+        # sets several large Set-Cookie/token headers. The nginx default (8k)
+        # overflows on a successful /api/auth/session/refresh (502 "upstream
+        # sent too big header").
+        proxy_buffer_size 16k;
+        proxy_buffers 8 16k;
+        proxy_busy_buffers_size 32k;
 
 {{#if isSpa}}
         # SPA mode: intercept 404s to fallback to index.html for client-side routing

--- a/apps/backend/templates/nginx/subdomain.conf.hbs
+++ b/apps/backend/templates/nginx/subdomain.conf.hbs
@@ -64,10 +64,15 @@ server {
         proxy_read_timeout 60s;
 
         # Buffer settings
+        # Header buffers must be large enough to hold SuperTokens' session
+        # refresh response, which sets several big Set-Cookie/token headers
+        # (rotated sAccessToken + sRefreshToken JWTs, front-token, anti-csrf).
+        # At 4k a successful /api/auth/session/refresh overflows the header
+        # buffer and nginx returns 502 "upstream sent too big header".
         proxy_buffering on;
-        proxy_buffer_size 4k;
-        proxy_buffers 8 4k;
-        proxy_busy_buffers_size 8k;
+        proxy_buffer_size 16k;
+        proxy_buffers 8 16k;
+        proxy_busy_buffers_size 32k;
 
 {{#if isSpa}}
         # SPA mode: intercept 404s to fallback to index.html for client-side routing
@@ -169,10 +174,15 @@ server {
         proxy_read_timeout 60s;
 
         # Buffer settings
+        # Header buffers must be large enough to hold SuperTokens' session
+        # refresh response, which sets several big Set-Cookie/token headers
+        # (rotated sAccessToken + sRefreshToken JWTs, front-token, anti-csrf).
+        # At 4k a successful /api/auth/session/refresh overflows the header
+        # buffer and nginx returns 502 "upstream sent too big header".
         proxy_buffering on;
-        proxy_buffer_size 4k;
-        proxy_buffers 8 4k;
-        proxy_busy_buffers_size 8k;
+        proxy_buffer_size 16k;
+        proxy_buffers 8 16k;
+        proxy_busy_buffers_size 32k;
 
 {{#if isSpa}}
         # SPA mode: intercept 404s to fallback to index.html for client-side routing

--- a/docker/nginx/sites-available/main.conf.template
+++ b/docker/nginx/sites-available/main.conf.template
@@ -68,6 +68,14 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Original-URI $request_uri;
 
+        # Header buffers must hold SuperTokens' session-refresh response, which
+        # sets several large Set-Cookie/token headers. The nginx default (8k)
+        # overflows on a successful /api/auth/session/refresh (502 "upstream
+        # sent too big header"), so subdomain apps proxying auth need headroom.
+        proxy_buffer_size 16k;
+        proxy_buffers 8 16k;
+        proxy_busy_buffers_size 32k;
+
         # Don't intercept errors - let backend's styled 404 page pass through
         # This ensures requests to non-existent files show proper 404, not index.html
         # SPA behavior is controlled per-domain via domain mapping settings


### PR DESCRIPTION
## Problem

`POST /api/auth/session/refresh` on subdomain apps (e.g. `handoff.j5s.dev`) returns **502** for logged-in users:

```
assethost-nginx | [error] upstream sent too big header while reading response header from upstream,
request: "POST /api/auth/session/refresh", server: handoff.j5s.dev
```

Subdomain apps proxy `/api/auth/*` through the backend's proxy-rule engine to SuperTokens. A **successful** refresh returns several large response headers — rotated `sAccessToken` + `sRefreshToken` JWTs, `front-token`, `anti-csrf`, `st-access-token`, `st-refresh-token`. The production nginx configs sized the proxy **header** buffer at `4k` (`subdomain.conf.hbs`) or relied on the `8k` default (wildcard block in `main.conf.template`, `custom-domain.conf.hbs`), which the combined headers exceed → nginx aborts with *"upstream sent too big header"* → **502**.

It only affects authenticated users: a guest's refresh returns a tiny `401` that fits in `4k`, which masked the bug (curl with no cookies returns 401, not 502).

## Why this was missed

Local-dev (`docker/nginx.conf`) and umbrel (`umbrel/nginx.conf.template`) already set `proxy_buffer_size 128k` **server-wide** for exactly this reason ("large headers (SuperTokens cookies)"). The production per-domain handlebars templates + the wildcard block set buffers per-location at `4k` / default — that was the gap.

## Fix

Bump `proxy_buffer_size` to `16k` (`8x16k` buffers, `32k` busy) in all five backend-proxying `location /` blocks:

- `apps/backend/templates/nginx/subdomain.conf.hbs` (SSL + non-SSL) — **serves `handoff.j5s.dev`**
- `apps/backend/templates/nginx/custom-domain.conf.hbs` (SSL + non-SSL)
- `docker/nginx/sites-available/main.conf.template` (wildcard `*.PRIMARY_DOMAIN` block)

`16k` is ample for SuperTokens headers and far lighter per-connection than the `128k` used by umbrel/local-dev.

## Rollout

On backend startup, `nginx-startup.service` regenerates all per-domain configs from these templates, so existing domains pick up the larger buffer and reload — no manual per-domain edits needed.

## Test plan

- [ ] Deploy; confirm a logged-in user on a subdomain app (handoff) gets `200` on `POST /api/auth/session/refresh` instead of `502`
- [ ] Confirm guests still get `401` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
