### PR TITLE
feat(auth): mint a content-domain session from a project API key (#372)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,37 @@
+# CE Domain Glossary
+
+The ubiquitous language for Community Edition. A glossary, not a spec — define what terms *mean*, not how they're implemented.
+
+## Authentication
+
+The most-confused area is *which auth path a deployed app should use*, which is decided entirely by *which kind of domain the app is served from*.
+
+**Primary domain**:
+The single domain SuperTokens is configured against. Its auth cookies (`sAccessToken`) are valid on it and all of its subdomains.
+
+**Subdomain**:
+A host under the primary domain (e.g. `handoff.j5s.dev` under `j5s.dev`). Shares the primary domain's SuperTokens cookies — so apps here authenticate via the **SuperTokens session path**, not the relay.
+
+**Custom domain**:
+A cross-origin host that is *not* under the primary domain (e.g. `app.acme.com`, or **`localhost`** during local/automated testing). SuperTokens cookies cannot reach it, so apps here authenticate via the **admin login relay**, which mints its own cookie. `localhost` qualifying as a custom domain is why a local headless browser (e.g. Sandcastle's Playwright) gets a `bffless_access` cookie, never an `sAccessToken`.
+
+**SuperTokens session path**:
+Authentication via the `/api/auth/*` reverse proxy straight to SuperTokens. The correct path for the primary domain and its subdomains. Yields an `sAccessToken`.
+_Avoid_: "the api/auth proxy"
+
+**Admin login relay**:
+Authentication via the `/_bffless/auth/*` endpoints, intended **only for custom (cross-origin) domains** where SuperTokens cookies can't reach. It mints a `bffless_access` cookie and adds custom-domain-specific behaviour on top. A common mistake (especially by code-gen) is defaulting to the relay without checking which domain the app sits on.
+_Avoid_: "the _bffless endpoint", "bffless auth"
+
+**sAccessToken**:
+The SuperTokens session cookie. Valid on the primary domain and its subdomains.
+
+**bffless_access**:
+The relay-minted access cookie for a single custom domain. The relay's answer to "SuperTokens can't set a cookie here."
+
+**Project API key**:
+An `X-API-Key` credential scoped to one project, authenticating the data layer (`/api/*`, pipelines, proxy rules). It does **not**, today, produce a user session — that gap is the subject of issue #372.
+_Avoid_: "the project key", "access key"
+
+**Owner session**:
+A browser session authenticated as the project owner, which login-gated SPA routes accept. The thing an automated client holding a Project API key currently cannot obtain.

--- a/apps/backend/src/auth/custom-domain-auth.controller.spec.ts
+++ b/apps/backend/src/auth/custom-domain-auth.controller.spec.ts
@@ -1,5 +1,15 @@
 import { Request, Response } from 'express';
 
+// ApiKeyGuard (imported transitively via the controller's @UseGuards) pulls in
+// bcrypt's native binding; replace it with a factory mock so the suite loads
+// without requiring the native module. The guard itself is never executed here
+// — sessionFromKey is called directly.
+jest.mock('bcrypt', () => ({
+  compare: jest.fn(),
+  hash: jest.fn(),
+  genSalt: jest.fn(),
+}));
+
 // Mock the database client used by trySupertokensSession's user lookup.
 const dbLimitMock = jest.fn();
 jest.mock('../db/client', () => ({
@@ -379,5 +389,117 @@ describe('CustomDomainAuthController.signUp (existing-email orphan re-create)', 
     expect(stSignInMock).not.toHaveBeenCalled();
     expect(authService.createUser).not.toHaveBeenCalled();
     expect(result).toEqual({ status: 'EMAIL_ALREADY_EXISTS_ERROR' });
+  });
+});
+
+describe('CustomDomainAuthController.sessionFromKey (API key → session)', () => {
+  let controller: CustomDomainAuthController;
+  let authService: jest.Mocked<AuthService>;
+  let customDomainAuthService: jest.Mocked<CustomDomainAuthService>;
+  let featureFlags: jest.Mocked<FeatureFlagsService>;
+  let projectResolver: jest.Mocked<ProjectResolverService>;
+  let permissions: jest.Mocked<PermissionsService>;
+
+  // The key owner's real workspace role is 'admin'. ApiKeyGuard hardcodes the
+  // request role to 'user', so this asserts we mint with the *owner's* role.
+  const keyOwner = { id: 'user-1', email: 'owner@example.com', role: 'admin', disabled: false };
+
+  const reqWithKeyUser = (user: unknown, host = HOST): Request =>
+    ({ headers: { host }, user }) as unknown as Request;
+
+  const cookieRes = (): Response =>
+    ({
+      cookie: jest.fn().mockReturnThis(),
+      clearCookie: jest.fn().mockReturnThis(),
+    }) as unknown as Response;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    authService = {
+      getUserById: jest.fn().mockResolvedValue(keyOwner),
+    } as unknown as jest.Mocked<AuthService>;
+
+    customDomainAuthService = {
+      createAccessToken: jest.fn().mockReturnValue('access-jwt'),
+      createRefreshToken: jest.fn().mockReturnValue('refresh-jwt'),
+      setAuthCookies: jest.fn(),
+    } as unknown as jest.Mocked<CustomDomainAuthService>;
+
+    featureFlags = {
+      isEnabled: jest.fn().mockResolvedValue(false),
+    } as unknown as jest.Mocked<FeatureFlagsService>;
+
+    projectResolver = {
+      resolveProjectFromRequest: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<ProjectResolverService>;
+
+    permissions = {
+      getUserProjectRole: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<PermissionsService>;
+
+    controller = new CustomDomainAuthController(
+      {} as DomainTokenService,
+      customDomainAuthService,
+      authService,
+      {} as SetupService,
+      featureFlags,
+      {} as EmailService,
+      projectResolver,
+      permissions,
+      {} as never,
+    );
+  });
+
+  const apiKeyUser = {
+    id: 'user-1',
+    apiKeyId: 'key-1',
+    apiKeyProjectId: 'proj-1',
+    role: 'user',
+  };
+
+  it('mints the access+refresh pair for the key owner and returns OK', async () => {
+    const res = cookieRes();
+
+    const result = await controller.sessionFromKey(reqWithKeyUser(apiKeyUser), res);
+
+    expect(authService.getUserById).toHaveBeenCalledWith('user-1');
+    // Signs the owner's real role ('admin'), not the API-key hardcoded 'user'.
+    expect(customDomainAuthService.createAccessToken).toHaveBeenCalledWith(
+      'user-1',
+      'owner@example.com',
+      'admin',
+      HOST,
+    );
+    expect(customDomainAuthService.createRefreshToken).toHaveBeenCalledWith('user-1', HOST);
+    expect(customDomainAuthService.setAuthCookies).toHaveBeenCalledWith(
+      res,
+      'access-jwt',
+      'refresh-jwt',
+      true,
+    );
+    expect(result).toEqual({
+      status: 'OK',
+      user: { id: 'user-1', email: 'owner@example.com', role: 'admin' },
+    });
+  });
+
+  it('rejects when no API key was used (session fallback / missing apiKeyId)', async () => {
+    await expect(
+      controller.sessionFromKey(reqWithKeyUser({ id: 'user-1' }), cookieRes()),
+    ).rejects.toThrow('A valid X-API-Key is required');
+    expect(customDomainAuthService.setAuthCookies).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the key owner is not a member of the resolved site', async () => {
+    featureFlags.isEnabled.mockResolvedValue(true);
+    projectResolver.resolveProjectFromRequest.mockResolvedValue({ id: 'proj-9' } as never);
+    permissions.getUserProjectRole.mockResolvedValue(null);
+
+    await expect(
+      controller.sessionFromKey(reqWithKeyUser(apiKeyUser), cookieRes()),
+    ).rejects.toThrow('not a member of this site');
+    expect(permissions.getUserProjectRole).toHaveBeenCalledWith('user-1', 'proj-9');
+    expect(customDomainAuthService.setAuthCookies).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/auth/custom-domain-auth.controller.ts
+++ b/apps/backend/src/auth/custom-domain-auth.controller.ts
@@ -11,8 +11,9 @@ import {
   HttpStatus,
   BadRequestException,
   UnauthorizedException,
+  UseGuards,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiQuery, ApiBody } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery, ApiBody, ApiHeader } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { getSession } from 'supertokens-node/recipe/session';
 import { SessionContainer } from 'supertokens-node/recipe/session';
@@ -29,6 +30,7 @@ import { EmailService } from '../email/email.service';
 import { ProjectResolverService } from './project-resolver.service';
 import { OidcProvidersService } from '../settings/oidc-providers.service';
 import { PermissionsService } from '../permissions/permissions.service';
+import { ApiKeyGuard } from './api-key.guard';
 import { PublicProjectAccess } from './decorators/public-project-access.decorator';
 import { buildLoginMethodsResponse } from './login-methods.helper';
 import { Project } from '../db/schema';
@@ -520,6 +522,76 @@ export class CustomDomainAuthController {
         // Opaque to client — same shape as wrong credentials so we don't leak
         // whether this email has an account on a sister site.
         return { status: 'WRONG_CREDENTIALS_ERROR' };
+      }
+    }
+
+    const { hostname, secure } = this.getRequestHost(req);
+    await this.issueDomainSession(res, user, hostname, secure);
+
+    return {
+      status: 'OK',
+      user: { id: user.id, email: user.email, role: user.role },
+    };
+  }
+
+  /**
+   * Mint a content-domain session from a project API key.
+   *
+   * The API-key counterpart of `signin`: instead of email+password, the caller
+   * presents an `X-API-Key`, and we mint `bffless_access` / `bffless_refresh`
+   * for the key's owner on the requesting host. Intended for headless automation
+   * (e.g. a `localhost` dev server driven by Playwright) that already holds a
+   * project key but has no password — so it can render login-gated SPA routes
+   * without seeding a cookie or storing credentials.
+   *
+   * `localhost` is cross-origin to the primary domain, so a SuperTokens
+   * `sAccessToken` can never reach it; the relay's self-signed `bffless_access`
+   * is the only cookie that works there. This path is SuperTokens-independent.
+   * The session carries the key owner's *actual* role — no elevation; it is
+   * exactly "log in as the key's owner, without their password". Acceptable
+   * because the key already authenticates `/api/*` as that owner. See CE
+   * `docs/adr/0001-api-key-mints-custom-domain-session.md`.
+   */
+  @Post('session-from-key')
+  @UseGuards(ApiKeyGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Mint a content-domain session from a project API key',
+    description:
+      'Authenticates via the X-API-Key header and sets bffless_access / bffless_refresh ' +
+      'cookies for the key owner on the requesting host. SuperTokens is not involved. ' +
+      'See CE ADR-0001.',
+  })
+  @ApiHeader({ name: 'X-API-Key', description: 'A project (or global) API key', required: true })
+  @ApiResponse({ status: 200, description: 'Session minted; sets auth cookies' })
+  @ApiResponse({
+    status: 401,
+    description: 'Missing/invalid key, or the key owner is not a member of this site',
+  })
+  async sessionFromKey(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    // ApiKeyGuard also falls back to SuperTokens session auth when no key is
+    // present; this endpoint is specifically the API-key bridge, so require the
+    // key path (the guard sets `apiKeyId` only on the API-key branch).
+    const apiUser = (req as unknown as { user?: { id?: string; apiKeyId?: string } }).user;
+    if (!apiUser?.id || !apiUser.apiKeyId) {
+      throw new UnauthorizedException('A valid X-API-Key is required');
+    }
+
+    const user = await this.authService.getUserById(apiUser.id);
+    if (!user) {
+      throw new UnauthorizedException('API key owner not found');
+    }
+    if (user.disabled) {
+      throw new UnauthorizedException('User account is disabled');
+    }
+
+    // Same membership gate as the password signin: when REQUIRE_PROJECT_MEMBERSHIP
+    // is on and the host maps to a project, the key owner must be a member.
+    const project = await this.resolveGatedProject(req);
+    if (project) {
+      const role = await this.permissions.getUserProjectRole(user.id, project.id);
+      if (!role) {
+        throw new UnauthorizedException('API key owner is not a member of this site');
       }
     }
 

--- a/docs/adr/0001-api-key-mints-custom-domain-session.md
+++ b/docs/adr/0001-api-key-mints-custom-domain-session.md
@@ -1,0 +1,24 @@
+# API key mints a custom-domain session, not a SuperTokens session
+
+**Status:** proposed
+
+## Context
+
+Headless automation (notably Sandcastle, which drives an app on a **`localhost`** Vite dev server via Playwright) holds a project `X-API-Key` but cannot authenticate the *browser*: the key authenticates the `/api/*` data layer, not a user session, so login-gated SPA routes never render. We want the key to mint a browser session.
+
+## Decision
+
+Add `POST /_bffless/auth/session-from-key`, guarded by `ApiKeyGuard`. It mints a **custom-domain `bffless_access` + `bffless_refresh` cookie pair** (a self-signed CE JWT) for the key's owner — *not* a SuperTokens `sAccessToken` session. It reuses the existing relay machinery (`resolveGatedProject` → `getRequestHost` → `issueDomainSession`); the only change from the password `signin` handler is that identity comes from the key's owner instead of `EmailPassword.signIn`.
+
+**Authorization:** any project key may mint, and the minted session carries the key owner's *actual* project role — no elevation, no new per-key flag. "session-from-key" is exactly "log in as the key's owner, without their password." This is acceptable because the key *already* authenticates the `/api/*` data layer as that owner, so a same-owner browser session is escalation *within the same trust boundary*, not across one. We explicitly rejected a per-key `canMintSession` flag as unnecessary schema/UI weight given that framing.
+
+## Considered Options
+
+- **SuperTokens `sAccessToken` path** — rejected. The actual consumer runs on `localhost`, which is **cross-origin to the primary domain**, so a `.<primary>`-scoped SuperTokens cookie can never reach it. `sAccessToken` is structurally impossible here.
+- **Seed a reusable cookie — no CE change.** Register `localhost` as a custom domain, log in once via the existing password relay, and inject the resulting `bffless_access` / `bffless_refresh` into the headless browser (Playwright `storageState` / `addCookies`). This works today with zero backend code and stays the no-code path for *manual* local testing. Rejected as the *autonomous* answer: it seeds a fresh sandbox with a long-lived bearer cookie (or a service-account password) — the exact "credential juggling" we're removing, and *less* manageable than the revocable, scoped API key the sandbox already holds. Choosing the endpoint means the sandbox carries **one** secret, not two.
+
+## Consequences
+
+- **No SuperTokens coupling.** `bffless_access` is verified with the CE `jwtSecret` (HS256), independent of SuperTokens. The issue's "refresh-token rotation interplay" concern does not apply.
+- **Authorization gap to respect:** the strict `SessionAuthGuard` does **not** honor `bffless_access` (only `OptionalAuthGuard`, the proxy data layer, and the relay `/session` check do). Fine for SPA gating + the API-key proxy data layer; any endpoint behind `SessionAuthGuard` stays unreachable to a key-minted session.
+- **Operational preconditions** (must be documented for consumers): the `localhost` host must be registered as a custom-domain mapping for the project, and the dev proxy must forward `X-Forwarded-Host` as that host (everything keys off it). Mint **before** first navigation, or the SPA's first session check 401s and triggers the benign SuperTokens-first refresh attempt.


### PR DESCRIPTION
Closes #372.

## What

Adds `POST /_bffless/auth/session-from-key` (guarded by `ApiKeyGuard`). A headless client holding a project `X-API-Key` can now establish an **owner browser session** — no password, no seeded cookie. It mints the relay's `bffless_access` + `bffless_refresh` pair for the key's owner, reusing the existing `resolveGatedProject → getRequestHost → issueDomainSession` machinery. The only change from the password `signin` handler is that identity comes from the key owner instead of `EmailPassword.signIn`.

```
POST /_bffless/auth/session-from-key
Header: X-API-Key: <project key>
→ Set-Cookie: bffless_access, bffless_refresh   (key owner's session, role mirrored)
→ { "status": "OK", "user": { id, email, role } }
```

## Why `bffless_access`, not a SuperTokens `sAccessToken`

The target consumer (Sandcastle's Playwright) runs on **`localhost`**, which is cross-origin to the primary domain — a SuperTokens cookie can never reach it. `localhost` is a *custom domain*; the relay's self-signed JWT is the only cookie that works there, and this path is SuperTokens-independent (so the issue's "refresh-rotation interplay" concern doesn't apply).

## Authorization

Any project key may mint, and the session carries the key owner's **actual** role — no elevation, no new schema. Acceptable because the key already authenticates `/api/*` as that owner (same trust boundary, not across one). Membership is gated exactly as the password `signin`. Full rationale + the rejected *seeded-cookie* alternative in **`docs/adr/0001-api-key-mints-custom-domain-session.md`**.

## ⚠️ Needs a real headless-run before merge

The endpoint is unit-tested, but the **`X-Forwarded-Host` / cookie-domain** precondition is not exercised here. For the minted cookie to be accepted by a `localhost` browser, the dev proxy must forward the *local* host (e.g. Vite `xfwd: true`) and `localhost` must be registered as a custom-domain mapping — otherwise `changeOrigin: true` scopes the cookie to `j5s.dev` and the browser rejects it. Please verify with an actual Playwright run on localhost before merging.

## Tests

`custom-domain-auth.controller.spec.ts` — mints the access+refresh pair with the owner's real role (not the API-key hardcoded `user`); rejects when no key was used (session-fallback path); rejects when the key owner isn't a member of the resolved site. `tsc --noEmit` clean; 15/15 in the suite pass.

## Companion docs (separate repos, land after merge)

- `repos/skills/.../authentication/SKILL.md` — "Headless / Automation Auth" section (currently 🚧 proposed → flip to live).
- `repos/apps/.sandcastle/prompt.md` — step 6 gated pointer → un-gate so Sandcastle screenshots authed pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)