### PR TITLE
fix(pipelines): skip in-memory debug snapshots when debug is disabled

### DIFF
--- a/apps/backend/src/onboarding-rules/onboarding-executor.service.ts
+++ b/apps/backend/src/onboarding-rules/onboarding-executor.service.ts
@@ -465,6 +465,8 @@ export class OnboardingExecutorService implements OnModuleInit {
       pipeline,
       syntheticReq,
       user,
+      // Only retain in-memory debug snapshots when this rule persists them.
+      { captureDebug: rule.debugEnabled },
     );
 
     // Persist execution log (fire-and-forget, same as proxy middleware)

--- a/apps/backend/src/pipelines/dto/response.dto.ts
+++ b/apps/backend/src/pipelines/dto/response.dto.ts
@@ -226,8 +226,10 @@ export class StepDebugInfoDto {
   @ApiProperty({ description: 'Execution status', enum: ['success', 'failed', 'skipped'] })
   status: 'success' | 'failed' | 'skipped';
 
-  @ApiProperty({ description: 'Input snapshot before execution' })
-  input: {
+  @ApiPropertyOptional({
+    description: 'Input snapshot before execution (omitted when debug capture is disabled)',
+  })
+  input?: {
     requestBody: Record<string, unknown>;
     previousStepOutputs: Record<string, unknown>;
   };

--- a/apps/backend/src/pipelines/execution/pipeline-context.interface.ts
+++ b/apps/backend/src/pipelines/execution/pipeline-context.interface.ts
@@ -149,9 +149,11 @@ export interface StepDebugInfo {
   status: 'success' | 'failed' | 'skipped';
 
   /**
-   * Input snapshot before execution (context state)
+   * Input snapshot before execution (context state).
+   * Omitted when debug capture is disabled (see captureDebug) to avoid retaining
+   * a per-step copy of all accumulated step outputs in memory.
    */
-  input: {
+  input?: {
     requestBody: Record<string, unknown>;
     previousStepOutputs: Record<string, unknown>;
   };

--- a/apps/backend/src/pipelines/execution/pipeline-execution.service.spec.ts
+++ b/apps/backend/src/pipelines/execution/pipeline-execution.service.spec.ts
@@ -146,4 +146,50 @@ describe('PipelineExecutionService — early termination', () => {
     expect(mainExecute).toHaveBeenCalledTimes(1);
     expect(postExecute).toHaveBeenCalledTimes(1);
   });
+
+  describe('debug capture gating (memory)', () => {
+    it('omits heavy per-step input/output snapshots when captureDebug is false', async () => {
+      const big = 'x'.repeat(1000);
+      const mainExecute = jest
+        .fn<Promise<StepResult>, unknown[]>()
+        .mockResolvedValue({ success: true, output: { big } });
+
+      const service = buildService({ execute: mainExecute }, { execute: jest.fn() });
+      const pipeline = buildPipeline(
+        [{ id: 'work', name: 'work', handlerType: 'main', isEnabled: true, config: {} } as PipelineStep],
+        [],
+      );
+
+      const result = await service.executePipelineWithDebug(pipeline, buildRequest(), undefined, {
+        captureDebug: false,
+      });
+
+      // Execution still works and runtime step outputs are intact (needed for chaining/response).
+      expect(result.success).toBe(true);
+      expect(result.stepOutputs?.work).toEqual({ big });
+
+      // But the heavy debug snapshots are NOT retained.
+      expect(result.debug?.steps).toHaveLength(1);
+      expect(result.debug?.steps[0].status).toBe('success');
+      expect(result.debug?.steps[0].input).toBeUndefined();
+      expect(result.debug?.steps[0].output).toBeUndefined();
+    });
+
+    it('retains per-step input/output snapshots when captureDebug defaults on', async () => {
+      const mainExecute = jest
+        .fn<Promise<StepResult>, unknown[]>()
+        .mockResolvedValue({ success: true, output: { ok: true } });
+
+      const service = buildService({ execute: mainExecute }, { execute: jest.fn() });
+      const pipeline = buildPipeline(
+        [{ id: 'work', name: 'work', handlerType: 'main', isEnabled: true, config: {} } as PipelineStep],
+        [],
+      );
+
+      const result = await service.executePipelineWithDebug(pipeline, buildRequest());
+
+      expect(result.debug?.steps[0].input).toBeDefined();
+      expect(result.debug?.steps[0].output).toEqual({ ok: true });
+    });
+  });
 });

--- a/apps/backend/src/pipelines/execution/pipeline-execution.service.ts
+++ b/apps/backend/src/pipelines/execution/pipeline-execution.service.ts
@@ -48,6 +48,14 @@ export class PipelineExecutionService {
     options?: {
       dryRun?: boolean;
       deployment?: { owner: string; repo: string; commitSha: string; alias?: string };
+      /**
+       * Whether to retain per-step input/output debug snapshots in memory.
+       * Defaults to true. Set to false (e.g. when the rule does not have debug
+       * logging enabled) to avoid holding a copy of every step's I/O — including
+       * a per-step snapshot of all accumulated step outputs — for the lifetime of
+       * the request, which on memory-constrained instances can exhaust the heap.
+       */
+      captureDebug?: boolean;
     },
   ): Promise<PipelineDebugResult> {
     let secrets: Record<string, string> = {};
@@ -101,13 +109,17 @@ export class PipelineExecutionService {
     options?: {
       dryRun?: boolean;
       deployment?: { owner: string; repo: string; commitSha: string; alias?: string };
+      captureDebug?: boolean;
     },
     secrets?: Record<string, string>,
   ): Promise<PipelineDebugResult> {
     const executionStartTime = Date.now();
     const executionStartIso = new Date(executionStartTime).toISOString();
+    const captureDebug = options?.captureDebug ?? true;
 
-    this.logger.log(`Executing pipeline '${pipeline.name}' (${pipeline.id}) with debug mode`);
+    this.logger.log(
+      `Executing pipeline '${pipeline.name}' (${pipeline.id})${captureDebug ? ' with debug mode' : ''}`,
+    );
 
     // Build context
     // Extract real client IP (prefer X-Forwarded-For for proxied requests)
@@ -153,7 +165,7 @@ export class PipelineExecutionService {
       // Execute steps sequentially with debug capture
       let lastStepResult: StepResult | null = null;
       for (const step of steps) {
-        const stepDebug = await this.executeStepWithDebug(step, context);
+        const stepDebug = await this.executeStepWithDebug(step, context, captureDebug);
         stepDebugInfo.push(stepDebug);
 
         // When a step is skipped (condition not met), preserve the previous step's output
@@ -227,7 +239,7 @@ export class PipelineExecutionService {
       const response = this.buildResponse(lastStepResult, context);
 
       // Fire-and-forget post-processing steps
-      const postStepsPromise = this.firePostSteps(pipeline, context);
+      const postStepsPromise = this.firePostSteps(pipeline, context, captureDebug);
 
       return {
         success: true,
@@ -387,17 +399,22 @@ export class PipelineExecutionService {
   private async executeStepWithDebug(
     step: PipelineStep,
     context: PipelineContext,
+    captureDebug = true,
   ): Promise<StepDebugInfo & { result: StepResult }> {
     const stepName = step.name || step.id;
     const config = step.config as BaseHandlerConfig;
     const startTime = Date.now();
     const startTimeIso = new Date(startTime).toISOString();
 
-    // Capture input snapshot
-    const inputSnapshot = {
-      requestBody: { ...context.metadata.body },
-      previousStepOutputs: { ...context.stepOutputs },
-    };
+    // Capture input snapshot only when debug capture is enabled. The snapshot
+    // copies all accumulated step outputs, so retaining one per step is what
+    // exhausts the heap on memory-constrained instances when debug is off.
+    const inputSnapshot = captureDebug
+      ? {
+          requestBody: { ...context.metadata.body },
+          previousStepOutputs: { ...context.stepOutputs },
+        }
+      : undefined;
 
     // Check condition if present
     let conditionResult: boolean | undefined;
@@ -450,7 +467,7 @@ export class PipelineExecutionService {
         durationMs: endTime - startTime,
         status: result.success ? 'success' : 'failed',
         input: inputSnapshot,
-        output: result.output,
+        output: captureDebug ? result.output : undefined,
         error: result.error,
         warning: result.warning,
         condition: config.condition,
@@ -491,14 +508,18 @@ export class PipelineExecutionService {
    * Fire post-processing steps as fire-and-forget if the pipeline has any.
    * Returns a promise that resolves with debug info for all post-steps.
    */
-  private firePostSteps(pipeline: Pipeline, context: PipelineContext): Promise<StepDebugInfo[]> | undefined {
+  private firePostSteps(
+    pipeline: Pipeline,
+    context: PipelineContext,
+    captureDebug = true,
+  ): Promise<StepDebugInfo[]> | undefined {
     if (pipeline.postSteps && pipeline.postSteps.length > 0) {
       const enabledPostSteps = pipeline.postSteps.filter((s) => s.isEnabled);
       if (enabledPostSteps.length > 0) {
         this.logger.log(
           `Running ${enabledPostSteps.length} post-processing step(s) for pipeline '${pipeline.name}'`,
         );
-        const promise = this.runPostSteps(enabledPostSteps, context);
+        const promise = this.runPostSteps(enabledPostSteps, context, captureDebug);
         // Still catch to prevent unhandled rejection
         promise.catch((err) =>
           this.logger.error(
@@ -519,6 +540,7 @@ export class PipelineExecutionService {
   private async runPostSteps(
     postSteps: PipelineStep[],
     context: PipelineContext,
+    captureDebug = true,
   ): Promise<StepDebugInfo[]> {
     const debugInfo: StepDebugInfo[] = [];
 
@@ -527,11 +549,13 @@ export class PipelineExecutionService {
       const startTime = Date.now();
       const startTimeIso = new Date(startTime).toISOString();
 
-      // Capture input snapshot
-      const inputSnapshot = {
-        requestBody: { ...(context.metadata.body || {}) },
-        previousStepOutputs: { ...context.stepOutputs },
-      };
+      // Capture input snapshot only when debug capture is enabled (see executeStepWithDebug).
+      const inputSnapshot = captureDebug
+        ? {
+            requestBody: { ...(context.metadata.body || {}) },
+            previousStepOutputs: { ...context.stepOutputs },
+          }
+        : undefined;
 
       try {
         const handler = this.handlerRegistry.get(step.handlerType as HandlerType, stepName);
@@ -581,7 +605,7 @@ export class PipelineExecutionService {
           durationMs: endTime - startTime,
           status: result.success ? 'success' : 'failed',
           input: inputSnapshot,
-          output: result.output,
+          output: captureDebug ? result.output : undefined,
           error: result.error,
           warning: result.warning,
         });

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -1115,7 +1115,9 @@ export class ProxyMiddleware implements NestMiddleware {
         pipeline,
         req,
         user,
-        { deployment },
+        // Only retain in-memory debug snapshots when this rule actually persists
+        // them; otherwise they're built and thrown away, needlessly pressuring the heap.
+        { deployment, captureDebug: rule.debugEnabled },
       );
 
       // If the response was already sent (e.g., by a streaming handler), don't try to send again

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -294,12 +294,12 @@ services:
     deploy:
       resources:
         limits:
-          memory: 192M
+          memory: 384M
         reservations:
           memory: 96M
     environment:
       # Node.js heap: 128 for 1GB VM, 180 for 2GB, 350 for 4GB
-      NODE_OPTIONS: '--max-old-space-size=128'
+      NODE_OPTIONS: '--max-old-space-size=256'
       NODE_ENV: production
       PORT: 3000
       # Log level: error,warn,log (default) or error,warn,log,debug for verbose


### PR DESCRIPTION
## Problem

The CE backend (`assethost-backend`, serving `j5s.dev`/`studio.j5s.dev`) hit a JavaScript heap OOM crash loop (`Reached heap limit Allocation failed`, exit 139 → restart) when the Studio app exercised its AI-director flow.

Root cause was two compounding factors:

1. **128 MB V8 heap cap** — `docker-compose.yml` sets `NODE_OPTIONS: '--max-old-space-size=128'` with container `memory: 192M` (the 1 GB VM profile). GC logs die thrashing at ~128 MB.
2. **Always-on debug snapshots** — `PipelineExecutionService.executePipelineWithDebug` is the *only* execution path (`proxy.middleware.ts`). For **every step** it captured an `input` snapshot that shallow-copies *all accumulated* `stepOutputs`, plus each step's `output` — regardless of whether the rule had debug logging enabled. The `rule.debugEnabled` flag only gated DB **persistence**, not the in-memory capture. So every request retained the full debug tree for its lifetime; a heavy pipeline path (large project blob / AI responses) exhausted the heap.

## Fix

**Code (primary):** thread a `captureDebug` option through `executePipelineWithDebug` into main-step and post-step execution. When `false`, skip building the heavy `input`/`output` snapshots entirely. Runtime `context.stepOutputs` is untouched, so step chaining and the final response are unaffected. Driven by `rule.debugEnabled` at the proxy-middleware and onboarding-executor call sites.

- `StepDebugInfo.input` and its DTO mirror (`response.dto.ts`) become optional.
- The "with debug mode" log line now only prints when capture is actually on.

**Docker (headroom):** raise the backend container `memory: 192M → 384M` and `--max-old-space-size: 128 → 256`, matching the value already hot-fixed on the hosted server so a redeploy from `main` doesn't revert it. Note: this nudges the shipped default above the strict 1 GB-VM profile documented in the compose comments — fine for the hosted box, but small-VM self-hosters should keep the 1 GB values.

## Testing

- New unit tests in `pipeline-execution.service.spec.ts` (omits snapshots when off; retains them when on) — written test-first (RED → GREEN).
- `tsc --noEmit` clean.
- 217 pipeline/proxy/onboarding tests pass. (`proxy.middleware.spec` / `proxy-rules.controller.spec` fail to compile on a missing `bcrypt` native binding in my local env — pre-existing, fails identically on `main`, unrelated to this change; CI has bcrypt built.)

## Operational note

The live mitigation for the active incident was disabling `debugEnabled` on the rules that had it on (done out-of-band via the API). This PR makes that pressure go away structurally, so debug can be safely re-enabled per-rule when needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)