### PR TITLE
fix(storage): forward downloadStream through DynamicStorageAdapter (fixes large-file serve OOM)

### DIFF
--- a/apps/backend/src/storage/dynamic-storage.adapter.spec.ts
+++ b/apps/backend/src/storage/dynamic-storage.adapter.spec.ts
@@ -190,4 +190,52 @@ describe('DynamicStorageAdapter', () => {
       });
     });
   });
+
+  describe('downloadStream', () => {
+    it('should expose downloadStream and delegate when the active adapter supports streaming', async () => {
+      const fakeStream = { pipe: jest.fn() } as unknown as NodeJS.ReadableStream;
+      const streamResult = { stream: fakeStream, size: 1024 };
+      const streamingAdapter: IStorageAdapter = {
+        upload: jest.fn(),
+        download: jest.fn(),
+        delete: jest.fn(),
+        exists: jest.fn(),
+        getUrl: jest.fn(),
+        listKeys: jest.fn(),
+        getMetadata: jest.fn(),
+        testConnection: jest.fn(),
+        deletePrefix: jest.fn(),
+        downloadStream: jest.fn().mockResolvedValue(streamResult),
+      };
+      adapter.setAdapter(streamingAdapter);
+
+      // Capability detection (FileServeHandler does `if (storageAdapter.downloadStream)`)
+      expect(typeof adapter.downloadStream).toBe('function');
+
+      const result = await adapter.downloadStream!('videos/clip.mp4', { start: 0, end: 1023 });
+
+      expect(result).toBe(streamResult);
+      expect(streamingAdapter.downloadStream).toHaveBeenCalledWith('videos/clip.mp4', {
+        start: 0,
+        end: 1023,
+      });
+    });
+
+    it('should report no streaming capability when the active adapter lacks downloadStream', () => {
+      const bufferingAdapter: IStorageAdapter = {
+        upload: jest.fn(),
+        download: jest.fn(),
+        delete: jest.fn(),
+        exists: jest.fn(),
+        getUrl: jest.fn(),
+        listKeys: jest.fn(),
+        getMetadata: jest.fn(),
+        testConnection: jest.fn(),
+        deletePrefix: jest.fn(),
+      };
+      adapter.setAdapter(bufferingAdapter);
+
+      expect(adapter.downloadStream).toBeUndefined();
+    });
+  });
 });

--- a/apps/backend/src/storage/dynamic-storage.adapter.ts
+++ b/apps/backend/src/storage/dynamic-storage.adapter.ts
@@ -1,5 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { IStorageAdapter, FileMetadata, DownloadResult } from './storage.interface';
+import {
+  IStorageAdapter,
+  FileMetadata,
+  DownloadResult,
+  DownloadStreamOptions,
+  StreamDownloadResult,
+} from './storage.interface';
 import { LocalStorageAdapter } from './local.adapter';
 
 /**
@@ -83,6 +89,27 @@ export class DynamicStorageAdapter implements IStorageAdapter {
     // Fallback: no caching layer, return 'none'
     const data = await this.adapter.download(key);
     return { data, cacheHit: 'none' };
+  }
+
+  /**
+   * Stream a file from the active adapter without buffering it into memory.
+   *
+   * Exposed as a getter so capability detection by property presence keeps
+   * working: callers (e.g. FileServeHandler) check `if (storageAdapter.downloadStream)`
+   * to choose between streaming and the buffer-everything fallback. Because the
+   * real adapter is swapped in at runtime (after the setup wizard), a plain
+   * delegating method would always be present and defeat that check — making the
+   * handler stream even for backends that can't, or, as happened here, this proxy
+   * lacking the method entirely forced every serve down the buffer path (OOM on
+   * large files). The getter returns a delegating function only when the active
+   * adapter actually supports streaming, and undefined otherwise.
+   */
+  get downloadStream():
+    | ((key: string, opts?: DownloadStreamOptions) => Promise<StreamDownloadResult>)
+    | undefined {
+    return this.adapter.downloadStream
+      ? (key: string, opts?: DownloadStreamOptions) => this.adapter.downloadStream!(key, opts)
+      : undefined;
   }
 
   async delete(key: string): Promise<void> {


### PR DESCRIPTION
## Problem

Downloading a large file (an 11-min studio export, ~hundreds of MB) from `GET /api/uploads/projects/.../*.mp4` returns a 500 at exactly +30s and crash-loops the backend.

### Root cause

`FileServeHandler.serveFile` chooses streaming vs buffering by capability detection:

```ts
if (this.storageAdapter.downloadStream) {
  return await this.serveWithStream(...);   // pipes a storage read-stream, Range-aware, no buffering
}
return await this.serveWithBuffer(...);     // await adapter.download(key) -> entire file into a Buffer
```

The injected `STORAGE_ADAPTER` is **`DynamicStorageAdapter`**, the runtime-swappable proxy that wraps the real adapter (GCS/MinIO/S3/...). It delegated `download`, `downloadWithCacheInfo`, `getMetadata`, etc., but **had no `downloadStream` method at all** — so `storageAdapter.downloadStream` was always `undefined` and *every* serve fell into `serveWithBuffer`.

For large files that buffer:
- exceeds the backend's V8 heap cap → `Reached heap limit` → exit 139 → restart, and
- the blocking `await download()` exceeds the 30 000 ms per-step pipeline timeout → 500 at +30s.

The streaming implementation already exists on the concrete adapters (`gcs`/`minio`/`local`/`azure` `downloadStream`, e.g. GCS uses `blob.createReadStream({start,end})`) and on the handler, and `CachingStorageAdapter` delegates it through — but the proxy in front of them silently dropped the capability.

## Fix

Add a `downloadStream` **getter** to `DynamicStorageAdapter` that returns a delegating function when the active adapter supports streaming, and `undefined` otherwise. This restores streaming through the proxy while preserving the handler's capability-by-presence check, so genuinely non-streaming backends still buffer correctly.

## Tests

- New `downloadStream` describe block in `dynamic-storage.adapter.spec.ts`: delegates with range opts when the active adapter supports streaming; reports `undefined` when it doesn't.
- `tsc --noEmit` clean; full `dynamic-storage.adapter` suite 18/18 green.

## Follow-up (not in this PR)

`s3.adapter.ts` also lacks `downloadStream`, so S3/Spaces tenants would still buffer. Worth adding a ranged S3 stream in a separate PR. (GCS — the affected deployment — is unaffected by that gap once this proxy fix lands.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)