### PR TITLE
fix(pipelines): flush headers in streaming file serve (fixes truncated large-file download)

### DIFF
--- a/apps/backend/src/pipelines/handlers/file-serve.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/file-serve.handler.spec.ts
@@ -17,6 +17,10 @@ describe('FileServeHandler — streaming & range', () => {
       json: jest.fn(),
     };
     res.status = jest.fn(() => res);
+    // Mirror Node: flushHeaders commits the headers synchronously.
+    res.flushHeaders = jest.fn(() => {
+      res.headersSent = true;
+    });
     return res;
   };
 
@@ -107,6 +111,28 @@ describe('FileServeHandler — streaming & range', () => {
     expect(stream.pipe).toHaveBeenCalledWith(res);
   });
 
+  it('flushes headers synchronously so the response is committed before returning (no result body clobber)', async () => {
+    const stream = makeStream();
+    const storage = {
+      downloadStream: jest.fn().mockResolvedValue({ stream, size: 10000, etag: 'abc' }),
+      getMetadata: jest.fn(),
+    };
+    const handler = buildHandler(storage);
+    const res = makeRes();
+
+    await handler.execute(buildContext(res, {}), step);
+
+    // Headers must be flushed before piping (pipe only flushes on its first
+    // async chunk), and committed before the handler resolves — otherwise the
+    // proxy middleware's `if (res.headersSent) return` guard misses and it
+    // overwrites the stream with the pipeline's JSON result body.
+    expect(res.flushHeaders).toHaveBeenCalled();
+    const flushOrder = res.flushHeaders.mock.invocationCallOrder[0];
+    const pipeOrder = stream.pipe.mock.invocationCallOrder[0];
+    expect(flushOrder).toBeLessThan(pipeOrder);
+    expect(res.headersSent).toBe(true);
+  });
+
   it('returns 416 for an unsatisfiable range without touching storage data', async () => {
     const storage = {
       downloadStream: jest.fn(),
@@ -179,6 +205,10 @@ describe('FileServeHandler — explicit key mode', () => {
       json: jest.fn(),
     };
     res.status = jest.fn(() => res);
+    // Mirror Node: flushHeaders commits the headers synchronously.
+    res.flushHeaders = jest.fn(() => {
+      res.headersSent = true;
+    });
     return res;
   };
 

--- a/apps/backend/src/pipelines/handlers/file-serve.handler.ts
+++ b/apps/backend/src/pipelines/handlers/file-serve.handler.ts
@@ -257,6 +257,14 @@ export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
 
     // Pipe a storage stream to the response with backpressure + cleanup.
     const pipeStream = (stream: NodeJS.ReadableStream) => {
+      // Commit the status line + headers synchronously, before this handler
+      // returns. stream.pipe() only flushes headers on its first (async) data
+      // chunk, so without this the proxy middleware sees res.headersSent === false
+      // when the pipeline resolves and writes its own JSON result body over the
+      // response — the client receives `{"success":true}` instead of the file.
+      if (typeof res.flushHeaders === 'function' && !res.headersSent) {
+        res.flushHeaders();
+      }
       stream.pipe(res);
       stream.on('error', (err: Error) => {
         this.logger.error(`Stream error during serve: ${err.message}`);


### PR DESCRIPTION
## Problem

Follow-up to #378. With `downloadStream` now reaching `FileServeHandler` (proxy gap fixed), the backend no longer OOM-crashes on large files — **but the downloaded file is truncated to a 16-byte body containing `{"success":true}`** instead of the actual video.

### Root cause

`serveWithStream` kicks off `stream.pipe(res)` and returns `{ success: true, terminates: true }`. But `pipe()` only flushes headers on its **first async data chunk**, so at the instant `executePipelineWithDebug` resolves, `res.headersSent` is still `false`.

The proxy middleware guards against double-sending with:

```ts
// proxy.middleware.ts
if (res.headersSent) return;   // streaming handler already owns the response
...
res.status(...).send(result.body);  // otherwise write the pipeline result
```

Because `headersSent` is false, the guard misses and the middleware writes the pipeline's JSON result body over the response, winning the race against the still-pending pipe. The client receives `{"success":true}`.

The buffer fallback path never hit this because `res.end(data)` finalizes the response **synchronously** before the handler returns.

## Fix

Flush the status line + headers synchronously in `serveWithStream` (before piping), so the response is committed by the time the handler returns. The middleware's `headersSent` guard then correctly detects that the handler owns the response and leaves the stream alone.

```ts
if (typeof res.flushHeaders === 'function' && !res.headersSent) {
  res.flushHeaders();
}
stream.pipe(res);
```

## Tests

- New regression test in `file-serve.handler.spec.ts`: asserts `flushHeaders` is called before `pipe`, and `res.headersSent` is true once the handler resolves (the exact contract the middleware relies on). Mock `res` updated to mirror Node's `flushHeaders` (commits headers synchronously).
- `tsc --noEmit` clean; `file-serve.handler` suite 10/10 green.

## Note

Both this and #378 are required for large-file streaming to work end-to-end: #378 stops the OOM crash; this stops the truncation. #378 alone (currently deployed) turns the crash into a 16-byte download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)