### PR TITLE
fix(settings): probe the OIDC discovery document, not the issuer root

### DIFF
--- a/apps/backend/src/settings/settings.controller.ts
+++ b/apps/backend/src/settings/settings.controller.ts
@@ -513,8 +513,18 @@ export class SettingsController {
     if (!cfg.oidcDiscoveryEndpoint) {
       return { ok: false, error: 'No oidcDiscoveryEndpoint configured.' };
     }
+    // The stored value is the bare issuer URL (validateInput strips the
+    // `/.well-known/openid-configuration` suffix because SuperTokens re-appends
+    // it at auth time). Fetching the issuer root returns the IdP's HTML landing
+    // page, not JSON — so build the discovery-document URL here. Tolerate a
+    // value that already includes the suffix (older / env-sourced rows).
+    const discoveryUrl =
+      cfg.oidcDiscoveryEndpoint
+        .replace(/\/+$/, '')
+        .replace(/\/\.well-known\/openid-configuration$/, '') +
+      '/.well-known/openid-configuration';
     try {
-      const res = await fetch(cfg.oidcDiscoveryEndpoint, { redirect: 'follow' });
+      const res = await fetch(discoveryUrl, { redirect: 'follow' });
       if (!res.ok) {
         return { ok: false, error: `Discovery endpoint returned HTTP ${res.status}` };
       }


### PR DESCRIPTION
## Summary

The SSO **Test** button on `/admin/settings/auth` always reports failure for a correctly-configured Generic OIDC provider, e.g.:

> Probe failed: Unexpected token '<', "<!DOCTYPE "... is not valid JSON

## Root cause

When an OIDC provider is saved, `validateInput` deliberately stores the **bare issuer URL**, stripping any `/.well-known/openid-configuration` suffix — because SuperTokens re-appends it itself at sign-in time (`oidc-providers.service.ts`).

The `POST /settings/sso/providers/:id/test` probe then `fetch()`-ed that stored value **directly** — i.e. it hit the issuer **root** (`https://<tenant>.us.auth0.com/`), which returns the IdP's **HTML landing page**. `res.json()` then chokes on `<!DOCTYPE` and the probe reports failure, even though the provider works fine in the real sign-in flow.

## Fix

Build the discovery-document URL (`<issuer>/.well-known/openid-configuration`) from the stored issuer before fetching, tolerating a value that already includes the suffix (older / env-sourced rows). Pure read — **no change to the actual OIDC sign-in flow**.

## Testing

- Verified against a live Auth0 Generic OIDC provider: probe now returns `{ ok: true, issuer, authorizationEndpoint }` instead of the JSON-parse error.
- `tsc --noEmit` passes for the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
