### PR TITLE
docs: bot-protection design (ADRs + glossary) for #383

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,3 +35,31 @@ _Avoid_: "the project key", "access key"
 
 **Owner session**:
 A browser session authenticated as the project owner, which login-gated SPA routes accept. The thing an automated client holding a Project API key currently cannot obtain.
+
+## Bot protection & request observability
+
+Admin-global (not project-scoped) concerns: refusing junk traffic and seeing what hits the instance. The guiding rule is that behaviour must not differ by where CE is hosted (docker-compose vs GKE) — see [[0002-dynamic-blocklist-via-regenerated-per-domain-rules]].
+
+**Blocklist**:
+A named, reusable set of request-path patterns (with its own allowlist of exceptions) that domains refuse to serve. Defined once in an admin-global library and attached to domains — the way a proxy rule set attaches to an alias. A domain's effective rules are the lists attached to it plus the Baseline.
+_Avoid_: "scanner map", "444 list", "firewall rules"
+
+**Baseline**:
+The code-shipped set of universal scanner signatures (WordPress, phpMyAdmin, `.env`, …) applied to every domain by default under a single master toggle, improved on upgrade. The floor of bot protection that needs no per-domain wiring.
+_Avoid_: "default blocklist" (it is not one of the named lists)
+
+**Edge drop**:
+Refusing a blocklisted request at nginx by closing the connection (HTTP 444) with no response body, so it never reaches the application. The cheap first line; an optimization over the application interceptor, not a separate policy.
+_Avoid_: "ban", "block at the edge"
+
+**Unmatched request**:
+A request that resolves to no deployment, alias, or asset — what bot scans for `/.env` or `/wp-login` produce. Currently answered with a 404 (which leaks internal paths). The primary signal feeding the Blocklist.
+_Avoid_: "404", "miss", "not found"
+
+**Request log**:
+The admin-global, cross-project record of requests the instance observed — especially Unmatched and blocked ones — used to discover bot activity and curate the Blocklist. A persisted, queryable concept owned by CE, distinct from nginx's raw access log.
+_Avoid_: "access log" (that is nginx's raw artifact), "audit log"
+
+**Application interceptor**:
+The single cross-topology authority that observes every request reaching the app, records it to the Request log, and applies the Blocklist as a fallback. Consistent regardless of host, because requests reach the app in every topology.
+_Avoid_: "catch-all pipeline", "fallback handler" (it is framework middleware, not a project-scoped proxy rule)

--- a/docs/adr/0002-dynamic-blocklist-via-regenerated-per-domain-rules.md
+++ b/docs/adr/0002-dynamic-blocklist-via-regenerated-per-domain-rules.md
@@ -1,0 +1,15 @@
+# Dynamic bot blocklist via backend-regenerated per-domain server-block rules
+
+The bot/scanner blocklist becomes admin-configurable at runtime. Instead of the static, image-baked `http`-level `map $request_uri $block_scanner` (`docker/nginx/blocklist.conf`), the backend compiles the admin-curated blocklist into **server-block `location` rules** (e.g. `location ~* ^/(\.env|wp-login|phpinfo\.php) { return 444; }`) injected into the per-domain configs it already generates into `sites-enabled/`, then triggers the existing nginx reload.
+
+## Why not keep the `http`-level `map`?
+
+An `http` `map` is marginally faster, but it **cannot be made dynamic on Kubernetes**: the GKE workspace nginx serves its `http` config from a read-only ConfigMap, nginx forbids redefining a `map`, and the only hot-reloadable include on both topologies is `sites-enabled/*.conf` (server blocks). Editing the map would require a pod restart — i.e. not dynamic. The per-domain `location` approach rides the config path that *already* hot-reloads on both docker-compose (inotify watcher) and GKE (the SIGHUP polling sidecar), so one mechanism serves both edges identically.
+
+This also closes a live gap: GKE's `$block_scanner` map is currently an empty `default 0` stub, so **edge bot-blocking does not exist on GKE today** — which is why scanner requests (`/.env`, `/phpinfo.php`, …) reach the application and hit 404s there. Regenerating per-domain rules makes edge blocking work on GKE for the first time.
+
+## Consequences
+
+- Blocklists are a named, admin-global library attached to domains (like proxy rule sets attach to aliases), compiled per-domain. A code-shipped Baseline of universal scanner signatures applies to every domain by default under a master toggle. A domain's effective rules = Baseline + attached lists. The same compiled patterns also feed the application-level interceptor that handles anything reaching the app before/without an edge drop.
+- Admin-supplied patterns are compiled into nginx config text, so they MUST be validated/escaped to prevent nginx-config injection: entries are structured `{matchType, value}`, metacharacter-escaped, and assembled into one anchored regex `location` per server block; the config is `nginx -t`-validated before reload.
+- The static `blocklist.conf` http-map is retired in favour of generated rules.

--- a/docs/adr/0003-application-interceptor-is-cross-topology-authority.md
+++ b/docs/adr/0003-application-interceptor-is-cross-topology-authority.md
@@ -1,0 +1,15 @@
+# The application interceptor is the cross-topology authority for bot handling and request observation
+
+Bot handling and request observation are owned by a NestJS application-level interceptor — the one layer that behaves identically whether CE runs via docker-compose (nginx is the edge) or on GKE (Cloud LB + Cloud Armor + Traefik are the edge, and the workspace nginx ships an empty `$block_scanner` stub). The nginx edge drop is treated as an optimization in front of this authority, not a separate policy. The Request log is sourced from the interceptor and is admin-global (cross-project), not project-scoped.
+
+## Why
+
+Edge behaviour diverges sharply by host: docker-compose has a full nginx blocklist and a local access log; GKE has no working nginx blocklist (so scanners reach the app and hit 404s today) and its access logs live in Cloud Logging / TimescaleDB, collected from Traefik, not the workspace nginx. Any scheme rooted at the edge would behave differently per host — the opposite of the requirement that the admin panel work the same everywhere. The application is the only layer every request reaches in every topology, so it is the only place a consistent policy and a consistent log can live.
+
+This also reframes the originally-imagined "catch-all pipeline route that calls `next()`": it is framework **middleware**, not a project-scoped proxy rule (proxy rules are project-scoped, first-match-wins, and always terminate — they cannot express a global observe-then-continue).
+
+## Consequences
+
+- The interceptor's response policy: serve matched requests normally; answer Unmatched-but-not-blocklisted with a generic 404 (fixing the current leak of internal paths like `sites/landing/dist/backend/.env`); refuse blocklisted requests that slip past the edge with a bare 403.
+- Request log: live view streams all app-observed requests ephemerally (access-log-formatted); only Unmatched + blocked requests are persisted (retained + row-capped) alongside a per-IP rollup. The rollup + an admin-global read API are the surface a future Cloudflare-IP-feed (an external app or a pipeline in a dedicated admin project) consumes.
+- This is deliberately *not* the platform's TimescaleDB/Vector analytics pipeline; that stays an ops/billing concern. CE owns its own consistent request log so behaviour does not depend on host.


### PR DESCRIPTION
Records the design decisions from the bot-protection / request-log grilling session as durable docs. **Docs only — no code changes.**

## What's here
- **ADR-0002** — dynamic blocklist enforced as backend-regenerated **per-domain server-block rules** (not an http-level `map`), the only mechanism that hot-reloads on both docker-compose and GKE. Also closes the fact that GKE has no working edge blocklist today.
- **ADR-0003** — the **application interceptor** is the cross-topology authority for bot handling + request observation; nginx's `444` edge drop is an optimization, not a separate policy.
- **CONTEXT.md** — new *Bot protection & request observability* glossary section (Blocklist, Baseline, Edge drop, Unmatched request, Request log, Application interceptor).

## Context
Design/PRD for the feature itself lives in #383. This PR just lands the ADRs + glossary so implementation stays consistent with what was decided.

Note: branch is based a couple commits behind `main` (local `package.json` collided with an incoming change on pull); these files are isolated, so it should merge cleanly — rebase in the PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019j525zgSj4fu1PvYLQGUpy
