### PR TITLE
chore: gitignore Impeccable tooling cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ Thumbs.db
 packages/github-action/dist/
 
 apps/frontend/storybook-static/
+
+# Impeccable tooling cache
+**/.impeccable/


### PR DESCRIPTION
Ignores the `**/.impeccable/` cache directory (e.g. `apps/backend/src/users/.impeccable/hook.cache.json`) that the Impeccable manual-edit tooling writes, so it stops appearing as an untracked artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019j525zgSj4fu1PvYLQGUpy