### PR TITLE
feat(traffic): application interceptor, admin live tail, and generic 404 (#389)

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -43,6 +43,7 @@ import { McpModule, McpTransportType } from '@rekog/mcp-nest';
 import { ApiKeyGuard } from './auth/api-key.guard';
 import { McpToolsModule } from './mcp/mcp-tools.module';
 import { TelemetryModule } from './telemetry/telemetry.module';
+import { TrafficModule } from './traffic/traffic.module';
 
 @Module({
   imports: [
@@ -171,6 +172,7 @@ import { TelemetryModule } from './telemetry/telemetry.module';
     OnboardingRulesModule,
     McpToolsModule,
     TelemetryModule,
+    TrafficModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/backend/src/common/utils/request-ip.util.ts
+++ b/apps/backend/src/common/utils/request-ip.util.ts
@@ -1,0 +1,28 @@
+import { Request } from 'express';
+
+/**
+ * Extract the real client IP address from a request.
+ * Prefers X-Forwarded-For (set by nginx/Traefik in every CE topology; the app
+ * does not set Express `trust proxy`, so req.ip is the proxy's socket peer).
+ * Strips the IPv6-mapped IPv4 prefix (::ffff:) for cleaner output.
+ */
+export function extractClientIp(req: Request): string | undefined {
+  const forwardedFor = req.headers['x-forwarded-for'];
+  let ip: string | undefined;
+
+  if (forwardedFor) {
+    // X-Forwarded-For can be a comma-separated list; first IP is the original client
+    const forwardedIp = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor.split(',')[0];
+    ip = forwardedIp?.trim();
+  }
+
+  if (!ip) {
+    ip = req.ip || req.socket?.remoteAddress;
+  }
+
+  if (ip?.startsWith('::ffff:')) {
+    ip = ip.slice(7);
+  }
+
+  return ip;
+}

--- a/apps/backend/src/deployments/public.controller.ts
+++ b/apps/backend/src/deployments/public.controller.ts
@@ -159,7 +159,7 @@ export class PublicController {
         if (served) return;
       }
 
-      return this.serve404Page(res, `Preview not found: ${aliasName}`);
+      return this.serve404Page(res);
     }
 
     this.logger.debug(
@@ -231,7 +231,7 @@ export class PublicController {
     const commitSha = await this.deploymentsService.getDefaultAlias(repository);
 
     if (!commitSha) {
-      return this.serve404Page(res, `No deployment found for ${repository}`);
+      return this.serve404Page(res);
     }
 
     // Get project for visibility check
@@ -382,7 +382,7 @@ export class PublicController {
     // Resolve alias to SHA
     const commitSha = await this.deploymentsService.resolveAlias(repository, effectiveAlias);
     if (!commitSha) {
-      return this.serve404Page(res, `Alias not found: ${effectiveAlias}`);
+      return this.serve404Page(res);
     }
 
     // Set variant cookie if new selection
@@ -598,7 +598,7 @@ export class PublicController {
       // Serve image placeholder for image requests, HTML page otherwise
       return this.isImageRequest(req)
         ? this.serve404Image(res)
-        : this.serve404Page(res, `File not found: ${normalizedPath}`);
+        : this.serve404Page(res);
     }
 
     // Add response headers
@@ -722,7 +722,7 @@ export class PublicController {
       res.status(statusCode).send(fileBuffer);
     } catch (error) {
       this.logger.error(`Failed to download from storage: ${asset.storageKey}`, error);
-      return this.serve404Page(res, `File not found: ${asset.fileName}`);
+      return this.serve404Page(res);
     }
   }
 
@@ -859,7 +859,7 @@ export class PublicController {
       }
     } catch (error) {
       this.logger.error(`Failed to stream from storage: ${asset.storageKey}`, error);
-      return this.serve404Page(res, `File not found: ${asset.fileName}`);
+      return this.serve404Page(res);
     }
   }
 
@@ -1231,12 +1231,14 @@ export class PublicController {
   }
 
   /**
-   * Serve a styled 404 HTML page with optional custom message
-   * This is used when access is denied or content is not found,
-   * providing a nicer user experience than nginx's default error page.
+   * Serve a styled, deliberately generic 404 HTML page.
+   * Used when access is denied or content is not found. The page carries no
+   * request- or filesystem-derived detail: earlier versions echoed internal
+   * storage paths (e.g. "File not found: sites/landing/dist/backend/.env"),
+   * handing scanners a map of the instance (issue #389).
    */
-  private serve404Page(res: Response, message?: string): void {
-    const displayMessage = message || "The page you're looking for doesn't exist.";
+  private serve404Page(res: Response): void {
+    const displayMessage = "The page you're looking for doesn't exist.";
     const html = `<!DOCTYPE html>
 <html lang="en">
 <head>

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -4,12 +4,19 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
+import { createTrafficObserver } from './traffic/traffic-observer.middleware';
+import { TrafficEventsService } from './traffic/traffic-events.service';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     logger: (process.env.LOG_LEVEL?.split(',') as LogLevel[]) || ['error', 'warn', 'log'],
     rawBody: true, // Needed for Stripe webhook signature verification
   });
+
+  // Traffic observation seam (ADR-0003): registered with app.use() so it sits
+  // above ALL Nest module middleware and observes every request that reaches
+  // the app — including ones ProxyMiddleware short-circuits before a controller.
+  app.use(createTrafficObserver(app.get(TrafficEventsService)));
 
   // Raise the request body limit above body-parser's 100kb default. Pipeline
   // endpoints (e.g. studio's /api/projects/save) POST large JSON documents that

--- a/apps/backend/src/traffic/access-log.util.spec.ts
+++ b/apps/backend/src/traffic/access-log.util.spec.ts
@@ -1,0 +1,44 @@
+import { formatAccessLogLine, formatNginxTime } from './access-log.util';
+
+describe('access-log.util', () => {
+  describe('formatNginxTime', () => {
+    it('formats a date like nginx $time_local in UTC', () => {
+      expect(formatNginxTime(new Date('2026-07-02T09:05:03.000Z'))).toBe(
+        '02/Jul/2026:09:05:03 +0000',
+      );
+    });
+  });
+
+  describe('formatAccessLogLine', () => {
+    const base = {
+      id: '1',
+      timestamp: '2026-07-02T09:05:03.000Z',
+      ip: '203.0.113.7',
+      method: 'GET',
+      path: '/backend/.env',
+      httpVersion: '1.1',
+      status: 404,
+      bytes: 1234,
+      referer: null as string | null,
+      userAgent: 'Mozilla/5.0 (scanner)' as string | null,
+      host: 'j5s.dev',
+      classification: 'unmatched' as const,
+    };
+
+    it('renders the combined log format', () => {
+      expect(formatAccessLogLine(base)).toBe(
+        '203.0.113.7 - - [02/Jul/2026:09:05:03 +0000] "GET /backend/.env HTTP/1.1" 404 1234 "-" "Mozilla/5.0 (scanner)"',
+      );
+    });
+
+    it('renders missing referer and user-agent as "-"', () => {
+      const line = formatAccessLogLine({ ...base, userAgent: null });
+      expect(line).toContain('"-" "-"');
+    });
+
+    it('includes the referer when present', () => {
+      const line = formatAccessLogLine({ ...base, referer: 'https://example.com/' });
+      expect(line).toContain('"https://example.com/"');
+    });
+  });
+});

--- a/apps/backend/src/traffic/access-log.util.ts
+++ b/apps/backend/src/traffic/access-log.util.ts
@@ -1,0 +1,43 @@
+import { TrafficEvent } from './traffic-event.interface';
+
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+/**
+ * Format a date like nginx's $time_local: 02/Jul/2026:10:15:30 +0000
+ * (always UTC — the server's local offset is noise for a hosted log view).
+ */
+export function formatNginxTime(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${pad(date.getUTCDate())}/${MONTHS[date.getUTCMonth()]}/${date.getUTCFullYear()}` +
+    `:${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())} +0000`
+  );
+}
+
+/**
+ * Render an observed request in nginx's combined log format:
+ * $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent"
+ */
+export function formatAccessLogLine(
+  event: Omit<TrafficEvent, 'line'>,
+): string {
+  const time = formatNginxTime(new Date(event.timestamp));
+  const request = `${event.method} ${event.path} HTTP/${event.httpVersion}`;
+  return (
+    `${event.ip} - - [${time}] "${request}" ${event.status} ${event.bytes} ` +
+    `"${event.referer ?? '-'}" "${event.userAgent ?? '-'}"`
+  );
+}

--- a/apps/backend/src/traffic/traffic-event.interface.ts
+++ b/apps/backend/src/traffic/traffic-event.interface.ts
@@ -1,0 +1,37 @@
+/**
+ * A single request observed by the application interceptor (the traffic
+ * observer middleware). This is the unit of the Traffic live stream and,
+ * in later slices, the persisted Request log.
+ */
+export interface TrafficEvent {
+  /** Monotonic id for client-side keying (not persisted) */
+  id: string;
+  /** ISO 8601 timestamp of when the response finished */
+  timestamp: string;
+  /** Client IP (X-Forwarded-For aware) */
+  ip: string;
+  /** HTTP method */
+  method: string;
+  /** Original request URL (path + query) */
+  path: string;
+  /** HTTP protocol version, e.g. "1.1" */
+  httpVersion: string;
+  /** Response status code */
+  status: number;
+  /** Response body bytes sent */
+  bytes: number;
+  /** Referer header, if any */
+  referer: string | null;
+  /** User-Agent header, if any */
+  userAgent: string | null;
+  /** Host the client requested (X-Forwarded-Host aware) */
+  host: string | null;
+  /**
+   * matched: the request resolved to a real asset/API/deployment.
+   * unmatched: it resolved to no deployment, alias, or asset (bot scans
+   * for /.env, /wp-login, ... produce these).
+   */
+  classification: 'matched' | 'unmatched';
+  /** The event rendered as an nginx combined-access-log line */
+  line: string;
+}

--- a/apps/backend/src/traffic/traffic-events.service.ts
+++ b/apps/backend/src/traffic/traffic-events.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { Observable, Subject } from 'rxjs';
+import { TrafficEvent } from './traffic-event.interface';
+
+/**
+ * In-process event bus for observed requests. The traffic observer middleware
+ * publishes every finished request here; the SSE live-tail endpoint (and, in
+ * later slices, the Request-log persister) subscribes. Events are ephemeral —
+ * nothing is buffered or persisted in this service.
+ */
+@Injectable()
+export class TrafficEventsService {
+  private readonly events$ = new Subject<TrafficEvent>();
+
+  emit(event: TrafficEvent): void {
+    this.events$.next(event);
+  }
+
+  stream(): Observable<TrafficEvent> {
+    return this.events$.asObservable();
+  }
+}

--- a/apps/backend/src/traffic/traffic-http.spec.ts
+++ b/apps/backend/src/traffic/traffic-http.spec.ts
@@ -1,0 +1,225 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { PublicController } from '../deployments/public.controller';
+import { DeploymentsService } from '../deployments/deployments.service';
+import { ProjectsService } from '../projects/projects.service';
+import { OptionalAuthGuard } from '../auth/optional-auth.guard';
+import { VisibilityService } from '../domains/visibility.service';
+import { TrafficRoutingService } from '../domains/traffic-routing.service';
+import { PermissionsService } from '../permissions/permissions.service';
+import { ConfigService } from '@nestjs/config';
+import { CacheConfigService } from '../cache-rules/cache-config.service';
+import { MetadataCacheService } from '../storage/cache/metadata-cache.service';
+import { ShareLinksService } from '../share-links/share-links.service';
+import { ResponseHeaderConfigService } from '../response-header-rules/response-header-config.service';
+import { STORAGE_ADAPTER } from '../storage/storage.interface';
+import { TrafficEventsService } from './traffic-events.service';
+import { createTrafficObserver } from './traffic-observer.middleware';
+import { TrafficEvent } from './traffic-event.interface';
+
+// bcrypt is a native module the guards import transitively; mock it like the
+// other guard specs do so the suite runs without the compiled binding.
+jest.mock('bcrypt');
+
+// PublicController falls through to the drizzle client when the metadata cache
+// misses; keep the test hermetic by answering every query with an empty set.
+jest.mock('../db/client', () => {
+  const chain: any = {};
+  chain.select = jest.fn(() => chain);
+  chain.from = jest.fn(() => chain);
+  chain.where = jest.fn(() => chain);
+  chain.limit = jest.fn(() => Promise.resolve([]));
+  return { db: chain };
+});
+
+/**
+ * Seam 1 (issue #389): drive real HTTP requests through the public-content
+ * controller with the traffic observer installed, and assert the response
+ * policy (serve matched / generic 404 for Unmatched with no path leak) and
+ * that every request is observed on the live stream.
+ */
+describe('Traffic observation at the HTTP boundary', () => {
+  let app: INestApplication;
+  let events: TrafficEventsService;
+  let observed: TrafficEvent[];
+  let subscription: { unsubscribe: () => void };
+
+  const project = {
+    id: 'p1',
+    owner: 'acme',
+    name: 'site',
+    displayName: 'Site',
+    isPublic: true,
+    unauthorizedBehavior: 'not_found',
+    requiredRole: 'authenticated',
+  };
+
+  const indexAsset = {
+    id: 'a1',
+    projectId: 'p1',
+    commitSha: 'abc123',
+    publicPath: 'index.html',
+    fileName: 'index.html',
+    mimeType: 'text/html',
+    storageKey: 'acme/site/abc123/index.html',
+    contentHash: 'deadbeef',
+    fileSize: 18,
+  };
+
+  const deploymentsService = { resolveAlias: jest.fn() };
+  const projectsService = { getProjectByOwnerName: jest.fn(), getProjectById: jest.fn() };
+  const visibilityService = {
+    resolveAccessControlByDomain: jest.fn(),
+    resolveAccessControlForAlias: jest.fn(),
+  };
+  const trafficRoutingService = { selectVariant: jest.fn() };
+  const permissionsService = { getUserProjectRole: jest.fn(), meetsRoleRequirement: jest.fn() };
+  const cacheConfigService = {
+    getCacheConfig: jest.fn(),
+    buildCacheControlHeader: jest.fn(),
+    calculateRedisTtl: jest.fn(),
+  };
+  const metadataCache = { assetKey: jest.fn(), get: jest.fn(), set: jest.fn() };
+  const storageAdapter = { download: jest.fn() };
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [PublicController],
+      providers: [
+        TrafficEventsService,
+        { provide: STORAGE_ADAPTER, useValue: storageAdapter },
+        { provide: DeploymentsService, useValue: deploymentsService },
+        { provide: ProjectsService, useValue: projectsService },
+        { provide: VisibilityService, useValue: visibilityService },
+        { provide: TrafficRoutingService, useValue: trafficRoutingService },
+        { provide: PermissionsService, useValue: permissionsService },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: CacheConfigService, useValue: cacheConfigService },
+        { provide: ShareLinksService, useValue: { validateToken: jest.fn() } },
+        { provide: ResponseHeaderConfigService, useValue: { getHeaderConfig: jest.fn().mockResolvedValue(null) } },
+        { provide: MetadataCacheService, useValue: metadataCache },
+      ],
+    })
+      .overrideGuard(OptionalAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    events = app.get(TrafficEventsService);
+    // Same wiring as main.ts: the observer sits above everything Nest routes.
+    app.use(createTrafficObserver(events));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(() => {
+    subscription.unsubscribe();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    observed = [];
+    subscription = events.stream().subscribe((e) => observed.push(e));
+
+    deploymentsService.resolveAlias.mockResolvedValue('abc123');
+    projectsService.getProjectByOwnerName.mockResolvedValue(project);
+    visibilityService.resolveAccessControlForAlias.mockResolvedValue({
+      isPublic: true,
+      unauthorizedBehavior: 'not_found',
+      requiredRole: 'authenticated',
+      source: 'alias',
+    });
+    trafficRoutingService.selectVariant.mockResolvedValue(null);
+    cacheConfigService.getCacheConfig.mockResolvedValue({ source: 'default' });
+    cacheConfigService.buildCacheControlHeader.mockReturnValue('public, max-age=60');
+    cacheConfigService.calculateRedisTtl.mockReturnValue(60);
+    metadataCache.assetKey.mockImplementation((...parts: string[]) => parts.join(':'));
+    metadataCache.get.mockResolvedValue(null);
+    storageAdapter.download.mockResolvedValue(Buffer.from('<html>hello</html>'));
+  });
+
+  const waitForEvents = async (count: number): Promise<void> => {
+    const deadline = Date.now() + 1000;
+    while (observed.length < count && Date.now() < deadline) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+  };
+
+  it('serves a matched request normally and observes it as matched', async () => {
+    metadataCache.get.mockResolvedValue(indexAsset);
+
+    const res = await request(app.getHttpServer())
+      .get('/public/acme/site/alias/production/index.html')
+      .set('X-Forwarded-For', '203.0.113.7')
+      .set('User-Agent', 'test-agent');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('hello');
+
+    await waitForEvents(1);
+    expect(observed).toHaveLength(1);
+    expect(observed[0]).toMatchObject({
+      classification: 'matched',
+      status: 200,
+      method: 'GET',
+      path: '/public/acme/site/alias/production/index.html',
+      ip: '203.0.113.7',
+      userAgent: 'test-agent',
+    });
+    expect(observed[0].bytes).toBeGreaterThan(0);
+    expect(observed[0].line).toContain('"GET /public/acme/site/alias/production/index.html HTTP/1.1" 200');
+  });
+
+  it('answers an Unmatched request with a generic 404 that leaks no paths, and observes it', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/public/acme/site/alias/production/backend/.env')
+      .set('X-Forwarded-For', '198.51.100.9');
+
+    expect(res.status).toBe(404);
+    expect(res.headers['content-type']).toContain('text/html');
+    // The friendly page for mistyping users...
+    expect(res.text).toContain("The page you're looking for doesn't exist.");
+    // ...with no echo of the requested or internal storage path.
+    expect(res.text).not.toContain('.env');
+    expect(res.text).not.toContain('backend');
+    expect(res.text).not.toContain('File not found');
+    expect(res.text).not.toContain('sites/');
+
+    await waitForEvents(1);
+    expect(observed).toHaveLength(1);
+    expect(observed[0]).toMatchObject({
+      classification: 'unmatched',
+      status: 404,
+      path: '/public/acme/site/alias/production/backend/.env',
+      ip: '198.51.100.9',
+    });
+  });
+
+  it('returns a generic 404 when the alias itself is unknown, without echoing it', async () => {
+    deploymentsService.resolveAlias.mockResolvedValue(null);
+
+    const res = await request(app.getHttpServer()).get(
+      '/public/acme/site/alias/no-such-alias/index.html',
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.text).not.toContain('no-such-alias');
+    expect(res.text).toContain("The page you're looking for doesn't exist.");
+
+    await waitForEvents(1);
+    expect(observed[0].classification).toBe('unmatched');
+  });
+
+  it('observes every request in order, live', async () => {
+    metadataCache.get.mockResolvedValueOnce(indexAsset);
+    await request(app.getHttpServer()).get('/public/acme/site/alias/production/index.html');
+    await request(app.getHttpServer()).get('/public/acme/site/alias/production/wp-login.php');
+
+    await waitForEvents(2);
+    expect(observed.map((e) => e.classification)).toEqual(['matched', 'unmatched']);
+  });
+});

--- a/apps/backend/src/traffic/traffic-observer.middleware.ts
+++ b/apps/backend/src/traffic/traffic-observer.middleware.ts
@@ -1,0 +1,73 @@
+import { Request, Response, NextFunction } from 'express';
+import { extractClientIp } from '../common/utils/request-ip.util';
+import { formatAccessLogLine } from './access-log.util';
+import { TrafficEvent } from './traffic-event.interface';
+import { TrafficEventsService } from './traffic-events.service';
+
+/** The SSE live-tail endpoint itself must not feed the stream it serves. */
+const OBSERVER_EXEMPT_PATHS = ['/api/traffic/stream'];
+
+let eventCounter = 0;
+
+/**
+ * The application interceptor's observation seam (ADR-0003).
+ *
+ * Installed with `app.use()` in main.ts — ABOVE all Nest module middleware —
+ * so it observes every request that reaches the app, including ones
+ * short-circuited by ProxyMiddleware or answered by guards/filters, in every
+ * topology (docker-compose and GKE). It never alters a response; it counts
+ * response bytes and publishes a TrafficEvent when the response finishes.
+ *
+ * Classification: a 404 response means the request resolved to no deployment,
+ * alias, or asset — an Unmatched request. Everything else is matched.
+ */
+export function createTrafficObserver(events: TrafficEventsService) {
+  return function trafficObserver(req: Request, res: Response, next: NextFunction): void {
+    if (OBSERVER_EXEMPT_PATHS.some((p) => req.path === p)) {
+      return next();
+    }
+
+    let bytes = 0;
+    const countChunk = (chunk: unknown, encoding?: unknown): void => {
+      if (chunk) {
+        bytes += Buffer.isBuffer(chunk)
+          ? chunk.length
+          : Buffer.byteLength(String(chunk), typeof encoding === 'string' ? (encoding as BufferEncoding) : 'utf8');
+      }
+    };
+
+    const originalWrite = res.write.bind(res);
+    const originalEnd = res.end.bind(res);
+
+    res.write = function (chunk: any, ...args: any[]): boolean {
+      countChunk(chunk, args[0]);
+      return originalWrite(chunk, ...args);
+    } as Response['write'];
+
+    res.end = function (chunk?: any, ...args: any[]): Response {
+      countChunk(chunk, args[0]);
+      return originalEnd(chunk, ...args);
+    } as Response['end'];
+
+    res.on('finish', () => {
+      const timestamp = new Date().toISOString();
+      const withoutLine: Omit<TrafficEvent, 'line'> = {
+        id: `${Date.now()}-${eventCounter++}`,
+        timestamp,
+        ip: extractClientIp(req) || '-',
+        method: req.method,
+        path: req.originalUrl,
+        httpVersion: req.httpVersion,
+        status: res.statusCode,
+        bytes,
+        referer: (req.headers.referer as string) || null,
+        userAgent: (req.headers['user-agent'] as string) || null,
+        host: (req.headers['x-forwarded-host'] as string) || req.headers.host || null,
+        classification: res.statusCode === 404 ? 'unmatched' : 'matched',
+      };
+      events.emit({ ...withoutLine, line: formatAccessLogLine(withoutLine) });
+    });
+
+    next();
+  };
+}

--- a/apps/backend/src/traffic/traffic.controller.spec.ts
+++ b/apps/backend/src/traffic/traffic.controller.spec.ts
@@ -1,0 +1,67 @@
+import { MessageEvent } from '@nestjs/common';
+import { Request } from 'express';
+import { ROLES_KEY } from '../auth/roles.guard';
+import { TrafficController } from './traffic.controller';
+import { TrafficEventsService } from './traffic-events.service';
+import { TrafficEvent } from './traffic-event.interface';
+
+// bcrypt is a native module the auth barrel imports transitively; mock it like
+// the other guard specs do so the suite runs without the compiled binding.
+jest.mock('bcrypt');
+
+describe('TrafficController', () => {
+  let controller: TrafficController;
+  let events: TrafficEventsService;
+
+  const sampleEvent: TrafficEvent = {
+    id: '1',
+    timestamp: '2026-07-02T09:05:03.000Z',
+    ip: '203.0.113.7',
+    method: 'GET',
+    path: '/backend/.env',
+    httpVersion: '1.1',
+    status: 404,
+    bytes: 42,
+    referer: null,
+    userAgent: 'scanner',
+    host: 'j5s.dev',
+    classification: 'unmatched',
+    line: 'formatted line',
+  };
+
+  const makeReq = () => ({ res: { setHeader: jest.fn() } }) as unknown as Request;
+
+  beforeEach(() => {
+    events = new TrafficEventsService();
+    controller = new TrafficController(events);
+  });
+
+  it('is admin-only: stream handler carries the admin roles metadata', () => {
+    const roles = Reflect.getMetadata(ROLES_KEY, controller.stream);
+    expect(roles).toEqual(['admin']);
+  });
+
+  it('is guarded: controller declares ApiKeyGuard + RolesGuard', () => {
+    const guards = Reflect.getMetadata('__guards__', TrafficController) ?? [];
+    const guardNames = guards.map((g: any) => g.name);
+    expect(guardNames).toEqual(expect.arrayContaining(['ApiKeyGuard', 'RolesGuard']));
+  });
+
+  it('relays observed requests to SSE subscribers as "request" events', (done) => {
+    const received: MessageEvent[] = [];
+    const subscription = controller.stream(makeReq()).subscribe((message) => {
+      received.push(message);
+      subscription.unsubscribe();
+      expect(received[0]).toEqual({ type: 'request', data: sampleEvent });
+      done();
+    });
+
+    events.emit(sampleEvent);
+  });
+
+  it('disables proxy buffering on the stream response', () => {
+    const req = makeReq();
+    controller.stream(req).subscribe().unsubscribe();
+    expect(req.res!.setHeader).toHaveBeenCalledWith('X-Accel-Buffering', 'no');
+  });
+});

--- a/apps/backend/src/traffic/traffic.controller.ts
+++ b/apps/backend/src/traffic/traffic.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, MessageEvent, Req, Sse, UseGuards } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { Observable, interval, map, merge } from 'rxjs';
+// Import from the concrete files (not the ../auth barrel): the barrel pulls in
+// auth.module -> settings.module, a cycle that leaves Roles undefined when this
+// controller is loaded first (e.g. in unit tests).
+import { ApiKeyGuard } from '../auth/api-key.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { TrafficEventsService } from './traffic-events.service';
+
+/** Keep-alive cadence so idle SSE connections survive proxy read timeouts. */
+const HEARTBEAT_MS = 30_000;
+
+@ApiTags('Traffic')
+@Controller('api/traffic')
+@UseGuards(ApiKeyGuard, RolesGuard)
+export class TrafficController {
+  constructor(private readonly trafficEvents: TrafficEventsService) {}
+
+  @Sse('stream')
+  @Roles('admin')
+  @SkipThrottle()
+  @ApiOperation({ summary: 'Live tail of app-observed requests (SSE, admin only)' })
+  stream(@Req() req: Request): Observable<MessageEvent> {
+    // nginx must not buffer the event stream
+    req.res?.setHeader('X-Accel-Buffering', 'no');
+    req.res?.setHeader('Cache-Control', 'no-cache, no-transform');
+
+    const events$ = this.trafficEvents
+      .stream()
+      .pipe(map((event): MessageEvent => ({ type: 'request', data: event })));
+
+    const heartbeat$ = interval(HEARTBEAT_MS).pipe(
+      map((): MessageEvent => ({ type: 'heartbeat', data: '' })),
+    );
+
+    return merge(events$, heartbeat$);
+  }
+}

--- a/apps/backend/src/traffic/traffic.module.ts
+++ b/apps/backend/src/traffic/traffic.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TrafficController } from './traffic.controller';
+import { TrafficEventsService } from './traffic-events.service';
+
+/**
+ * Bot protection & request observability (issue #383).
+ *
+ * This slice (#389) provides the observation seam: the traffic observer
+ * middleware (installed in main.ts) publishes every app-observed request to
+ * TrafficEventsService, and TrafficController exposes an admin-only SSE live
+ * tail. Persistence and the Blocklist arrive in later slices.
+ */
+@Module({
+  controllers: [TrafficController],
+  providers: [TrafficEventsService],
+  exports: [TrafficEventsService],
+})
+export class TrafficModule {}

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import { AuthTab } from '@/pages/admin-settings/AuthTab';
 import { EmailTab } from '@/pages/admin-settings/EmailTab';
 import { InfrastructureTab } from '@/pages/admin-settings/InfrastructureTab';
 import { DomainsPage } from '@/pages/DomainsPage';
+import { TrafficPage } from '@/pages/TrafficPage';
 import { HomePage } from '@/pages/HomePage';
 import { LoginPage } from '@/pages/LoginPage';
 import { LogoutPage } from '@/pages/LogoutPage';
@@ -128,6 +129,9 @@ function App() {
 
         {/* Domains route (admin only) */}
         <Route path="/domains" element={<ProtectedRoute requireAdmin><DomainsPage /></ProtectedRoute>} />
+
+        {/* Traffic route (admin only) */}
+        <Route path="/traffic" element={<ProtectedRoute requireAdmin><TrafficPage /></ProtectedRoute>} />
         </Routes>
         <Toaster />
       </div>

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -260,6 +260,9 @@ export function HomePage() {
               <Button asChild variant="outline" className="border-[#4a4a4a]/20 hover:border-[#d96459]/50 hover:bg-[#ede8dd] dark:hover:bg-accent">
                 <Link to="/domains">Domains</Link>
               </Button>
+              <Button asChild variant="outline" className="border-[#4a4a4a]/20 hover:border-[#d96459]/50 hover:bg-[#ede8dd] dark:hover:bg-accent">
+                <Link to="/traffic">Traffic</Link>
+              </Button>
             </div>
           </div>
         )}

--- a/apps/frontend/src/pages/TrafficPage.test.tsx
+++ b/apps/frontend/src/pages/TrafficPage.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { TrafficPage, isSignalEvent, type TrafficStreamEvent } from './TrafficPage';
+
+// Radix Switch doesn't play well with happy-dom; stub it like other page tests do
+vi.mock('@/components/ui/switch', () => ({
+  Switch: ({ checked, onCheckedChange, id }: any) => (
+    <input
+      type="checkbox"
+      id={id}
+      role="switch"
+      checked={checked}
+      onChange={(e) => onCheckedChange(e.target.checked)}
+    />
+  ),
+}));
+
+type Listener = (event: { data: string }) => void;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  url: string;
+  withCredentials: boolean;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+  private listeners: Record<string, Listener[]> = {};
+
+  constructor(url: string, options?: { withCredentials?: boolean }) {
+    this.url = url;
+    this.withCredentials = options?.withCredentials ?? false;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: Listener) {
+    (this.listeners[type] ??= []).push(listener);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  emit(type: string, data: unknown) {
+    for (const listener of this.listeners[type] ?? []) {
+      listener({ data: JSON.stringify(data) });
+    }
+  }
+}
+
+const makeEvent = (overrides: Partial<TrafficStreamEvent>): TrafficStreamEvent => ({
+  id: Math.random().toString(36).slice(2),
+  timestamp: '2026-07-02T09:05:03.000Z',
+  ip: '203.0.113.7',
+  method: 'GET',
+  path: '/index.html',
+  httpVersion: '1.1',
+  status: 200,
+  bytes: 512,
+  referer: null,
+  userAgent: 'test',
+  host: 'j5s.dev',
+  classification: 'matched',
+  line: '203.0.113.7 - - [02/Jul/2026:09:05:03 +0000] "GET /index.html HTTP/1.1" 200 512 "-" "test"',
+  ...overrides,
+});
+
+describe('isSignalEvent', () => {
+  it('keeps unmatched requests', () => {
+    expect(isSignalEvent(makeEvent({ classification: 'unmatched', status: 404 }))).toBe(true);
+  });
+
+  it('keeps 4xx/5xx responses even when matched', () => {
+    expect(isSignalEvent(makeEvent({ status: 403 }))).toBe(true);
+    expect(isSignalEvent(makeEvent({ status: 502 }))).toBe(true);
+  });
+
+  it('drops matched 2xx/3xx traffic', () => {
+    expect(isSignalEvent(makeEvent({ status: 200 }))).toBe(false);
+    expect(isSignalEvent(makeEvent({ status: 304 }))).toBe(false);
+  });
+});
+
+describe('TrafficPage', () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+  });
+
+  const source = () => MockEventSource.instances[0];
+
+  it('opens a credentialed SSE connection to the traffic stream', () => {
+    render(<TrafficPage />);
+    expect(source().url).toContain('/api/traffic/stream');
+    expect(source().withCredentials).toBe(true);
+  });
+
+  it('defaults to showing only Unmatched and 4xx/5xx requests', () => {
+    render(<TrafficPage />);
+    act(() => {
+      source().emit('request', makeEvent({ line: 'MATCHED-OK-LINE', status: 200 }));
+      source().emit(
+        'request',
+        makeEvent({ line: 'SCANNER-LINE', status: 404, classification: 'unmatched', path: '/.env' }),
+      );
+    });
+
+    expect(screen.getByText(/SCANNER-LINE/)).toBeInTheDocument();
+    expect(screen.queryByText(/MATCHED-OK-LINE/)).not.toBeInTheDocument();
+    expect(screen.getByText(/1 matched request hidden/)).toBeInTheDocument();
+  });
+
+  it('reveals all traffic when "Show all" is toggled', () => {
+    render(<TrafficPage />);
+    act(() => {
+      source().emit('request', makeEvent({ line: 'MATCHED-OK-LINE', status: 200 }));
+    });
+    expect(screen.queryByText(/MATCHED-OK-LINE/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('switch'));
+    expect(screen.getByText(/MATCHED-OK-LINE/)).toBeInTheDocument();
+  });
+
+  it('stops appending while paused and closes the stream on unmount', () => {
+    const { unmount } = render(<TrafficPage />);
+    fireEvent.click(screen.getByRole('button', { name: /pause/i }));
+    act(() => {
+      source().emit('request', makeEvent({ line: 'WHILE-PAUSED', status: 404, classification: 'unmatched' }));
+    });
+    expect(screen.queryByText(/WHILE-PAUSED/)).not.toBeInTheDocument();
+
+    unmount();
+    expect(source().closed).toBe(true);
+  });
+});

--- a/apps/frontend/src/pages/TrafficPage.test.tsx
+++ b/apps/frontend/src/pages/TrafficPage.test.tsx
@@ -84,6 +84,7 @@ describe('TrafficPage', () => {
   beforeEach(() => {
     MockEventSource.instances = [];
     vi.stubGlobal('EventSource', MockEventSource);
+    localStorage.clear();
   });
 
   const source = () => MockEventSource.instances[0];
@@ -116,8 +117,38 @@ describe('TrafficPage', () => {
     });
     expect(screen.queryByText(/MATCHED-OK-LINE/)).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('switch'));
+    fireEvent.click(screen.getByLabelText(/show all/i));
     expect(screen.getByText(/MATCHED-OK-LINE/)).toBeInTheDocument();
+  });
+
+  it('defaults to unwrapped lines and persists the wrap preference', () => {
+    render(<TrafficPage />);
+    act(() => {
+      source().emit('request', makeEvent({ line: 'SCANNER-LINE', status: 404, classification: 'unmatched' }));
+    });
+
+    const line = screen.getByText(/SCANNER-LINE/).parentElement!;
+    expect(line.className).toContain('whitespace-pre');
+    expect(line.className).not.toContain('whitespace-pre-wrap');
+
+    fireEvent.click(screen.getByLabelText(/wrap lines/i));
+    expect(screen.getByText(/SCANNER-LINE/).parentElement!.className).toContain(
+      'whitespace-pre-wrap',
+    );
+    expect(localStorage.getItem('bffless.traffic.wrapLines')).toBe('true');
+  });
+
+  it('shows a Paused badge instead of Live while paused', () => {
+    render(<TrafficPage />);
+    act(() => source().onopen?.());
+    expect(screen.getByText('Live')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /pause/i }));
+    expect(screen.queryByText('Live')).not.toBeInTheDocument();
+    expect(screen.getByText('Paused')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /resume/i }));
+    expect(screen.getByText('Live')).toBeInTheDocument();
   });
 
   it('stops appending while paused and closes the stream on unmount', () => {

--- a/apps/frontend/src/pages/TrafficPage.tsx
+++ b/apps/frontend/src/pages/TrafficPage.tsx
@@ -1,0 +1,185 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Activity, Pause, Play, Trash2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+
+/** A request observed by the backend's application interceptor (issue #389). */
+export interface TrafficStreamEvent {
+  id: string;
+  timestamp: string;
+  ip: string;
+  method: string;
+  path: string;
+  httpVersion: string;
+  status: number;
+  bytes: number;
+  referer: string | null;
+  userAgent: string | null;
+  host: string | null;
+  classification: 'matched' | 'unmatched';
+  line: string;
+}
+
+type ConnectionState = 'connecting' | 'live' | 'disconnected';
+
+/** Cap the in-memory tail so a scanner storm can't grow the page unbounded. */
+const MAX_EVENTS = 1000;
+
+/**
+ * Default view: only the signal (Unmatched requests and 4xx/5xx responses).
+ * "Show all" reveals the 200-OK asset firehose too.
+ */
+export function isSignalEvent(event: TrafficStreamEvent): boolean {
+  return event.classification === 'unmatched' || event.status >= 400;
+}
+
+function statusColorClass(status: number): string {
+  if (status >= 500) return 'text-red-600 dark:text-red-400';
+  if (status >= 400) return 'text-amber-600 dark:text-amber-400';
+  if (status >= 300) return 'text-blue-600 dark:text-blue-400';
+  return 'text-emerald-700 dark:text-emerald-400';
+}
+
+export function TrafficPage() {
+  const [events, setEvents] = useState<TrafficStreamEvent[]>([]);
+  const [showAll, setShowAll] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const [connection, setConnection] = useState<ConnectionState>('connecting');
+
+  const pausedRef = useRef(paused);
+  pausedRef.current = paused;
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const baseUrl = import.meta.env.VITE_API_URL || '';
+    const source = new EventSource(`${baseUrl}/api/traffic/stream`, {
+      withCredentials: true,
+    });
+
+    source.onopen = () => setConnection('live');
+    source.onerror = () => setConnection('disconnected');
+    source.addEventListener('request', (message) => {
+      if (pausedRef.current) return;
+      const event = JSON.parse((message as MessageEvent).data) as TrafficStreamEvent;
+      setEvents((prev) => {
+        const next = prev.length >= MAX_EVENTS ? prev.slice(prev.length - MAX_EVENTS + 1) : prev.slice();
+        next.push(event);
+        return next;
+      });
+    });
+
+    return () => source.close();
+  }, []);
+
+  const visibleEvents = showAll ? events : events.filter(isSignalEvent);
+
+  // Keep the tail pinned to the newest line, like `docker compose logs -f`
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [visibleEvents.length]);
+
+  const clear = useCallback(() => setEvents([]), []);
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-7xl">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-[#3a3a3a] dark:text-foreground flex items-center gap-2">
+            <Activity className="h-6 w-6 text-[#d96459]" />
+            Traffic
+          </h1>
+          <p className="text-sm text-[#4a4a4a] dark:text-muted-foreground mt-1">
+            Live tail of requests hitting this instance, as the application observes them
+          </p>
+        </div>
+        <ConnectionBadge state={connection} />
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <CardTitle className="text-base">Live requests</CardTitle>
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-2">
+                <Switch id="show-all" checked={showAll} onCheckedChange={setShowAll} />
+                <Label htmlFor="show-all" className="text-sm cursor-pointer">
+                  Show all
+                </Label>
+              </div>
+              <Button variant="outline" size="sm" onClick={() => setPaused((p) => !p)}>
+                {paused ? <Play className="h-4 w-4 mr-1" /> : <Pause className="h-4 w-4 mr-1" />}
+                {paused ? 'Resume' : 'Pause'}
+              </Button>
+              <Button variant="outline" size="sm" onClick={clear}>
+                <Trash2 className="h-4 w-4 mr-1" />
+                Clear
+              </Button>
+            </div>
+          </div>
+          {!showAll && (
+            <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground">
+              Showing Unmatched and 4xx/5xx requests only
+              {events.length > visibleEvents.length &&
+                ` — ${events.length - visibleEvents.length} matched request${events.length - visibleEvents.length === 1 ? '' : 's'} hidden`}
+            </p>
+          )}
+        </CardHeader>
+        <CardContent>
+          <div
+            ref={scrollRef}
+            data-testid="traffic-log"
+            className="bg-[#1e1e1e] rounded-md p-3 h-[32rem] overflow-y-auto font-mono text-xs leading-5"
+          >
+            {visibleEvents.length === 0 ? (
+              <p className="text-gray-400">
+                {connection === 'live'
+                  ? 'Waiting for requests…'
+                  : connection === 'connecting'
+                    ? 'Connecting to stream…'
+                    : 'Stream disconnected — retrying…'}
+              </p>
+            ) : (
+              visibleEvents.map((event) => (
+                <div key={event.id} className="whitespace-pre-wrap break-all text-gray-200">
+                  {event.classification === 'unmatched' && (
+                    <span className="text-[#d96459] mr-1" title="Unmatched request">
+                      ●
+                    </span>
+                  )}
+                  <span className={statusColorClass(event.status)}>{event.line}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function ConnectionBadge({ state }: { state: ConnectionState }) {
+  if (state === 'live') {
+    return (
+      <Badge variant="outline" className="border-emerald-500/50 text-emerald-600 dark:text-emerald-400">
+        <span className="h-2 w-2 rounded-full bg-emerald-500 mr-1.5 animate-pulse" />
+        Live
+      </Badge>
+    );
+  }
+  if (state === 'connecting') {
+    return (
+      <Badge variant="outline" className="text-[#4a4a4a] dark:text-muted-foreground">
+        Connecting…
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" className="border-red-500/50 text-red-600 dark:text-red-400">
+      Disconnected
+    </Badge>
+  );
+}

--- a/apps/frontend/src/pages/TrafficPage.tsx
+++ b/apps/frontend/src/pages/TrafficPage.tsx
@@ -28,6 +28,9 @@ type ConnectionState = 'connecting' | 'live' | 'disconnected';
 /** Cap the in-memory tail so a scanner storm can't grow the page unbounded. */
 const MAX_EVENTS = 1000;
 
+/** Display preference only — deliberately not pause state, which stays ephemeral. */
+const WRAP_LINES_STORAGE_KEY = 'bffless.traffic.wrapLines';
+
 /**
  * Default view: only the signal (Unmatched requests and 4xx/5xx responses).
  * "Show all" reveals the 200-OK asset firehose too.
@@ -47,6 +50,9 @@ export function TrafficPage() {
   const [events, setEvents] = useState<TrafficStreamEvent[]>([]);
   const [showAll, setShowAll] = useState(false);
   const [paused, setPaused] = useState(false);
+  const [wrapLines, setWrapLines] = useState(
+    () => localStorage.getItem(WRAP_LINES_STORAGE_KEY) === 'true',
+  );
   const [connection, setConnection] = useState<ConnectionState>('connecting');
 
   const pausedRef = useRef(paused);
@@ -84,6 +90,11 @@ export function TrafficPage() {
 
   const clear = useCallback(() => setEvents([]), []);
 
+  const toggleWrapLines = useCallback((checked: boolean) => {
+    setWrapLines(checked);
+    localStorage.setItem(WRAP_LINES_STORAGE_KEY, String(checked));
+  }, []);
+
   return (
     <div className="container mx-auto px-4 py-8 max-w-7xl">
       <div className="flex items-center justify-between mb-6">
@@ -96,7 +107,7 @@ export function TrafficPage() {
             Live tail of requests hitting this instance, as the application observes them
           </p>
         </div>
-        <ConnectionBadge state={connection} />
+        <ConnectionBadge state={connection} paused={paused} />
       </div>
 
       <Card>
@@ -108,6 +119,12 @@ export function TrafficPage() {
                 <Switch id="show-all" checked={showAll} onCheckedChange={setShowAll} />
                 <Label htmlFor="show-all" className="text-sm cursor-pointer">
                   Show all
+                </Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <Switch id="wrap-lines" checked={wrapLines} onCheckedChange={toggleWrapLines} />
+                <Label htmlFor="wrap-lines" className="text-sm cursor-pointer">
+                  Wrap lines
                 </Label>
               </div>
               <Button variant="outline" size="sm" onClick={() => setPaused((p) => !p)}>
@@ -132,7 +149,7 @@ export function TrafficPage() {
           <div
             ref={scrollRef}
             data-testid="traffic-log"
-            className="bg-[#1e1e1e] rounded-md p-3 h-[32rem] overflow-y-auto font-mono text-xs leading-5"
+            className={`bg-[#1e1e1e] rounded-md p-3 h-[32rem] overflow-y-auto font-mono text-xs leading-5 ${wrapLines ? '' : 'overflow-x-auto'}`}
           >
             {visibleEvents.length === 0 ? (
               <p className="text-gray-400">
@@ -144,7 +161,10 @@ export function TrafficPage() {
               </p>
             ) : (
               visibleEvents.map((event) => (
-                <div key={event.id} className="whitespace-pre-wrap break-all text-gray-200">
+                <div
+                  key={event.id}
+                  className={`text-gray-200 ${wrapLines ? 'whitespace-pre-wrap break-all' : 'whitespace-pre w-max min-w-full'}`}
+                >
                   {event.classification === 'unmatched' && (
                     <span className="text-[#d96459] mr-1" title="Unmatched request">
                       ●
@@ -161,7 +181,17 @@ export function TrafficPage() {
   );
 }
 
-function ConnectionBadge({ state }: { state: ConnectionState }) {
+function ConnectionBadge({ state, paused }: { state: ConnectionState; paused: boolean }) {
+  // Pause is a view state that trumps the connection state: while paused the
+  // stream stays open but nothing appends, so advertising "Live" would lie.
+  if (paused) {
+    return (
+      <Badge variant="outline" className="border-amber-500/50 text-amber-600 dark:text-amber-400">
+        <span className="h-2 w-2 rounded-full bg-amber-500 mr-1.5" />
+        Paused
+      </Badge>
+    );
+  }
   if (state === 'live') {
     return (
       <Badge variant="outline" className="border-emerald-500/50 text-emerald-600 dark:text-emerald-400">


### PR DESCRIPTION
Closes #389 (first slice of #383).

## What this does

Per **ADR-0003**, the application layer becomes the cross-topology authority for request observation:

- **Observation seam (backend).** A traffic observer middleware is installed with `app.use()` in `main.ts`, *above all Nest module middleware*, so it sees every request that reaches the app — including requests `ProxyMiddleware` short-circuits before any controller, and identically on docker-compose and GKE. On response finish it classifies the request (**matched** vs **Unmatched** = 404) and publishes a `TrafficEvent` to an in-process rxjs bus. Ephemeral only — no persistence in this slice.
- **Live tail (SSE).** `GET /api/traffic/stream` (admin-only: `ApiKeyGuard` + `RolesGuard` + `@Roles('admin')`) relays observed requests, each pre-rendered as an nginx **combined access-log line**, with a 30s heartbeat and `X-Accel-Buffering: no`.
- **Traffic admin page.** New top-level `/traffic` route (`ProtectedRoute requireAdmin`, linked from the Home page Admin section) with a live tail that defaults to **Unmatched + 4xx/5xx** and has a **Show all** toggle, pause/resume, clear, a 1000-event ring buffer, and a connection badge.
- **404-leak fix.** `serve404Page` no longer accepts a message: every public-content 404 renders the same friendly generic page. Previously it echoed internal storage paths unescaped (e.g. `File not found: sites/landing/dist/backend/.env`), which both leaked the filesystem layout to scanners and was an XSS-shaped hole (unescaped interpolation into HTML).

Prefactoring: `extractClientIp` (X-Forwarded-For-aware; the app sets no `trust proxy`) extracted to `src/common/utils/request-ip.util.ts` for reuse by the #390 per-IP rollup.

## Test coverage

- **Seam 1 (supertest at the HTTP boundary)** — `src/traffic/traffic-http.spec.ts` drives real HTTP through `PublicController` with the observer installed exactly as `main.ts` wires it: matched request serves normally and is observed as `matched`; scanner path gets a generic 404 that contains **no** echo of the requested/internal path and is observed as `unmatched`; unknown alias is not echoed; events arrive on the stream in order.
- `access-log.util.spec.ts` — combined-log-format rendering.
- `traffic.controller.spec.ts` — admin roles metadata + guards present; SSE relays events; proxy buffering disabled.
- `TrafficPage.test.tsx` — default signal-only filter, Show-all toggle, pause, stream teardown, credentialed EventSource URL.

Full suites green: backend 76/76 suites (1222 tests), frontend 22/22 files (377 tests), both typechecks clean.

## Manual validation steps

Not yet exercised against a running instance (no local DB in my env) — please validate:

1. **Start the stack**: `pnpm dev:full`, log in as an admin.
2. **Traffic page**: from Home → Admin → **Traffic** (or `/traffic`). Badge should go **Live** within a second (SSE connect). As a non-admin (or logged out), `/traffic` should redirect away and `curl -i http://localhost:3000/api/traffic/stream` should return 401/403, not a stream.
3. **Live tail — signal filter**: in another tab, hit a deployed site path that exists (200) and a junk path like `https://<your-domain>/backend/.env` or `/wp-login.php`. Default view should show only the 404 lines (amber, with the ● unmatched marker); toggling **Show all** should reveal the 200 asset traffic too. Lines should read like `docker compose logs` on assethost-nginx: `IP - - [time] "GET /path HTTP/1.1" 404 bytes "-" "UA"`.
4. **Client IP**: through nginx, the IP column should be the real client IP (X-Forwarded-For), not the proxy's.
5. **404-leak fix (the key one)**: request `curl -s https://<domain>/backend/.env` — the HTML must say only *"The page you're looking for doesn't exist."* with **no** `File not found:` / `sites/...` internal path. A mistyped URL on a real site should show the same friendly page; a deployment that ships its own `404.html` should still get it (that path is untouched).
6. **Pause/Clear**: pause the tail, generate traffic, confirm nothing appends; resume and confirm new events flow. Clear empties the pane.
7. **Long-lived stream**: leave the page idle >2 min; the connection badge should stay **Live** (30s heartbeats should hold the connection through nginx).
8. **No behavior change elsewhere**: normal site serving, API, admin UI all unaffected (the observer only listens; it never alters a response).

## Out of scope (later slices)

Persistence + per-IP rollup (#390), Blocklist library/compiler (#391), nginx edge enforcement (#392), inline add-to-blocklist (#393).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKcWfgVZevHdobRQXzRqHA
