### PR TITLE
feat(traffic): persist Unmatched requests, per-IP rollup, history + read API (#390)

### DIFF
--- a/apps/backend/drizzle/0034_shiny_sandman.sql
+++ b/apps/backend/drizzle/0034_shiny_sandman.sql
@@ -1,0 +1,35 @@
+CREATE TABLE "traffic_ip_rollups" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"ip" varchar(45) NOT NULL,
+	"request_count" bigint DEFAULT 0 NOT NULL,
+	"first_seen_at" timestamp NOT NULL,
+	"last_seen_at" timestamp NOT NULL,
+	"sample_paths" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"sample_user_agents" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "traffic_requests" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"timestamp" timestamp NOT NULL,
+	"ip" varchar(45) NOT NULL,
+	"method" varchar(16) NOT NULL,
+	"path" text NOT NULL,
+	"http_version" varchar(16) NOT NULL,
+	"status" integer NOT NULL,
+	"bytes" bigint NOT NULL,
+	"referer" text,
+	"user_agent" text,
+	"host" varchar(255),
+	"classification" varchar(20) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "traffic_ip_rollups_ip_unique" ON "traffic_ip_rollups" USING btree ("ip");--> statement-breakpoint
+CREATE INDEX "traffic_ip_rollups_request_count_idx" ON "traffic_ip_rollups" USING btree ("request_count");--> statement-breakpoint
+CREATE INDEX "traffic_ip_rollups_last_seen_idx" ON "traffic_ip_rollups" USING btree ("last_seen_at");--> statement-breakpoint
+CREATE INDEX "traffic_requests_timestamp_idx" ON "traffic_requests" USING btree ("timestamp");--> statement-breakpoint
+CREATE INDEX "traffic_requests_ip_idx" ON "traffic_requests" USING btree ("ip","timestamp");--> statement-breakpoint
+CREATE INDEX "traffic_requests_status_idx" ON "traffic_requests" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "traffic_requests_classification_idx" ON "traffic_requests" USING btree ("classification");

--- a/apps/backend/drizzle/meta/0034_snapshot.json
+++ b/apps/backend/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,6512 @@
+{
+  "id": "1872d282-ecfd-4af5-83a5-6891f4229c69",
+  "prevId": "5f5d3bcc-94cf-4ac6-930b-d0113ca38222",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alias_proxy_rule_sets": {
+      "name": "alias_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alias_proxy_rule_sets_alias_ruleset_unique": {
+          "name": "alias_proxy_rule_sets_alias_ruleset_unique",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_alias_id_idx": {
+          "name": "alias_proxy_rule_sets_alias_id_idx",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_rule_set_id_idx": {
+          "name": "alias_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk": {
+          "name": "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "deployment_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_project_id_idx": {
+          "name": "api_keys_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_path": {
+          "name": "original_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_number": {
+          "name": "workflow_run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'commits'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_project_id_idx": {
+          "name": "assets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_type_idx": {
+          "name": "assets_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_path_idx": {
+          "name": "assets_project_commit_path_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_branch_idx": {
+          "name": "assets_project_branch_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_idx": {
+          "name": "assets_project_commit_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_created_at_idx": {
+          "name": "assets_project_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_committed_at_idx": {
+          "name": "assets_project_committed_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_path_idx": {
+          "name": "assets_deployment_path_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_id_idx": {
+          "name": "assets_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_size_idx": {
+          "name": "assets_deployment_size_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_uploaded_by_users_id_fk": {
+          "name": "assets_uploaded_by_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cache_rules": {
+      "name": "cache_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_max_age": {
+          "name": "browser_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "cdn_max_age": {
+          "name": "cdn_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stale_while_revalidate": {
+          "name": "stale_while_revalidate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immutable": {
+          "name": "immutable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cacheability": {
+          "name": "cacheability",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cache_rules_project_pattern_unique": {
+          "name": "cache_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_id_idx": {
+          "name": "cache_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_priority_idx": {
+          "name": "cache_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cache_rules_project_id_projects_id_fk": {
+          "name": "cache_rules_project_id_projects_id_fk",
+          "tableFrom": "cache_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_aliases": {
+      "name": "deployment_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_preview": {
+          "name": "is_auto_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployment_aliases_project_alias_unique": {
+          "name": "deployment_aliases_project_alias_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_project_id_idx": {
+          "name": "deployment_aliases_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_alias_unique": {
+          "name": "deployment_aliases_repository_alias_unique",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_idx": {
+          "name": "deployment_aliases_repository_idx",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_commit_sha_idx": {
+          "name": "deployment_aliases_commit_sha_idx",
+          "columns": [
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_deployment_id_idx": {
+          "name": "deployment_aliases_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_aliases_project_id_projects_id_fk": {
+          "name": "deployment_aliases_project_id_projects_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_mappings": {
+      "name": "domain_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_type": {
+          "name": "domain_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ssl_expires_at": {
+          "name": "ssl_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_verified": {
+          "name": "dns_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dns_verified_at": {
+          "name": "dns_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_renew_ssl": {
+          "name": "auto_renew_ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_renewed_at": {
+          "name": "ssl_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_status": {
+          "name": "ssl_renewal_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_error": {
+          "name": "ssl_renewal_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sticky_sessions_enabled": {
+          "name": "sticky_sessions_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sticky_session_duration": {
+          "name": "sticky_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 86400
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_mappings_project_id_idx": {
+          "name": "domain_mappings_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_domain_idx": {
+          "name": "domain_mappings_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_is_active_idx": {
+          "name": "domain_mappings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_mappings_project_id_projects_id_fk": {
+          "name": "domain_mappings_project_id_projects_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_mappings_created_by_users_id_fk": {
+          "name": "domain_mappings_created_by_users_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_mappings_domain_unique": {
+          "name": "domain_mappings_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_redirects": {
+      "name": "domain_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_domain": {
+          "name": "source_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_domain_id": {
+          "name": "target_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_redirects_target_domain_id_idx": {
+          "name": "domain_redirects_target_domain_id_idx",
+          "columns": [
+            {
+              "expression": "target_domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_redirects_source_domain_idx": {
+          "name": "domain_redirects_source_domain_idx",
+          "columns": [
+            {
+              "expression": "source_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_redirects_target_domain_id_domain_mappings_id_fk": {
+          "name": "domain_redirects_target_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "target_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_redirects_created_by_users_id_fk": {
+          "name": "domain_redirects_created_by_users_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_redirects_source_domain_unique": {
+          "name": "domain_redirects_source_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_rules": {
+      "name": "domain_traffic_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_key": {
+          "name": "condition_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_value": {
+          "name": "condition_value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_rules_domain_id_idx": {
+          "name": "domain_traffic_rules_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_traffic_rules_domain_id_priority_idx": {
+          "name": "domain_traffic_rules_domain_id_priority_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_rules_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_rules_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_rules",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_weights": {
+      "name": "domain_traffic_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_weights_domain_id_idx": {
+          "name": "domain_traffic_weights_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_weights_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_weights_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_weights",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_traffic_weights_domain_alias_unique": {
+          "name": "domain_traffic_weights_domain_alias_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain_id",
+            "alias"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flags_key_idx": {
+          "name": "feature_flags_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_integration_credentials": {
+      "name": "google_integration_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured": {
+          "name": "configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "google_integration_credentials_service_unique": {
+          "name": "google_integration_credentials_service_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oidc_providers_provider_id_unique": {
+          "name": "oidc_providers_provider_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rule_executions": {
+      "name": "onboarding_rule_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rule_executions_user_idx": {
+          "name": "onboarding_rule_executions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_rule_idx": {
+          "name": "onboarding_rule_executions_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_executed_at_idx": {
+          "name": "onboarding_rule_executions_executed_at_idx",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_status_idx": {
+          "name": "onboarding_rule_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rule_executions_rule_id_onboarding_rules_id_fk": {
+          "name": "onboarding_rule_executions_rule_id_onboarding_rules_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "onboarding_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "onboarding_rule_executions_user_id_users_id_fk": {
+          "name": "onboarding_rule_executions_user_id_users_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rules": {
+      "name": "onboarding_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_signup'"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rules_enabled_trigger_idx": {
+          "name": "onboarding_rules_enabled_trigger_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rules_priority_idx": {
+          "name": "onboarding_rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rules_created_by_users_id_fk": {
+          "name": "onboarding_rules_created_by_users_id_fk",
+          "tableFrom": "onboarding_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_preferences": {
+      "name": "path_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spa_mode": {
+          "name": "spa_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_path_preferences_project_id": {
+          "name": "idx_path_preferences_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_preferences_project_id_projects_id_fk": {
+          "name": "path_preferences_project_id_projects_id_fk",
+          "tableFrom": "path_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "path_preferences_project_filepath_unique": {
+          "name": "path_preferences_project_filepath_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "filepath"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_redirects": {
+      "name": "path_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'100'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "path_redirects_domain_mapping_id_idx": {
+          "name": "path_redirects_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "path_redirects_source_path_idx": {
+          "name": "path_redirects_source_path_idx",
+          "columns": [
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_redirects_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "path_redirects_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "path_redirects_created_by_users_id_fk": {
+          "name": "path_redirects_created_by_users_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_token": {
+          "name": "upload_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_token_idx": {
+          "name": "pending_uploads_token_idx",
+          "columns": [
+            {
+              "expression": "upload_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_project_idx": {
+          "name": "pending_uploads_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_project_id_projects_id_fk": {
+          "name": "pending_uploads_project_id_projects_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_uploaded_by_users_id_fk": {
+          "name": "pending_uploads_uploaded_by_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_uploads_upload_token_unique": {
+          "name": "pending_uploads_upload_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data_embeddings": {
+      "name": "pipeline_data_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_data_id": {
+          "name": "pipeline_data_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_embeddings_data_id_idx": {
+          "name": "pipeline_data_embeddings_data_id_idx",
+          "columns": [
+            {
+              "expression": "pipeline_data_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_embeddings_schema_field_idx": {
+          "name": "pipeline_data_embeddings_schema_field_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk": {
+          "name": "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_data",
+          "columnsFrom": [
+            "pipeline_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data": {
+      "name": "pipeline_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_project_id_idx": {
+          "name": "pipeline_data_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_schema_id_idx": {
+          "name": "pipeline_data_schema_id_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_created_at_idx": {
+          "name": "pipeline_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_project_id_projects_id_fk": {
+          "name": "pipeline_data_project_id_projects_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_created_by_users_id_fk": {
+          "name": "pipeline_data_created_by_users_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_execution_logs": {
+      "name": "pipeline_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_id": {
+          "name": "proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps_count": {
+          "name": "steps_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_step": {
+          "name": "error_step",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_meta": {
+          "name": "request_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_exec_logs_rule_created_idx": {
+          "name": "pipeline_exec_logs_rule_created_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_project_idx": {
+          "name": "pipeline_exec_logs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_created_idx": {
+          "name": "pipeline_exec_logs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_execution_logs_project_id_projects_id_fk": {
+          "name": "pipeline_execution_logs_project_id_projects_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schemas": {
+      "name": "pipeline_schemas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schemas_project_id_idx": {
+          "name": "pipeline_schemas_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schemas_project_id_projects_id_fk": {
+          "name": "pipeline_schemas_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schemas",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pipeline_schemas_project_name_unique": {
+          "name": "pipeline_schemas_project_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.primary_content": {
+      "name": "primary_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "www_enabled": {
+          "name": "www_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'redirect-to-www'"
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "primary_content_project_id_projects_id_fk": {
+          "name": "primary_content_project_id_projects_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "primary_content_configured_by_users_id_fk": {
+          "name": "primary_content_configured_by_users_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_default_proxy_rule_sets": {
+      "name": "project_default_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_default_proxy_rule_sets_project_ruleset_unique": {
+          "name": "project_default_proxy_rule_sets_project_ruleset_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_project_id_idx": {
+          "name": "project_default_proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_rule_set_id_idx": {
+          "name": "project_default_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_default_proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "project_default_proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite_links": {
+      "name": "project_invite_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guest'"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invite_links_project_id_idx": {
+          "name": "project_invite_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_token_idx": {
+          "name": "project_invite_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_is_active_idx": {
+          "name": "project_invite_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_links_project_id_projects_id_fk": {
+          "name": "project_invite_links_project_id_projects_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_links_created_by_users_id_fk": {
+          "name": "project_invite_links_created_by_users_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_links_token_unique": {
+          "name": "project_invite_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_group_permissions": {
+      "name": "project_group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_group_permissions_project_idx": {
+          "name": "project_group_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_permissions_group_idx": {
+          "name": "project_group_permissions_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_permissions_project_id_projects_id_fk": {
+          "name": "project_group_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_group_id_user_groups_id_fk": {
+          "name": "project_group_permissions_group_id_user_groups_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_granted_by_users_id_fk": {
+          "name": "project_group_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_group_permissions_unique": {
+          "name": "project_group_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "group_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_permissions": {
+      "name": "project_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_permissions_project_idx": {
+          "name": "project_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_permissions_user_idx": {
+          "name": "project_permissions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_permissions_project_id_projects_id_fk": {
+          "name": "project_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_user_id_users_id_fk": {
+          "name": "project_permissions_user_id_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_granted_by_users_id_fk": {
+          "name": "project_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_permissions_unique": {
+          "name": "project_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_secrets": {
+      "name": "project_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_secrets_project_name_unique": {
+          "name": "project_secrets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_secrets_project_id_idx": {
+          "name": "project_secrets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_secrets_project_id_projects_id_fk": {
+          "name": "project_secrets_project_id_projects_id_fk",
+          "tableFrom": "project_secrets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_found'"
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authenticated'"
+        },
+        "allow_public_signup": {
+          "name": "allow_public_signup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_providers": {
+          "name": "ai_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_services": {
+          "name": "ai_services",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_proxy_rule_set_id": {
+          "name": "default_proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_created_by_idx": {
+          "name": "projects_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_owner_idx": {
+          "name": "projects_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_owner_name_unique": {
+          "name": "projects_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_sets": {
+      "name": "proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_sets_project_name_unique": {
+          "name": "proxy_rule_sets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_project_id_idx": {
+          "name": "proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_environment_idx": {
+          "name": "proxy_rule_sets_environment_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rules": {
+      "name": "proxy_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "methods": {
+          "name": "methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strip_prefix": {
+          "name": "strip_prefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "preserve_host": {
+          "name": "preserve_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forward_cookies": {
+          "name": "forward_cookies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "header_config": {
+          "name": "header_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_transform": {
+          "name": "auth_transform",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_rewrite": {
+          "name": "internal_rewrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proxy_type": {
+          "name": "proxy_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external_proxy'"
+        },
+        "email_handler_config": {
+          "name": "email_handler_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "debug_enabled": {
+          "name": "debug_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rules_rule_set_path_method_unique": {
+          "name": "proxy_rules_rule_set_path_method_unique",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_id_idx": {
+          "name": "proxy_rules_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_order_idx": {
+          "name": "proxy_rules_rule_set_order_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_proxy_type_idx": {
+          "name": "proxy_rules_proxy_type_idx",
+          "columns": [
+            {
+              "expression": "proxy_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rules_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rules_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rules",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_header_rules": {
+      "name": "response_header_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_policy": {
+          "name": "frame_policy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sameorigin'"
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_header_rules_project_pattern_unique": {
+          "name": "response_header_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_id_idx": {
+          "name": "response_header_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_priority_idx": {
+          "name": "response_header_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "response_header_rules_project_id_projects_id_fk": {
+          "name": "response_header_rules_project_id_projects_id_fk",
+          "tableFrom": "response_header_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_logs": {
+      "name": "retention_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_count": {
+          "name": "asset_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "freed_bytes": {
+          "name": "freed_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_partial": {
+          "name": "is_partial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_logs_project_id_idx": {
+          "name": "retention_logs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_rule_id_idx": {
+          "name": "retention_logs_rule_id_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_deleted_at_idx": {
+          "name": "retention_logs_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_project_deleted_at_idx": {
+          "name": "retention_logs_project_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_logs_project_id_projects_id_fk": {
+          "name": "retention_logs_project_id_projects_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retention_logs_rule_id_retention_rules_id_fk": {
+          "name": "retention_logs_rule_id_retention_rules_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "retention_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_rules": {
+      "name": "retention_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_pattern": {
+          "name": "branch_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_branches": {
+          "name": "exclude_branches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keep_with_alias": {
+          "name": "keep_with_alias",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "keep_minimum": {
+          "name": "keep_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "path_patterns": {
+          "name": "path_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_mode": {
+          "name": "path_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_summary": {
+          "name": "last_run_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_rules_project_id_idx": {
+          "name": "retention_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_next_run_idx": {
+          "name": "retention_rules_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_enabled_next_run_idx": {
+          "name": "retention_rules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_rules_project_id_projects_id_fk": {
+          "name": "retention_rules_project_id_projects_id_fk",
+          "tableFrom": "retention_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "share_links_project_id_idx": {
+          "name": "share_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_domain_mapping_id_idx": {
+          "name": "share_links_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_token_idx": {
+          "name": "share_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_is_active_idx": {
+          "name": "share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_project_id_projects_id_fk": {
+          "name": "share_links_project_id_projects_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "share_links_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_created_by_users_id_fk": {
+          "name": "share_links_created_by_users_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "share_links_token_unique": {
+          "name": "share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_challenges": {
+      "name": "ssl_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "base_domain": {
+          "name": "base_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_type": {
+          "name": "challenge_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_name": {
+          "name": "record_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_value": {
+          "name": "record_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_data": {
+          "name": "order_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authz_data": {
+          "name": "authz_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_authorization": {
+          "name": "key_authorization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_challenges_base_domain_idx": {
+          "name": "ssl_challenges_base_domain_idx",
+          "columns": [
+            {
+              "expression": "base_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_challenges_status_idx": {
+          "name": "ssl_challenges_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ssl_challenges_base_domain_unique": {
+          "name": "ssl_challenges_base_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "base_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_renewal_history": {
+      "name": "ssl_renewal_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_type": {
+          "name": "certificate_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_expires_at": {
+          "name": "new_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_renewal_history_domain_id_idx": {
+          "name": "ssl_renewal_history_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_renewal_history_created_at_idx": {
+          "name": "ssl_renewal_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssl_renewal_history_domain_id_domain_mappings_id_fk": {
+          "name": "ssl_renewal_history_domain_id_domain_mappings_id_fk",
+          "tableFrom": "ssl_renewal_history",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_settings": {
+      "name": "ssl_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_config": {
+      "name": "system_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_setup_complete": {
+          "name": "is_setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_config": {
+          "name": "storage_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_provider": {
+          "name": "email_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_config": {
+          "name": "email_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_configured": {
+          "name": "email_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "smtp_config": {
+          "name": "smtp_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_configured": {
+          "name": "smtp_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_config": {
+          "name": "cache_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwt_secret": {
+          "name": "jwt_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_salt": {
+          "name": "api_key_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_public_signups": {
+          "name": "allow_public_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "telemetry_enabled": {
+          "name": "telemetry_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "telemetry_last_sent": {
+          "name": "telemetry_last_sent",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_config": {
+          "name": "branding_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_ip_rollups": {
+      "name": "traffic_ip_rollups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_paths": {
+          "name": "sample_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "sample_user_agents": {
+          "name": "sample_user_agents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_ip_rollups_ip_unique": {
+          "name": "traffic_ip_rollups_ip_unique",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_request_count_idx": {
+          "name": "traffic_ip_rollups_request_count_idx",
+          "columns": [
+            {
+              "expression": "request_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_last_seen_idx": {
+          "name": "traffic_ip_rollups_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_requests": {
+      "name": "traffic_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_version": {
+          "name": "http_version",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referer": {
+          "name": "referer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_requests_timestamp_idx": {
+          "name": "traffic_requests_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_ip_idx": {
+          "name": "traffic_requests_ip_idx",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_status_idx": {
+          "name": "traffic_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_classification_idx": {
+          "name": "traffic_requests_classification_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_group_members": {
+      "name": "user_group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_members_group_idx": {
+          "name": "user_group_members_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_group_members_user_idx": {
+          "name": "user_group_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_group_members_group_id_user_groups_id_fk": {
+          "name": "user_group_members_group_id_user_groups_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_user_id_users_id_fk": {
+          "name": "user_group_members_user_id_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_added_by_users_id_fk": {
+          "name": "user_group_members_added_by_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_group_members_unique": {
+          "name": "user_group_members_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_groups_created_by_idx": {
+          "name": "user_groups_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_created_by_users_id_fk": {
+          "name": "user_groups_created_by_users_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_verified_at": {
+          "name": "oidc_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_invitations_email": {
+          "name": "idx_workspace_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_invitations_token": {
+          "name": "idx_workspace_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invitations_invited_by_users_id_fk": {
+          "name": "workspace_invitations_invited_by_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_accepted_user_id_users_id_fk": {
+          "name": "workspace_invitations_accepted_user_id_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitations_token_unique": {
+          "name": "workspace_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1782853348877,
       "tag": "0033_dazzling_spitfire",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1782993567563,
+      "tag": "0034_shiny_sandman",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema/index.ts
+++ b/apps/backend/src/db/schema/index.ts
@@ -38,3 +38,5 @@ export * from './pipeline-execution-logs.schema';
 export * from './response-header-rules.schema';
 export * from './oidc-providers.schema';
 export * from './google-integration-credentials.schema';
+export * from './traffic-requests.schema';
+export * from './traffic-ip-rollups.schema';

--- a/apps/backend/src/db/schema/traffic-ip-rollups.schema.ts
+++ b/apps/backend/src/db/schema/traffic-ip-rollups.schema.ts
@@ -1,0 +1,46 @@
+import { pgTable, uuid, varchar, bigint, timestamp, jsonb, uniqueIndex, index } from 'drizzle-orm/pg-core';
+
+/**
+ * Per-IP rollup over the Request log (issue #390): one row per client IP that
+ * produced persisted (Unmatched/blocked) requests, aggregating request count,
+ * first/last seen, and small samples of paths and user-agents. This is the
+ * "worst offenders" view, and the surface a future Cloudflare-IP feed consumes.
+ *
+ * Maintained incrementally by RequestLogService as events are persisted; rows
+ * whose lastSeenAt falls outside the retention window are pruned, and a hard
+ * row cap bounds a distributed (many-IP) scan.
+ */
+export const trafficIpRollups = pgTable(
+  'traffic_ip_rollups',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    /** Client IP; IPv6 needs up to 45 chars */
+    ip: varchar('ip', { length: 45 }).notNull(),
+
+    /** Total persisted requests seen from this IP (within retention) */
+    requestCount: bigint('request_count', { mode: 'number' }).notNull().default(0),
+
+    firstSeenAt: timestamp('first_seen_at').notNull(),
+    lastSeenAt: timestamp('last_seen_at').notNull(),
+
+    /** First few distinct request paths seen from this IP (capped) */
+    samplePaths: jsonb('sample_paths').$type<string[]>().notNull().default([]),
+
+    /** First few distinct user-agents seen from this IP (capped) */
+    sampleUserAgents: jsonb('sample_user_agents').$type<string[]>().notNull().default([]),
+
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('traffic_ip_rollups_ip_unique').on(table.ip),
+    // "Worst offenders" sort
+    index('traffic_ip_rollups_request_count_idx').on(table.requestCount),
+    // Retention pruning + recency sort
+    index('traffic_ip_rollups_last_seen_idx').on(table.lastSeenAt),
+  ],
+);
+
+export type TrafficIpRollup = typeof trafficIpRollups.$inferSelect;
+export type NewTrafficIpRollup = typeof trafficIpRollups.$inferInsert;

--- a/apps/backend/src/db/schema/traffic-requests.schema.ts
+++ b/apps/backend/src/db/schema/traffic-requests.schema.ts
@@ -1,0 +1,64 @@
+import { pgTable, uuid, varchar, text, integer, bigint, timestamp, index } from 'drizzle-orm/pg-core';
+
+/**
+ * The Request log (issue #383/#390): the admin-global, cross-project record of
+ * requests the instance observed — the bot-signal subset only. The application
+ * interceptor observes every request, but only Unmatched requests (and, once
+ * Blocklist enforcement lands in #391, blocked ones) are persisted here.
+ *
+ * Retention is bounded: rows older than the configured window are pruned, and
+ * a hard row cap keeps a scanner storm from filling the database (see
+ * RequestLogService.prune).
+ */
+export const trafficRequests = pgTable(
+  'traffic_requests',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    /** When the response finished (from the observer's TrafficEvent) */
+    timestamp: timestamp('timestamp').notNull(),
+
+    /** Client IP (X-Forwarded-For aware); IPv6 needs up to 45 chars */
+    ip: varchar('ip', { length: 45 }).notNull(),
+
+    method: varchar('method', { length: 16 }).notNull(),
+
+    /** Original request URL (path + query) */
+    path: text('path').notNull(),
+
+    httpVersion: varchar('http_version', { length: 16 }).notNull(),
+
+    status: integer('status').notNull(),
+
+    /** Response body bytes sent */
+    bytes: bigint('bytes', { mode: 'number' }).notNull(),
+
+    referer: text('referer'),
+    userAgent: text('user_agent'),
+
+    /** Host the client requested (X-Forwarded-Host aware) */
+    host: varchar('host', { length: 255 }),
+
+    /**
+     * Why this request was persisted:
+     * - unmatched: resolved to no deployment, alias, or asset
+     * - blocked: refused by the Blocklist (arrives with #391)
+     */
+    classification: varchar('classification', { length: 20 })
+      .$type<'unmatched' | 'blocked'>()
+      .notNull(),
+
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [
+    // Retention pruning, cap enforcement, and the default time-ordered listing
+    index('traffic_requests_timestamp_idx').on(table.timestamp),
+    // Per-IP filtering (drill-down from the rollup)
+    index('traffic_requests_ip_idx').on(table.ip, table.timestamp),
+    index('traffic_requests_status_idx').on(table.status),
+    index('traffic_requests_classification_idx').on(table.classification),
+  ],
+);
+
+export type TrafficRequest = typeof trafficRequests.$inferSelect;
+export type NewTrafficRequest = typeof trafficRequests.$inferInsert;

--- a/apps/backend/src/traffic/access-log.util.ts
+++ b/apps/backend/src/traffic/access-log.util.ts
@@ -30,9 +30,15 @@ export function formatNginxTime(date: Date): string {
 /**
  * Render an observed request in nginx's combined log format:
  * $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent"
+ *
+ * Accepts the structural subset it renders so both live TrafficEvents and
+ * persisted Request-log records (whose classification set differs) qualify.
  */
 export function formatAccessLogLine(
-  event: Omit<TrafficEvent, 'line'>,
+  event: Pick<
+    TrafficEvent,
+    'timestamp' | 'ip' | 'method' | 'path' | 'httpVersion' | 'status' | 'bytes' | 'referer' | 'userAgent'
+  >,
 ): string {
   const time = formatNginxTime(new Date(event.timestamp));
   const request = `${event.method} ${event.path} HTTP/${event.httpVersion}`;

--- a/apps/backend/src/traffic/request-log.service.spec.ts
+++ b/apps/backend/src/traffic/request-log.service.spec.ts
@@ -1,0 +1,352 @@
+import { RequestLogService } from './request-log.service';
+import { TrafficEventsService } from './traffic-events.service';
+import { TrafficEvent } from './traffic-event.interface';
+
+// Mock the db client with a thenable chainable: every builder method returns
+// the chain, and awaiting the chain consumes the next queued result (in the
+// order the service awaits its queries). Mirrors proxy-rules.service.spec.
+jest.mock('../db/client', () => {
+  const queued: unknown[] = [];
+  const methods = [
+    'select',
+    'from',
+    'where',
+    'orderBy',
+    'limit',
+    'offset',
+    'insert',
+    'values',
+    'onConflictDoUpdate',
+    'update',
+    'set',
+    'delete',
+  ];
+  const chainable: Record<string, unknown> = {};
+  for (const method of methods) {
+    chainable[method] = jest.fn(() => chainable);
+  }
+  chainable.then = (
+    resolve: (value: unknown) => unknown,
+    reject: (reason: unknown) => unknown,
+  ) => Promise.resolve(queued.length > 0 ? queued.shift() : []).then(resolve, reject);
+  chainable.__queue = (result: unknown) => queued.push(result);
+  chainable.__reset = () => {
+    queued.length = 0;
+    for (const method of methods) {
+      (chainable[method] as jest.Mock).mockClear();
+    }
+  };
+  return { db: chainable };
+});
+
+import { db } from '../db/client';
+
+const mockDb = db as unknown as Record<string, jest.Mock> & {
+  __queue: (result: unknown) => void;
+  __reset: () => void;
+};
+
+/** postgres.js DELETE results are array-likes carrying a count property. */
+const deleteResult = (count: number) => Object.assign([], { count });
+
+const makeEvent = (overrides: Partial<TrafficEvent> = {}): TrafficEvent => ({
+  id: '1',
+  timestamp: '2026-07-02T09:05:03.000Z',
+  ip: '203.0.113.7',
+  method: 'GET',
+  path: '/backend/.env',
+  httpVersion: '1.1',
+  status: 404,
+  bytes: 42,
+  referer: null,
+  userAgent: 'scanner',
+  host: 'j5s.dev',
+  classification: 'unmatched',
+  line: 'formatted line',
+  ...overrides,
+});
+
+describe('RequestLogService', () => {
+  const envBackup = { ...process.env };
+  let events: TrafficEventsService;
+
+  const makeService = () => new RequestLogService(events);
+
+  beforeEach(() => {
+    process.env = { ...envBackup };
+    delete process.env.TRAFFIC_LOG_ENABLED;
+    delete process.env.TRAFFIC_LOG_RETENTION_DAYS;
+    delete process.env.TRAFFIC_LOG_MAX_ROWS;
+    delete process.env.TRAFFIC_LOG_MAX_IPS;
+    mockDb.__reset();
+    events = new TrafficEventsService();
+  });
+
+  afterAll(() => {
+    process.env = envBackup;
+  });
+
+  describe('configuration', () => {
+    it('uses bounded-retention defaults', () => {
+      const service = makeService();
+      expect(service.enabled).toBe(true);
+      expect(service.retentionDays).toBe(14);
+      expect(service.maxRows).toBe(100_000);
+      expect(service.maxIps).toBe(50_000);
+    });
+
+    it('honours env overrides and rejects garbage values', () => {
+      process.env.TRAFFIC_LOG_RETENTION_DAYS = '30';
+      process.env.TRAFFIC_LOG_MAX_ROWS = 'not-a-number';
+      process.env.TRAFFIC_LOG_MAX_IPS = '-5';
+      const service = makeService();
+      expect(service.retentionDays).toBe(30);
+      expect(service.maxRows).toBe(100_000);
+      expect(service.maxIps).toBe(50_000);
+    });
+  });
+
+  describe('persistence', () => {
+    it('persists only the non-matched subset of observed events', async () => {
+      const service = makeService();
+      service.observe(makeEvent({ classification: 'matched', status: 200 }));
+      await service.flush();
+      expect(mockDb.insert).not.toHaveBeenCalled();
+
+      service.observe(makeEvent());
+      await service.flush();
+      expect(mockDb.insert).toHaveBeenCalled();
+    });
+
+    it('maps the TrafficEvent onto a traffic_requests row', async () => {
+      const service = makeService();
+      service.observe(makeEvent());
+      await service.flush();
+
+      const rows = mockDb.values.mock.calls[0][0];
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        ip: '203.0.113.7',
+        method: 'GET',
+        path: '/backend/.env',
+        httpVersion: '1.1',
+        status: 404,
+        bytes: 42,
+        userAgent: 'scanner',
+        host: 'j5s.dev',
+        classification: 'unmatched',
+      });
+      expect(rows[0].timestamp).toEqual(new Date('2026-07-02T09:05:03.000Z'));
+    });
+
+    it('creates a rollup row for a first-seen IP with capped samples', async () => {
+      const service = makeService();
+      service.observe(makeEvent({ path: '/.env' }));
+      service.observe(makeEvent({ path: '/wp-login.php', userAgent: 'other-scanner' }));
+      // rollup lookup finds nothing for this IP
+      mockDb.__queue([]); // insert traffic_requests
+      mockDb.__queue([]); // select existing rollup -> none
+      await service.flush();
+
+      // second values() call is the rollup insert
+      const rollup = mockDb.values.mock.calls[1][0];
+      expect(rollup).toMatchObject({
+        ip: '203.0.113.7',
+        requestCount: 2,
+        samplePaths: ['/.env', '/wp-login.php'],
+        sampleUserAgents: ['scanner', 'other-scanner'],
+      });
+      expect(mockDb.onConflictDoUpdate).toHaveBeenCalled();
+    });
+
+    it('increments an existing rollup and merges samples without duplicates', async () => {
+      const service = makeService();
+      service.observe(makeEvent({ path: '/.env' }));
+      service.observe(makeEvent({ path: '/phpmyadmin' }));
+
+      mockDb.__queue([]); // insert traffic_requests
+      mockDb.__queue([
+        {
+          id: 'rollup-1',
+          ip: '203.0.113.7',
+          requestCount: 10,
+          firstSeenAt: new Date('2026-06-01T00:00:00.000Z'),
+          lastSeenAt: new Date('2026-06-30T00:00:00.000Z'),
+          samplePaths: ['/.env'],
+          sampleUserAgents: ['scanner'],
+        },
+      ]);
+      await service.flush();
+
+      expect(mockDb.update).toHaveBeenCalled();
+      const set = mockDb.set.mock.calls[0][0];
+      expect(set.requestCount).toBe(12);
+      expect(set.firstSeenAt).toEqual(new Date('2026-06-01T00:00:00.000Z'));
+      expect(set.lastSeenAt).toEqual(new Date('2026-07-02T09:05:03.000Z'));
+      expect(set.samplePaths).toEqual(['/.env', '/phpmyadmin']);
+      expect(set.sampleUserAgents).toEqual(['scanner']);
+    });
+
+    it('subscribes on module init and flushes on destroy', async () => {
+      const service = makeService();
+      service.onModuleInit();
+      events.emit(makeEvent());
+      await service.onModuleDestroy();
+      expect(mockDb.insert).toHaveBeenCalled();
+    });
+
+    it('does nothing when TRAFFIC_LOG_ENABLED=false', async () => {
+      process.env.TRAFFIC_LOG_ENABLED = 'false';
+      const service = makeService();
+      service.onModuleInit();
+      events.emit(makeEvent());
+      await service.onModuleDestroy();
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('retention and row caps', () => {
+    it('prunes by age and trims both tables to their caps', async () => {
+      process.env.TRAFFIC_LOG_MAX_ROWS = '10';
+      process.env.TRAFFIC_LOG_MAX_IPS = '5';
+      const service = makeService();
+
+      mockDb.__queue(deleteResult(3)); // requests age prune
+      mockDb.__queue([{ value: 12 }]); // requests count -> 2 over cap
+      mockDb.__queue([{ id: 'a' }, { id: 'b' }]); // oldest victims
+      mockDb.__queue(deleteResult(2)); // victim delete
+      mockDb.__queue(deleteResult(1)); // rollups age prune
+      mockDb.__queue([{ value: 7 }]); // rollup count -> 2 over cap
+      mockDb.__queue([{ id: 'r1' }, { id: 'r2' }]); // stalest rollups
+      mockDb.__queue(deleteResult(2)); // rollup victim delete
+
+      const summary = await service.prune();
+      expect(summary).toEqual({
+        requestsDeletedByAge: 3,
+        requestsDeletedOverCap: 2,
+        rollupsDeletedByAge: 1,
+        rollupsDeletedOverCap: 2,
+      });
+      expect(mockDb.delete).toHaveBeenCalledTimes(4);
+    });
+
+    it('deletes nothing when within bounds', async () => {
+      const service = makeService();
+      mockDb.__queue(deleteResult(0)); // requests age prune
+      mockDb.__queue([{ value: 100 }]); // under cap
+      mockDb.__queue(deleteResult(0)); // rollups age prune
+      mockDb.__queue([{ value: 10 }]); // under cap
+
+      const summary = await service.prune();
+      expect(summary).toEqual({
+        requestsDeletedByAge: 0,
+        requestsDeletedOverCap: 0,
+        rollupsDeletedByAge: 0,
+        rollupsDeletedOverCap: 0,
+      });
+      // only the two age-prune deletes ran; no victim selection
+      expect(mockDb.delete).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('read API', () => {
+    const dbRow = {
+      id: 'row-1',
+      timestamp: new Date('2026-07-02T09:05:03.000Z'),
+      ip: '203.0.113.7',
+      method: 'GET',
+      path: '/backend/.env',
+      httpVersion: '1.1',
+      status: 404,
+      bytes: 42,
+      referer: null,
+      userAgent: 'scanner',
+      host: 'j5s.dev',
+      classification: 'unmatched' as const,
+      createdAt: new Date('2026-07-02T09:05:04.000Z'),
+    };
+
+    it('lists requests with pagination metadata and rendered log lines', async () => {
+      const service = makeService();
+      mockDb.__queue([{ value: 101 }]); // count
+      mockDb.__queue([dbRow]); // page rows
+
+      const result = await service.listRequests({ ip: '203.0.113.7' }, 2, 50);
+      expect(result.total).toBe(101);
+      expect(result.totalPages).toBe(3);
+      expect(result.page).toBe(2);
+      expect(result.data[0].timestamp).toBe('2026-07-02T09:05:03.000Z');
+      expect(result.data[0].line).toContain('203.0.113.7 - - [02/Jul/2026:09:05:03 +0000]');
+      expect(result.data[0].line).toContain('"GET /backend/.env HTTP/1.1" 404 42');
+      expect(mockDb.offset).toHaveBeenCalledWith(50);
+    });
+
+    it('lists the per-IP rollup with pagination', async () => {
+      const service = makeService();
+      const rollup = {
+        id: 'rollup-1',
+        ip: '203.0.113.7',
+        requestCount: 12,
+        firstSeenAt: new Date('2026-06-01T00:00:00.000Z'),
+        lastSeenAt: new Date('2026-07-02T09:05:03.000Z'),
+        samplePaths: ['/.env'],
+        sampleUserAgents: ['scanner'],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockDb.__queue([{ value: 1 }]);
+      mockDb.__queue([rollup]);
+
+      const result = await service.listIpRollups({}, 'requestCount', 'desc', 1, 50);
+      expect(result.total).toBe(1);
+      expect(result.data[0].ip).toBe('203.0.113.7');
+    });
+
+    it('exports requests as CSV with proper escaping', async () => {
+      const service = makeService();
+      mockDb.__queue([{ ...dbRow, path: '/a,b', userAgent: 'quote "ua"' }]);
+
+      const csv = await service.exportRequests({}, 'csv', 100);
+      const lines = csv.split('\n');
+      expect(lines[0]).toBe(
+        'timestamp,ip,method,path,status,bytes,referer,userAgent,host,classification',
+      );
+      expect(lines[1]).toContain('"/a,b"');
+      expect(lines[1]).toContain('"quote ""ua"""');
+    });
+
+    it('exports requests as JSON', async () => {
+      const service = makeService();
+      mockDb.__queue([dbRow]);
+
+      const json = await service.exportRequests({}, 'json', 100);
+      const parsed = JSON.parse(json);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].ip).toBe('203.0.113.7');
+      expect(parsed[0].line).toContain('404');
+    });
+
+    it('exports the rollup as CSV', async () => {
+      const service = makeService();
+      mockDb.__queue([
+        {
+          id: 'rollup-1',
+          ip: '203.0.113.7',
+          requestCount: 12,
+          firstSeenAt: new Date('2026-06-01T00:00:00.000Z'),
+          lastSeenAt: new Date('2026-07-02T09:05:03.000Z'),
+          samplePaths: ['/.env', '/wp-login.php'],
+          sampleUserAgents: ['scanner'],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+      const csv = await service.exportIpRollups({}, 'csv', 100);
+      const lines = csv.split('\n');
+      expect(lines[0]).toBe('ip,requestCount,firstSeenAt,lastSeenAt,samplePaths,sampleUserAgents');
+      expect(lines[1]).toContain('203.0.113.7,12,2026-06-01T00:00:00.000Z');
+      expect(lines[1]).toContain('/.env /wp-login.php');
+    });
+  });
+});

--- a/apps/backend/src/traffic/request-log.service.ts
+++ b/apps/backend/src/traffic/request-log.service.ts
@@ -1,0 +1,508 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Subscription } from 'rxjs';
+import { SQL, and, count, desc, asc, eq, gte, ilike, inArray, lt, lte, sql } from 'drizzle-orm';
+import { db } from '../db/client';
+import {
+  trafficRequests,
+  trafficIpRollups,
+  TrafficRequest,
+  TrafficIpRollup,
+  NewTrafficRequest,
+} from '../db/schema';
+import { TrafficEvent } from './traffic-event.interface';
+import { TrafficEventsService } from './traffic-events.service';
+import { formatAccessLogLine } from './access-log.util';
+
+/** How often buffered events are written to the database. */
+const FLUSH_INTERVAL_MS = 3_000;
+/** Max events held in memory between flushes; beyond this a storm is dropped, not queued. */
+const BUFFER_CAP = 5_000;
+/** Rows per INSERT statement. */
+const INSERT_CHUNK_SIZE = 500;
+/** Rows per DELETE ... IN (...) statement when pruning. */
+const DELETE_CHUNK_SIZE = 1_000;
+/** Distinct sample paths / user-agents kept per IP rollup. */
+const SAMPLE_PATHS_CAP = 10;
+const SAMPLE_UAS_CAP = 5;
+/** Re-check the hard row cap after this many inserts (a storm must not wait for the hourly prune). */
+const CAP_CHECK_EVERY_ROWS = 5_000;
+
+export interface RequestLogFilters {
+  ip?: string;
+  /** Substring match on the request path */
+  path?: string;
+  status?: number;
+  classification?: 'unmatched' | 'blocked';
+  /** ISO 8601 lower bound (inclusive) on the request timestamp */
+  from?: string;
+  /** ISO 8601 upper bound (inclusive) on the request timestamp */
+  to?: string;
+}
+
+export interface IpRollupFilters {
+  /** Substring match on the IP */
+  ip?: string;
+}
+
+/** A persisted Request-log record plus its rendered access-log line. */
+export type RequestLogEntry = Omit<TrafficRequest, 'timestamp' | 'createdAt'> & {
+  timestamp: string;
+  line: string;
+};
+
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+export interface PruneSummary {
+  requestsDeletedByAge: number;
+  requestsDeletedOverCap: number;
+  rollupsDeletedByAge: number;
+  rollupsDeletedOverCap: number;
+}
+
+/**
+ * The Request log (issue #390): persists the bot-signal subset of what the
+ * application interceptor observes.
+ *
+ * Subscribes to TrafficEventsService.stream() and buffers every non-matched
+ * event (Unmatched today; blocked once #391 lands), flushing to Postgres on an
+ * interval so a scanner burst becomes a handful of batched INSERTs instead of
+ * a write per request. Alongside the raw records it maintains the per-IP
+ * rollup (count, first/last seen, sample paths/user-agents).
+ *
+ * Retention is bounded twice over: an age window and a hard row cap, both
+ * enforced by prune() (called hourly by TrafficRetentionScheduler, and the cap
+ * alone re-checked inline every CAP_CHECK_EVERY_ROWS inserts).
+ *
+ * Config (env):
+ * - TRAFFIC_LOG_ENABLED   ('false' disables persistence entirely; default on)
+ * - TRAFFIC_LOG_RETENTION_DAYS (default 14)
+ * - TRAFFIC_LOG_MAX_ROWS  (hard cap on traffic_requests; default 100000)
+ * - TRAFFIC_LOG_MAX_IPS   (hard cap on traffic_ip_rollups; default 50000)
+ */
+@Injectable()
+export class RequestLogService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(RequestLogService.name);
+
+  readonly enabled = process.env.TRAFFIC_LOG_ENABLED !== 'false';
+  readonly retentionDays = parsePositiveInt(process.env.TRAFFIC_LOG_RETENTION_DAYS, 14);
+  readonly maxRows = parsePositiveInt(process.env.TRAFFIC_LOG_MAX_ROWS, 100_000);
+  readonly maxIps = parsePositiveInt(process.env.TRAFFIC_LOG_MAX_IPS, 50_000);
+
+  private buffer: TrafficEvent[] = [];
+  private droppedSinceLastFlush = 0;
+  private insertedSinceCapCheck = 0;
+  private isFlushing = false;
+  private subscription: Subscription | null = null;
+  private flushTimer: NodeJS.Timeout | null = null;
+
+  constructor(private readonly trafficEvents: TrafficEventsService) {}
+
+  onModuleInit(): void {
+    if (!this.enabled) {
+      this.logger.log({ event: 'request_log_disabled', reason: 'TRAFFIC_LOG_ENABLED=false' });
+      return;
+    }
+    this.subscription = this.trafficEvents.stream().subscribe((event) => this.observe(event));
+    this.flushTimer = setInterval(() => void this.flush(), FLUSH_INTERVAL_MS);
+    this.flushTimer.unref?.();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    this.subscription?.unsubscribe();
+    this.subscription = null;
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = null;
+    }
+    await this.flush();
+  }
+
+  /** Buffer a single observed event (only the persisted subset). */
+  observe(event: TrafficEvent): void {
+    if (event.classification === 'matched') {
+      return;
+    }
+    if (this.buffer.length >= BUFFER_CAP) {
+      this.droppedSinceLastFlush++;
+      return;
+    }
+    this.buffer.push(event);
+  }
+
+  /**
+   * Write all buffered events: batched inserts into traffic_requests plus
+   * per-IP rollup upserts (one per distinct IP in the batch).
+   */
+  async flush(): Promise<void> {
+    if (this.isFlushing || this.buffer.length === 0) {
+      return;
+    }
+    this.isFlushing = true;
+    const events = this.buffer.splice(0);
+    const dropped = this.droppedSinceLastFlush;
+    this.droppedSinceLastFlush = 0;
+    try {
+      if (dropped > 0) {
+        this.logger.warn({ event: 'request_log_buffer_overflow', dropped });
+      }
+
+      const rows: NewTrafficRequest[] = events.map((e) => ({
+        timestamp: new Date(e.timestamp),
+        ip: e.ip,
+        method: e.method,
+        path: e.path,
+        httpVersion: e.httpVersion,
+        status: e.status,
+        bytes: e.bytes,
+        referer: e.referer,
+        userAgent: e.userAgent,
+        host: e.host,
+        classification: e.classification as 'unmatched' | 'blocked',
+      }));
+      for (let i = 0; i < rows.length; i += INSERT_CHUNK_SIZE) {
+        await db.insert(trafficRequests).values(rows.slice(i, i + INSERT_CHUNK_SIZE));
+      }
+
+      await this.updateRollups(events);
+
+      this.insertedSinceCapCheck += rows.length;
+      if (this.insertedSinceCapCheck >= CAP_CHECK_EVERY_ROWS) {
+        this.insertedSinceCapCheck = 0;
+        await this.enforceRequestRowCap();
+      }
+    } catch (error) {
+      this.logger.error({ event: 'request_log_flush_failed', error: String(error) });
+    } finally {
+      this.isFlushing = false;
+    }
+  }
+
+  private async updateRollups(events: TrafficEvent[]): Promise<void> {
+    const groups = new Map<
+      string,
+      { count: number; firstSeen: Date; lastSeen: Date; paths: string[]; userAgents: string[] }
+    >();
+    for (const e of events) {
+      const at = new Date(e.timestamp);
+      const group = groups.get(e.ip);
+      if (!group) {
+        groups.set(e.ip, {
+          count: 1,
+          firstSeen: at,
+          lastSeen: at,
+          paths: [e.path],
+          userAgents: e.userAgent ? [e.userAgent] : [],
+        });
+        continue;
+      }
+      group.count++;
+      if (at < group.firstSeen) group.firstSeen = at;
+      if (at > group.lastSeen) group.lastSeen = at;
+      if (!group.paths.includes(e.path) && group.paths.length < SAMPLE_PATHS_CAP) {
+        group.paths.push(e.path);
+      }
+      if (
+        e.userAgent &&
+        !group.userAgents.includes(e.userAgent) &&
+        group.userAgents.length < SAMPLE_UAS_CAP
+      ) {
+        group.userAgents.push(e.userAgent);
+      }
+    }
+
+    for (const [ip, group] of groups) {
+      const [existing] = await db
+        .select()
+        .from(trafficIpRollups)
+        .where(eq(trafficIpRollups.ip, ip))
+        .limit(1);
+
+      if (existing) {
+        await db
+          .update(trafficIpRollups)
+          .set({
+            requestCount: existing.requestCount + group.count,
+            firstSeenAt: existing.firstSeenAt < group.firstSeen ? existing.firstSeenAt : group.firstSeen,
+            lastSeenAt: existing.lastSeenAt > group.lastSeen ? existing.lastSeenAt : group.lastSeen,
+            samplePaths: mergeSamples(existing.samplePaths, group.paths, SAMPLE_PATHS_CAP),
+            sampleUserAgents: mergeSamples(existing.sampleUserAgents, group.userAgents, SAMPLE_UAS_CAP),
+            updatedAt: new Date(),
+          })
+          .where(eq(trafficIpRollups.id, existing.id));
+      } else {
+        // Concurrent first-insert races (two flushes, or a future second
+        // instance) collapse into an increment instead of a duplicate-key error.
+        await db
+          .insert(trafficIpRollups)
+          .values({
+            ip,
+            requestCount: group.count,
+            firstSeenAt: group.firstSeen,
+            lastSeenAt: group.lastSeen,
+            samplePaths: group.paths,
+            sampleUserAgents: group.userAgents,
+          })
+          .onConflictDoUpdate({
+            target: trafficIpRollups.ip,
+            set: {
+              requestCount: sql`${trafficIpRollups.requestCount} + ${group.count}`,
+              lastSeenAt: group.lastSeen,
+              updatedAt: new Date(),
+            },
+          });
+      }
+    }
+  }
+
+  /**
+   * Enforce both retention bounds on both tables. Returns what was deleted.
+   */
+  async prune(): Promise<PruneSummary> {
+    const cutoff = new Date(Date.now() - this.retentionDays * 24 * 60 * 60 * 1000);
+
+    const requestsDeletedByAge = await this.deleteWhereCount(
+      db.delete(trafficRequests).where(lt(trafficRequests.timestamp, cutoff)),
+    );
+    const requestsDeletedOverCap = await this.enforceRequestRowCap();
+
+    const rollupsDeletedByAge = await this.deleteWhereCount(
+      db.delete(trafficIpRollups).where(lt(trafficIpRollups.lastSeenAt, cutoff)),
+    );
+    const rollupsDeletedOverCap = await this.enforceRollupRowCap();
+
+    return { requestsDeletedByAge, requestsDeletedOverCap, rollupsDeletedByAge, rollupsDeletedOverCap };
+  }
+
+  /** Trim traffic_requests to maxRows, dropping the oldest first. */
+  private async enforceRequestRowCap(): Promise<number> {
+    const [{ value: total }] = await db.select({ value: count() }).from(trafficRequests);
+    const excess = total - this.maxRows;
+    if (excess <= 0) {
+      return 0;
+    }
+    const victims = await db
+      .select({ id: trafficRequests.id })
+      .from(trafficRequests)
+      .orderBy(asc(trafficRequests.timestamp))
+      .limit(excess);
+    await this.deleteByIds(trafficRequests, trafficRequests.id, victims.map((v) => v.id));
+    return victims.length;
+  }
+
+  /** Trim traffic_ip_rollups to maxIps, dropping the least-recently-seen first. */
+  private async enforceRollupRowCap(): Promise<number> {
+    const [{ value: total }] = await db.select({ value: count() }).from(trafficIpRollups);
+    const excess = total - this.maxIps;
+    if (excess <= 0) {
+      return 0;
+    }
+    const victims = await db
+      .select({ id: trafficIpRollups.id })
+      .from(trafficIpRollups)
+      .orderBy(asc(trafficIpRollups.lastSeenAt))
+      .limit(excess);
+    await this.deleteByIds(trafficIpRollups, trafficIpRollups.id, victims.map((v) => v.id));
+    return victims.length;
+  }
+
+  private async deleteByIds(
+    table: typeof trafficRequests | typeof trafficIpRollups,
+    idColumn: typeof trafficRequests.id | typeof trafficIpRollups.id,
+    ids: string[],
+  ): Promise<void> {
+    for (let i = 0; i < ids.length; i += DELETE_CHUNK_SIZE) {
+      await db.delete(table).where(inArray(idColumn, ids.slice(i, i + DELETE_CHUNK_SIZE)));
+    }
+  }
+
+  private async deleteWhereCount(query: PromiseLike<unknown>): Promise<number> {
+    const result = (await query) as { count?: number } | undefined;
+    return result?.count ?? 0;
+  }
+
+  // ==================== Read API ====================
+
+  async listRequests(
+    filters: RequestLogFilters,
+    page: number,
+    pageSize: number,
+  ): Promise<PaginatedResult<RequestLogEntry>> {
+    const where = buildRequestWhere(filters);
+    const [{ value: total }] = await db.select({ value: count() }).from(trafficRequests).where(where);
+    const rows = await db
+      .select()
+      .from(trafficRequests)
+      .where(where)
+      .orderBy(desc(trafficRequests.timestamp))
+      .limit(pageSize)
+      .offset((page - 1) * pageSize);
+    return {
+      data: rows.map(toRequestLogEntry),
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  async listIpRollups(
+    filters: IpRollupFilters,
+    sortBy: 'requestCount' | 'lastSeenAt' | 'firstSeenAt',
+    sortOrder: 'asc' | 'desc',
+    page: number,
+    pageSize: number,
+  ): Promise<PaginatedResult<TrafficIpRollup>> {
+    const where = buildRollupWhere(filters);
+    const [{ value: total }] = await db.select({ value: count() }).from(trafficIpRollups).where(where);
+    const sortColumn = {
+      requestCount: trafficIpRollups.requestCount,
+      lastSeenAt: trafficIpRollups.lastSeenAt,
+      firstSeenAt: trafficIpRollups.firstSeenAt,
+    }[sortBy];
+    const rows = await db
+      .select()
+      .from(trafficIpRollups)
+      .where(where)
+      .orderBy(sortOrder === 'asc' ? asc(sortColumn) : desc(sortColumn))
+      .limit(pageSize)
+      .offset((page - 1) * pageSize);
+    return { data: rows, total, page, pageSize, totalPages: Math.ceil(total / pageSize) };
+  }
+
+  async exportRequests(
+    filters: RequestLogFilters,
+    format: 'csv' | 'json',
+    limit: number,
+  ): Promise<string> {
+    const rows = await db
+      .select()
+      .from(trafficRequests)
+      .where(buildRequestWhere(filters))
+      .orderBy(desc(trafficRequests.timestamp))
+      .limit(limit);
+    const entries = rows.map(toRequestLogEntry);
+
+    if (format === 'json') {
+      return JSON.stringify(entries, null, 2);
+    }
+    const headers = [
+      'timestamp',
+      'ip',
+      'method',
+      'path',
+      'status',
+      'bytes',
+      'referer',
+      'userAgent',
+      'host',
+      'classification',
+    ];
+    const lines = [headers.join(',')];
+    for (const e of entries) {
+      lines.push(
+        [
+          escapeCsv(e.timestamp),
+          escapeCsv(e.ip),
+          escapeCsv(e.method),
+          escapeCsv(e.path),
+          escapeCsv(String(e.status)),
+          escapeCsv(String(e.bytes)),
+          escapeCsv(e.referer ?? ''),
+          escapeCsv(e.userAgent ?? ''),
+          escapeCsv(e.host ?? ''),
+          escapeCsv(e.classification),
+        ].join(','),
+      );
+    }
+    return lines.join('\n');
+  }
+
+  async exportIpRollups(
+    filters: IpRollupFilters,
+    format: 'csv' | 'json',
+    limit: number,
+  ): Promise<string> {
+    const rows = await db
+      .select()
+      .from(trafficIpRollups)
+      .where(buildRollupWhere(filters))
+      .orderBy(desc(trafficIpRollups.requestCount))
+      .limit(limit);
+
+    if (format === 'json') {
+      return JSON.stringify(rows, null, 2);
+    }
+    const headers = ['ip', 'requestCount', 'firstSeenAt', 'lastSeenAt', 'samplePaths', 'sampleUserAgents'];
+    const lines = [headers.join(',')];
+    for (const r of rows) {
+      lines.push(
+        [
+          escapeCsv(r.ip),
+          escapeCsv(String(r.requestCount)),
+          escapeCsv(r.firstSeenAt.toISOString()),
+          escapeCsv(r.lastSeenAt.toISOString()),
+          escapeCsv(r.samplePaths.join(' ')),
+          escapeCsv(r.sampleUserAgents.join(' ')),
+        ].join(','),
+      );
+    }
+    return lines.join('\n');
+  }
+}
+
+function buildRequestWhere(filters: RequestLogFilters) {
+  const conditions: SQL<unknown>[] = [];
+  if (filters.ip) conditions.push(eq(trafficRequests.ip, filters.ip));
+  if (filters.path) conditions.push(ilike(trafficRequests.path, `%${escapeLike(filters.path)}%`));
+  if (filters.status !== undefined) conditions.push(eq(trafficRequests.status, filters.status));
+  if (filters.classification) conditions.push(eq(trafficRequests.classification, filters.classification));
+  if (filters.from) conditions.push(gte(trafficRequests.timestamp, new Date(filters.from)));
+  if (filters.to) conditions.push(lte(trafficRequests.timestamp, new Date(filters.to)));
+  return conditions.length > 0 ? and(...conditions) : undefined;
+}
+
+function buildRollupWhere(filters: IpRollupFilters) {
+  if (filters.ip) {
+    return ilike(trafficIpRollups.ip, `%${escapeLike(filters.ip)}%`);
+  }
+  return undefined;
+}
+
+function toRequestLogEntry(row: TrafficRequest): RequestLogEntry {
+  const { createdAt: _createdAt, ...rest } = row;
+  const entry = { ...rest, timestamp: row.timestamp.toISOString() };
+  return { ...entry, line: formatAccessLogLine(entry) };
+}
+
+/** Escape LIKE/ILIKE wildcards in user-supplied substrings. */
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, '\\$&');
+}
+
+function escapeCsv(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/** Merge new samples into existing ones, deduped, capped, existing first. */
+function mergeSamples(existing: string[], incoming: string[], cap: number): string[] {
+  const merged = [...existing];
+  for (const value of incoming) {
+    if (merged.length >= cap) break;
+    if (!merged.includes(value)) merged.push(value);
+  }
+  return merged;
+}
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  const parsed = raw !== undefined ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/apps/backend/src/traffic/traffic-retention.scheduler.spec.ts
+++ b/apps/backend/src/traffic/traffic-retention.scheduler.spec.ts
@@ -1,0 +1,68 @@
+import { TrafficRetentionScheduler } from './traffic-retention.scheduler';
+import { RequestLogService } from './request-log.service';
+
+jest.mock('../db/client', () => ({ db: {} }));
+
+const emptySummary = {
+  requestsDeletedByAge: 0,
+  requestsDeletedOverCap: 0,
+  rollupsDeletedByAge: 0,
+  rollupsDeletedOverCap: 0,
+};
+
+describe('TrafficRetentionScheduler', () => {
+  const makeRequestLog = (overrides: Partial<RequestLogService> = {}) =>
+    ({
+      enabled: true,
+      prune: jest.fn().mockResolvedValue(emptySummary),
+      ...overrides,
+    }) as unknown as jest.Mocked<RequestLogService>;
+
+  it('prunes on schedule', async () => {
+    const requestLog = makeRequestLog();
+    const scheduler = new TrafficRetentionScheduler(requestLog);
+    await scheduler.handleRetention();
+    expect(requestLog.prune).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when the Request log is disabled', async () => {
+    const requestLog = makeRequestLog({ enabled: false } as Partial<RequestLogService>);
+    const scheduler = new TrafficRetentionScheduler(requestLog);
+    await scheduler.handleRetention();
+    expect(requestLog.prune).not.toHaveBeenCalled();
+  });
+
+  it('skips a run while the previous one is still in progress', async () => {
+    let release!: () => void;
+    let calls = 0;
+    const requestLog = makeRequestLog({
+      prune: jest.fn().mockImplementation(() => {
+        calls++;
+        if (calls === 1) {
+          return new Promise((resolve) => {
+            release = () => resolve(emptySummary);
+          });
+        }
+        return Promise.resolve(emptySummary);
+      }),
+    } as Partial<RequestLogService>);
+    const scheduler = new TrafficRetentionScheduler(requestLog);
+
+    const first = scheduler.handleRetention();
+    await scheduler.handleRetention(); // overlapping run
+    expect(requestLog.prune).toHaveBeenCalledTimes(1);
+
+    release();
+    await first;
+    await scheduler.handleRetention(); // next run proceeds again
+    expect(requestLog.prune).toHaveBeenCalledTimes(2);
+  });
+
+  it('survives a failing prune without throwing', async () => {
+    const requestLog = makeRequestLog({
+      prune: jest.fn().mockRejectedValue(new Error('db down')),
+    } as Partial<RequestLogService>);
+    const scheduler = new TrafficRetentionScheduler(requestLog);
+    await expect(scheduler.handleRetention()).resolves.toBeUndefined();
+  });
+});

--- a/apps/backend/src/traffic/traffic-retention.scheduler.ts
+++ b/apps/backend/src/traffic/traffic-retention.scheduler.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { RequestLogService } from './request-log.service';
+
+/**
+ * Hourly enforcement of the Request log's retention bounds (age window + hard
+ * row caps on both traffic_requests and traffic_ip_rollups). The row cap is
+ * additionally re-checked inline by RequestLogService during insert bursts, so
+ * this schedule mainly handles age-based expiry and quiet-period cleanup.
+ */
+@Injectable()
+export class TrafficRetentionScheduler {
+  private readonly logger = new Logger(TrafficRetentionScheduler.name);
+  private isRunning = false;
+
+  constructor(private readonly requestLog: RequestLogService) {}
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async handleRetention(): Promise<void> {
+    if (!this.requestLog.enabled) {
+      return;
+    }
+    if (this.isRunning) {
+      this.logger.warn({ event: 'traffic_retention_skipped', reason: 'previous run still in progress' });
+      return;
+    }
+    this.isRunning = true;
+    try {
+      const summary = await this.requestLog.prune();
+      const total =
+        summary.requestsDeletedByAge +
+        summary.requestsDeletedOverCap +
+        summary.rollupsDeletedByAge +
+        summary.rollupsDeletedOverCap;
+      if (total > 0) {
+        this.logger.log({ event: 'traffic_retention_pruned', ...summary });
+      }
+    } catch (error) {
+      this.logger.error({ event: 'traffic_retention_failed', error: String(error) });
+    } finally {
+      this.isRunning = false;
+    }
+  }
+}

--- a/apps/backend/src/traffic/traffic.controller.spec.ts
+++ b/apps/backend/src/traffic/traffic.controller.spec.ts
@@ -1,17 +1,21 @@
 import { MessageEvent } from '@nestjs/common';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 import { ROLES_KEY } from '../auth/roles.guard';
 import { TrafficController } from './traffic.controller';
 import { TrafficEventsService } from './traffic-events.service';
 import { TrafficEvent } from './traffic-event.interface';
+import { RequestLogService } from './request-log.service';
 
 // bcrypt is a native module the auth barrel imports transitively; mock it like
 // the other guard specs do so the suite runs without the compiled binding.
 jest.mock('bcrypt');
+// RequestLogService imports the db client; keep this spec db-free.
+jest.mock('../db/client', () => ({ db: {} }));
 
 describe('TrafficController', () => {
   let controller: TrafficController;
   let events: TrafficEventsService;
+  let requestLog: jest.Mocked<RequestLogService>;
 
   const sampleEvent: TrafficEvent = {
     id: '1',
@@ -31,14 +35,30 @@ describe('TrafficController', () => {
 
   const makeReq = () => ({ res: { setHeader: jest.fn() } }) as unknown as Request;
 
+  const makeRes = () =>
+    ({ setHeader: jest.fn(), send: jest.fn() }) as unknown as Response;
+
   beforeEach(() => {
     events = new TrafficEventsService();
-    controller = new TrafficController(events);
+    requestLog = {
+      listRequests: jest.fn(),
+      listIpRollups: jest.fn(),
+      exportRequests: jest.fn(),
+      exportIpRollups: jest.fn(),
+    } as unknown as jest.Mocked<RequestLogService>;
+    controller = new TrafficController(events, requestLog);
   });
 
-  it('is admin-only: stream handler carries the admin roles metadata', () => {
-    const roles = Reflect.getMetadata(ROLES_KEY, controller.stream);
-    expect(roles).toEqual(['admin']);
+  it('is admin-only: every handler carries the admin roles metadata', () => {
+    for (const handler of [
+      controller.stream,
+      controller.listRequests,
+      controller.exportRequests,
+      controller.listIpRollups,
+      controller.exportIpRollups,
+    ]) {
+      expect(Reflect.getMetadata(ROLES_KEY, handler)).toEqual(['admin']);
+    }
   });
 
   it('is guarded: controller declares ApiKeyGuard + RolesGuard', () => {
@@ -63,5 +83,61 @@ describe('TrafficController', () => {
     const req = makeReq();
     controller.stream(req).subscribe().unsubscribe();
     expect(req.res!.setHeader).toHaveBeenCalledWith('X-Accel-Buffering', 'no');
+  });
+
+  describe('Request-log read API', () => {
+    it('lists requests with default pagination and passes filters through', async () => {
+      requestLog.listRequests.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        pageSize: 50,
+        totalPages: 0,
+      });
+      await controller.listRequests({ ip: '203.0.113.7', status: 404 });
+      expect(requestLog.listRequests).toHaveBeenCalledWith(
+        { ip: '203.0.113.7', status: 404 },
+        1,
+        50,
+      );
+    });
+
+    it('lists the per-IP rollup with default sort (worst offenders first)', async () => {
+      requestLog.listIpRollups.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        pageSize: 50,
+        totalPages: 0,
+      });
+      await controller.listIpRollups({});
+      expect(requestLog.listIpRollups).toHaveBeenCalledWith({}, 'requestCount', 'desc', 1, 50);
+    });
+
+    it('exports the Request log as a CSV attachment', async () => {
+      requestLog.exportRequests.mockResolvedValue('a,b\n1,2');
+      const res = makeRes();
+      await controller.exportRequests({ classification: 'unmatched' }, res);
+      expect(requestLog.exportRequests).toHaveBeenCalledWith(
+        { classification: 'unmatched' },
+        'csv',
+        10_000,
+      );
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv');
+      expect(res.setHeader).toHaveBeenCalledWith(
+        'Content-Disposition',
+        'attachment; filename="request-log.csv"',
+      );
+      expect(res.send).toHaveBeenCalledWith('a,b\n1,2');
+    });
+
+    it('exports the rollup as JSON when requested', async () => {
+      requestLog.exportIpRollups.mockResolvedValue('[]');
+      const res = makeRes();
+      await controller.exportIpRollups({ format: 'json', limit: 5 }, res);
+      expect(requestLog.exportIpRollups).toHaveBeenCalledWith({}, 'json', 5);
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
+      expect(res.send).toHaveBeenCalledWith('[]');
+    });
   });
 });

--- a/apps/backend/src/traffic/traffic.controller.ts
+++ b/apps/backend/src/traffic/traffic.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, MessageEvent, Req, Sse, UseGuards } from '@nestjs/common';
+import { Controller, Get, MessageEvent, Query, Req, Res, Sse, UseGuards } from '@nestjs/common';
 import { SkipThrottle } from '@nestjs/throttler';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 import { Observable, interval, map, merge } from 'rxjs';
 // Import from the concrete files (not the ../auth barrel): the barrel pulls in
 // auth.module -> settings.module, a cycle that leaves Roles undefined when this
@@ -10,6 +10,13 @@ import { ApiKeyGuard } from '../auth/api-key.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { TrafficEventsService } from './traffic-events.service';
+import { RequestLogService } from './request-log.service';
+import {
+  ExportTrafficIpRollupsQueryDto,
+  ExportTrafficRequestsQueryDto,
+  ListTrafficIpRollupsQueryDto,
+  ListTrafficRequestsQueryDto,
+} from './traffic.dto';
 
 /** Keep-alive cadence so idle SSE connections survive proxy read timeouts. */
 const HEARTBEAT_MS = 30_000;
@@ -18,7 +25,10 @@ const HEARTBEAT_MS = 30_000;
 @Controller('api/traffic')
 @UseGuards(ApiKeyGuard, RolesGuard)
 export class TrafficController {
-  constructor(private readonly trafficEvents: TrafficEventsService) {}
+  constructor(
+    private readonly trafficEvents: TrafficEventsService,
+    private readonly requestLog: RequestLogService,
+  ) {}
 
   @Sse('stream')
   @Roles('admin')
@@ -38,5 +48,55 @@ export class TrafficController {
     );
 
     return merge(events$, heartbeat$);
+  }
+
+  @Get('requests')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Persisted Request log (Unmatched/blocked), filterable (admin only)' })
+  async listRequests(@Query() query: ListTrafficRequestsQueryDto) {
+    const { page = 1, pageSize = 50, ...filters } = query;
+    return this.requestLog.listRequests(filters, page, pageSize);
+  }
+
+  @Get('requests/export')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Export the persisted Request log as CSV or JSON (admin only)' })
+  async exportRequests(
+    @Query() query: ExportTrafficRequestsQueryDto,
+    @Res() res: Response,
+  ): Promise<void> {
+    const { format = 'csv', limit = 10_000, ...filters } = query;
+    const body = await this.requestLog.exportRequests(filters, format, limit);
+    res.setHeader('Content-Type', format === 'csv' ? 'text/csv' : 'application/json');
+    res.setHeader('Content-Disposition', `attachment; filename="request-log.${format}"`);
+    res.send(body);
+  }
+
+  @Get('ips')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Per-IP rollup of persisted requests (admin only)' })
+  async listIpRollups(@Query() query: ListTrafficIpRollupsQueryDto) {
+    const {
+      page = 1,
+      pageSize = 50,
+      sortBy = 'requestCount',
+      sortOrder = 'desc',
+      ...filters
+    } = query;
+    return this.requestLog.listIpRollups(filters, sortBy, sortOrder, page, pageSize);
+  }
+
+  @Get('ips/export')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Export the per-IP rollup as CSV or JSON (admin only)' })
+  async exportIpRollups(
+    @Query() query: ExportTrafficIpRollupsQueryDto,
+    @Res() res: Response,
+  ): Promise<void> {
+    const { format = 'csv', limit = 10_000, ...filters } = query;
+    const body = await this.requestLog.exportIpRollups(filters, format, limit);
+    res.setHeader('Content-Type', format === 'csv' ? 'text/csv' : 'application/json');
+    res.setHeader('Content-Disposition', `attachment; filename="ip-rollup.${format}"`);
+    res.send(body);
   }
 }

--- a/apps/backend/src/traffic/traffic.dto.ts
+++ b/apps/backend/src/traffic/traffic.dto.ts
@@ -1,0 +1,130 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsIn, IsInt, IsISO8601, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+
+const toInt = ({ value }: { value: unknown }) =>
+  typeof value === 'string' ? parseInt(value, 10) : value;
+
+/** Shared Request-log filters (history list + export). */
+export class TrafficRequestFiltersDto {
+  @ApiPropertyOptional({ description: 'Exact client IP' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(45)
+  ip?: string;
+
+  @ApiPropertyOptional({ description: 'Substring match on the request path' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  path?: string;
+
+  @ApiPropertyOptional({ description: 'Exact response status code' })
+  @IsOptional()
+  @Transform(toInt)
+  @IsInt()
+  @Min(100)
+  @Max(599)
+  status?: number;
+
+  @ApiPropertyOptional({ enum: ['unmatched', 'blocked'] })
+  @IsOptional()
+  @IsIn(['unmatched', 'blocked'])
+  classification?: 'unmatched' | 'blocked';
+
+  @ApiPropertyOptional({ description: 'ISO 8601 lower bound (inclusive) on the request time' })
+  @IsOptional()
+  @IsISO8601()
+  from?: string;
+
+  @ApiPropertyOptional({ description: 'ISO 8601 upper bound (inclusive) on the request time' })
+  @IsOptional()
+  @IsISO8601()
+  to?: string;
+}
+
+export class ListTrafficRequestsQueryDto extends TrafficRequestFiltersDto {
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  @Transform(toInt)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 50, maximum: 500 })
+  @IsOptional()
+  @Transform(toInt)
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  pageSize?: number = 50;
+}
+
+export class ExportTrafficRequestsQueryDto extends TrafficRequestFiltersDto {
+  @ApiPropertyOptional({ enum: ['csv', 'json'], default: 'csv' })
+  @IsOptional()
+  @IsIn(['csv', 'json'])
+  format?: 'csv' | 'json' = 'csv';
+
+  @ApiPropertyOptional({ default: 10000, maximum: 50000 })
+  @IsOptional()
+  @Transform(toInt)
+  @IsInt()
+  @Min(1)
+  @Max(50_000)
+  limit?: number = 10_000;
+}
+
+export class ListTrafficIpRollupsQueryDto {
+  @ApiPropertyOptional({ description: 'Substring match on the IP' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(45)
+  ip?: string;
+
+  @ApiPropertyOptional({ enum: ['requestCount', 'lastSeenAt', 'firstSeenAt'], default: 'requestCount' })
+  @IsOptional()
+  @IsIn(['requestCount', 'lastSeenAt', 'firstSeenAt'])
+  sortBy?: 'requestCount' | 'lastSeenAt' | 'firstSeenAt' = 'requestCount';
+
+  @ApiPropertyOptional({ enum: ['asc', 'desc'], default: 'desc' })
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sortOrder?: 'asc' | 'desc' = 'desc';
+
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  @Transform(toInt)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 50, maximum: 500 })
+  @IsOptional()
+  @Transform(toInt)
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  pageSize?: number = 50;
+}
+
+export class ExportTrafficIpRollupsQueryDto {
+  @ApiPropertyOptional({ description: 'Substring match on the IP' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(45)
+  ip?: string;
+
+  @ApiPropertyOptional({ enum: ['csv', 'json'], default: 'csv' })
+  @IsOptional()
+  @IsIn(['csv', 'json'])
+  format?: 'csv' | 'json' = 'csv';
+
+  @ApiPropertyOptional({ default: 10000, maximum: 50000 })
+  @IsOptional()
+  @Transform(toInt)
+  @IsInt()
+  @Min(1)
+  @Max(50_000)
+  limit?: number = 10_000;
+}

--- a/apps/backend/src/traffic/traffic.module.ts
+++ b/apps/backend/src/traffic/traffic.module.ts
@@ -1,18 +1,24 @@
 import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import { TrafficController } from './traffic.controller';
 import { TrafficEventsService } from './traffic-events.service';
+import { RequestLogService } from './request-log.service';
+import { TrafficRetentionScheduler } from './traffic-retention.scheduler';
 
 /**
  * Bot protection & request observability (issue #383).
  *
- * This slice (#389) provides the observation seam: the traffic observer
- * middleware (installed in main.ts) publishes every app-observed request to
+ * Slice #389 provided the observation seam: the traffic observer middleware
+ * (installed in main.ts) publishes every app-observed request to
  * TrafficEventsService, and TrafficController exposes an admin-only SSE live
- * tail. Persistence and the Blocklist arrive in later slices.
+ * tail. Slice #390 adds the Request log: RequestLogService persists the
+ * Unmatched (and, with #391, blocked) subset with bounded retention and a
+ * per-IP rollup, exposed through admin read/export endpoints.
  */
 @Module({
+  imports: [ScheduleModule.forRoot()],
   controllers: [TrafficController],
-  providers: [TrafficEventsService],
+  providers: [TrafficEventsService, RequestLogService, TrafficRetentionScheduler],
   exports: [TrafficEventsService],
 })
 export class TrafficModule {}

--- a/apps/frontend/src/components/traffic/TrafficHistoryTab.test.tsx
+++ b/apps/frontend/src/components/traffic/TrafficHistoryTab.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TrafficHistoryTab } from './TrafficHistoryTab';
+import type { TrafficRequestEntry } from '@/services/trafficApi';
+
+const mockUseListTrafficRequestsQuery = vi.fn();
+const mockDownloadTrafficExport = vi.fn();
+
+vi.mock('@/services/trafficApi', () => ({
+  useListTrafficRequestsQuery: (params: unknown) => mockUseListTrafficRequestsQuery(params),
+  downloadTrafficExport: (...args: unknown[]) => mockDownloadTrafficExport(...args),
+}));
+
+// Radix Select doesn't play well with happy-dom; the time-range filter is
+// exercised indirectly through the query params assertion instead.
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children }: any) => <div>{children}</div>,
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectValue: () => null,
+}));
+
+const makeEntry = (overrides: Partial<TrafficRequestEntry> = {}): TrafficRequestEntry => ({
+  id: 'entry-1',
+  timestamp: '2026-07-02T09:05:03.000Z',
+  ip: '203.0.113.7',
+  method: 'GET',
+  path: '/backend/.env',
+  httpVersion: '1.1',
+  status: 404,
+  bytes: 42,
+  referer: null,
+  userAgent: 'scanner',
+  host: 'j5s.dev',
+  classification: 'unmatched',
+  line: '203.0.113.7 - - [02/Jul/2026:09:05:03 +0000] "GET /backend/.env HTTP/1.1" 404 42 "-" "scanner"',
+  ...overrides,
+});
+
+const queryResult = (entries: TrafficRequestEntry[], total = entries.length) => ({
+  data: { data: entries, total, page: 1, pageSize: 100, totalPages: Math.ceil(total / 100) },
+  isLoading: false,
+  isFetching: false,
+  error: undefined,
+});
+
+describe('TrafficHistoryTab', () => {
+  beforeEach(() => {
+    mockUseListTrafficRequestsQuery.mockReset();
+    mockDownloadTrafficExport.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('renders persisted requests as access-log lines with pagination summary', () => {
+    mockUseListTrafficRequestsQuery.mockReturnValue(queryResult([makeEntry()]));
+    render(<TrafficHistoryTab />);
+
+    expect(screen.getByText(/GET \/backend\/\.env HTTP\/1\.1/)).toBeInTheDocument();
+    expect(screen.getByText(/Showing 1 to 1 of 1/)).toBeInTheDocument();
+  });
+
+  it('shows an empty state when nothing matches', () => {
+    mockUseListTrafficRequestsQuery.mockReturnValue(queryResult([]));
+    render(<TrafficHistoryTab />);
+    expect(screen.getByText(/No persisted requests match these filters/)).toBeInTheDocument();
+  });
+
+  it('passes filters to the query and resets to page 1 on change', () => {
+    mockUseListTrafficRequestsQuery.mockReturnValue(queryResult([]));
+    render(<TrafficHistoryTab />);
+
+    fireEvent.change(screen.getByLabelText('IP'), { target: { value: '203.0.113.7' } });
+    fireEvent.change(screen.getByLabelText('Path contains'), { target: { value: '/.env' } });
+    fireEvent.change(screen.getByLabelText('Status'), { target: { value: '404' } });
+
+    const lastCall = mockUseListTrafficRequestsQuery.mock.calls.at(-1)![0];
+    expect(lastCall).toMatchObject({
+      ip: '203.0.113.7',
+      path: '/.env',
+      status: 404,
+      page: 1,
+      pageSize: 100,
+    });
+  });
+
+  it('exports with the active filters', () => {
+    mockUseListTrafficRequestsQuery.mockReturnValue(queryResult([]));
+    render(<TrafficHistoryTab />);
+
+    fireEvent.change(screen.getByLabelText('IP'), { target: { value: '203.0.113.7' } });
+    fireEvent.click(screen.getByRole('button', { name: /csv/i }));
+
+    expect(mockDownloadTrafficExport).toHaveBeenCalledWith(
+      'requests',
+      'csv',
+      expect.objectContaining({ ip: '203.0.113.7' }),
+    );
+  });
+
+  it('disables Previous on the first page and Next on the last', () => {
+    mockUseListTrafficRequestsQuery.mockReturnValue(queryResult([makeEntry()], 1));
+    render(<TrafficHistoryTab />);
+
+    expect(screen.getByRole('button', { name: /previous/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+  });
+});

--- a/apps/frontend/src/components/traffic/TrafficHistoryTab.tsx
+++ b/apps/frontend/src/components/traffic/TrafficHistoryTab.tsx
@@ -1,0 +1,228 @@
+import { useMemo, useState } from 'react';
+import { ChevronLeft, ChevronRight, Download, Loader2 } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import { downloadTrafficExport, useListTrafficRequestsQuery } from '@/services/trafficApi';
+import { statusColorClass } from './traffic-format';
+
+const PAGE_SIZE = 100;
+
+const TIME_RANGES: Record<string, { label: string; hours?: number }> = {
+  all: { label: 'Any time' },
+  '1h': { label: 'Last hour', hours: 1 },
+  '24h': { label: 'Last 24 hours', hours: 24 },
+  '7d': { label: 'Last 7 days', hours: 24 * 7 },
+};
+
+/**
+ * History view over the persisted Request log (issue #390): the Unmatched
+ * (and, later, blocked) requests the application interceptor recorded,
+ * rendered as access-log lines like the Live tail, with filters and export.
+ */
+export function TrafficHistoryTab() {
+  const { toast } = useToast();
+  const [ip, setIp] = useState('');
+  const [path, setPath] = useState('');
+  const [status, setStatus] = useState('');
+  const [timeRange, setTimeRange] = useState('all');
+  const [page, setPage] = useState(1);
+  const [exporting, setExporting] = useState(false);
+
+  // Recomputed only when the range selection changes, so the query arg is stable
+  const from = useMemo(() => {
+    const hours = TIME_RANGES[timeRange]?.hours;
+    return hours ? new Date(Date.now() - hours * 60 * 60 * 1000).toISOString() : undefined;
+  }, [timeRange]);
+
+  const filters = {
+    ip: ip.trim() || undefined,
+    path: path.trim() || undefined,
+    status: status.trim() ? Number(status.trim()) : undefined,
+    from,
+  };
+
+  const { data, isLoading, isFetching, error } = useListTrafficRequestsQuery({
+    ...filters,
+    page,
+    pageSize: PAGE_SIZE,
+  });
+
+  const handleExport = async (format: 'csv' | 'json') => {
+    setExporting(true);
+    try {
+      await downloadTrafficExport('requests', format, filters);
+    } catch {
+      toast({ title: 'Export failed', variant: 'destructive' });
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const resetPageAnd =
+    <T,>(setter: (value: T) => void) =>
+    (value: T) => {
+      setPage(1);
+      setter(value);
+    };
+
+  const total = data?.total ?? 0;
+  const showingFrom = total === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
+  const showingTo = Math.min(page * PAGE_SIZE, total);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <CardTitle className="text-base">Request log</CardTitle>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={exporting}
+              onClick={() => handleExport('csv')}
+            >
+              <Download className="h-4 w-4 mr-1" />
+              CSV
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={exporting}
+              onClick={() => handleExport('json')}
+            >
+              <Download className="h-4 w-4 mr-1" />
+              JSON
+            </Button>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-end gap-3 pt-2">
+          <div>
+            <Label htmlFor="history-ip" className="text-xs">
+              IP
+            </Label>
+            <Input
+              id="history-ip"
+              value={ip}
+              onChange={(e) => resetPageAnd(setIp)(e.target.value)}
+              placeholder="203.0.113.7"
+              className="h-8 w-40"
+            />
+          </div>
+          <div>
+            <Label htmlFor="history-path" className="text-xs">
+              Path contains
+            </Label>
+            <Input
+              id="history-path"
+              value={path}
+              onChange={(e) => resetPageAnd(setPath)(e.target.value)}
+              placeholder="/.env"
+              className="h-8 w-48"
+            />
+          </div>
+          <div>
+            <Label htmlFor="history-status" className="text-xs">
+              Status
+            </Label>
+            <Input
+              id="history-status"
+              value={status}
+              onChange={(e) => resetPageAnd(setStatus)(e.target.value.replace(/\D/g, ''))}
+              placeholder="404"
+              className="h-8 w-20"
+              inputMode="numeric"
+            />
+          </div>
+          <div>
+            <Label className="text-xs">Time range</Label>
+            <Select value={timeRange} onValueChange={resetPageAnd(setTimeRange)}>
+              <SelectTrigger className="h-8 w-40">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(TIME_RANGES).map(([key, range]) => (
+                  <SelectItem key={key} value={key}>
+                    {range.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {error ? (
+          <Alert variant="destructive">
+            <AlertDescription>Failed to load the Request log.</AlertDescription>
+          </Alert>
+        ) : isLoading ? (
+          <div className="flex justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-[#d96459]" />
+          </div>
+        ) : (
+          <>
+            <div
+              data-testid="traffic-history-log"
+              className="bg-[#1e1e1e] rounded-md p-3 h-[28rem] overflow-y-auto overflow-x-auto font-mono text-xs leading-5"
+            >
+              {!data || data.data.length === 0 ? (
+                <p className="text-gray-400">No persisted requests match these filters.</p>
+              ) : (
+                data.data.map((entry) => (
+                  <div key={entry.id} className="text-gray-200 whitespace-pre w-max min-w-full">
+                    <span
+                      className="text-[#d96459] mr-1"
+                      title={
+                        entry.classification === 'blocked' ? 'Blocked request' : 'Unmatched request'
+                      }
+                    >
+                      ●
+                    </span>
+                    <span className={statusColorClass(entry.status)}>{entry.line}</span>
+                  </div>
+                ))
+              )}
+            </div>
+            <div className="flex items-center justify-between mt-3 text-sm text-[#4a4a4a] dark:text-muted-foreground">
+              <span>
+                Showing {showingFrom} to {showingTo} of {total}
+                {isFetching && ' …'}
+              </span>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => p - 1)}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={!data || page >= data.totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Next
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/traffic/TrafficHistoryTab.tsx
+++ b/apps/frontend/src/components/traffic/TrafficHistoryTab.tsx
@@ -52,11 +52,16 @@ export function TrafficHistoryTab() {
     from,
   };
 
-  const { data, isLoading, isFetching, error } = useListTrafficRequestsQuery({
-    ...filters,
-    page,
-    pageSize: PAGE_SIZE,
-  });
+  const { data, isLoading, isFetching, error } = useListTrafficRequestsQuery(
+    {
+      ...filters,
+      page,
+      pageSize: PAGE_SIZE,
+    },
+    // New records land continuously server-side; a cached page from before the
+    // last flush would read as "no data", so always refetch on mount/arg change.
+    { refetchOnMountOrArgChange: true },
+  );
 
   const handleExport = async (format: 'csv' | 'json') => {
     setExporting(true);
@@ -84,7 +89,14 @@ export function TrafficHistoryTab() {
     <Card>
       <CardHeader className="pb-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <CardTitle className="text-base">Request log</CardTitle>
+          <div>
+            <CardTitle className="text-base">Request log</CardTitle>
+            <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground mt-1">
+              Only the bot-signal subset is persisted: Unmatched requests (404 — paths that resolve
+              to no deployment, alias, or asset) and, once Blocklists land, blocked ones. Matched
+              traffic appears only in the Live tab.
+            </p>
+          </div>
           <div className="flex items-center gap-2">
             <Button
               variant="outline"

--- a/apps/frontend/src/components/traffic/TrafficRollupTab.test.tsx
+++ b/apps/frontend/src/components/traffic/TrafficRollupTab.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TrafficRollupTab } from './TrafficRollupTab';
+import type { TrafficIpRollupEntry } from '@/services/trafficApi';
+
+const mockUseListTrafficIpRollupsQuery = vi.fn();
+const mockDownloadTrafficExport = vi.fn();
+
+vi.mock('@/services/trafficApi', () => ({
+  useListTrafficIpRollupsQuery: (params: unknown) => mockUseListTrafficIpRollupsQuery(params),
+  downloadTrafficExport: (...args: unknown[]) => mockDownloadTrafficExport(...args),
+}));
+
+// Radix Select doesn't play well with happy-dom; sorting is asserted through
+// the default query params instead.
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children }: any) => <div>{children}</div>,
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectValue: () => null,
+}));
+
+const makeRollup = (overrides: Partial<TrafficIpRollupEntry> = {}): TrafficIpRollupEntry => ({
+  id: 'rollup-1',
+  ip: '203.0.113.7',
+  requestCount: 1234,
+  firstSeenAt: '2026-06-01T00:00:00.000Z',
+  lastSeenAt: '2026-07-02T09:05:03.000Z',
+  samplePaths: ['/.env', '/wp-login.php'],
+  sampleUserAgents: ['scanner-bot/1.0'],
+  ...overrides,
+});
+
+const queryResult = (entries: TrafficIpRollupEntry[], total = entries.length) => ({
+  data: { data: entries, total, page: 1, pageSize: 50, totalPages: Math.ceil(total / 50) },
+  isLoading: false,
+  isFetching: false,
+  error: undefined,
+});
+
+describe('TrafficRollupTab', () => {
+  beforeEach(() => {
+    mockUseListTrafficIpRollupsQuery.mockReset();
+    mockDownloadTrafficExport.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('renders the worst offenders with count and samples', () => {
+    mockUseListTrafficIpRollupsQuery.mockReturnValue(queryResult([makeRollup()]));
+    render(<TrafficRollupTab />);
+
+    expect(screen.getByText('203.0.113.7')).toBeInTheDocument();
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+    expect(screen.getByText(/\/\.env \/wp-login\.php/)).toBeInTheDocument();
+    expect(screen.getByText('scanner-bot/1.0')).toBeInTheDocument();
+  });
+
+  it('defaults to sorting by request count, worst first', () => {
+    mockUseListTrafficIpRollupsQuery.mockReturnValue(queryResult([]));
+    render(<TrafficRollupTab />);
+
+    expect(mockUseListTrafficIpRollupsQuery.mock.calls.at(-1)![0]).toMatchObject({
+      sortBy: 'requestCount',
+      sortOrder: 'desc',
+      page: 1,
+    });
+  });
+
+  it('shows an empty state when nothing matches', () => {
+    mockUseListTrafficIpRollupsQuery.mockReturnValue(queryResult([]));
+    render(<TrafficRollupTab />);
+    expect(screen.getByText(/No IPs match these filters/)).toBeInTheDocument();
+  });
+
+  it('filters by IP substring', () => {
+    mockUseListTrafficIpRollupsQuery.mockReturnValue(queryResult([]));
+    render(<TrafficRollupTab />);
+
+    fireEvent.change(screen.getByLabelText('IP contains'), { target: { value: '203.0' } });
+    expect(mockUseListTrafficIpRollupsQuery.mock.calls.at(-1)![0]).toMatchObject({ ip: '203.0' });
+  });
+
+  it('exports the rollup with the active filter', () => {
+    mockUseListTrafficIpRollupsQuery.mockReturnValue(queryResult([]));
+    render(<TrafficRollupTab />);
+
+    fireEvent.change(screen.getByLabelText('IP contains'), { target: { value: '203.0' } });
+    fireEvent.click(screen.getByRole('button', { name: /json/i }));
+
+    expect(mockDownloadTrafficExport).toHaveBeenCalledWith('ips', 'json', { ip: '203.0' });
+  });
+});

--- a/apps/frontend/src/components/traffic/TrafficRollupTab.tsx
+++ b/apps/frontend/src/components/traffic/TrafficRollupTab.tsx
@@ -45,13 +45,17 @@ export function TrafficRollupTab() {
   const [exporting, setExporting] = useState(false);
 
   const ipFilter = ip.trim() || undefined;
-  const { data, isLoading, isFetching, error } = useListTrafficIpRollupsQuery({
-    ip: ipFilter,
-    sortBy,
-    sortOrder: 'desc',
-    page,
-    pageSize: PAGE_SIZE,
-  });
+  const { data, isLoading, isFetching, error } = useListTrafficIpRollupsQuery(
+    {
+      ip: ipFilter,
+      sortBy,
+      sortOrder: 'desc',
+      page,
+      pageSize: PAGE_SIZE,
+    },
+    // Rollups update continuously server-side; don't serve a stale cached page.
+    { refetchOnMountOrArgChange: true },
+  );
 
   const handleExport = async (format: 'csv' | 'json') => {
     setExporting(true);
@@ -72,7 +76,13 @@ export function TrafficRollupTab() {
     <Card>
       <CardHeader className="pb-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <CardTitle className="text-base">Per-IP rollup</CardTitle>
+          <div>
+            <CardTitle className="text-base">Per-IP rollup</CardTitle>
+            <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground mt-1">
+              IPs that produced persisted (Unmatched/blocked) requests — matched traffic doesn't
+              count here.
+            </p>
+          </div>
           <div className="flex items-center gap-2">
             <Button
               variant="outline"

--- a/apps/frontend/src/components/traffic/TrafficRollupTab.tsx
+++ b/apps/frontend/src/components/traffic/TrafficRollupTab.tsx
@@ -1,0 +1,222 @@
+import { useState } from 'react';
+import { ChevronLeft, ChevronRight, Download, Loader2 } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useToast } from '@/hooks/use-toast';
+import { downloadTrafficExport, useListTrafficIpRollupsQuery } from '@/services/trafficApi';
+
+const PAGE_SIZE = 50;
+
+type SortBy = 'requestCount' | 'lastSeenAt' | 'firstSeenAt';
+
+const SORT_OPTIONS: Record<SortBy, string> = {
+  requestCount: 'Most requests',
+  lastSeenAt: 'Last seen',
+  firstSeenAt: 'First seen',
+};
+
+/**
+ * Per-IP rollup view (issue #390): the worst offenders across the persisted
+ * Request log — request count, first/last seen, sample paths and user-agents.
+ */
+export function TrafficRollupTab() {
+  const { toast } = useToast();
+  const [ip, setIp] = useState('');
+  const [sortBy, setSortBy] = useState<SortBy>('requestCount');
+  const [page, setPage] = useState(1);
+  const [exporting, setExporting] = useState(false);
+
+  const ipFilter = ip.trim() || undefined;
+  const { data, isLoading, isFetching, error } = useListTrafficIpRollupsQuery({
+    ip: ipFilter,
+    sortBy,
+    sortOrder: 'desc',
+    page,
+    pageSize: PAGE_SIZE,
+  });
+
+  const handleExport = async (format: 'csv' | 'json') => {
+    setExporting(true);
+    try {
+      await downloadTrafficExport('ips', format, { ip: ipFilter });
+    } catch {
+      toast({ title: 'Export failed', variant: 'destructive' });
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const total = data?.total ?? 0;
+  const showingFrom = total === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
+  const showingTo = Math.min(page * PAGE_SIZE, total);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <CardTitle className="text-base">Per-IP rollup</CardTitle>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={exporting}
+              onClick={() => handleExport('csv')}
+            >
+              <Download className="h-4 w-4 mr-1" />
+              CSV
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={exporting}
+              onClick={() => handleExport('json')}
+            >
+              <Download className="h-4 w-4 mr-1" />
+              JSON
+            </Button>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-end gap-3 pt-2">
+          <div>
+            <Label htmlFor="rollup-ip" className="text-xs">
+              IP contains
+            </Label>
+            <Input
+              id="rollup-ip"
+              value={ip}
+              onChange={(e) => {
+                setPage(1);
+                setIp(e.target.value);
+              }}
+              placeholder="203.0.113"
+              className="h-8 w-40"
+            />
+          </div>
+          <div>
+            <Label className="text-xs">Sort by</Label>
+            <Select
+              value={sortBy}
+              onValueChange={(value) => {
+                setPage(1);
+                setSortBy(value as SortBy);
+              }}
+            >
+              <SelectTrigger className="h-8 w-40">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(SORT_OPTIONS).map(([key, label]) => (
+                  <SelectItem key={key} value={key}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {error ? (
+          <Alert variant="destructive">
+            <AlertDescription>Failed to load the per-IP rollup.</AlertDescription>
+          </Alert>
+        ) : isLoading ? (
+          <div className="flex justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-[#d96459]" />
+          </div>
+        ) : !data || data.data.length === 0 ? (
+          <p className="text-sm text-[#4a4a4a] dark:text-muted-foreground py-8 text-center">
+            No IPs match these filters.
+          </p>
+        ) : (
+          <>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>IP</TableHead>
+                  <TableHead className="text-right">Requests</TableHead>
+                  <TableHead>First seen</TableHead>
+                  <TableHead>Last seen</TableHead>
+                  <TableHead>Sample paths</TableHead>
+                  <TableHead>Sample user-agents</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.data.map((rollup) => (
+                  <TableRow key={rollup.id}>
+                    <TableCell className="font-mono text-xs">{rollup.ip}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {rollup.requestCount.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-xs whitespace-nowrap">
+                      {new Date(rollup.firstSeenAt).toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-xs whitespace-nowrap">
+                      {new Date(rollup.lastSeenAt).toLocaleString()}
+                    </TableCell>
+                    <TableCell
+                      className="font-mono text-xs max-w-64 truncate"
+                      title={rollup.samplePaths.join('\n')}
+                    >
+                      {rollup.samplePaths.join(' ')}
+                    </TableCell>
+                    <TableCell
+                      className="text-xs max-w-64 truncate"
+                      title={rollup.sampleUserAgents.join('\n')}
+                    >
+                      {rollup.sampleUserAgents.join(' ')}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            <div className="flex items-center justify-between mt-3 text-sm text-[#4a4a4a] dark:text-muted-foreground">
+              <span>
+                Showing {showingFrom} to {showingTo} of {total}
+                {isFetching && ' …'}
+              </span>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => p - 1)}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= data.totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Next
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/traffic/traffic-format.ts
+++ b/apps/frontend/src/components/traffic/traffic-format.ts
@@ -1,0 +1,7 @@
+/** Access-log status coloring shared by the Live tail and History views. */
+export function statusColorClass(status: number): string {
+  if (status >= 500) return 'text-red-600 dark:text-red-400';
+  if (status >= 400) return 'text-amber-600 dark:text-amber-400';
+  if (status >= 300) return 'text-blue-600 dark:text-blue-400';
+  return 'text-emerald-700 dark:text-emerald-400';
+}

--- a/apps/frontend/src/pages/TrafficPage.test.tsx
+++ b/apps/frontend/src/pages/TrafficPage.test.tsx
@@ -112,6 +112,30 @@ describe('TrafficPage tabs', () => {
     fireEvent.mouseDown(screen.getByRole('tab', { name: 'By IP' }), { button: 0 });
     expect(screen.getByText('ROLLUP-TAB-CONTENT')).toBeInTheDocument();
   });
+
+  it('keeps the live tail (stream + events) alive across tab switches', () => {
+    render(
+      <MemoryRouter>
+        <TrafficPage />
+      </MemoryRouter>,
+    );
+    const live = MockEventSource.instances[0];
+    act(() => {
+      live.emit(
+        'request',
+        makeEvent({ line: 'SURVIVES-TAB-SWITCH', status: 404, classification: 'unmatched' }),
+      );
+    });
+    expect(screen.getByText(/SURVIVES-TAB-SWITCH/)).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'History' }), { button: 0 });
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Live' }), { button: 0 });
+
+    // same EventSource (no reconnect), events not wiped
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(live.closed).toBe(false);
+    expect(screen.getByText(/SURVIVES-TAB-SWITCH/)).toBeInTheDocument();
+  });
 });
 
 describe('LiveTrafficTab', () => {
@@ -135,7 +159,12 @@ describe('LiveTrafficTab', () => {
       source().emit('request', makeEvent({ line: 'MATCHED-OK-LINE', status: 200 }));
       source().emit(
         'request',
-        makeEvent({ line: 'SCANNER-LINE', status: 404, classification: 'unmatched', path: '/.env' }),
+        makeEvent({
+          line: 'SCANNER-LINE',
+          status: 404,
+          classification: 'unmatched',
+          path: '/.env',
+        }),
       );
     });
 
@@ -158,7 +187,10 @@ describe('LiveTrafficTab', () => {
   it('defaults to unwrapped lines and persists the wrap preference', () => {
     render(<LiveTrafficTab />);
     act(() => {
-      source().emit('request', makeEvent({ line: 'SCANNER-LINE', status: 404, classification: 'unmatched' }));
+      source().emit(
+        'request',
+        makeEvent({ line: 'SCANNER-LINE', status: 404, classification: 'unmatched' }),
+      );
     });
 
     const line = screen.getByText(/SCANNER-LINE/).parentElement!;
@@ -189,7 +221,10 @@ describe('LiveTrafficTab', () => {
     const { unmount } = render(<LiveTrafficTab />);
     fireEvent.click(screen.getByRole('button', { name: /pause/i }));
     act(() => {
-      source().emit('request', makeEvent({ line: 'WHILE-PAUSED', status: 404, classification: 'unmatched' }));
+      source().emit(
+        'request',
+        makeEvent({ line: 'WHILE-PAUSED', status: 404, classification: 'unmatched' }),
+      );
     });
     expect(screen.queryByText(/WHILE-PAUSED/)).not.toBeInTheDocument();
 

--- a/apps/frontend/src/pages/TrafficPage.test.tsx
+++ b/apps/frontend/src/pages/TrafficPage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import { TrafficPage, isSignalEvent, type TrafficStreamEvent } from './TrafficPage';
+import { MemoryRouter } from 'react-router-dom';
+import { TrafficPage, LiveTrafficTab, isSignalEvent, type TrafficStreamEvent } from './TrafficPage';
 
 // Radix Switch doesn't play well with happy-dom; stub it like other page tests do
 vi.mock('@/components/ui/switch', () => ({
@@ -13,6 +14,15 @@ vi.mock('@/components/ui/switch', () => ({
       onChange={(e) => onCheckedChange(e.target.checked)}
     />
   ),
+}));
+
+// The History/Rollup tabs have their own tests; stub them so TrafficPage tests
+// don't need the RTK Query store.
+vi.mock('@/components/traffic/TrafficHistoryTab', () => ({
+  TrafficHistoryTab: () => <div>HISTORY-TAB-CONTENT</div>,
+}));
+vi.mock('@/components/traffic/TrafficRollupTab', () => ({
+  TrafficRollupTab: () => <div>ROLLUP-TAB-CONTENT</div>,
 }));
 
 type Listener = (event: { data: string }) => void;
@@ -80,7 +90,31 @@ describe('isSignalEvent', () => {
   });
 });
 
-describe('TrafficPage', () => {
+describe('TrafficPage tabs', () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    localStorage.clear();
+  });
+
+  it('shows the live tail by default and switches to History and By IP', () => {
+    render(
+      <MemoryRouter>
+        <TrafficPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Live requests')).toBeInTheDocument();
+    expect(screen.queryByText('HISTORY-TAB-CONTENT')).not.toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'History' }), { button: 0 });
+    expect(screen.getByText('HISTORY-TAB-CONTENT')).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'By IP' }), { button: 0 });
+    expect(screen.getByText('ROLLUP-TAB-CONTENT')).toBeInTheDocument();
+  });
+});
+
+describe('LiveTrafficTab', () => {
   beforeEach(() => {
     MockEventSource.instances = [];
     vi.stubGlobal('EventSource', MockEventSource);
@@ -90,13 +124,13 @@ describe('TrafficPage', () => {
   const source = () => MockEventSource.instances[0];
 
   it('opens a credentialed SSE connection to the traffic stream', () => {
-    render(<TrafficPage />);
+    render(<LiveTrafficTab />);
     expect(source().url).toContain('/api/traffic/stream');
     expect(source().withCredentials).toBe(true);
   });
 
   it('defaults to showing only Unmatched and 4xx/5xx requests', () => {
-    render(<TrafficPage />);
+    render(<LiveTrafficTab />);
     act(() => {
       source().emit('request', makeEvent({ line: 'MATCHED-OK-LINE', status: 200 }));
       source().emit(
@@ -111,7 +145,7 @@ describe('TrafficPage', () => {
   });
 
   it('reveals all traffic when "Show all" is toggled', () => {
-    render(<TrafficPage />);
+    render(<LiveTrafficTab />);
     act(() => {
       source().emit('request', makeEvent({ line: 'MATCHED-OK-LINE', status: 200 }));
     });
@@ -122,7 +156,7 @@ describe('TrafficPage', () => {
   });
 
   it('defaults to unwrapped lines and persists the wrap preference', () => {
-    render(<TrafficPage />);
+    render(<LiveTrafficTab />);
     act(() => {
       source().emit('request', makeEvent({ line: 'SCANNER-LINE', status: 404, classification: 'unmatched' }));
     });
@@ -139,7 +173,7 @@ describe('TrafficPage', () => {
   });
 
   it('shows a Paused badge instead of Live while paused', () => {
-    render(<TrafficPage />);
+    render(<LiveTrafficTab />);
     act(() => source().onopen?.());
     expect(screen.getByText('Live')).toBeInTheDocument();
 
@@ -152,7 +186,7 @@ describe('TrafficPage', () => {
   });
 
   it('stops appending while paused and closes the stream on unmount', () => {
-    const { unmount } = render(<TrafficPage />);
+    const { unmount } = render(<LiveTrafficTab />);
     fireEvent.click(screen.getByRole('button', { name: /pause/i }));
     act(() => {
       source().emit('request', makeEvent({ line: 'WHILE-PAUSED', status: 404, classification: 'unmatched' }));

--- a/apps/frontend/src/pages/TrafficPage.tsx
+++ b/apps/frontend/src/pages/TrafficPage.tsx
@@ -1,10 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Activity, Pause, Play, Trash2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { TrafficHistoryTab } from '@/components/traffic/TrafficHistoryTab';
+import { TrafficRollupTab } from '@/components/traffic/TrafficRollupTab';
+import { statusColorClass } from '@/components/traffic/traffic-format';
 
 /** A request observed by the backend's application interceptor (issue #389). */
 export interface TrafficStreamEvent {
@@ -39,14 +44,45 @@ export function isSignalEvent(event: TrafficStreamEvent): boolean {
   return event.classification === 'unmatched' || event.status >= 400;
 }
 
-function statusColorClass(status: number): string {
-  if (status >= 500) return 'text-red-600 dark:text-red-400';
-  if (status >= 400) return 'text-amber-600 dark:text-amber-400';
-  if (status >= 300) return 'text-blue-600 dark:text-blue-400';
-  return 'text-emerald-700 dark:text-emerald-400';
+export function TrafficPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = searchParams.get('tab') || 'live';
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-7xl">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-[#3a3a3a] dark:text-foreground flex items-center gap-2">
+            <Activity className="h-6 w-6 text-[#d96459]" />
+            Traffic
+          </h1>
+          <p className="text-sm text-[#4a4a4a] dark:text-muted-foreground mt-1">
+            Requests hitting this instance, as the application observes them
+          </p>
+        </div>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={(tab) => setSearchParams({ tab })}>
+        <TabsList className="mb-4">
+          <TabsTrigger value="live">Live</TabsTrigger>
+          <TabsTrigger value="history">History</TabsTrigger>
+          <TabsTrigger value="rollup">By IP</TabsTrigger>
+        </TabsList>
+        <TabsContent value="live">
+          <LiveTrafficTab />
+        </TabsContent>
+        <TabsContent value="history">
+          <TrafficHistoryTab />
+        </TabsContent>
+        <TabsContent value="rollup">
+          <TrafficRollupTab />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
 }
 
-export function TrafficPage() {
+export function LiveTrafficTab() {
   const [events, setEvents] = useState<TrafficStreamEvent[]>([]);
   const [showAll, setShowAll] = useState(false);
   const [paused, setPaused] = useState(false);
@@ -71,7 +107,8 @@ export function TrafficPage() {
       if (pausedRef.current) return;
       const event = JSON.parse((message as MessageEvent).data) as TrafficStreamEvent;
       setEvents((prev) => {
-        const next = prev.length >= MAX_EVENTS ? prev.slice(prev.length - MAX_EVENTS + 1) : prev.slice();
+        const next =
+          prev.length >= MAX_EVENTS ? prev.slice(prev.length - MAX_EVENTS + 1) : prev.slice();
         next.push(event);
         return next;
       });
@@ -96,88 +133,76 @@ export function TrafficPage() {
   }, []);
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-7xl">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-[#3a3a3a] dark:text-foreground flex items-center gap-2">
-            <Activity className="h-6 w-6 text-[#d96459]" />
-            Traffic
-          </h1>
-          <p className="text-sm text-[#4a4a4a] dark:text-muted-foreground mt-1">
-            Live tail of requests hitting this instance, as the application observes them
-          </p>
-        </div>
-        <ConnectionBadge state={connection} paused={paused} />
-      </div>
-
-      <Card>
-        <CardHeader className="pb-3">
-          <div className="flex flex-wrap items-center justify-between gap-3">
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
             <CardTitle className="text-base">Live requests</CardTitle>
-            <div className="flex items-center gap-4">
-              <div className="flex items-center gap-2">
-                <Switch id="show-all" checked={showAll} onCheckedChange={setShowAll} />
-                <Label htmlFor="show-all" className="text-sm cursor-pointer">
-                  Show all
-                </Label>
-              </div>
-              <div className="flex items-center gap-2">
-                <Switch id="wrap-lines" checked={wrapLines} onCheckedChange={toggleWrapLines} />
-                <Label htmlFor="wrap-lines" className="text-sm cursor-pointer">
-                  Wrap lines
-                </Label>
-              </div>
-              <Button variant="outline" size="sm" onClick={() => setPaused((p) => !p)}>
-                {paused ? <Play className="h-4 w-4 mr-1" /> : <Pause className="h-4 w-4 mr-1" />}
-                {paused ? 'Resume' : 'Pause'}
-              </Button>
-              <Button variant="outline" size="sm" onClick={clear}>
-                <Trash2 className="h-4 w-4 mr-1" />
-                Clear
-              </Button>
+            <ConnectionBadge state={connection} paused={paused} />
+          </div>
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <Switch id="show-all" checked={showAll} onCheckedChange={setShowAll} />
+              <Label htmlFor="show-all" className="text-sm cursor-pointer">
+                Show all
+              </Label>
             </div>
+            <div className="flex items-center gap-2">
+              <Switch id="wrap-lines" checked={wrapLines} onCheckedChange={toggleWrapLines} />
+              <Label htmlFor="wrap-lines" className="text-sm cursor-pointer">
+                Wrap lines
+              </Label>
+            </div>
+            <Button variant="outline" size="sm" onClick={() => setPaused((p) => !p)}>
+              {paused ? <Play className="h-4 w-4 mr-1" /> : <Pause className="h-4 w-4 mr-1" />}
+              {paused ? 'Resume' : 'Pause'}
+            </Button>
+            <Button variant="outline" size="sm" onClick={clear}>
+              <Trash2 className="h-4 w-4 mr-1" />
+              Clear
+            </Button>
           </div>
-          {!showAll && (
-            <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground">
-              Showing Unmatched and 4xx/5xx requests only
-              {events.length > visibleEvents.length &&
-                ` — ${events.length - visibleEvents.length} matched request${events.length - visibleEvents.length === 1 ? '' : 's'} hidden`}
+        </div>
+        {!showAll && (
+          <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground">
+            Showing Unmatched and 4xx/5xx requests only
+            {events.length > visibleEvents.length &&
+              ` — ${events.length - visibleEvents.length} matched request${events.length - visibleEvents.length === 1 ? '' : 's'} hidden`}
+          </p>
+        )}
+      </CardHeader>
+      <CardContent>
+        <div
+          ref={scrollRef}
+          data-testid="traffic-log"
+          className={`bg-[#1e1e1e] rounded-md p-3 h-[32rem] overflow-y-auto font-mono text-xs leading-5 ${wrapLines ? '' : 'overflow-x-auto'}`}
+        >
+          {visibleEvents.length === 0 ? (
+            <p className="text-gray-400">
+              {connection === 'live'
+                ? 'Waiting for requests…'
+                : connection === 'connecting'
+                  ? 'Connecting to stream…'
+                  : 'Stream disconnected — retrying…'}
             </p>
+          ) : (
+            visibleEvents.map((event) => (
+              <div
+                key={event.id}
+                className={`text-gray-200 ${wrapLines ? 'whitespace-pre-wrap break-all' : 'whitespace-pre w-max min-w-full'}`}
+              >
+                {event.classification === 'unmatched' && (
+                  <span className="text-[#d96459] mr-1" title="Unmatched request">
+                    ●
+                  </span>
+                )}
+                <span className={statusColorClass(event.status)}>{event.line}</span>
+              </div>
+            ))
           )}
-        </CardHeader>
-        <CardContent>
-          <div
-            ref={scrollRef}
-            data-testid="traffic-log"
-            className={`bg-[#1e1e1e] rounded-md p-3 h-[32rem] overflow-y-auto font-mono text-xs leading-5 ${wrapLines ? '' : 'overflow-x-auto'}`}
-          >
-            {visibleEvents.length === 0 ? (
-              <p className="text-gray-400">
-                {connection === 'live'
-                  ? 'Waiting for requests…'
-                  : connection === 'connecting'
-                    ? 'Connecting to stream…'
-                    : 'Stream disconnected — retrying…'}
-              </p>
-            ) : (
-              visibleEvents.map((event) => (
-                <div
-                  key={event.id}
-                  className={`text-gray-200 ${wrapLines ? 'whitespace-pre-wrap break-all' : 'whitespace-pre w-max min-w-full'}`}
-                >
-                  {event.classification === 'unmatched' && (
-                    <span className="text-[#d96459] mr-1" title="Unmatched request">
-                      ●
-                    </span>
-                  )}
-                  <span className={statusColorClass(event.status)}>{event.line}</span>
-                </div>
-              ))
-            )}
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -194,7 +219,10 @@ function ConnectionBadge({ state, paused }: { state: ConnectionState; paused: bo
   }
   if (state === 'live') {
     return (
-      <Badge variant="outline" className="border-emerald-500/50 text-emerald-600 dark:text-emerald-400">
+      <Badge
+        variant="outline"
+        className="border-emerald-500/50 text-emerald-600 dark:text-emerald-400"
+      >
         <span className="h-2 w-2 rounded-full bg-emerald-500 mr-1.5 animate-pulse" />
         Live
       </Badge>

--- a/apps/frontend/src/pages/TrafficPage.tsx
+++ b/apps/frontend/src/pages/TrafficPage.tsx
@@ -68,7 +68,10 @@ export function TrafficPage() {
           <TabsTrigger value="history">History</TabsTrigger>
           <TabsTrigger value="rollup">By IP</TabsTrigger>
         </TabsList>
-        <TabsContent value="live">
+        {/* forceMount keeps the live tail mounted (hidden) across tab switches,
+            so the SSE connection and accumulated events survive visiting
+            History / By IP. The other tabs re-query on mount instead. */}
+        <TabsContent value="live" forceMount hidden={activeTab !== 'live'}>
           <LiveTrafficTab />
         </TabsContent>
         <TabsContent value="history">

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -212,6 +212,8 @@ export const api = createApi({
     'SsoProvider',
     'ProjectInviteLink',
     'MyProjects',
+    'TrafficRequest',
+    'TrafficIpRollup',
   ],
   endpoints: () => ({}),
 });

--- a/apps/frontend/src/services/trafficApi.ts
+++ b/apps/frontend/src/services/trafficApi.ts
@@ -1,0 +1,127 @@
+import { api } from './api';
+
+/**
+ * The persisted Request log + per-IP rollup (issue #390): the bot-signal
+ * subset (Unmatched, and blocked once #391 lands) of what the application
+ * interceptor observes, admin-only.
+ */
+
+export interface TrafficRequestEntry {
+  id: string;
+  timestamp: string;
+  ip: string;
+  method: string;
+  path: string;
+  httpVersion: string;
+  status: number;
+  bytes: number;
+  referer: string | null;
+  userAgent: string | null;
+  host: string | null;
+  classification: 'unmatched' | 'blocked';
+  /** The record rendered as an nginx combined-access-log line */
+  line: string;
+}
+
+export interface TrafficIpRollupEntry {
+  id: string;
+  ip: string;
+  requestCount: number;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  samplePaths: string[];
+  sampleUserAgents: string[];
+}
+
+export interface TrafficPaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+export interface TrafficRequestFilters {
+  ip?: string;
+  path?: string;
+  status?: number;
+  classification?: 'unmatched' | 'blocked';
+  from?: string;
+  to?: string;
+}
+
+export interface ListTrafficRequestsParams extends TrafficRequestFilters {
+  page?: number;
+  pageSize?: number;
+}
+
+export interface ListTrafficIpRollupsParams {
+  ip?: string;
+  sortBy?: 'requestCount' | 'lastSeenAt' | 'firstSeenAt';
+  sortOrder?: 'asc' | 'desc';
+  page?: number;
+  pageSize?: number;
+}
+
+function toQueryString(params: Record<string, string | number | undefined>): string {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== '') {
+      searchParams.set(key, String(value));
+    }
+  }
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+export const trafficApi = api.injectEndpoints({
+  endpoints: (builder) => ({
+    listTrafficRequests: builder.query<
+      TrafficPaginatedResponse<TrafficRequestEntry>,
+      ListTrafficRequestsParams | void
+    >({
+      query: (params) => `/api/traffic/requests${toQueryString({ ...(params ?? {}) })}`,
+      providesTags: [{ type: 'TrafficRequest' as const, id: 'LIST' }],
+    }),
+
+    listTrafficIpRollups: builder.query<
+      TrafficPaginatedResponse<TrafficIpRollupEntry>,
+      ListTrafficIpRollupsParams | void
+    >({
+      query: (params) => `/api/traffic/ips${toQueryString({ ...(params ?? {}) })}`,
+      providesTags: [{ type: 'TrafficIpRollup' as const, id: 'LIST' }],
+    }),
+  }),
+});
+
+export const { useListTrafficRequestsQuery, useListTrafficIpRollupsQuery } = trafficApi;
+
+/**
+ * Download a Request-log or per-IP-rollup export (CSV/JSON) as a file.
+ * Mirrors downloadSchemaExport in pipelineSchemasApi.
+ */
+export async function downloadTrafficExport(
+  kind: 'requests' | 'ips',
+  format: 'csv' | 'json',
+  filters: Record<string, string | number | undefined> = {},
+): Promise<void> {
+  const baseUrl = import.meta.env.VITE_API_URL || '';
+  const qs = toQueryString({ ...filters, format });
+  const response = await fetch(`${baseUrl}/api/traffic/${kind}/export${qs}`, {
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error('Export failed');
+  }
+
+  const blob = await response.blob();
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = kind === 'requests' ? `request-log.${format}` : `ip-rollup.${format}`;
+  document.body.appendChild(a);
+  a.click();
+  window.URL.revokeObjectURL(url);
+  document.body.removeChild(a);
+}


### PR DESCRIPTION
## Summary

Slice 2 of the bot-protection initiative (#383), building on the #389 observation seam: persist the bot-signal subset of what the application interceptor observes, expose it for review, and bound its growth.

Closes #390

### Backend

- **Request log store**: new `traffic_requests` + `traffic_ip_rollups` tables (migration `0034`). Only Unmatched requests are persisted (the schema and persister already accept `blocked` for #391); the rollup keeps per-IP request count, first/last seen, and capped sample paths/user-agents.
- **Persister**: `RequestLogService` subscribes to `TrafficEventsService.stream()` (per the #389 handoff — the middleware is untouched), buffers the non-matched subset with a 5k in-memory cap, and flushes batched inserts every 3s. A scanner storm degrades to dropped log rows, never unbounded memory or a write per request.
- **Bounded retention**: age window `TRAFFIC_LOG_RETENTION_DAYS` (default 14) plus hard row caps `TRAFFIC_LOG_MAX_ROWS` (100k) and `TRAFFIC_LOG_MAX_IPS` (50k). Enforced hourly by `TrafficRetentionScheduler` and re-checked inline every 5k inserts so a storm can't outrun the hourly prune. `TRAFFIC_LOG_ENABLED=false` disables persistence entirely.
- **Admin read API** on `api/traffic` (same guard stance as the SSE tail: `ApiKeyGuard` + `RolesGuard` + `@Roles('admin')`, concrete-file guard imports preserved):
  - `GET /api/traffic/requests` — filter by IP / path substring / status / classification / from / to, paginated
  - `GET /api/traffic/requests/export` — CSV/JSON attachment, same filters
  - `GET /api/traffic/ips` — per-IP rollup, sortable (worst offenders first by default)
  - `GET /api/traffic/ips/export` — CSV/JSON; the surface a future Cloudflare-IP feed consumes

### Frontend

- `/traffic` now has **Live / History / By IP** tabs (URL-driven, like UsersPage). Live is the existing tail unchanged.
- **History**: persisted records rendered as the same terminal-style access-log lines, with IP/path/status/time-range filters, pagination, and CSV/JSON export.
- **By IP**: rollup table (count, first/last seen, samples) with substring filter, sort, and export.
- New `trafficApi` RTK Query endpoints + fetch-blob download helper; new `TrafficRequest`/`TrafficIpRollup` cache tags.

### Acceptance criteria (from #390)

- [x] Unmatched requests persisted to an admin-global store (plain Postgres)
- [x] Retention window and row cap enforced; old/over-cap rows pruned
- [x] Per-IP rollup maintained (count, first/last seen, sample paths, sample UAs)
- [x] Traffic page shows History + Rollup views, admin-guarded
- [x] Admin read API supports filtering by IP/path/status/time and export
- [x] API seam tests cover the read API + rollup and retention/cap enforcement

## Test plan

- 35 backend traffic tests (persister mapping, rollup create/merge dedupe, retention + both row caps, admin-role metadata on every endpoint, CSV escaping, scheduler re-entrancy) — mirror the proxy-rule-sets db-mock seams
- 20 frontend traffic tests (tab switching, live tail unchanged, history lines + filters + pagination + export args, rollup table + defaults)
- Full suites green: backend 78/78 (1245 tests), frontend 24/24 (390 tests); both typechecks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKcWfgVZevHdobRQXzRqHA