### PR TITLE
feat(storage): edit provider credentials in place without migrating

### DIFF
--- a/apps/backend/src/setup/setup.controller.spec.ts
+++ b/apps/backend/src/setup/setup.controller.spec.ts
@@ -17,6 +17,7 @@ describe('SetupController', () => {
             getSetupStatus: jest.fn(),
             initialize: jest.fn(),
             configureStorage: jest.fn(),
+            updateStorageCredentials: jest.fn(),
             testStorageConnection: jest.fn(),
             completeSetup: jest.fn(),
           },

--- a/apps/backend/src/setup/setup.controller.ts
+++ b/apps/backend/src/setup/setup.controller.ts
@@ -243,6 +243,36 @@ export class SetupController {
     return this.setupService.configureStorage(dto);
   }
 
+  @Post('storage/credentials')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(SessionAuthGuard, RolesGuard)
+  @Roles('admin')
+  @ApiOperation({
+    summary: 'Update storage credentials in place',
+    description:
+      'Update the credentials / connection details for the CURRENT storage provider (e.g. rotate an ' +
+      'AWS access key) without migrating data. Admin only. Fields left out of the request keep their ' +
+      'existing value (so a secret can be left blank to preserve it). The new credentials are validated ' +
+      'with a live connection test before anything is saved, and provider changes are rejected — use ' +
+      'storage migration to switch providers.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Storage credentials updated successfully',
+    type: StorageConfigResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid credentials, connection test failed, or a provider change was attempted',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - Admin role required' })
+  async updateStorageCredentials(
+    @Body() dto: ConfigureStorageDto,
+  ): Promise<StorageConfigResponseDto> {
+    return this.setupService.updateStorageCredentials(dto);
+  }
+
   @Post('test-storage')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({

--- a/apps/backend/src/setup/setup.service.spec.ts
+++ b/apps/backend/src/setup/setup.service.spec.ts
@@ -13,6 +13,7 @@ describe('SetupService', () => {
             getSetupStatus: jest.fn(),
             initialize: jest.fn(),
             configureStorage: jest.fn(),
+            updateStorageCredentials: jest.fn(),
             testStorageConnection: jest.fn(),
             completeSetup: jest.fn(),
           },
@@ -51,6 +52,18 @@ describe('SetupService', () => {
       jest.spyOn(service, 'configureStorage').mockResolvedValue(mockResult as any);
 
       expect(service.configureStorage({} as any)).resolves.toEqual(mockResult);
+    });
+  });
+
+  describe('updateStorageCredentials', () => {
+    it('should update storage credentials in place', () => {
+      const mockResult = {
+        message: 'Storage credentials updated successfully',
+        storageProvider: 's3',
+      };
+      jest.spyOn(service, 'updateStorageCredentials').mockResolvedValue(mockResult as any);
+
+      expect(service.updateStorageCredentials({} as any)).resolves.toEqual(mockResult);
     });
   });
 });

--- a/apps/backend/src/setup/setup.service.ts
+++ b/apps/backend/src/setup/setup.service.ts
@@ -540,62 +540,9 @@ export class SetupService {
 
       this.logger.log(`Storage connection test passed for ${config.storageProvider}`);
 
-      // Swap the dynamic adapter to use the new storage configuration
-      // This allows the app to use the new storage without restarting
-      try {
-        // Prefer injected instance, fall back to moduleRef
-        let dynamicAdapter = this.dynamicStorageAdapter;
-        if (dynamicAdapter) {
-          this.logger.log(
-            `Using injected DynamicStorageAdapter [${dynamicAdapter.getInstanceId()}]`,
-          );
-        } else {
-          this.logger.log('No injected adapter, attempting moduleRef.get()...');
-          dynamicAdapter = this.moduleRef.get<DynamicStorageAdapter>(DYNAMIC_STORAGE_ADAPTER, {
-            strict: false,
-          });
-          this.logger.log(
-            `moduleRef.get() returned: ${dynamicAdapter ? 'instance' : 'null/undefined'}`,
-          );
-        }
-
-        if (dynamicAdapter) {
-          this.logger.log(
-            `Found DynamicStorageAdapter instance [${dynamicAdapter.getInstanceId()}], current adapter: ${dynamicAdapter.getAdapterType()}`,
-          );
-          const mappedConfig = await this.getStorageConfig();
-          // Add keyPrefix for workspace isolation (PaaS deployments)
-          const keyPrefix = this.getManagedStoragePrefix();
-          const configWithPrefix = keyPrefix ? { ...mappedConfig, keyPrefix } : mappedConfig;
-          // Managed storage uses S3 adapter under the hood
-          const effectiveStorageType =
-            config.storageProvider === StorageProvider.MANAGED ? 's3' : config.storageProvider;
-          let newAdapter = StorageModule.createAdapter({
-            storageType: effectiveStorageType as 'local' | 'minio' | 's3' | 'gcs' | 'azure',
-            config: configWithPrefix,
-          });
-
-          // Wrap with caching layer if cache adapter is available
-          const cacheConfig = await this.getCacheConfig();
-          if (this.cacheAdapter && cacheConfig.enabled !== false) {
-            this.logger.log('Wrapping storage adapter with caching layer');
-            newAdapter = new CachingStorageAdapter(newAdapter, this.cacheAdapter, cacheConfig);
-          }
-
-          dynamicAdapter.setAdapter(newAdapter);
-          this.logger.log(
-            `Storage adapter swapped to ${config.storageProvider} on instance [${dynamicAdapter.getInstanceId()}] (no restart needed)`,
-          );
-        } else {
-          this.logger.warn(
-            'DynamicStorageAdapter not available (null/undefined) - storage will be updated on next restart',
-          );
-        }
-      } catch (err) {
-        this.logger.error(`Failed to get DynamicStorageAdapter: ${err.message}`);
-        this.logger.error(err.stack);
-        this.logger.warn('Storage will be updated on next restart');
-      }
+      // Swap the dynamic adapter to use the (now persisted) storage configuration
+      // so the change takes effect without restarting.
+      await this.swapDynamicStorageAdapter();
 
       return {
         success: true,
@@ -608,6 +555,172 @@ export class SetupService {
         message: 'Storage connection test failed',
         error: error.message,
       };
+    }
+  }
+
+  /**
+   * Swap the runtime DynamicStorageAdapter to the currently-persisted storage
+   * configuration, so a credential/provider change takes effect without a restart.
+   *
+   * Best-effort: if the adapter can't be resolved, it logs and returns — the new
+   * config is already saved and will be picked up on the next restart.
+   */
+  private async swapDynamicStorageAdapter(): Promise<void> {
+    const config = await this.getSystemConfig();
+    if (!config || !config.storageProvider) {
+      this.logger.warn('Cannot swap storage adapter - storage is not configured');
+      return;
+    }
+
+    try {
+      // Prefer injected instance, fall back to moduleRef
+      let dynamicAdapter = this.dynamicStorageAdapter;
+      if (dynamicAdapter) {
+        this.logger.log(`Using injected DynamicStorageAdapter [${dynamicAdapter.getInstanceId()}]`);
+      } else {
+        this.logger.log('No injected adapter, attempting moduleRef.get()...');
+        dynamicAdapter = this.moduleRef.get<DynamicStorageAdapter>(DYNAMIC_STORAGE_ADAPTER, {
+          strict: false,
+        });
+        this.logger.log(
+          `moduleRef.get() returned: ${dynamicAdapter ? 'instance' : 'null/undefined'}`,
+        );
+      }
+
+      if (dynamicAdapter) {
+        this.logger.log(
+          `Found DynamicStorageAdapter instance [${dynamicAdapter.getInstanceId()}], current adapter: ${dynamicAdapter.getAdapterType()}`,
+        );
+        const mappedConfig = await this.getStorageConfig();
+        // Add keyPrefix for workspace isolation (PaaS deployments)
+        const keyPrefix = this.getManagedStoragePrefix();
+        const configWithPrefix = keyPrefix ? { ...mappedConfig, keyPrefix } : mappedConfig;
+        // Managed storage uses S3 adapter under the hood
+        const effectiveStorageType =
+          config.storageProvider === StorageProvider.MANAGED ? 's3' : config.storageProvider;
+        let newAdapter = StorageModule.createAdapter({
+          storageType: effectiveStorageType as 'local' | 'minio' | 's3' | 'gcs' | 'azure',
+          config: configWithPrefix,
+        });
+
+        // Wrap with caching layer if cache adapter is available
+        const cacheConfig = await this.getCacheConfig();
+        if (this.cacheAdapter && cacheConfig.enabled !== false) {
+          this.logger.log('Wrapping storage adapter with caching layer');
+          newAdapter = new CachingStorageAdapter(newAdapter, this.cacheAdapter, cacheConfig);
+        }
+
+        dynamicAdapter.setAdapter(newAdapter);
+        this.logger.log(
+          `Storage adapter swapped to ${config.storageProvider} on instance [${dynamicAdapter.getInstanceId()}] (no restart needed)`,
+        );
+      } else {
+        this.logger.warn(
+          'DynamicStorageAdapter not available (null/undefined) - storage will be updated on next restart',
+        );
+      }
+    } catch (err) {
+      this.logger.error(`Failed to get DynamicStorageAdapter: ${err.message}`);
+      this.logger.error(err.stack);
+      this.logger.warn('Storage will be updated on next restart');
+    }
+  }
+
+  /**
+   * Update the credentials / connection details for the CURRENT storage provider
+   * in place (e.g. rotating an AWS access key) without migrating any data.
+   *
+   * Unlike {@link configureStorage}, this is allowed *after* setup is complete, but
+   * it is deliberately restricted to the provider already in use — switching to a
+   * different provider still goes through the migration flow so files are copied first.
+   *
+   * Behaviour:
+   * - Merges the submitted fields over the existing config, so fields the caller
+   *   doesn't send (e.g. `forcePathStyle`, or an unchanged secret left blank) are
+   *   preserved rather than wiped.
+   * - Connection-tests the merged config BEFORE persisting, so a bad credential can
+   *   never lock the instance out of its own storage.
+   * - Hot-swaps the runtime adapter so the change applies without a restart.
+   */
+  async updateStorageCredentials(dto: ConfigureStorageDto): Promise<StorageConfigResponseDto> {
+    const config = await this.getSystemConfig();
+    if (!config || !config.storageProvider || !config.storageConfig) {
+      throw new BadRequestException(
+        'Storage is not configured yet. Complete setup before editing credentials.',
+      );
+    }
+
+    if (config.storageProvider === StorageProvider.MANAGED) {
+      throw new BadRequestException(
+        'Managed storage uses platform-provided credentials and cannot be edited here.',
+      );
+    }
+
+    if (dto.storageProvider !== config.storageProvider) {
+      throw new BadRequestException(
+        `Cannot change the storage provider here. This only updates credentials for the current ` +
+          `provider (${config.storageProvider}). To switch to ${dto.storageProvider}, use storage ` +
+          `migration so your files are copied to the new provider first.`,
+      );
+    }
+
+    // Merge new values over the existing config so untouched fields (and secrets
+    // left blank to keep the current value) are preserved.
+    let existingConfig: Record<string, unknown>;
+    try {
+      existingConfig = JSON.parse(this.decryptData(config.storageConfig));
+    } catch (error) {
+      this.logger.error('Error decrypting existing storage config:', error);
+      throw new InternalServerErrorException('Failed to read existing storage configuration');
+    }
+    const mergedConfig = {
+      ...existingConfig,
+      ...(dto.config as unknown as Record<string, unknown>),
+    };
+
+    // Validate the merged configuration for this provider
+    this.validateStorageConfig(dto.storageProvider, mergedConfig);
+
+    // Verify the new credentials actually work BEFORE persisting anything.
+    try {
+      const adapter = await this.createStorageAdapter(dto.storageProvider, mergedConfig);
+      const connected = await adapter.testConnection();
+      if (!connected) {
+        throw new BadRequestException(
+          'Could not connect to storage with the provided credentials. No changes were saved.',
+        );
+      }
+    } catch (error) {
+      if (error instanceof BadRequestException) throw error;
+      throw new BadRequestException(
+        `Could not connect to storage with the provided credentials: ${error.message}. ` +
+          'No changes were saved.',
+      );
+    }
+
+    try {
+      const encryptedConfig = this.encryptData(JSON.stringify(mergedConfig));
+      await db
+        .update(systemConfig)
+        .set({
+          storageConfig: encryptedConfig,
+          updatedAt: new Date(),
+        })
+        .where(eq(systemConfig.id, config.id));
+
+      this.logger.log(`Storage credentials updated for provider: ${dto.storageProvider}`);
+
+      // Apply the new credentials to the running app without a restart.
+      await this.swapDynamicStorageAdapter();
+
+      return {
+        message: 'Storage credentials updated successfully',
+        storageProvider: dto.storageProvider,
+      };
+    } catch (error) {
+      if (error instanceof BadRequestException) throw error;
+      this.logger.error('Error updating storage credentials:', error);
+      throw new InternalServerErrorException('Failed to update storage credentials');
     }
   }
 

--- a/apps/frontend/src/components/settings/StorageSettings.tsx
+++ b/apps/frontend/src/components/settings/StorageSettings.tsx
@@ -11,6 +11,8 @@ import {
 import { useGetMigrationJobQuery } from '@/services/migrationApi';
 import { MigrationWizard } from '@/components/storage/MigrationWizard';
 import { MigrationProgress } from '@/components/storage/MigrationProgress';
+import { EditStorageCredentials } from '@/components/storage/EditStorageCredentials';
+import type { StorageProvider } from '@/services/setupApi';
 import {
   Database,
   HardDrive,
@@ -22,6 +24,7 @@ import {
   Globe,
   AlertTriangle,
   Shield,
+  KeyRound,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 
@@ -54,6 +57,7 @@ const getProviderDisplayName = (
 
 export function StorageSettings() {
   const [showMigrationWizard, setShowMigrationWizard] = useState(false);
+  const [showEditCredentials, setShowEditCredentials] = useState(false);
   const { data: setupStatus, isLoading: isLoadingStatus } = useGetSetupStatusQuery();
   const { data: storageConfig, isLoading: isLoadingConfig } = useGetCurrentStorageConfigQuery();
   const { data: migrationJob } = useGetMigrationJobQuery();
@@ -82,6 +86,12 @@ export function StorageSettings() {
   };
 
   const canMigrate = getAvailableProviderCount() > 1;
+
+  // Credential editing applies only to providers that actually have credentials.
+  // Managed storage is platform-provided, and local filesystem has none.
+  const currentProviderRaw = setupStatus?.storageProvider;
+  const canEditCredentials =
+    !!currentProviderRaw && ['s3', 'minio', 'gcs', 'azure'].includes(currentProviderRaw);
 
   // Only poll when there's an active migration
   const hasMigrationInProgress =
@@ -146,6 +156,18 @@ export function StorageSettings() {
           />
         </CardContent>
       </Card>
+    );
+  }
+
+  // Show the edit-credentials panel if active
+  if (showEditCredentials) {
+    return (
+      <EditStorageCredentials
+        currentProvider={currentProvider as StorageProvider}
+        currentConfig={storageConfig}
+        onDone={() => setShowEditCredentials(false)}
+        onCancel={() => setShowEditCredentials(false)}
+      />
     );
   }
 
@@ -318,25 +340,44 @@ export function StorageSettings() {
           )}
         </div>
 
+        {/* Rotate credentials for the current provider (no data migration) */}
+        {canEditCredentials && (
+          <Alert>
+            <KeyRound className="h-4 w-4" />
+            <AlertDescription>
+              Rotated an access key or need to update your connection details? Edit the credentials
+              for your current provider in place — no data is moved.
+            </AlertDescription>
+          </Alert>
+        )}
+
         {/* Migration Info - only show if migration is possible */}
         {canMigrate && (
-          <>
-            <Alert>
-              <ArrowRightLeft className="h-4 w-4" />
-              <AlertDescription>
-                Need to switch storage providers? Use the migration wizard to safely copy all your
-                files to a new provider before switching.
-              </AlertDescription>
-            </Alert>
+          <Alert>
+            <ArrowRightLeft className="h-4 w-4" />
+            <AlertDescription>
+              Need to switch storage providers? Use the migration wizard to safely copy all your
+              files to a new provider before switching.
+            </AlertDescription>
+          </Alert>
+        )}
 
-            {/* Migration Button */}
-            <div className="flex justify-end">
+        {/* Actions */}
+        {(canEditCredentials || canMigrate) && (
+          <div className="flex justify-end gap-2">
+            {canEditCredentials && (
+              <Button variant="outline" onClick={() => setShowEditCredentials(true)}>
+                <KeyRound className="h-4 w-4 mr-2" />
+                Edit Credentials
+              </Button>
+            )}
+            {canMigrate && (
               <Button onClick={() => setShowMigrationWizard(true)}>
                 <ArrowRightLeft className="h-4 w-4 mr-2" />
                 Migrate Storage
               </Button>
-            </div>
-          </>
+            )}
+          </div>
         )}
       </CardContent>
     </Card>

--- a/apps/frontend/src/components/storage/EditStorageCredentials.tsx
+++ b/apps/frontend/src/components/storage/EditStorageCredentials.tsx
@@ -1,0 +1,453 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  useUpdateStorageCredentialsMutation,
+  type StorageProvider,
+  type StorageConfig,
+  type CurrentStorageConfigResponse,
+} from '@/services/setupApi';
+import { AlertTriangle, CheckCircle, KeyRound, Loader2 } from 'lucide-react';
+
+interface EditStorageCredentialsProps {
+  currentProvider: StorageProvider;
+  /** Non-sensitive current config used to pre-fill the form. */
+  currentConfig?: CurrentStorageConfigResponse;
+  onDone?: () => void;
+  onCancel?: () => void;
+}
+
+const AWS_REGIONS = [
+  'us-east-1',
+  'us-east-2',
+  'us-west-1',
+  'us-west-2',
+  'eu-west-1',
+  'eu-west-2',
+  'eu-west-3',
+  'eu-central-1',
+  'ap-northeast-1',
+  'ap-northeast-2',
+  'ap-southeast-1',
+  'ap-southeast-2',
+  'sa-east-1',
+  'ca-central-1',
+];
+
+const providerLabels: Record<string, string> = {
+  s3: 'S3 / S3-Compatible',
+  minio: 'MinIO',
+  gcs: 'Google Cloud Storage',
+  azure: 'Azure Blob Storage',
+  local: 'Local Filesystem',
+};
+
+export function EditStorageCredentials({
+  currentProvider,
+  currentConfig,
+  onDone,
+  onCancel,
+}: EditStorageCredentialsProps) {
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [updateCredentials, { isLoading }] = useUpdateStorageCredentialsMutation();
+
+  // S3 / S3-compatible ----------------------------------------------------
+  const s3IsCompatible = currentProvider === 's3' && !!currentConfig?.isS3Compatible;
+  const [s3Region, setS3Region] = useState(currentConfig?.region || 'us-east-1');
+  const [s3Endpoint, setS3Endpoint] = useState(currentConfig?.endpoint || '');
+  const [s3Bucket, setS3Bucket] = useState(currentConfig?.bucket || '');
+  const [s3AccessKeyId, setS3AccessKeyId] = useState('');
+  const [s3SecretAccessKey, setS3SecretAccessKey] = useState('');
+
+  // MinIO -----------------------------------------------------------------
+  const [minioEndpoint, setMinioEndpoint] = useState(currentConfig?.endpoint || '');
+  const [minioPort, setMinioPort] = useState<number>(currentConfig?.port ?? 9000);
+  const [minioBucket, setMinioBucket] = useState(currentConfig?.bucket || '');
+  const [minioAccessKey, setMinioAccessKey] = useState('');
+  const [minioSecretKey, setMinioSecretKey] = useState('');
+
+  // GCS -------------------------------------------------------------------
+  const [gcsProjectId, setGcsProjectId] = useState(currentConfig?.projectId || '');
+  const [gcsBucket, setGcsBucket] = useState(currentConfig?.bucket || '');
+  const [gcsCredentialsJson, setGcsCredentialsJson] = useState('');
+
+  // Azure -----------------------------------------------------------------
+  const [azureAccountName, setAzureAccountName] = useState(currentConfig?.accountName || '');
+  const [azureContainerName, setAzureContainerName] = useState(
+    currentConfig?.containerName || ''
+  );
+  const [azureAccountKey, setAzureAccountKey] = useState('');
+
+  // Local -----------------------------------------------------------------
+  const [localPath, setLocalPath] = useState(currentConfig?.localPath || './uploads');
+
+  const providerLabel = providerLabels[currentProvider] || currentProvider;
+
+  // Build the config payload. Secret fields left blank are omitted so the
+  // backend keeps the currently-stored value.
+  const buildConfig = (): { config: StorageConfig } | { error: string } => {
+    switch (currentProvider) {
+      case 's3': {
+        const config: Record<string, unknown> = { bucket: s3Bucket };
+        if (s3IsCompatible) {
+          config.endpoint = s3Endpoint;
+        } else {
+          config.region = s3Region;
+        }
+        if (s3AccessKeyId.trim()) config.accessKeyId = s3AccessKeyId.trim();
+        if (s3SecretAccessKey) config.secretAccessKey = s3SecretAccessKey;
+        return { config: config as unknown as StorageConfig };
+      }
+      case 'minio': {
+        const config: Record<string, unknown> = {
+          endpoint: minioEndpoint,
+          port: minioPort,
+          bucket: minioBucket,
+        };
+        if (minioAccessKey.trim()) config.accessKey = minioAccessKey.trim();
+        if (minioSecretKey) config.secretKey = minioSecretKey;
+        return { config: config as unknown as StorageConfig };
+      }
+      case 'gcs': {
+        const config: Record<string, unknown> = {
+          projectId: gcsProjectId,
+          bucket: gcsBucket,
+        };
+        if (gcsCredentialsJson.trim()) {
+          try {
+            config.credentials = JSON.parse(gcsCredentialsJson);
+          } catch {
+            return { error: 'Service Account JSON is not valid JSON.' };
+          }
+        }
+        return { config: config as unknown as StorageConfig };
+      }
+      case 'azure': {
+        const config: Record<string, unknown> = {
+          accountName: azureAccountName,
+          containerName: azureContainerName,
+        };
+        if (azureAccountKey) config.accountKey = azureAccountKey;
+        return { config: config as unknown as StorageConfig };
+      }
+      case 'local': {
+        return { config: { localPath } as unknown as StorageConfig };
+      }
+      default:
+        return { error: `Editing credentials for ${currentProvider} is not supported.` };
+    }
+  };
+
+  const handleSubmit = async () => {
+    setError(null);
+    const result = buildConfig();
+    if ('error' in result) {
+      setError(result.error);
+      return;
+    }
+    try {
+      await updateCredentials({
+        storageProvider: currentProvider,
+        config: result.config,
+      }).unwrap();
+      setSuccess(true);
+      // Give the user a moment to see the success state, then close.
+      setTimeout(() => onDone?.(), 1200);
+    } catch (err: unknown) {
+      const e = err as { data?: { message?: string } };
+      setError(e.data?.message || 'Failed to update storage credentials.');
+    }
+  };
+
+  const renderFields = () => {
+    switch (currentProvider) {
+      case 's3':
+        return (
+          <div className="space-y-4">
+            {s3IsCompatible ? (
+              <div className="space-y-2">
+                <Label htmlFor="editS3Endpoint">Endpoint *</Label>
+                <Input
+                  id="editS3Endpoint"
+                  value={s3Endpoint}
+                  onChange={(e) => setS3Endpoint(e.target.value)}
+                  placeholder="https://nyc3.digitaloceanspaces.com"
+                  className="font-mono text-sm"
+                />
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <Label htmlFor="editS3Region">AWS Region</Label>
+                <Select value={s3Region} onValueChange={setS3Region}>
+                  <SelectTrigger id="editS3Region">
+                    <SelectValue placeholder="Select region" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {AWS_REGIONS.map((r) => (
+                      <SelectItem key={r} value={r}>
+                        {r}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="editS3Bucket">Bucket Name *</Label>
+              <Input
+                id="editS3Bucket"
+                value={s3Bucket}
+                onChange={(e) => setS3Bucket(e.target.value)}
+                placeholder="my-deployment-assets"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="editS3AccessKey">Access Key ID</Label>
+              <Input
+                id="editS3AccessKey"
+                value={s3AccessKeyId}
+                onChange={(e) => setS3AccessKeyId(e.target.value)}
+                placeholder="Leave blank to keep current"
+                className="font-mono"
+                autoComplete="off"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="editS3SecretKey">Secret Access Key</Label>
+              <Input
+                id="editS3SecretKey"
+                type="password"
+                value={s3SecretAccessKey}
+                onChange={(e) => setS3SecretAccessKey(e.target.value)}
+                placeholder="Leave blank to keep current"
+                className="font-mono"
+                autoComplete="new-password"
+              />
+            </div>
+          </div>
+        );
+
+      case 'minio':
+        return (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="editMinioEndpoint">Endpoint *</Label>
+                <Input
+                  id="editMinioEndpoint"
+                  value={minioEndpoint}
+                  onChange={(e) => setMinioEndpoint(e.target.value)}
+                  placeholder="minio.example.com"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="editMinioPort">Port</Label>
+                <Input
+                  id="editMinioPort"
+                  type="number"
+                  value={minioPort}
+                  onChange={(e) => setMinioPort(parseInt(e.target.value) || 9000)}
+                  placeholder="9000"
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="editMinioBucket">Bucket Name *</Label>
+              <Input
+                id="editMinioBucket"
+                value={minioBucket}
+                onChange={(e) => setMinioBucket(e.target.value)}
+                placeholder="my-bucket"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="editMinioAccessKey">Access Key</Label>
+                <Input
+                  id="editMinioAccessKey"
+                  value={minioAccessKey}
+                  onChange={(e) => setMinioAccessKey(e.target.value)}
+                  placeholder="Leave blank to keep current"
+                  autoComplete="off"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="editMinioSecretKey">Secret Key</Label>
+                <Input
+                  id="editMinioSecretKey"
+                  type="password"
+                  value={minioSecretKey}
+                  onChange={(e) => setMinioSecretKey(e.target.value)}
+                  placeholder="Leave blank to keep current"
+                  autoComplete="new-password"
+                />
+              </div>
+            </div>
+          </div>
+        );
+
+      case 'gcs':
+        return (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="editGcsProject">Project ID *</Label>
+                <Input
+                  id="editGcsProject"
+                  value={gcsProjectId}
+                  onChange={(e) => setGcsProjectId(e.target.value)}
+                  placeholder="my-project-123"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="editGcsBucket">Bucket Name *</Label>
+                <Input
+                  id="editGcsBucket"
+                  value={gcsBucket}
+                  onChange={(e) => setGcsBucket(e.target.value)}
+                  placeholder="my-bucket"
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="editGcsCredentials">Service Account JSON</Label>
+              <Textarea
+                id="editGcsCredentials"
+                value={gcsCredentialsJson}
+                onChange={(e) => setGcsCredentialsJson(e.target.value)}
+                placeholder="Leave blank to keep current credentials"
+                className="font-mono text-xs h-32"
+              />
+            </div>
+          </div>
+        );
+
+      case 'azure':
+        return (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="editAzureAccount">Account Name *</Label>
+                <Input
+                  id="editAzureAccount"
+                  value={azureAccountName}
+                  onChange={(e) => setAzureAccountName(e.target.value)}
+                  placeholder="mystorageaccount"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="editAzureContainer">Container Name *</Label>
+                <Input
+                  id="editAzureContainer"
+                  value={azureContainerName}
+                  onChange={(e) => setAzureContainerName(e.target.value)}
+                  placeholder="my-container"
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="editAzureKey">Account Key</Label>
+              <Input
+                id="editAzureKey"
+                type="password"
+                value={azureAccountKey}
+                onChange={(e) => setAzureAccountKey(e.target.value)}
+                placeholder="Leave blank to keep current"
+                autoComplete="new-password"
+              />
+            </div>
+          </div>
+        );
+
+      case 'local':
+        return (
+          <div className="space-y-2">
+            <Label htmlFor="editLocalPath">Storage Path *</Label>
+            <Input
+              id="editLocalPath"
+              value={localPath}
+              onChange={(e) => setLocalPath(e.target.value)}
+              placeholder="./uploads"
+            />
+            <p className="text-xs text-muted-foreground">
+              Path relative to the backend working directory
+            </p>
+          </div>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <KeyRound className="h-5 w-5" />
+          Edit {providerLabel} Credentials
+        </CardTitle>
+        <CardDescription>
+          Update the connection details for your current storage provider — for example, rotating an
+          access key — without migrating any files.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <Alert>
+          <KeyRound className="h-4 w-4" />
+          <AlertDescription>
+            Leave secret fields blank to keep the current value. Your new credentials are verified
+            with a live connection test before anything is saved, so a bad key can&apos;t lock you
+            out of your storage.
+          </AlertDescription>
+        </Alert>
+
+        {renderFields()}
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {success && (
+          <Alert className="bg-green-500/10 border-green-500/20">
+            <CheckCircle className="h-4 w-4 text-green-500" />
+            <AlertDescription className="text-green-700 dark:text-green-400">
+              Storage credentials updated successfully.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <div className="flex justify-between">
+          <Button variant="outline" onClick={onCancel} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={isLoading || success}>
+            {isLoading ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Verifying &amp; saving...
+              </>
+            ) : (
+              'Test & Save'
+            )}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/services/setupApi.ts
+++ b/apps/frontend/src/services/setupApi.ts
@@ -537,6 +537,16 @@ export const setupApi = api.injectEndpoints({
       invalidatesTags: ['Setup'],
     }),
 
+    // Update credentials for the current storage provider in place (no migration)
+    updateStorageCredentials: builder.mutation<StorageConfigResponse, ConfigureStorageRequest>({
+      query: (body) => ({
+        url: '/api/setup/storage/credentials',
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: ['Setup'],
+    }),
+
     // Test storage connection
     testStorage: builder.mutation<TestStorageResponse, void>({
       query: () => ({
@@ -712,6 +722,7 @@ export const {
   useAdoptExistingUserMutation,
   useAdoptSessionUserMutation,
   useConfigureStorageMutation,
+  useUpdateStorageCredentialsMutation,
   useTestStorageMutation,
   useGetEnvStorageConfigQuery,
   useGetCurrentStorageConfigQuery,


### PR DESCRIPTION
## Problem

There was no way to rotate storage credentials from the admin UI. Storage config is locked after setup completes (`configureStorage` throws `Cannot modify storage configuration after setup is complete`), so the **only** path to change an access key was the **Migrate Storage** flow — which copies every object to a "new" provider. For a simple secret-key rotation on the *same* bucket, that's heavyweight and semantically wrong.

Reported from the Infrastructure settings page (`/admin/settings/infrastructure`) while rotating an AWS secret access key.

## What this adds

An **Edit Credentials** action on the Infrastructure page that updates the connection details for the **current** provider *in place*, no data migration.

### Backend
- New admin-guarded endpoint **`POST /api/setup/storage/credentials`** → `SetupService.updateStorageCredentials()`.
- **Merge semantics**: submitted fields are merged over the existing decrypted config, so fields the form doesn't send — `forcePathStyle`, `presignedUrlExpiration`, or a secret left blank — keep their current value. Leave a secret blank to preserve it.
- **Test-before-persist**: the merged config is connection-tested (`adapter.testConnection()`) *before* anything is written, so a bad credential can never lock the instance out of its own storage. Nothing is saved on failure.
- **Hot-swap**: on success the runtime `DynamicStorageAdapter` is swapped so the change applies without a restart.
- **Guardrails**: provider changes are rejected with a message pointing to migration; **managed** storage (platform-provided credentials) is not editable here.
- Refactor: extracted the adapter-swap block out of `testStorageConnection()` into a shared `swapDynamicStorageAdapter()` helper (no behavior change to the existing test flow).

### Frontend
- `EditStorageCredentials` panel supporting S3 / S3-compatible, MinIO, GCS, and Azure (and local path), pre-filled from the non-sensitive `storage/current` config; secret fields default to blank = "keep current".
- `updateStorageCredentials` RTK Query mutation; "Edit Credentials" button on the storage card (shown for credential-bearing providers only).

## Why not just reuse `force-switch`?

The migration controller's `force-switch` already persists + swaps without copying, but it's framed as a "recovery path" for unreachable storage, requires re-entering the full config, and allows provider changes. This endpoint is purpose-built for in-place credential edits: same-provider only, merge-preserving, and validated before write.

## Testing
- `pnpm --filter backend exec tsc --noEmit` ✅
- `pnpm --filter frontend exec tsc --noEmit` ✅
- `pnpm test -- setup.service.spec setup.controller.spec` ✅ (8 passed)
- ESLint clean on changed files (2 pre-existing `no-empty-object-type` config warnings in `setupApi.ts` are unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)