### PR TITLE
feat(traffic): blocklist library, baseline + app-side enforcement (#391)

### DIFF
--- a/apps/backend/drizzle/0035_lying_shooting_star.sql
+++ b/apps/backend/drizzle/0035_lying_shooting_star.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "blocklist_entries" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"blocklist_id" uuid NOT NULL,
+	"kind" varchar(10) DEFAULT 'block' NOT NULL,
+	"match_type" varchar(20) DEFAULT 'prefix' NOT NULL,
+	"value" varchar(512) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "blocklists" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"description" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "blocklist_entries" ADD CONSTRAINT "blocklist_entries_blocklist_id_blocklists_id_fk" FOREIGN KEY ("blocklist_id") REFERENCES "public"."blocklists"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "blocklist_entries_blocklist_id_idx" ON "blocklist_entries" USING btree ("blocklist_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "blocklist_entries_unique" ON "blocklist_entries" USING btree ("blocklist_id","kind","match_type","value");--> statement-breakpoint
+CREATE UNIQUE INDEX "blocklists_name_unique" ON "blocklists" USING btree ("name");

--- a/apps/backend/drizzle/meta/0035_snapshot.json
+++ b/apps/backend/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,6690 @@
+{
+  "id": "952d7ffa-f0e4-402f-af59-c30eae4fa678",
+  "prevId": "1872d282-ecfd-4af5-83a5-6891f4229c69",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alias_proxy_rule_sets": {
+      "name": "alias_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alias_proxy_rule_sets_alias_ruleset_unique": {
+          "name": "alias_proxy_rule_sets_alias_ruleset_unique",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_alias_id_idx": {
+          "name": "alias_proxy_rule_sets_alias_id_idx",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_rule_set_id_idx": {
+          "name": "alias_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk": {
+          "name": "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "deployment_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_project_id_idx": {
+          "name": "api_keys_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_path": {
+          "name": "original_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_number": {
+          "name": "workflow_run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'commits'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_project_id_idx": {
+          "name": "assets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_type_idx": {
+          "name": "assets_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_path_idx": {
+          "name": "assets_project_commit_path_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_branch_idx": {
+          "name": "assets_project_branch_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_idx": {
+          "name": "assets_project_commit_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_created_at_idx": {
+          "name": "assets_project_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_committed_at_idx": {
+          "name": "assets_project_committed_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_path_idx": {
+          "name": "assets_deployment_path_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_id_idx": {
+          "name": "assets_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_size_idx": {
+          "name": "assets_deployment_size_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_uploaded_by_users_id_fk": {
+          "name": "assets_uploaded_by_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist_entries": {
+      "name": "blocklist_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prefix'"
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklist_entries_blocklist_id_idx": {
+          "name": "blocklist_entries_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocklist_entries_unique": {
+          "name": "blocklist_entries_unique",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocklist_entries_blocklist_id_blocklists_id_fk": {
+          "name": "blocklist_entries_blocklist_id_blocklists_id_fk",
+          "tableFrom": "blocklist_entries",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklists": {
+      "name": "blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklists_name_unique": {
+          "name": "blocklists_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cache_rules": {
+      "name": "cache_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_max_age": {
+          "name": "browser_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "cdn_max_age": {
+          "name": "cdn_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stale_while_revalidate": {
+          "name": "stale_while_revalidate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immutable": {
+          "name": "immutable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cacheability": {
+          "name": "cacheability",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cache_rules_project_pattern_unique": {
+          "name": "cache_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_id_idx": {
+          "name": "cache_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_priority_idx": {
+          "name": "cache_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cache_rules_project_id_projects_id_fk": {
+          "name": "cache_rules_project_id_projects_id_fk",
+          "tableFrom": "cache_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_aliases": {
+      "name": "deployment_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_preview": {
+          "name": "is_auto_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployment_aliases_project_alias_unique": {
+          "name": "deployment_aliases_project_alias_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_project_id_idx": {
+          "name": "deployment_aliases_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_alias_unique": {
+          "name": "deployment_aliases_repository_alias_unique",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_idx": {
+          "name": "deployment_aliases_repository_idx",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_commit_sha_idx": {
+          "name": "deployment_aliases_commit_sha_idx",
+          "columns": [
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_deployment_id_idx": {
+          "name": "deployment_aliases_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_aliases_project_id_projects_id_fk": {
+          "name": "deployment_aliases_project_id_projects_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_mappings": {
+      "name": "domain_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_type": {
+          "name": "domain_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ssl_expires_at": {
+          "name": "ssl_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_verified": {
+          "name": "dns_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dns_verified_at": {
+          "name": "dns_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_renew_ssl": {
+          "name": "auto_renew_ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_renewed_at": {
+          "name": "ssl_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_status": {
+          "name": "ssl_renewal_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_error": {
+          "name": "ssl_renewal_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sticky_sessions_enabled": {
+          "name": "sticky_sessions_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sticky_session_duration": {
+          "name": "sticky_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 86400
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_mappings_project_id_idx": {
+          "name": "domain_mappings_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_domain_idx": {
+          "name": "domain_mappings_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_is_active_idx": {
+          "name": "domain_mappings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_mappings_project_id_projects_id_fk": {
+          "name": "domain_mappings_project_id_projects_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_mappings_created_by_users_id_fk": {
+          "name": "domain_mappings_created_by_users_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_mappings_domain_unique": {
+          "name": "domain_mappings_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_redirects": {
+      "name": "domain_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_domain": {
+          "name": "source_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_domain_id": {
+          "name": "target_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_redirects_target_domain_id_idx": {
+          "name": "domain_redirects_target_domain_id_idx",
+          "columns": [
+            {
+              "expression": "target_domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_redirects_source_domain_idx": {
+          "name": "domain_redirects_source_domain_idx",
+          "columns": [
+            {
+              "expression": "source_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_redirects_target_domain_id_domain_mappings_id_fk": {
+          "name": "domain_redirects_target_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "target_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_redirects_created_by_users_id_fk": {
+          "name": "domain_redirects_created_by_users_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_redirects_source_domain_unique": {
+          "name": "domain_redirects_source_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_rules": {
+      "name": "domain_traffic_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_key": {
+          "name": "condition_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_value": {
+          "name": "condition_value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_rules_domain_id_idx": {
+          "name": "domain_traffic_rules_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_traffic_rules_domain_id_priority_idx": {
+          "name": "domain_traffic_rules_domain_id_priority_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_rules_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_rules_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_rules",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_weights": {
+      "name": "domain_traffic_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_weights_domain_id_idx": {
+          "name": "domain_traffic_weights_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_weights_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_weights_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_weights",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_traffic_weights_domain_alias_unique": {
+          "name": "domain_traffic_weights_domain_alias_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain_id",
+            "alias"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flags_key_idx": {
+          "name": "feature_flags_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_integration_credentials": {
+      "name": "google_integration_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured": {
+          "name": "configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "google_integration_credentials_service_unique": {
+          "name": "google_integration_credentials_service_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oidc_providers_provider_id_unique": {
+          "name": "oidc_providers_provider_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rule_executions": {
+      "name": "onboarding_rule_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rule_executions_user_idx": {
+          "name": "onboarding_rule_executions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_rule_idx": {
+          "name": "onboarding_rule_executions_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_executed_at_idx": {
+          "name": "onboarding_rule_executions_executed_at_idx",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_status_idx": {
+          "name": "onboarding_rule_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rule_executions_rule_id_onboarding_rules_id_fk": {
+          "name": "onboarding_rule_executions_rule_id_onboarding_rules_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "onboarding_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "onboarding_rule_executions_user_id_users_id_fk": {
+          "name": "onboarding_rule_executions_user_id_users_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rules": {
+      "name": "onboarding_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_signup'"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rules_enabled_trigger_idx": {
+          "name": "onboarding_rules_enabled_trigger_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rules_priority_idx": {
+          "name": "onboarding_rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rules_created_by_users_id_fk": {
+          "name": "onboarding_rules_created_by_users_id_fk",
+          "tableFrom": "onboarding_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_preferences": {
+      "name": "path_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spa_mode": {
+          "name": "spa_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_path_preferences_project_id": {
+          "name": "idx_path_preferences_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_preferences_project_id_projects_id_fk": {
+          "name": "path_preferences_project_id_projects_id_fk",
+          "tableFrom": "path_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "path_preferences_project_filepath_unique": {
+          "name": "path_preferences_project_filepath_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "filepath"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_redirects": {
+      "name": "path_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'100'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "path_redirects_domain_mapping_id_idx": {
+          "name": "path_redirects_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "path_redirects_source_path_idx": {
+          "name": "path_redirects_source_path_idx",
+          "columns": [
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_redirects_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "path_redirects_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "path_redirects_created_by_users_id_fk": {
+          "name": "path_redirects_created_by_users_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_token": {
+          "name": "upload_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_token_idx": {
+          "name": "pending_uploads_token_idx",
+          "columns": [
+            {
+              "expression": "upload_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_project_idx": {
+          "name": "pending_uploads_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_project_id_projects_id_fk": {
+          "name": "pending_uploads_project_id_projects_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_uploaded_by_users_id_fk": {
+          "name": "pending_uploads_uploaded_by_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_uploads_upload_token_unique": {
+          "name": "pending_uploads_upload_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data_embeddings": {
+      "name": "pipeline_data_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_data_id": {
+          "name": "pipeline_data_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_embeddings_data_id_idx": {
+          "name": "pipeline_data_embeddings_data_id_idx",
+          "columns": [
+            {
+              "expression": "pipeline_data_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_embeddings_schema_field_idx": {
+          "name": "pipeline_data_embeddings_schema_field_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk": {
+          "name": "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_data",
+          "columnsFrom": [
+            "pipeline_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data": {
+      "name": "pipeline_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_project_id_idx": {
+          "name": "pipeline_data_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_schema_id_idx": {
+          "name": "pipeline_data_schema_id_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_created_at_idx": {
+          "name": "pipeline_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_project_id_projects_id_fk": {
+          "name": "pipeline_data_project_id_projects_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_created_by_users_id_fk": {
+          "name": "pipeline_data_created_by_users_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_execution_logs": {
+      "name": "pipeline_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_id": {
+          "name": "proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps_count": {
+          "name": "steps_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_step": {
+          "name": "error_step",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_meta": {
+          "name": "request_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_exec_logs_rule_created_idx": {
+          "name": "pipeline_exec_logs_rule_created_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_project_idx": {
+          "name": "pipeline_exec_logs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_created_idx": {
+          "name": "pipeline_exec_logs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_execution_logs_project_id_projects_id_fk": {
+          "name": "pipeline_execution_logs_project_id_projects_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schemas": {
+      "name": "pipeline_schemas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schemas_project_id_idx": {
+          "name": "pipeline_schemas_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schemas_project_id_projects_id_fk": {
+          "name": "pipeline_schemas_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schemas",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pipeline_schemas_project_name_unique": {
+          "name": "pipeline_schemas_project_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.primary_content": {
+      "name": "primary_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "www_enabled": {
+          "name": "www_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'redirect-to-www'"
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "primary_content_project_id_projects_id_fk": {
+          "name": "primary_content_project_id_projects_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "primary_content_configured_by_users_id_fk": {
+          "name": "primary_content_configured_by_users_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_default_proxy_rule_sets": {
+      "name": "project_default_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_default_proxy_rule_sets_project_ruleset_unique": {
+          "name": "project_default_proxy_rule_sets_project_ruleset_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_project_id_idx": {
+          "name": "project_default_proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_rule_set_id_idx": {
+          "name": "project_default_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_default_proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "project_default_proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite_links": {
+      "name": "project_invite_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guest'"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invite_links_project_id_idx": {
+          "name": "project_invite_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_token_idx": {
+          "name": "project_invite_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_is_active_idx": {
+          "name": "project_invite_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_links_project_id_projects_id_fk": {
+          "name": "project_invite_links_project_id_projects_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_links_created_by_users_id_fk": {
+          "name": "project_invite_links_created_by_users_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_links_token_unique": {
+          "name": "project_invite_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_group_permissions": {
+      "name": "project_group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_group_permissions_project_idx": {
+          "name": "project_group_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_permissions_group_idx": {
+          "name": "project_group_permissions_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_permissions_project_id_projects_id_fk": {
+          "name": "project_group_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_group_id_user_groups_id_fk": {
+          "name": "project_group_permissions_group_id_user_groups_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_granted_by_users_id_fk": {
+          "name": "project_group_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_group_permissions_unique": {
+          "name": "project_group_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "group_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_permissions": {
+      "name": "project_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_permissions_project_idx": {
+          "name": "project_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_permissions_user_idx": {
+          "name": "project_permissions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_permissions_project_id_projects_id_fk": {
+          "name": "project_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_user_id_users_id_fk": {
+          "name": "project_permissions_user_id_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_granted_by_users_id_fk": {
+          "name": "project_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_permissions_unique": {
+          "name": "project_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_secrets": {
+      "name": "project_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_secrets_project_name_unique": {
+          "name": "project_secrets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_secrets_project_id_idx": {
+          "name": "project_secrets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_secrets_project_id_projects_id_fk": {
+          "name": "project_secrets_project_id_projects_id_fk",
+          "tableFrom": "project_secrets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_found'"
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authenticated'"
+        },
+        "allow_public_signup": {
+          "name": "allow_public_signup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_providers": {
+          "name": "ai_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_services": {
+          "name": "ai_services",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_proxy_rule_set_id": {
+          "name": "default_proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_created_by_idx": {
+          "name": "projects_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_owner_idx": {
+          "name": "projects_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_owner_name_unique": {
+          "name": "projects_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_sets": {
+      "name": "proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_sets_project_name_unique": {
+          "name": "proxy_rule_sets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_project_id_idx": {
+          "name": "proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_environment_idx": {
+          "name": "proxy_rule_sets_environment_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rules": {
+      "name": "proxy_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "methods": {
+          "name": "methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strip_prefix": {
+          "name": "strip_prefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "preserve_host": {
+          "name": "preserve_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forward_cookies": {
+          "name": "forward_cookies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "header_config": {
+          "name": "header_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_transform": {
+          "name": "auth_transform",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_rewrite": {
+          "name": "internal_rewrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proxy_type": {
+          "name": "proxy_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external_proxy'"
+        },
+        "email_handler_config": {
+          "name": "email_handler_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "debug_enabled": {
+          "name": "debug_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rules_rule_set_path_method_unique": {
+          "name": "proxy_rules_rule_set_path_method_unique",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_id_idx": {
+          "name": "proxy_rules_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_order_idx": {
+          "name": "proxy_rules_rule_set_order_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_proxy_type_idx": {
+          "name": "proxy_rules_proxy_type_idx",
+          "columns": [
+            {
+              "expression": "proxy_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rules_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rules_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rules",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_header_rules": {
+      "name": "response_header_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_policy": {
+          "name": "frame_policy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sameorigin'"
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_header_rules_project_pattern_unique": {
+          "name": "response_header_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_id_idx": {
+          "name": "response_header_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_priority_idx": {
+          "name": "response_header_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "response_header_rules_project_id_projects_id_fk": {
+          "name": "response_header_rules_project_id_projects_id_fk",
+          "tableFrom": "response_header_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_logs": {
+      "name": "retention_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_count": {
+          "name": "asset_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "freed_bytes": {
+          "name": "freed_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_partial": {
+          "name": "is_partial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_logs_project_id_idx": {
+          "name": "retention_logs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_rule_id_idx": {
+          "name": "retention_logs_rule_id_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_deleted_at_idx": {
+          "name": "retention_logs_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_project_deleted_at_idx": {
+          "name": "retention_logs_project_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_logs_project_id_projects_id_fk": {
+          "name": "retention_logs_project_id_projects_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retention_logs_rule_id_retention_rules_id_fk": {
+          "name": "retention_logs_rule_id_retention_rules_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "retention_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_rules": {
+      "name": "retention_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_pattern": {
+          "name": "branch_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_branches": {
+          "name": "exclude_branches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keep_with_alias": {
+          "name": "keep_with_alias",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "keep_minimum": {
+          "name": "keep_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "path_patterns": {
+          "name": "path_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_mode": {
+          "name": "path_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_summary": {
+          "name": "last_run_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_rules_project_id_idx": {
+          "name": "retention_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_next_run_idx": {
+          "name": "retention_rules_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_enabled_next_run_idx": {
+          "name": "retention_rules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_rules_project_id_projects_id_fk": {
+          "name": "retention_rules_project_id_projects_id_fk",
+          "tableFrom": "retention_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "share_links_project_id_idx": {
+          "name": "share_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_domain_mapping_id_idx": {
+          "name": "share_links_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_token_idx": {
+          "name": "share_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_is_active_idx": {
+          "name": "share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_project_id_projects_id_fk": {
+          "name": "share_links_project_id_projects_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "share_links_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_created_by_users_id_fk": {
+          "name": "share_links_created_by_users_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "share_links_token_unique": {
+          "name": "share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_challenges": {
+      "name": "ssl_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "base_domain": {
+          "name": "base_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_type": {
+          "name": "challenge_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_name": {
+          "name": "record_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_value": {
+          "name": "record_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_data": {
+          "name": "order_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authz_data": {
+          "name": "authz_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_authorization": {
+          "name": "key_authorization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_challenges_base_domain_idx": {
+          "name": "ssl_challenges_base_domain_idx",
+          "columns": [
+            {
+              "expression": "base_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_challenges_status_idx": {
+          "name": "ssl_challenges_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ssl_challenges_base_domain_unique": {
+          "name": "ssl_challenges_base_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "base_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_renewal_history": {
+      "name": "ssl_renewal_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_type": {
+          "name": "certificate_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_expires_at": {
+          "name": "new_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_renewal_history_domain_id_idx": {
+          "name": "ssl_renewal_history_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_renewal_history_created_at_idx": {
+          "name": "ssl_renewal_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssl_renewal_history_domain_id_domain_mappings_id_fk": {
+          "name": "ssl_renewal_history_domain_id_domain_mappings_id_fk",
+          "tableFrom": "ssl_renewal_history",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_settings": {
+      "name": "ssl_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_config": {
+      "name": "system_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_setup_complete": {
+          "name": "is_setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_config": {
+          "name": "storage_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_provider": {
+          "name": "email_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_config": {
+          "name": "email_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_configured": {
+          "name": "email_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "smtp_config": {
+          "name": "smtp_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_configured": {
+          "name": "smtp_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_config": {
+          "name": "cache_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwt_secret": {
+          "name": "jwt_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_salt": {
+          "name": "api_key_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_public_signups": {
+          "name": "allow_public_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "telemetry_enabled": {
+          "name": "telemetry_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "telemetry_last_sent": {
+          "name": "telemetry_last_sent",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_config": {
+          "name": "branding_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_ip_rollups": {
+      "name": "traffic_ip_rollups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_paths": {
+          "name": "sample_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "sample_user_agents": {
+          "name": "sample_user_agents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_ip_rollups_ip_unique": {
+          "name": "traffic_ip_rollups_ip_unique",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_request_count_idx": {
+          "name": "traffic_ip_rollups_request_count_idx",
+          "columns": [
+            {
+              "expression": "request_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_last_seen_idx": {
+          "name": "traffic_ip_rollups_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_requests": {
+      "name": "traffic_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_version": {
+          "name": "http_version",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referer": {
+          "name": "referer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_requests_timestamp_idx": {
+          "name": "traffic_requests_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_ip_idx": {
+          "name": "traffic_requests_ip_idx",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_status_idx": {
+          "name": "traffic_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_classification_idx": {
+          "name": "traffic_requests_classification_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_group_members": {
+      "name": "user_group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_members_group_idx": {
+          "name": "user_group_members_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_group_members_user_idx": {
+          "name": "user_group_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_group_members_group_id_user_groups_id_fk": {
+          "name": "user_group_members_group_id_user_groups_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_user_id_users_id_fk": {
+          "name": "user_group_members_user_id_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_added_by_users_id_fk": {
+          "name": "user_group_members_added_by_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_group_members_unique": {
+          "name": "user_group_members_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_groups_created_by_idx": {
+          "name": "user_groups_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_created_by_users_id_fk": {
+          "name": "user_groups_created_by_users_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_verified_at": {
+          "name": "oidc_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_invitations_email": {
+          "name": "idx_workspace_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_invitations_token": {
+          "name": "idx_workspace_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invitations_invited_by_users_id_fk": {
+          "name": "workspace_invitations_invited_by_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_accepted_user_id_users_id_fk": {
+          "name": "workspace_invitations_accepted_user_id_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitations_token_unique": {
+          "name": "workspace_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1782993567563,
       "tag": "0034_shiny_sandman",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1783015226726,
+      "tag": "0035_lying_shooting_star",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema/blocklists.schema.ts
+++ b/apps/backend/src/db/schema/blocklists.schema.ts
@@ -1,0 +1,91 @@
+import { relations } from 'drizzle-orm';
+import { pgTable, uuid, varchar, text, timestamp, uniqueIndex, index } from 'drizzle-orm/pg-core';
+
+/**
+ * Blocklists (issue #383/#391): the admin-global library of named bot/scanner
+ * blocklists, per ADR-0002. Each Blocklist owns custom path patterns plus its
+ * own allowlist of exceptions that always win (both stored in
+ * blocklist_entries, discriminated by `kind`).
+ *
+ * Blocklists are admin-global (not project-scoped): they curate instance-wide
+ * bot protection. Attachment to specific domains arrives with #393; the
+ * code-shipped Baseline (see traffic/blocklist-baseline.ts) is NOT one of
+ * these rows — it ships as code and improves on upgrade.
+ */
+export const blocklists = pgTable(
+  'blocklists',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    /** Human-readable name, unique across the instance (the library is admin-global). */
+    name: varchar('name', { length: 255 }).notNull(),
+
+    description: text('description'),
+
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  },
+  (table) => [uniqueIndex('blocklists_name_unique').on(table.name)],
+);
+
+/**
+ * A single structured pattern belonging to a Blocklist.
+ *
+ * Patterns are stored structured — never as raw regex or nginx config — so the
+ * compiler (traffic/blocklist-compiler.ts) is the only thing that ever turns
+ * admin input into matching rules. `value` is validated against a strict path
+ * charset before insert; see validateBlocklistValue.
+ */
+export const blocklistEntries = pgTable(
+  'blocklist_entries',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    blocklistId: uuid('blocklist_id')
+      .references(() => blocklists.id, { onDelete: 'cascade' })
+      .notNull(),
+
+    /**
+     * block: the pattern refuses matching requests.
+     * allow: the pattern is an exception that always wins over any block
+     *        pattern (including the Baseline's) — the false-positive rescue.
+     */
+    kind: varchar('kind', { length: 10 }).$type<'block' | 'allow'>().notNull().default('block'),
+
+    /** How `value` matches the request path (see BlocklistMatchType). */
+    matchType: varchar('match_type', { length: 20 })
+      .$type<'prefix' | 'exact' | 'suffix' | 'extension' | 'contains'>()
+      .notNull()
+      .default('prefix'),
+
+    value: varchar('value', { length: 512 }).notNull(),
+
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+  },
+  (table) => [
+    index('blocklist_entries_blocklist_id_idx').on(table.blocklistId),
+    // The same pattern twice in one list is a no-op; keep the data clean.
+    uniqueIndex('blocklist_entries_unique').on(
+      table.blocklistId,
+      table.kind,
+      table.matchType,
+      table.value,
+    ),
+  ],
+);
+
+export const blocklistsRelations = relations(blocklists, ({ many }) => ({
+  entries: many(blocklistEntries),
+}));
+
+export const blocklistEntriesRelations = relations(blocklistEntries, ({ one }) => ({
+  blocklist: one(blocklists, {
+    fields: [blocklistEntries.blocklistId],
+    references: [blocklists.id],
+  }),
+}));
+
+export type Blocklist = typeof blocklists.$inferSelect;
+export type NewBlocklist = typeof blocklists.$inferInsert;
+export type BlocklistEntry = typeof blocklistEntries.$inferSelect;
+export type NewBlocklistEntry = typeof blocklistEntries.$inferInsert;

--- a/apps/backend/src/db/schema/index.ts
+++ b/apps/backend/src/db/schema/index.ts
@@ -40,3 +40,4 @@ export * from './oidc-providers.schema';
 export * from './google-integration-credentials.schema';
 export * from './traffic-requests.schema';
 export * from './traffic-ip-rollups.schema';
+export * from './blocklists.schema';

--- a/apps/backend/src/feature-flags/feature-flags.definitions.ts
+++ b/apps/backend/src/feature-flags/feature-flags.definitions.ts
@@ -519,6 +519,19 @@ export const FLAG_DEFINITIONS: Record<string, FlagDefinition> = {
     description: 'Enable traffic analytics dashboard',
     category: 'experimental',
   },
+
+  // ==========================================================================
+  // Bot Protection (issue #383/#391)
+  // ==========================================================================
+
+  BOT_PROTECTION_ENABLED: {
+    envKey: 'BOT_PROTECTION_ENABLED',
+    defaultValue: true,
+    type: 'boolean',
+    description:
+      'Master toggle for bot protection: when off, no Blocklist (Baseline or named lists) blocks anything, instantly.',
+    category: 'features',
+  },
 };
 
 /**

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -6,6 +6,7 @@ import cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
 import { createTrafficObserver } from './traffic/traffic-observer.middleware';
 import { TrafficEventsService } from './traffic/traffic-events.service';
+import { BlocklistService } from './traffic/blocklist.service';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -13,10 +14,12 @@ async function bootstrap() {
     rawBody: true, // Needed for Stripe webhook signature verification
   });
 
-  // Traffic observation seam (ADR-0003): registered with app.use() so it sits
-  // above ALL Nest module middleware and observes every request that reaches
-  // the app — including ones ProxyMiddleware short-circuits before a controller.
-  app.use(createTrafficObserver(app.get(TrafficEventsService)));
+  // Traffic observation + Blocklist enforcement seam (ADR-0003): registered
+  // with app.use() so it sits above ALL Nest module middleware and observes
+  // every request that reaches the app — including ones ProxyMiddleware
+  // short-circuits before a controller. Blocklisted requests are refused
+  // here with a bare 403 before any routing (issue #391).
+  app.use(createTrafficObserver(app.get(TrafficEventsService), app.get(BlocklistService)));
 
   // Raise the request body limit above body-parser's 100kb default. Pipeline
   // endpoints (e.g. studio's /api/projects/save) POST large JSON documents that

--- a/apps/backend/src/traffic/blocklist-baseline.ts
+++ b/apps/backend/src/traffic/blocklist-baseline.ts
@@ -1,0 +1,218 @@
+import { BlocklistPatternEntry } from './blocklist-compiler';
+
+/**
+ * The Baseline (issue #383/#391): the code-shipped set of universal
+ * bot/scanner signatures applied to every domain by default, under the single
+ * BOT_PROTECTION_ENABLED master toggle.
+ *
+ * Transcribed from the static nginx http-level map (docker/nginx/blocklist.conf,
+ * retired by #392) into the structured { matchType, value } model, so the same
+ * compiler that handles admin lists handles the Baseline. It is deliberately
+ * NOT stored as data: it ships with the code so every upgrade improves it
+ * without admins re-editing their lists, and it is not editable. A false
+ * positive is rescued through a named Blocklist's allowlist, which always
+ * wins over the Baseline.
+ *
+ * Case-insensitive matching (nginx `~*` parity) means one entry covers all
+ * casings — e.g. /phpmyadmin also matches /phpMyAdmin.
+ */
+
+const prefix = (value: string): BlocklistPatternEntry => ({ matchType: 'prefix', value });
+const exact = (value: string): BlocklistPatternEntry => ({ matchType: 'exact', value });
+const extension = (value: string): BlocklistPatternEntry => ({ matchType: 'extension', value });
+
+export const BASELINE_BLOCKLIST_ENTRIES: BlocklistPatternEntry[] = [
+  // WordPress paths
+  prefix('/wp-admin'),
+  prefix('/wp-includes'),
+  prefix('/wp-content'),
+  prefix('/wp-login'),
+  prefix('/wp-config'),
+  prefix('/wordpress'),
+  prefix('/wp/'),
+  prefix('/blog/wp-'),
+  prefix('/site/wp-'),
+  prefix('/cms/wp-'),
+
+  // Drupal paths
+  prefix('/sites/default'),
+  prefix('/sites/all'),
+  prefix('/drupal'),
+  prefix('/misc/drupal'),
+  prefix('/modules/'),
+  prefix('/includes/'),
+
+  // Joomla paths
+  prefix('/administrator'),
+  prefix('/joomla'),
+  prefix('/components/com_'),
+
+  // Magento paths
+  prefix('/magento'),
+  prefix('/downloader'),
+  prefix('/skin/adminhtml'),
+
+  // phpMyAdmin and database tools
+  prefix('/phpmyadmin'), // also covers /phpMyAdmin and /phpmyadmin2, /pma2, ... via prefix
+  prefix('/pma'),
+  prefix('/myadmin'),
+  prefix('/mysql'),
+  prefix('/mysqladmin'),
+  prefix('/dbadmin'),
+  prefix('/sqlmanager'),
+  prefix('/mysqlmanager'),
+  prefix('/php-my-admin'),
+
+  // Admin/management paths (generic).
+  // Note: /admin/settings is a legitimate React route, so only specific
+  // scanner targets are blocked.
+  prefix('/admin.php'),
+  prefix('/admin/config'),
+  prefix('/admin/login'),
+  prefix('/admin/index.php'),
+  prefix('/admin/admin'),
+  prefix('/admin/includes'),
+  prefix('/admin/images/slider'),
+  prefix('/admin/fckeditor'),
+  prefix('/admin/ckeditor'),
+  prefix('/manager'),
+  prefix('/cpanel'),
+  prefix('/webadmin'),
+  prefix('/siteadmin'),
+  prefix('/adminpanel'),
+
+  // File editors
+  prefix('/fckeditor'),
+  prefix('/ckeditor'),
+  prefix('/kcfinder'),
+  prefix('/editor'),
+  prefix('/filemanager'),
+  prefix('/elfinder'),
+  prefix('/tinymce'),
+
+  // CGI paths
+  prefix('/cgi-bin'),
+  prefix('/cgi/'),
+  prefix('/wwwroot'),
+
+  // Config and sensitive files (but NOT .well-known, which ACME needs)
+  prefix('/.git'),
+  prefix('/.svn'),
+  prefix('/.hg'),
+  prefix('/.env'),
+  prefix('/.htaccess'),
+  prefix('/.htpasswd'),
+  prefix('/.DS_Store'),
+  prefix('/.config'),
+  prefix('/.aws'),
+  prefix('/.ssh'),
+  prefix('/.bash'),
+  prefix('/.npm'),
+  prefix('/.composer'),
+  prefix('/config.php'),
+  prefix('/config.inc'),
+  prefix('/configuration.php'),
+  prefix('/settings.php'),
+  prefix('/web.config'),
+  prefix('/database.yml'),
+  prefix('/secrets.yml'),
+
+  // Backup files
+  prefix('/backup'),
+  prefix('/backups'),
+  prefix('/dump'),
+  prefix('/dumps'),
+  prefix('/.bak'),
+  prefix('/.old'),
+  prefix('/.orig'),
+  prefix('/.save'),
+  prefix('/.swp'),
+  exact('/~'),
+  extension('sql'),
+  extension('sql.gz'),
+  extension('sql.zip'),
+  extension('tar.gz'),
+  extension('tgz'),
+  // Note: .zip, .rar, .7z stay allowed — they're legitimate assets.
+
+  // Common exploit paths
+  prefix('/shell'),
+  prefix('/c99'),
+  prefix('/r57'),
+  prefix('/cmd'),
+  prefix('/eval'),
+  prefix('/exec'),
+  prefix('/system'),
+  prefix('/console'),
+  prefix('/invoke'),
+  prefix('/debug'),
+  prefix('/test.php'),
+  prefix('/info.php'),
+  prefix('/phpinfo'),
+  prefix('/server-status'),
+  prefix('/server-info'),
+  prefix('/status'),
+  prefix('/jmx-console'),
+  prefix('/web-console'),
+  prefix('/axis2-admin'),
+  prefix('/axis2/'),
+  prefix('/solr'),
+  prefix('/jenkins'),
+  prefix('/hudson'),
+  prefix('/actuator'),
+  prefix('/api-docs'),
+  prefix('/swagger'),
+  prefix('/graphql'),
+  prefix('/graphiql'),
+  prefix('/playground'),
+
+  // Version control web interfaces (/.git/* is covered by the /.git prefix)
+  prefix('/.gitignore'),
+  prefix('/.gitconfig'),
+
+  // Log files
+  prefix('/logs/'),
+  prefix('/log/'),
+  prefix('/error.log'),
+  prefix('/access.log'),
+  prefix('/debug.log'),
+  extension('log'),
+
+  // Other common scanner targets
+  prefix('/xmlrpc.php'),
+  prefix('/wlwmanifest.xml'),
+  prefix('/license.txt'),
+  prefix('/readme.html'),
+  prefix('/readme.txt'),
+  prefix('/changelog'),
+
+  // Server-side script extensions this platform never serves
+  extension('php'),
+  ...Array.from({ length: 10 }, (_, i) => extension(`php${i}`)),
+  extension('phtml'),
+  extension('asp'),
+  extension('aspx'),
+  extension('ashx'),
+  extension('asmx'),
+  extension('jsp'),
+  extension('jsf'),
+  extension('jspx'),
+  extension('cgi'),
+  extension('pl'),
+  extension('py'),
+  extension('rb'),
+  extension('lua'),
+  extension('cfm'),
+  extension('cfml'),
+
+  // Shell scripts
+  extension('sh'),
+  extension('bash'),
+  extension('zsh'),
+
+  // Dangerous file types
+  extension('exe'),
+  extension('dll'),
+  extension('bat'),
+  extension('cmd'),
+];

--- a/apps/backend/src/traffic/blocklist-baseline.ts
+++ b/apps/backend/src/traffic/blocklist-baseline.ts
@@ -20,6 +20,7 @@ import { BlocklistPatternEntry } from './blocklist-compiler';
 const prefix = (value: string): BlocklistPatternEntry => ({ matchType: 'prefix', value });
 const exact = (value: string): BlocklistPatternEntry => ({ matchType: 'exact', value });
 const extension = (value: string): BlocklistPatternEntry => ({ matchType: 'extension', value });
+const contains = (value: string): BlocklistPatternEntry => ({ matchType: 'contains', value });
 
 export const BASELINE_BLOCKLIST_ENTRIES: BlocklistPatternEntry[] = [
   // WordPress paths
@@ -99,7 +100,11 @@ export const BASELINE_BLOCKLIST_ENTRIES: BlocklistPatternEntry[] = [
   prefix('/.git'),
   prefix('/.svn'),
   prefix('/.hg'),
-  prefix('/.env'),
+  // Bots probe .env in subdirectories too (/backend/.env, /app/.env.local, …),
+  // so this is a contains match, not just a root prefix — deliberately wider
+  // than the old nginx map, which only covered ^/.env. A legitimate path like
+  // /docs/.envelope would need an allowlist rescue.
+  contains('/.env'),
   prefix('/.htaccess'),
   prefix('/.htpasswd'),
   prefix('/.DS_Store'),

--- a/apps/backend/src/traffic/blocklist-compiler.spec.ts
+++ b/apps/backend/src/traffic/blocklist-compiler.spec.ts
@@ -1,0 +1,213 @@
+import {
+  BlocklistPatternEntry,
+  buildBlocklistMatcher,
+  compileBlocklistRegexSource,
+  compileEntryPattern,
+  validateBlocklistValue,
+  BLOCKLIST_VALUE_MAX_LENGTH,
+} from './blocklist-compiler';
+import { BASELINE_BLOCKLIST_ENTRIES } from './blocklist-baseline';
+
+/**
+ * Seam 2 (issue #391): the injection-safety guarantee lives below HTTP, in the
+ * compiled matching rules, so it is asserted here against the compiler as a
+ * pure function.
+ */
+describe('blocklist compiler', () => {
+  describe('validateBlocklistValue', () => {
+    it('accepts realistic path patterns', () => {
+      for (const value of [
+        '/wp-admin',
+        '/.env',
+        '/admin/index.php',
+        'sql.gz',
+        '/components/com_users',
+        '/a-b_c~d%2e',
+        '/weird(but)real*path[1]',
+      ]) {
+        expect(validateBlocklistValue(value)).toBeNull();
+      }
+    });
+
+    it.each([
+      ['nginx block open', '/foo{'],
+      ['nginx block close', '/foo}'],
+      ['nginx directive terminator', '/foo;return'],
+      ['nginx variable', '/foo$uri'],
+      ['space', '/foo bar'],
+      ['newline', '/foo\nlocation / {}'],
+      ['tab', '/foo\tbar'],
+      ['double quote', '/foo"'],
+      ['backslash', '/foo\\d'],
+      ['null byte', '/foo\0'],
+    ])('rejects %s', (_label, value) => {
+      expect(validateBlocklistValue(value)).not.toBeNull();
+    });
+
+    it('rejects empty and over-long values', () => {
+      expect(validateBlocklistValue('')).not.toBeNull();
+      expect(validateBlocklistValue('/a'.repeat(BLOCKLIST_VALUE_MAX_LENGTH))).not.toBeNull();
+    });
+  });
+
+  describe('compileEntryPattern escaping', () => {
+    it('escapes regex metacharacters so values match only literally', () => {
+      const source = compileEntryPattern({ matchType: 'prefix', value: '/a.b(c)*[d]' });
+      const regex = new RegExp(source, 'i');
+      expect(regex.test('/a.b(c)*[d]/x')).toBe(true);
+      // Unescaped, "." would match any char and "(c)*" would match zero c's.
+      expect(regex.test('/aXb')).toBe(false);
+      expect(regex.test('/a.b')).toBe(false);
+    });
+
+    it('cannot widen matching beyond the literal value (no alternation smuggling)', () => {
+      // "," is allowed in paths but must stay a literal comma, never a separator.
+      const source = compileBlocklistRegexSource([{ matchType: 'exact', value: '/a,/b' }])!;
+      const regex = new RegExp(source, 'i');
+      expect(regex.test('/a')).toBe(false);
+      expect(regex.test('/b')).toBe(false);
+      expect(regex.test('/a,/b')).toBe(true);
+    });
+
+    it('throws on values that failed validation (bug guard, not user input)', () => {
+      expect(() => compileEntryPattern({ matchType: 'prefix', value: '/x;{}' })).toThrow(
+        /Invalid blocklist pattern/,
+      );
+      expect(() => compileEntryPattern({ matchType: 'extension', value: '.' })).toThrow(
+        /extension is empty/,
+      );
+    });
+
+    it('anchors each matchType correctly', () => {
+      const cases: Array<[BlocklistPatternEntry, string[], string[]]> = [
+        [
+          { matchType: 'prefix', value: '/wp-login' },
+          ['/wp-login', '/wp-login.php', '/WP-LOGIN.PHP'],
+          ['/blog/wp-login', '/wp'],
+        ],
+        [{ matchType: 'exact', value: '/~' }, ['/~'], ['/~root', '/x/~']],
+        [
+          { matchType: 'suffix', value: '.sql.gz' },
+          ['/dump.sql.gz', '/backups/db.SQL.GZ'],
+          ['/dump.sql.gz.txt'],
+        ],
+        [
+          { matchType: 'extension', value: 'php' },
+          ['/index.php', '/a/b/INDEX.PHP'],
+          ['/index.phps', '/phpinfo'],
+        ],
+        [
+          { matchType: 'contains', value: 'phpunit' },
+          ['/vendor/phpunit/whatever', '/PHPUnit'],
+          ['/php-unit'],
+        ],
+      ];
+
+      for (const [entry, matches, misses] of cases) {
+        const matcher = buildBlocklistMatcher([entry], []);
+        for (const path of matches) {
+          expect(matcher.isBlocked(path)).toBe(true);
+        }
+        for (const path of misses) {
+          expect(matcher.isBlocked(path)).toBe(false);
+        }
+      }
+    });
+
+    it('treats "php" and ".php" extensions identically', () => {
+      expect(compileEntryPattern({ matchType: 'extension', value: 'php' })).toBe(
+        compileEntryPattern({ matchType: 'extension', value: '.php' }),
+      );
+    });
+  });
+
+  describe('buildBlocklistMatcher', () => {
+    it('blocks nothing when there are no entries', () => {
+      const matcher = buildBlocklistMatcher([], []);
+      expect(matcher.isBlocked('/.env')).toBe(false);
+      expect(matcher.blockSource).toBeNull();
+    });
+
+    it('matches the percent-decoded form of the path too', () => {
+      const matcher = buildBlocklistMatcher([{ matchType: 'prefix', value: '/.env' }], []);
+      expect(matcher.isBlocked('/%2eenv')).toBe(true);
+      expect(matcher.isBlocked('/.e%6ev')).toBe(true);
+    });
+
+    it('survives malformed percent-encoding', () => {
+      const matcher = buildBlocklistMatcher([{ matchType: 'prefix', value: '/.env' }], []);
+      expect(matcher.isBlocked('/%zz/.env-not-prefix')).toBe(false);
+      expect(matcher.isBlocked('/.env%zz')).toBe(true);
+    });
+
+    it('gives allowlist entries precedence over block entries', () => {
+      const matcher = buildBlocklistMatcher(
+        [{ matchType: 'prefix', value: '/admin' }],
+        [{ matchType: 'prefix', value: '/admin/settings' }],
+      );
+      expect(matcher.isBlocked('/admin/login')).toBe(true);
+      expect(matcher.isBlocked('/admin/settings')).toBe(false);
+      expect(matcher.isBlocked('/admin/settings/profile')).toBe(false);
+    });
+
+    it('lets a list allowlist rescue a Baseline block (no forking the Baseline)', () => {
+      const matcher = buildBlocklistMatcher(BASELINE_BLOCKLIST_ENTRIES, [
+        { matchType: 'exact', value: '/status' },
+      ]);
+      expect(matcher.isBlocked('/status')).toBe(false);
+      // The rescue is surgical: other Baseline patterns still block.
+      expect(matcher.isBlocked('/status/probe')).toBe(true);
+      expect(matcher.isBlocked('/.env')).toBe(true);
+    });
+
+    it('merges Baseline and custom-list entries into one blocked set', () => {
+      const matcher = buildBlocklistMatcher(
+        [...BASELINE_BLOCKLIST_ENTRIES, { matchType: 'prefix', value: '/my-custom-probe' }],
+        [],
+      );
+      expect(matcher.isBlocked('/my-custom-probe/x')).toBe(true);
+      expect(matcher.isBlocked('/wp-login.php')).toBe(true);
+    });
+  });
+
+  describe('Baseline', () => {
+    it('every Baseline entry passes validation and compiles', () => {
+      expect(BASELINE_BLOCKLIST_ENTRIES.length).toBeGreaterThan(150);
+      expect(() => compileBlocklistRegexSource(BASELINE_BLOCKLIST_ENTRIES)).not.toThrow();
+    });
+
+    it('blocks canonical scanner probes', () => {
+      const matcher = buildBlocklistMatcher(BASELINE_BLOCKLIST_ENTRIES, []);
+      for (const path of [
+        '/.env',
+        '/.git/config',
+        '/wp-login.php',
+        '/phpMyAdmin/index.php',
+        '/phpinfo.php',
+        '/cgi-bin/test.cgi',
+        '/db.sql',
+        '/shell.php',
+        '/xmlrpc.php',
+      ]) {
+        expect(matcher.isBlocked(path)).toBe(true);
+      }
+    });
+
+    it('does not block ordinary static-site paths', () => {
+      const matcher = buildBlocklistMatcher(BASELINE_BLOCKLIST_ENTRIES, []);
+      for (const path of [
+        '/',
+        '/index.html',
+        '/assets/app.4f2c.js',
+        '/css/style.css',
+        '/images/logo.svg',
+        '/.well-known/acme-challenge/token123',
+        '/robots.txt',
+        '/favicon.ico',
+        '/docs/getting-started',
+      ]) {
+        expect(matcher.isBlocked(path)).toBe(false);
+      }
+    });
+  });
+});

--- a/apps/backend/src/traffic/blocklist-compiler.spec.ts
+++ b/apps/backend/src/traffic/blocklist-compiler.spec.ts
@@ -180,6 +180,8 @@ describe('blocklist compiler', () => {
       const matcher = buildBlocklistMatcher(BASELINE_BLOCKLIST_ENTRIES, []);
       for (const path of [
         '/.env',
+        '/backend/.env',
+        '/app/.env.local',
         '/.git/config',
         '/wp-login.php',
         '/phpMyAdmin/index.php',

--- a/apps/backend/src/traffic/blocklist-compiler.ts
+++ b/apps/backend/src/traffic/blocklist-compiler.ts
@@ -1,0 +1,171 @@
+/**
+ * The Blocklist compiler (issue #391, ADR-0002): the ONLY code that turns
+ * admin-supplied blocklist patterns into matching rules.
+ *
+ * Patterns are stored structured as { matchType, value } — never as raw regex.
+ * The compiler validates each value against a strict path charset, escapes
+ * every regex metacharacter, and assembles anchored regex sources. Admin input
+ * can therefore only widen the *blocked set*; it can never inject regex
+ * syntax — and, when #392 feeds these same sources into generated nginx
+ * `location ~*` rules, never emit an nginx directive.
+ *
+ * Everything in this file is a pure function (Seam 2 of the testing plan):
+ * no I/O, no Nest, no database.
+ */
+
+export type BlocklistMatchType = 'prefix' | 'exact' | 'suffix' | 'extension' | 'contains';
+
+export const BLOCKLIST_MATCH_TYPES: BlocklistMatchType[] = [
+  'prefix',
+  'exact',
+  'suffix',
+  'extension',
+  'contains',
+];
+
+/** A structured blocklist pattern, as stored in blocklist_entries. */
+export interface BlocklistPatternEntry {
+  matchType: BlocklistMatchType;
+  value: string;
+}
+
+export const BLOCKLIST_VALUE_MAX_LENGTH = 256;
+
+/**
+ * The strict charset admin-supplied values must stay inside. Deliberately a
+ * whitelist: everything nginx or PCRE could treat as syntax (`{ } ; $ " \`,
+ * whitespace, newlines, ...) is simply not representable. Metacharacters that
+ * ARE allowed (`. ( ) * + ? [ ]` etc. appear in real paths) get escaped by the
+ * compiler.
+ */
+const VALUE_CHARSET = /^[A-Za-z0-9/._~%+=:@!,()*&[\]-]+$/;
+
+/**
+ * Validate a pattern value. Returns an error message, or null if valid.
+ */
+export function validateBlocklistValue(value: string): string | null {
+  if (typeof value !== 'string' || value.length === 0) {
+    return 'Pattern is empty';
+  }
+  if (value.length > BLOCKLIST_VALUE_MAX_LENGTH) {
+    return `Pattern is longer than ${BLOCKLIST_VALUE_MAX_LENGTH} characters`;
+  }
+  if (!VALUE_CHARSET.test(value)) {
+    return 'Pattern contains unsupported characters (allowed: letters, digits, and / . _ - ~ % + = : @ ! , ( ) * & [ ])';
+  }
+  return null;
+}
+
+/** Escape every regex metacharacter so the value matches only literally. */
+export function escapeRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Compile one structured entry into an (unanchored-on-the-outside) regex
+ * source. Anchoring is what gives each matchType its meaning:
+ *
+ *   prefix    /wp-admin   -> ^/wp\-admin        (nginx `~*^/wp-admin`)
+ *   exact     /~          -> ^/~$
+ *   suffix    .sql.gz     -> \.sql\.gz$
+ *   extension php         -> \.php$             (leading dot implied)
+ *   contains  phpunit     -> phpunit
+ *
+ * Throws on an invalid value — callers must have validated already; an
+ * exception here means a bug upstream, not bad user input.
+ */
+export function compileEntryPattern(entry: BlocklistPatternEntry): string {
+  const error = validateBlocklistValue(entry.value);
+  if (error) {
+    throw new Error(`Invalid blocklist pattern "${entry.value}": ${error}`);
+  }
+
+  switch (entry.matchType) {
+    case 'prefix':
+      return `^${escapeRegexLiteral(entry.value)}`;
+    case 'exact':
+      return `^${escapeRegexLiteral(entry.value)}$`;
+    case 'suffix':
+      return `${escapeRegexLiteral(entry.value)}$`;
+    case 'extension': {
+      // Accept "php" and ".php" identically; the dot is part of the semantics.
+      const bare = entry.value.startsWith('.') ? entry.value.slice(1) : entry.value;
+      if (bare.length === 0) {
+        throw new Error(`Invalid blocklist pattern "${entry.value}": extension is empty`);
+      }
+      return `\\.${escapeRegexLiteral(bare)}$`;
+    }
+    case 'contains':
+      return escapeRegexLiteral(entry.value);
+    default:
+      throw new Error(`Unknown blocklist matchType "${String(entry.matchType)}"`);
+  }
+}
+
+/**
+ * Combine entries into a single alternation regex source, or null when there
+ * are no entries. The source is valid both as a JS RegExp (app-side
+ * enforcement, case-insensitive flag) and as a PCRE for nginx `location ~*`
+ * (edge enforcement, #392).
+ */
+export function compileBlocklistRegexSource(entries: BlocklistPatternEntry[]): string | null {
+  if (entries.length === 0) {
+    return null;
+  }
+  return `(?:${entries.map(compileEntryPattern).join('|')})`;
+}
+
+/** A compiled, ready-to-enforce matcher over request paths. */
+export interface CompiledBlocklistMatcher {
+  /**
+   * Decide whether a request path is blocked. `pathname` is the client-visible
+   * path WITHOUT the query string. Matching is case-insensitive (nginx `~*`
+   * parity) and also considers the percent-decoded form, so `/%2e%65nv`
+   * cannot sneak past a `/.env` pattern. Allow entries always win.
+   */
+  isBlocked(pathname: string): boolean;
+  /** Combined block regex source (null = nothing to block). */
+  blockSource: string | null;
+  /** Combined allow regex source (null = no exceptions). */
+  allowSource: string | null;
+}
+
+/**
+ * Build the effective matcher from block entries (Baseline + lists) and allow
+ * entries (every list's exceptions). Allowlist entries take precedence over
+ * ALL block entries — that is the false-positive rescue that lets an admin
+ * exempt a path without forking the Baseline.
+ */
+export function buildBlocklistMatcher(
+  blockEntries: BlocklistPatternEntry[],
+  allowEntries: BlocklistPatternEntry[],
+): CompiledBlocklistMatcher {
+  const blockSource = compileBlocklistRegexSource(blockEntries);
+  const allowSource = compileBlocklistRegexSource(allowEntries);
+  const blockRegex = blockSource ? new RegExp(blockSource, 'i') : null;
+  const allowRegex = allowSource ? new RegExp(allowSource, 'i') : null;
+
+  return {
+    blockSource,
+    allowSource,
+    isBlocked(pathname: string): boolean {
+      if (!blockRegex) {
+        return false;
+      }
+      const candidates = [pathname];
+      try {
+        const decoded = decodeURIComponent(pathname);
+        if (decoded !== pathname) {
+          candidates.push(decoded);
+        }
+      } catch {
+        // Malformed percent-encoding: match on the raw path only.
+      }
+      // An allow match on ANY interpretation of the path rescues the request.
+      if (allowRegex && candidates.some((c) => allowRegex.test(c))) {
+        return false;
+      }
+      return candidates.some((c) => blockRegex.test(c));
+    },
+  };
+}

--- a/apps/backend/src/traffic/blocklist-http.spec.ts
+++ b/apps/backend/src/traffic/blocklist-http.spec.ts
@@ -1,0 +1,148 @@
+import { Controller, Get, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { TrafficEventsService } from './traffic-events.service';
+import { TrafficEvent } from './traffic-event.interface';
+import { createTrafficObserver, BlocklistEnforcer } from './traffic-observer.middleware';
+import { buildBlocklistMatcher } from './blocklist-compiler';
+import { BASELINE_BLOCKLIST_ENTRIES } from './blocklist-baseline';
+
+/**
+ * Seam 1 for #391: drive real HTTP requests through an app with the traffic
+ * observer + Blocklist enforcement installed, and assert the blocked-case
+ * response policy — bare 403, empty body, decided BEFORE routing, classified
+ * and observed as 'blocked'. (The matched/Unmatched cases of the policy are
+ * covered in traffic-http.spec.ts; the matcher itself in
+ * blocklist-compiler.spec.ts.)
+ */
+describe('Blocklist enforcement at the HTTP boundary', () => {
+  let app: INestApplication;
+  let events: TrafficEventsService;
+  let observed: TrafficEvent[];
+  let subscription: { unsubscribe: () => void };
+
+  // Swappable per test; the middleware holds only the reference.
+  const baselineMatcher = buildBlocklistMatcher(BASELINE_BLOCKLIST_ENTRIES, []);
+  let shouldBlock: (pathname: string) => boolean;
+  const enforcer: BlocklistEnforcer = { shouldBlock: (pathname) => shouldBlock(pathname) };
+
+  @Controller()
+  class ProbeController {
+    @Get('public/:owner/:repo/alias/:alias/*')
+    serveContent(): string {
+      return 'content';
+    }
+
+    @Get('api/traffic/requests')
+    listRequests(): string {
+      return 'admin api';
+    }
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ProbeController],
+      providers: [TrafficEventsService],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    events = app.get(TrafficEventsService);
+    // Same wiring as main.ts: observer + enforcement above everything Nest routes.
+    app.use(createTrafficObserver(events, enforcer));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    shouldBlock = (pathname) => baselineMatcher.isBlocked(pathname);
+    observed = [];
+    subscription = events.stream().subscribe((e) => observed.push(e));
+  });
+
+  afterEach(() => {
+    subscription.unsubscribe();
+  });
+
+  const waitForEvents = async (count: number): Promise<void> => {
+    const deadline = Date.now() + 1000;
+    while (observed.length < count && Date.now() < deadline) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+  };
+
+  it('refuses a blocklisted request with a bare 403 and empty body, observed as blocked', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/wp-login.php')
+      .set('X-Forwarded-For', '198.51.100.9')
+      .set('User-Agent', 'scanner');
+
+    expect(res.status).toBe(403);
+    expect(res.text).toBe('');
+    expect(res.headers['content-type']).toBeUndefined();
+
+    await waitForEvents(1);
+    expect(observed).toHaveLength(1);
+    expect(observed[0]).toMatchObject({
+      classification: 'blocked',
+      status: 403,
+      bytes: 0,
+      path: '/wp-login.php',
+      ip: '198.51.100.9',
+    });
+  });
+
+  it('enforces against the client-visible path from X-Original-URI, not the nginx rewrite', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/public/acme/site/alias/production/.env')
+      .set('X-Original-URI', '/.env?probe=1');
+
+    expect(res.status).toBe(403);
+    expect(res.text).toBe('');
+
+    await waitForEvents(1);
+    expect(observed[0].classification).toBe('blocked');
+  });
+
+  it('serves a clean content request normally', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/public/acme/site/alias/production/index.html')
+      .set('X-Original-URI', '/index.html');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('content');
+
+    await waitForEvents(1);
+    expect(observed[0].classification).toBe('matched');
+  });
+
+  it('never enforces on the app control surfaces, so the master toggle stays reachable', async () => {
+    // A runaway pattern set that would block everything...
+    shouldBlock = () => true;
+
+    // ...still cannot block the admin API or auth.
+    const api = await request(app.getHttpServer()).get('/api/traffic/requests');
+    expect(api.status).toBe(200);
+    const auth = await request(app.getHttpServer()).get('/auth/session/refresh');
+    expect(auth.status).not.toBe(403);
+
+    // Everything else is blocked as configured.
+    const content = await request(app.getHttpServer()).get('/anything-else');
+    expect(content.status).toBe(403);
+
+    await waitForEvents(3);
+    expect(observed.map((e) => e.classification)).toEqual(['matched', 'unmatched', 'blocked']);
+  });
+
+  it('blocks nothing when enforcement is off (master toggle)', async () => {
+    shouldBlock = () => false;
+
+    const res = await request(app.getHttpServer()).get('/wp-login.php');
+    expect(res.status).toBe(404); // falls through to routing: Unmatched, not blocked
+
+    await waitForEvents(1);
+    expect(observed[0].classification).toBe('unmatched');
+  });
+});

--- a/apps/backend/src/traffic/blocklist.dto.ts
+++ b/apps/backend/src/traffic/blocklist.dto.ts
@@ -1,0 +1,103 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+import {
+  BLOCKLIST_MATCH_TYPES,
+  BLOCKLIST_VALUE_MAX_LENGTH,
+  BlocklistMatchType,
+} from './blocklist-compiler';
+
+/** Guard against a pathological payload; real lists are tens of patterns. */
+const MAX_ENTRIES_PER_LIST = 1_000;
+
+export class BlocklistPatternEntryDto {
+  @ApiProperty({ enum: BLOCKLIST_MATCH_TYPES, default: 'prefix' })
+  @IsIn(BLOCKLIST_MATCH_TYPES)
+  matchType: BlocklistMatchType = 'prefix';
+
+  @ApiProperty({ description: 'The literal path fragment to match (strict charset, escaped by the compiler)' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(BLOCKLIST_VALUE_MAX_LENGTH)
+  value!: string;
+}
+
+export class CreateBlocklistDto {
+  @ApiProperty({ description: 'Unique name for the Blocklist' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  name!: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @MaxLength(2_000)
+  description?: string;
+
+  @ApiPropertyOptional({ type: [BlocklistPatternEntryDto], description: 'Block patterns' })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(MAX_ENTRIES_PER_LIST)
+  @ValidateNested({ each: true })
+  @Type(() => BlocklistPatternEntryDto)
+  entries?: BlocklistPatternEntryDto[];
+
+  @ApiPropertyOptional({
+    type: [BlocklistPatternEntryDto],
+    description: 'Allowlist exceptions that always win over any block pattern',
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(MAX_ENTRIES_PER_LIST)
+  @ValidateNested({ each: true })
+  @Type(() => BlocklistPatternEntryDto)
+  allowlist?: BlocklistPatternEntryDto[];
+}
+
+export class UpdateBlocklistDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  name?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @MaxLength(2_000)
+  description?: string;
+
+  @ApiPropertyOptional({ type: [BlocklistPatternEntryDto], description: 'Replaces all block patterns when present' })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(MAX_ENTRIES_PER_LIST)
+  @ValidateNested({ each: true })
+  @Type(() => BlocklistPatternEntryDto)
+  entries?: BlocklistPatternEntryDto[];
+
+  @ApiPropertyOptional({ type: [BlocklistPatternEntryDto], description: 'Replaces the allowlist when present' })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(MAX_ENTRIES_PER_LIST)
+  @ValidateNested({ each: true })
+  @Type(() => BlocklistPatternEntryDto)
+  allowlist?: BlocklistPatternEntryDto[];
+}
+
+export class UpdateBlocklistSettingsDto {
+  @ApiProperty({ description: 'Master toggle: false disables ALL blocking instantly' })
+  @IsBoolean()
+  enabled!: boolean;
+}

--- a/apps/backend/src/traffic/blocklist.service.spec.ts
+++ b/apps/backend/src/traffic/blocklist.service.spec.ts
@@ -1,0 +1,254 @@
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+
+// Mock the db client with a thenable chainable: every builder method returns
+// the chain, and awaiting the chain consumes the next queued result (in the
+// order the service awaits its queries). Mirrors request-log.service.spec.
+jest.mock('../db/client', () => {
+  const queued: unknown[] = [];
+  const methods = [
+    'select',
+    'from',
+    'where',
+    'orderBy',
+    'limit',
+    'insert',
+    'values',
+    'update',
+    'set',
+    'delete',
+    'returning',
+  ];
+  const chainable: Record<string, unknown> = {};
+  for (const method of methods) {
+    chainable[method] = jest.fn(() => chainable);
+  }
+  chainable.then = (
+    resolve: (value: unknown) => unknown,
+    reject: (reason: unknown) => unknown,
+  ) => Promise.resolve(queued.length > 0 ? queued.shift() : []).then(resolve, reject);
+  chainable.transaction = jest.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(chainable));
+  chainable.__queue = (result: unknown) => queued.push(result);
+  chainable.__reset = () => {
+    queued.length = 0;
+    for (const method of methods) {
+      (chainable[method] as jest.Mock).mockClear();
+    }
+  };
+  return { db: chainable };
+});
+
+import { db } from '../db/client';
+import { BlocklistService, BOT_PROTECTION_FLAG } from './blocklist.service';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+
+const mockDb = db as unknown as Record<string, jest.Mock> & {
+  __queue: (result: unknown) => void;
+  __reset: () => void;
+};
+
+const listRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: 'b1',
+  name: 'my-list',
+  description: null,
+  createdAt: new Date('2026-07-01T00:00:00Z'),
+  updatedAt: new Date('2026-07-01T00:00:00Z'),
+  ...overrides,
+});
+
+const entryRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: 'e1',
+  blocklistId: 'b1',
+  kind: 'block',
+  matchType: 'prefix',
+  value: '/custom-probe',
+  createdAt: new Date('2026-07-01T00:00:00Z'),
+  ...overrides,
+});
+
+describe('BlocklistService', () => {
+  let service: BlocklistService;
+  let featureFlags: jest.Mocked<FeatureFlagsService>;
+
+  beforeEach(() => {
+    mockDb.__reset();
+    featureFlags = {
+      isEnabled: jest.fn().mockResolvedValue(true),
+      setFlag: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<FeatureFlagsService>;
+    service = new BlocklistService(featureFlags);
+  });
+
+  describe('enforcement state (refresh + shouldBlock)', () => {
+    it('enforces the Baseline before any refresh (protected by default)', () => {
+      expect(service.shouldBlock('/wp-login.php')).toBe(true);
+      expect(service.shouldBlock('/index.html')).toBe(false);
+    });
+
+    it('after refresh with the toggle on, Baseline + list patterns block and allowlists win', async () => {
+      mockDb.__queue([listRow()]); // listBlocklists: lists
+      mockDb.__queue([
+        entryRow(),
+        entryRow({ id: 'e2', kind: 'allow', matchType: 'exact', value: '/status' }),
+      ]); // listBlocklists: entries
+      await service.refresh();
+
+      expect(service.shouldBlock('/custom-probe/x')).toBe(true); // list pattern
+      expect(service.shouldBlock('/.env')).toBe(true); // Baseline
+      expect(service.shouldBlock('/status')).toBe(false); // allowlist rescues a Baseline block
+      expect(service.shouldBlock('/index.html')).toBe(false);
+    });
+
+    it('blocks nothing when the master toggle is off', async () => {
+      featureFlags.isEnabled.mockResolvedValue(false);
+      mockDb.__queue([]); // listBlocklists: no lists
+      await service.refresh();
+
+      expect(service.shouldBlock('/wp-login.php')).toBe(false);
+      expect(service.shouldBlock('/.env')).toBe(false);
+    });
+
+    it('keeps the last good matcher when a refresh fails', async () => {
+      mockDb.__queue([]); // successful refresh: Baseline only, enabled
+      await service.refresh();
+      expect(service.shouldBlock('/.env')).toBe(true);
+
+      featureFlags.isEnabled.mockRejectedValue(new Error('db down'));
+      await service.refresh();
+      expect(service.shouldBlock('/.env')).toBe(true);
+    });
+
+    it('falls back to Baseline-only enforcement when the lists cannot load', async () => {
+      const failure = {
+        then: (_resolve: unknown, reject: (reason: unknown) => void) =>
+          reject(new Error('relation does not exist')),
+      };
+      mockDb.orderBy.mockImplementationOnce(() => failure);
+      await service.refresh();
+
+      expect(service.shouldBlock('/.env')).toBe(true);
+    });
+  });
+
+  describe('settings', () => {
+    it('reports the toggle and Baseline size', async () => {
+      const settings = await service.getSettings();
+      expect(settings.enabled).toBe(true);
+      expect(settings.baselineEntryCount).toBeGreaterThan(150);
+      expect(featureFlags.isEnabled).toHaveBeenCalledWith(BOT_PROTECTION_FLAG);
+    });
+
+    it('setEnabled writes the flag and rebuilds the matcher immediately', async () => {
+      featureFlags.isEnabled.mockResolvedValue(false);
+      mockDb.__queue([]); // refresh -> listBlocklists
+      await service.setEnabled(false);
+
+      expect(featureFlags.setFlag).toHaveBeenCalledWith(BOT_PROTECTION_FLAG, false);
+      expect(service.shouldBlock('/.env')).toBe(false);
+    });
+  });
+
+  describe('library CRUD', () => {
+    beforeEach(() => {
+      // CRUD methods refresh() after mutating; isolate the queue bookkeeping
+      // to the mutation itself. refresh() behaviour is covered above.
+      jest.spyOn(service, 'refresh').mockResolvedValue(undefined);
+    });
+
+    it('creates a Blocklist, normalizing a missing leading slash on path patterns', async () => {
+      mockDb.__queue([]); // name-uniqueness check
+      mockDb.__queue([listRow()]); // insert().returning()
+      // replaceEntries(block): delete, insert values
+      // replaceEntries(allow): delete (no insert; allowlist empty)
+      mockDb.__queue([]);
+      mockDb.__queue([]);
+      mockDb.__queue([]);
+      mockDb.__queue([listRow()]); // getBlocklist: list
+      mockDb.__queue([entryRow({ value: '/wp-extra' })]); // getBlocklist: entries
+
+      const created = await service.createBlocklist({
+        name: 'my-list',
+        entries: [{ matchType: 'prefix', value: 'wp-extra' }],
+        allowlist: [],
+      });
+
+      expect(created.entries).toEqual([{ matchType: 'prefix', value: '/wp-extra' }]);
+      expect(mockDb.values).toHaveBeenCalledWith([
+        expect.objectContaining({ kind: 'block', matchType: 'prefix', value: '/wp-extra' }),
+      ]);
+      expect(service.refresh).toHaveBeenCalled();
+    });
+
+    it('rejects invalid patterns with a per-pattern error list and writes nothing', async () => {
+      await expect(
+        service.createBlocklist({
+          name: 'bad',
+          entries: [
+            { matchType: 'prefix', value: '/ok' },
+            { matchType: 'prefix', value: '/bad;{}' },
+          ],
+        }),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it('rejects a duplicate name', async () => {
+      mockDb.__queue([listRow()]); // name-uniqueness check finds a clash
+      await expect(service.createBlocklist({ name: 'my-list' })).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('update replaces entries only when provided', async () => {
+      mockDb.__queue([listRow()]); // existence check
+      // update(blocklists).set().where() is awaited
+      mockDb.__queue([]);
+      // replaceEntries(block): delete + insert
+      mockDb.__queue([]);
+      mockDb.__queue([]);
+      mockDb.__queue([listRow()]); // getBlocklist: list
+      mockDb.__queue([entryRow()]); // getBlocklist: entries
+
+      const updated = await service.updateBlocklist('b1', {
+        entries: [{ matchType: 'prefix', value: '/custom-probe' }],
+      });
+
+      expect(updated.entries).toEqual([{ matchType: 'prefix', value: '/custom-probe' }]);
+      // Allowlist untouched: exactly one delete (the block-kind replacement).
+      expect(mockDb.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('update of a missing Blocklist 404s', async () => {
+      mockDb.__queue([]); // existence check
+      await expect(service.updateBlocklist('nope', { name: 'x' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('delete of a missing Blocklist 404s', async () => {
+      mockDb.__queue([]); // delete().returning() -> nothing deleted
+      await expect(service.deleteBlocklist('nope')).rejects.toThrow(NotFoundException);
+    });
+
+    it('deduplicates repeated patterns case-insensitively', async () => {
+      mockDb.__queue([]); // name-uniqueness check
+      mockDb.__queue([listRow()]); // insert().returning()
+      mockDb.__queue([]); // delete (block)
+      mockDb.__queue([]); // insert values (block)
+      mockDb.__queue([]); // delete (allow)
+      mockDb.__queue([listRow()]); // getBlocklist: list
+      mockDb.__queue([]); // getBlocklist: entries
+
+      await service.createBlocklist({
+        name: 'my-list',
+        entries: [
+          { matchType: 'prefix', value: '/Probe' },
+          { matchType: 'prefix', value: '/probe' },
+        ],
+      });
+
+      expect(mockDb.values).toHaveBeenCalledWith([
+        expect.objectContaining({ value: '/Probe' }),
+      ]);
+    });
+  });
+});

--- a/apps/backend/src/traffic/blocklist.service.ts
+++ b/apps/backend/src/traffic/blocklist.service.ts
@@ -1,0 +1,339 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnModuleInit,
+} from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
+import { and, asc, eq, inArray } from 'drizzle-orm';
+import { db } from '../db/client';
+import { blocklists, blocklistEntries, Blocklist, BlocklistEntry } from '../db/schema';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import {
+  BlocklistPatternEntry,
+  CompiledBlocklistMatcher,
+  buildBlocklistMatcher,
+  validateBlocklistValue,
+} from './blocklist-compiler';
+import { BASELINE_BLOCKLIST_ENTRIES } from './blocklist-baseline';
+
+/** Master toggle flag key (DB > file > env > default-on, see FLAG_DEFINITIONS). */
+export const BOT_PROTECTION_FLAG = 'BOT_PROTECTION_ENABLED';
+
+/** How often the compiled matcher re-syncs with the database (covers toggle
+ *  flips made through the generic feature-flags API and multi-replica drift). */
+const REFRESH_INTERVAL_MS = 30_000;
+
+export interface BlocklistWithEntries {
+  id: string;
+  name: string;
+  description: string | null;
+  entries: BlocklistPatternEntry[];
+  allowlist: BlocklistPatternEntry[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface UpsertBlocklistInput {
+  name?: string;
+  description?: string | null;
+  entries?: BlocklistPatternEntry[];
+  allowlist?: BlocklistPatternEntry[];
+}
+
+export interface BlocklistSettings {
+  /** The master toggle: false disables ALL blocking (Baseline and lists) instantly. */
+  enabled: boolean;
+  /** Size of the code-shipped Baseline, for display. */
+  baselineEntryCount: number;
+}
+
+/**
+ * The Blocklist library + app-side enforcement authority (issue #391).
+ *
+ * Owns the admin-global library of named Blocklists and keeps an in-memory
+ * compiled matcher (Baseline + every list's block patterns, minus every
+ * list's allowlist) that the traffic observer middleware consults
+ * synchronously on EVERY request — so enforcement adds no I/O to the hot
+ * path. The matcher is rebuilt after each mutation and re-synced on an
+ * interval.
+ *
+ * Until #393 lands per-domain attachment, named Blocklists apply
+ * instance-wide at the application layer, exactly like the Baseline.
+ */
+@Injectable()
+export class BlocklistService implements OnModuleInit {
+  private readonly logger = new Logger(BlocklistService.name);
+
+  // Start protected-by-default: Baseline-only, toggle at its default. The
+  // first refresh() replaces this with the real database state; if that
+  // fails (e.g. the migration has not run yet), the Baseline still applies.
+  private matcher: CompiledBlocklistMatcher = buildBlocklistMatcher(BASELINE_BLOCKLIST_ENTRIES, []);
+  private enabled = true;
+
+  constructor(private readonly featureFlags: FeatureFlagsService) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.refresh();
+  }
+
+  /**
+   * Synchronous enforcement check for the observer middleware. Must never
+   * throw — a matcher bug must not take down request serving.
+   */
+  shouldBlock(pathname: string): boolean {
+    if (!this.enabled) {
+      return false;
+    }
+    try {
+      return this.matcher.isBlocked(pathname);
+    } catch (error) {
+      this.logger.error(`Blocklist match failed for ${pathname}: ${String(error)}`);
+      return false;
+    }
+  }
+
+  /** Rebuild the compiled matcher from the toggle + Baseline + all lists. */
+  @Interval(REFRESH_INTERVAL_MS)
+  async refresh(): Promise<void> {
+    try {
+      const enabled = await this.featureFlags.isEnabled(BOT_PROTECTION_FLAG);
+      let lists: BlocklistWithEntries[] = [];
+      try {
+        lists = await this.listBlocklists();
+      } catch (error) {
+        // Pre-migration or transient DB failure: enforce the Baseline alone
+        // rather than dropping protection.
+        this.logger.warn(`Could not load Blocklists; enforcing Baseline only: ${String(error)}`);
+      }
+
+      const blockEntries = [
+        ...BASELINE_BLOCKLIST_ENTRIES,
+        ...lists.flatMap((list) => list.entries),
+      ];
+      const allowEntries = lists.flatMap((list) => list.allowlist);
+
+      this.matcher = buildBlocklistMatcher(blockEntries, allowEntries);
+      this.enabled = enabled;
+    } catch (error) {
+      // Keep the last good matcher; never let a refresh failure break serving.
+      this.logger.error(`Blocklist refresh failed: ${String(error)}`);
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Settings (master toggle)
+  // ---------------------------------------------------------------------
+
+  async getSettings(): Promise<BlocklistSettings> {
+    return {
+      enabled: await this.featureFlags.isEnabled(BOT_PROTECTION_FLAG),
+      baselineEntryCount: BASELINE_BLOCKLIST_ENTRIES.length,
+    };
+  }
+
+  async setEnabled(enabled: boolean): Promise<BlocklistSettings> {
+    await this.featureFlags.setFlag(BOT_PROTECTION_FLAG, enabled);
+    await this.refresh();
+    return this.getSettings();
+  }
+
+  /** The code-shipped Baseline, read-only (for display on the Traffic page). */
+  getBaselineEntries(): BlocklistPatternEntry[] {
+    return BASELINE_BLOCKLIST_ENTRIES;
+  }
+
+  // ---------------------------------------------------------------------
+  // Library CRUD
+  // ---------------------------------------------------------------------
+
+  async listBlocklists(): Promise<BlocklistWithEntries[]> {
+    const lists = await db.select().from(blocklists).orderBy(asc(blocklists.name));
+    if (lists.length === 0) {
+      return [];
+    }
+    const entries = await db
+      .select()
+      .from(blocklistEntries)
+      .where(
+        inArray(
+          blocklistEntries.blocklistId,
+          lists.map((list) => list.id),
+        ),
+      );
+    return lists.map((list) =>
+      this.toDto(
+        list,
+        entries.filter((entry) => entry.blocklistId === list.id),
+      ),
+    );
+  }
+
+  async getBlocklist(id: string): Promise<BlocklistWithEntries> {
+    const [list] = await db.select().from(blocklists).where(eq(blocklists.id, id)).limit(1);
+    if (!list) {
+      throw new NotFoundException('Blocklist not found');
+    }
+    const entries = await db
+      .select()
+      .from(blocklistEntries)
+      .where(eq(blocklistEntries.blocklistId, id));
+    return this.toDto(list, entries);
+  }
+
+  async createBlocklist(input: UpsertBlocklistInput): Promise<BlocklistWithEntries> {
+    const name = input.name?.trim();
+    if (!name) {
+      throw new BadRequestException('Blocklist name is required');
+    }
+    const entries = this.normalizeAndValidate(input.entries ?? [], 'entries');
+    const allowlist = this.normalizeAndValidate(input.allowlist ?? [], 'allowlist');
+
+    const [existing] = await db.select().from(blocklists).where(eq(blocklists.name, name)).limit(1);
+    if (existing) {
+      throw new ConflictException(`A Blocklist named "${name}" already exists`);
+    }
+
+    const [created] = await db
+      .insert(blocklists)
+      .values({ name, description: input.description ?? null })
+      .returning();
+    await this.replaceEntries(created.id, 'block', entries);
+    await this.replaceEntries(created.id, 'allow', allowlist);
+
+    await this.refresh();
+    return this.getBlocklist(created.id);
+  }
+
+  async updateBlocklist(id: string, input: UpsertBlocklistInput): Promise<BlocklistWithEntries> {
+    const [existing] = await db.select().from(blocklists).where(eq(blocklists.id, id)).limit(1);
+    if (!existing) {
+      throw new NotFoundException('Blocklist not found');
+    }
+
+    const updates: Partial<Blocklist> = { updatedAt: new Date() };
+    if (input.name !== undefined) {
+      const name = input.name.trim();
+      if (!name) {
+        throw new BadRequestException('Blocklist name cannot be empty');
+      }
+      const [clash] = await db.select().from(blocklists).where(eq(blocklists.name, name)).limit(1);
+      if (clash && clash.id !== id) {
+        throw new ConflictException(`A Blocklist named "${name}" already exists`);
+      }
+      updates.name = name;
+    }
+    if (input.description !== undefined) {
+      updates.description = input.description;
+    }
+
+    const entries =
+      input.entries !== undefined ? this.normalizeAndValidate(input.entries, 'entries') : undefined;
+    const allowlist =
+      input.allowlist !== undefined
+        ? this.normalizeAndValidate(input.allowlist, 'allowlist')
+        : undefined;
+
+    await db.update(blocklists).set(updates).where(eq(blocklists.id, id));
+    if (entries !== undefined) {
+      await this.replaceEntries(id, 'block', entries);
+    }
+    if (allowlist !== undefined) {
+      await this.replaceEntries(id, 'allow', allowlist);
+    }
+
+    await this.refresh();
+    return this.getBlocklist(id);
+  }
+
+  async deleteBlocklist(id: string): Promise<void> {
+    const [deleted] = await db.delete(blocklists).where(eq(blocklists.id, id)).returning();
+    if (!deleted) {
+      throw new NotFoundException('Blocklist not found');
+    }
+    await this.refresh();
+  }
+
+  // ---------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------
+
+  /**
+   * Trim, normalize, dedupe, and validate structured pattern entries.
+   * Rejects the whole request with a per-pattern error list so the admin can
+   * fix their textarea in one round trip.
+   */
+  private normalizeAndValidate(
+    entries: BlocklistPatternEntry[],
+    label: 'entries' | 'allowlist',
+  ): BlocklistPatternEntry[] {
+    const errors: string[] = [];
+    const seen = new Set<string>();
+    const normalized: BlocklistPatternEntry[] = [];
+
+    for (const entry of entries) {
+      let value = entry.value?.trim() ?? '';
+      // A path pattern that doesn't start with "/" would never match; treat
+      // the leading slash as implied for path-anchored match types.
+      if ((entry.matchType === 'prefix' || entry.matchType === 'exact') && value !== '' && !value.startsWith('/')) {
+        value = `/${value}`;
+      }
+      const error = validateBlocklistValue(value);
+      if (error) {
+        errors.push(`${label}: "${entry.value}" — ${error}`);
+        continue;
+      }
+      const key = `${entry.matchType}:${value.toLowerCase()}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      normalized.push({ matchType: entry.matchType, value });
+    }
+
+    if (errors.length > 0) {
+      throw new BadRequestException({ message: 'Invalid blocklist patterns', errors });
+    }
+    return normalized;
+  }
+
+  private async replaceEntries(
+    blocklistId: string,
+    kind: 'block' | 'allow',
+    entries: BlocklistPatternEntry[],
+  ): Promise<void> {
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(blocklistEntries)
+        .where(and(eq(blocklistEntries.blocklistId, blocklistId), eq(blocklistEntries.kind, kind)));
+      if (entries.length > 0) {
+        await tx.insert(blocklistEntries).values(
+          entries.map((entry) => ({
+            blocklistId,
+            kind,
+            matchType: entry.matchType,
+            value: entry.value,
+          })),
+        );
+      }
+    });
+  }
+
+  private toDto(list: Blocklist, entries: BlocklistEntry[]): BlocklistWithEntries {
+    const pattern = (entry: BlocklistEntry): BlocklistPatternEntry => ({
+      matchType: entry.matchType,
+      value: entry.value,
+    });
+    return {
+      id: list.id,
+      name: list.name,
+      description: list.description,
+      entries: entries.filter((entry) => entry.kind === 'block').map(pattern),
+      allowlist: entries.filter((entry) => entry.kind === 'allow').map(pattern),
+      createdAt: list.createdAt,
+      updatedAt: list.updatedAt,
+    };
+  }
+}

--- a/apps/backend/src/traffic/blocklists.controller.spec.ts
+++ b/apps/backend/src/traffic/blocklists.controller.spec.ts
@@ -1,0 +1,73 @@
+import { ROLES_KEY } from '../auth/roles.guard';
+import { BlocklistsController } from './blocklists.controller';
+import { BlocklistService } from './blocklist.service';
+
+// bcrypt is a native module the auth guards import transitively; mock it like
+// the other guard specs do so the suite runs without the compiled binding.
+jest.mock('bcrypt');
+// BlocklistService imports the db client; keep this spec db-free.
+jest.mock('../db/client', () => ({ db: {} }));
+
+describe('BlocklistsController', () => {
+  let controller: BlocklistsController;
+  let service: jest.Mocked<BlocklistService>;
+
+  beforeEach(() => {
+    service = {
+      getSettings: jest.fn(),
+      setEnabled: jest.fn(),
+      getBaselineEntries: jest.fn().mockReturnValue([]),
+      listBlocklists: jest.fn(),
+      getBlocklist: jest.fn(),
+      createBlocklist: jest.fn(),
+      updateBlocklist: jest.fn(),
+      deleteBlocklist: jest.fn(),
+    } as unknown as jest.Mocked<BlocklistService>;
+    controller = new BlocklistsController(service);
+  });
+
+  it('is admin-only: every handler carries the admin roles metadata', () => {
+    for (const handler of [
+      controller.getSettings,
+      controller.updateSettings,
+      controller.getBaseline,
+      controller.list,
+      controller.create,
+      controller.get,
+      controller.update,
+      controller.remove,
+    ]) {
+      expect(Reflect.getMetadata(ROLES_KEY, handler)).toEqual(['admin']);
+    }
+  });
+
+  it('is guarded: controller declares ApiKeyGuard + RolesGuard', () => {
+    const guards = Reflect.getMetadata('__guards__', BlocklistsController) ?? [];
+    const guardNames = guards.map((g: any) => g.name);
+    expect(guardNames).toEqual(expect.arrayContaining(['ApiKeyGuard', 'RolesGuard']));
+  });
+
+  it('delegates the master toggle to the service', async () => {
+    service.setEnabled.mockResolvedValue({ enabled: false, baselineEntryCount: 200 });
+    await expect(controller.updateSettings({ enabled: false })).resolves.toEqual({
+      enabled: false,
+      baselineEntryCount: 200,
+    });
+    expect(service.setEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('exposes the Baseline read-only', () => {
+    expect(controller.getBaseline()).toEqual({ entries: [] });
+  });
+
+  it('delegates CRUD to the service', async () => {
+    await controller.create({ name: 'list' });
+    expect(service.createBlocklist).toHaveBeenCalledWith({ name: 'list' });
+
+    await controller.update('b1', { description: 'd' });
+    expect(service.updateBlocklist).toHaveBeenCalledWith('b1', { description: 'd' });
+
+    await controller.remove('b1');
+    expect(service.deleteBlocklist).toHaveBeenCalledWith('b1');
+  });
+});

--- a/apps/backend/src/traffic/blocklists.controller.ts
+++ b/apps/backend/src/traffic/blocklists.controller.ts
@@ -1,0 +1,90 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+// Import from the concrete files (not the ../auth barrel): the barrel pulls in
+// auth.module -> settings.module, a cycle that leaves Roles undefined when this
+// controller is loaded first (e.g. in unit tests).
+import { ApiKeyGuard } from '../auth/api-key.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { BlocklistService } from './blocklist.service';
+import { CreateBlocklistDto, UpdateBlocklistDto, UpdateBlocklistSettingsDto } from './blocklist.dto';
+
+/**
+ * The Blocklist library + bot-protection settings (issue #391), admin-only
+ * like the rest of /api/traffic. CRUD here rebuilds the app-side enforcement
+ * matcher immediately; edge (nginx) enforcement rides on top in #392.
+ */
+@ApiTags('Traffic')
+@Controller('api/traffic')
+@UseGuards(ApiKeyGuard, RolesGuard)
+export class BlocklistsController {
+  constructor(private readonly blocklistService: BlocklistService) {}
+
+  @Get('blocklist-settings')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Bot-protection settings: master toggle + Baseline size (admin only)' })
+  async getSettings() {
+    return this.blocklistService.getSettings();
+  }
+
+  @Patch('blocklist-settings')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Flip the bot-protection master toggle (admin only)' })
+  async updateSettings(@Body() dto: UpdateBlocklistSettingsDto) {
+    return this.blocklistService.setEnabled(dto.enabled);
+  }
+
+  @Get('blocklists/baseline')
+  @Roles('admin')
+  @ApiOperation({ summary: 'The code-shipped Baseline scanner signatures, read-only (admin only)' })
+  getBaseline() {
+    return { entries: this.blocklistService.getBaselineEntries() };
+  }
+
+  @Get('blocklists')
+  @Roles('admin')
+  @ApiOperation({ summary: 'List all Blocklists with their patterns (admin only)' })
+  async list() {
+    return this.blocklistService.listBlocklists();
+  }
+
+  @Post('blocklists')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Create a Blocklist (admin only)' })
+  async create(@Body() dto: CreateBlocklistDto) {
+    return this.blocklistService.createBlocklist(dto);
+  }
+
+  @Get('blocklists/:id')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Get one Blocklist (admin only)' })
+  async get(@Param('id', ParseUUIDPipe) id: string) {
+    return this.blocklistService.getBlocklist(id);
+  }
+
+  @Patch('blocklists/:id')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Update a Blocklist; entries/allowlist replace wholesale (admin only)' })
+  async update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateBlocklistDto) {
+    return this.blocklistService.updateBlocklist(id, dto);
+  }
+
+  @Delete('blocklists/:id')
+  @Roles('admin')
+  @HttpCode(204)
+  @ApiOperation({ summary: 'Delete a Blocklist (admin only)' })
+  async remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    await this.blocklistService.deleteBlocklist(id);
+  }
+}

--- a/apps/backend/src/traffic/traffic-event.interface.ts
+++ b/apps/backend/src/traffic/traffic-event.interface.ts
@@ -30,8 +30,9 @@ export interface TrafficEvent {
    * matched: the request resolved to a real asset/API/deployment.
    * unmatched: it resolved to no deployment, alias, or asset (bot scans
    * for /.env, /wp-login, ... produce these).
+   * blocked: refused by the Blocklist with a bare 403 (issue #391).
    */
-  classification: 'matched' | 'unmatched';
+  classification: 'matched' | 'unmatched' | 'blocked';
   /** The event rendered as an nginx combined-access-log line */
   line: string;
 }

--- a/apps/backend/src/traffic/traffic-observer.middleware.ts
+++ b/apps/backend/src/traffic/traffic-observer.middleware.ts
@@ -7,25 +7,64 @@ import { TrafficEventsService } from './traffic-events.service';
 /** The SSE live-tail endpoint itself must not feed the stream it serves. */
 const OBSERVER_EXEMPT_PATHS = ['/api/traffic/stream'];
 
+/**
+ * The app's own control surfaces are never Blocklist-enforced: an admin must
+ * always be able to reach the API that turns bot protection off, and auth
+ * must keep working. These are still observed. Content-domain traffic is
+ * unaffected — nginx rewrites it to /public/... before it reaches the app.
+ */
+const ENFORCEMENT_EXEMPT_PREFIXES = ['/api/', '/auth/'];
+
+/** What the middleware needs from BlocklistService (kept as an interface so
+ *  the middleware stays constructible without Nest in tests). */
+export interface BlocklistEnforcer {
+  shouldBlock(pathname: string): boolean;
+}
+
 let eventCounter = 0;
 
 /**
- * The application interceptor's observation seam (ADR-0003).
+ * The client-visible path for enforcement. Content requests are rewritten by
+ * nginx (e.g. /wp-login.php -> /public/{owner}/{repo}/alias/{alias}/wp-login.php)
+ * with the original URI preserved in X-Original-URI — the Blocklist matches
+ * what the client asked for, not the internal rewrite. Query strings are not
+ * matched.
+ */
+function clientVisiblePath(req: Request): string {
+  const header = req.headers['x-original-uri'];
+  const raw = typeof header === 'string' && header.startsWith('/') ? header : req.originalUrl;
+  const queryStart = raw.indexOf('?');
+  return queryStart === -1 ? raw : raw.slice(0, queryStart);
+}
+
+/**
+ * The application interceptor's observation + enforcement seam (ADR-0003).
  *
  * Installed with `app.use()` in main.ts — ABOVE all Nest module middleware —
  * so it observes every request that reaches the app, including ones
  * short-circuited by ProxyMiddleware or answered by guards/filters, in every
- * topology (docker-compose and GKE). It never alters a response; it counts
- * response bytes and publishes a TrafficEvent when the response finishes.
+ * topology (docker-compose and GKE). It counts response bytes and publishes a
+ * TrafficEvent when the response finishes.
  *
- * Classification: a 404 response means the request resolved to no deployment,
- * alias, or asset — an Unmatched request. Everything else is matched.
+ * Since #391 it is also the app-side Blocklist authority: a blocklisted
+ * request is refused with a bare 403 (empty body — the same no-detail
+ * discipline as the generic 404) BEFORE next(), and its event is classified
+ * 'blocked'. For everything else, classification derives from the response
+ * status: 404 means the request resolved to no deployment, alias, or asset —
+ * an Unmatched request.
  */
-export function createTrafficObserver(events: TrafficEventsService) {
+export function createTrafficObserver(events: TrafficEventsService, blocklist?: BlocklistEnforcer) {
   return function trafficObserver(req: Request, res: Response, next: NextFunction): void {
     if (OBSERVER_EXEMPT_PATHS.some((p) => req.path === p)) {
       return next();
     }
+
+    const blocked =
+      blocklist !== undefined &&
+      !ENFORCEMENT_EXEMPT_PREFIXES.some(
+        (prefix) => req.path.startsWith(prefix) || req.path === prefix.slice(0, -1),
+      ) &&
+      blocklist.shouldBlock(clientVisiblePath(req));
 
     let bytes = 0;
     const countChunk = (chunk: unknown, encoding?: unknown): void => {
@@ -63,10 +102,17 @@ export function createTrafficObserver(events: TrafficEventsService) {
         referer: (req.headers.referer as string) || null,
         userAgent: (req.headers['user-agent'] as string) || null,
         host: (req.headers['x-forwarded-host'] as string) || req.headers.host || null,
-        classification: res.statusCode === 404 ? 'unmatched' : 'matched',
+        classification: blocked ? 'blocked' : res.statusCode === 404 ? 'unmatched' : 'matched',
       };
       events.emit({ ...withoutLine, line: formatAccessLogLine(withoutLine) });
     });
+
+    if (blocked) {
+      // Bare 403, empty body: a scanner learns nothing, and the app does not
+      // attempt to replicate nginx's 444 socket-close.
+      res.status(403).end();
+      return;
+    }
 
     next();
   };

--- a/apps/backend/src/traffic/traffic.module.ts
+++ b/apps/backend/src/traffic/traffic.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
+import { FeatureFlagsModule } from '../feature-flags/feature-flags.module';
 import { TrafficController } from './traffic.controller';
+import { BlocklistsController } from './blocklists.controller';
 import { TrafficEventsService } from './traffic-events.service';
 import { RequestLogService } from './request-log.service';
+import { BlocklistService } from './blocklist.service';
 import { TrafficRetentionScheduler } from './traffic-retention.scheduler';
 
 /**
@@ -11,14 +14,16 @@ import { TrafficRetentionScheduler } from './traffic-retention.scheduler';
  * Slice #389 provided the observation seam: the traffic observer middleware
  * (installed in main.ts) publishes every app-observed request to
  * TrafficEventsService, and TrafficController exposes an admin-only SSE live
- * tail. Slice #390 adds the Request log: RequestLogService persists the
- * Unmatched (and, with #391, blocked) subset with bounded retention and a
- * per-IP rollup, exposed through admin read/export endpoints.
+ * tail. Slice #390 added the Request log: RequestLogService persists the
+ * Unmatched and blocked subset with bounded retention and a per-IP rollup,
+ * exposed through admin read/export endpoints. Slice #391 adds the Blocklist
+ * library + Baseline: BlocklistService compiles them into the in-memory
+ * matcher the observer middleware enforces (bare 403) app-side.
  */
 @Module({
-  imports: [ScheduleModule.forRoot()],
-  controllers: [TrafficController],
-  providers: [TrafficEventsService, RequestLogService, TrafficRetentionScheduler],
-  exports: [TrafficEventsService],
+  imports: [ScheduleModule.forRoot(), FeatureFlagsModule],
+  controllers: [TrafficController, BlocklistsController],
+  providers: [TrafficEventsService, RequestLogService, BlocklistService, TrafficRetentionScheduler],
+  exports: [TrafficEventsService, BlocklistService],
 })
 export class TrafficModule {}

--- a/apps/frontend/src/components/traffic/TrafficBlocklistTab.test.tsx
+++ b/apps/frontend/src/components/traffic/TrafficBlocklistTab.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TrafficBlocklistTab } from './TrafficBlocklistTab';
+import type { BlocklistEntry } from '@/services/trafficApi';
+
+const mockGetSettings = vi.fn();
+const mockUpdateSettings = vi.fn();
+const mockGetBaseline = vi.fn();
+const mockListBlocklists = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock('@/services/trafficApi', () => ({
+  useGetBlocklistSettingsQuery: () => mockGetSettings(),
+  useUpdateBlocklistSettingsMutation: () => [mockUpdateSettings, { isLoading: false }],
+  useGetBaselineBlocklistQuery: (_arg: unknown, opts: { skip?: boolean }) =>
+    mockGetBaseline(opts),
+  useListBlocklistsQuery: () => mockListBlocklists(),
+  useCreateBlocklistMutation: () => [mockCreate, { isLoading: false }],
+  useUpdateBlocklistMutation: () => [mockUpdate, { isLoading: false }],
+  useDeleteBlocklistMutation: () => [mockDelete, { isLoading: false }],
+}));
+
+// Radix AlertDialog doesn't play well with happy-dom; render a plain stand-in.
+vi.mock('@/components/ui/alert-dialog', () => ({
+  AlertDialog: ({ children, open }: any) => (open ? <div>{children}</div> : null),
+  AlertDialogAction: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+  AlertDialogCancel: ({ children }: any) => <button>{children}</button>,
+  AlertDialogContent: ({ children }: any) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: any) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: any) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: any) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: any) => <div>{children}</div>,
+}));
+
+const makeList = (overrides: Partial<BlocklistEntry> = {}): BlocklistEntry => ({
+  id: 'b1',
+  name: 'aggressive-scanners',
+  description: 'Custom probes seen in the wild',
+  entries: [
+    { matchType: 'prefix', value: '/hidden-probe' },
+    { matchType: 'extension', value: 'php' },
+  ],
+  allowlist: [{ matchType: 'exact', value: '/status' }],
+  createdAt: '2026-07-01T00:00:00Z',
+  updatedAt: '2026-07-01T00:00:00Z',
+  ...overrides,
+});
+
+describe('TrafficBlocklistTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSettings.mockReturnValue({
+      data: { enabled: true, baselineEntryCount: 200 },
+      isLoading: false,
+    });
+    mockGetBaseline.mockReturnValue({ data: undefined });
+    mockListBlocklists.mockReturnValue({ data: [], isLoading: false, error: undefined });
+    mockUpdateSettings.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    mockCreate.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    mockUpdate.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    mockDelete.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+  });
+
+  it('shows the master toggle state and Baseline size', () => {
+    render(<TrafficBlocklistTab />);
+    expect(screen.getByLabelText('On')).toBeInTheDocument();
+    expect(screen.getByText(/200 scanner signatures/)).toBeInTheDocument();
+  });
+
+  it('flips the master toggle through the settings mutation', async () => {
+    render(<TrafficBlocklistTab />);
+    fireEvent.click(screen.getByRole('switch'));
+    await waitFor(() => expect(mockUpdateSettings).toHaveBeenCalledWith({ enabled: false }));
+  });
+
+  it('lists Blocklists with pattern and exception counts', () => {
+    mockListBlocklists.mockReturnValue({ data: [makeList()], isLoading: false, error: undefined });
+    render(<TrafficBlocklistTab />);
+
+    expect(screen.getByText('aggressive-scanners')).toBeInTheDocument();
+    expect(screen.getByText('2 patterns')).toBeInTheDocument();
+    expect(screen.getByText('1 exception')).toBeInTheDocument();
+  });
+
+  it('creates a Blocklist from the textarea, parsing one pattern per line', async () => {
+    render(<TrafficBlocklistTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: /New Blocklist/ }));
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'my-list' } });
+    fireEvent.change(screen.getByLabelText(/Blocked patterns/), {
+      target: { value: '/hidden-probe\nextension:php\n# comment\n' },
+    });
+    fireEvent.change(screen.getByLabelText(/Allowlist exceptions/), {
+      target: { value: 'exact:/status' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith({
+        name: 'my-list',
+        description: undefined,
+        entries: [
+          { matchType: 'prefix', value: '/hidden-probe' },
+          { matchType: 'extension', value: 'php' },
+        ],
+        allowlist: [{ matchType: 'exact', value: '/status' }],
+      }),
+    );
+  });
+
+  it('surfaces the backend per-pattern validation errors', async () => {
+    mockCreate.mockReturnValue({
+      unwrap: () =>
+        Promise.reject({
+          data: { message: 'Invalid blocklist patterns', errors: ['entries: "/x;{}" — bad'] },
+        }),
+    });
+    render(<TrafficBlocklistTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: /New Blocklist/ }));
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'bad' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(await screen.findByText(/\/x;\{\}/)).toBeInTheDocument();
+  });
+
+  it('pre-fills the editor with the existing patterns when editing', () => {
+    mockListBlocklists.mockReturnValue({ data: [makeList()], isLoading: false, error: undefined });
+    render(<TrafficBlocklistTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit aggressive-scanners' }));
+
+    expect(screen.getByLabelText(/Blocked patterns/)).toHaveValue('/hidden-probe\nextension:php');
+    expect(screen.getByLabelText(/Allowlist exceptions/)).toHaveValue('exact:/status');
+  });
+
+  it('deletes after confirmation', async () => {
+    mockListBlocklists.mockReturnValue({ data: [makeList()], isLoading: false, error: undefined });
+    render(<TrafficBlocklistTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete aggressive-scanners' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith('b1'));
+  });
+});

--- a/apps/frontend/src/components/traffic/TrafficBlocklistTab.tsx
+++ b/apps/frontend/src/components/traffic/TrafficBlocklistTab.tsx
@@ -1,0 +1,403 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Loader2, Pencil, Plus, Shield, Trash2 } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/use-toast';
+import {
+  BlocklistEntry,
+  useCreateBlocklistMutation,
+  useDeleteBlocklistMutation,
+  useGetBaselineBlocklistQuery,
+  useGetBlocklistSettingsQuery,
+  useListBlocklistsQuery,
+  useUpdateBlocklistMutation,
+  useUpdateBlocklistSettingsMutation,
+} from '@/services/trafficApi';
+import { formatPatternEntries, parsePatternLines } from './blocklist-format';
+
+/**
+ * Blocklist configuration on the Traffic page (issue #391): the bot-protection
+ * master toggle, the code-shipped Baseline (read-only), and the admin-global
+ * library of named Blocklists with their patterns + allowlist exceptions.
+ *
+ * App-side enforcement takes effect within seconds of saving; edge (nginx)
+ * enforcement rides on top in a later slice (#392).
+ */
+export function TrafficBlocklistTab() {
+  return (
+    <div className="space-y-6">
+      <MasterToggleCard />
+      <BlocklistLibraryCard />
+    </div>
+  );
+}
+
+function MasterToggleCard() {
+  const { toast } = useToast();
+  const { data: settings, isLoading } = useGetBlocklistSettingsQuery();
+  const [updateSettings, { isLoading: saving }] = useUpdateBlocklistSettingsMutation();
+  const [showBaseline, setShowBaseline] = useState(false);
+  const { data: baseline } = useGetBaselineBlocklistQuery(undefined, { skip: !showBaseline });
+
+  const handleToggle = async (enabled: boolean) => {
+    try {
+      await updateSettings({ enabled }).unwrap();
+      toast({
+        title: enabled ? 'Bot protection enabled' : 'Bot protection disabled',
+        description: enabled
+          ? 'The Baseline and your Blocklists are enforced again.'
+          : 'Nothing is blocked until you turn it back on.',
+      });
+    } catch {
+      toast({ title: 'Could not update bot protection', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Shield className="h-4 w-4 text-[#d96459]" />
+              Bot protection
+            </CardTitle>
+            <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground mt-1">
+              Requests matching the Baseline or a Blocklist are refused with an empty 403 before
+              they reach any content. Turning this off disables all blocking instantly.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {(isLoading || saving) && <Loader2 className="h-4 w-4 animate-spin" />}
+            <Switch
+              id="bot-protection"
+              checked={settings?.enabled ?? false}
+              disabled={isLoading || saving}
+              onCheckedChange={handleToggle}
+            />
+            <Label htmlFor="bot-protection" className="text-sm cursor-pointer">
+              {settings?.enabled ? 'On' : 'Off'}
+            </Label>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <button
+          type="button"
+          className="flex items-center gap-1 text-sm text-[#4a4a4a] dark:text-muted-foreground hover:text-foreground"
+          onClick={() => setShowBaseline((open) => !open)}
+        >
+          {showBaseline ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+          Baseline: {settings?.baselineEntryCount ?? '…'} scanner signatures shipped with CE
+          (updated on upgrade, not editable)
+        </button>
+        {showBaseline && (
+          <div className="mt-2 bg-[#1e1e1e] rounded-md p-3 max-h-64 overflow-y-auto font-mono text-xs leading-5 text-gray-200">
+            {baseline ? (
+              baseline.entries.map((entry, index) => (
+                <div key={index}>
+                  {entry.matchType === 'prefix' ? entry.value : `${entry.matchType}:${entry.value}`}
+                </div>
+              ))
+            ) : (
+              <p className="text-gray-400">Loading…</p>
+            )}
+          </div>
+        )}
+        <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground mt-2">
+          A false positive? Add the path to a Blocklist&apos;s allowlist below — allowlist
+          exceptions always win, including over the Baseline.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface EditorState {
+  id: string | null; // null = creating
+  name: string;
+  description: string;
+  patternsText: string;
+  allowlistText: string;
+}
+
+const emptyEditor = (): EditorState => ({
+  id: null,
+  name: '',
+  description: '',
+  patternsText: '',
+  allowlistText: '',
+});
+
+const editorFor = (list: BlocklistEntry): EditorState => ({
+  id: list.id,
+  name: list.name,
+  description: list.description ?? '',
+  patternsText: formatPatternEntries(list.entries),
+  allowlistText: formatPatternEntries(list.allowlist),
+});
+
+/** Pull the per-pattern error list out of a 400 from the backend. */
+function extractErrors(error: unknown): string[] {
+  const data = (error as { data?: { errors?: string[]; message?: string } })?.data;
+  if (Array.isArray(data?.errors)) {
+    return data.errors;
+  }
+  return [typeof data?.message === 'string' ? data.message : 'Saving the Blocklist failed'];
+}
+
+function BlocklistLibraryCard() {
+  const { toast } = useToast();
+  const { data: blocklists, isLoading, error } = useListBlocklistsQuery();
+  const [createBlocklist, { isLoading: creating }] = useCreateBlocklistMutation();
+  const [updateBlocklist, { isLoading: updating }] = useUpdateBlocklistMutation();
+  const [deleteBlocklist] = useDeleteBlocklistMutation();
+
+  const [editor, setEditor] = useState<EditorState | null>(null);
+  const [editorErrors, setEditorErrors] = useState<string[]>([]);
+  const [pendingDelete, setPendingDelete] = useState<BlocklistEntry | null>(null);
+  const saving = creating || updating;
+
+  const handleSave = async () => {
+    if (!editor) return;
+    const payload = {
+      name: editor.name.trim(),
+      description: editor.description.trim() || undefined,
+      entries: parsePatternLines(editor.patternsText),
+      allowlist: parsePatternLines(editor.allowlistText),
+    };
+    try {
+      if (editor.id === null) {
+        await createBlocklist(payload).unwrap();
+      } else {
+        await updateBlocklist({ id: editor.id, ...payload }).unwrap();
+      }
+      toast({
+        title: editor.id === null ? 'Blocklist created' : 'Blocklist updated',
+        description: 'App-side enforcement is live; edge rules follow in a later release.',
+      });
+      setEditor(null);
+      setEditorErrors([]);
+    } catch (err) {
+      setEditorErrors(extractErrors(err));
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!pendingDelete) return;
+    try {
+      await deleteBlocklist(pendingDelete.id).unwrap();
+      toast({ title: `Deleted "${pendingDelete.name}"` });
+    } catch {
+      toast({ title: 'Delete failed', variant: 'destructive' });
+    } finally {
+      setPendingDelete(null);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <CardTitle className="text-base">Blocklists</CardTitle>
+            <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground mt-1">
+              Named pattern lists on top of the Baseline. Until per-domain attachment lands, a
+              Blocklist applies to all traffic reaching this instance.
+            </p>
+          </div>
+          <Button
+            size="sm"
+            onClick={() => {
+              setEditor(emptyEditor());
+              setEditorErrors([]);
+            }}
+            disabled={editor !== null}
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            New Blocklist
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error !== undefined && (
+          <Alert variant="destructive">
+            <AlertDescription>Could not load the Blocklist library.</AlertDescription>
+          </Alert>
+        )}
+
+        {editor && (
+          <div className="border rounded-md p-4 space-y-3" data-testid="blocklist-editor">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <Label htmlFor="blocklist-name">Name</Label>
+                <Input
+                  id="blocklist-name"
+                  value={editor.name}
+                  placeholder="e.g. aggressive-scanners"
+                  onChange={(e) => setEditor({ ...editor, name: e.target.value })}
+                />
+              </div>
+              <div>
+                <Label htmlFor="blocklist-description">Description</Label>
+                <Input
+                  id="blocklist-description"
+                  value={editor.description}
+                  placeholder="Optional"
+                  onChange={(e) => setEditor({ ...editor, description: e.target.value })}
+                />
+              </div>
+            </div>
+            <div>
+              <Label htmlFor="blocklist-patterns">Blocked patterns (one per line)</Label>
+              <Textarea
+                id="blocklist-patterns"
+                className="font-mono text-xs min-h-32"
+                value={editor.patternsText}
+                placeholder={'/hidden-probe\nexact:/status\nsuffix:.tar.bz2\nextension:php\ncontains:phpunit'}
+                onChange={(e) => setEditor({ ...editor, patternsText: e.target.value })}
+              />
+              <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground mt-1">
+                A bare line matches as a path prefix. Prefix with{' '}
+                <code>exact:</code>, <code>suffix:</code>, <code>extension:</code> or{' '}
+                <code>contains:</code> for other match types. Lines starting with # are ignored.
+              </p>
+            </div>
+            <div>
+              <Label htmlFor="blocklist-allowlist">Allowlist exceptions (one per line)</Label>
+              <Textarea
+                id="blocklist-allowlist"
+                className="font-mono text-xs min-h-20"
+                value={editor.allowlistText}
+                placeholder={'exact:/status'}
+                onChange={(e) => setEditor({ ...editor, allowlistText: e.target.value })}
+              />
+              <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground mt-1">
+                Exceptions always win — over this list and over the Baseline. Use them to rescue a
+                legitimate path.
+              </p>
+            </div>
+            {editorErrors.length > 0 && (
+              <Alert variant="destructive">
+                <AlertDescription>
+                  <ul className="list-disc pl-4">
+                    {editorErrors.map((message, index) => (
+                      <li key={index}>{message}</li>
+                    ))}
+                  </ul>
+                </AlertDescription>
+              </Alert>
+            )}
+            <div className="flex gap-2 justify-end">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setEditor(null);
+                  setEditorErrors([]);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button size="sm" onClick={handleSave} disabled={saving || !editor.name.trim()}>
+                {saving && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+                {editor.id === null ? 'Create' : 'Save'}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-[#4a4a4a] dark:text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading Blocklists…
+          </div>
+        ) : (blocklists?.length ?? 0) === 0 && !editor ? (
+          <p className="text-sm text-[#4a4a4a] dark:text-muted-foreground">
+            No Blocklists yet. The Baseline still protects every domain while bot protection is on.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {blocklists?.map((list) => (
+              <div
+                key={list.id}
+                className="flex flex-wrap items-center justify-between gap-2 border rounded-md px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-sm">{list.name}</span>
+                    <Badge variant="outline" className="text-xs">
+                      {list.entries.length} pattern{list.entries.length === 1 ? '' : 's'}
+                    </Badge>
+                    {list.allowlist.length > 0 && (
+                      <Badge variant="outline" className="text-xs">
+                        {list.allowlist.length} exception{list.allowlist.length === 1 ? '' : 's'}
+                      </Badge>
+                    )}
+                  </div>
+                  {list.description && (
+                    <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground truncate">
+                      {list.description}
+                    </p>
+                  )}
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-label={`Edit ${list.name}`}
+                    onClick={() => {
+                      setEditor(editorFor(list));
+                      setEditorErrors([]);
+                    }}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-label={`Delete ${list.name}`}
+                    onClick={() => setPendingDelete(list)}
+                  >
+                    <Trash2 className="h-4 w-4 text-red-500" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <AlertDialog open={pendingDelete !== null} onOpenChange={(open) => !open && setPendingDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete “{pendingDelete?.name}”?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Its patterns stop blocking within seconds. The Baseline is unaffected.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete}>Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/traffic/TrafficHistoryTab.tsx
+++ b/apps/frontend/src/components/traffic/TrafficHistoryTab.tsx
@@ -27,7 +27,7 @@ const TIME_RANGES: Record<string, { label: string; hours?: number }> = {
 
 /**
  * History view over the persisted Request log (issue #390): the Unmatched
- * (and, later, blocked) requests the application interceptor recorded,
+ * and blocked requests the application interceptor recorded,
  * rendered as access-log lines like the Live tail, with filters and export.
  */
 export function TrafficHistoryTab() {
@@ -93,7 +93,7 @@ export function TrafficHistoryTab() {
             <CardTitle className="text-base">Request log</CardTitle>
             <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground mt-1">
               Only the bot-signal subset is persisted: Unmatched requests (404 — paths that resolve
-              to no deployment, alias, or asset) and, once Blocklists land, blocked ones. Matched
+              to no deployment, alias, or asset) and requests blocked by a Blocklist. Matched
               traffic appears only in the Live tab.
             </p>
           </div>

--- a/apps/frontend/src/components/traffic/blocklist-format.test.ts
+++ b/apps/frontend/src/components/traffic/blocklist-format.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { parsePatternLines, formatPatternEntries } from './blocklist-format';
+
+describe('blocklist textarea format', () => {
+  it('parses bare lines as prefix patterns', () => {
+    expect(parsePatternLines('/wp-login\n/hidden-probe')).toEqual([
+      { matchType: 'prefix', value: '/wp-login' },
+      { matchType: 'prefix', value: '/hidden-probe' },
+    ]);
+  });
+
+  it('parses matchType tags case-insensitively', () => {
+    expect(
+      parsePatternLines('exact:/status\nSUFFIX:.tar.bz2\nextension:php\ncontains:phpunit'),
+    ).toEqual([
+      { matchType: 'exact', value: '/status' },
+      { matchType: 'suffix', value: '.tar.bz2' },
+      { matchType: 'extension', value: 'php' },
+      { matchType: 'contains', value: 'phpunit' },
+    ]);
+  });
+
+  it('skips blank lines and # comments', () => {
+    expect(parsePatternLines('# scanners\n\n/probe\n   \n# done')).toEqual([
+      { matchType: 'prefix', value: '/probe' },
+    ]);
+  });
+
+  it('keeps a path containing a colon as a prefix pattern (only known tags parse)', () => {
+    expect(parsePatternLines('/weird:path')).toEqual([
+      { matchType: 'prefix', value: '/weird:path' },
+    ]);
+  });
+
+  it('round-trips through formatPatternEntries', () => {
+    const text = '/wp-login\nexact:/status\nextension:php';
+    expect(formatPatternEntries(parsePatternLines(text))).toBe(text);
+  });
+});

--- a/apps/frontend/src/components/traffic/blocklist-format.ts
+++ b/apps/frontend/src/components/traffic/blocklist-format.ts
@@ -1,0 +1,49 @@
+import type { BlocklistMatchType, BlocklistPatternEntry } from '@/services/trafficApi';
+
+/**
+ * The textarea sugar over the structured Blocklist pattern model (issue #391).
+ *
+ * One pattern per line. A bare line is a prefix match (the common case for
+ * scanner paths); the other match types are written as an explicit
+ * `matchType:value` tag:
+ *
+ *   /wp-login              -> { matchType: 'prefix',    value: '/wp-login' }
+ *   exact:/status          -> { matchType: 'exact',     value: '/status' }
+ *   suffix:.sql.gz         -> { matchType: 'suffix',    value: '.sql.gz' }
+ *   extension:php          -> { matchType: 'extension', value: 'php' }
+ *   contains:phpunit       -> { matchType: 'contains',  value: 'phpunit' }
+ *
+ * Blank lines and `#` comments are ignored. Parsing is intentionally lax —
+ * the backend re-validates every value against the strict charset and
+ * returns per-pattern errors.
+ */
+
+const MATCH_TYPES: BlocklistMatchType[] = ['prefix', 'exact', 'suffix', 'extension', 'contains'];
+
+const TAGGED_LINE = new RegExp(`^(${MATCH_TYPES.join('|')}):(.*)$`, 'i');
+
+export function parsePatternLines(text: string): BlocklistPatternEntry[] {
+  const entries: BlocklistPatternEntry[] = [];
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (line === '' || line.startsWith('#')) {
+      continue;
+    }
+    const tagged = TAGGED_LINE.exec(line);
+    if (tagged) {
+      entries.push({
+        matchType: tagged[1].toLowerCase() as BlocklistMatchType,
+        value: tagged[2].trim(),
+      });
+    } else {
+      entries.push({ matchType: 'prefix', value: line });
+    }
+  }
+  return entries;
+}
+
+export function formatPatternEntries(entries: BlocklistPatternEntry[]): string {
+  return entries
+    .map((entry) => (entry.matchType === 'prefix' ? entry.value : `${entry.matchType}:${entry.value}`))
+    .join('\n');
+}

--- a/apps/frontend/src/pages/TrafficPage.tsx
+++ b/apps/frontend/src/pages/TrafficPage.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { TrafficBlocklistTab } from '@/components/traffic/TrafficBlocklistTab';
 import { TrafficHistoryTab } from '@/components/traffic/TrafficHistoryTab';
 import { TrafficRollupTab } from '@/components/traffic/TrafficRollupTab';
 import { statusColorClass } from '@/components/traffic/traffic-format';
@@ -24,7 +25,7 @@ export interface TrafficStreamEvent {
   referer: string | null;
   userAgent: string | null;
   host: string | null;
-  classification: 'matched' | 'unmatched';
+  classification: 'matched' | 'unmatched' | 'blocked';
   line: string;
 }
 
@@ -37,11 +38,11 @@ const MAX_EVENTS = 1000;
 const WRAP_LINES_STORAGE_KEY = 'bffless.traffic.wrapLines';
 
 /**
- * Default view: only the signal (Unmatched requests and 4xx/5xx responses).
- * "Show all" reveals the 200-OK asset firehose too.
+ * Default view: only the signal (Unmatched/blocked requests and 4xx/5xx
+ * responses). "Show all" reveals the 200-OK asset firehose too.
  */
 export function isSignalEvent(event: TrafficStreamEvent): boolean {
-  return event.classification === 'unmatched' || event.status >= 400;
+  return event.classification !== 'matched' || event.status >= 400;
 }
 
 export function TrafficPage() {
@@ -67,6 +68,7 @@ export function TrafficPage() {
           <TabsTrigger value="live">Live</TabsTrigger>
           <TabsTrigger value="history">History</TabsTrigger>
           <TabsTrigger value="rollup">By IP</TabsTrigger>
+          <TabsTrigger value="blocklist">Blocklist</TabsTrigger>
         </TabsList>
         {/* forceMount keeps the live tail mounted (hidden) across tab switches,
             so the SSE connection and accumulated events survive visiting
@@ -79,6 +81,9 @@ export function TrafficPage() {
         </TabsContent>
         <TabsContent value="rollup">
           <TrafficRollupTab />
+        </TabsContent>
+        <TabsContent value="blocklist">
+          <TrafficBlocklistTab />
         </TabsContent>
       </Tabs>
     </div>
@@ -196,6 +201,11 @@ export function LiveTrafficTab() {
               >
                 {event.classification === 'unmatched' && (
                   <span className="text-[#d96459] mr-1" title="Unmatched request">
+                    ●
+                  </span>
+                )}
+                {event.classification === 'blocked' && (
+                  <span className="text-purple-400 mr-1" title="Blocked by Blocklist">
                     ●
                   </span>
                 )}

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -214,6 +214,8 @@ export const api = createApi({
     'MyProjects',
     'TrafficRequest',
     'TrafficIpRollup',
+    'Blocklist',
+    'BlocklistSettings',
   ],
   endpoints: () => ({}),
 });

--- a/apps/frontend/src/services/trafficApi.ts
+++ b/apps/frontend/src/services/trafficApi.ts
@@ -6,6 +6,37 @@ import { api } from './api';
  * interceptor observes, admin-only.
  */
 
+export type BlocklistMatchType = 'prefix' | 'exact' | 'suffix' | 'extension' | 'contains';
+
+export interface BlocklistPatternEntry {
+  matchType: BlocklistMatchType;
+  value: string;
+}
+
+/** A named Blocklist from the admin-global library (issue #391). */
+export interface BlocklistEntry {
+  id: string;
+  name: string;
+  description: string | null;
+  entries: BlocklistPatternEntry[];
+  allowlist: BlocklistPatternEntry[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BlocklistSettings {
+  /** Master toggle: false disables ALL blocking (Baseline and lists) instantly. */
+  enabled: boolean;
+  baselineEntryCount: number;
+}
+
+export interface UpsertBlocklistInput {
+  name?: string;
+  description?: string;
+  entries?: BlocklistPatternEntry[];
+  allowlist?: BlocklistPatternEntry[];
+}
+
 export interface TrafficRequestEntry {
   id: string;
   timestamp: string;
@@ -91,10 +122,69 @@ export const trafficApi = api.injectEndpoints({
       query: (params) => `/api/traffic/ips${toQueryString({ ...(params ?? {}) })}`,
       providesTags: [{ type: 'TrafficIpRollup' as const, id: 'LIST' }],
     }),
+
+    getBlocklistSettings: builder.query<BlocklistSettings, void>({
+      query: () => '/api/traffic/blocklist-settings',
+      providesTags: ['BlocklistSettings'],
+    }),
+
+    updateBlocklistSettings: builder.mutation<BlocklistSettings, { enabled: boolean }>({
+      query: (body) => ({
+        url: '/api/traffic/blocklist-settings',
+        method: 'PATCH',
+        body,
+      }),
+      invalidatesTags: ['BlocklistSettings'],
+    }),
+
+    getBaselineBlocklist: builder.query<{ entries: BlocklistPatternEntry[] }, void>({
+      query: () => '/api/traffic/blocklists/baseline',
+    }),
+
+    listBlocklists: builder.query<BlocklistEntry[], void>({
+      query: () => '/api/traffic/blocklists',
+      providesTags: [{ type: 'Blocklist' as const, id: 'LIST' }],
+    }),
+
+    createBlocklist: builder.mutation<BlocklistEntry, UpsertBlocklistInput>({
+      query: (body) => ({
+        url: '/api/traffic/blocklists',
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: [{ type: 'Blocklist' as const, id: 'LIST' }],
+    }),
+
+    updateBlocklist: builder.mutation<BlocklistEntry, { id: string } & UpsertBlocklistInput>({
+      query: ({ id, ...body }) => ({
+        url: `/api/traffic/blocklists/${id}`,
+        method: 'PATCH',
+        body,
+      }),
+      invalidatesTags: [{ type: 'Blocklist' as const, id: 'LIST' }],
+    }),
+
+    deleteBlocklist: builder.mutation<void, string>({
+      query: (id) => ({
+        url: `/api/traffic/blocklists/${id}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: [{ type: 'Blocklist' as const, id: 'LIST' }],
+    }),
   }),
 });
 
-export const { useListTrafficRequestsQuery, useListTrafficIpRollupsQuery } = trafficApi;
+export const {
+  useListTrafficRequestsQuery,
+  useListTrafficIpRollupsQuery,
+  useGetBlocklistSettingsQuery,
+  useUpdateBlocklistSettingsMutation,
+  useGetBaselineBlocklistQuery,
+  useListBlocklistsQuery,
+  useCreateBlocklistMutation,
+  useUpdateBlocklistMutation,
+  useDeleteBlocklistMutation,
+} = trafficApi;
 
 /**
  * Download a Request-log or per-IP-rollup export (CSV/JSON) as a file.


### PR DESCRIPTION
Closes #391 (parent #383). Third tracer-bullet slice: Blocklists exist and are enforced at the application layer. Edge (nginx) enforcement is #392; per-domain attachment + inline add-to-blocklist is #393.

## What's here

**Data model** — `blocklists` + `blocklist_entries` (migration 0035): an admin-global library of named lists. Entries are stored structured as `{ matchType, value }` (`prefix` | `exact` | `suffix` | `extension` | `contains`, default `prefix`), discriminated by `kind` into block patterns and allowlist exceptions. Allowlist entries always win — including over the Baseline, so a false positive is rescued without forking it.

**Compiler** (`blocklist-compiler.ts`, pure) — the only code that turns admin input into matching rules. Values are validated against a strict charset whitelist (nginx/PCRE syntax like `{ } ; $ "` and whitespace is unrepresentable), every regex metacharacter is escaped, and each matchType compiles to an anchored source. Admin input can only widen the blocked set. The same sources will feed #392's generated nginx `location ~*` rules.

**Baseline** (`blocklist-baseline.ts`) — the ~200 signatures from the static `docker/nginx/blocklist.conf` http-map, transcribed into the structured model. Ships as code (improves on upgrade, not editable as data), applied to every request by default.

**Master toggle** — feature flag `BOT_PROTECTION_ENABLED` (default on): DB > file > env > default layering, so there's an env kill switch for free. Off = nothing blocks, instantly.

**Enforcement** — `BlocklistService` holds a compiled in-memory matcher (rebuilt on every mutation, re-synced every 30s, degrades to Baseline-only if the tables are unreachable). The traffic observer middleware decides the blocked verdict **before `next()`**, answers a bare empty-body 403 (same no-detail discipline as the #389 404 fix), and emits `classification: 'blocked'` — #390's persistence, History/By IP tabs, and exports pick blocked requests up unchanged. Matching runs against the client-visible path from `X-Original-URI` (nginx rewrites content requests to `/public/...`), case-insensitively, raw + percent-decoded. `/api/` and `/auth/` are enforcement-exempt so a runaway pattern can never lock an admin out of the toggle.

**API** — admin-only (`ApiKeyGuard` + `RolesGuard` + `@Roles('admin')`): CRUD under `/api/traffic/blocklists`, `GET/PATCH /api/traffic/blocklist-settings`, read-only `GET /api/traffic/blocklists/baseline`.

**UI** — new **Blocklist** tab on `/traffic`: master toggle with expandable Baseline viewer, library editor with one-pattern-per-line textareas (`exact:` / `suffix:` / `extension:` / `contains:` tags, bare line = prefix, `#` comments), per-pattern server validation errors inline, delete confirmation. The Live tail marks blocked lines.

## Behaviour notes

- Until #393, named Blocklists apply instance-wide app-side (Baseline semantics).
- Bot protection defaults ON. This matches today's docker-compose edge behaviour; on GKE (where the edge map is an empty stub) scanner paths now get 403s app-side instead of leaky 404s — the gap #383 documents.
- Pre-migration / DB-failure the service falls back to Baseline-only enforcement rather than dropping protection.

## Testing (per the #383 seam plan)

- **Seam 2** — compiler pure-function tests: charset rejection (incl. injection attempts), literal-only matching, anchoring per matchType, allowlist precedence over Baseline, Baseline sanity (blocks `/.env`, `/wp-login.php`…; does not block `/index.html`, `/.well-known/...`, `/robots.txt`).
- **Seam 1** — supertest through a real Nest app with the middleware installed: bare-403 + empty body + `blocked` event, X-Original-URI matching, control-surface exemption, toggle-off passthrough.
- Service tests (CRUD validation/normalization/dedupe, refresh failure modes) and guard-metadata tests on every new endpoint.
- Full suites green: backend 84/84 (1313 tests), frontend 26/26 (403 tests), both typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKcWfgVZevHdobRQXzRqHA