### PR TITLE
feat(traffic): per-domain Blocklist attachment + inline add-to-blocklist (#393)

### DIFF
--- a/apps/backend/drizzle/0036_stale_hydra.sql
+++ b/apps/backend/drizzle/0036_stale_hydra.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "domain_blocklists" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"domain_mapping_id" uuid NOT NULL,
+	"blocklist_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "blocklists" ADD COLUMN "is_default" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "domain_blocklists" ADD CONSTRAINT "domain_blocklists_domain_mapping_id_domain_mappings_id_fk" FOREIGN KEY ("domain_mapping_id") REFERENCES "public"."domain_mappings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "domain_blocklists" ADD CONSTRAINT "domain_blocklists_blocklist_id_blocklists_id_fk" FOREIGN KEY ("blocklist_id") REFERENCES "public"."blocklists"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "domain_blocklists_domain_blocklist_unique" ON "domain_blocklists" USING btree ("domain_mapping_id","blocklist_id");--> statement-breakpoint
+CREATE INDEX "domain_blocklists_domain_mapping_id_idx" ON "domain_blocklists" USING btree ("domain_mapping_id");--> statement-breakpoint
+CREATE INDEX "domain_blocklists_blocklist_id_idx" ON "domain_blocklists" USING btree ("blocklist_id");

--- a/apps/backend/drizzle/meta/0036_snapshot.json
+++ b/apps/backend/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,6815 @@
+{
+  "id": "40a73e58-941a-4dab-8ce1-39e256f91c12",
+  "prevId": "952d7ffa-f0e4-402f-af59-c30eae4fa678",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alias_proxy_rule_sets": {
+      "name": "alias_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alias_proxy_rule_sets_alias_ruleset_unique": {
+          "name": "alias_proxy_rule_sets_alias_ruleset_unique",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_alias_id_idx": {
+          "name": "alias_proxy_rule_sets_alias_id_idx",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_rule_set_id_idx": {
+          "name": "alias_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk": {
+          "name": "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "deployment_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_project_id_idx": {
+          "name": "api_keys_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_path": {
+          "name": "original_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_number": {
+          "name": "workflow_run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'commits'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_project_id_idx": {
+          "name": "assets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_type_idx": {
+          "name": "assets_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_path_idx": {
+          "name": "assets_project_commit_path_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_branch_idx": {
+          "name": "assets_project_branch_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_idx": {
+          "name": "assets_project_commit_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_created_at_idx": {
+          "name": "assets_project_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_committed_at_idx": {
+          "name": "assets_project_committed_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_path_idx": {
+          "name": "assets_deployment_path_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_id_idx": {
+          "name": "assets_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_size_idx": {
+          "name": "assets_deployment_size_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_uploaded_by_users_id_fk": {
+          "name": "assets_uploaded_by_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist_entries": {
+      "name": "blocklist_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prefix'"
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklist_entries_blocklist_id_idx": {
+          "name": "blocklist_entries_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocklist_entries_unique": {
+          "name": "blocklist_entries_unique",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocklist_entries_blocklist_id_blocklists_id_fk": {
+          "name": "blocklist_entries_blocklist_id_blocklists_id_fk",
+          "tableFrom": "blocklist_entries",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklists": {
+      "name": "blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklists_name_unique": {
+          "name": "blocklists_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cache_rules": {
+      "name": "cache_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_max_age": {
+          "name": "browser_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "cdn_max_age": {
+          "name": "cdn_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stale_while_revalidate": {
+          "name": "stale_while_revalidate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immutable": {
+          "name": "immutable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cacheability": {
+          "name": "cacheability",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cache_rules_project_pattern_unique": {
+          "name": "cache_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_id_idx": {
+          "name": "cache_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_priority_idx": {
+          "name": "cache_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cache_rules_project_id_projects_id_fk": {
+          "name": "cache_rules_project_id_projects_id_fk",
+          "tableFrom": "cache_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_aliases": {
+      "name": "deployment_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_preview": {
+          "name": "is_auto_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployment_aliases_project_alias_unique": {
+          "name": "deployment_aliases_project_alias_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_project_id_idx": {
+          "name": "deployment_aliases_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_alias_unique": {
+          "name": "deployment_aliases_repository_alias_unique",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_idx": {
+          "name": "deployment_aliases_repository_idx",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_commit_sha_idx": {
+          "name": "deployment_aliases_commit_sha_idx",
+          "columns": [
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_deployment_id_idx": {
+          "name": "deployment_aliases_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_aliases_project_id_projects_id_fk": {
+          "name": "deployment_aliases_project_id_projects_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_blocklists": {
+      "name": "domain_blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_blocklists_domain_blocklist_unique": {
+          "name": "domain_blocklists_domain_blocklist_unique",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_blocklists_domain_mapping_id_idx": {
+          "name": "domain_blocklists_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_blocklists_blocklist_id_idx": {
+          "name": "domain_blocklists_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_blocklists_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "domain_blocklists_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "domain_blocklists",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_blocklists_blocklist_id_blocklists_id_fk": {
+          "name": "domain_blocklists_blocklist_id_blocklists_id_fk",
+          "tableFrom": "domain_blocklists",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_mappings": {
+      "name": "domain_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_type": {
+          "name": "domain_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ssl_expires_at": {
+          "name": "ssl_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_verified": {
+          "name": "dns_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dns_verified_at": {
+          "name": "dns_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_renew_ssl": {
+          "name": "auto_renew_ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_renewed_at": {
+          "name": "ssl_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_status": {
+          "name": "ssl_renewal_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_error": {
+          "name": "ssl_renewal_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sticky_sessions_enabled": {
+          "name": "sticky_sessions_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sticky_session_duration": {
+          "name": "sticky_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 86400
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_mappings_project_id_idx": {
+          "name": "domain_mappings_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_domain_idx": {
+          "name": "domain_mappings_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_is_active_idx": {
+          "name": "domain_mappings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_mappings_project_id_projects_id_fk": {
+          "name": "domain_mappings_project_id_projects_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_mappings_created_by_users_id_fk": {
+          "name": "domain_mappings_created_by_users_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_mappings_domain_unique": {
+          "name": "domain_mappings_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_redirects": {
+      "name": "domain_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_domain": {
+          "name": "source_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_domain_id": {
+          "name": "target_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_redirects_target_domain_id_idx": {
+          "name": "domain_redirects_target_domain_id_idx",
+          "columns": [
+            {
+              "expression": "target_domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_redirects_source_domain_idx": {
+          "name": "domain_redirects_source_domain_idx",
+          "columns": [
+            {
+              "expression": "source_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_redirects_target_domain_id_domain_mappings_id_fk": {
+          "name": "domain_redirects_target_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "target_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_redirects_created_by_users_id_fk": {
+          "name": "domain_redirects_created_by_users_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_redirects_source_domain_unique": {
+          "name": "domain_redirects_source_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_rules": {
+      "name": "domain_traffic_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_key": {
+          "name": "condition_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_value": {
+          "name": "condition_value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_rules_domain_id_idx": {
+          "name": "domain_traffic_rules_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_traffic_rules_domain_id_priority_idx": {
+          "name": "domain_traffic_rules_domain_id_priority_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_rules_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_rules_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_rules",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_weights": {
+      "name": "domain_traffic_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_weights_domain_id_idx": {
+          "name": "domain_traffic_weights_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_weights_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_weights_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_weights",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_traffic_weights_domain_alias_unique": {
+          "name": "domain_traffic_weights_domain_alias_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain_id",
+            "alias"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flags_key_idx": {
+          "name": "feature_flags_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_integration_credentials": {
+      "name": "google_integration_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured": {
+          "name": "configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "google_integration_credentials_service_unique": {
+          "name": "google_integration_credentials_service_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oidc_providers_provider_id_unique": {
+          "name": "oidc_providers_provider_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rule_executions": {
+      "name": "onboarding_rule_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rule_executions_user_idx": {
+          "name": "onboarding_rule_executions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_rule_idx": {
+          "name": "onboarding_rule_executions_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_executed_at_idx": {
+          "name": "onboarding_rule_executions_executed_at_idx",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_status_idx": {
+          "name": "onboarding_rule_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rule_executions_rule_id_onboarding_rules_id_fk": {
+          "name": "onboarding_rule_executions_rule_id_onboarding_rules_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "onboarding_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "onboarding_rule_executions_user_id_users_id_fk": {
+          "name": "onboarding_rule_executions_user_id_users_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rules": {
+      "name": "onboarding_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_signup'"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rules_enabled_trigger_idx": {
+          "name": "onboarding_rules_enabled_trigger_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rules_priority_idx": {
+          "name": "onboarding_rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rules_created_by_users_id_fk": {
+          "name": "onboarding_rules_created_by_users_id_fk",
+          "tableFrom": "onboarding_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_preferences": {
+      "name": "path_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spa_mode": {
+          "name": "spa_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_path_preferences_project_id": {
+          "name": "idx_path_preferences_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_preferences_project_id_projects_id_fk": {
+          "name": "path_preferences_project_id_projects_id_fk",
+          "tableFrom": "path_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "path_preferences_project_filepath_unique": {
+          "name": "path_preferences_project_filepath_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "filepath"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_redirects": {
+      "name": "path_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'100'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "path_redirects_domain_mapping_id_idx": {
+          "name": "path_redirects_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "path_redirects_source_path_idx": {
+          "name": "path_redirects_source_path_idx",
+          "columns": [
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_redirects_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "path_redirects_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "path_redirects_created_by_users_id_fk": {
+          "name": "path_redirects_created_by_users_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_token": {
+          "name": "upload_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_token_idx": {
+          "name": "pending_uploads_token_idx",
+          "columns": [
+            {
+              "expression": "upload_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_project_idx": {
+          "name": "pending_uploads_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_project_id_projects_id_fk": {
+          "name": "pending_uploads_project_id_projects_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_uploaded_by_users_id_fk": {
+          "name": "pending_uploads_uploaded_by_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_uploads_upload_token_unique": {
+          "name": "pending_uploads_upload_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data_embeddings": {
+      "name": "pipeline_data_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_data_id": {
+          "name": "pipeline_data_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_embeddings_data_id_idx": {
+          "name": "pipeline_data_embeddings_data_id_idx",
+          "columns": [
+            {
+              "expression": "pipeline_data_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_embeddings_schema_field_idx": {
+          "name": "pipeline_data_embeddings_schema_field_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk": {
+          "name": "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_data",
+          "columnsFrom": [
+            "pipeline_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data": {
+      "name": "pipeline_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_project_id_idx": {
+          "name": "pipeline_data_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_schema_id_idx": {
+          "name": "pipeline_data_schema_id_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_created_at_idx": {
+          "name": "pipeline_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_project_id_projects_id_fk": {
+          "name": "pipeline_data_project_id_projects_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_created_by_users_id_fk": {
+          "name": "pipeline_data_created_by_users_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_execution_logs": {
+      "name": "pipeline_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_id": {
+          "name": "proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps_count": {
+          "name": "steps_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_step": {
+          "name": "error_step",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_meta": {
+          "name": "request_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_exec_logs_rule_created_idx": {
+          "name": "pipeline_exec_logs_rule_created_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_project_idx": {
+          "name": "pipeline_exec_logs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_created_idx": {
+          "name": "pipeline_exec_logs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_execution_logs_project_id_projects_id_fk": {
+          "name": "pipeline_execution_logs_project_id_projects_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schemas": {
+      "name": "pipeline_schemas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schemas_project_id_idx": {
+          "name": "pipeline_schemas_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schemas_project_id_projects_id_fk": {
+          "name": "pipeline_schemas_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schemas",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pipeline_schemas_project_name_unique": {
+          "name": "pipeline_schemas_project_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.primary_content": {
+      "name": "primary_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "www_enabled": {
+          "name": "www_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'redirect-to-www'"
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "primary_content_project_id_projects_id_fk": {
+          "name": "primary_content_project_id_projects_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "primary_content_configured_by_users_id_fk": {
+          "name": "primary_content_configured_by_users_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_default_proxy_rule_sets": {
+      "name": "project_default_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_default_proxy_rule_sets_project_ruleset_unique": {
+          "name": "project_default_proxy_rule_sets_project_ruleset_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_project_id_idx": {
+          "name": "project_default_proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_rule_set_id_idx": {
+          "name": "project_default_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_default_proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "project_default_proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite_links": {
+      "name": "project_invite_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guest'"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invite_links_project_id_idx": {
+          "name": "project_invite_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_token_idx": {
+          "name": "project_invite_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_is_active_idx": {
+          "name": "project_invite_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_links_project_id_projects_id_fk": {
+          "name": "project_invite_links_project_id_projects_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_links_created_by_users_id_fk": {
+          "name": "project_invite_links_created_by_users_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_links_token_unique": {
+          "name": "project_invite_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_group_permissions": {
+      "name": "project_group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_group_permissions_project_idx": {
+          "name": "project_group_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_permissions_group_idx": {
+          "name": "project_group_permissions_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_permissions_project_id_projects_id_fk": {
+          "name": "project_group_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_group_id_user_groups_id_fk": {
+          "name": "project_group_permissions_group_id_user_groups_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_granted_by_users_id_fk": {
+          "name": "project_group_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_group_permissions_unique": {
+          "name": "project_group_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "group_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_permissions": {
+      "name": "project_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_permissions_project_idx": {
+          "name": "project_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_permissions_user_idx": {
+          "name": "project_permissions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_permissions_project_id_projects_id_fk": {
+          "name": "project_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_user_id_users_id_fk": {
+          "name": "project_permissions_user_id_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_granted_by_users_id_fk": {
+          "name": "project_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_permissions_unique": {
+          "name": "project_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_secrets": {
+      "name": "project_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_secrets_project_name_unique": {
+          "name": "project_secrets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_secrets_project_id_idx": {
+          "name": "project_secrets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_secrets_project_id_projects_id_fk": {
+          "name": "project_secrets_project_id_projects_id_fk",
+          "tableFrom": "project_secrets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_found'"
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authenticated'"
+        },
+        "allow_public_signup": {
+          "name": "allow_public_signup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_providers": {
+          "name": "ai_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_services": {
+          "name": "ai_services",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_proxy_rule_set_id": {
+          "name": "default_proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_created_by_idx": {
+          "name": "projects_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_owner_idx": {
+          "name": "projects_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_owner_name_unique": {
+          "name": "projects_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_sets": {
+      "name": "proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_sets_project_name_unique": {
+          "name": "proxy_rule_sets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_project_id_idx": {
+          "name": "proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_environment_idx": {
+          "name": "proxy_rule_sets_environment_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rules": {
+      "name": "proxy_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "methods": {
+          "name": "methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strip_prefix": {
+          "name": "strip_prefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "preserve_host": {
+          "name": "preserve_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forward_cookies": {
+          "name": "forward_cookies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "header_config": {
+          "name": "header_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_transform": {
+          "name": "auth_transform",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_rewrite": {
+          "name": "internal_rewrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proxy_type": {
+          "name": "proxy_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external_proxy'"
+        },
+        "email_handler_config": {
+          "name": "email_handler_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "debug_enabled": {
+          "name": "debug_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rules_rule_set_path_method_unique": {
+          "name": "proxy_rules_rule_set_path_method_unique",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_id_idx": {
+          "name": "proxy_rules_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_order_idx": {
+          "name": "proxy_rules_rule_set_order_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_proxy_type_idx": {
+          "name": "proxy_rules_proxy_type_idx",
+          "columns": [
+            {
+              "expression": "proxy_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rules_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rules_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rules",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_header_rules": {
+      "name": "response_header_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_policy": {
+          "name": "frame_policy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sameorigin'"
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_header_rules_project_pattern_unique": {
+          "name": "response_header_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_id_idx": {
+          "name": "response_header_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_priority_idx": {
+          "name": "response_header_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "response_header_rules_project_id_projects_id_fk": {
+          "name": "response_header_rules_project_id_projects_id_fk",
+          "tableFrom": "response_header_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_logs": {
+      "name": "retention_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_count": {
+          "name": "asset_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "freed_bytes": {
+          "name": "freed_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_partial": {
+          "name": "is_partial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_logs_project_id_idx": {
+          "name": "retention_logs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_rule_id_idx": {
+          "name": "retention_logs_rule_id_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_deleted_at_idx": {
+          "name": "retention_logs_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_project_deleted_at_idx": {
+          "name": "retention_logs_project_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_logs_project_id_projects_id_fk": {
+          "name": "retention_logs_project_id_projects_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retention_logs_rule_id_retention_rules_id_fk": {
+          "name": "retention_logs_rule_id_retention_rules_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "retention_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_rules": {
+      "name": "retention_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_pattern": {
+          "name": "branch_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_branches": {
+          "name": "exclude_branches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keep_with_alias": {
+          "name": "keep_with_alias",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "keep_minimum": {
+          "name": "keep_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "path_patterns": {
+          "name": "path_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_mode": {
+          "name": "path_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_summary": {
+          "name": "last_run_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_rules_project_id_idx": {
+          "name": "retention_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_next_run_idx": {
+          "name": "retention_rules_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_enabled_next_run_idx": {
+          "name": "retention_rules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_rules_project_id_projects_id_fk": {
+          "name": "retention_rules_project_id_projects_id_fk",
+          "tableFrom": "retention_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "share_links_project_id_idx": {
+          "name": "share_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_domain_mapping_id_idx": {
+          "name": "share_links_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_token_idx": {
+          "name": "share_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_is_active_idx": {
+          "name": "share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_project_id_projects_id_fk": {
+          "name": "share_links_project_id_projects_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "share_links_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_created_by_users_id_fk": {
+          "name": "share_links_created_by_users_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "share_links_token_unique": {
+          "name": "share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_challenges": {
+      "name": "ssl_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "base_domain": {
+          "name": "base_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_type": {
+          "name": "challenge_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_name": {
+          "name": "record_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_value": {
+          "name": "record_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_data": {
+          "name": "order_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authz_data": {
+          "name": "authz_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_authorization": {
+          "name": "key_authorization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_challenges_base_domain_idx": {
+          "name": "ssl_challenges_base_domain_idx",
+          "columns": [
+            {
+              "expression": "base_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_challenges_status_idx": {
+          "name": "ssl_challenges_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ssl_challenges_base_domain_unique": {
+          "name": "ssl_challenges_base_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "base_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_renewal_history": {
+      "name": "ssl_renewal_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_type": {
+          "name": "certificate_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_expires_at": {
+          "name": "new_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_renewal_history_domain_id_idx": {
+          "name": "ssl_renewal_history_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_renewal_history_created_at_idx": {
+          "name": "ssl_renewal_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssl_renewal_history_domain_id_domain_mappings_id_fk": {
+          "name": "ssl_renewal_history_domain_id_domain_mappings_id_fk",
+          "tableFrom": "ssl_renewal_history",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_settings": {
+      "name": "ssl_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_config": {
+      "name": "system_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_setup_complete": {
+          "name": "is_setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_config": {
+          "name": "storage_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_provider": {
+          "name": "email_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_config": {
+          "name": "email_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_configured": {
+          "name": "email_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "smtp_config": {
+          "name": "smtp_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_configured": {
+          "name": "smtp_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_config": {
+          "name": "cache_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwt_secret": {
+          "name": "jwt_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_salt": {
+          "name": "api_key_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_public_signups": {
+          "name": "allow_public_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "telemetry_enabled": {
+          "name": "telemetry_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "telemetry_last_sent": {
+          "name": "telemetry_last_sent",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_config": {
+          "name": "branding_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_ip_rollups": {
+      "name": "traffic_ip_rollups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_paths": {
+          "name": "sample_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "sample_user_agents": {
+          "name": "sample_user_agents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_ip_rollups_ip_unique": {
+          "name": "traffic_ip_rollups_ip_unique",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_request_count_idx": {
+          "name": "traffic_ip_rollups_request_count_idx",
+          "columns": [
+            {
+              "expression": "request_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_last_seen_idx": {
+          "name": "traffic_ip_rollups_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_requests": {
+      "name": "traffic_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_version": {
+          "name": "http_version",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referer": {
+          "name": "referer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_requests_timestamp_idx": {
+          "name": "traffic_requests_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_ip_idx": {
+          "name": "traffic_requests_ip_idx",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_status_idx": {
+          "name": "traffic_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_classification_idx": {
+          "name": "traffic_requests_classification_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_group_members": {
+      "name": "user_group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_members_group_idx": {
+          "name": "user_group_members_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_group_members_user_idx": {
+          "name": "user_group_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_group_members_group_id_user_groups_id_fk": {
+          "name": "user_group_members_group_id_user_groups_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_user_id_users_id_fk": {
+          "name": "user_group_members_user_id_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_added_by_users_id_fk": {
+          "name": "user_group_members_added_by_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_group_members_unique": {
+          "name": "user_group_members_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_groups_created_by_idx": {
+          "name": "user_groups_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_created_by_users_id_fk": {
+          "name": "user_groups_created_by_users_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_verified_at": {
+          "name": "oidc_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_invitations_email": {
+          "name": "idx_workspace_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_invitations_token": {
+          "name": "idx_workspace_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invitations_invited_by_users_id_fk": {
+          "name": "workspace_invitations_invited_by_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_accepted_user_id_users_id_fk": {
+          "name": "workspace_invitations_accepted_user_id_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitations_token_unique": {
+          "name": "workspace_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1783015226726,
       "tag": "0035_lying_shooting_star",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1783024474244,
+      "tag": "0036_stale_hydra",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema/blocklists.schema.ts
+++ b/apps/backend/src/db/schema/blocklists.schema.ts
@@ -1,5 +1,14 @@
 import { relations } from 'drizzle-orm';
-import { pgTable, uuid, varchar, text, timestamp, uniqueIndex, index } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  uuid,
+  varchar,
+  text,
+  boolean,
+  timestamp,
+  uniqueIndex,
+  index,
+} from 'drizzle-orm/pg-core';
 
 /**
  * Blocklists (issue #383/#391): the admin-global library of named bot/scanner
@@ -8,9 +17,11 @@ import { pgTable, uuid, varchar, text, timestamp, uniqueIndex, index } from 'dri
  * blocklist_entries, discriminated by `kind`).
  *
  * Blocklists are admin-global (not project-scoped): they curate instance-wide
- * bot protection. Attachment to specific domains arrives with #393; the
- * code-shipped Baseline (see traffic/blocklist-baseline.ts) is NOT one of
- * these rows — it ships as code and improves on upgrade.
+ * bot protection. Since #393 a Blocklist applies per-domain: to every domain
+ * when `isDefault` is true, otherwise only to the domains it is attached to
+ * via domain_blocklists. The code-shipped Baseline (see
+ * traffic/blocklist-baseline.ts) is NOT one of these rows — it ships as code,
+ * improves on upgrade, and applies to every domain unconditionally.
  */
 export const blocklists = pgTable(
   'blocklists',
@@ -21,6 +32,14 @@ export const blocklists = pgTable(
     name: varchar('name', { length: 255 }).notNull(),
 
     description: text('description'),
+
+    /**
+     * The all-domains default attachment (#393): true means the list applies
+     * to every domain (plus the wildcard/unknown-host fallback), no explicit
+     * attachment needed. Defaults true so pre-#393 lists keep their original
+     * instance-wide behaviour across the upgrade.
+     */
+    isDefault: boolean('is_default').notNull().default(true),
 
     createdAt: timestamp('created_at').notNull().defaultNow(),
     updatedAt: timestamp('updated_at').notNull().defaultNow(),

--- a/apps/backend/src/db/schema/domain-blocklists.schema.ts
+++ b/apps/backend/src/db/schema/domain-blocklists.schema.ts
@@ -1,0 +1,56 @@
+import { pgTable, uuid, timestamp, uniqueIndex, index } from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { domainMappings } from './domain-mappings.schema';
+import { blocklists } from './blocklists.schema';
+
+/**
+ * Join table for domain mapping → Blocklist (issue #393), mirroring how proxy
+ * rule sets attach to aliases (alias_proxy_rule_sets).
+ *
+ * A domain's effective enforcement set = the code-shipped Baseline + every
+ * Blocklist with isDefault=true + the Blocklists attached here. There is no
+ * `order` column: unlike proxy rules, blocklist patterns merge as a plain
+ * union (allow always beats block), so attachment order carries no meaning.
+ *
+ * ON DELETE CASCADE on both FKs:
+ * - Deleting a domain mapping removes its attachments
+ * - Deleting a Blocklist detaches it everywhere (no orphaned references)
+ */
+export const domainBlocklists = pgTable(
+  'domain_blocklists',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+
+    domainMappingId: uuid('domain_mapping_id')
+      .references(() => domainMappings.id, { onDelete: 'cascade' })
+      .notNull(),
+
+    blocklistId: uuid('blocklist_id')
+      .references(() => blocklists.id, { onDelete: 'cascade' })
+      .notNull(),
+
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('domain_blocklists_domain_blocklist_unique').on(
+      table.domainMappingId,
+      table.blocklistId,
+    ),
+    index('domain_blocklists_domain_mapping_id_idx').on(table.domainMappingId),
+    index('domain_blocklists_blocklist_id_idx').on(table.blocklistId),
+  ],
+);
+
+export const domainBlocklistsRelations = relations(domainBlocklists, ({ one }) => ({
+  domainMapping: one(domainMappings, {
+    fields: [domainBlocklists.domainMappingId],
+    references: [domainMappings.id],
+  }),
+  blocklist: one(blocklists, {
+    fields: [domainBlocklists.blocklistId],
+    references: [blocklists.id],
+  }),
+}));
+
+export type DomainBlocklist = typeof domainBlocklists.$inferSelect;
+export type NewDomainBlocklist = typeof domainBlocklists.$inferInsert;

--- a/apps/backend/src/db/schema/index.ts
+++ b/apps/backend/src/db/schema/index.ts
@@ -41,3 +41,4 @@ export * from './google-integration-credentials.schema';
 export * from './traffic-requests.schema';
 export * from './traffic-ip-rollups.schema';
 export * from './blocklists.schema';
+export * from './domain-blocklists.schema';

--- a/apps/backend/src/domains/edge-blocklist.service.spec.ts
+++ b/apps/backend/src/domains/edge-blocklist.service.spec.ts
@@ -21,10 +21,12 @@ const mockExecFile = execFile as unknown as jest.Mock;
 
 describe('EdgeBlocklistService', () => {
   let state: CompiledBlocklistState;
+  let domainStates: Map<string, CompiledBlocklistState>;
   let service: EdgeBlocklistService;
 
   const blocklistService = {
     getCompiledState: jest.fn((): CompiledBlocklistState => state),
+    getCompiledDomainStates: jest.fn(() => domainStates),
   } as unknown as BlocklistService;
 
   beforeEach(() => {
@@ -34,6 +36,7 @@ describe('EdgeBlocklistService', () => {
         cb(null, { stdout: '', stderr: '' }),
     );
     state = { enabled: true, blockSource: '(?:^/wp\\-admin)', allowSource: null };
+    domainStates = new Map();
     service = new EdgeBlocklistService(blocklistService);
   });
 
@@ -124,5 +127,62 @@ describe('EdgeBlocklistService', () => {
     expect(rules.indexOf('set $blocklist_hit 1;')).toBeLessThan(
       rules.lastIndexOf('set $blocklist_hit 0;'),
     );
+  });
+
+  describe('per-domain rules (#393)', () => {
+    it('resolves a domain-specific set, falling back to the default for other ids', async () => {
+      domainStates = new Map([
+        ['dom-1', { enabled: true, blockSource: '(?:^/wp\\-admin|^/custom)', allowSource: null }],
+      ]);
+      await expect(service.sync()).resolves.toBe(true);
+
+      expect(service.getServerRules('444', 'dom-1')).toContain('^/custom');
+      expect(service.getServerRules('444', 'dom-2')).not.toContain('^/custom');
+      expect(service.getServerRules('444')).not.toContain('^/custom');
+      expect(service.getServerRules('444', 'dom-2')).toContain('^/wp\\-admin');
+    });
+
+    it('validates each distinct source pair exactly once', async () => {
+      domainStates = new Map([
+        ['dom-1', { enabled: true, blockSource: '(?:^/custom)', allowSource: null }],
+        ['dom-2', { enabled: true, blockSource: '(?:^/custom)', allowSource: null }],
+      ]);
+      await service.sync();
+      // default pair + one shared per-domain pair = 2 nginx -t runs
+      expect(mockExecFile).toHaveBeenCalledTimes(2);
+    });
+
+    it('treats an attachment change as a sync change', async () => {
+      await service.sync();
+      domainStates = new Map([
+        ['dom-1', { enabled: true, blockSource: '(?:^/custom)', allowSource: null }],
+      ]);
+      await expect(service.sync()).resolves.toBe(true);
+      expect(service.getServerRules('403', 'dom-1')).toContain('^/custom');
+    });
+
+    it('rolls back only the invalid pair, keeping other domains enforced', async () => {
+      domainStates = new Map([
+        ['dom-1', { enabled: true, blockSource: '(?:^/custom)', allowSource: null }],
+      ]);
+      mockExecFile.mockImplementation(
+        (_cmd: string, args: string[], cb: (err: unknown, out?: unknown) => void) => {
+          // The sandbox config is written per-pair; reject only the run whose
+          // rules contain the per-domain pattern (second call in sync order).
+          const writes = (jest.requireMock('fs/promises').writeFile as jest.Mock).mock.calls;
+          const lastConfig = String(writes[writes.length - 1]?.[1] ?? '');
+          if (lastConfig.includes('^/custom')) {
+            const error = new Error('nginx failed') as Error & { stderr: string };
+            error.stderr = 'nginx: [emerg] invalid regex';
+            cb(error);
+            return;
+          }
+          cb(null, { stdout: '', stderr: '' });
+        },
+      );
+      await service.sync();
+      expect(service.getServerRules('444')).toContain('return 444;');
+      expect(service.getServerRules('444', 'dom-1')).toBe('');
+    });
   });
 });

--- a/apps/backend/src/domains/edge-blocklist.service.ts
+++ b/apps/backend/src/domains/edge-blocklist.service.ts
@@ -12,19 +12,28 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+/** A validated pair of compiled regex sources, ready to render. */
+interface EdgeRuleSources {
+  blockSource: string | null;
+  allowSource: string | null;
+}
+
 /**
- * The edge enforcement seam (issue #392, ADR-0002): turns BlocklistService's
- * compiled effective set into validated nginx server-block rules that
- * NginxConfigService injects into every generated per-domain config.
+ * The edge enforcement seam (issues #392/#393, ADR-0002): turns
+ * BlocklistService's compiled effective sets into validated nginx
+ * server-block rules that NginxConfigService injects into every generated
+ * per-domain config. Since #393 the effective set is per-domain: the default
+ * set (Baseline + all-domains lists) plus, for domains with attachments,
+ * their own compiled pair.
  *
- * sync() pulls the compiled state, renders the rules, and — when an nginx
- * binary is available — validates them with `nginx -t` against a sandboxed,
- * self-contained config BEFORE they can ever reach sites-enabled/. An
- * invalid snippet rolls back to "no edge rules" (with a loud error): the
- * app-side interceptor still enforces the same set, so blocking degrades
- * gracefully instead of a broken config risking nginx startup. The compose
- * watcher's full-config `nginx -t` and nginx's own SIGHUP validation remain
- * the final gates on the reload itself.
+ * sync() pulls the compiled states, renders the rules, and — when an nginx
+ * binary is available — validates each DISTINCT source pair with `nginx -t`
+ * against a sandboxed, self-contained config BEFORE it can ever reach
+ * sites-enabled/. An invalid pair rolls back to "no edge rules" for the
+ * domains using it (with a loud error): the app-side interceptor still
+ * enforces the same set, so blocking degrades gracefully instead of a broken
+ * config risking nginx startup. The compose watcher's full-config `nginx -t`
+ * and nginx's own SIGHUP validation remain the final gates on the reload.
  *
  * getServerRules() is synchronous from the cache so config generators stay
  * simple; regeneration entry points call sync() first.
@@ -34,54 +43,87 @@ export class EdgeBlocklistService {
   private readonly logger = new Logger(EdgeBlocklistService.name);
 
   private fingerprint: string | null = null;
-  private blockSource: string | null = null;
-  private allowSource: string | null = null;
+  private defaultSources: EdgeRuleSources = { blockSource: null, allowSource: null };
+  /** Per-domain validated sources, only for domains that differ from the default. */
+  private domainSources = new Map<string, EdgeRuleSources>();
   private warnedMissingNginx = false;
 
   constructor(private readonly blocklistService: BlocklistService) {}
 
   /**
    * Re-derive (and validate) the cached edge rules from the current compiled
-   * Blocklist state. Returns true when the cached rules changed — callers use
+   * Blocklist states. Returns true when the cached rules changed — callers use
    * that to decide whether a config regeneration is needed.
    */
   async sync(): Promise<boolean> {
     const state = this.blocklistService.getCompiledState();
-    const fingerprint = `${state.enabled}|${state.blockSource ?? ''}|${state.allowSource ?? ''}`;
+    const domainStates = this.blocklistService.getCompiledDomainStates();
+
+    const pairKey = (pair: EdgeRuleSources): string =>
+      `${pair.blockSource ?? ''}~${pair.allowSource ?? ''}`;
+    const domainPart = [...domainStates.entries()]
+      .map(([id, s]) => `${id}=${pairKey(s)}`)
+      .sort()
+      .join(';');
+    const fingerprint = `${state.enabled}|${pairKey(state)}|${domainPart}`;
     if (fingerprint === this.fingerprint) {
       return false;
     }
 
-    // Disabled or empty set: edge rules are simply omitted.
-    let blockSource = state.enabled ? state.blockSource : null;
-    let allowSource = state.enabled ? state.allowSource : null;
-
-    if (blockSource) {
-      const rules = this.renderOrNull(blockSource, allowSource);
-      const valid = rules !== null && (await this.validateWithNginx(rules));
-      if (!valid) {
-        this.logger.error(
-          'Generated edge blocklist rules failed validation; omitting edge rules ' +
-            '(app-side enforcement still applies)',
-        );
-        blockSource = null;
-        allowSource = null;
-      }
+    // Disabled: edge rules are simply omitted everywhere.
+    if (!state.enabled) {
+      this.defaultSources = { blockSource: null, allowSource: null };
+      this.domainSources = new Map();
+      this.fingerprint = fingerprint;
+      return true;
     }
 
-    this.blockSource = blockSource;
-    this.allowSource = allowSource;
+    // Validate each DISTINCT pair once — most domains share the default set.
+    const validated = new Map<string, EdgeRuleSources>();
+    const validatePair = async (pair: EdgeRuleSources): Promise<EdgeRuleSources> => {
+      const key = pairKey(pair);
+      const cached = validated.get(key);
+      if (cached) {
+        return cached;
+      }
+      let result: EdgeRuleSources = { blockSource: pair.blockSource, allowSource: pair.allowSource };
+      if (result.blockSource) {
+        const rules = this.renderOrNull(result.blockSource, result.allowSource);
+        const valid = rules !== null && (await this.validateWithNginx(rules));
+        if (!valid) {
+          this.logger.error(
+            'Generated edge blocklist rules failed validation; omitting edge rules ' +
+              '(app-side enforcement still applies)',
+          );
+          result = { blockSource: null, allowSource: null };
+        }
+      }
+      validated.set(key, result);
+      return result;
+    };
+
+    this.defaultSources = await validatePair(state);
+    const domainSources = new Map<string, EdgeRuleSources>();
+    for (const [id, domainState] of domainStates) {
+      domainSources.set(id, await validatePair(domainState));
+    }
+    this.domainSources = domainSources;
     this.fingerprint = fingerprint;
     return true;
   }
 
   /**
    * The server-block rules for a generated config, from the last sync().
-   * Empty string when bot protection is off, the effective set is empty, or
-   * the last sync rolled back on a validation failure.
+   * `domainMappingId` selects that domain's effective set (#393); omitted or
+   * unknown ids get the default set (welcome page, redirect sources, mappings
+   * created since the last sync). Empty string when bot protection is off,
+   * the effective set is empty, or the last sync rolled back on a validation
+   * failure.
    */
-  getServerRules(returnCode: '444' | '403'): string {
-    const rules = this.renderOrNull(this.blockSource, this.allowSource, returnCode);
+  getServerRules(returnCode: '444' | '403', domainMappingId?: string): string {
+    const sources =
+      (domainMappingId && this.domainSources.get(domainMappingId)) || this.defaultSources;
+    const rules = this.renderOrNull(sources.blockSource, sources.allowSource, returnCode);
     return rules ?? '';
   }
 

--- a/apps/backend/src/domains/nginx-config.service.spec.ts
+++ b/apps/backend/src/domains/nginx-config.service.spec.ts
@@ -221,6 +221,8 @@ server {
       expect(config).toContain('testrepo');
       expect(config).toContain('production');
       expect(config).toContain('/apps/frontend/coverage');
+      // #393: edge rules are resolved for THIS mapping's effective set.
+      expect(mockEdgeBlocklistService.getServerRules).toHaveBeenCalledWith('444', 'domain-1');
     });
 
     // Regression: redirect targets that are absolute external URLs must be emitted

--- a/apps/backend/src/domains/nginx-config.service.ts
+++ b/apps/backend/src/domains/nginx-config.service.ts
@@ -126,11 +126,13 @@ export class NginxConfigService implements OnModuleInit {
 
   /**
    * Edge blocklist rules for embedding into a generated server block (#392).
-   * Shaped like the old static scanner block: either '' or a leading-newline
-   * section, so call sites can interpolate it unconditionally.
+   * `domainMappingId` selects the domain's effective set (#393); configs that
+   * serve no mapping (welcome page, redirect sources) omit it and get the
+   * default set. Shaped like the old static scanner block: either '' or a
+   * leading-newline section, so call sites can interpolate it unconditionally.
    */
-  private buildEdgeBlocklistRules(returnCode: '444' | '403'): string {
-    const rules = this.edgeBlocklistService.getServerRules(returnCode);
+  private buildEdgeBlocklistRules(returnCode: '444' | '403', domainMappingId?: string): string {
+    const rules = this.edgeBlocklistService.getServerRules(returnCode, domainMappingId);
     return rules ? `\n${rules}` : '';
   }
 
@@ -280,7 +282,7 @@ export class NginxConfigService implements OnModuleInit {
       backendPort: this.getBackendPort(),
       listenPort: this.getNginxListenPort(),
       createdAt: domainMapping.createdAt.toISOString(),
-      blocklistRules: this.edgeBlocklistService.getServerRules('444'),
+      blocklistRules: this.edgeBlocklistService.getServerRules('444', domainMapping.id),
     };
 
     let config = template(context);
@@ -434,7 +436,7 @@ export class NginxConfigService implements OnModuleInit {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;`;
 
-    const scannerBlock = this.buildEdgeBlocklistRules('403');
+    const scannerBlock = this.buildEdgeBlocklistRules('403', domainMapping.id);
 
     const errorPages = `
     # Custom error pages
@@ -674,7 +676,7 @@ server {
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
-${this.buildEdgeBlocklistRules('403')}
+${this.buildEdgeBlocklistRules('403', domainMapping.id)}
     # Custom error pages
     error_page 404 /404.html;
     error_page 500 502 503 504 /50x.html;
@@ -868,7 +870,7 @@ ${spaFallback}
 server {
     listen ${this.getNginxListenPort()};
     server_name ${config.domain};
-${this.buildEdgeBlocklistRules('403')}
+${this.buildEdgeBlocklistRules('403', config.id)}
     # Health check endpoint (used for DNS verification)
     location /.well-known/health {
         access_log off;
@@ -899,7 +901,7 @@ ${this.buildEdgeBlocklistRules('403')}
 server {
     listen ${this.getNginxListenPort()};
     server_name ${config.domain};
-${this.buildEdgeBlocklistRules('444')}
+${this.buildEdgeBlocklistRules('444', config.id)}
     # Health check endpoint
     location /.well-known/health {
         access_log off;
@@ -925,7 +927,7 @@ server {
     ssl_certificate_key ${sslKeyPath};
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
-${this.buildEdgeBlocklistRules('444')}
+${this.buildEdgeBlocklistRules('444', config.id)}
     # Redirect all traffic to target domain (HTTPS)
     location / {
         return ${redirectType} https://${config.redirectTarget}$request_uri;
@@ -1013,7 +1015,7 @@ ${httpServerBlock}${httpsServerBlock}
     add_header Link "<https://${canonicalDomain}$request_uri>; rel=\\"canonical\\"" always;`;
 
     // Edge blocklist rules (403 for Traefik compatibility)
-    const scannerBlock = this.buildEdgeBlocklistRules('403');
+    const scannerBlock = this.buildEdgeBlocklistRules('403', config.id);
 
     // Error page configuration
     const errorPages = `
@@ -1206,7 +1208,7 @@ ${serverBlocks}`;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Link "<https://${canonicalDomain}$request_uri>; rel=\\"canonical\\"" always;`;
 
-    const scannerBlock = this.buildEdgeBlocklistRules('444');
+    const scannerBlock = this.buildEdgeBlocklistRules('444', config.id);
 
     const errorPages = `
     # Custom error pages

--- a/apps/backend/src/traffic/blocklist-http.spec.ts
+++ b/apps/backend/src/traffic/blocklist-http.spec.ts
@@ -145,4 +145,34 @@ describe('Blocklist enforcement at the HTTP boundary', () => {
     await waitForEvents(1);
     expect(observed[0].classification).toBe('unmatched');
   });
+
+  it('passes the client-visible host so per-domain sets apply (#393)', async () => {
+    // Domain-scoped enforcer: blocks /scoped-probe only on attached.example.com.
+    shouldBlock = () => false;
+    const hostAware = jest.fn(
+      (pathname: string, host?: string | null) =>
+        pathname === '/scoped-probe' && host === 'attached.example.com',
+    );
+    (enforcer as { shouldBlock: BlocklistEnforcer['shouldBlock'] }).shouldBlock = hostAware;
+    try {
+      const onAttached = await request(app.getHttpServer())
+        .get('/scoped-probe')
+        .set('X-Forwarded-Host', 'attached.example.com');
+      expect(onAttached.status).toBe(403);
+
+      const elsewhere = await request(app.getHttpServer())
+        .get('/scoped-probe')
+        .set('X-Forwarded-Host', 'plain.example.com');
+      expect(elsewhere.status).toBe(404);
+
+      expect(hostAware).toHaveBeenCalledWith('/scoped-probe', 'attached.example.com');
+      expect(hostAware).toHaveBeenCalledWith('/scoped-probe', 'plain.example.com');
+
+      await waitForEvents(2);
+      expect(observed.map((e) => e.classification)).toEqual(['blocked', 'unmatched']);
+    } finally {
+      (enforcer as { shouldBlock: BlocklistEnforcer['shouldBlock'] }).shouldBlock = (pathname) =>
+        shouldBlock(pathname);
+    }
+  });
 });

--- a/apps/backend/src/traffic/blocklist.dto.ts
+++ b/apps/backend/src/traffic/blocklist.dto.ts
@@ -8,6 +8,7 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
+  IsUUID,
   MaxLength,
   ValidateNested,
 } from 'class-validator';
@@ -45,6 +46,14 @@ export class CreateBlocklistDto {
   @MaxLength(2_000)
   description?: string;
 
+  @ApiPropertyOptional({
+    description: 'Apply to all domains (default attachment). Defaults to true.',
+    default: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isDefault?: boolean;
+
   @ApiPropertyOptional({ type: [BlocklistPatternEntryDto], description: 'Block patterns' })
   @IsOptional()
   @IsArray()
@@ -79,6 +88,11 @@ export class UpdateBlocklistDto {
   @MaxLength(2_000)
   description?: string;
 
+  @ApiPropertyOptional({ description: 'Apply to all domains (default attachment)' })
+  @IsOptional()
+  @IsBoolean()
+  isDefault?: boolean;
+
   @ApiPropertyOptional({ type: [BlocklistPatternEntryDto], description: 'Replaces all block patterns when present' })
   @IsOptional()
   @IsArray()
@@ -100,4 +114,16 @@ export class UpdateBlocklistSettingsDto {
   @ApiProperty({ description: 'Master toggle: false disables ALL blocking instantly' })
   @IsBoolean()
   enabled!: boolean;
+}
+
+/** Inline "add to blocklist" from the Traffic views (#393): one block pattern. */
+export class AppendBlocklistEntryDto extends BlocklistPatternEntryDto {}
+
+/** Replace-all attachment of Blocklists to a domain mapping (#393). */
+export class SyncDomainBlocklistsDto {
+  @ApiProperty({ type: [String], description: 'Blocklist ids attached to the domain (replaces the set)' })
+  @IsArray()
+  @ArrayMaxSize(100)
+  @IsUUID('4', { each: true })
+  blocklistIds!: string[];
 }

--- a/apps/backend/src/traffic/blocklist.service.spec.ts
+++ b/apps/backend/src/traffic/blocklist.service.spec.ts
@@ -8,11 +8,13 @@ jest.mock('../db/client', () => {
   const methods = [
     'select',
     'from',
+    'innerJoin',
     'where',
     'orderBy',
     'limit',
     'insert',
     'values',
+    'onConflictDoNothing',
     'update',
     'set',
     'delete',
@@ -50,6 +52,7 @@ const listRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
   id: 'b1',
   name: 'my-list',
   description: null,
+  isDefault: true,
   createdAt: new Date('2026-07-01T00:00:00Z'),
   updatedAt: new Date('2026-07-01T00:00:00Z'),
   ...overrides,
@@ -90,6 +93,8 @@ describe('BlocklistService', () => {
         entryRow(),
         entryRow({ id: 'e2', kind: 'allow', matchType: 'exact', value: '/status' }),
       ]); // listBlocklists: entries
+      mockDb.__queue([]); // listBlocklists: attachments
+      mockDb.__queue([]); // refresh: domain mappings
       await service.refresh();
 
       expect(service.shouldBlock('/custom-probe/x')).toBe(true); // list pattern
@@ -101,6 +106,7 @@ describe('BlocklistService', () => {
     it('blocks nothing when the master toggle is off', async () => {
       featureFlags.isEnabled.mockResolvedValue(false);
       mockDb.__queue([]); // listBlocklists: no lists
+      mockDb.__queue([]); // refresh: domain mappings
       await service.refresh();
 
       expect(service.shouldBlock('/wp-login.php')).toBe(false);
@@ -109,6 +115,7 @@ describe('BlocklistService', () => {
 
     it('keeps the last good matcher when a refresh fails', async () => {
       mockDb.__queue([]); // successful refresh: Baseline only, enabled
+      mockDb.__queue([]); // refresh: domain mappings
       await service.refresh();
       expect(service.shouldBlock('/.env')).toBe(true);
 
@@ -132,6 +139,7 @@ describe('BlocklistService', () => {
   describe('compiled state + change listeners (edge enforcement, #392)', () => {
     it('exposes the compiled sources the matcher enforces', async () => {
       mockDb.__queue([]); // listBlocklists: no lists
+      mockDb.__queue([]); // refresh: domain mappings
       await service.refresh();
 
       const state = service.getCompiledState();
@@ -144,9 +152,11 @@ describe('BlocklistService', () => {
       const listener = jest.fn();
       service.onEffectiveChange(listener);
 
-      mockDb.__queue([]); // first refresh
+      mockDb.__queue([]); // first refresh: lists
+      mockDb.__queue([]); // first refresh: domain mappings
       await service.refresh();
       mockDb.__queue([]); // identical second refresh (interval re-sync)
+      mockDb.__queue([]);
       await service.refresh();
 
       expect(listener).not.toHaveBeenCalled();
@@ -156,17 +166,22 @@ describe('BlocklistService', () => {
       const listener = jest.fn();
       service.onEffectiveChange(listener);
 
-      mockDb.__queue([]); // initial load: Baseline only
+      mockDb.__queue([]); // initial load: Baseline only, lists
+      mockDb.__queue([]); // initial load: domain mappings
       await service.refresh();
 
       mockDb.__queue([listRow()]);
       mockDb.__queue([entryRow()]); // a list appears
+      mockDb.__queue([]); // attachments
+      mockDb.__queue([]); // domain mappings
       await service.refresh();
       expect(listener).toHaveBeenCalledTimes(1);
 
       featureFlags.isEnabled.mockResolvedValue(false); // toggle flips
       mockDb.__queue([listRow()]);
       mockDb.__queue([entryRow()]);
+      mockDb.__queue([]);
+      mockDb.__queue([]);
       await service.refresh();
       expect(listener).toHaveBeenCalledTimes(2);
     });
@@ -178,10 +193,13 @@ describe('BlocklistService', () => {
       });
       service.onEffectiveChange(second);
 
-      mockDb.__queue([]); // initial load
+      mockDb.__queue([]); // initial load: lists
+      mockDb.__queue([]); // initial load: domain mappings
       await service.refresh();
       mockDb.__queue([listRow()]);
       mockDb.__queue([entryRow()]); // change
+      mockDb.__queue([]); // attachments
+      mockDb.__queue([]); // domain mappings
       await service.refresh();
 
       expect(second).toHaveBeenCalledTimes(1);
@@ -200,6 +218,7 @@ describe('BlocklistService', () => {
     it('setEnabled writes the flag and rebuilds the matcher immediately', async () => {
       featureFlags.isEnabled.mockResolvedValue(false);
       mockDb.__queue([]); // refresh -> listBlocklists
+      mockDb.__queue([]); // refresh -> domain mappings
       await service.setEnabled(false);
 
       expect(featureFlags.setFlag).toHaveBeenCalledWith(BOT_PROTECTION_FLAG, false);
@@ -224,6 +243,7 @@ describe('BlocklistService', () => {
       mockDb.__queue([]);
       mockDb.__queue([listRow()]); // getBlocklist: list
       mockDb.__queue([entryRow({ value: '/wp-extra' })]); // getBlocklist: entries
+      mockDb.__queue([]); // getBlocklist: attachments
 
       const created = await service.createBlocklist({
         name: 'my-list',
@@ -267,6 +287,7 @@ describe('BlocklistService', () => {
       mockDb.__queue([]);
       mockDb.__queue([listRow()]); // getBlocklist: list
       mockDb.__queue([entryRow()]); // getBlocklist: entries
+      mockDb.__queue([]); // getBlocklist: attachments
 
       const updated = await service.updateBlocklist('b1', {
         entries: [{ matchType: 'prefix', value: '/custom-probe' }],
@@ -297,6 +318,7 @@ describe('BlocklistService', () => {
       mockDb.__queue([]); // delete (allow)
       mockDb.__queue([listRow()]); // getBlocklist: list
       mockDb.__queue([]); // getBlocklist: entries
+      mockDb.__queue([]); // getBlocklist: attachments
 
       await service.createBlocklist({
         name: 'my-list',
@@ -309,6 +331,192 @@ describe('BlocklistService', () => {
       expect(mockDb.values).toHaveBeenCalledWith([
         expect.objectContaining({ value: '/Probe' }),
       ]);
+    });
+  });
+
+  describe('per-domain enforcement (#393)', () => {
+    const attachmentRow = (blocklistId: string, domainMappingId: string, domain: string) => ({
+      blocklistId,
+      domainMappingId,
+      domain,
+    });
+
+    /** Refresh with one default list (b1), one attached-only list (b2 → dom-2). */
+    const refreshWithAttachment = async (service: BlocklistService) => {
+      mockDb.__queue([listRow(), listRow({ id: 'b2', name: 'scoped', isDefault: false })]);
+      mockDb.__queue([
+        entryRow(), // b1: /custom-probe (default list)
+        entryRow({ id: 'e2', blocklistId: 'b2', value: '/scoped-probe' }),
+        entryRow({
+          id: 'e3',
+          blocklistId: 'b2',
+          kind: 'allow',
+          matchType: 'exact',
+          value: '/status',
+        }),
+      ]);
+      mockDb.__queue([attachmentRow('b2', 'dom-2', 'attached.example.com')]);
+      mockDb.__queue([
+        { id: 'dom-1', domain: 'plain.example.com' },
+        { id: 'dom-2', domain: 'attached.example.com' },
+      ]);
+      await service.refresh();
+    };
+
+    it('scopes an attached list to its domain; other hosts get the default set', async () => {
+      await refreshWithAttachment(service);
+
+      // Attached list applies only on its domain (and its www variant).
+      expect(service.shouldBlock('/scoped-probe', 'attached.example.com')).toBe(true);
+      expect(service.shouldBlock('/scoped-probe', 'www.attached.example.com')).toBe(true);
+      expect(service.shouldBlock('/scoped-probe', 'ATTACHED.example.com:443')).toBe(true);
+      expect(service.shouldBlock('/scoped-probe', 'plain.example.com')).toBe(false);
+      expect(service.shouldBlock('/scoped-probe', 'unknown.example.com')).toBe(false);
+      expect(service.shouldBlock('/scoped-probe')).toBe(false);
+
+      // Default list + Baseline apply everywhere.
+      expect(service.shouldBlock('/custom-probe', 'plain.example.com')).toBe(true);
+      expect(service.shouldBlock('/.env', 'unknown.example.com')).toBe(true);
+
+      // b2's allowlist rescues only where b2 applies.
+      expect(service.shouldBlock('/status', 'attached.example.com')).toBe(false);
+      expect(service.shouldBlock('/status', 'plain.example.com')).toBe(true); // Baseline /status block
+    });
+
+    it('exposes per-domain compiled state only for domains that differ from the default', async () => {
+      await refreshWithAttachment(service);
+
+      const domainStates = service.getCompiledDomainStates();
+      expect([...domainStates.keys()]).toEqual(['dom-2']);
+      expect(domainStates.get('dom-2')!.blockSource).toContain('/scoped-probe');
+
+      expect(service.getCompiledStateForDomain('dom-2').blockSource).toContain('/scoped-probe');
+      expect(service.getCompiledStateForDomain('dom-1').blockSource).not.toContain(
+        '/scoped-probe',
+      );
+      expect(service.getCompiledStateForDomain('unknown').blockSource).not.toContain(
+        '/scoped-probe',
+      );
+    });
+
+    it('attaching an already-default list keeps the domain on the default matcher', async () => {
+      mockDb.__queue([listRow()]); // b1, isDefault: true
+      mockDb.__queue([entryRow()]);
+      mockDb.__queue([attachmentRow('b1', 'dom-1', 'plain.example.com')]); // redundant attach
+      mockDb.__queue([{ id: 'dom-1', domain: 'plain.example.com' }]);
+      await service.refresh();
+
+      expect(service.getCompiledDomainStates().size).toBe(0);
+      expect(service.getCompiledStateForDomain('dom-1')).toEqual(service.getCompiledState());
+    });
+
+    it('fires change listeners when an attachment lands', async () => {
+      const listener = jest.fn();
+      service.onEffectiveChange(listener);
+
+      mockDb.__queue([listRow({ id: 'b2', name: 'scoped', isDefault: false })]);
+      mockDb.__queue([entryRow({ blocklistId: 'b2', value: '/scoped-probe' })]);
+      mockDb.__queue([]); // no attachments yet
+      mockDb.__queue([{ id: 'dom-2', domain: 'attached.example.com' }]);
+      await service.refresh();
+      expect(listener).not.toHaveBeenCalled(); // initial load
+
+      mockDb.__queue([listRow({ id: 'b2', name: 'scoped', isDefault: false })]);
+      mockDb.__queue([entryRow({ blocklistId: 'b2', value: '/scoped-probe' })]);
+      mockDb.__queue([attachmentRow('b2', 'dom-2', 'attached.example.com')]);
+      mockDb.__queue([{ id: 'dom-2', domain: 'attached.example.com' }]);
+      await service.refresh();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('domain attachment API (#393)', () => {
+    beforeEach(() => {
+      jest.spyOn(service, 'refresh').mockResolvedValue(undefined);
+    });
+
+    it('syncDomainBlocklists replaces the set (delete + insert) and refreshes', async () => {
+      mockDb.__queue([{ id: 'dom-1' }]); // mapping existence check
+      mockDb.__queue([{ id: 'b1' }, { id: 'b2' }]); // blocklist ids check
+      mockDb.__queue([]); // tx delete
+      mockDb.__queue([]); // tx insert
+
+      const result = await service.syncDomainBlocklists('dom-1', ['b1', 'b2', 'b1']);
+
+      expect(result).toEqual({ domainMappingId: 'dom-1', blocklistIds: ['b1', 'b2'] });
+      expect(mockDb.delete).toHaveBeenCalledTimes(1);
+      expect(mockDb.values).toHaveBeenCalledWith([
+        { domainMappingId: 'dom-1', blocklistId: 'b1' },
+        { domainMappingId: 'dom-1', blocklistId: 'b2' },
+      ]);
+      expect(service.refresh).toHaveBeenCalled();
+    });
+
+    it('detaching everything skips the insert', async () => {
+      mockDb.__queue([{ id: 'dom-1' }]); // mapping existence check
+      mockDb.__queue([]); // tx delete
+
+      const result = await service.syncDomainBlocklists('dom-1', []);
+      expect(result.blocklistIds).toEqual([]);
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it('404s on an unknown domain mapping', async () => {
+      mockDb.__queue([]); // mapping existence check
+      await expect(service.syncDomainBlocklists('nope', [])).rejects.toThrow(NotFoundException);
+    });
+
+    it('400s on unknown blocklist ids, naming them', async () => {
+      mockDb.__queue([{ id: 'dom-1' }]);
+      mockDb.__queue([{ id: 'b1' }]); // only b1 exists
+      await expect(service.syncDomainBlocklists('dom-1', ['b1', 'b2'])).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    it('getDomainBlocklistIds returns the attached ids', async () => {
+      mockDb.__queue([{ blocklistId: 'b1' }, { blocklistId: 'b2' }]);
+      await expect(service.getDomainBlocklistIds('dom-1')).resolves.toEqual(['b1', 'b2']);
+    });
+  });
+
+  describe('appendEntry (inline add-to-blocklist, #393)', () => {
+    beforeEach(() => {
+      jest.spyOn(service, 'refresh').mockResolvedValue(undefined);
+    });
+
+    it('appends a normalized block pattern idempotently and refreshes', async () => {
+      mockDb.__queue([listRow()]); // existence check
+      mockDb.__queue([]); // insert … onConflictDoNothing
+      mockDb.__queue([]); // touch updatedAt
+      mockDb.__queue([listRow()]); // getBlocklist: list
+      mockDb.__queue([entryRow({ value: '/wp-extra' })]); // getBlocklist: entries
+      mockDb.__queue([]); // getBlocklist: attachments
+
+      const result = await service.appendEntry('b1', { matchType: 'prefix', value: 'wp-extra' });
+
+      expect(mockDb.values).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'block', matchType: 'prefix', value: '/wp-extra' }),
+      );
+      expect(mockDb.onConflictDoNothing).toHaveBeenCalled();
+      expect(result.entries).toEqual([{ matchType: 'prefix', value: '/wp-extra' }]);
+      expect(service.refresh).toHaveBeenCalled();
+    });
+
+    it('404s on an unknown Blocklist', async () => {
+      mockDb.__queue([]); // existence check
+      await expect(
+        service.appendEntry('nope', { matchType: 'prefix', value: '/x' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects an invalid pattern without writing', async () => {
+      mockDb.__queue([listRow()]); // existence check
+      await expect(
+        service.appendEntry('b1', { matchType: 'prefix', value: '/bad;{}' }),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockDb.insert).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/traffic/blocklist.service.ts
+++ b/apps/backend/src/traffic/blocklist.service.ts
@@ -9,7 +9,14 @@ import {
 import { Interval } from '@nestjs/schedule';
 import { and, asc, eq, inArray } from 'drizzle-orm';
 import { db } from '../db/client';
-import { blocklists, blocklistEntries, Blocklist, BlocklistEntry } from '../db/schema';
+import {
+  blocklists,
+  blocklistEntries,
+  domainBlocklists,
+  domainMappings,
+  Blocklist,
+  BlocklistEntry,
+} from '../db/schema';
 import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 import {
   BlocklistPatternEntry,
@@ -22,14 +29,23 @@ import { BASELINE_BLOCKLIST_ENTRIES } from './blocklist-baseline';
 /** Master toggle flag key (DB > file > env > default-on, see FLAG_DEFINITIONS). */
 export const BOT_PROTECTION_FLAG = 'BOT_PROTECTION_ENABLED';
 
-/** How often the compiled matcher re-syncs with the database (covers toggle
+/** How often the compiled matchers re-sync with the database (covers toggle
  *  flips made through the generic feature-flags API and multi-replica drift). */
 const REFRESH_INTERVAL_MS = 30_000;
+
+export interface AttachedDomainRef {
+  id: string;
+  domain: string;
+}
 
 export interface BlocklistWithEntries {
   id: string;
   name: string;
   description: string | null;
+  /** True = applies to all domains (the optional all-domains default, #393). */
+  isDefault: boolean;
+  /** Domains this list is explicitly attached to (relevant when !isDefault). */
+  attachedDomains: AttachedDomainRef[];
   entries: BlocklistPatternEntry[];
   allowlist: BlocklistPatternEntry[];
   createdAt: Date;
@@ -39,6 +55,7 @@ export interface BlocklistWithEntries {
 export interface UpsertBlocklistInput {
   name?: string;
   description?: string | null;
+  isDefault?: boolean;
   entries?: BlocklistPatternEntry[];
   allowlist?: BlocklistPatternEntry[];
 }
@@ -51,9 +68,9 @@ export interface BlocklistSettings {
 }
 
 /**
- * The compiled effective set, as consumed by edge enforcement (#392): the
- * same regex sources the in-memory matcher enforces app-side, plus the
- * toggle. Sources are null when there is nothing to block/allow.
+ * A compiled effective set, as consumed by edge enforcement (#392): the same
+ * regex sources the in-memory matcher enforces app-side, plus the toggle.
+ * Sources are null when there is nothing to block/allow.
  */
 export interface CompiledBlocklistState {
   enabled: boolean;
@@ -61,18 +78,26 @@ export interface CompiledBlocklistState {
   allowSource: string | null;
 }
 
+/** Normalize a Host/X-Forwarded-Host value for matcher lookup. */
+function normalizeHost(host: string): string {
+  return host.trim().toLowerCase().replace(/\.$/, '').replace(/:\d+$/, '');
+}
+
 /**
- * The Blocklist library + app-side enforcement authority (issue #391).
+ * The Blocklist library + app-side enforcement authority (issues #391/#393).
  *
- * Owns the admin-global library of named Blocklists and keeps an in-memory
- * compiled matcher (Baseline + every list's block patterns, minus every
- * list's allowlist) that the traffic observer middleware consults
- * synchronously on EVERY request — so enforcement adds no I/O to the hot
- * path. The matcher is rebuilt after each mutation and re-synced on an
- * interval.
+ * Owns the admin-global library of named Blocklists and their per-domain
+ * attachments. A domain's effective set = the code-shipped Baseline + every
+ * default (all-domains) list + the lists attached to that domain; allowlist
+ * exceptions apply on the same per-domain scope. Requests whose host matches
+ * no domain mapping (wildcard subdomain sites, the admin host, direct hits)
+ * are enforced with the default set: Baseline + default lists.
  *
- * Until #393 lands per-domain attachment, named Blocklists apply
- * instance-wide at the application layer, exactly like the Baseline.
+ * The compiled matchers live in memory and are consulted synchronously by the
+ * traffic observer middleware on EVERY request — enforcement adds no I/O to
+ * the hot path. They are rebuilt after each mutation and re-synced on an
+ * interval; edge enforcement (#392) consumes the identical compiled sources
+ * per domain, so app and edge can never disagree.
  */
 @Injectable()
 export class BlocklistService implements OnModuleInit {
@@ -81,7 +106,14 @@ export class BlocklistService implements OnModuleInit {
   // Start protected-by-default: Baseline-only, toggle at its default. The
   // first refresh() replaces this with the real database state; if that
   // fails (e.g. the migration has not run yet), the Baseline still applies.
-  private matcher: CompiledBlocklistMatcher = buildBlocklistMatcher(BASELINE_BLOCKLIST_ENTRIES, []);
+  private defaultMatcher: CompiledBlocklistMatcher = buildBlocklistMatcher(
+    BASELINE_BLOCKLIST_ENTRIES,
+    [],
+  );
+  /** Matcher per normalized hostname (includes www/apex variants). */
+  private hostMatchers = new Map<string, CompiledBlocklistMatcher>();
+  /** Matcher per domain mapping id, for edge config generation. */
+  private domainMatchers = new Map<string, CompiledBlocklistMatcher>();
   private enabled = true;
 
   /** Fingerprint of the last compiled state; null until the first refresh. */
@@ -95,22 +127,56 @@ export class BlocklistService implements OnModuleInit {
   }
 
   /**
-   * The compiled effective set for edge enforcement (#392). Same in-memory
-   * state shouldBlock() enforces, so app and edge can never disagree about
-   * what the effective rules are.
+   * The compiled default set (Baseline + all-domains lists), used for
+   * generated configs that serve no specific domain mapping (welcome page)
+   * and as the fallback for hosts no mapping claims.
    */
   getCompiledState(): CompiledBlocklistState {
     return {
       enabled: this.enabled,
-      blockSource: this.matcher.blockSource,
-      allowSource: this.matcher.allowSource,
+      blockSource: this.defaultMatcher.blockSource,
+      allowSource: this.defaultMatcher.allowSource,
     };
   }
 
   /**
+   * The compiled effective set for one domain mapping (#393), for edge
+   * enforcement. Unknown ids (e.g. a mapping created since the last refresh)
+   * fall back to the default set — the interval re-sync or the mutation-driven
+   * refresh converges them.
+   */
+  getCompiledStateForDomain(domainMappingId: string): CompiledBlocklistState {
+    const matcher = this.domainMatchers.get(domainMappingId) ?? this.defaultMatcher;
+    return {
+      enabled: this.enabled,
+      blockSource: matcher.blockSource,
+      allowSource: matcher.allowSource,
+    };
+  }
+
+  /**
+   * Every domain mapping whose compiled set DIFFERS from the default one, for
+   * edge enforcement (#392/#393): the edge service validates each distinct
+   * pair once and resolves per-domain rules at config-generation time.
+   */
+  getCompiledDomainStates(): Map<string, CompiledBlocklistState> {
+    const states = new Map<string, CompiledBlocklistState>();
+    for (const [id, matcher] of this.domainMatchers) {
+      if (matcher !== this.defaultMatcher) {
+        states.set(id, {
+          enabled: this.enabled,
+          blockSource: matcher.blockSource,
+          allowSource: matcher.allowSource,
+        });
+      }
+    }
+    return states;
+  }
+
+  /**
    * Register a listener fired whenever a refresh lands a DIFFERENT effective
-   * set (toggle flip, list mutation, or interval re-sync picking up another
-   * replica's change). Not fired for the initial load — startup config
+   * set (toggle flip, list/attachment mutation, or interval re-sync picking up
+   * another replica's change). Not fired for the initial load — startup config
    * regeneration reads the state directly. Listener errors are logged, never
    * propagated into refresh().
    */
@@ -119,52 +185,122 @@ export class BlocklistService implements OnModuleInit {
   }
 
   /**
-   * Synchronous enforcement check for the observer middleware. Must never
+   * Synchronous enforcement check for the observer middleware. `host` is the
+   * client-visible hostname (X-Forwarded-Host/Host) selecting the domain's
+   * effective set; unknown or missing hosts use the default set. Must never
    * throw — a matcher bug must not take down request serving.
    */
-  shouldBlock(pathname: string): boolean {
+  shouldBlock(pathname: string, host?: string | null): boolean {
     if (!this.enabled) {
       return false;
     }
     try {
-      return this.matcher.isBlocked(pathname);
+      const matcher = (host && this.hostMatchers.get(normalizeHost(host))) || this.defaultMatcher;
+      return matcher.isBlocked(pathname);
     } catch (error) {
       this.logger.error(`Blocklist match failed for ${pathname}: ${String(error)}`);
       return false;
     }
   }
 
-  /** Rebuild the compiled matcher from the toggle + Baseline + all lists. */
+  /** Rebuild all compiled matchers from the toggle + Baseline + lists + attachments. */
   @Interval(REFRESH_INTERVAL_MS)
   async refresh(): Promise<void> {
     try {
       const enabled = await this.featureFlags.isEnabled(BOT_PROTECTION_FLAG);
       let lists: BlocklistWithEntries[] = [];
+      let domains: Array<{ id: string; domain: string }> = [];
       try {
         lists = await this.listBlocklists();
+        domains = await db
+          .select({ id: domainMappings.id, domain: domainMappings.domain })
+          .from(domainMappings);
       } catch (error) {
         // Pre-migration or transient DB failure: enforce the Baseline alone
         // rather than dropping protection.
         this.logger.warn(`Could not load Blocklists; enforcing Baseline only: ${String(error)}`);
       }
 
-      const blockEntries = [
-        ...BASELINE_BLOCKLIST_ENTRIES,
-        ...lists.flatMap((list) => list.entries),
-      ];
-      const allowEntries = lists.flatMap((list) => list.allowlist);
+      const byId = new Map(lists.map((list) => [list.id, list]));
+      const defaultIds = lists.filter((list) => list.isDefault).map((list) => list.id);
 
-      this.matcher = buildBlocklistMatcher(blockEntries, allowEntries);
+      // Compile each distinct effective set once — most domains share the
+      // default set, and scanners hammer many domains with the same paths.
+      const compiled = new Map<string, CompiledBlocklistMatcher>();
+      const compileSet = (ids: string[]): CompiledBlocklistMatcher => {
+        // Dedupe: attaching a list that is already a default must compile to
+        // the SAME set (and matcher) as the default, not a lookalike.
+        const unique = [...new Set(ids)].sort();
+        const key = unique.join(',');
+        let matcher = compiled.get(key);
+        if (!matcher) {
+          const effective = unique.map((id) => byId.get(id)!).filter(Boolean);
+          matcher = buildBlocklistMatcher(
+            [...BASELINE_BLOCKLIST_ENTRIES, ...effective.flatMap((list) => list.entries)],
+            effective.flatMap((list) => list.allowlist),
+          );
+          compiled.set(key, matcher);
+        }
+        return matcher;
+      };
+
+      const defaultMatcher = compileSet(defaultIds);
+
+      const attachedByDomain = new Map<string, string[]>();
+      for (const list of lists) {
+        for (const ref of list.attachedDomains) {
+          const existing = attachedByDomain.get(ref.id);
+          if (existing) {
+            existing.push(list.id);
+          } else {
+            attachedByDomain.set(ref.id, [list.id]);
+          }
+        }
+      }
+
+      const domainMatchers = new Map<string, CompiledBlocklistMatcher>();
+      const hostMatchers = new Map<string, CompiledBlocklistMatcher>();
+      const variantHosts = new Map<string, CompiledBlocklistMatcher>();
+      for (const mapping of domains) {
+        const attached = attachedByDomain.get(mapping.id) ?? [];
+        const matcher = compileSet([...defaultIds, ...attached]);
+        domainMatchers.set(mapping.id, matcher);
+
+        // Register the exact host, plus its www/apex counterpart: wwwBehavior
+        // routes both variants into this mapping's server blocks, and the
+        // wildcard fallback path resolves mappings www-insensitively too.
+        const host = normalizeHost(mapping.domain);
+        hostMatchers.set(host, matcher);
+        variantHosts.set(host.startsWith('www.') ? host.slice(4) : `www.${host}`, matcher);
+      }
+      // Variants must not shadow a host another mapping owns explicitly.
+      for (const [host, matcher] of variantHosts) {
+        if (!hostMatchers.has(host)) {
+          hostMatchers.set(host, matcher);
+        }
+      }
+
+      this.defaultMatcher = defaultMatcher;
+      this.domainMatchers = domainMatchers;
+      this.hostMatchers = hostMatchers;
       this.enabled = enabled;
 
-      const fingerprint = `${enabled}|${this.matcher.blockSource ?? ''}|${this.matcher.allowSource ?? ''}`;
+      // Fingerprint the full effective state: toggle, default sources, and
+      // every domain whose set differs from the default — so attachment and
+      // entry mutations (and nothing else) trigger config regeneration.
+      const domainPart = [...domainMatchers.entries()]
+        .filter(([, matcher]) => matcher !== defaultMatcher)
+        .map(([id, matcher]) => `${id}=${matcher.blockSource ?? ''}~${matcher.allowSource ?? ''}`)
+        .sort()
+        .join(';');
+      const fingerprint = `${enabled}|${defaultMatcher.blockSource ?? ''}|${defaultMatcher.allowSource ?? ''}|${domainPart}`;
       const changed = this.lastFingerprint !== null && this.lastFingerprint !== fingerprint;
       this.lastFingerprint = fingerprint;
       if (changed) {
         this.notifyEffectiveChange();
       }
     } catch (error) {
-      // Keep the last good matcher; never let a refresh failure break serving.
+      // Keep the last good matchers; never let a refresh failure break serving.
       this.logger.error(`Blocklist refresh failed: ${String(error)}`);
     }
   }
@@ -210,19 +346,17 @@ export class BlocklistService implements OnModuleInit {
     if (lists.length === 0) {
       return [];
     }
+    const listIds = lists.map((list) => list.id);
     const entries = await db
       .select()
       .from(blocklistEntries)
-      .where(
-        inArray(
-          blocklistEntries.blocklistId,
-          lists.map((list) => list.id),
-        ),
-      );
+      .where(inArray(blocklistEntries.blocklistId, listIds));
+    const attachments = await this.loadAttachments(listIds);
     return lists.map((list) =>
       this.toDto(
         list,
         entries.filter((entry) => entry.blocklistId === list.id),
+        attachments.get(list.id) ?? [],
       ),
     );
   }
@@ -236,7 +370,8 @@ export class BlocklistService implements OnModuleInit {
       .select()
       .from(blocklistEntries)
       .where(eq(blocklistEntries.blocklistId, id));
-    return this.toDto(list, entries);
+    const attachments = await this.loadAttachments([id]);
+    return this.toDto(list, entries, attachments.get(id) ?? []);
   }
 
   async createBlocklist(input: UpsertBlocklistInput): Promise<BlocklistWithEntries> {
@@ -254,7 +389,7 @@ export class BlocklistService implements OnModuleInit {
 
     const [created] = await db
       .insert(blocklists)
-      .values({ name, description: input.description ?? null })
+      .values({ name, description: input.description ?? null, isDefault: input.isDefault ?? true })
       .returning();
     await this.replaceEntries(created.id, 'block', entries);
     await this.replaceEntries(created.id, 'allow', allowlist);
@@ -284,6 +419,9 @@ export class BlocklistService implements OnModuleInit {
     if (input.description !== undefined) {
       updates.description = input.description;
     }
+    if (input.isDefault !== undefined) {
+      updates.isDefault = input.isDefault;
+    }
 
     const entries =
       input.entries !== undefined ? this.normalizeAndValidate(input.entries, 'entries') : undefined;
@@ -312,9 +450,113 @@ export class BlocklistService implements OnModuleInit {
     await this.refresh();
   }
 
+  /**
+   * Append a single block pattern to a Blocklist — the inline
+   * "add to blocklist" action from the Traffic views (#393). Duplicate
+   * patterns are a silent no-op (the unique index already guarantees it).
+   */
+  async appendEntry(id: string, entry: BlocklistPatternEntry): Promise<BlocklistWithEntries> {
+    const [existing] = await db.select().from(blocklists).where(eq(blocklists.id, id)).limit(1);
+    if (!existing) {
+      throw new NotFoundException('Blocklist not found');
+    }
+    const [normalized] = this.normalizeAndValidate([entry], 'entries');
+    await db
+      .insert(blocklistEntries)
+      .values({ blocklistId: id, kind: 'block', matchType: normalized.matchType, value: normalized.value })
+      .onConflictDoNothing();
+    await db.update(blocklists).set({ updatedAt: new Date() }).where(eq(blocklists.id, id));
+
+    await this.refresh();
+    return this.getBlocklist(id);
+  }
+
+  // ---------------------------------------------------------------------
+  // Per-domain attachment (#393)
+  // ---------------------------------------------------------------------
+
+  /** Blocklist ids attached to one domain mapping (excludes defaults). */
+  async getDomainBlocklistIds(domainMappingId: string): Promise<string[]> {
+    const rows = await db
+      .select({ blocklistId: domainBlocklists.blocklistId })
+      .from(domainBlocklists)
+      .where(eq(domainBlocklists.domainMappingId, domainMappingId))
+      .orderBy(asc(domainBlocklists.createdAt));
+    return rows.map((row) => row.blocklistId);
+  }
+
+  /**
+   * Replace the set of Blocklists attached to a domain mapping — the same
+   * replace-all shape as alias↔proxy-rule-set attachment. Rebuilds matchers,
+   * which triggers edge config regeneration when the effective set changed.
+   */
+  async syncDomainBlocklists(
+    domainMappingId: string,
+    blocklistIds: string[],
+  ): Promise<{ domainMappingId: string; blocklistIds: string[] }> {
+    const [mapping] = await db
+      .select({ id: domainMappings.id })
+      .from(domainMappings)
+      .where(eq(domainMappings.id, domainMappingId))
+      .limit(1);
+    if (!mapping) {
+      throw new NotFoundException('Domain mapping not found');
+    }
+
+    const unique = [...new Set(blocklistIds)];
+    if (unique.length > 0) {
+      const found = await db
+        .select({ id: blocklists.id })
+        .from(blocklists)
+        .where(inArray(blocklists.id, unique));
+      if (found.length !== unique.length) {
+        const foundIds = new Set(found.map((row) => row.id));
+        const missing = unique.filter((id) => !foundIds.has(id));
+        throw new BadRequestException(`Unknown Blocklist id(s): ${missing.join(', ')}`);
+      }
+    }
+
+    await db.transaction(async (tx) => {
+      await tx.delete(domainBlocklists).where(eq(domainBlocklists.domainMappingId, domainMappingId));
+      if (unique.length > 0) {
+        await tx
+          .insert(domainBlocklists)
+          .values(unique.map((blocklistId) => ({ domainMappingId, blocklistId })));
+      }
+    });
+
+    await this.refresh();
+    return { domainMappingId, blocklistIds: unique };
+  }
+
   // ---------------------------------------------------------------------
   // Internals
   // ---------------------------------------------------------------------
+
+  /** Attached domains per blocklist id, resolved to {id, domain} refs. */
+  private async loadAttachments(listIds: string[]): Promise<Map<string, AttachedDomainRef[]>> {
+    const rows = await db
+      .select({
+        blocklistId: domainBlocklists.blocklistId,
+        domainMappingId: domainBlocklists.domainMappingId,
+        domain: domainMappings.domain,
+      })
+      .from(domainBlocklists)
+      .innerJoin(domainMappings, eq(domainBlocklists.domainMappingId, domainMappings.id))
+      .where(inArray(domainBlocklists.blocklistId, listIds));
+
+    const byList = new Map<string, AttachedDomainRef[]>();
+    for (const row of rows) {
+      const ref: AttachedDomainRef = { id: row.domainMappingId, domain: row.domain };
+      const existing = byList.get(row.blocklistId);
+      if (existing) {
+        existing.push(ref);
+      } else {
+        byList.set(row.blocklistId, [ref]);
+      }
+    }
+    return byList;
+  }
 
   /**
    * Trim, normalize, dedupe, and validate structured pattern entries.
@@ -377,7 +619,11 @@ export class BlocklistService implements OnModuleInit {
     });
   }
 
-  private toDto(list: Blocklist, entries: BlocklistEntry[]): BlocklistWithEntries {
+  private toDto(
+    list: Blocklist,
+    entries: BlocklistEntry[],
+    attachedDomains: AttachedDomainRef[],
+  ): BlocklistWithEntries {
     const pattern = (entry: BlocklistEntry): BlocklistPatternEntry => ({
       matchType: entry.matchType,
       value: entry.value,
@@ -386,6 +632,8 @@ export class BlocklistService implements OnModuleInit {
       id: list.id,
       name: list.name,
       description: list.description,
+      isDefault: list.isDefault,
+      attachedDomains,
       entries: entries.filter((entry) => entry.kind === 'block').map(pattern),
       allowlist: entries.filter((entry) => entry.kind === 'allow').map(pattern),
       createdAt: list.createdAt,

--- a/apps/backend/src/traffic/blocklists.controller.spec.ts
+++ b/apps/backend/src/traffic/blocklists.controller.spec.ts
@@ -22,6 +22,9 @@ describe('BlocklistsController', () => {
       createBlocklist: jest.fn(),
       updateBlocklist: jest.fn(),
       deleteBlocklist: jest.fn(),
+      appendEntry: jest.fn(),
+      getDomainBlocklistIds: jest.fn(),
+      syncDomainBlocklists: jest.fn(),
     } as unknown as jest.Mocked<BlocklistService>;
     controller = new BlocklistsController(service);
   });
@@ -36,6 +39,9 @@ describe('BlocklistsController', () => {
       controller.get,
       controller.update,
       controller.remove,
+      controller.appendEntry,
+      controller.getDomainBlocklists,
+      controller.syncDomainBlocklists,
     ]) {
       expect(Reflect.getMetadata(ROLES_KEY, handler)).toEqual(['admin']);
     }
@@ -69,5 +75,24 @@ describe('BlocklistsController', () => {
 
     await controller.remove('b1');
     expect(service.deleteBlocklist).toHaveBeenCalledWith('b1');
+  });
+
+  it('delegates the inline entry append to the service (#393)', async () => {
+    await controller.appendEntry('b1', { matchType: 'prefix', value: '/wp-extra' });
+    expect(service.appendEntry).toHaveBeenCalledWith('b1', {
+      matchType: 'prefix',
+      value: '/wp-extra',
+    });
+  });
+
+  it('delegates domain attachment reads and writes to the service (#393)', async () => {
+    service.getDomainBlocklistIds.mockResolvedValue(['b1']);
+    await expect(controller.getDomainBlocklists('dom-1')).resolves.toEqual({
+      domainMappingId: 'dom-1',
+      blocklistIds: ['b1'],
+    });
+
+    await controller.syncDomainBlocklists('dom-1', { blocklistIds: ['b1', 'b2'] });
+    expect(service.syncDomainBlocklists).toHaveBeenCalledWith('dom-1', ['b1', 'b2']);
   });
 });

--- a/apps/backend/src/traffic/blocklists.controller.ts
+++ b/apps/backend/src/traffic/blocklists.controller.ts
@@ -8,6 +8,7 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Put,
   UseGuards,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
@@ -18,12 +19,19 @@ import { ApiKeyGuard } from '../auth/api-key.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { BlocklistService } from './blocklist.service';
-import { CreateBlocklistDto, UpdateBlocklistDto, UpdateBlocklistSettingsDto } from './blocklist.dto';
+import {
+  AppendBlocklistEntryDto,
+  CreateBlocklistDto,
+  SyncDomainBlocklistsDto,
+  UpdateBlocklistDto,
+  UpdateBlocklistSettingsDto,
+} from './blocklist.dto';
 
 /**
- * The Blocklist library + bot-protection settings (issue #391), admin-only
- * like the rest of /api/traffic. CRUD here rebuilds the app-side enforcement
- * matcher immediately; edge (nginx) enforcement rides on top in #392.
+ * The Blocklist library + bot-protection settings + per-domain attachment
+ * (issues #391/#393), admin-only like the rest of /api/traffic. Mutations here
+ * rebuild the app-side enforcement matchers immediately and trigger edge
+ * (nginx) config regeneration when the effective set changed.
  */
 @ApiTags('Traffic')
 @Controller('api/traffic')
@@ -86,5 +94,32 @@ export class BlocklistsController {
   @ApiOperation({ summary: 'Delete a Blocklist (admin only)' })
   async remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
     await this.blocklistService.deleteBlocklist(id);
+  }
+
+  @Post('blocklists/:id/entries')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Append one block pattern (inline add-to-blocklist, admin only)' })
+  async appendEntry(@Param('id', ParseUUIDPipe) id: string, @Body() dto: AppendBlocklistEntryDto) {
+    return this.blocklistService.appendEntry(id, dto);
+  }
+
+  @Get('domains/:domainMappingId/blocklists')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Blocklist ids attached to a domain mapping (admin only)' })
+  async getDomainBlocklists(@Param('domainMappingId', ParseUUIDPipe) domainMappingId: string) {
+    return {
+      domainMappingId,
+      blocklistIds: await this.blocklistService.getDomainBlocklistIds(domainMappingId),
+    };
+  }
+
+  @Put('domains/:domainMappingId/blocklists')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Replace the Blocklists attached to a domain mapping (admin only)' })
+  async syncDomainBlocklists(
+    @Param('domainMappingId', ParseUUIDPipe) domainMappingId: string,
+    @Body() dto: SyncDomainBlocklistsDto,
+  ) {
+    return this.blocklistService.syncDomainBlocklists(domainMappingId, dto.blocklistIds);
   }
 }

--- a/apps/backend/src/traffic/traffic-observer.middleware.ts
+++ b/apps/backend/src/traffic/traffic-observer.middleware.ts
@@ -16,9 +16,10 @@ const OBSERVER_EXEMPT_PATHS = ['/api/traffic/stream'];
 const ENFORCEMENT_EXEMPT_PREFIXES = ['/api/', '/auth/'];
 
 /** What the middleware needs from BlocklistService (kept as an interface so
- *  the middleware stays constructible without Nest in tests). */
+ *  the middleware stays constructible without Nest in tests). `host` selects
+ *  the domain's effective set (#393); unknown hosts use the default set. */
 export interface BlocklistEnforcer {
-  shouldBlock(pathname: string): boolean;
+  shouldBlock(pathname: string, host?: string | null): boolean;
 }
 
 let eventCounter = 0;
@@ -59,12 +60,13 @@ export function createTrafficObserver(events: TrafficEventsService, blocklist?: 
       return next();
     }
 
+    const clientHost = (req.headers['x-forwarded-host'] as string) || req.headers.host || null;
     const blocked =
       blocklist !== undefined &&
       !ENFORCEMENT_EXEMPT_PREFIXES.some(
         (prefix) => req.path.startsWith(prefix) || req.path === prefix.slice(0, -1),
       ) &&
-      blocklist.shouldBlock(clientVisiblePath(req));
+      blocklist.shouldBlock(clientVisiblePath(req), clientHost);
 
     let bytes = 0;
     const countChunk = (chunk: unknown, encoding?: unknown): void => {
@@ -101,7 +103,7 @@ export function createTrafficObserver(events: TrafficEventsService, blocklist?: 
         bytes,
         referer: (req.headers.referer as string) || null,
         userAgent: (req.headers['user-agent'] as string) || null,
-        host: (req.headers['x-forwarded-host'] as string) || req.headers.host || null,
+        host: clientHost,
         classification: blocked ? 'blocked' : res.statusCode === 404 ? 'unmatched' : 'matched',
       };
       events.emit({ ...withoutLine, line: formatAccessLogLine(withoutLine) });

--- a/apps/frontend/src/components/domains/DomainBlocklistsSection.test.tsx
+++ b/apps/frontend/src/components/domains/DomainBlocklistsSection.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { DomainBlocklistsSection } from './DomainBlocklistsSection';
+import type { BlocklistEntry } from '@/services/trafficApi';
+
+const mockListBlocklists = vi.fn();
+const mockGetDomainBlocklists = vi.fn();
+const mockSync = vi.fn();
+
+vi.mock('@/services/trafficApi', () => ({
+  useListBlocklistsQuery: () => mockListBlocklists(),
+  useGetDomainBlocklistsQuery: (domainId: string) => mockGetDomainBlocklists(domainId),
+  useSyncDomainBlocklistsMutation: () => [mockSync, { isLoading: false }],
+}));
+
+// Radix Popover doesn't play well with happy-dom; render trigger + content flat.
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: any) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: any) => <div>{children}</div>,
+  PopoverContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+const makeList = (overrides: Partial<BlocklistEntry> = {}): BlocklistEntry => ({
+  id: 'b1',
+  name: 'aggressive-scanners',
+  description: null,
+  isDefault: false,
+  attachedDomains: [],
+  entries: [{ matchType: 'prefix', value: '/probe' }],
+  allowlist: [],
+  createdAt: '2026-07-01T00:00:00Z',
+  updatedAt: '2026-07-01T00:00:00Z',
+  ...overrides,
+});
+
+describe('DomainBlocklistsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListBlocklists.mockReturnValue({ data: [makeList()], isLoading: false });
+    mockGetDomainBlocklists.mockReturnValue({
+      data: { domainMappingId: 'dom-1', blocklistIds: [] },
+      isLoading: false,
+    });
+    mockSync.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+  });
+
+  it('attaches a Blocklist through the replace-all mutation', async () => {
+    render(<DomainBlocklistsSection domainId="dom-1" domain="shop.example.com" />);
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    await waitFor(() =>
+      expect(mockSync).toHaveBeenCalledWith({
+        domainMappingId: 'dom-1',
+        blocklistIds: ['b1'],
+      }),
+    );
+  });
+
+  it('detaches from the attached badge', async () => {
+    mockGetDomainBlocklists.mockReturnValue({
+      data: { domainMappingId: 'dom-1', blocklistIds: ['b1'] },
+      isLoading: false,
+    });
+    render(<DomainBlocklistsSection domainId="dom-1" domain="shop.example.com" />);
+
+    expect(screen.getByText('1 Blocklist attached')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Detach aggressive-scanners' }));
+
+    await waitFor(() =>
+      expect(mockSync).toHaveBeenCalledWith({
+        domainMappingId: 'dom-1',
+        blocklistIds: [],
+      }),
+    );
+  });
+
+  it('marks all-domain lists as already applying', () => {
+    mockListBlocklists.mockReturnValue({
+      data: [makeList({ isDefault: true })],
+      isLoading: false,
+    });
+    render(<DomainBlocklistsSection domainId="dom-1" domain="shop.example.com" />);
+    expect(screen.getByText('(already on all domains)')).toBeInTheDocument();
+  });
+
+  it('points at the Blocklist tab when the library is empty', () => {
+    mockListBlocklists.mockReturnValue({ data: [], isLoading: false });
+    render(<DomainBlocklistsSection domainId="dom-1" domain="shop.example.com" />);
+    expect(screen.getByText(/No Blocklists exist yet/)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/domains/DomainBlocklistsSection.tsx
+++ b/apps/frontend/src/components/domains/DomainBlocklistsSection.tsx
@@ -1,0 +1,139 @@
+import { ChevronDown, Loader2, Shield, X } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useToast } from '@/hooks/use-toast';
+import {
+  useGetDomainBlocklistsQuery,
+  useListBlocklistsQuery,
+  useSyncDomainBlocklistsMutation,
+} from '@/services/trafficApi';
+
+interface DomainBlocklistsSectionProps {
+  domainId: string;
+  domain: string;
+}
+
+/**
+ * Per-domain Blocklist attachment (issue #393), mirroring how proxy rule sets
+ * attach to aliases: a popover multi-select over the admin-global library plus
+ * removable badges. Changes apply immediately — the backend rebuilds app-side
+ * enforcement and regenerates this domain's nginx config behind the save.
+ *
+ * Lists marked "all domains" already apply here without an attachment; the
+ * Baseline always applies. Curate both from the Traffic page's Blocklist tab.
+ */
+export function DomainBlocklistsSection({ domainId, domain }: DomainBlocklistsSectionProps) {
+  const { toast } = useToast();
+  const { data: blocklists, isLoading: listsLoading } = useListBlocklistsQuery();
+  const { data: attached, isLoading: attachedLoading } = useGetDomainBlocklistsQuery(domainId);
+  const [syncDomainBlocklists, { isLoading: saving }] = useSyncDomainBlocklistsMutation();
+
+  const loading = listsLoading || attachedLoading;
+  const attachedIds = attached?.blocklistIds ?? [];
+  const byId = new Map((blocklists ?? []).map((list) => [list.id, list]));
+
+  const applySelection = async (blocklistIds: string[]) => {
+    try {
+      await syncDomainBlocklists({ domainMappingId: domainId, blocklistIds }).unwrap();
+      toast({
+        title: 'Blocklists updated',
+        description: `Enforcement for ${domain} now includes the Baseline, all-domain lists, and ${blocklistIds.length} attached list${blocklistIds.length === 1 ? '' : 's'}.`,
+      });
+    } catch {
+      toast({ title: 'Could not update the attached Blocklists', variant: 'destructive' });
+    }
+  };
+
+  const toggle = (id: string) => {
+    void applySelection(
+      attachedIds.includes(id) ? attachedIds.filter((x) => x !== id) : [...attachedIds, id],
+    );
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Shield className="h-4 w-4 text-[#d96459]" />
+          Blocklists
+        </CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Attach named Blocklists to this domain. Its effective rules are the Baseline +
+          all-domain lists + everything attached here, enforced at the edge and in the app.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {loading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading Blocklists…
+          </div>
+        ) : (blocklists?.length ?? 0) === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No Blocklists exist yet — create them on the Traffic page&apos;s Blocklist tab. The
+            Baseline still protects this domain while bot protection is on.
+          </p>
+        ) : (
+          <>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button variant="outline" className="justify-between w-full" disabled={saving}>
+                  <span className="text-sm truncate">
+                    {attachedIds.length === 0
+                      ? 'None attached (Baseline + all-domain lists apply)'
+                      : `${attachedIds.length} Blocklist${attachedIds.length !== 1 ? 's' : ''} attached`}
+                  </span>
+                  {saving ? (
+                    <Loader2 className="h-4 w-4 ml-2 shrink-0 animate-spin" />
+                  ) : (
+                    <ChevronDown className="h-4 w-4 ml-2 shrink-0 opacity-50" />
+                  )}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-2" align="start">
+                {blocklists?.map((list) => (
+                  <Label
+                    key={list.id}
+                    className="flex items-center gap-2 p-2 rounded hover:bg-accent cursor-pointer font-normal"
+                  >
+                    <Checkbox
+                      checked={attachedIds.includes(list.id)}
+                      disabled={saving}
+                      onCheckedChange={() => toggle(list.id)}
+                    />
+                    <span className="text-sm">{list.name}</span>
+                    {list.isDefault && (
+                      <span className="text-xs text-muted-foreground">(already on all domains)</span>
+                    )}
+                  </Label>
+                ))}
+              </PopoverContent>
+            </Popover>
+            {attachedIds.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {attachedIds.map((id) => (
+                  <Badge key={id} variant="secondary" className="gap-1 pr-1">
+                    {byId.get(id)?.name ?? id.substring(0, 8)}
+                    <button
+                      type="button"
+                      aria-label={`Detach ${byId.get(id)?.name ?? id}`}
+                      className="ml-0.5 rounded-sm hover:bg-muted-foreground/20 p-0.5"
+                      disabled={saving}
+                      onClick={() => toggle(id)}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/domains/EditDomainDialog.tsx
+++ b/apps/frontend/src/components/domains/EditDomainDialog.tsx
@@ -33,6 +33,7 @@ import { Globe, Lock, ArrowDown, Shield } from 'lucide-react';
 import { RedirectsTab } from './RedirectsTab';
 import { SslTab } from './SslTab';
 import { TrafficTab } from './TrafficTab';
+import { DomainBlocklistsSection } from './DomainBlocklistsSection';
 import { DomainShareLinksSection } from './DomainShareLinksSection';
 import { PathTypeahead } from './PathTypeahead';
 import { useFeatureFlags } from '@/services/featureFlagsApi';
@@ -543,8 +544,9 @@ export function EditDomainDialog({ domain, open, onOpenChange }: EditDomainDialo
             <RedirectsTab domainId={domain.id} targetDomain={domain.domain} />
           </TabsContent>
 
-          <TabsContent value="traffic" className="mt-4">
+          <TabsContent value="traffic" className="mt-4 space-y-4">
             <TrafficTab domainId={domain.id} domain={domain.domain} />
+            <DomainBlocklistsSection domainId={domain.id} domain={domain.domain} />
           </TabsContent>
 
           {!isRedirectDomain && (

--- a/apps/frontend/src/components/traffic/AddToBlocklistDialog.test.tsx
+++ b/apps/frontend/src/components/traffic/AddToBlocklistDialog.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { AddToBlocklistDialog } from './AddToBlocklistDialog';
+import type { BlocklistEntry } from '@/services/trafficApi';
+
+const mockListBlocklists = vi.fn();
+const mockAppendEntry = vi.fn();
+
+vi.mock('@/services/trafficApi', () => ({
+  useListBlocklistsQuery: (_arg: unknown, opts: { skip?: boolean }) => mockListBlocklists(opts),
+  useAppendBlocklistEntryMutation: () => [mockAppendEntry, { isLoading: false }],
+}));
+
+// Radix Select doesn't play well with happy-dom; the selection logic is
+// asserted through the mutation payload (default target) instead.
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children }: any) => <div>{children}</div>,
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectValue: () => null,
+}));
+
+const makeList = (overrides: Partial<BlocklistEntry> = {}): BlocklistEntry => ({
+  id: 'b1',
+  name: 'default-list',
+  description: null,
+  isDefault: true,
+  attachedDomains: [],
+  entries: [],
+  allowlist: [],
+  createdAt: '2026-07-01T00:00:00Z',
+  updatedAt: '2026-07-01T00:00:00Z',
+  ...overrides,
+});
+
+describe('AddToBlocklistDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListBlocklists.mockReturnValue({ data: [makeList()], isLoading: false });
+    mockAppendEntry.mockReturnValue({
+      unwrap: () => Promise.resolve(makeList({ name: 'default-list' })),
+    });
+  });
+
+  it('renders nothing until a target is set', () => {
+    render(<AddToBlocklistDialog target={null} onOpenChange={() => {}} />);
+    expect(screen.queryByText('Add to Blocklist')).not.toBeInTheDocument();
+  });
+
+  it('prefills the pattern with the offending path and appends as a prefix by default', async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <AddToBlocklistDialog
+        target={{ path: '/backend/.env', host: 'example.com' }}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    expect(screen.getByLabelText('Pattern')).toHaveValue('/backend/.env');
+    fireEvent.click(screen.getByRole('button', { name: 'Block it' }));
+
+    await waitFor(() =>
+      expect(mockAppendEntry).toHaveBeenCalledWith({
+        id: 'b1',
+        matchType: 'prefix',
+        value: '/backend/.env',
+      }),
+    );
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it('defaults the target to a Blocklist attached to the request host (www-insensitive)', async () => {
+    mockListBlocklists.mockReturnValue({
+      data: [
+        makeList(),
+        makeList({
+          id: 'b2',
+          name: 'scoped',
+          isDefault: false,
+          attachedDomains: [{ id: 'dom-1', domain: 'shop.example.com' }],
+        }),
+      ],
+      isLoading: false,
+    });
+    render(
+      <AddToBlocklistDialog
+        target={{ path: '/probe', host: 'www.shop.example.com' }}
+        onOpenChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Block it' }));
+    await waitFor(() =>
+      expect(mockAppendEntry).toHaveBeenCalledWith(expect.objectContaining({ id: 'b2' })),
+    );
+  });
+
+  it('surfaces the backend validation error and stays open', async () => {
+    mockAppendEntry.mockReturnValue({
+      unwrap: () =>
+        Promise.reject({ data: { errors: ['entries: "/x;{}" — unsupported characters'] } }),
+    });
+    const onOpenChange = vi.fn();
+    render(
+      <AddToBlocklistDialog target={{ path: '/x', host: null }} onOpenChange={onOpenChange} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Block it' }));
+
+    expect(await screen.findByText(/unsupported characters/)).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('points at the Blocklist tab when no lists exist yet', () => {
+    mockListBlocklists.mockReturnValue({ data: [], isLoading: false });
+    render(
+      <AddToBlocklistDialog target={{ path: '/probe', host: null }} onOpenChange={() => {}} />,
+    );
+    expect(screen.getByText(/No Blocklists exist yet/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Block it' })).toBeDisabled();
+  });
+});

--- a/apps/frontend/src/components/traffic/AddToBlocklistDialog.tsx
+++ b/apps/frontend/src/components/traffic/AddToBlocklistDialog.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Loader2, ShieldPlus } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import {
+  BlocklistMatchType,
+  useAppendBlocklistEntryMutation,
+  useListBlocklistsQuery,
+} from '@/services/trafficApi';
+
+const MATCH_TYPES: Array<{ value: BlocklistMatchType; label: string }> = [
+  { value: 'prefix', label: 'Prefix — path starts with' },
+  { value: 'exact', label: 'Exact — path equals' },
+  { value: 'suffix', label: 'Suffix — path ends with' },
+  { value: 'extension', label: 'Extension — file extension' },
+  { value: 'contains', label: 'Contains — anywhere in the path' },
+];
+
+export interface AddToBlocklistTarget {
+  /** The offending path, prefilled as the pattern value (query string stripped). */
+  path: string;
+  /** The host the request hit, used to preselect a Blocklist attached to it. */
+  host?: string | null;
+}
+
+interface AddToBlocklistDialogProps {
+  target: AddToBlocklistTarget | null;
+  onOpenChange: (open: boolean) => void;
+}
+
+/** www-insensitive host → attached/default Blocklist match (#393). */
+function hostMatchesDomain(host: string, domain: string): boolean {
+  const normalize = (value: string) =>
+    value.trim().toLowerCase().replace(/:\d+$/, '').replace(/^www\./, '');
+  return normalize(host) === normalize(domain);
+}
+
+/**
+ * The inline "add to blocklist" action from the Traffic views (issue #393):
+ * pick a target Blocklist (defaulting to one that already applies to the
+ * request's domain), adjust the pattern, and append it. The backend rebuilds
+ * enforcement and regenerates the edge configs immediately.
+ */
+export function AddToBlocklistDialog({ target, onOpenChange }: AddToBlocklistDialogProps) {
+  const { toast } = useToast();
+  const { data: blocklists, isLoading } = useListBlocklistsQuery(undefined, {
+    skip: target === null,
+  });
+  const [appendEntry, { isLoading: saving }] = useAppendBlocklistEntryMutation();
+
+  const [blocklistId, setBlocklistId] = useState('');
+  const [matchType, setMatchType] = useState<BlocklistMatchType>('prefix');
+  const [value, setValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  // A list already covering the request's domain is the natural target.
+  const defaultTargetId = useMemo(() => {
+    if (!blocklists || blocklists.length === 0) {
+      return '';
+    }
+    const host = target?.host;
+    if (host) {
+      const attachedToHost = blocklists.find((list) =>
+        list.attachedDomains.some((ref) => hostMatchesDomain(host, ref.domain)),
+      );
+      if (attachedToHost) {
+        return attachedToHost.id;
+      }
+    }
+    return (blocklists.find((list) => list.isDefault) ?? blocklists[0]).id;
+  }, [blocklists, target?.host]);
+
+  useEffect(() => {
+    if (target) {
+      setMatchType('prefix');
+      setValue(target.path);
+      setError(null);
+    }
+  }, [target]);
+
+  useEffect(() => {
+    setBlocklistId(defaultTargetId);
+  }, [defaultTargetId]);
+
+  const handleAdd = async () => {
+    if (!blocklistId || !value.trim()) return;
+    try {
+      const updated = await appendEntry({ id: blocklistId, matchType, value: value.trim() }).unwrap();
+      toast({
+        title: `Added to "${updated.name}"`,
+        description: 'Matching requests are refused within seconds, app-side and at the edge.',
+      });
+      onOpenChange(false);
+    } catch (err) {
+      const data = (err as { data?: { errors?: string[]; message?: string } })?.data;
+      setError(data?.errors?.[0] ?? data?.message ?? 'Adding the pattern failed');
+    }
+  };
+
+  return (
+    <Dialog open={target !== null} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ShieldPlus className="h-4 w-4 text-[#d96459]" />
+            Add to Blocklist
+          </DialogTitle>
+          <DialogDescription>
+            Block requests matching this pattern
+            {target?.host ? (
+              <>
+                {' '}
+                (seen on <span className="font-mono">{target.host}</span>)
+              </>
+            ) : null}
+            .
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading Blocklists…
+          </div>
+        ) : (blocklists?.length ?? 0) === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No Blocklists exist yet — create one on the Blocklist tab first, then add patterns to
+            it from here.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <Label htmlFor="add-blocklist-target">Blocklist</Label>
+              <Select value={blocklistId} onValueChange={setBlocklistId}>
+                <SelectTrigger id="add-blocklist-target">
+                  <SelectValue placeholder="Choose a Blocklist" />
+                </SelectTrigger>
+                <SelectContent>
+                  {blocklists?.map((list) => (
+                    <SelectItem key={list.id} value={list.id}>
+                      {list.name}
+                      {list.isDefault
+                        ? ' — all domains'
+                        : list.attachedDomains.length > 0
+                          ? ` — ${list.attachedDomains.length} domain${list.attachedDomains.length === 1 ? '' : 's'}`
+                          : ' — not attached'}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="add-blocklist-match-type">Match type</Label>
+              <Select
+                value={matchType}
+                onValueChange={(v) => setMatchType(v as BlocklistMatchType)}
+              >
+                <SelectTrigger id="add-blocklist-match-type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MATCH_TYPES.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="add-blocklist-value">Pattern</Label>
+              <Input
+                id="add-blocklist-value"
+                className="font-mono text-xs"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+              />
+            </div>
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleAdd}
+            disabled={saving || !blocklistId || !value.trim() || (blocklists?.length ?? 0) === 0}
+          >
+            {saving && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+            Block it
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/traffic/TrafficBlocklistTab.test.tsx
+++ b/apps/frontend/src/components/traffic/TrafficBlocklistTab.test.tsx
@@ -38,6 +38,8 @@ const makeList = (overrides: Partial<BlocklistEntry> = {}): BlocklistEntry => ({
   id: 'b1',
   name: 'aggressive-scanners',
   description: 'Custom probes seen in the wild',
+  isDefault: true,
+  attachedDomains: [],
   entries: [
     { matchType: 'prefix', value: '/hidden-probe' },
     { matchType: 'extension', value: 'php' },
@@ -101,6 +103,7 @@ describe('TrafficBlocklistTab', () => {
       expect(mockCreate).toHaveBeenCalledWith({
         name: 'my-list',
         description: undefined,
+        isDefault: true,
         entries: [
           { matchType: 'prefix', value: '/hidden-probe' },
           { matchType: 'extension', value: 'php' },

--- a/apps/frontend/src/components/traffic/TrafficBlocklistTab.tsx
+++ b/apps/frontend/src/components/traffic/TrafficBlocklistTab.tsx
@@ -14,6 +14,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
@@ -32,12 +33,14 @@ import {
 import { formatPatternEntries, parsePatternLines } from './blocklist-format';
 
 /**
- * Blocklist configuration on the Traffic page (issue #391): the bot-protection
- * master toggle, the code-shipped Baseline (read-only), and the admin-global
- * library of named Blocklists with their patterns + allowlist exceptions.
+ * Blocklist configuration on the Traffic page (issues #391/#393): the
+ * bot-protection master toggle, the code-shipped Baseline (read-only), and the
+ * admin-global library of named Blocklists with their patterns + allowlist
+ * exceptions. A list applies to all domains by default, or only to the domains
+ * it is attached to (attachment lives in each domain's settings dialog).
  *
- * App-side enforcement takes effect within seconds of saving; edge (nginx)
- * enforcement rides on top in a later slice (#392).
+ * App-side enforcement takes effect within seconds of saving; the edge (nginx)
+ * configs regenerate and hot-reload right behind it (#392).
  */
 export function TrafficBlocklistTab() {
   return (
@@ -133,6 +136,7 @@ interface EditorState {
   id: string | null; // null = creating
   name: string;
   description: string;
+  isDefault: boolean;
   patternsText: string;
   allowlistText: string;
 }
@@ -141,6 +145,7 @@ const emptyEditor = (): EditorState => ({
   id: null,
   name: '',
   description: '',
+  isDefault: true,
   patternsText: '',
   allowlistText: '',
 });
@@ -149,6 +154,7 @@ const editorFor = (list: BlocklistEntry): EditorState => ({
   id: list.id,
   name: list.name,
   description: list.description ?? '',
+  isDefault: list.isDefault,
   patternsText: formatPatternEntries(list.entries),
   allowlistText: formatPatternEntries(list.allowlist),
 });
@@ -179,6 +185,7 @@ function BlocklistLibraryCard() {
     const payload = {
       name: editor.name.trim(),
       description: editor.description.trim() || undefined,
+      isDefault: editor.isDefault,
       entries: parsePatternLines(editor.patternsText),
       allowlist: parsePatternLines(editor.allowlistText),
     };
@@ -190,7 +197,7 @@ function BlocklistLibraryCard() {
       }
       toast({
         title: editor.id === null ? 'Blocklist created' : 'Blocklist updated',
-        description: 'App-side enforcement is live; edge rules follow in a later release.',
+        description: 'App-side enforcement is live; edge rules regenerate right behind it.',
       });
       setEditor(null);
       setEditorErrors([]);
@@ -218,8 +225,8 @@ function BlocklistLibraryCard() {
           <div>
             <CardTitle className="text-base">Blocklists</CardTitle>
             <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground mt-1">
-              Named pattern lists on top of the Baseline. Until per-domain attachment lands, a
-              Blocklist applies to all traffic reaching this instance.
+              Named pattern lists on top of the Baseline. A list applies to all domains, or only
+              to the domains it is attached to — attach lists from a domain&apos;s settings.
             </p>
           </div>
           <Button
@@ -293,6 +300,22 @@ function BlocklistLibraryCard() {
                 legitimate path.
               </p>
             </div>
+            <div className="flex items-start gap-2">
+              <Checkbox
+                id="blocklist-default"
+                checked={editor.isDefault}
+                onCheckedChange={(checked) => setEditor({ ...editor, isDefault: checked === true })}
+              />
+              <div>
+                <Label htmlFor="blocklist-default" className="text-sm cursor-pointer">
+                  Apply to all domains
+                </Label>
+                <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground">
+                  Unchecked, this list only enforces on the domains it is attached to (attach it
+                  from a domain&apos;s settings). Its allowlist exceptions scope the same way.
+                </p>
+              </div>
+            </div>
             {editorErrors.length > 0 && (
               <Alert variant="destructive">
                 <AlertDescription>
@@ -348,6 +371,25 @@ function BlocklistLibraryCard() {
                     {list.allowlist.length > 0 && (
                       <Badge variant="outline" className="text-xs">
                         {list.allowlist.length} exception{list.allowlist.length === 1 ? '' : 's'}
+                      </Badge>
+                    )}
+                    {list.isDefault ? (
+                      <Badge variant="secondary" className="text-xs">
+                        All domains
+                      </Badge>
+                    ) : list.attachedDomains.length > 0 ? (
+                      <Badge
+                        variant="secondary"
+                        className="text-xs"
+                        title={list.attachedDomains.map((d) => d.domain).join(', ')}
+                      >
+                        {list.attachedDomains.length === 1
+                          ? list.attachedDomains[0].domain
+                          : `${list.attachedDomains.length} domains`}
+                      </Badge>
+                    ) : (
+                      <Badge variant="outline" className="text-xs text-amber-600">
+                        Not attached
                       </Badge>
                     )}
                   </div>

--- a/apps/frontend/src/components/traffic/TrafficHistoryTab.test.tsx
+++ b/apps/frontend/src/components/traffic/TrafficHistoryTab.test.tsx
@@ -9,6 +9,9 @@ const mockDownloadTrafficExport = vi.fn();
 vi.mock('@/services/trafficApi', () => ({
   useListTrafficRequestsQuery: (params: unknown) => mockUseListTrafficRequestsQuery(params),
   downloadTrafficExport: (...args: unknown[]) => mockDownloadTrafficExport(...args),
+  // Consumed by the embedded AddToBlocklistDialog (#393)
+  useListBlocklistsQuery: () => ({ data: [], isLoading: false }),
+  useAppendBlocklistEntryMutation: () => [vi.fn(), { isLoading: false }],
 }));
 
 // Radix Select doesn't play well with happy-dom; the time-range filter is

--- a/apps/frontend/src/components/traffic/TrafficHistoryTab.tsx
+++ b/apps/frontend/src/components/traffic/TrafficHistoryTab.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { ChevronLeft, ChevronRight, Download, Loader2 } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Download, Loader2, ShieldPlus } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
 import { downloadTrafficExport, useListTrafficRequestsQuery } from '@/services/trafficApi';
+import { AddToBlocklistDialog, AddToBlocklistTarget } from './AddToBlocklistDialog';
 import { statusColorClass } from './traffic-format';
 
 const PAGE_SIZE = 100;
@@ -38,6 +39,7 @@ export function TrafficHistoryTab() {
   const [timeRange, setTimeRange] = useState('all');
   const [page, setPage] = useState(1);
   const [exporting, setExporting] = useState(false);
+  const [blockTarget, setBlockTarget] = useState<AddToBlocklistTarget | null>(null);
 
   // Recomputed only when the range selection changes, so the query arg is stable
   const from = useMemo(() => {
@@ -193,6 +195,17 @@ export function TrafficHistoryTab() {
               ) : (
                 data.data.map((entry) => (
                   <div key={entry.id} className="text-gray-200 whitespace-pre w-max min-w-full">
+                    <button
+                      type="button"
+                      className="text-gray-500 hover:text-[#d96459] mr-1 align-middle"
+                      title="Add to blocklist"
+                      aria-label={`Add ${entry.path} to a blocklist`}
+                      onClick={() =>
+                        setBlockTarget({ path: entry.path.split('?')[0], host: entry.host })
+                      }
+                    >
+                      <ShieldPlus className="h-3.5 w-3.5 inline" />
+                    </button>
                     <span
                       className="text-[#d96459] mr-1"
                       title={
@@ -235,6 +248,10 @@ export function TrafficHistoryTab() {
           </>
         )}
       </CardContent>
+      <AddToBlocklistDialog
+        target={blockTarget}
+        onOpenChange={(open) => !open && setBlockTarget(null)}
+      />
     </Card>
   );
 }

--- a/apps/frontend/src/components/traffic/TrafficRollupTab.test.tsx
+++ b/apps/frontend/src/components/traffic/TrafficRollupTab.test.tsx
@@ -9,6 +9,9 @@ const mockDownloadTrafficExport = vi.fn();
 vi.mock('@/services/trafficApi', () => ({
   useListTrafficIpRollupsQuery: (params: unknown) => mockUseListTrafficIpRollupsQuery(params),
   downloadTrafficExport: (...args: unknown[]) => mockDownloadTrafficExport(...args),
+  // Consumed by the embedded AddToBlocklistDialog (#393)
+  useListBlocklistsQuery: () => ({ data: [], isLoading: false }),
+  useAppendBlocklistEntryMutation: () => [vi.fn(), { isLoading: false }],
 }));
 
 // Radix Select doesn't play well with happy-dom; sorting is asserted through

--- a/apps/frontend/src/components/traffic/TrafficRollupTab.tsx
+++ b/apps/frontend/src/components/traffic/TrafficRollupTab.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ChevronLeft, ChevronRight, Download, Loader2 } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Download, Loader2, ShieldPlus } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -20,8 +20,16 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useToast } from '@/hooks/use-toast';
 import { downloadTrafficExport, useListTrafficIpRollupsQuery } from '@/services/trafficApi';
+import { AddToBlocklistDialog, AddToBlocklistTarget } from './AddToBlocklistDialog';
 
 const PAGE_SIZE = 50;
 
@@ -43,6 +51,7 @@ export function TrafficRollupTab() {
   const [sortBy, setSortBy] = useState<SortBy>('requestCount');
   const [page, setPage] = useState(1);
   const [exporting, setExporting] = useState(false);
+  const [blockTarget, setBlockTarget] = useState<AddToBlocklistTarget | null>(null);
 
   const ipFilter = ip.trim() || undefined;
   const { data, isLoading, isFetching, error } = useListTrafficIpRollupsQuery(
@@ -167,6 +176,9 @@ export function TrafficRollupTab() {
                   <TableHead>Last seen</TableHead>
                   <TableHead>Sample paths</TableHead>
                   <TableHead>Sample user-agents</TableHead>
+                  <TableHead className="w-10">
+                    <span className="sr-only">Actions</span>
+                  </TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -193,6 +205,37 @@ export function TrafficRollupTab() {
                       title={rollup.sampleUserAgents.join('\n')}
                     >
                       {rollup.sampleUserAgents.join(' ')}
+                    </TableCell>
+                    <TableCell>
+                      {rollup.samplePaths.length > 0 && (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              aria-label={`Add a path from ${rollup.ip} to a blocklist`}
+                            >
+                              <ShieldPlus className="h-4 w-4" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuLabel className="text-xs">
+                              Add to blocklist…
+                            </DropdownMenuLabel>
+                            {rollup.samplePaths.map((path) => (
+                              <DropdownMenuItem
+                                key={path}
+                                className="font-mono text-xs"
+                                onClick={() =>
+                                  setBlockTarget({ path: path.split('?')[0], host: null })
+                                }
+                              >
+                                {path}
+                              </DropdownMenuItem>
+                            ))}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
                     </TableCell>
                   </TableRow>
                 ))}
@@ -227,6 +270,10 @@ export function TrafficRollupTab() {
           </>
         )}
       </CardContent>
+      <AddToBlocklistDialog
+        target={blockTarget}
+        onOpenChange={(open) => !open && setBlockTarget(null)}
+      />
     </Card>
   );
 }

--- a/apps/frontend/src/pages/TrafficPage.test.tsx
+++ b/apps/frontend/src/pages/TrafficPage.test.tsx
@@ -24,6 +24,12 @@ vi.mock('@/components/traffic/TrafficHistoryTab', () => ({
 vi.mock('@/components/traffic/TrafficRollupTab', () => ({
   TrafficRollupTab: () => <div>ROLLUP-TAB-CONTENT</div>,
 }));
+// The live tail embeds the add-to-blocklist dialog (#393), which talks to RTK
+// Query; stub it for the same reason as the tabs above.
+vi.mock('@/components/traffic/AddToBlocklistDialog', () => ({
+  AddToBlocklistDialog: ({ target }: any) =>
+    target ? <div>ADD-TO-BLOCKLIST-DIALOG</div> : null,
+}));
 
 type Listener = (event: { data: string }) => void;
 

--- a/apps/frontend/src/pages/TrafficPage.tsx
+++ b/apps/frontend/src/pages/TrafficPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Activity, Pause, Play, Trash2 } from 'lucide-react';
+import { Activity, Pause, Play, ShieldPlus, Trash2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -10,6 +10,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { TrafficBlocklistTab } from '@/components/traffic/TrafficBlocklistTab';
 import { TrafficHistoryTab } from '@/components/traffic/TrafficHistoryTab';
 import { TrafficRollupTab } from '@/components/traffic/TrafficRollupTab';
+import {
+  AddToBlocklistDialog,
+  AddToBlocklistTarget,
+} from '@/components/traffic/AddToBlocklistDialog';
 import { statusColorClass } from '@/components/traffic/traffic-format';
 
 /** A request observed by the backend's application interceptor (issue #389). */
@@ -98,6 +102,7 @@ export function LiveTrafficTab() {
     () => localStorage.getItem(WRAP_LINES_STORAGE_KEY) === 'true',
   );
   const [connection, setConnection] = useState<ConnectionState>('connecting');
+  const [blockTarget, setBlockTarget] = useState<AddToBlocklistTarget | null>(null);
 
   const pausedRef = useRef(paused);
   pausedRef.current = paused;
@@ -199,6 +204,17 @@ export function LiveTrafficTab() {
                 key={event.id}
                 className={`text-gray-200 ${wrapLines ? 'whitespace-pre-wrap break-all' : 'whitespace-pre w-max min-w-full'}`}
               >
+                <button
+                  type="button"
+                  className="text-gray-500 hover:text-[#d96459] mr-1 align-middle"
+                  title="Add to blocklist"
+                  aria-label={`Add ${event.path} to a blocklist`}
+                  onClick={() =>
+                    setBlockTarget({ path: event.path.split('?')[0], host: event.host })
+                  }
+                >
+                  <ShieldPlus className="h-3.5 w-3.5 inline" />
+                </button>
                 {event.classification === 'unmatched' && (
                   <span className="text-[#d96459] mr-1" title="Unmatched request">
                     ●
@@ -215,6 +231,10 @@ export function LiveTrafficTab() {
           )}
         </div>
       </CardContent>
+      <AddToBlocklistDialog
+        target={blockTarget}
+        onOpenChange={(open) => !open && setBlockTarget(null)}
+      />
     </Card>
   );
 }

--- a/apps/frontend/src/services/trafficApi.ts
+++ b/apps/frontend/src/services/trafficApi.ts
@@ -13,11 +13,21 @@ export interface BlocklistPatternEntry {
   value: string;
 }
 
-/** A named Blocklist from the admin-global library (issue #391). */
+/** A domain a Blocklist is attached to (issue #393). */
+export interface AttachedDomainRef {
+  id: string;
+  domain: string;
+}
+
+/** A named Blocklist from the admin-global library (issues #391/#393). */
 export interface BlocklistEntry {
   id: string;
   name: string;
   description: string | null;
+  /** True = applies to all domains (the all-domains default attachment). */
+  isDefault: boolean;
+  /** Domains this list is explicitly attached to (relevant when !isDefault). */
+  attachedDomains: AttachedDomainRef[];
   entries: BlocklistPatternEntry[];
   allowlist: BlocklistPatternEntry[];
   createdAt: string;
@@ -33,6 +43,7 @@ export interface BlocklistSettings {
 export interface UpsertBlocklistInput {
   name?: string;
   description?: string;
+  isDefault?: boolean;
   entries?: BlocklistPatternEntry[];
   allowlist?: BlocklistPatternEntry[];
 }
@@ -171,6 +182,43 @@ export const trafficApi = api.injectEndpoints({
       }),
       invalidatesTags: [{ type: 'Blocklist' as const, id: 'LIST' }],
     }),
+
+    appendBlocklistEntry: builder.mutation<
+      BlocklistEntry,
+      { id: string } & BlocklistPatternEntry
+    >({
+      query: ({ id, ...body }) => ({
+        url: `/api/traffic/blocklists/${id}/entries`,
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: [{ type: 'Blocklist' as const, id: 'LIST' }],
+    }),
+
+    getDomainBlocklists: builder.query<
+      { domainMappingId: string; blocklistIds: string[] },
+      string
+    >({
+      query: (domainMappingId) => `/api/traffic/domains/${domainMappingId}/blocklists`,
+      providesTags: (_result, _error, domainMappingId) => [
+        { type: 'Blocklist' as const, id: `DOMAIN-${domainMappingId}` },
+      ],
+    }),
+
+    syncDomainBlocklists: builder.mutation<
+      { domainMappingId: string; blocklistIds: string[] },
+      { domainMappingId: string; blocklistIds: string[] }
+    >({
+      query: ({ domainMappingId, blocklistIds }) => ({
+        url: `/api/traffic/domains/${domainMappingId}/blocklists`,
+        method: 'PUT',
+        body: { blocklistIds },
+      }),
+      invalidatesTags: (_result, _error, { domainMappingId }) => [
+        { type: 'Blocklist' as const, id: 'LIST' },
+        { type: 'Blocklist' as const, id: `DOMAIN-${domainMappingId}` },
+      ],
+    }),
   }),
 });
 
@@ -184,6 +232,9 @@ export const {
   useCreateBlocklistMutation,
   useUpdateBlocklistMutation,
   useDeleteBlocklistMutation,
+  useAppendBlocklistEntryMutation,
+  useGetDomainBlocklistsQuery,
+  useSyncDomainBlocklistsMutation,
 } = trafficApi;
 
 /**


### PR DESCRIPTION
## Summary

Implements #393, the final slice of #383: Blocklists become **attachable to domains** (the way proxy rule sets attach to aliases), and the Traffic views gain a one-click **"add to blocklist"** action — closing the discover→curate→enforce loop. An admin can spot a scanner path in Live/History/By IP, add it in one click, and have it dropped at the edge on that domain.

### Schema
- `domain_blocklists` junction (migration 0036) mirroring `alias_proxy_rule_sets` — no `order` column, since blocklist patterns merge as a plain union.
- `blocklists.is_default boolean not null default true` — the optional all-domains default attachment. Defaulting **true** preserves pre-#393 instance-wide behaviour across the upgrade with no data migration.

### Enforcement (app + edge stay in lockstep)
- `BlocklistService` compiles **per-domain matchers**: effective set = Baseline + default lists + attached lists; a list's allowlist rescues only where the list applies. Distinct sets compile once; identical sets share one matcher (attaching an already-default list is a true no-op).
- App-side enforcement is now **host-aware** (`X-Forwarded-Host`/`Host`, www/apex-insensitive, port-stripped). Unknown hosts and wildcard subdomain sites get the default set — behaviour is unchanged when nothing is attached.
- `EdgeBlocklistService.getServerRules()` / `NginxConfigService.buildEdgeBlocklistRules()` grew a `domainMappingId` parameter; every generated server block now embeds **its domain's** rules. Each distinct compiled pair is `nginx -t` sandbox-validated once; an invalid pair degrades only its own domains to app-side enforcement. The welcome-page and redirect-source configs keep the default set.
- Attachment/entry mutations ride the existing `onEffectiveChange` → debounced regenerate-all → hot-reload plumbing from #392 (the per-domain map is part of the fingerprint).

### API (admin-only, existing guards)
- `PUT /api/traffic/domains/:id/blocklists` — replace-all attachment (mirrors `syncAliasProxyRuleSets`), `GET` for the domain-centric read.
- `POST /api/traffic/blocklists/:id/entries` — idempotent single-pattern append for the inline action.
- `isDefault` on create/update; list responses carry `isDefault` + `attachedDomains`.

### UI
- **Add to blocklist** inline on all three Traffic views (Live tail, History log lines, per-sample-path menu on By IP). The dialog prefills the offending path and defaults the target to a list already covering that request's domain.
- **Edit Domain → Traffic** gains a Blocklists attach section (popover multi-select + removable badges, the `UpdateAliasDialog` pattern), applying immediately.
- Blocklist tab: "Apply to all domains" checkbox in the editor + scope badges per list (All domains / attached domains / Not attached).

## Testing

- Backend: 86/86 suites, 1361 tests — including attachment API tests mirroring the proxy-rule-set attachment style, per-domain matcher/edge-resolution tests, and host-aware HTTP-boundary tests.
- Frontend: 28/28 files, 412 tests — including new `AddToBlocklistDialog` + `DomainBlocklistsSection` suites.
- **End-to-end against real nginx (docker)**, config generated by the production compiler/emitters: full Baseline passes `nginx -t`; `/secret-probe` → connection dropped on the attached domain, served on a plain domain; `/wp-login.php` dropped on both; allowlisted `/status` rescued only where the list applies.

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKcWfgVZevHdobRQXzRqHA