### PR TITLE
fix(pipeline-schedules): honor repo-scoped API key project scope (#411)

### DIFF
--- a/apps/backend/src/mcp/mcp-tools.module.ts
+++ b/apps/backend/src/mcp/mcp-tools.module.ts
@@ -10,6 +10,7 @@ import { ApiKeysModule } from '../api-keys/api-keys.module';
 import { ProxyRulesModule } from '../proxy-rules/proxy-rules.module';
 import { CacheRulesModule } from '../cache-rules/cache-rules.module';
 import { ResponseHeaderRulesModule } from '../response-header-rules/response-header-rules.module';
+import { PipelineSchedulesModule } from '../pipeline-schedules/pipeline-schedules.module';
 import { ProjectTools } from './tools/project.tools';
 import { DeploymentTools } from './tools/deployment.tools';
 import { DomainTools } from './tools/domain.tools';
@@ -18,6 +19,7 @@ import { SettingsTools } from './tools/settings.tools';
 import { UserTools } from './tools/user.tools';
 import { ApiKeyTools } from './tools/api-key.tools';
 import { ProxyRulesTools } from './tools/proxy-rules.tools';
+import { PipelineSchedulesTools } from './tools/pipeline-schedules.tools';
 import { CacheRulesTools } from './tools/cache-rules.tools';
 import { ResponseHeaderRulesTools } from './tools/response-header-rules.tools';
 import { StorageTools } from './tools/storage.tools';
@@ -32,6 +34,7 @@ const ALL_TOOLS = [
   UserTools,
   ApiKeyTools,
   ProxyRulesTools,
+  PipelineSchedulesTools,
   CacheRulesTools,
   ResponseHeaderRulesTools,
   StorageTools,
@@ -52,6 +55,7 @@ const ALL_TOOLS = [
     UsersModule,
     ApiKeysModule,
     ProxyRulesModule,
+    PipelineSchedulesModule,
     CacheRulesModule,
     ResponseHeaderRulesModule,
     McpModule.forFeature(ALL_TOOLS, 'bffless-ce'),

--- a/apps/backend/src/mcp/tools/pipeline-schedules.tools.ts
+++ b/apps/backend/src/mcp/tools/pipeline-schedules.tools.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@nestjs/common';
+import { Tool, Context } from '@rekog/mcp-nest';
+import { z } from 'zod';
+import { Request } from 'express';
+import { PipelineSchedulesService } from '../../pipeline-schedules/pipeline-schedules.service';
+import { AuthService } from '../../auth/auth.service';
+import { getUserContext } from '../helpers/user-context.helper';
+
+@Injectable()
+export class PipelineSchedulesTools {
+  constructor(
+    private readonly schedulesService: PipelineSchedulesService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Tool({
+    name: 'list_pipeline_schedules',
+    description:
+      'List all pipeline schedules (cron-triggered pipeline runs) for a project. Each schedule fires a pipeline-type proxy rule on a cron cadence.',
+    parameters: z.object({
+      projectId: z.string().describe('Project ID'),
+    }),
+  })
+  async listSchedules({ projectId }: { projectId: string }, _context: Context, request: Request) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.schedulesService.listSchedules(
+      projectId,
+      user.id,
+      user.role,
+      user.apiKeyProjectId,
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'create_pipeline_schedule',
+    description:
+      'Create a pipeline schedule: fire a pipeline-type proxy rule on a cron cadence. The target proxy rule must belong to the project and have a pipeline configuration. The run executes as a system trigger (no user context).',
+    parameters: z.object({
+      projectId: z.string().describe('Project ID'),
+      name: z.string().describe('Schedule name'),
+      targetProxyRuleId: z
+        .string()
+        .describe('ID of the pipeline-type proxy rule to fire (must belong to this project)'),
+      cronExpression: z
+        .string()
+        .describe(
+          'Cron expression, e.g. "*/15 * * * *" (every 15 min) or "17 3 * * *" (03:17 daily)',
+        ),
+      timezone: z
+        .string()
+        .optional()
+        .describe('IANA timezone for the cron expression (default UTC)'),
+      enabled: z.boolean().optional().describe('Whether the schedule is active (default true)'),
+    }),
+  })
+  async createSchedule(
+    args: {
+      projectId: string;
+      name: string;
+      targetProxyRuleId: string;
+      cronExpression: string;
+      timezone?: string;
+      enabled?: boolean;
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const { projectId, ...dto } = args;
+    const result = await this.schedulesService.createSchedule(
+      projectId,
+      dto,
+      user.id,
+      user.role,
+      user.apiKeyProjectId,
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'update_pipeline_schedule',
+    description:
+      'Update a pipeline schedule (rename, change cron/timezone, enable/disable). Only provided fields change; nextRunAt is recomputed when the cadence changes or a disabled schedule is re-enabled.',
+    parameters: z.object({
+      id: z.string().describe('Schedule ID'),
+      name: z.string().optional().describe('New schedule name'),
+      cronExpression: z.string().optional().describe('New cron expression'),
+      timezone: z.string().optional().describe('New IANA timezone'),
+      enabled: z.boolean().optional().describe('Enable or disable the schedule'),
+    }),
+  })
+  async updateSchedule(
+    args: {
+      id: string;
+      name?: string;
+      cronExpression?: string;
+      timezone?: string;
+      enabled?: boolean;
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const { id, ...dto } = args;
+    const result = await this.schedulesService.updateSchedule(
+      id,
+      dto,
+      user.id,
+      user.role,
+      user.apiKeyProjectId,
+    );
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'delete_pipeline_schedule',
+    description: 'Delete a pipeline schedule. The target proxy rule is not affected.',
+    parameters: z.object({
+      id: z.string().describe('Schedule ID to delete'),
+    }),
+    annotations: { destructiveHint: true },
+  })
+  async deleteSchedule({ id }: { id: string }, _context: Context, request: Request) {
+    const user = await getUserContext(request, this.authService);
+    await this.schedulesService.deleteSchedule(id, user.id, user.role, user.apiKeyProjectId);
+    return JSON.stringify({ success: true, id });
+  }
+}

--- a/apps/backend/src/pipeline-schedules/pipeline-schedules.controller.ts
+++ b/apps/backend/src/pipeline-schedules/pipeline-schedules.controller.ts
@@ -29,6 +29,20 @@ import {
   ListPipelineSchedulesResponseDto,
 } from './pipeline-schedules.dto';
 
+/**
+ * REST surface for pipeline schedules. Route shape:
+ *
+ *   GET/POST          /api/pipeline-schedules/projects/:projectId/schedules
+ *   GET/PUT/DELETE    /api/pipeline-schedules/schedules/:id
+ *
+ * Deliberately NOT nested under /api/projects/:id/... — that prefix is owned by
+ * ProjectsController, whose two-segment catch-all (@Get(':owner/:name')) would
+ * swallow such paths and fail with a misleading "Project not found". Same reason
+ * proxy-rule-sets lives at /api/proxy-rule-sets/project/:projectId.
+ *
+ * Works with session auth and API keys; a project-scoped key (apiKeyProjectId)
+ * is authorized only for its own project's schedules.
+ */
 @ApiTags('Pipeline Schedules')
 @Controller('api/pipeline-schedules')
 @UseGuards(ApiKeyGuard)
@@ -45,7 +59,12 @@ export class PipelineSchedulesController {
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<ListPipelineSchedulesResponseDto> {
-    const data = await this.schedulesService.listSchedules(projectId, user.id, user.role);
+    const data = await this.schedulesService.listSchedules(
+      projectId,
+      user.id,
+      user.role,
+      user.apiKeyProjectId,
+    );
     return { data };
   }
 
@@ -58,7 +77,13 @@ export class PipelineSchedulesController {
     @Body() dto: CreatePipelineScheduleDto,
     @CurrentUser() user: CurrentUserData,
   ): Promise<PipelineScheduleResponseDto> {
-    return this.schedulesService.createSchedule(projectId, dto, user.id, user.role);
+    return this.schedulesService.createSchedule(
+      projectId,
+      dto,
+      user.id,
+      user.role,
+      user.apiKeyProjectId,
+    );
   }
 
   @Get('schedules/:id')
@@ -69,7 +94,7 @@ export class PipelineSchedulesController {
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<PipelineScheduleResponseDto> {
-    return this.schedulesService.getSchedule(id, user.id, user.role);
+    return this.schedulesService.getSchedule(id, user.id, user.role, user.apiKeyProjectId);
   }
 
   @Put('schedules/:id')
@@ -81,7 +106,7 @@ export class PipelineSchedulesController {
     @Body() dto: UpdatePipelineScheduleDto,
     @CurrentUser() user: CurrentUserData,
   ): Promise<PipelineScheduleResponseDto> {
-    return this.schedulesService.updateSchedule(id, dto, user.id, user.role);
+    return this.schedulesService.updateSchedule(id, dto, user.id, user.role, user.apiKeyProjectId);
   }
 
   @Delete('schedules/:id')
@@ -93,6 +118,6 @@ export class PipelineSchedulesController {
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<void> {
-    return this.schedulesService.deleteSchedule(id, user.id, user.role);
+    return this.schedulesService.deleteSchedule(id, user.id, user.role, user.apiKeyProjectId);
   }
 }

--- a/apps/backend/src/pipeline-schedules/pipeline-schedules.service.spec.ts
+++ b/apps/backend/src/pipeline-schedules/pipeline-schedules.service.spec.ts
@@ -35,6 +35,7 @@ jest.mock('../db/client', () => {
   return { db: chainable };
 });
 
+import { ForbiddenException } from '@nestjs/common';
 import { db } from '../db/client';
 import { PipelineSchedulesService } from './pipeline-schedules.service';
 import { PermissionsService } from '../permissions/permissions.service';
@@ -83,6 +84,132 @@ function advanceSetArg(): Record<string, unknown> | undefined {
     .map((c) => c[0] as Record<string, unknown>)
     .find((arg) => arg && 'nextRunAt' in arg && 'lastRunAt' in arg);
 }
+
+describe('PipelineSchedulesService CRUD api-key project scope', () => {
+  beforeEach(() => mockDb.__reset());
+
+  // Mirrors the real requireProjectAccess short-circuit: a project-scoped
+  // api-key is authorized iff its scope matches the target project.
+  function buildScopedService() {
+    const requireProjectAccess = jest.fn(
+      async (
+        projectId: string,
+        _userId: string,
+        _userRole?: string,
+        _requiredRole?: string,
+        apiKeyProjectId?: string | null,
+      ) => {
+        if (apiKeyProjectId !== undefined && apiKeyProjectId !== null) {
+          if (apiKeyProjectId !== projectId) {
+            throw new ForbiddenException('API key is not authorized for this project');
+          }
+        }
+      },
+    );
+    const permissions = { requireProjectAccess } as unknown as PermissionsService;
+    const systemTrigger = {
+      triggerByProxyRuleId: jest.fn(),
+    } as unknown as SystemPipelineTriggerService;
+    const service = new PipelineSchedulesService(permissions, systemTrigger);
+    return { service, requireProjectAccess };
+  }
+
+  const createDto = {
+    name: 'Refresh',
+    targetProxyRuleId: 'rule-1',
+    cronExpression: '*/15 * * * *',
+  };
+
+  it('createSchedule threads apiKeyProjectId and succeeds for a key scoped to the project', async () => {
+    const { service, requireProjectAccess } = buildScopedService();
+    mockDb.__queue([{ projectId: 'proj-1' }]); // assertTargetInProject
+    mockDb.__queue([schedule()]); // insert .returning()
+
+    await expect(
+      service.createSchedule('proj-1', createDto, 'user-1', 'user', 'proj-1'),
+    ).resolves.toMatchObject({ id: 'sched-1', projectId: 'proj-1' });
+
+    expect(requireProjectAccess).toHaveBeenCalledWith(
+      'proj-1',
+      'user-1',
+      'user',
+      'contributor',
+      'proj-1',
+    );
+  });
+
+  it('createSchedule rejects a key scoped to another project before touching the db', async () => {
+    const { service } = buildScopedService();
+
+    await expect(
+      service.createSchedule('proj-1', createDto, 'user-1', 'user', 'proj-2'),
+    ).rejects.toThrow(ForbiddenException);
+
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('listSchedules threads apiKeyProjectId and rejects a cross-project scoped key', async () => {
+    const { service, requireProjectAccess } = buildScopedService();
+    mockDb.__queue([schedule()]);
+
+    await expect(service.listSchedules('proj-1', 'user-1', 'user', 'proj-1')).resolves.toHaveLength(
+      1,
+    );
+    expect(requireProjectAccess).toHaveBeenCalledWith(
+      'proj-1',
+      'user-1',
+      'user',
+      'viewer',
+      'proj-1',
+    );
+
+    await expect(service.listSchedules('proj-1', 'user-1', 'user', 'proj-2')).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('by-id methods enforce scope against the row project (cross-project isolation)', async () => {
+    const { service, requireProjectAccess } = buildScopedService();
+
+    // The schedule row belongs to proj-1; the key is scoped to proj-2.
+    mockDb.__queue([schedule()]); // getById for getSchedule
+    await expect(service.getSchedule('sched-1', 'user-1', 'user', 'proj-2')).rejects.toThrow(
+      ForbiddenException,
+    );
+
+    mockDb.__queue([schedule()]); // getById for updateSchedule
+    await expect(
+      service.updateSchedule('sched-1', { enabled: false }, 'user-1', 'user', 'proj-2'),
+    ).rejects.toThrow(ForbiddenException);
+
+    mockDb.__queue([schedule()]); // getById for deleteSchedule
+    await expect(service.deleteSchedule('sched-1', 'user-1', 'user', 'proj-2')).rejects.toThrow(
+      ForbiddenException,
+    );
+
+    // Scope was checked against the row's projectId, with the key's scope threaded.
+    for (const call of requireProjectAccess.mock.calls) {
+      expect(call[0]).toBe('proj-1');
+      expect(call[4]).toBe('proj-2');
+    }
+    expect(mockDb.update).not.toHaveBeenCalled();
+    expect(mockDb.delete).not.toHaveBeenCalled();
+  });
+
+  it('session auth (no apiKeyProjectId) still passes undefined through unchanged', async () => {
+    const { service, requireProjectAccess } = buildScopedService();
+    mockDb.__queue([]);
+
+    await expect(service.listSchedules('proj-1', 'user-1', 'admin')).resolves.toEqual([]);
+    expect(requireProjectAccess).toHaveBeenCalledWith(
+      'proj-1',
+      'user-1',
+      'admin',
+      'viewer',
+      undefined,
+    );
+  });
+});
 
 describe('PipelineSchedulesService.runDueSchedules', () => {
   beforeEach(() => mockDb.__reset());

--- a/apps/backend/src/pipeline-schedules/pipeline-schedules.service.ts
+++ b/apps/backend/src/pipeline-schedules/pipeline-schedules.service.ts
@@ -47,8 +47,15 @@ export class PipelineSchedulesService {
     projectId: string,
     userId: string,
     userRole?: string,
+    apiKeyProjectId?: string | null,
   ): Promise<PipelineScheduleResponseDto[]> {
-    await this.permissionsService.requireProjectAccess(projectId, userId, userRole, 'viewer');
+    await this.permissionsService.requireProjectAccess(
+      projectId,
+      userId,
+      userRole,
+      'viewer',
+      apiKeyProjectId,
+    );
     const rows = await db
       .select()
       .from(pipelineSchedules)
@@ -60,9 +67,16 @@ export class PipelineSchedulesService {
     id: string,
     userId: string,
     userRole?: string,
+    apiKeyProjectId?: string | null,
   ): Promise<PipelineScheduleResponseDto> {
     const row = await this.getById(id);
-    await this.permissionsService.requireProjectAccess(row.projectId, userId, userRole, 'viewer');
+    await this.permissionsService.requireProjectAccess(
+      row.projectId,
+      userId,
+      userRole,
+      'viewer',
+      apiKeyProjectId,
+    );
     return this.toResponse(row);
   }
 
@@ -71,8 +85,15 @@ export class PipelineSchedulesService {
     dto: CreatePipelineScheduleDto,
     userId: string,
     userRole?: string,
+    apiKeyProjectId?: string | null,
   ): Promise<PipelineScheduleResponseDto> {
-    await this.permissionsService.requireProjectAccess(projectId, userId, userRole, 'contributor');
+    await this.permissionsService.requireProjectAccess(
+      projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
 
     const timezone = dto.timezone || 'UTC';
     // Validate cron + tz, and seed the first nextRunAt.
@@ -103,6 +124,7 @@ export class PipelineSchedulesService {
     dto: UpdatePipelineScheduleDto,
     userId: string,
     userRole?: string,
+    apiKeyProjectId?: string | null,
   ): Promise<PipelineScheduleResponseDto> {
     const existing = await this.getById(id);
     await this.permissionsService.requireProjectAccess(
@@ -110,6 +132,7 @@ export class PipelineSchedulesService {
       userId,
       userRole,
       'contributor',
+      apiKeyProjectId,
     );
 
     const cronExpression = dto.cronExpression ?? existing.cronExpression;
@@ -144,13 +167,19 @@ export class PipelineSchedulesService {
     return this.toResponse(row);
   }
 
-  async deleteSchedule(id: string, userId: string, userRole?: string): Promise<void> {
+  async deleteSchedule(
+    id: string,
+    userId: string,
+    userRole?: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<void> {
     const existing = await this.getById(id);
     await this.permissionsService.requireProjectAccess(
       existing.projectId,
       userId,
       userRole,
       'contributor',
+      apiKeyProjectId,
     );
     await db.delete(pipelineSchedules).where(eq(pipelineSchedules.id, id));
     this.logger.log(`Deleted pipeline schedule ${id}`);


### PR DESCRIPTION
Closes #411. Unblocks bffless/apps#119 (Sandcastle creating schedules on the live project with a repository-scoped `X-API-Key`).

## Problem

The pipeline-schedules CRUD (#408) was built without the api-key project-scope plumbing the rest of the codebase uses: every `requireProjectAccess` call omitted the 5th arg (`apiKeyProjectId`). Since `ApiKeyGuard` hardcodes `role: 'user'` and a repo-scoped key's owner typically has no `project_permissions` row, the check fell through to a role lookup and returned `403 "You do not have access to this project"` — even on the key's own project.

## Fix

Mirror the proxy-rule-sets pattern:

- **Controller** — all five handlers pass `user.apiKeyProjectId` into the service.
- **Service** — `listSchedules` / `createSchedule` / `getSchedule` / `updateSchedule` / `deleteSchedule` accept `apiKeyProjectId?: string | null` and forward it as the 5th arg of `requireProjectAccess`. The by-id methods enforce it against the row's `projectId`, so a scoped key cannot read or mutate another project's schedule by id. No change to `requireProjectAccess` itself.

## Also (optional items from the issue)

- **MCP tools**: `list_pipeline_schedules`, `create_pipeline_schedule`, `update_pipeline_schedule`, `delete_pipeline_schedule` in `mcp/tools/pipeline-schedules.tools.ts`, registered in `McpToolsModule`, each resolving the real DB role via `getUserContext` and calling `PipelineSchedulesService`.
- **DX**: controller doc comment records the real route shape and why it is deliberately not nested under `/api/projects/:id/...` (the ProjectsController `:owner/:name` catch-all collision that produces the misleading `400 "Project not found"`).

## Acceptance criteria

- [x] Repo-scoped key with matching `apiKeyProjectId` can `POST`/`GET` `/api/pipeline-schedules/projects/:projectId/schedules` (scope short-circuit authorizes without a permissions row)
- [x] Key scoped to project A is 403-rejected in project B — both by `:projectId` and by `schedules/:id`
- [x] Session/cookie auth unchanged (`apiKeyProjectId` stays `undefined`)
- [x] Unit coverage: 5 new tests in `pipeline-schedules.service.spec.ts` (scoped-key pass, cross-project 403 on every method, session passthrough)
- [x] MCP `create_pipeline_schedule` calls the same service path (admin keys work; scoped keys also work now that the service threads scope)

## Testing

- `npx jest` — 92 suites, 1413 passed
- `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)