### PR TITLE
fix(pipelines): send large strict-JSON response bodies verbatim to avoid OOM (#418)

### DIFF
--- a/apps/backend/src/pipelines/handlers/response.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/response.handler.spec.ts
@@ -1,0 +1,158 @@
+import { ResponseHandler } from './response.handler';
+import { StepHandlerRegistry } from '../execution/step-handler.registry';
+import { ExpressionEvaluator } from '../execution/expression-evaluator';
+import { PipelineContext } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+
+describe('ResponseHandler', () => {
+  const buildHandler = () => {
+    const registry = { register: jest.fn() } as unknown as StepHandlerRegistry;
+    return new ResponseHandler(registry, new ExpressionEvaluator());
+  };
+
+  const step = (config: Record<string, unknown>): PipelineStep =>
+    ({
+      id: 'respond',
+      name: 'respond',
+      handlerType: 'response_handler',
+      config,
+    } as unknown as PipelineStep);
+
+  const contextWithStep = (name: string, output: unknown): PipelineContext =>
+    ({
+      stepOutputs: { [name]: output },
+      request: {},
+    } as unknown as PipelineContext);
+
+  const responseOf = async (handler: ResponseHandler, config: Record<string, unknown>, ctx: PipelineContext) => {
+    const result = await handler.execute(ctx, step(config));
+    expect(result.success).toBe(true);
+    return { result, output: result.output as Record<string, unknown> };
+  };
+
+  describe('JSON string bodies (formatBody)', () => {
+    it('passes a large strict-JSON rendered template through as a string without re-materializing it (#418)', async () => {
+      const handler = buildHandler();
+      // Above the 256 KiB pass-through threshold.
+      const items = [
+        { id: 1, content: 'a'.repeat(300 * 1024) },
+        { id: 2, content: 'b' },
+      ];
+      const ctx = contextWithStep('query', items);
+
+      const { output } = await responseOf(handler, { body: '{"items":{{{steps.query}}}}' }, ctx);
+
+      // Body must remain the rendered string (sent verbatim by res.send),
+      // not a parsed object that Express would JSON.stringify a second time.
+      expect(typeof output.body).toBe('string');
+      expect(JSON.parse(output.body as string)).toEqual({ items });
+    });
+
+    it('keeps parsing small strict-JSON bodies into objects so steps.<respond>.body.<field> access still works', async () => {
+      const handler = buildHandler();
+      const items = [{ id: 1 }, { id: 2 }];
+      const ctx = contextWithStep('query', items);
+
+      const { output } = await responseOf(handler, { body: '{"items":{{{steps.query}}}}' }, ctx);
+
+      // Below the threshold, legacy behavior is preserved byte-for-byte:
+      // post-steps referencing the response body as an object keep working.
+      expect(output.body).toEqual({ items });
+    });
+
+    it('still JSON5-normalizes large non-strict bodies rather than passing them through', async () => {
+      const handler = buildHandler();
+      const big = 'a'.repeat(300 * 1024);
+      const ctx = contextWithStep('query', { content: big });
+
+      const { output } = await responseOf(
+        handler,
+        { body: '{ success: true, data: {{{steps.query}}}, }' },
+        ctx,
+      );
+
+      expect(output.body).toEqual({ success: true, data: { content: big } });
+    });
+
+    it('normalizes JSON5-style template output (unquoted keys) into an object', async () => {
+      const handler = buildHandler();
+      const ctx = contextWithStep('query', { value: 42 });
+
+      const { result, output } = await responseOf(
+        handler,
+        { body: '{ success: true, data: {{{steps.query}}} }' },
+        ctx,
+      );
+
+      expect(output.body).toEqual({ success: true, data: { value: 42 } });
+      expect(result.warning).toBeUndefined();
+    });
+
+    it('wraps invalid JSON in { message } with a warning', async () => {
+      const handler = buildHandler();
+      const ctx = contextWithStep('who', 'John Doe');
+
+      const { result, output } = await responseOf(handler, { body: '{ name: {{steps.who}} }' }, ctx);
+
+      expect(output.body).toEqual({ message: '{ name: John Doe }' });
+      expect(result.warning).toContain('invalid JSON');
+    });
+
+    it('keeps parsing small scalar-rendering templates (legacy behavior below the threshold)', async () => {
+      const handler = buildHandler();
+      const ctx = contextWithStep('count', 123);
+
+      const { output } = await responseOf(handler, { body: '{{{steps.count}}}' }, ctx);
+
+      expect(output.body).toBe(123);
+    });
+  });
+
+  describe('non-string and non-JSON bodies', () => {
+    it('evaluates object bodies per-key and returns the object', async () => {
+      const handler = buildHandler();
+      const ctx = contextWithStep('user', { id: 'u1' });
+
+      const { output } = await responseOf(handler, { body: { user: 'steps.user', ok: 'true' } }, ctx);
+
+      expect(output.body).toEqual({ user: { id: 'u1' }, ok: true });
+    });
+
+    it('returns text bodies verbatim for text content types', async () => {
+      const handler = buildHandler();
+      const ctx = contextWithStep('unused', null);
+
+      const { output } = await responseOf(
+        handler,
+        { body: 'hello world', contentType: 'text/plain' },
+        ctx,
+      );
+
+      expect(output.body).toBe('hello world');
+    });
+  });
+
+  describe('response envelope', () => {
+    it('sets status, content type, and evaluated headers', async () => {
+      const handler = buildHandler();
+      const ctx = contextWithStep('id', 'abc');
+
+      const { output } = await responseOf(
+        handler,
+        {
+          body: '{"ok":true}',
+          status: 201,
+          headers: { 'X-Request-Id': '{{steps.id}}' },
+        },
+        ctx,
+      );
+
+      expect(output.__isResponse).toBe(true);
+      expect(output.status).toBe(201);
+      expect(output.headers).toEqual({
+        'Content-Type': 'application/json',
+        'X-Request-Id': 'abc',
+      });
+    });
+  });
+});

--- a/apps/backend/src/pipelines/handlers/response.handler.ts
+++ b/apps/backend/src/pipelines/handlers/response.handler.ts
@@ -19,6 +19,16 @@ export class ResponseHandler implements StepHandler<ResponseHandlerConfig> {
   readonly type = 'response_handler' as const;
   private readonly logger = new Logger(ResponseHandler.name);
 
+  /**
+   * String bodies at or above this size are sent verbatim when they are
+   * already strict JSON instead of being JSON5-parsed into an object (#418).
+   * Below the threshold the legacy parse is kept so existing pipelines that
+   * read `steps.<respond>.body.<field>` still see an object; above it,
+   * retaining a parsed copy of the payload (plus Express re-stringifying it)
+   * is what OOMs small-heap deployments.
+   */
+  private static readonly JSON_PASSTHROUGH_MIN_CHARS = 256 * 1024;
+
   constructor(
     private readonly registry: StepHandlerRegistry,
     private readonly expressionEvaluator: ExpressionEvaluator,
@@ -106,6 +116,21 @@ export class ResponseHandler implements StepHandler<ResponseHandlerConfig> {
     // For JSON content type, ensure body is properly formatted
     if (contentType.includes('application/json')) {
       if (typeof body === 'string') {
+        // Large-body fast path: if the rendered template is already strict
+        // JSON, send the string verbatim. Materializing it into an object here
+        // only for Express to JSON.stringify it again multiplies peak heap by
+        // several times the payload size and OOMs the worker on large list
+        // responses (#418). The JSON.parse is validation only; its result is
+        // discarded.
+        if (body.length >= ResponseHandler.JSON_PASSTHROUGH_MIN_CHARS) {
+          try {
+            JSON.parse(body);
+            return { body };
+          } catch {
+            // Not strict JSON — fall through to JSON5 normalization.
+          }
+        }
+
         // Try to parse as JSON5 (handles unquoted keys, trailing commas, etc.)
         // This allows templates like { success: true, data: {{ steps.foo.value }} }
         // to work even though they produce non-strict JSON


### PR DESCRIPTION
## Summary

Implements tier 1 of #418: `response_handler` no longer triple-materializes large JSON bodies.

Previously every JSON string body took three full copies of the payload through the heap: the template render (`expression-evaluator.ts` `{{{expr}}}` → `JSON.stringify`), a `JSON5.parse` back into an object in `formatBody` (validation/normalization only), and Express re-`JSON.stringify`-ing that object in `res.send`. With the `data_query` source rows still live, a ~1 MB list response could exhaust a 128 MB heap, OOM the worker, and 502 every in-flight request.

## Change

In `formatBody`, string bodies **≥ 256 KiB** (`JSON_PASSTHROUGH_MIN_CHARS`) that are already strict JSON are now sent verbatim as the rendered string — `JSON.parse` runs for validation only and its result is discarded, and `res.send` writes strings as-is with the Content-Type the handler already sets. This removes the two largest heap copies (the retained parsed object and the re-serialization) exactly where they matter.

**Below the threshold, behavior is byte-for-byte unchanged**: small bodies still go through `JSON5.parse`, so existing pipelines whose post-steps/conditions read `steps.<respond>.body.<field>` as an object keep working. Large non-strict (JSON5-style) bodies still normalize as before, and invalid JSON still gets the `{ "message": … }` wrap + warning.

What HTTP clients see is unchanged in all cases (valid JSON, same content); the only seam is the in-pipeline type of `steps.<respond>.body` for ≥256 KiB strict-JSON responses — pipelines that today crash the worker outright.

## Tests

- New `response.handler.spec.ts` (9 tests, real `ExpressionEvaluator` so the actual `{{{ }}}` render path is exercised): large strict-JSON pass-through, small-body legacy object behavior, large JSON5 normalization, invalid-JSON wrap, object/text bodies, response envelope.
- Full pipelines suite: 16 suites / 212 tests passing; `proxy.middleware.spec` and `pipeline-execution.service.spec` passing; backend `tsc --noEmit` clean.

## Follow-ups (not in this PR)

- Tier 2: opt-in streaming response path for array outputs (O(1) memory, `terminates: true` like `file_serve`/`ai`).
- Tier 3: `data_query` column projection + configurable response-size warning.

Fixes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)