### PR TITLE
fix(pipelines): don't send Content-Type on bodyless http_request GETs

### DIFF
--- a/apps/backend/src/pipelines/handlers/http-request.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/http-request.handler.spec.ts
@@ -255,4 +255,44 @@ describe('HttpRequestHandler', () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
   });
+
+  describe('execute — Content-Type header', () => {
+    function sentHeaders(): Record<string, string> {
+      return (mockFetch.mock.calls[0][1] as { headers: Record<string, string> }).headers;
+    }
+
+    it('omits Content-Type on a bodyless GET (strict upstreams 415 otherwise)', async () => {
+      mockFetch.mockResolvedValue(makeFetchResponse({ status: 200, body: '<rss/>', isJson: false }));
+
+      await handler.execute(makeContext(), makeStep({ url: 'https://example.com/rss' }));
+
+      expect(sentHeaders()['Content-Type']).toBeUndefined();
+    });
+
+    it('sends Content-Type: application/json when a body is present', async () => {
+      mockFetch.mockResolvedValue(makeFetchResponse({ status: 200, body: { ok: true } }));
+
+      await handler.execute(
+        makeContext(),
+        makeStep({ url: 'https://example.com/post', method: 'POST', body: { a: 1 } }),
+      );
+
+      expect(sentHeaders()['Content-Type']).toBe('application/json');
+    });
+
+    it('lets a caller override Content-Type via config.headers', async () => {
+      mockFetch.mockResolvedValue(makeFetchResponse({ status: 200, body: '<rss/>', isJson: false }));
+
+      await handler.execute(
+        makeContext(),
+        makeStep({
+          url: 'https://example.com/rss',
+          headers: { Accept: 'application/rss+xml' },
+        }),
+      );
+
+      expect(sentHeaders()['accept']).toBe('application/rss+xml');
+      expect(sentHeaders()['Content-Type']).toBeUndefined();
+    });
+  });
 });

--- a/apps/backend/src/pipelines/handlers/http-request.handler.ts
+++ b/apps/backend/src/pipelines/handlers/http-request.handler.ts
@@ -158,10 +158,16 @@ export class HttpRequestHandler implements StepHandler<HttpRequestHandlerConfig>
       };
     }
 
-    // Build headers
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
+    // Build headers. Only advertise a JSON Content-Type when we will actually
+    // send a body: a bodyless GET carrying `Content-Type: application/json` is
+    // semantically wrong and strict upstreams (e.g. nginx) reject it with a
+    // 415 Unsupported Media Type. A caller can still set its own Content-Type
+    // via `config.headers` below.
+    const headers: Record<string, string> = {};
+    const willSendBody = method !== 'GET' && config.body !== undefined;
+    if (willSendBody) {
+      headers['Content-Type'] = 'application/json';
+    }
 
     // Forward specific headers from original request
     if (config.forwardHeaders) {


### PR DESCRIPTION
-