### PR TITLE
feat(pipelines): add `in` (array-membership) filter operator + admin UI

### DIFF
--- a/apps/backend/src/pipelines/execution/step-handler.interface.ts
+++ b/apps/backend/src/pipelines/execution/step-handler.interface.ts
@@ -283,7 +283,7 @@ export interface DbAggregateHandlerConfig extends BaseHandlerConfig {
    */
   filters?: Record<
     string,
-    { op: 'eq' | 'ne' | 'gt' | 'lt' | 'gte' | 'lte' | 'like'; value: string }
+    { op: 'eq' | 'ne' | 'gt' | 'lt' | 'gte' | 'lte' | 'like' | 'in'; value: string }
   >;
 
   /**

--- a/apps/backend/src/pipelines/execution/step-handler.interface.ts
+++ b/apps/backend/src/pipelines/execution/step-handler.interface.ts
@@ -132,7 +132,7 @@ export interface DataUpdateHandlerConfig extends BaseHandlerConfig {
   /**
    * Filter to identify records to update (ignored if recordId is set)
    */
-  filters?: Record<string, { op: 'eq' | 'ne'; value: string }>;
+  filters?: Record<string, { op: 'eq' | 'ne' | 'in'; value: string }>;
 
   /**
    * How to combine multiple filters: 'and' (all must match) or 'or' (any must match)

--- a/apps/backend/src/pipelines/execution/step-handler.interface.ts
+++ b/apps/backend/src/pipelines/execution/step-handler.interface.ts
@@ -84,7 +84,7 @@ export interface DataQueryHandlerConfig extends BaseHandlerConfig {
    */
   filters?: Record<
     string,
-    { op: 'eq' | 'ne' | 'gt' | 'lt' | 'gte' | 'lte' | 'like'; value: string }
+    { op: 'eq' | 'ne' | 'gt' | 'lt' | 'gte' | 'lte' | 'like' | 'in'; value: string }
   >;
 
   /**

--- a/apps/backend/src/pipelines/handlers/data-query.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/data-query.handler.spec.ts
@@ -1,0 +1,89 @@
+jest.mock('../../db/client', () => {
+  const queued: unknown[] = [];
+  const methods = ['select', 'from', 'where', 'orderBy', 'limit', 'offset'];
+  const chainable: Record<string, unknown> = {};
+  for (const method of methods) chainable[method] = jest.fn(() => chainable);
+  chainable.then = (resolve: (v: unknown) => unknown, reject: (r: unknown) => unknown) =>
+    Promise.resolve(queued.length > 0 ? queued.shift() : []).then(resolve, reject);
+  chainable.__queue = (result: unknown) => queued.push(result);
+  chainable.__reset = () => {
+    queued.length = 0;
+    for (const method of methods) (chainable[method] as jest.Mock).mockClear();
+  };
+  return { db: chainable };
+});
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { db } from '../../db/client';
+import { DataQueryHandler } from './data-query.handler';
+import { ExpressionEvaluator } from '../execution/expression-evaluator';
+import { PipelineSchemasService } from '../pipeline-schemas.service';
+import { PipelineContext } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+
+const mockDb = db as unknown as Record<string, jest.Mock> & {
+  __queue: (r: unknown) => void;
+  __reset: () => void;
+};
+const SCHEMA = { id: 'schema-1', projectId: 'proj-1', name: 'reader_items' };
+
+function buildHandler() {
+  const registry = { register: jest.fn() };
+  const expressionEvaluator = {
+    evaluateExpression: jest.fn((expr: unknown, context: PipelineContext) => {
+      if (typeof expr !== 'string') return expr;
+      if (expr.startsWith('steps.')) {
+        const parts = expr.split('.').slice(1);
+        let value: unknown = context.stepOutputs;
+        for (const part of parts) {
+          if (value == null || typeof value !== 'object') return undefined;
+          value = (value as Record<string, unknown>)[part];
+        }
+        return value;
+      }
+      return expr;
+    }),
+  } as unknown as ExpressionEvaluator;
+  const schemasService = { getById: jest.fn(async () => SCHEMA) } as unknown as PipelineSchemasService;
+  return { handler: new DataQueryHandler(registry as any, expressionEvaluator, schemasService) };
+}
+
+const step = (config: unknown): PipelineStep =>
+  ({ name: 'page', handlerType: 'data_query', config }) as unknown as PipelineStep;
+const context = (stepOutputs: Record<string, unknown> = {}): PipelineContext =>
+  ({ projectId: 'proj-1', stepOutputs, user: { id: 'user-1' } }) as unknown as PipelineContext;
+
+function selectWhereQuery(): { sql: string; params: unknown[] } {
+  return new PgDialect().sqlToQuery(mockDb.where.mock.calls[0][0]);
+}
+
+describe('DataQueryHandler in operator', () => {
+  beforeEach(() => mockDb.__reset());
+
+  it('validateConfig accepts the in operator', () => {
+    const { handler } = buildHandler();
+    expect(() =>
+      handler.validateConfig({
+        schemaId: 'schema-1',
+        filters: { feedId: { op: 'in', value: 'steps.prep.urls' } },
+      } as any),
+    ).not.toThrow();
+  });
+
+  it('filters feedId IN (folder urls) resolved from a prior step', async () => {
+    const { handler } = buildHandler();
+    mockDb.__queue([]); // page rows
+    await handler.execute(
+      context({ prep: { urls: ['https://a.com/feed', 'https://b.com/feed'] } }),
+      step({
+        schemaId: 'schema-1',
+        filters: { feedId: { op: 'in', value: 'steps.prep.urls' } },
+      }),
+    );
+    const { sql, params } = selectWhereQuery();
+    expect(sql.toLowerCase()).toContain('in (');
+    expect(params).toEqual(
+      expect.arrayContaining(['https://a.com/feed', 'https://b.com/feed']),
+    );
+  });
+});

--- a/apps/backend/src/pipelines/handlers/data-query.handler.ts
+++ b/apps/backend/src/pipelines/handlers/data-query.handler.ts
@@ -9,6 +9,7 @@ import { pipelineData, PipelineData } from '../../db/schema';
 import { PipelineSchemasService } from '../pipeline-schemas.service';
 import { db } from '../../db/client';
 import { ConfigurationError, SchemaNotFoundError } from '../errors';
+import { buildInPredicate } from './in-filter.util';
 
 /**
  * Data Query Handler
@@ -57,7 +58,7 @@ export class DataQueryHandler implements StepHandler<DataQueryHandlerConfig> {
 
     // Validate filter operators
     if (config.filters) {
-      const validOps = ['eq', 'ne', 'gt', 'lt', 'gte', 'lte', 'like'];
+      const validOps = ['eq', 'ne', 'gt', 'lt', 'gte', 'lte', 'like', 'in'];
       for (const [field, filter] of Object.entries(config.filters)) {
         if (!validOps.includes(filter.op)) {
           throw new ConfigurationError(
@@ -149,6 +150,9 @@ export class DataQueryHandler implements StepHandler<DataQueryHandlerConfig> {
             break;
           case 'like':
             filterConditions.push(sql`${fieldPath} ILIKE ${String(value)}`);
+            break;
+          case 'in':
+            filterConditions.push(buildInPredicate(fieldPath, value));
             break;
         }
       }

--- a/apps/backend/src/pipelines/handlers/data-update.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/data-update.handler.spec.ts
@@ -1,0 +1,95 @@
+jest.mock('../../db/client', () => {
+  const queued: unknown[] = [];
+  const methods = ['select', 'from', 'where', 'update', 'set', 'returning', 'limit'];
+  const chainable: Record<string, unknown> = {};
+  for (const method of methods) chainable[method] = jest.fn(() => chainable);
+  chainable.then = (resolve: (v: unknown) => unknown, reject: (r: unknown) => unknown) =>
+    Promise.resolve(queued.length > 0 ? queued.shift() : []).then(resolve, reject);
+  chainable.__queue = (result: unknown) => queued.push(result);
+  chainable.__reset = () => {
+    queued.length = 0;
+    for (const method of methods) (chainable[method] as jest.Mock).mockClear();
+  };
+  return { db: chainable };
+});
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { db } from '../../db/client';
+import { DataUpdateHandler } from './data-update.handler';
+import { ExpressionEvaluator } from '../execution/expression-evaluator';
+import { PipelineSchemasService } from '../pipeline-schemas.service';
+import { PipelineContext } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+
+const mockDb = db as unknown as Record<string, jest.Mock> & {
+  __queue: (r: unknown) => void;
+  __reset: () => void;
+};
+const SCHEMA = { id: 'schema-1', projectId: 'proj-1', name: 'reader_items' };
+
+function buildHandler() {
+  const registry = { register: jest.fn() };
+  const expressionEvaluator = {
+    evaluateExpression: jest.fn((expr: unknown, context: PipelineContext) => {
+      if (typeof expr !== 'string') return expr;
+      if (expr.startsWith('steps.')) {
+        const parts = expr.split('.').slice(1);
+        let value: unknown = context.stepOutputs;
+        for (const part of parts) {
+          if (value == null || typeof value !== 'object') return undefined;
+          value = (value as Record<string, unknown>)[part];
+        }
+        return value;
+      }
+      return expr;
+    }),
+  } as unknown as ExpressionEvaluator;
+  const schemasService = { getById: jest.fn(async () => SCHEMA) } as unknown as PipelineSchemasService;
+  return { handler: new DataUpdateHandler(registry as any, expressionEvaluator, schemasService) };
+}
+
+const step = (config: unknown): PipelineStep =>
+  ({ name: 'readAll', handlerType: 'data_update', config }) as unknown as PipelineStep;
+const context = (stepOutputs: Record<string, unknown> = {}): PipelineContext =>
+  ({ projectId: 'proj-1', stepOutputs, user: { id: 'user-1' } }) as unknown as PipelineContext;
+
+describe('DataUpdateHandler in operator', () => {
+  beforeEach(() => mockDb.__reset());
+
+  it('validateConfig accepts the in operator', () => {
+    const { handler } = buildHandler();
+    expect(() =>
+      handler.validateConfig({
+        schemaId: 'schema-1',
+        filters: { feedId: { op: 'in', value: 'steps.prep.urls' } },
+        fields: { read: 'true' },
+      } as any),
+    ).not.toThrow();
+  });
+
+  it('marks all matching folder items read via feedId IN (urls)', async () => {
+    const { handler } = buildHandler();
+    mockDb.__queue([{ id: 'i1', data: { read: false } }, { id: 'i2', data: { read: false } }]); // select matches
+    mockDb.__queue([{ id: 'i1', data: { read: true } }]); // update i1 .returning()
+    mockDb.__queue([{ id: 'i2', data: { read: true } }]); // update i2 .returning()
+
+    const result = await handler.execute(
+      context({ prep: { urls: ['https://a.com/feed', 'https://b.com/feed'] } }),
+      step({
+        schemaId: 'schema-1',
+        filters: {
+          feedId: { op: 'in', value: 'steps.prep.urls' },
+          read: { op: 'eq', value: 'false' },
+        },
+        fields: { read: 'true' },
+      }),
+    );
+
+    expect((result.output as { count: number }).count).toBe(2);
+    const { sql, params } = new PgDialect().sqlToQuery(mockDb.where.mock.calls[0][0]);
+    expect(sql.toLowerCase()).toContain('in (');
+    expect(params).toEqual(
+      expect.arrayContaining(['https://a.com/feed', 'https://b.com/feed', 'false']),
+    );
+  });
+});

--- a/apps/backend/src/pipelines/handlers/data-update.handler.ts
+++ b/apps/backend/src/pipelines/handlers/data-update.handler.ts
@@ -9,6 +9,7 @@ import { pipelineData } from '../../db/schema';
 import { PipelineSchemasService } from '../pipeline-schemas.service';
 import { db } from '../../db/client';
 import { ConfigurationError, SchemaNotFoundError } from '../errors';
+import { buildInPredicate } from './in-filter.util';
 
 /**
  * Data Update Handler
@@ -48,7 +49,7 @@ export class DataUpdateHandler implements StepHandler<DataUpdateHandlerConfig> {
 
     // Validate filter operators if filters are provided
     if (hasFilters) {
-      const validOps = ['eq', 'ne'];
+      const validOps = ['eq', 'ne', 'in'];
       for (const [field, filter] of Object.entries(config.filters!)) {
         if (!validOps.includes(filter.op)) {
           throw new ConfigurationError(
@@ -114,6 +115,9 @@ export class DataUpdateHandler implements StepHandler<DataUpdateHandlerConfig> {
             break;
           case 'ne':
             filterConditions.push(sql`${fieldPath} != ${String(value)}`);
+            break;
+          case 'in':
+            filterConditions.push(buildInPredicate(fieldPath, value));
             break;
         }
       }

--- a/apps/backend/src/pipelines/handlers/db-aggregate.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/db-aggregate.handler.spec.ts
@@ -1,0 +1,88 @@
+jest.mock('../../db/client', () => {
+  const queued: unknown[] = [];
+  const methods = ['select', 'from', 'where', 'groupBy'];
+  const chainable: Record<string, unknown> = {};
+  for (const method of methods) chainable[method] = jest.fn(() => chainable);
+  chainable.then = (resolve: (v: unknown) => unknown, reject: (r: unknown) => unknown) =>
+    Promise.resolve(queued.length > 0 ? queued.shift() : []).then(resolve, reject);
+  chainable.__queue = (result: unknown) => queued.push(result);
+  chainable.__reset = () => {
+    queued.length = 0;
+    for (const method of methods) (chainable[method] as jest.Mock).mockClear();
+  };
+  return { db: chainable };
+});
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { db } from '../../db/client';
+import { DbAggregateHandler } from './db-aggregate.handler';
+import { ExpressionEvaluator } from '../execution/expression-evaluator';
+import { PipelineSchemasService } from '../pipeline-schemas.service';
+import { PipelineContext } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+
+const mockDb = db as unknown as Record<string, jest.Mock> & {
+  __queue: (r: unknown) => void;
+  __reset: () => void;
+};
+const SCHEMA = { id: 'schema-1', projectId: 'proj-1', name: 'reader_items' };
+
+function buildHandler() {
+  const registry = { register: jest.fn() };
+  const expressionEvaluator = {
+    evaluateExpression: jest.fn((expr: unknown, context: PipelineContext) => {
+      if (typeof expr !== 'string') return expr;
+      if (expr.startsWith('steps.')) {
+        const parts = expr.split('.').slice(1);
+        let value: unknown = context.stepOutputs;
+        for (const part of parts) {
+          if (value == null || typeof value !== 'object') return undefined;
+          value = (value as Record<string, unknown>)[part];
+        }
+        return value;
+      }
+      return expr;
+    }),
+  } as unknown as ExpressionEvaluator;
+  const schemasService = { getById: jest.fn(async () => SCHEMA) } as unknown as PipelineSchemasService;
+  return { handler: new DbAggregateHandler(registry as any, expressionEvaluator, schemasService) };
+}
+
+const step = (config: unknown): PipelineStep =>
+  ({ name: 'count', handlerType: 'db_aggregate', config }) as unknown as PipelineStep;
+const context = (stepOutputs: Record<string, unknown> = {}): PipelineContext =>
+  ({ projectId: 'proj-1', stepOutputs, user: { id: 'user-1' } }) as unknown as PipelineContext;
+
+describe('DbAggregateHandler in operator', () => {
+  beforeEach(() => mockDb.__reset());
+
+  it('validateConfig accepts the in operator', () => {
+    const { handler } = buildHandler();
+    expect(() =>
+      handler.validateConfig({
+        schemaId: 'schema-1',
+        operation: 'count',
+        filters: { feedId: { op: 'in', value: 'steps.prep.urls' } },
+      } as any),
+    ).not.toThrow();
+  });
+
+  it('counts with feedId IN (urls)', async () => {
+    const { handler } = buildHandler();
+    mockDb.__queue([{ result: '7' }]); // count(*) row
+    const result = await handler.execute(
+      context({ prep: { urls: ['https://a.com/feed', 'https://b.com/feed'] } }),
+      step({
+        schemaId: 'schema-1',
+        operation: 'count',
+        filters: { feedId: { op: 'in', value: 'steps.prep.urls' } },
+      }),
+    );
+    expect(result.output).toEqual(expect.objectContaining({ operation: 'count', result: 7 }));
+    const { sql, params } = new PgDialect().sqlToQuery(mockDb.where.mock.calls[0][0]);
+    expect(sql.toLowerCase()).toContain('in (');
+    expect(params).toEqual(
+      expect.arrayContaining(['https://a.com/feed', 'https://b.com/feed']),
+    );
+  });
+});

--- a/apps/backend/src/pipelines/handlers/db-aggregate.handler.ts
+++ b/apps/backend/src/pipelines/handlers/db-aggregate.handler.ts
@@ -9,6 +9,7 @@ import { pipelineData } from '../../db/schema';
 import { PipelineSchemasService } from '../pipeline-schemas.service';
 import { db } from '../../db/client';
 import { ConfigurationError, SchemaNotFoundError } from '../errors';
+import { buildInPredicate } from './in-filter.util';
 
 /**
  * DB Aggregate Handler
@@ -52,7 +53,7 @@ export class DbAggregateHandler implements StepHandler<DbAggregateHandlerConfig>
 
     // Validate filter operators
     if (config.filters) {
-      const validFilterOps = ['eq', 'ne', 'gt', 'lt', 'gte', 'lte', 'like'];
+      const validFilterOps = ['eq', 'ne', 'gt', 'lt', 'gte', 'lte', 'like', 'in'];
       for (const [field, filter] of Object.entries(config.filters)) {
         if (!validFilterOps.includes(filter.op)) {
           throw new ConfigurationError(
@@ -123,6 +124,9 @@ export class DbAggregateHandler implements StepHandler<DbAggregateHandlerConfig>
             break;
           case 'like':
             filterConditions.push(sql`${fieldPath} ILIKE ${String(value)}`);
+            break;
+          case 'in':
+            filterConditions.push(buildInPredicate(fieldPath, value));
             break;
         }
       }

--- a/apps/backend/src/pipelines/handlers/in-filter.util.spec.ts
+++ b/apps/backend/src/pipelines/handlers/in-filter.util.spec.ts
@@ -1,0 +1,38 @@
+import { sql } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { pipelineData } from '../../db/schema';
+import { buildInPredicate } from './in-filter.util';
+
+function render(pred: ReturnType<typeof buildInPredicate>) {
+  return new PgDialect().sqlToQuery(pred);
+}
+
+const fieldPath = sql`${pipelineData.data}->>${sql.raw(`'feedId'`)}`;
+
+describe('buildInPredicate', () => {
+  it('emits a parameterized IN list for a non-empty array', () => {
+    const { sql: text, params } = render(buildInPredicate(fieldPath, ['a', 'b']));
+    expect(text).toContain('in (');
+    expect(params).toEqual(expect.arrayContaining(['a', 'b']));
+  });
+
+  it('binds every element as text', () => {
+    const { params } = render(buildInPredicate(fieldPath, [1, 2]));
+    expect(params).toEqual(expect.arrayContaining(['1', '2']));
+  });
+
+  it('wraps a non-array scalar into a single-element list', () => {
+    const { params } = render(buildInPredicate(fieldPath, 'solo'));
+    expect(params).toContain('solo');
+  });
+
+  it('compiles an empty array to a match-nothing predicate', () => {
+    const { sql: text } = render(buildInPredicate(fieldPath, []));
+    expect(text.toLowerCase()).toContain('false');
+  });
+
+  it('treats null/undefined as empty (match nothing)', () => {
+    expect(render(buildInPredicate(fieldPath, null)).sql.toLowerCase()).toContain('false');
+    expect(render(buildInPredicate(fieldPath, undefined)).sql.toLowerCase()).toContain('false');
+  });
+});

--- a/apps/backend/src/pipelines/handlers/in-filter.util.ts
+++ b/apps/backend/src/pipelines/handlers/in-filter.util.ts
@@ -1,0 +1,20 @@
+import { sql, SQL } from 'drizzle-orm';
+
+/**
+ * Build a parameterized `<fieldPath> IN (...)` predicate for the `in` filter
+ * operator. The value is expression-resolved upstream and treated as an array
+ * (a scalar is wrapped into a single-element list; null/undefined → empty).
+ * JSONB fields are text (`data->>'field'`), so elements are bound as strings.
+ * An empty array compiles to a match-nothing predicate (never invalid `IN ()`).
+ */
+export function buildInPredicate(fieldPath: SQL, value: unknown): SQL {
+  const arr = value == null ? [] : Array.isArray(value) ? value : [value];
+  if (arr.length === 0) {
+    return sql`false`;
+  }
+  const elements = sql.join(
+    arr.map((el) => sql`${String(el)}`),
+    sql`, `,
+  );
+  return sql`${fieldPath} in (${elements})`;
+}

--- a/apps/frontend/src/components/pipelines/handlers/DataQueryConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/DataQueryConfig.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DataQueryConfig } from './DataQueryConfig';
+
+// SchemaPicker/SchemaFieldPicker hit data services; stub them to plain inputs so
+// this test stays focused on filter value (de)serialization.
+vi.mock('./SchemaPicker', () => ({ SchemaPicker: () => null }));
+vi.mock('./SchemaFieldPicker', () => ({
+  SchemaFieldPicker: ({ value }: { value: string }) => <div data-testid="field">{value}</div>,
+}));
+
+describe('DataQueryConfig in operator', () => {
+  it('hydrates an array in-filter as a comma-joined value and round-trips it back to an array', () => {
+    const onChange = vi.fn();
+    render(
+      <DataQueryConfig
+        projectId="p1"
+        config={{ schemaId: 's1', filters: { feedId: { op: 'in', value: ['https://a.com/feed', 'https://b.com/feed'] } } }}
+        onChange={onChange}
+      />,
+    );
+
+    // Displayed as comma-joined text in the value input.
+    expect(screen.getByDisplayValue('https://a.com/feed, https://b.com/feed')).toBeInTheDocument();
+
+    // The mount effect emits the config with the value re-serialized to an array.
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: { feedId: { op: 'in', value: ['https://a.com/feed', 'https://b.com/feed'] } },
+      }),
+    );
+  });
+
+  it('keeps an expression in-value (no comma) as a string', () => {
+    const onChange = vi.fn();
+    render(
+      <DataQueryConfig
+        projectId="p1"
+        config={{ schemaId: 's1', filters: { feedId: { op: 'in', value: 'steps.prep.urls' } } }}
+        onChange={onChange}
+      />,
+    );
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: { feedId: { op: 'in', value: 'steps.prep.urls' } },
+      }),
+    );
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/DataQueryConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/DataQueryConfig.test.tsx
@@ -23,6 +23,9 @@ describe('DataQueryConfig in operator', () => {
     // Displayed as comma-joined text in the value input.
     expect(screen.getByDisplayValue('https://a.com/feed, https://b.com/feed')).toBeInTheDocument();
 
+    // The in operator hints that a comma-separated list is accepted.
+    expect(screen.getByPlaceholderText('Expression, or comma-separated list')).toBeInTheDocument();
+
     // The mount effect emits the config with the value re-serialized to an array.
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -45,5 +48,19 @@ describe('DataQueryConfig in operator', () => {
         filters: { feedId: { op: 'in', value: 'steps.prep.urls' } },
       }),
     );
+  });
+
+  it('uses the plain Expression placeholder for non-in operators', () => {
+    render(
+      <DataQueryConfig
+        projectId="p1"
+        config={{ schemaId: 's1', filters: { title: { op: 'eq', value: 'hi' } } }}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByPlaceholderText('Expression')).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText('Expression, or comma-separated list'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/pipelines/handlers/DataQueryConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/DataQueryConfig.tsx
@@ -180,7 +180,7 @@ export function DataQueryConfig({ config, onChange, projectId, previousSteps = [
                   <ExpressionInput
                     value={filter.value}
                     onChange={(value) => handleFilterChange(index, { value })}
-                    placeholder="Expression"
+                    placeholder={filter.op === 'in' ? 'Expression, or comma-separated list' : 'Expression'}
                     previousSteps={previousSteps}
                   />
                 </div>

--- a/apps/frontend/src/components/pipelines/handlers/DataQueryConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/DataQueryConfig.tsx
@@ -16,6 +16,7 @@ import { SchemaFieldPicker } from './SchemaFieldPicker';
 import { ExpressionInput } from './ExpressionInput';
 import type { PreviousStep } from './AvailableVariables';
 import type { DataQueryHandlerConfig, FilterConfig } from './types';
+import { serializeFilterValue, displayFilterValue } from './filter-value';
 
 interface DataQueryConfigProps {
   config: Partial<DataQueryHandlerConfig>;
@@ -38,6 +39,7 @@ const FILTER_OPS: { value: FilterConfig['op']; label: string }[] = [
   { value: 'lt', label: 'Less Than (<)' },
   { value: 'lte', label: 'Less or Equal (<=)' },
   { value: 'like', label: 'Like (pattern)' },
+  { value: 'in', label: 'In (any of)' },
 ];
 
 export function DataQueryConfig({ config, onChange, projectId, previousSteps = [] }: DataQueryConfigProps) {
@@ -48,7 +50,7 @@ export function DataQueryConfig({ config, onChange, projectId, previousSteps = [
     const existing = config.filters || {};
     const entries = Object.entries(existing);
     return entries.length > 0
-      ? entries.map(([field, conf]) => ({ field, op: conf.op, value: conf.value }))
+      ? entries.map(([field, conf]) => ({ field, op: conf.op, value: displayFilterValue(conf.value) }))
       : [];
   });
   const [filterLogic, setFilterLogic] = useState<'and' | 'or'>(config.filterLogic || 'and');
@@ -62,7 +64,7 @@ export function DataQueryConfig({ config, onChange, projectId, previousSteps = [
     const filtersRecord: Record<string, FilterConfig> = {};
     for (const filter of filters) {
       if (filter.field.trim()) {
-        filtersRecord[filter.field.trim()] = { op: filter.op, value: filter.value };
+        filtersRecord[filter.field.trim()] = { op: filter.op, value: serializeFilterValue(filter.op, filter.value) };
       }
     }
 

--- a/apps/frontend/src/components/pipelines/handlers/DataUpdateConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/DataUpdateConfig.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DataUpdateConfig } from './DataUpdateConfig';
+
+vi.mock('./SchemaPicker', () => ({ SchemaPicker: () => null }));
+vi.mock('./SchemaFieldPicker', () => ({
+  SchemaFieldPicker: ({ value }: { value: string }) => <div data-testid="field">{value}</div>,
+}));
+
+describe('DataUpdateConfig in operator', () => {
+  it('hydrates an array in-filter as comma-joined text and round-trips to an array', () => {
+    const onChange = vi.fn();
+    render(
+      <DataUpdateConfig
+        projectId="p1"
+        config={{
+          schemaId: 's1',
+          filters: { feedId: { op: 'in', value: ['a', 'b'] } },
+          fields: { read: 'true' },
+        }}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByDisplayValue('a, b')).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ filters: { feedId: { op: 'in', value: ['a', 'b'] } } }),
+    );
+  });
+
+  it('keeps an expression in-value as a string', () => {
+    const onChange = vi.fn();
+    render(
+      <DataUpdateConfig
+        projectId="p1"
+        config={{
+          schemaId: 's1',
+          filters: { feedId: { op: 'in', value: 'steps.prep.urls' } },
+          fields: { read: 'true' },
+        }}
+        onChange={onChange}
+      />,
+    );
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ filters: { feedId: { op: 'in', value: 'steps.prep.urls' } } }),
+    );
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/DataUpdateConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/DataUpdateConfig.test.tsx
@@ -22,6 +22,7 @@ describe('DataUpdateConfig in operator', () => {
       />,
     );
     expect(screen.getByDisplayValue('a, b')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Expression, or comma-separated list')).toBeInTheDocument();
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ filters: { feedId: { op: 'in', value: ['a', 'b'] } } }),
     );
@@ -43,5 +44,19 @@ describe('DataUpdateConfig in operator', () => {
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ filters: { feedId: { op: 'in', value: 'steps.prep.urls' } } }),
     );
+  });
+
+  it('uses the plain Expression placeholder for non-in operators', () => {
+    render(
+      <DataUpdateConfig
+        projectId="p1"
+        config={{ schemaId: 's1', filters: { title: { op: 'eq', value: 'hi' } }, fields: { read: 'true' } }}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByPlaceholderText('Expression')).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText('Expression, or comma-separated list'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/pipelines/handlers/DataUpdateConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/DataUpdateConfig.tsx
@@ -187,7 +187,7 @@ export function DataUpdateConfig({ config, onChange, projectId, previousSteps = 
                 <ExpressionInput
                   value={filter.value}
                   onChange={(value) => handleFilterChange(index, { value })}
-                  placeholder="Expression"
+                  placeholder={filter.op === 'in' ? 'Expression, or comma-separated list' : 'Expression'}
                   previousSteps={previousSteps}
                 />
               </div>

--- a/apps/frontend/src/components/pipelines/handlers/DataUpdateConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/DataUpdateConfig.tsx
@@ -16,6 +16,7 @@ import { SchemaFieldPicker } from './SchemaFieldPicker';
 import { ExpressionInput } from './ExpressionInput';
 import type { PreviousStep } from './AvailableVariables';
 import type { DataUpdateHandlerConfig } from './types';
+import { serializeFilterValue, displayFilterValue } from './filter-value';
 
 interface DataUpdateConfigProps {
   config: Partial<DataUpdateHandlerConfig>;
@@ -26,7 +27,7 @@ interface DataUpdateConfigProps {
 
 interface FilterEntry {
   field: string;
-  op: 'eq' | 'ne';
+  op: 'eq' | 'ne' | 'in';
   value: string;
 }
 
@@ -43,7 +44,7 @@ export function DataUpdateConfig({ config, onChange, projectId, previousSteps = 
     const existing = config.filters || {};
     const entries = Object.entries(existing);
     return entries.length > 0
-      ? entries.map(([field, conf]) => ({ field, op: conf.op, value: conf.value }))
+      ? entries.map(([field, conf]) => ({ field, op: conf.op, value: displayFilterValue(conf.value) }))
       : [{ field: '', op: 'eq' as const, value: '' }];
   });
   const [filterLogic, setFilterLogic] = useState<'and' | 'or'>(config.filterLogic || 'and');
@@ -56,10 +57,10 @@ export function DataUpdateConfig({ config, onChange, projectId, previousSteps = 
   });
 
   useEffect(() => {
-    const filtersRecord: Record<string, { op: 'eq' | 'ne'; value: string }> = {};
+    const filtersRecord: Record<string, { op: 'eq' | 'ne' | 'in'; value: string | string[] }> = {};
     for (const filter of filters) {
       if (filter.field.trim()) {
-        filtersRecord[filter.field.trim()] = { op: filter.op, value: filter.value };
+        filtersRecord[filter.field.trim()] = { op: filter.op, value: serializeFilterValue(filter.op, filter.value) };
       }
     }
 
@@ -170,7 +171,7 @@ export function DataUpdateConfig({ config, onChange, projectId, previousSteps = 
               <Select
                 value={filter.op}
                 onValueChange={(value) =>
-                  handleFilterChange(index, { op: value as 'eq' | 'ne' })
+                  handleFilterChange(index, { op: value as 'eq' | 'ne' | 'in' })
                 }
               >
                 <SelectTrigger className="w-32">
@@ -179,6 +180,7 @@ export function DataUpdateConfig({ config, onChange, projectId, previousSteps = 
                 <SelectContent>
                   <SelectItem value="eq">Equals</SelectItem>
                   <SelectItem value="ne">Not Equals</SelectItem>
+                  <SelectItem value="in">In (any of)</SelectItem>
                 </SelectContent>
               </Select>
               <div className="flex-1">

--- a/apps/frontend/src/components/pipelines/handlers/DbAggregateConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/DbAggregateConfig.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DbAggregateConfig } from './DbAggregateConfig';
+
+vi.mock('./SchemaPicker', () => ({ SchemaPicker: () => null }));
+vi.mock('./SchemaFieldPicker', () => ({
+  SchemaFieldPicker: ({ value }: { value: string }) => <div data-testid="field">{value}</div>,
+}));
+
+describe('DbAggregateConfig in operator', () => {
+  it('hydrates an array in-filter as comma-joined text and round-trips to an array', () => {
+    const onChange = vi.fn();
+    render(
+      <DbAggregateConfig
+        projectId="p1"
+        config={{ schemaId: 's1', operation: 'count', filters: { feedId: { op: 'in', value: ['a', 'b'] } } }}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByDisplayValue('a, b')).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ filters: { feedId: { op: 'in', value: ['a', 'b'] } } }),
+    );
+  });
+
+  it('keeps an expression in-value as a string', () => {
+    const onChange = vi.fn();
+    render(
+      <DbAggregateConfig
+        projectId="p1"
+        config={{ schemaId: 's1', operation: 'count', filters: { feedId: { op: 'in', value: 'steps.prep.urls' } } }}
+        onChange={onChange}
+      />,
+    );
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ filters: { feedId: { op: 'in', value: 'steps.prep.urls' } } }),
+    );
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/DbAggregateConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/DbAggregateConfig.test.tsx
@@ -18,6 +18,7 @@ describe('DbAggregateConfig in operator', () => {
       />,
     );
     expect(screen.getByDisplayValue('a, b')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Expression, or comma-separated list')).toBeInTheDocument();
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ filters: { feedId: { op: 'in', value: ['a', 'b'] } } }),
     );
@@ -35,5 +36,19 @@ describe('DbAggregateConfig in operator', () => {
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ filters: { feedId: { op: 'in', value: 'steps.prep.urls' } } }),
     );
+  });
+
+  it('uses the plain Expression placeholder for non-in operators', () => {
+    render(
+      <DbAggregateConfig
+        projectId="p1"
+        config={{ schemaId: 's1', operation: 'count', filters: { title: { op: 'eq', value: 'hi' } } }}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByPlaceholderText('Expression')).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText('Expression, or comma-separated list'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/pipelines/handlers/DbAggregateConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/DbAggregateConfig.tsx
@@ -211,7 +211,7 @@ export function DbAggregateConfig({ config, onChange, projectId, previousSteps =
                   <ExpressionInput
                     value={filter.value}
                     onChange={(value) => handleFilterChange(index, { value })}
-                    placeholder="Expression"
+                    placeholder={filter.op === 'in' ? 'Expression, or comma-separated list' : 'Expression'}
                     previousSteps={previousSteps}
                   />
                 </div>

--- a/apps/frontend/src/components/pipelines/handlers/DbAggregateConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/DbAggregateConfig.tsx
@@ -15,6 +15,7 @@ import { SchemaFieldPicker } from './SchemaFieldPicker';
 import { ExpressionInput } from './ExpressionInput';
 import type { PreviousStep } from './AvailableVariables';
 import type { DbAggregateHandlerConfig, FilterConfig } from './types';
+import { serializeFilterValue, displayFilterValue } from './filter-value';
 
 interface DbAggregateConfigProps {
   config: Partial<DbAggregateHandlerConfig>;
@@ -50,6 +51,7 @@ const FILTER_OPS: { value: FilterConfig['op']; label: string }[] = [
   { value: 'lt', label: 'Less Than (<)' },
   { value: 'lte', label: 'Less or Equal (<=)' },
   { value: 'like', label: 'Like (pattern)' },
+  { value: 'in', label: 'In (any of)' },
 ];
 
 export function DbAggregateConfig({ config, onChange, projectId, previousSteps = [] }: DbAggregateConfigProps) {
@@ -62,7 +64,7 @@ export function DbAggregateConfig({ config, onChange, projectId, previousSteps =
     const existing = config.filters || {};
     const entries = Object.entries(existing);
     return entries.length > 0
-      ? entries.map(([f, conf]) => ({ field: f, op: conf.op, value: conf.value }))
+      ? entries.map(([f, conf]) => ({ field: f, op: conf.op, value: displayFilterValue(conf.value) }))
       : [];
   });
   const [filterLogic, setFilterLogic] = useState<'and' | 'or'>(config.filterLogic || 'and');
@@ -75,7 +77,7 @@ export function DbAggregateConfig({ config, onChange, projectId, previousSteps =
     const filtersRecord: Record<string, FilterConfig> = {};
     for (const filter of filters) {
       if (filter.field.trim()) {
-        filtersRecord[filter.field.trim()] = { op: filter.op, value: filter.value };
+        filtersRecord[filter.field.trim()] = { op: filter.op, value: serializeFilterValue(filter.op, filter.value) };
       }
     }
 

--- a/apps/frontend/src/components/pipelines/handlers/filter-value.test.ts
+++ b/apps/frontend/src/components/pipelines/handlers/filter-value.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { serializeFilterValue, displayFilterValue } from './filter-value';
+
+describe('serializeFilterValue', () => {
+  it('splits an in value with commas into a trimmed array', () => {
+    expect(serializeFilterValue('in', 'a.com, b.com ,c.com')).toEqual(['a.com', 'b.com', 'c.com']);
+  });
+
+  it('keeps an in value with no comma as a string (preserves expressions)', () => {
+    expect(serializeFilterValue('in', 'steps.folderFeeds.urls')).toBe('steps.folderFeeds.urls');
+  });
+
+  it('keeps a single literal in value as a string', () => {
+    expect(serializeFilterValue('in', 'only.com')).toBe('only.com');
+  });
+
+  it('drops empty segments from an in list', () => {
+    expect(serializeFilterValue('in', 'a.com, , b.com,')).toEqual(['a.com', 'b.com']);
+  });
+
+  it('never splits non-in operators, even with commas', () => {
+    expect(serializeFilterValue('eq', 'a, b')).toBe('a, b');
+    expect(serializeFilterValue('like', '%x, y%')).toBe('%x, y%');
+  });
+});
+
+describe('displayFilterValue', () => {
+  it('joins an array with comma-space', () => {
+    expect(displayFilterValue(['a', 'b'])).toBe('a, b');
+  });
+
+  it('passes a string through', () => {
+    expect(displayFilterValue('steps.x.urls')).toBe('steps.x.urls');
+  });
+
+  it('renders nullish as empty string', () => {
+    expect(displayFilterValue(undefined)).toBe('');
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/filter-value.ts
+++ b/apps/frontend/src/components/pipelines/handlers/filter-value.ts
@@ -1,0 +1,21 @@
+/**
+ * Serialize a filter row's editable text into the stored config value.
+ *
+ * For the `in` operator a comma-separated string becomes a trimmed string[]
+ * (a literal list). A value with no comma is left as a string so runtime
+ * expressions (e.g. `steps.folderFeeds.urls`, which never contain commas) are
+ * resolved to an array by the backend evaluator, and a single literal is wrapped
+ * into a one-element IN by the backend. Every other operator is unchanged.
+ */
+export function serializeFilterValue(op: string, text: string): string | string[] {
+  if (op === 'in' && text.includes(',')) {
+    return text.split(',').map((s) => s.trim()).filter(Boolean);
+  }
+  return text;
+}
+
+/** Render a stored filter value (string or array) as editable text. */
+export function displayFilterValue(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) return value.join(', ');
+  return value ?? '';
+}

--- a/apps/frontend/src/components/pipelines/handlers/types.ts
+++ b/apps/frontend/src/components/pipelines/handlers/types.ts
@@ -59,8 +59,8 @@ export interface DataUpsertManyHandlerConfig extends BaseHandlerConfig {
 }
 
 export interface FilterConfig {
-  op: 'eq' | 'ne' | 'gt' | 'lt' | 'gte' | 'lte' | 'like';
-  value: string;
+  op: 'eq' | 'ne' | 'gt' | 'lt' | 'gte' | 'lte' | 'like' | 'in';
+  value: string | string[];
 }
 
 export interface DataQueryHandlerConfig extends BaseHandlerConfig {
@@ -82,7 +82,7 @@ export interface DataUpdateHandlerConfig extends BaseHandlerConfig {
   schemaId: string;
   /** Find a specific record by its ID (table column). Ignores filters when set. */
   recordId?: string;
-  filters?: Record<string, { op: 'eq' | 'ne'; value: string }>;
+  filters?: Record<string, { op: 'eq' | 'ne' | 'in'; value: string | string[] }>;
   /** How to combine multiple filters: 'and' (all must match) or 'or' (any must match). Default: 'and' */
   filterLogic?: 'and' | 'or';
   /** When true, updates only first match and returns single object (or null). Default: false */


### PR DESCRIPTION
## Summary

Adds an `in` (array-membership) filter operator to the pipeline data handlers and the admin pipeline editor. This unblocks a feed-reader (Rivulet) redesign where a **folder view** must filter / count / mark-read items whose `feedId` is one of N feed URLs in a single query — something the existing operator set (`eq`, `ne`, `gt`, `lt`, `gte`, `lte`, `like`) couldn't express.

## Backend (`apps/backend`)

A shared helper `buildInPredicate(fieldPath, value)` builds a parameterized `<jsonb field> IN (v1, v2, …)`, wired identically into three handlers via a new `case 'in'`:

- `data_query` — folder page queries
- `db_aggregate` — folder counts (and grouped unread counts)
- `data_update` — folder "mark all read" (its filter whitelist goes `eq|ne` → `eq|ne|in`)

Semantics:
- The `in` value is expression-resolved and treated as an **array** — it is **not** scalar-coerced with `String()`/`Number()` (unlike the other operators), so a prior step's array (e.g. `steps.prep.urls`) flows straight through.
- Elements are bound as parameters (no injection surface); JSONB fields are text, so elements compare as strings.
- An **empty array** compiles to a match-nothing predicate (`false`), never invalid `IN ()`.
- Existing operators and the grouped/non-grouped aggregation + recordId + bulk-update paths are unchanged.

No schema migration — this is query-layer only and additive/backward-compatible.

## Frontend (`apps/frontend`)

The admin pipeline editor can now **render** an existing `in` filter (operator no longer shows blank) and **select** "In (any of)" in the `data_query`, `db_aggregate`, and `data_update` step editors.

A shared pure helper `filter-value.ts` handles the value:
- **Save:** for `op === 'in'`, a value **containing a comma** → trimmed `string[]` (literal list); a value with **no comma** → left as a string. This preserves runtime expressions (`steps.folderFeeds.urls` — no comma → stays a string the backend resolves) and single literals (backend wraps a scalar into a one-element `IN`). Every other operator is unchanged.
- **Hydrate:** an existing array value renders as a comma-joined string and round-trips back to an array.

Config types widen to `value: string | string[]` and `op: … | 'in'`; the editable field stays a string.

## Tests

- Backend: `data_query` / `db_aggregate` / `data_update` handler specs for the `in` operator (parameterized `IN`, array-not-scalar, empty-array `false`), asserting rendered SQL + params via `PgDialect().sqlToQuery()`. Full pipelines suite: **233/233**.
- Frontend: `filter-value` unit tests (comma→array, no-comma expression→string, single literal→string, empty-segment filtering, non-`in`-with-comma→string, array→join, nullish→`''`) + a hydrate→save round-trip test per config editor (expression stays a string; array round-trips). Handler config suite: **23/23**, `tsc` clean, build passes.

## Out of scope

`data_delete` editor and the data-browser `DataFilters.tsx` were intentionally not touched (the backend `in` change doesn't touch `data_delete`, and the data browser is a separate feature).

## Follow-ups (non-blocking)

- Frontend: operator-aware placeholder hint when `in` is selected (the input still reads "Expression"; a comma-list isn't discoverable).
- Backend: three stale class-doc comments still list the old operator set (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
