### PR TITLE
fix(pipelines): data_query returns array unless single/recordId set (#428)

### DIFF
--- a/apps/backend/src/pipelines/handlers/data-query.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/data-query.handler.spec.ts
@@ -87,3 +87,62 @@ describe('DataQueryHandler in operator', () => {
     );
   });
 });
+
+describe('DataQueryHandler output shape (array vs single object)', () => {
+  beforeEach(() => mockDb.__reset());
+
+  const row = (guid: string) => ({
+    id: `id-${guid}`,
+    alias: null,
+    version: 1,
+    data: { guid },
+    createdAt: 'c',
+    updatedAt: 'u',
+  });
+
+  it('returns an ARRAY when limit is 1 and single/recordId are not set (bffless/ce#428)', async () => {
+    // Regression: limit:1 used to implicitly return a single object, which
+    // silently dropped the row for any array-shaped consumer.
+    const { handler } = buildHandler();
+    mockDb.__queue([row('g1')]);
+    const result = await handler.execute(
+      context(),
+      step({ schemaId: 'schema-1', limit: 1 }),
+    );
+    expect(Array.isArray(result.output)).toBe(true);
+    expect(result.output).toHaveLength(1);
+    expect((result.output as Array<{ guid: string }>)[0].guid).toBe('g1');
+  });
+
+  it('returns a single OBJECT when single:true is set explicitly', async () => {
+    const { handler } = buildHandler();
+    mockDb.__queue([row('g1')]);
+    const result = await handler.execute(
+      context(),
+      step({ schemaId: 'schema-1', single: true }),
+    );
+    expect(Array.isArray(result.output)).toBe(false);
+    expect((result.output as { guid: string }).guid).toBe('g1');
+  });
+
+  it('returns null when single:true matches no rows', async () => {
+    const { handler } = buildHandler();
+    mockDb.__queue([]);
+    const result = await handler.execute(
+      context(),
+      step({ schemaId: 'schema-1', single: true }),
+    );
+    expect(result.output).toBeNull();
+  });
+
+  it('returns a single OBJECT when recordId is set', async () => {
+    const { handler } = buildHandler();
+    mockDb.__queue([row('g1')]);
+    const result = await handler.execute(
+      context(),
+      step({ schemaId: 'schema-1', recordId: 'id-g1' }),
+    );
+    expect(Array.isArray(result.output)).toBe(false);
+    expect((result.output as { guid: string }).guid).toBe('g1');
+  });
+});

--- a/apps/backend/src/pipelines/handlers/data-query.handler.ts
+++ b/apps/backend/src/pipelines/handlers/data-query.handler.ts
@@ -230,12 +230,14 @@ export class DataQueryHandler implements StepHandler<DataQueryHandlerConfig> {
 
     this.logger.debug(`Query returned ${results.length} records`);
 
-    // Return single object when:
+    // Return a single object ONLY when explicitly requested:
     // - recordId is specified (find by ID)
-    // - single is true (find one)
-    // - limit is 1 (legacy behavior)
-    const resolvedLimit = this.resolveNumericExpression(config.limit, 100, context, stepName);
-    const returnSingle = config.recordId || config.single || resolvedLimit === 1;
+    // - single is true (the "Return Single Object" option)
+    // Otherwise always return an array, so the output TYPE never depends on the
+    // row count / limit. (Previously `limit === 1` implicitly returned a single
+    // object, overriding the explicit `single` flag and silently dropping the
+    // row for any array-shaped consumer — see bffless/ce#428.)
+    const returnSingle = config.recordId || config.single;
     const output = returnSingle ? (results[0] || null) : results;
 
     return {


### PR DESCRIPTION
Fixes #428.

## Problem

`data_query` silently switched its **output type** based on the row limit: `limit === 1` implicitly returned a single object (`results[0]`) instead of an array, **overriding the explicit `single` flag** (the "Return Single Object" checkbox). A step author who leaves `single` unchecked but sets `limit: 1` still got an object — which any array-shaped consumer then dropped (a bare object has no `.length`).

Surfaced in the `bffless/apps` reader (Rivulet): a `data_query` fetching a single item by unique `guid` with `limit: 1` returned **zero items** downstream. Verified live: `limit 1 → 0`, `2 → 2`, `3 → 3`. See bffless/apps#165.

## Fix

`apps/backend/src/pipelines/handlers/data-query.handler.ts` — output type is now governed **solely by the explicit flags**:

```diff
-    const resolvedLimit = this.resolveNumericExpression(config.limit, 100, context, stepName);
-    const returnSingle = config.recordId || config.single || resolvedLimit === 1;
+    const returnSingle = config.recordId || config.single;
```

`data_query` now always returns an array unless `single: true` or `recordId` is set — type-stable, and the "Return Single Object" checkbox is the single source of truth.

## Tests

Added a `DataQueryHandler output shape` suite (4 cases) — no existing test covered the `limit === 1` path:
- `limit: 1`, `single` unset → **one-element array** (the regression)
- `single: true` → single object
- `single: true`, no match → `null`
- `recordId` set → single object

`npx jest data-query.handler.spec.ts` → **6 passed** (2 pre-existing + 4 new).

## Backward-compatibility

- No handler unit test exercised the `limit === 1` legacy path, so the suite is unaffected.
- The only real risk is **live pipelines** that relied on `limit: 1` returning a bare object (reading `steps.x.field` instead of `steps.x[0].field`). Mitigation: set the explicit `single: true` (same result). If a gentler rollout is preferred, we can deprecate-with-warning first instead of removing outright — happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
