### PR TITLE
fix(pipelines): allow custom content types in response_handler UI

### DIFF
--- a/apps/frontend/src/components/pipelines/handlers/ResponseHandlerConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/ResponseHandlerConfig.test.tsx
@@ -1,0 +1,87 @@
+import { useState, useCallback } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ResponseHandlerConfig } from './ResponseHandlerConfig';
+import type { ResponseHandlerConfig as Config } from './types';
+
+// Radix Popover doesn't play well with happy-dom; render trigger + content flat.
+// (Same workaround used by DomainBlocklistsSection.test.tsx.)
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: any) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: any) => <div>{children}</div>,
+  PopoverContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+function Harness({
+  initial = {},
+  sink,
+}: {
+  initial?: Partial<Config>;
+  sink?: { current: Record<string, unknown> };
+}) {
+  const [config, setConfig] = useState<Partial<Config>>(initial);
+  const handleChange = useCallback(
+    (c: Config) => {
+      const record = c as unknown as Record<string, unknown>;
+      setConfig(record);
+      if (sink) sink.current = record;
+    },
+    [sink],
+  );
+  return <ResponseHandlerConfig config={config} onChange={handleChange} />;
+}
+
+describe('ResponseHandlerConfig content type', () => {
+  it('defaults to application/json', () => {
+    render(<Harness />);
+    expect(screen.getByRole('combobox', { name: /content type/i })).toHaveTextContent(
+      'application/json',
+    );
+  });
+
+  it('shows an unrecognized stored content type instead of blanking it out', () => {
+    const sink = { current: {} as Record<string, unknown> };
+    render(<Harness initial={{ contentType: 'application/rss+xml' }} sink={sink} />);
+
+    expect(screen.getByRole('combobox', { name: /content type/i })).toHaveTextContent(
+      'application/rss+xml',
+    );
+    // Untouched, so the emitted config must still carry the original value.
+    expect(sink.current.contentType).toBe('application/rss+xml');
+  });
+
+  it('selecting a preset updates the emitted config', async () => {
+    const sink = { current: {} as Record<string, unknown> };
+    render(<Harness sink={sink} />);
+
+    fireEvent.click(screen.getByRole('combobox', { name: /content type/i }));
+    fireEvent.click(screen.getByText('HTML (text/html)'));
+
+    expect(sink.current.contentType).toBe('text/html');
+    expect(screen.getByRole('combobox', { name: /content type/i })).toHaveTextContent(
+      'text/html',
+    );
+  });
+
+  it('shows the full preset list on open even with a custom value stored, so it stays pickable', () => {
+    render(<Harness initial={{ contentType: 'application/rss+xml' }} />);
+
+    fireEvent.click(screen.getByRole('combobox', { name: /content type/i }));
+
+    expect(screen.getByText('HTML (text/html)')).toBeInTheDocument();
+    expect(screen.getByText('JSON (application/json)')).toBeInTheDocument();
+  });
+
+  it('typing a custom content type preserves it verbatim', async () => {
+    const sink = { current: {} as Record<string, unknown> };
+    render(<Harness sink={sink} />);
+
+    fireEvent.click(screen.getByRole('combobox', { name: /content type/i }));
+    const input = screen.getByPlaceholderText('Search or type a content type...');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'application/vnd.custom+json');
+
+    expect(sink.current.contentType).toBe('application/vnd.custom+json');
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/ResponseHandlerConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/ResponseHandlerConfig.tsx
@@ -10,14 +10,28 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Plus, Trash2, HelpCircle } from 'lucide-react';
+import { Plus, Trash2, HelpCircle, Check, ChevronsUpDown } from 'lucide-react';
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
 import type { ResponseHandlerConfig } from './types';
 import type { PreviousStep } from './AvailableVariables';
 import { ExpressionInput } from './ExpressionInput';
@@ -53,11 +67,21 @@ const CONTENT_TYPES = [
   { value: 'application/json', label: 'JSON (application/json)' },
   { value: 'text/html', label: 'HTML (text/html)' },
   { value: 'text/plain', label: 'Plain Text (text/plain)' },
+  { value: 'application/xml', label: 'XML (application/xml)' },
+  { value: 'text/xml', label: 'XML (text/xml)' },
+  { value: 'application/rss+xml', label: 'RSS (application/rss+xml)' },
+  { value: 'application/atom+xml', label: 'Atom (application/atom+xml)' },
+  { value: 'text/csv', label: 'CSV (text/csv)' },
+  { value: 'text/calendar', label: 'Calendar (text/calendar)' },
 ];
 
 export function ResponseHandlerConfig({ config, onChange, previousSteps = [] }: ResponseHandlerConfigProps) {
   const [status, setStatus] = useState<number>(config.status || 200);
   const [contentType, setContentType] = useState(config.contentType || 'application/json');
+  const [contentTypeOpen, setContentTypeOpen] = useState(false);
+  // Search text is kept separate from contentType so opening the picker always
+  // shows the full preset list instead of pre-filtering by the current value.
+  const [contentTypeSearch, setContentTypeSearch] = useState('');
   const [bodyMode, setBodyMode] = useState<'template' | 'json'>(() => {
     return typeof config.body === 'object' ? 'json' : 'template';
   });
@@ -159,18 +183,67 @@ export function ResponseHandlerConfig({ config, onChange, previousSteps = [] }: 
         </div>
         <div className="space-y-2">
           <Label htmlFor="contentType">Content Type</Label>
-          <Select value={contentType} onValueChange={setContentType}>
-            <SelectTrigger id="contentType">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {CONTENT_TYPES.map((ct) => (
-                <SelectItem key={ct.value} value={ct.value}>
-                  {ct.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <Popover
+            open={contentTypeOpen}
+            onOpenChange={(open) => {
+              setContentTypeOpen(open);
+              if (open) setContentTypeSearch('');
+            }}
+          >
+            <PopoverTrigger asChild>
+              <Button
+                id="contentType"
+                type="button"
+                variant="outline"
+                role="combobox"
+                aria-expanded={contentTypeOpen}
+                className="w-full justify-between font-normal font-mono text-sm"
+              >
+                {contentType || 'Select or type a content type...'}
+                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+              <Command>
+                <CommandInput
+                  placeholder="Search or type a content type..."
+                  value={contentTypeSearch}
+                  onValueChange={(v) => {
+                    setContentTypeSearch(v);
+                    setContentType(v);
+                  }}
+                />
+                <CommandList>
+                  <CommandEmpty>
+                    <div className="py-2 text-sm text-muted-foreground">
+                      Using custom type: <span className="font-mono">{contentType}</span>
+                    </div>
+                  </CommandEmpty>
+                  <CommandGroup>
+                    {CONTENT_TYPES.map((ct) => (
+                      <CommandItem
+                        key={ct.value}
+                        value={ct.value}
+                        onSelect={() => {
+                          setContentType(ct.value);
+                          setContentTypeSearch('');
+                          setContentTypeOpen(false);
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            'mr-2 h-4 w-4 shrink-0',
+                            contentType === ct.value ? 'opacity-100' : 'opacity-0',
+                          )}
+                        />
+                        {ct.label}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- The `response_handler` (Custom HTTP Response) Content Type field was a fixed 3-option dropdown (JSON/HTML/Plain Text), so any other `contentType` set on the step (e.g. `application/rss+xml`) rendered **blank** in the admin UI and risked being clobbered on save.
- Replaced it with a searchable combobox (Popover + Command, same pattern as the model pickers in `AIHandlerConfig.tsx` / `ReplicateHandlerConfig.tsx`) that supports picking a preset or typing an arbitrary content type.
- Expanded the preset list with common non-JSON/HTML types (RSS, Atom, XML, CSV, calendar).
- Fixed a latent bug found while wiring this up: since the reused pattern binds the search input directly to the field's value, opening the picker on a long/custom value fuzzy-filtered out every preset, effectively hiding the picker's own option list. Decoupled search text from the committed value so the full list is always visible on open.

Fixes #433

## Test plan
- [x] `tsc --noEmit` (frontend) — clean
- [x] `eslint` on changed files — clean
- [x] New tests in `ResponseHandlerConfig.test.tsx` (5, all passing): default value, unrecognized value preserved (not blanked), preset selection, full list visible on open with a custom stored value, typed custom value preserved verbatim
- [x] Full `pipelines/handlers` test suite (31 tests) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)