### PR TITLE
feat(storage): sign Content-Disposition into presigned download URLs

### DIFF
--- a/apps/backend/src/pipelines/handlers/signed-url.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/signed-url.handler.spec.ts
@@ -1,0 +1,107 @@
+import { SignedUrlHandler, sanitizeDownloadFilename } from './signed-url.handler';
+
+describe('sanitizeDownloadFilename', () => {
+  it('passes a clean filename through', () => {
+    expect(sanitizeDownloadFilename('my-video.mp4')).toBe('my-video.mp4');
+  });
+
+  it('reduces a path to its basename', () => {
+    expect(sanitizeDownloadFilename('a/b/c/my-video.mp4')).toBe('my-video.mp4');
+    expect(sanitizeDownloadFilename('a\\b\\my-video.mp4')).toBe('my-video.mp4');
+  });
+
+  it('strips quotes, backslashes and control characters', () => {
+    expect(sanitizeDownloadFilename('ev"il\r\nX-Evil: 1.mp4')).toBe('evilX-Evil: 1.mp4');
+  });
+
+  it('returns undefined for empty, whitespace-only, or non-string input', () => {
+    expect(sanitizeDownloadFilename('')).toBeUndefined();
+    expect(sanitizeDownloadFilename('   ')).toBeUndefined();
+    expect(sanitizeDownloadFilename('"')).toBeUndefined();
+    expect(sanitizeDownloadFilename(undefined)).toBeUndefined();
+    expect(sanitizeDownloadFilename(42)).toBeUndefined();
+  });
+
+  it('caps the length at 200 characters', () => {
+    expect(sanitizeDownloadFilename('a'.repeat(500))).toHaveLength(200);
+  });
+});
+
+describe('SignedUrlHandler', () => {
+  let handler: SignedUrlHandler;
+  let storageAdapter: { getUrl: jest.Mock };
+  const registry = { register: jest.fn() } as any;
+  const evaluator = {
+    evaluateExpression: jest.fn((expr: string) =>
+      expr === 'steps.resolvePath.storagePath'
+        ? 'owner/repo/uploads/final.mp4'
+        : expr === 'steps.resolvePath.filename'
+          ? 'my-video.mp4'
+          : expr === 'steps.resolvePath.empty'
+            ? ''
+            : expr,
+    ),
+  } as any;
+
+  const step = (config: Record<string, unknown>) => ({ id: 'sign', name: 'sign', config }) as any;
+
+  beforeEach(() => {
+    storageAdapter = { getUrl: jest.fn().mockResolvedValue('https://signed') };
+    handler = new SignedUrlHandler(registry, evaluator, storageAdapter as any);
+  });
+
+  it('passes a sanitized downloadFilename to the adapter', async () => {
+    const result = await handler.execute(
+      {} as any,
+      step({
+        path: 'steps.resolvePath.storagePath',
+        filename: 'steps.resolvePath.filename',
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(storageAdapter.getUrl).toHaveBeenCalledWith('owner/repo/uploads/final.mp4', 3600, {
+      downloadFilename: 'my-video.mp4',
+    });
+  });
+
+  it('passes undefined options when filename is absent', async () => {
+    await handler.execute({} as any, step({ path: 'steps.resolvePath.storagePath' }));
+
+    expect(storageAdapter.getUrl).toHaveBeenCalledWith(
+      'owner/repo/uploads/final.mp4',
+      3600,
+      undefined,
+    );
+  });
+
+  it('passes undefined options when filename resolves to empty', async () => {
+    await handler.execute(
+      {} as any,
+      step({
+        path: 'steps.resolvePath.storagePath',
+        filename: 'steps.resolvePath.empty',
+      }),
+    );
+
+    expect(storageAdapter.getUrl).toHaveBeenCalledWith(
+      'owner/repo/uploads/final.mp4',
+      3600,
+      undefined,
+    );
+  });
+
+  it('accepts a literal filename', async () => {
+    await handler.execute(
+      {} as any,
+      step({
+        path: 'steps.resolvePath.storagePath',
+        filename: 'literal.mp4',
+      }),
+    );
+
+    expect(storageAdapter.getUrl).toHaveBeenCalledWith('owner/repo/uploads/final.mp4', 3600, {
+      downloadFilename: 'literal.mp4',
+    });
+  });
+});

--- a/apps/backend/src/pipelines/handlers/signed-url.handler.ts
+++ b/apps/backend/src/pipelines/handlers/signed-url.handler.ts
@@ -18,6 +18,39 @@ export interface SignedUrlHandlerConfig {
    * @default 3600
    */
   expiresIn?: number;
+
+  /**
+   * Optional filename to force a download under (supports expressions, e.g.
+   * "steps.resolvePath.filename", or a literal like "video.mp4"). When present
+   * and non-empty after sanitizing, the signed URL carries
+   * `Content-Disposition: attachment; filename="..."`.
+   *
+   * Ignored on local storage, which cannot presign.
+   */
+  filename?: string;
+}
+
+/**
+ * Reduce an arbitrary value to a filename safe to interpolate into a
+ * `Content-Disposition` header value. THE choke point: every adapter trusts
+ * that `SignedUrlOptions.downloadFilename` came through here.
+ *
+ * Strips path separators (basename only), then control characters, double
+ * quotes and backslashes — the characters that could break out of the quoted
+ * header value or inject a second header. Returns `undefined` when nothing
+ * usable survives, which makes the handler omit the disposition entirely.
+ */
+export function sanitizeDownloadFilename(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined;
+
+  const basename = raw.split(/[/\\]/).pop() ?? '';
+  const cleaned = basename
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f"\\]/g, '')
+    .trim()
+    .slice(0, 200);
+
+  return cleaned || undefined;
 }
 
 /**
@@ -68,12 +101,22 @@ export class SignedUrlHandler implements StepHandler<SignedUrlHandlerConfig> {
       };
     }
 
-    try {
-      const url = await this.storageAdapter.getUrl(resolvedPath, expiresIn);
+    // Resolve + sanitize the optional download filename. An absent or
+    // unusable filename means no disposition at all, which keeps every existing
+    // caller (e.g. Studio's `useSignedBytes`) byte-identical.
+    const resolvedFilename = config.filename
+      ? this.expressionEvaluator.evaluateExpression(config.filename, context, stepName)
+      : undefined;
+    const downloadFilename = sanitizeDownloadFilename(resolvedFilename);
 
-      this.logger.debug(
-        `Generated signed URL for ${resolvedPath} (expires in ${expiresIn}s)`,
+    try {
+      const url = await this.storageAdapter.getUrl(
+        resolvedPath,
+        expiresIn,
+        downloadFilename ? { downloadFilename } : undefined,
       );
+
+      this.logger.debug(`Generated signed URL for ${resolvedPath} (expires in ${expiresIn}s)`);
 
       return {
         success: true,

--- a/apps/backend/src/storage/azure.adapter.spec.ts
+++ b/apps/backend/src/storage/azure.adapter.spec.ts
@@ -387,6 +387,28 @@ describe('AzureBlobStorageAdapter', () => {
       // URL should be generated (we can't test exact expiration without more complex mocking)
       expect(result).toContain('https://');
     });
+
+    it('sets contentDisposition when a downloadFilename is given', async () => {
+      await adapter.getUrl('test/file.mp4', 600, {
+        downloadFilename: 'my-video.mp4',
+      });
+
+      expect(generateBlobSASQueryParameters).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contentDisposition: 'attachment; filename="my-video.mp4"',
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('omits contentDisposition when no downloadFilename is given', async () => {
+      await adapter.getUrl('test/file.mp4', 600);
+
+      const sasOptions = (generateBlobSASQueryParameters as jest.Mock).mock.calls[
+        (generateBlobSASQueryParameters as jest.Mock).mock.calls.length - 1
+      ][0];
+      expect(sasOptions).not.toHaveProperty('contentDisposition');
+    });
   });
 
   describe('testConnection', () => {

--- a/apps/backend/src/storage/azure.adapter.ts
+++ b/apps/backend/src/storage/azure.adapter.ts
@@ -6,6 +6,7 @@ import {
   BlobSASPermissions,
   generateBlobSASQueryParameters,
   SASProtocol,
+  BlobSASSignatureValues,
 } from '@azure/storage-blob';
 import { DefaultAzureCredential, ManagedIdentityCredential } from '@azure/identity';
 import {
@@ -13,6 +14,7 @@ import {
   FileMetadata,
   StreamDownloadResult,
   DownloadStreamOptions,
+  SignedUrlOptions,
 } from './storage.interface';
 import { AzureBlobStorageConfig, validateAzureConfig } from './azure.config';
 
@@ -225,7 +227,11 @@ export class AzureBlobStorageAdapter implements IStorageAdapter {
   /**
    * Get a SAS URL for accessing the file (read)
    */
-  async getUrl(key: string, expiresIn?: number): Promise<string> {
+  async getUrl(
+    key: string,
+    expiresIn?: number,
+    options?: SignedUrlOptions,
+  ): Promise<string> {
     const sanitizedKey = this.sanitizeKey(key);
     const storageKey = this.prefixKey(sanitizedKey);
     const blockBlobClient = this.containerClient.getBlockBlobClient(storageKey);
@@ -234,7 +240,7 @@ export class AzureBlobStorageAdapter implements IStorageAdapter {
     try {
       // If we have shared key credential, generate SAS URL
       if (this.sharedKeyCredential) {
-        const sasOptions = {
+        const sasOptions: BlobSASSignatureValues = {
           containerName: this.config.containerName,
           blobName: storageKey,
           permissions: BlobSASPermissions.parse('r'), // Read only
@@ -242,6 +248,11 @@ export class AzureBlobStorageAdapter implements IStorageAdapter {
           expiresOn: new Date(Date.now() + expiration * 1000),
           protocol: SASProtocol.HttpsAndHttp,
         };
+
+        // Signed into the SAS token, so it cannot be tampered with or appended.
+        if (options?.downloadFilename) {
+          sasOptions.contentDisposition = `attachment; filename="${options.downloadFilename}"`;
+        }
 
         const sasToken = generateBlobSASQueryParameters(
           sasOptions,

--- a/apps/backend/src/storage/cache/caching-storage.adapter.spec.ts
+++ b/apps/backend/src/storage/cache/caching-storage.adapter.spec.ts
@@ -159,10 +159,26 @@ describe('CachingStorageAdapter', () => {
     });
   });
 
+  describe('getUrl', () => {
+    it('should forward downloadFilename options to storage', async () => {
+      await cachingAdapter.getUrl('k', 600, { downloadFilename: 'my-video.mp4' });
+
+      expect(mockStorage.getUrl).toHaveBeenCalledWith('k', 600, {
+        downloadFilename: 'my-video.mp4',
+      });
+    });
+
+    it('should forward undefined options to storage when omitted', async () => {
+      await cachingAdapter.getUrl('k', 600);
+
+      expect(mockStorage.getUrl).toHaveBeenCalledWith('k', 600, undefined);
+    });
+  });
+
   describe('pass-through methods', () => {
     it('should pass getUrl to storage', async () => {
       await cachingAdapter.getUrl('key', 3600);
-      expect(mockStorage.getUrl).toHaveBeenCalledWith('key', 3600);
+      expect(mockStorage.getUrl).toHaveBeenCalledWith('key', 3600, undefined);
     });
 
     it('should pass listKeys to storage', async () => {

--- a/apps/backend/src/storage/cache/caching-storage.adapter.ts
+++ b/apps/backend/src/storage/cache/caching-storage.adapter.ts
@@ -5,6 +5,7 @@ import {
   DownloadResult,
   StreamDownloadResult,
   DownloadStreamOptions,
+  SignedUrlOptions,
 } from '../storage.interface';
 import { ICacheAdapter, CacheConfig } from './cache.interface';
 
@@ -137,9 +138,16 @@ export class CachingStorageAdapter implements IStorageAdapter {
 
   /**
    * Get URL (pass through, URLs are temporary)
+   *
+   * Forwards `options` — a dropped `downloadFilename` here would silently strip
+   * `Content-Disposition` from every presigned URL on cache-enabled deployments.
    */
-  async getUrl(key: string, expiresIn?: number): Promise<string> {
-    return this.storage.getUrl(key, expiresIn);
+  async getUrl(
+    key: string,
+    expiresIn?: number,
+    options?: SignedUrlOptions,
+  ): Promise<string> {
+    return this.storage.getUrl(key, expiresIn, options);
   }
 
   /**

--- a/apps/backend/src/storage/dynamic-storage.adapter.spec.ts
+++ b/apps/backend/src/storage/dynamic-storage.adapter.spec.ts
@@ -140,7 +140,7 @@ describe('DynamicStorageAdapter', () => {
         const result = await adapter.getUrl(key, expiresIn);
 
         expect(result).toBe('https://example.com/file');
-        expect(mockAdapter.getUrl).toHaveBeenCalledWith(key, expiresIn);
+        expect(mockAdapter.getUrl).toHaveBeenCalledWith(key, expiresIn, undefined);
       });
 
       it('should work without expiresIn parameter', async () => {
@@ -148,7 +148,7 @@ describe('DynamicStorageAdapter', () => {
 
         await adapter.getUrl(key);
 
-        expect(mockAdapter.getUrl).toHaveBeenCalledWith(key, undefined);
+        expect(mockAdapter.getUrl).toHaveBeenCalledWith(key, undefined, undefined);
       });
     });
 
@@ -188,6 +188,28 @@ describe('DynamicStorageAdapter', () => {
         expect(result).toBe(true);
         expect(mockAdapter.testConnection).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('getUrl', () => {
+    it('forwards signed URL options to the wrapped adapter', async () => {
+      const inner = { getUrl: jest.fn().mockResolvedValue('https://signed') };
+      (adapter as any).adapter = inner;
+
+      await adapter.getUrl('a/b.mp4', 600, { downloadFilename: 'my-video.mp4' });
+
+      expect(inner.getUrl).toHaveBeenCalledWith('a/b.mp4', 600, {
+        downloadFilename: 'my-video.mp4',
+      });
+    });
+
+    it('forwards undefined options unchanged', async () => {
+      const inner = { getUrl: jest.fn().mockResolvedValue('https://signed') };
+      (adapter as any).adapter = inner;
+
+      await adapter.getUrl('a/b.mp4', 600);
+
+      expect(inner.getUrl).toHaveBeenCalledWith('a/b.mp4', 600, undefined);
     });
   });
 

--- a/apps/backend/src/storage/dynamic-storage.adapter.ts
+++ b/apps/backend/src/storage/dynamic-storage.adapter.ts
@@ -5,6 +5,7 @@ import {
   DownloadResult,
   DownloadStreamOptions,
   StreamDownloadResult,
+  SignedUrlOptions,
 } from './storage.interface';
 import { LocalStorageAdapter } from './local.adapter';
 
@@ -120,8 +121,12 @@ export class DynamicStorageAdapter implements IStorageAdapter {
     return this.adapter.exists(key);
   }
 
-  async getUrl(key: string, expiresIn?: number): Promise<string> {
-    return this.adapter.getUrl(key, expiresIn);
+  async getUrl(
+    key: string,
+    expiresIn?: number,
+    options?: SignedUrlOptions,
+  ): Promise<string> {
+    return this.adapter.getUrl(key, expiresIn, options);
   }
 
   async listKeys(prefix?: string): Promise<string[]> {

--- a/apps/backend/src/storage/gcs.adapter.spec.ts
+++ b/apps/backend/src/storage/gcs.adapter.spec.ts
@@ -359,9 +359,8 @@ describe('GcsStorageAdapter', () => {
     it('omits promptSaveAs when no downloadFilename is given', async () => {
       await adapter.getUrl('test/file.mp4', 600);
 
-      expect(mockFile.getSignedUrl).toHaveBeenCalledWith(
-        expect.not.objectContaining({ promptSaveAs: expect.anything() }),
-      );
+      const config = mockFile.getSignedUrl.mock.calls[0][0];
+      expect(config).not.toHaveProperty('promptSaveAs');
     });
   });
 

--- a/apps/backend/src/storage/gcs.adapter.spec.ts
+++ b/apps/backend/src/storage/gcs.adapter.spec.ts
@@ -345,6 +345,24 @@ describe('GcsStorageAdapter', () => {
 
       await expect(adapter.getUrl('test/file.txt')).rejects.toThrow('Failed to generate signed URL');
     });
+
+    it('sets promptSaveAs when a downloadFilename is given', async () => {
+      await adapter.getUrl('test/file.mp4', 600, {
+        downloadFilename: 'my-video.mp4',
+      });
+
+      expect(mockFile.getSignedUrl).toHaveBeenCalledWith(
+        expect.objectContaining({ promptSaveAs: 'my-video.mp4' }),
+      );
+    });
+
+    it('omits promptSaveAs when no downloadFilename is given', async () => {
+      await adapter.getUrl('test/file.mp4', 600);
+
+      expect(mockFile.getSignedUrl).toHaveBeenCalledWith(
+        expect.not.objectContaining({ promptSaveAs: expect.anything() }),
+      );
+    });
   });
 
   describe('testConnection', () => {

--- a/apps/backend/src/storage/gcs.adapter.ts
+++ b/apps/backend/src/storage/gcs.adapter.ts
@@ -5,6 +5,7 @@ import {
   FileMetadata,
   StreamDownloadResult,
   DownloadStreamOptions,
+  SignedUrlOptions,
 } from './storage.interface';
 import { GcsStorageConfig, validateGcsConfig } from './gcs.config';
 
@@ -185,20 +186,31 @@ export class GcsStorageAdapter implements IStorageAdapter {
   /**
    * Get a signed URL for accessing the file (read)
    */
-  async getUrl(key: string, expiresIn?: number): Promise<string> {
+  async getUrl(
+    key: string,
+    expiresIn?: number,
+    options?: SignedUrlOptions,
+  ): Promise<string> {
     const sanitizedKey = this.sanitizeKey(key);
     const storageKey = this.prefixKey(sanitizedKey);
     const blob = this.bucket.file(storageKey);
     const expiration = expiresIn ?? this.config.signedUrlExpiration ?? 3600;
 
-    const options: GetSignedUrlConfig = {
+    const signedUrlConfig: GetSignedUrlConfig = {
       version: 'v4',
       action: 'read',
       expires: Date.now() + expiration * 1000,
     };
 
+    // Signs `response-content-disposition: attachment; filename="..."` into the
+    // URL. It cannot be appended afterward — V4 signing covers the whole query
+    // string, so a bolted-on param yields 403 SignatureDoesNotMatch.
+    if (options?.downloadFilename) {
+      signedUrlConfig.promptSaveAs = options.downloadFilename;
+    }
+
     try {
-      const [url] = await blob.getSignedUrl(options);
+      const [url] = await blob.getSignedUrl(signedUrlConfig);
       return url;
     } catch (error: any) {
       this.logger.error(`Failed to generate signed URL: ${storageKey}`, error);

--- a/apps/backend/src/storage/local.adapter.ts
+++ b/apps/backend/src/storage/local.adapter.ts
@@ -178,8 +178,11 @@ export class LocalStorageAdapter implements IStorageAdapter {
   }
 
   /**
-   * Get URL for accessing the file
-   * For local storage, this returns a URL that will be served by the backend
+   * Local storage serves files through the backend API rather than presigning,
+   * so there is no signature to embed a `Content-Disposition` into. A
+   * `SignedUrlOptions.downloadFilename` passed here is deliberately IGNORED —
+   * the browser will render the object inline. Presigned-only apps (e.g. Studio,
+   * whose uploads bypass the 1 MB body cap) cannot run on local storage anyway.
    */
   async getUrl(key: string): Promise<string> {
     const sanitizedKey = this.sanitizeKey(key);

--- a/apps/backend/src/storage/minio.adapter.spec.ts
+++ b/apps/backend/src/storage/minio.adapter.spec.ts
@@ -251,6 +251,12 @@ describe('MinioStorageAdapter', () => {
         600,
         {},
       );
+
+      // Verify the key is actually absent (not just undefined), to catch future
+      // regressions where respHeaders is built unconditionally with undefined values
+      const respHeaders = mockMinioClient.presignedGetObject.mock.calls[0][3];
+      expect(respHeaders).not.toHaveProperty('response-content-disposition');
+      expect(respHeaders).toEqual({});
     });
   });
 

--- a/apps/backend/src/storage/minio.adapter.spec.ts
+++ b/apps/backend/src/storage/minio.adapter.spec.ts
@@ -210,7 +210,7 @@ describe('MinioStorageAdapter', () => {
       const url = await adapter.getUrl(key, 3600);
 
       expect(url).toBe(expectedUrl);
-      expect(mockMinioClient.presignedGetObject).toHaveBeenCalledWith('test-bucket', key, 3600);
+      expect(mockMinioClient.presignedGetObject).toHaveBeenCalledWith('test-bucket', key, 3600, {});
     });
 
     it('should use default expiration if not provided', async () => {
@@ -225,6 +225,31 @@ describe('MinioStorageAdapter', () => {
         'test-bucket',
         key,
         3600, // default expiration
+        {},
+      );
+    });
+
+    it('sets response-content-disposition when a downloadFilename is given', async () => {
+      await adapter.getUrl('test/file.mp4', 600, {
+        downloadFilename: 'my-video.mp4',
+      });
+
+      expect(mockMinioClient.presignedGetObject).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        600,
+        { 'response-content-disposition': 'attachment; filename="my-video.mp4"' },
+      );
+    });
+
+    it('passes no response headers when no downloadFilename is given', async () => {
+      await adapter.getUrl('test/file.mp4', 600);
+
+      expect(mockMinioClient.presignedGetObject).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        600,
+        {},
       );
     });
   });

--- a/apps/backend/src/storage/minio.adapter.ts
+++ b/apps/backend/src/storage/minio.adapter.ts
@@ -4,6 +4,7 @@ import {
   FileMetadata,
   StreamDownloadResult,
   DownloadStreamOptions,
+  SignedUrlOptions,
 } from './storage.interface';
 import * as Minio from 'minio';
 
@@ -210,13 +211,30 @@ export class MinioStorageAdapter implements IStorageAdapter {
   /**
    * Get presigned URL for accessing the file (GET)
    */
-  async getUrl(key: string, expiresIn: number = 3600): Promise<string> {
+  async getUrl(
+    key: string,
+    expiresIn: number = 3600,
+    options?: SignedUrlOptions,
+  ): Promise<string> {
     const sanitizedKey = this.sanitizeKey(key);
     const storageKey = this.prefixKey(sanitizedKey);
 
+    // Signed into the URL, not appended to it: S3/MinIO V4 signatures cover the
+    // query string. An empty object is equivalent to passing nothing.
+    const respHeaders: Record<string, string> = options?.downloadFilename
+      ? {
+          'response-content-disposition': `attachment; filename="${options.downloadFilename}"`,
+        }
+      : {};
+
     try {
       // Generate presigned URL (default 1 hour expiration)
-      const url = await this.client.presignedGetObject(this.bucket, storageKey, expiresIn);
+      const url = await this.client.presignedGetObject(
+        this.bucket,
+        storageKey,
+        expiresIn,
+        respHeaders,
+      );
       return url;
     } catch (error) {
       this.logger.error(`Failed to generate presigned URL: ${storageKey}`, error);

--- a/apps/backend/src/storage/storage.interface.ts
+++ b/apps/backend/src/storage/storage.interface.ts
@@ -76,6 +76,27 @@ export interface StreamDownloadResult {
   lastModified?: Date;
 }
 
+/**
+ * Options for a signed/presigned read URL.
+ */
+export interface SignedUrlOptions {
+  /**
+   * Force the browser to save rather than render, under this exact name, by
+   * signing `Content-Disposition: attachment; filename="..."` into the URL.
+   *
+   * Required because `<a download>` is ignored on cross-origin URLs, so the
+   * name can only arrive as a response header — and the header can only be
+   * signed in, never appended afterward (the signature covers the query string).
+   *
+   * Ignored by the local adapter, which cannot presign at all.
+   *
+   * Callers MUST pass a value already sanitized by `sanitizeDownloadFilename`
+   * (see `signed-url.handler.ts`): adapters interpolate this straight into a
+   * header value.
+   */
+  downloadFilename?: string;
+}
+
 export interface IStorageAdapter {
   /**
    * Upload a file to storage
@@ -118,9 +139,10 @@ export interface IStorageAdapter {
    * Get a URL for accessing the file
    * @param key - Storage key/path
    * @param expiresIn - Optional expiration time in seconds (for presigned URLs)
+   * @param options - Optional signed-URL options (e.g. force download w/ filename)
    * @returns URL to access the file
    */
-  getUrl(key: string, expiresIn?: number): Promise<string>;
+  getUrl(key: string, expiresIn?: number, options?: SignedUrlOptions): Promise<string>;
 
   /**
    * List all storage keys with optional prefix filter


### PR DESCRIPTION
## Why

Studio (bffless-apps) downloads a stitched final-cut video by streaming it through this backend's `file_serve` pipeline handler. A ~473 MB cut took an estimated **19 minutes** and was cancelled before it finished. Playback and every ffmpeg read already sign the object to a direct bucket URL; only the download still streams through the backend.

The download can't simply switch to the existing signed URL, because it also needs to name the file. And the filename is exactly the part that needs a backend change:

- A cross-origin `<a download="…">` attribute is **ignored** by browsers, so the name must arrive as a `Content-Disposition` response header.
- That header can't be appended to an already-signed URL. GCS V4 signing covers the entire canonical query string — verified against the live bucket: appending `response-content-disposition` to a signed URL returns `403 SignatureDoesNotMatch`.
- Without the header, navigating to a `video/mp4` signed URL makes Chrome open its built-in player instead of saving.

So `response-content-disposition` can only enter the URL inside `signed_url` → `getUrl`, and neither accepted it.

## What

Threads an optional `downloadFilename` from the `signed_url` pipeline handler into each storage adapter's native presign parameter:

| Adapter | Parameter |
| --- | --- |
| GCS | `promptSaveAs` (SDK builds the header) |
| MinIO / S3 | `response-content-disposition` respHeader |
| Azure | SAS `contentDisposition` |
| Local | ignored (cannot presign) |

- `SignedUrlOptions { downloadFilename?: string }` added to `IStorageAdapter.getUrl(key, expiresIn?, options?)`.
- `sanitizeDownloadFilename` in `signed-url.handler.ts` is the **single choke point** — the value is attacker-influenceable (a POST body field forwarded by an app proxy rule) and is interpolated directly into a header. It strips control chars / `"` / `\`, reduces to a basename, caps length, and omits the disposition entirely when nothing survives.
- `S3StorageAdapter extends MinioStorageAdapter` and has no `getUrl` of its own, so the MinIO change covers both — `s3.adapter.ts` is untouched.

**Omitting `filename` is behavior-identical to before this branch** — a live caller (Studio's `useSignedBytes`) signs this endpoint on every read. `getUrl`'s third arg is literally `undefined` and each adapter omits its disposition key entirely (asserted, not merely `expect.anything()`).

## Notable

- `cb7f992` fixes `CachingStorageAdapter.getUrl`, which sat in the live `getUrl` chain and dropped the options arg. Caching wraps **by default**, so without this fix the feature would silently no-op (no `Content-Disposition`) on any cache-enabled deployment — and TypeScript couldn't catch it, since a 2-param method is assignable to the wider interface.
- Adversarial review of the sanitizer: CRLF injection, quote breakout, DEL, traversal, non-string input, and empty-after-sanitize all resolve safely.

## Follow-up (not in this PR)

The sanitizer is enforced by a doc-comment contract, not structurally. `signed-url.handler.ts` is the only caller passing `downloadFilename` today, but the trust boundary is the adapter — a future second caller could bypass it. Durable fix: move the sanitize into a shared choke point.

## Verification

- `tsc --noEmit`: clean.
- `jest src/storage src/pipelines`: **36 suites, 631 passed, 36 skipped** (baseline 629; +2 = new caching-adapter forwarding tests).

This is the CE half. The consuming change (Studio's "Download MP4") is a separate PR in `bffless/apps` that lands after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)