### PR TITLE
fix(proxy-rules): let auth-proxy rules through the visibility gate on private deployments

### DIFF
--- a/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
@@ -437,4 +437,82 @@ describe('ProxyMiddleware', () => {
       expect((middleware as any).extractPathFromUri('/?foo=bar')).toBe('/');
     });
   });
+
+  describe('checkVisibilityAndAuth', () => {
+    const project = { id: 'proj-1', owner: 'owner', name: 'repo' } as any;
+
+    const makePrivate = () => {
+      mockVisibilityService.resolveAccessControlForAlias.mockResolvedValue({
+        isPublic: false,
+        unauthorizedBehavior: 'redirect_login',
+        requiredRole: 'authenticated',
+        source: 'alias',
+      });
+    };
+
+    // An API request whose access token has expired, but whose refresh token is
+    // still good - the state a long-running build lands in.
+    const expiredTokenRequest = (path: string): Request => {
+      const req = createMockRequest(path, { accept: 'application/json' });
+      (req as any).tokenExpired = true;
+      return req;
+    };
+
+    const authRule = createMockRule({
+      pathPattern: '/api/auth/*',
+      targetUrl: 'http://localhost:3000/api/auth',
+      proxyType: 'external_proxy',
+    });
+
+    it('allows a matched auth-proxy rule through on a private deployment', async () => {
+      makePrivate();
+      const req = expiredTokenRequest('/api/auth/session/refresh');
+      const res = createMockResponse();
+
+      const result = await (middleware as any).checkVisibilityAndAuth(
+        req,
+        res,
+        project,
+        'studio',
+        authRule,
+      );
+
+      expect(result).toBe('allowed');
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('still blocks a normal API rule on a private deployment when the token expired', async () => {
+      makePrivate();
+      const req = expiredTokenRequest('/api/works');
+      const res = createMockResponse();
+
+      const result = await (middleware as any).checkVisibilityAndAuth(
+        req,
+        res,
+        project,
+        'studio',
+        createMockRule({ pathPattern: '/api/*' }),
+      );
+
+      expect(result).toBe('blocked');
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: 'try refresh token' });
+    });
+
+    it('does not exempt a non-proxy rule served from an auth path', async () => {
+      makePrivate();
+      const req = expiredTokenRequest('/api/auth/session/refresh');
+      const res = createMockResponse();
+
+      const result = await (middleware as any).checkVisibilityAndAuth(
+        req,
+        res,
+        project,
+        'studio',
+        createMockRule({ pathPattern: '/api/auth/*', proxyType: 'pipeline' }),
+      );
+
+      expect(result).toBe('blocked');
+    });
+  });
 });

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -72,6 +72,22 @@ export class ProxyMiddleware implements NestMiddleware {
     return rule.proxyType || 'external_proxy';
   }
 
+  /**
+   * True when a rule forwards an auth endpoint (/api/auth/*) to a backend.
+   *
+   * Only rules the project owner explicitly mapped to the auth backend qualify, and
+   * only as a plain proxy - a pipeline or email handler mounted on an auth path is
+   * app code, so it stays behind the visibility gate.
+   */
+  private isAuthProxyRule(rule: ProxyRule): boolean {
+    if (this.getProxyType(rule) !== 'external_proxy') {
+      return false;
+    }
+
+    const pattern = rule.pathPattern ?? '';
+    return pattern === '/api/auth' || pattern.startsWith('/api/auth/');
+  }
+
   async use(req: Request, res: Response, next: NextFunction): Promise<void> {
     // Only handle /public/* routes
     if (!req.path.startsWith('/public/')) {
@@ -236,7 +252,13 @@ export class ProxyMiddleware implements NestMiddleware {
 
       // For all other proxy types (pipeline, email_form_handler, external_proxy),
       // check visibility BEFORE handling - these bypass PublicController
-      const visibilityResult = await this.checkVisibilityAndAuth(req, res, project, aliasName);
+      const visibilityResult = await this.checkVisibilityAndAuth(
+        req,
+        res,
+        project,
+        aliasName,
+        matchedRule,
+      );
       if (visibilityResult === 'blocked') {
         return; // Response already sent
       }
@@ -453,6 +475,7 @@ export class ProxyMiddleware implements NestMiddleware {
       res,
       project,
       resolvedAliasName,
+      matchedRule,
     );
     if (visibilityResult === 'blocked') {
       return; // Response already sent
@@ -505,7 +528,16 @@ export class ProxyMiddleware implements NestMiddleware {
     res: Response,
     project: typeof projects.$inferSelect,
     aliasName: string | null,
+    matchedRule?: ProxyRule,
   ): Promise<'allowed' | 'blocked'> {
+    // A private deployment gates every /api/* call on a valid session. That would
+    // include the endpoint used to renew an expired session, leaving the client no
+    // way out: refreshing requires the session that only refreshing can restore.
+    // Let the auth endpoints through - SuperTokens authenticates them itself.
+    if (matchedRule && this.isAuthProxyRule(matchedRule)) {
+      return 'allowed';
+    }
+
     // Resolve access control - check domain mapping first (for subdomain requests),
     // then fall back to alias/project
     let accessControl: AccessControlInfo | null = null;


### PR DESCRIPTION
## The bug

On a **private** deployment, `checkVisibilityAndAuth` runs *before* proxy forwarding (`proxy.middleware.ts`, both the `/public/...` and subdomain call sites). It demands a valid session — so it also 401s `POST /api/auth/session/refresh`, the one call that would restore an expired one.

That's a closed loop: **refreshing requires the session that only refreshing can restore.**

A client whose access token expires mid-flight (a Studio auto-build outliving its token) gets `401 {"message":"try refresh token"}`, tries to refresh, and gets the same 401 back — from *us*, never reaching SuperTokens. The app-origin `/api/auth/*` proxy rule looks correct but is inert: nothing is ever forwarded, so its `targetUrl` is irrelevant.

Public deployments were never affected — their gate short-circuits on `isPublic`, which is the only reason the identical rule already works on `handoff.j5s.dev`. `studio.j5s.dev` and `reader.j5s.dev` are private and both hit this.

> Diagnostic note: CE's gate emits `{"message":"unauthorised"}`, byte-identical to SuperTokens'. The tell is the `front-token` header — SuperTokens sets it, our gate doesn't.

## The fix

`checkVisibilityAndAuth` takes the matched rule and returns `allowed` early when it's an `external_proxy` rule under `/api/auth/*`.

The exemption is deliberately narrow:
- The gate already runs **after** `findMatchingRule`, so only a path the project owner *explicitly mapped* to the auth backend can qualify.
- `external_proxy` only — a pipeline or email handler mounted on an auth path is app code and stays gated.
- No new exposure: anything reachable this way is the same SuperTokens surface already public on the admin origin.

The gate exists to protect app content and APIs. The auth endpoints are the mechanism by which you *become* authenticated, so gating them on already being authenticated is the bug.

## Tests

`proxy.middleware.spec.ts` — 92/92 pass, 3 new:
- a matched auth-proxy rule is allowed through on a private deployment;
- a normal `/api/*` rule **still** 401s `try refresh token` there (regression guard);
- a `pipeline` rule on an auth path is **not** exempted.

`tsc` clean; ESLint unchanged from baseline.

## Deploy note

This unblocks bffless/apps#223 (Studio session refresh), which cannot pass an end-to-end check until this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)