### PR TITLE
feat: proxy-rules-as-code — Phase 1 (CE sync surface: export + sync endpoints, source tracking, live CLI)

### DIFF
--- a/apps/backend/drizzle/0038_faithful_santa_claus.sql
+++ b/apps/backend/drizzle/0038_faithful_santa_claus.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "proxy_rule_sets" ADD COLUMN "source" jsonb;

--- a/apps/backend/drizzle/meta/0038_snapshot.json
+++ b/apps/backend/drizzle/meta/0038_snapshot.json
@@ -1,0 +1,6996 @@
+{
+  "id": "92a1cfa5-3137-49a8-a0af-f20405a49fd6",
+  "prevId": "76dd0099-4be5-411f-b5d9-cd10e80c9c49",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alias_proxy_rule_sets": {
+      "name": "alias_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alias_proxy_rule_sets_alias_ruleset_unique": {
+          "name": "alias_proxy_rule_sets_alias_ruleset_unique",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_alias_id_idx": {
+          "name": "alias_proxy_rule_sets_alias_id_idx",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_rule_set_id_idx": {
+          "name": "alias_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk": {
+          "name": "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "deployment_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_project_id_idx": {
+          "name": "api_keys_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_path": {
+          "name": "original_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_number": {
+          "name": "workflow_run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'commits'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_project_id_idx": {
+          "name": "assets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_type_idx": {
+          "name": "assets_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_path_idx": {
+          "name": "assets_project_commit_path_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_branch_idx": {
+          "name": "assets_project_branch_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_idx": {
+          "name": "assets_project_commit_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_created_at_idx": {
+          "name": "assets_project_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_committed_at_idx": {
+          "name": "assets_project_committed_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_path_idx": {
+          "name": "assets_deployment_path_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_id_idx": {
+          "name": "assets_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_size_idx": {
+          "name": "assets_deployment_size_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_uploaded_by_users_id_fk": {
+          "name": "assets_uploaded_by_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist_entries": {
+      "name": "blocklist_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prefix'"
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklist_entries_blocklist_id_idx": {
+          "name": "blocklist_entries_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocklist_entries_unique": {
+          "name": "blocklist_entries_unique",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocklist_entries_blocklist_id_blocklists_id_fk": {
+          "name": "blocklist_entries_blocklist_id_blocklists_id_fk",
+          "tableFrom": "blocklist_entries",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklists": {
+      "name": "blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklists_name_unique": {
+          "name": "blocklists_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cache_rules": {
+      "name": "cache_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_max_age": {
+          "name": "browser_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "cdn_max_age": {
+          "name": "cdn_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stale_while_revalidate": {
+          "name": "stale_while_revalidate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immutable": {
+          "name": "immutable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cacheability": {
+          "name": "cacheability",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cache_rules_project_pattern_unique": {
+          "name": "cache_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_id_idx": {
+          "name": "cache_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_priority_idx": {
+          "name": "cache_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cache_rules_project_id_projects_id_fk": {
+          "name": "cache_rules_project_id_projects_id_fk",
+          "tableFrom": "cache_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_aliases": {
+      "name": "deployment_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_preview": {
+          "name": "is_auto_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployment_aliases_project_alias_unique": {
+          "name": "deployment_aliases_project_alias_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_project_id_idx": {
+          "name": "deployment_aliases_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_alias_unique": {
+          "name": "deployment_aliases_repository_alias_unique",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_idx": {
+          "name": "deployment_aliases_repository_idx",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_commit_sha_idx": {
+          "name": "deployment_aliases_commit_sha_idx",
+          "columns": [
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_deployment_id_idx": {
+          "name": "deployment_aliases_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_aliases_project_id_projects_id_fk": {
+          "name": "deployment_aliases_project_id_projects_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_blocklists": {
+      "name": "domain_blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_blocklists_domain_blocklist_unique": {
+          "name": "domain_blocklists_domain_blocklist_unique",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_blocklists_domain_mapping_id_idx": {
+          "name": "domain_blocklists_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_blocklists_blocklist_id_idx": {
+          "name": "domain_blocklists_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_blocklists_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "domain_blocklists_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "domain_blocklists",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_blocklists_blocklist_id_blocklists_id_fk": {
+          "name": "domain_blocklists_blocklist_id_blocklists_id_fk",
+          "tableFrom": "domain_blocklists",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_mappings": {
+      "name": "domain_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_type": {
+          "name": "domain_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ssl_expires_at": {
+          "name": "ssl_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_verified": {
+          "name": "dns_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dns_verified_at": {
+          "name": "dns_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_renew_ssl": {
+          "name": "auto_renew_ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_renewed_at": {
+          "name": "ssl_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_status": {
+          "name": "ssl_renewal_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_error": {
+          "name": "ssl_renewal_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sticky_sessions_enabled": {
+          "name": "sticky_sessions_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sticky_session_duration": {
+          "name": "sticky_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 86400
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_mappings_project_id_idx": {
+          "name": "domain_mappings_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_domain_idx": {
+          "name": "domain_mappings_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_is_active_idx": {
+          "name": "domain_mappings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_mappings_project_id_projects_id_fk": {
+          "name": "domain_mappings_project_id_projects_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_mappings_created_by_users_id_fk": {
+          "name": "domain_mappings_created_by_users_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_mappings_domain_unique": {
+          "name": "domain_mappings_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_redirects": {
+      "name": "domain_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_domain": {
+          "name": "source_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_domain_id": {
+          "name": "target_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_redirects_target_domain_id_idx": {
+          "name": "domain_redirects_target_domain_id_idx",
+          "columns": [
+            {
+              "expression": "target_domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_redirects_source_domain_idx": {
+          "name": "domain_redirects_source_domain_idx",
+          "columns": [
+            {
+              "expression": "source_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_redirects_target_domain_id_domain_mappings_id_fk": {
+          "name": "domain_redirects_target_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "target_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_redirects_created_by_users_id_fk": {
+          "name": "domain_redirects_created_by_users_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_redirects_source_domain_unique": {
+          "name": "domain_redirects_source_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_rules": {
+      "name": "domain_traffic_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_key": {
+          "name": "condition_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_value": {
+          "name": "condition_value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_rules_domain_id_idx": {
+          "name": "domain_traffic_rules_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_traffic_rules_domain_id_priority_idx": {
+          "name": "domain_traffic_rules_domain_id_priority_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_rules_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_rules_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_rules",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_weights": {
+      "name": "domain_traffic_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_weights_domain_id_idx": {
+          "name": "domain_traffic_weights_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_weights_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_weights_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_weights",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_traffic_weights_domain_alias_unique": {
+          "name": "domain_traffic_weights_domain_alias_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain_id",
+            "alias"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flags_key_idx": {
+          "name": "feature_flags_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_integration_credentials": {
+      "name": "google_integration_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured": {
+          "name": "configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "google_integration_credentials_service_unique": {
+          "name": "google_integration_credentials_service_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oidc_providers_provider_id_unique": {
+          "name": "oidc_providers_provider_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rule_executions": {
+      "name": "onboarding_rule_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rule_executions_user_idx": {
+          "name": "onboarding_rule_executions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_rule_idx": {
+          "name": "onboarding_rule_executions_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_executed_at_idx": {
+          "name": "onboarding_rule_executions_executed_at_idx",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_status_idx": {
+          "name": "onboarding_rule_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rule_executions_rule_id_onboarding_rules_id_fk": {
+          "name": "onboarding_rule_executions_rule_id_onboarding_rules_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "onboarding_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "onboarding_rule_executions_user_id_users_id_fk": {
+          "name": "onboarding_rule_executions_user_id_users_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rules": {
+      "name": "onboarding_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_signup'"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rules_enabled_trigger_idx": {
+          "name": "onboarding_rules_enabled_trigger_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rules_priority_idx": {
+          "name": "onboarding_rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rules_created_by_users_id_fk": {
+          "name": "onboarding_rules_created_by_users_id_fk",
+          "tableFrom": "onboarding_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_preferences": {
+      "name": "path_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spa_mode": {
+          "name": "spa_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_path_preferences_project_id": {
+          "name": "idx_path_preferences_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_preferences_project_id_projects_id_fk": {
+          "name": "path_preferences_project_id_projects_id_fk",
+          "tableFrom": "path_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "path_preferences_project_filepath_unique": {
+          "name": "path_preferences_project_filepath_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "filepath"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_redirects": {
+      "name": "path_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'100'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "path_redirects_domain_mapping_id_idx": {
+          "name": "path_redirects_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "path_redirects_source_path_idx": {
+          "name": "path_redirects_source_path_idx",
+          "columns": [
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_redirects_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "path_redirects_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "path_redirects_created_by_users_id_fk": {
+          "name": "path_redirects_created_by_users_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_token": {
+          "name": "upload_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_token_idx": {
+          "name": "pending_uploads_token_idx",
+          "columns": [
+            {
+              "expression": "upload_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_project_idx": {
+          "name": "pending_uploads_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_project_id_projects_id_fk": {
+          "name": "pending_uploads_project_id_projects_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_uploaded_by_users_id_fk": {
+          "name": "pending_uploads_uploaded_by_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_uploads_upload_token_unique": {
+          "name": "pending_uploads_upload_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data_embeddings": {
+      "name": "pipeline_data_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_data_id": {
+          "name": "pipeline_data_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_embeddings_data_id_idx": {
+          "name": "pipeline_data_embeddings_data_id_idx",
+          "columns": [
+            {
+              "expression": "pipeline_data_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_embeddings_schema_field_idx": {
+          "name": "pipeline_data_embeddings_schema_field_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk": {
+          "name": "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_data",
+          "columnsFrom": [
+            "pipeline_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data": {
+      "name": "pipeline_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_project_id_idx": {
+          "name": "pipeline_data_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_schema_id_idx": {
+          "name": "pipeline_data_schema_id_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_created_at_idx": {
+          "name": "pipeline_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_project_id_projects_id_fk": {
+          "name": "pipeline_data_project_id_projects_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_created_by_users_id_fk": {
+          "name": "pipeline_data_created_by_users_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_execution_logs": {
+      "name": "pipeline_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_id": {
+          "name": "proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps_count": {
+          "name": "steps_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_step": {
+          "name": "error_step",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_meta": {
+          "name": "request_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_exec_logs_rule_created_idx": {
+          "name": "pipeline_exec_logs_rule_created_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_project_idx": {
+          "name": "pipeline_exec_logs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_created_idx": {
+          "name": "pipeline_exec_logs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_execution_logs_project_id_projects_id_fk": {
+          "name": "pipeline_execution_logs_project_id_projects_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schedules": {
+      "name": "pipeline_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_proxy_rule_id": {
+          "name": "target_proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schedules_project_id_idx": {
+          "name": "pipeline_schedules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_schedules_target_proxy_rule_id_idx": {
+          "name": "pipeline_schedules_target_proxy_rule_id_idx",
+          "columns": [
+            {
+              "expression": "target_proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_schedules_enabled_next_run_idx": {
+          "name": "pipeline_schedules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schedules_project_id_projects_id_fk": {
+          "name": "pipeline_schedules_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schedules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_schedules_target_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_schedules_target_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_schedules",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "target_proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schemas": {
+      "name": "pipeline_schemas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schemas_project_id_idx": {
+          "name": "pipeline_schemas_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schemas_project_id_projects_id_fk": {
+          "name": "pipeline_schemas_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schemas",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pipeline_schemas_project_name_unique": {
+          "name": "pipeline_schemas_project_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.primary_content": {
+      "name": "primary_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "www_enabled": {
+          "name": "www_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'redirect-to-www'"
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "primary_content_project_id_projects_id_fk": {
+          "name": "primary_content_project_id_projects_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "primary_content_configured_by_users_id_fk": {
+          "name": "primary_content_configured_by_users_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_default_proxy_rule_sets": {
+      "name": "project_default_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_default_proxy_rule_sets_project_ruleset_unique": {
+          "name": "project_default_proxy_rule_sets_project_ruleset_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_project_id_idx": {
+          "name": "project_default_proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_rule_set_id_idx": {
+          "name": "project_default_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_default_proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "project_default_proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite_links": {
+      "name": "project_invite_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guest'"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invite_links_project_id_idx": {
+          "name": "project_invite_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_token_idx": {
+          "name": "project_invite_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_is_active_idx": {
+          "name": "project_invite_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_links_project_id_projects_id_fk": {
+          "name": "project_invite_links_project_id_projects_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_links_created_by_users_id_fk": {
+          "name": "project_invite_links_created_by_users_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_links_token_unique": {
+          "name": "project_invite_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_group_permissions": {
+      "name": "project_group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_group_permissions_project_idx": {
+          "name": "project_group_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_permissions_group_idx": {
+          "name": "project_group_permissions_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_permissions_project_id_projects_id_fk": {
+          "name": "project_group_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_group_id_user_groups_id_fk": {
+          "name": "project_group_permissions_group_id_user_groups_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_granted_by_users_id_fk": {
+          "name": "project_group_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_group_permissions_unique": {
+          "name": "project_group_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "group_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_permissions": {
+      "name": "project_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_permissions_project_idx": {
+          "name": "project_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_permissions_user_idx": {
+          "name": "project_permissions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_permissions_project_id_projects_id_fk": {
+          "name": "project_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_user_id_users_id_fk": {
+          "name": "project_permissions_user_id_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_granted_by_users_id_fk": {
+          "name": "project_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_permissions_unique": {
+          "name": "project_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_secrets": {
+      "name": "project_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_secrets_project_name_unique": {
+          "name": "project_secrets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_secrets_project_id_idx": {
+          "name": "project_secrets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_secrets_project_id_projects_id_fk": {
+          "name": "project_secrets_project_id_projects_id_fk",
+          "tableFrom": "project_secrets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_found'"
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authenticated'"
+        },
+        "allow_public_signup": {
+          "name": "allow_public_signup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_providers": {
+          "name": "ai_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_services": {
+          "name": "ai_services",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_proxy_rule_set_id": {
+          "name": "default_proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_created_by_idx": {
+          "name": "projects_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_owner_idx": {
+          "name": "projects_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_owner_name_unique": {
+          "name": "projects_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_sets": {
+      "name": "proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_sets_project_name_unique": {
+          "name": "proxy_rule_sets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_project_id_idx": {
+          "name": "proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_environment_idx": {
+          "name": "proxy_rule_sets_environment_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rules": {
+      "name": "proxy_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "methods": {
+          "name": "methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strip_prefix": {
+          "name": "strip_prefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "preserve_host": {
+          "name": "preserve_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forward_cookies": {
+          "name": "forward_cookies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "header_config": {
+          "name": "header_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_transform": {
+          "name": "auth_transform",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_rewrite": {
+          "name": "internal_rewrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proxy_type": {
+          "name": "proxy_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external_proxy'"
+        },
+        "email_handler_config": {
+          "name": "email_handler_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "debug_enabled": {
+          "name": "debug_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rules_rule_set_path_method_unique": {
+          "name": "proxy_rules_rule_set_path_method_unique",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_id_idx": {
+          "name": "proxy_rules_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_order_idx": {
+          "name": "proxy_rules_rule_set_order_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_proxy_type_idx": {
+          "name": "proxy_rules_proxy_type_idx",
+          "columns": [
+            {
+              "expression": "proxy_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rules_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rules_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rules",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_header_rules": {
+      "name": "response_header_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_policy": {
+          "name": "frame_policy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sameorigin'"
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_header_rules_project_pattern_unique": {
+          "name": "response_header_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_id_idx": {
+          "name": "response_header_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_priority_idx": {
+          "name": "response_header_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "response_header_rules_project_id_projects_id_fk": {
+          "name": "response_header_rules_project_id_projects_id_fk",
+          "tableFrom": "response_header_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_logs": {
+      "name": "retention_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_count": {
+          "name": "asset_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "freed_bytes": {
+          "name": "freed_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_partial": {
+          "name": "is_partial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_logs_project_id_idx": {
+          "name": "retention_logs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_rule_id_idx": {
+          "name": "retention_logs_rule_id_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_deleted_at_idx": {
+          "name": "retention_logs_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_project_deleted_at_idx": {
+          "name": "retention_logs_project_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_logs_project_id_projects_id_fk": {
+          "name": "retention_logs_project_id_projects_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retention_logs_rule_id_retention_rules_id_fk": {
+          "name": "retention_logs_rule_id_retention_rules_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "retention_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_rules": {
+      "name": "retention_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_pattern": {
+          "name": "branch_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_branches": {
+          "name": "exclude_branches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keep_with_alias": {
+          "name": "keep_with_alias",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "keep_minimum": {
+          "name": "keep_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "path_patterns": {
+          "name": "path_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_mode": {
+          "name": "path_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_summary": {
+          "name": "last_run_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_rules_project_id_idx": {
+          "name": "retention_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_next_run_idx": {
+          "name": "retention_rules_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_enabled_next_run_idx": {
+          "name": "retention_rules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_rules_project_id_projects_id_fk": {
+          "name": "retention_rules_project_id_projects_id_fk",
+          "tableFrom": "retention_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "share_links_project_id_idx": {
+          "name": "share_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_domain_mapping_id_idx": {
+          "name": "share_links_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_token_idx": {
+          "name": "share_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_is_active_idx": {
+          "name": "share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_project_id_projects_id_fk": {
+          "name": "share_links_project_id_projects_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "share_links_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_created_by_users_id_fk": {
+          "name": "share_links_created_by_users_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "share_links_token_unique": {
+          "name": "share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_challenges": {
+      "name": "ssl_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "base_domain": {
+          "name": "base_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_type": {
+          "name": "challenge_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_name": {
+          "name": "record_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_value": {
+          "name": "record_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_data": {
+          "name": "order_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authz_data": {
+          "name": "authz_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_authorization": {
+          "name": "key_authorization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_challenges_base_domain_idx": {
+          "name": "ssl_challenges_base_domain_idx",
+          "columns": [
+            {
+              "expression": "base_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_challenges_status_idx": {
+          "name": "ssl_challenges_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ssl_challenges_base_domain_unique": {
+          "name": "ssl_challenges_base_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "base_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_renewal_history": {
+      "name": "ssl_renewal_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_type": {
+          "name": "certificate_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_expires_at": {
+          "name": "new_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_renewal_history_domain_id_idx": {
+          "name": "ssl_renewal_history_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_renewal_history_created_at_idx": {
+          "name": "ssl_renewal_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssl_renewal_history_domain_id_domain_mappings_id_fk": {
+          "name": "ssl_renewal_history_domain_id_domain_mappings_id_fk",
+          "tableFrom": "ssl_renewal_history",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_settings": {
+      "name": "ssl_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_config": {
+      "name": "system_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_setup_complete": {
+          "name": "is_setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_config": {
+          "name": "storage_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_provider": {
+          "name": "email_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_config": {
+          "name": "email_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_configured": {
+          "name": "email_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "smtp_config": {
+          "name": "smtp_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_configured": {
+          "name": "smtp_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_config": {
+          "name": "cache_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwt_secret": {
+          "name": "jwt_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_salt": {
+          "name": "api_key_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_public_signups": {
+          "name": "allow_public_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "telemetry_enabled": {
+          "name": "telemetry_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "telemetry_last_sent": {
+          "name": "telemetry_last_sent",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_config": {
+          "name": "branding_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_ip_rollups": {
+      "name": "traffic_ip_rollups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_paths": {
+          "name": "sample_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "sample_user_agents": {
+          "name": "sample_user_agents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_ip_rollups_ip_unique": {
+          "name": "traffic_ip_rollups_ip_unique",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_request_count_idx": {
+          "name": "traffic_ip_rollups_request_count_idx",
+          "columns": [
+            {
+              "expression": "request_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_last_seen_idx": {
+          "name": "traffic_ip_rollups_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_requests": {
+      "name": "traffic_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_version": {
+          "name": "http_version",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referer": {
+          "name": "referer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_requests_timestamp_idx": {
+          "name": "traffic_requests_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_ip_idx": {
+          "name": "traffic_requests_ip_idx",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_status_idx": {
+          "name": "traffic_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_classification_idx": {
+          "name": "traffic_requests_classification_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_group_members": {
+      "name": "user_group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_members_group_idx": {
+          "name": "user_group_members_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_group_members_user_idx": {
+          "name": "user_group_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_group_members_group_id_user_groups_id_fk": {
+          "name": "user_group_members_group_id_user_groups_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_user_id_users_id_fk": {
+          "name": "user_group_members_user_id_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_added_by_users_id_fk": {
+          "name": "user_group_members_added_by_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_group_members_unique": {
+          "name": "user_group_members_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_groups_created_by_idx": {
+          "name": "user_groups_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_created_by_users_id_fk": {
+          "name": "user_groups_created_by_users_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_verified_at": {
+          "name": "oidc_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_invitations_email": {
+          "name": "idx_workspace_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_invitations_token": {
+          "name": "idx_workspace_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invitations_invited_by_users_id_fk": {
+          "name": "workspace_invitations_invited_by_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_accepted_user_id_users_id_fk": {
+          "name": "workspace_invitations_accepted_user_id_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitations_token_unique": {
+          "name": "workspace_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1783096365744,
       "tag": "0037_fluffy_chimera",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1783821249372,
+      "tag": "0038_faithful_santa_claus",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -136,6 +136,9 @@
     ],
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    },
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/apps/backend/src/db/schema/proxy-rule-sets.schema.ts
+++ b/apps/backend/src/db/schema/proxy-rule-sets.schema.ts
@@ -7,6 +7,7 @@ import {
   timestamp,
   uniqueIndex,
   index,
+  jsonb,
 } from 'drizzle-orm/pg-core';
 import { projects } from './projects.schema';
 import { aliasProxyRuleSets } from './alias-proxy-rule-sets.schema';
@@ -65,6 +66,16 @@ export const proxyRuleSets = pgTable(
      */
     environment: varchar('environment', { length: 50 }),
 
+    /**
+     * Rules-as-code provenance, written by the sync endpoint
+     * (PUT /api/proxy-rule-sets/project/:projectId/sync) and never by manual
+     * edits. Null for sets that have never been synced from git. Kept (not
+     * cleared) when a set is later edited via the dashboard/MCP — drift is
+     * detected by contentHash comparison, and the UI warns that manual edits
+     * will be overwritten on the next deploy.
+     */
+    source: jsonb('source').$type<ProxyRuleSetSource>(),
+
     // Timestamps
     createdAt: timestamp('created_at').notNull().defaultNow(),
     updatedAt: timestamp('updated_at').notNull().defaultNow(),
@@ -98,6 +109,24 @@ export const proxyRuleSetsRelations = relations(proxyRuleSets, ({ one, many }) =
   // Aliases using this rule set (via join table)
   aliasProxyRuleSets: many(aliasProxyRuleSets),
 }));
+
+/**
+ * Provenance metadata for a rule set managed from git via the sync endpoint.
+ * repo/path/gitSha are caller-supplied (best-effort from CI env or git);
+ * syncedAt and contentHash are stamped server-side on every successful sync.
+ */
+export interface ProxyRuleSetSource {
+  /** Source repository, e.g. "bffless/apps". */
+  repo?: string;
+  /** Rule-set directory path within the repo. */
+  path?: string;
+  /** Commit SHA the synced payload was built from. */
+  gitSha?: string;
+  /** ISO timestamp of the last successful sync. */
+  syncedAt: string;
+  /** sha256 of the defaults-normalized synced payload (see the Phase 1 plan doc). */
+  contentHash: string;
+}
 
 // Type exports
 export type ProxyRuleSet = typeof proxyRuleSets.$inferSelect;

--- a/apps/backend/src/mcp/tools/proxy-rules.tools.spec.ts
+++ b/apps/backend/src/mcp/tools/proxy-rules.tools.spec.ts
@@ -1,0 +1,48 @@
+import { ProxyRulesTools } from './proxy-rules.tools';
+
+/**
+ * The rule-set MCP tools JSON.stringify the service DTOs verbatim, so the
+ * git provenance `source` field (written by the rules-as-code sync endpoint)
+ * must reach MCP clients on both list and get. These specs guard against a
+ * future explicit field mapping silently dropping it (decision 3: expose the
+ * field, no extra warning logic).
+ */
+describe('proxy-rule-set MCP tools source passthrough', () => {
+  const source = {
+    repo: 'bffless/apps',
+    path: 'apps/studio/proxy-rules',
+    gitSha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+    syncedAt: '2026-07-10T00:00:00.000Z',
+    contentHash: 'sha256:deadbeef',
+  };
+
+  const request = { user: { apiKeyProjectId: null } } as any;
+
+  it('list_proxy_rule_sets includes source on managed sets and null on unmanaged', async () => {
+    const listByProject = jest.fn().mockResolvedValue([
+      { id: 'rs-1', projectId: 'p1', name: 'managed', source },
+      { id: 'rs-2', projectId: 'p1', name: 'manual', source: null },
+    ]);
+    const tools = new ProxyRulesTools({ listByProject } as any, {} as any, {} as any);
+
+    const raw = await tools.listRuleSets({ projectId: 'p1' }, {} as any, request);
+    const parsed = JSON.parse(raw);
+
+    expect(listByProject).toHaveBeenCalledWith('p1', null);
+    expect(parsed[0].source).toEqual(source);
+    expect(parsed[1].source).toBeNull();
+  });
+
+  it('get_proxy_rule_set includes source', async () => {
+    const getById = jest
+      .fn()
+      .mockResolvedValue({ id: 'rs-1', projectId: 'p1', name: 'managed', source, rules: [] });
+    const tools = new ProxyRulesTools({ getById } as any, {} as any, {} as any);
+
+    const raw = await tools.getRuleSet({ id: 'rs-1' }, {} as any, request);
+    const parsed = JSON.parse(raw);
+
+    expect(getById).toHaveBeenCalledWith('rs-1', null);
+    expect(parsed.source).toEqual(source);
+  });
+});

--- a/apps/backend/src/proxy-rules/dto/export-proxy-rule-set.dto.ts
+++ b/apps/backend/src/proxy-rules/dto/export-proxy-rule-set.dto.ts
@@ -1,0 +1,132 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  AuthTransformConfigDto,
+  EmailHandlerConfigDto,
+  HeaderConfigDto,
+  PipelineConfigDto,
+} from './create-proxy-rule.dto';
+import { SchemaFieldDto } from '../../pipelines/dto/create-pipeline-schema.dto';
+
+/**
+ * Response DTOs for `GET /api/proxy-rule-sets/:id/export` — the canonical v2
+ * export envelope. Swagger documentation for the shapes defined in
+ * `../export-format.util.ts` (which is the runtime source of truth; the CLI's
+ * `packages/cli/src/format/types.ts` is the cross-package ground truth).
+ */
+
+export class ExportedSchemaDto {
+  @ApiProperty({ description: 'Schema id as referenced by the exported rules' })
+  id: string;
+
+  @ApiProperty({ description: 'Schema name' })
+  name: string;
+
+  @ApiProperty({ type: [SchemaFieldDto], description: 'Schema field definitions (no data rows)' })
+  fields: SchemaFieldDto[];
+}
+
+/**
+ * A single exported rule: portable config only — server-managed fields
+ * (`id`, `ruleSetId`, timestamps) never appear, and `null` values are
+ * stripped at the rule top level. Header `add` values are blanked to `''`
+ * (secrets are never exported).
+ */
+export class ExportedProxyRuleDto {
+  @ApiProperty({ description: 'Path pattern to match', example: '/api/*' })
+  pathPattern: string;
+
+  @ApiPropertyOptional({ description: 'HTTP method to match (absent = any)' })
+  method?: string;
+
+  @ApiPropertyOptional({
+    description: 'HTTP methods to match (takes precedence over method when set)',
+    isArray: true,
+  })
+  methods?: string[];
+
+  @ApiProperty({ description: 'Target URL to forward requests to' })
+  targetUrl: string;
+
+  @ApiPropertyOptional({ description: 'Remove matched prefix from path' })
+  stripPrefix?: boolean;
+
+  @ApiPropertyOptional({ description: 'Rule evaluation order' })
+  order?: number;
+
+  @ApiPropertyOptional({ description: 'Request timeout in milliseconds' })
+  timeout?: number;
+
+  @ApiPropertyOptional({ description: 'Preserve original Host header' })
+  preserveHost?: boolean;
+
+  @ApiPropertyOptional({ description: 'Forward cookies to the target' })
+  forwardCookies?: boolean;
+
+  @ApiPropertyOptional({
+    type: HeaderConfigDto,
+    description: 'Header configuration; added-header values are blanked to empty strings',
+  })
+  headerConfig?: HeaderConfigDto;
+
+  @ApiPropertyOptional({ type: AuthTransformConfigDto, description: 'Auth transform configuration' })
+  authTransform?: AuthTransformConfigDto;
+
+  @ApiPropertyOptional({ description: 'Rewrite internally instead of proxying' })
+  internalRewrite?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Rule type',
+    enum: ['external_proxy', 'internal_rewrite', 'email_form_handler', 'pipeline'],
+  })
+  proxyType?: string;
+
+  @ApiPropertyOptional({ type: EmailHandlerConfigDto, description: 'Email form handler configuration' })
+  emailHandlerConfig?: EmailHandlerConfigDto;
+
+  @ApiPropertyOptional({ type: PipelineConfigDto, description: 'Pipeline configuration' })
+  pipelineConfig?: PipelineConfigDto;
+
+  @ApiPropertyOptional({ description: 'Whether this rule is active' })
+  isEnabled?: boolean;
+
+  @ApiPropertyOptional({ description: 'Whether debug logging is enabled' })
+  debugEnabled?: boolean;
+
+  @ApiPropertyOptional({ description: 'Optional description' })
+  description?: string;
+}
+
+export class ExportedRuleSetMetaDto {
+  @ApiProperty({ description: 'Rule set name' })
+  name: string;
+
+  @ApiPropertyOptional({ description: 'Rule set description' })
+  description?: string;
+
+  @ApiPropertyOptional({ description: 'Environment tag' })
+  environment?: string;
+}
+
+export class ExportProxyRuleSetResponseDto {
+  @ApiProperty({ description: 'Export format version', example: 2 })
+  version: 2;
+
+  @ApiProperty({ description: 'ISO timestamp the export was created' })
+  exportedAt: string;
+
+  @ApiProperty({ description: 'Export kind discriminator', example: 'bffless-proxy-rule-set' })
+  kind: 'bffless-proxy-rule-set';
+
+  @ApiProperty({ type: ExportedRuleSetMetaDto, description: 'Rule set metadata' })
+  ruleSet: ExportedRuleSetMetaDto;
+
+  @ApiProperty({ type: [ExportedProxyRuleDto], description: 'Exported rules in evaluation order' })
+  rules: ExportedProxyRuleDto[];
+
+  @ApiPropertyOptional({
+    type: [ExportedSchemaDto],
+    description:
+      'Schema definitions the pipeline rules depend on (bundled for portability); omitted when none',
+  })
+  schemas?: ExportedSchemaDto[];
+}

--- a/apps/backend/src/proxy-rules/dto/index.ts
+++ b/apps/backend/src/proxy-rules/dto/index.ts
@@ -5,3 +5,4 @@ export * from './proxy-rule-response.dto';
 export * from './proxy-rule-set.dto';
 export * from './import-proxy-rule-set.dto';
 export * from './export-proxy-rule-set.dto';
+export * from './sync-proxy-rule-set.dto';

--- a/apps/backend/src/proxy-rules/dto/index.ts
+++ b/apps/backend/src/proxy-rules/dto/index.ts
@@ -4,3 +4,4 @@ export * from './reorder-proxy-rules.dto';
 export * from './proxy-rule-response.dto';
 export * from './proxy-rule-set.dto';
 export * from './import-proxy-rule-set.dto';
+export * from './export-proxy-rule-set.dto';

--- a/apps/backend/src/proxy-rules/dto/proxy-rule-set.dto.ts
+++ b/apps/backend/src/proxy-rules/dto/proxy-rule-set.dto.ts
@@ -1,6 +1,32 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsOptional, IsUUID, MaxLength } from 'class-validator';
 import { ProxyRuleResponseDto } from './proxy-rule-response.dto';
+import type { ProxyRuleSetSource } from '../../db/schema/proxy-rule-sets.schema';
+
+/**
+ * Rules-as-code provenance for a git-managed rule set (see
+ * ProxyRuleSetSource in the schema). Response-only; written exclusively
+ * by the sync endpoint.
+ */
+export class ProxyRuleSetSourceDto implements ProxyRuleSetSource {
+  @ApiPropertyOptional({ description: 'Source repository', example: 'bffless/apps' })
+  repo?: string;
+
+  @ApiPropertyOptional({
+    description: 'Rule-set directory path within the repo',
+    example: 'apps/studio/.bffless/proxy-rules/studio',
+  })
+  path?: string;
+
+  @ApiPropertyOptional({ description: 'Commit SHA the synced payload was built from' })
+  gitSha?: string;
+
+  @ApiProperty({ description: 'ISO timestamp of the last successful sync' })
+  syncedAt: string;
+
+  @ApiProperty({ description: 'sha256 of the defaults-normalized synced payload' })
+  contentHash: string;
+}
 
 export class CreateProxyRuleSetDto {
   @ApiProperty({
@@ -72,6 +98,14 @@ export class ProxyRuleSetResponseDto {
 
   @ApiPropertyOptional({ description: 'Environment tag' })
   environment?: string | null;
+
+  @ApiPropertyOptional({
+    type: ProxyRuleSetSourceDto,
+    description:
+      'Rules-as-code provenance — set when this rule set is managed from git via the ' +
+      'sync endpoint, null/absent otherwise. Kept (not cleared) on manual edits.',
+  })
+  source?: ProxyRuleSetSourceDto | null;
 
   @ApiProperty({ description: 'Creation timestamp' })
   createdAt: Date;

--- a/apps/backend/src/proxy-rules/dto/sync-proxy-rule-set.dto.spec.ts
+++ b/apps/backend/src/proxy-rules/dto/sync-proxy-rule-set.dto.spec.ts
@@ -1,0 +1,176 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { SyncProxyRuleDto, SyncProxyRuleSetDto } from './sync-proxy-rule-set.dto';
+
+/**
+ * DTO validation for the sync endpoint — the SSRF gap closure (Task 7 of the
+ * Phase 1 plan): sync rule targetUrls go through IsValidTargetUrlOrPath
+ * semantics (via IsValidSyncTargetUrl) while remaining optional so elided
+ * canonical pipeline payloads keep working.
+ */
+describe('SyncProxyRuleDto', () => {
+  const validateRule = async (rule: Record<string, unknown>) =>
+    validate(plainToInstance(SyncProxyRuleDto, rule));
+
+  const propertiesWithErrors = (errors: { property: string }[]) =>
+    errors.map((e) => e.property);
+
+  describe('targetUrl SSRF validation', () => {
+    it('rejects an HTTP URL to the cloud metadata IP (169.254.169.254)', async () => {
+      const errors = await validateRule({
+        pathPattern: '/api/*',
+        targetUrl: 'http://169.254.169.254/latest/meta-data',
+      });
+      expect(propertiesWithErrors(errors)).toContain('targetUrl');
+    });
+
+    it('rejects a plain external HTTP URL (only *.svc / localhost may use http)', async () => {
+      const errors = await validateRule({
+        pathPattern: '/api/*',
+        targetUrl: 'http://internal-api.example.com',
+      });
+      expect(propertiesWithErrors(errors)).toContain('targetUrl');
+    });
+
+    it('accepts an HTTPS URL', async () => {
+      const errors = await validateRule({
+        pathPattern: '/api/*',
+        targetUrl: 'https://api.example.com',
+      });
+      expect(errors).toEqual([]);
+    });
+
+    it('accepts HTTP for K8s-internal service hosts (*.svc)', async () => {
+      const errors = await validateRule({
+        pathPattern: '/api/*',
+        targetUrl: 'http://backend.default.svc:3000',
+      });
+      expect(errors).toEqual([]);
+    });
+
+    it('accepts a path targetUrl for internal rewrites', async () => {
+      const errors = await validateRule({
+        pathPattern: '/env.json',
+        proxyType: 'internal_rewrite',
+        targetUrl: '/environments/production.json',
+      });
+      expect(errors).toEqual([]);
+    });
+
+    it('rejects a non-URL string on an external rule', async () => {
+      const errors = await validateRule({
+        pathPattern: '/api/*',
+        targetUrl: 'not a url',
+      });
+      expect(propertiesWithErrors(errors)).toContain('targetUrl');
+    });
+  });
+
+  describe('elided canonical pipeline payloads', () => {
+    const pipelineConfig = {
+      name: 'contact',
+      steps: [{ handlerType: 'form_handler', config: { fields: {} } }],
+    };
+
+    it('accepts an absent targetUrl (targetUrl is optional; normalization fills the default later)', async () => {
+      const errors = await validateRule({
+        pathPattern: '/api/contact',
+        method: 'POST',
+        pipelineConfig,
+      });
+      expect(errors).toEqual([]);
+    });
+
+    it('accepts the pipeline default URL with an explicit proxyType', async () => {
+      const errors = await validateRule({
+        pathPattern: '/api/contact',
+        method: 'POST',
+        proxyType: 'pipeline',
+        targetUrl: 'http://internal/pipeline',
+        pipelineConfig,
+      });
+      expect(errors).toEqual([]);
+    });
+
+    it('accepts the pipeline default URL with an ELIDED proxyType (inferred from pipelineConfig)', async () => {
+      // Without inference the base validator would reject http://internal/pipeline
+      // as a non-internal HTTP URL — see IsValidSyncTargetUrl.
+      const errors = await validateRule({
+        pathPattern: '/api/contact',
+        method: 'POST',
+        targetUrl: 'http://internal/pipeline',
+        pipelineConfig,
+      });
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('method whitelist (match-key protection)', () => {
+    it('rejects a non-whitelisted method', async () => {
+      const errors = await validateRule({
+        pathPattern: '/api/*',
+        method: 'FETCH',
+        targetUrl: 'https://api.example.com',
+      });
+      expect(propertiesWithErrors(errors)).toContain('method');
+    });
+
+    it('rejects a lowercase method (uppercase HTTP methods only)', async () => {
+      const errors = await validateRule({
+        pathPattern: '/api/*',
+        method: 'get',
+        targetUrl: 'https://api.example.com',
+      });
+      expect(propertiesWithErrors(errors)).toContain('method');
+    });
+
+    it('rejects a non-whitelisted entry in methods[]', async () => {
+      const errors = await validateRule({
+        pathPattern: '/api/*',
+        methods: ['GET', 'TRACE'],
+        targetUrl: 'https://api.example.com',
+      });
+      expect(propertiesWithErrors(errors)).toContain('methods');
+    });
+  });
+});
+
+describe('SyncProxyRuleSetDto', () => {
+  it('accepts a full payload (envelope extras, options, source)', async () => {
+    const dto = plainToInstance(SyncProxyRuleSetDto, {
+      version: 2,
+      exportedAt: '2026-07-11T00:00:00.000Z',
+      kind: 'bffless-proxy-rule-set',
+      ruleSet: { name: 'studio', description: 'Studio API', environment: 'production' },
+      rules: [{ pathPattern: '/api/*', targetUrl: 'https://api.example.com' }],
+      schemas: [
+        { id: 'f4b6e9a0-0000-4000-8000-000000000001', name: 'comments', fields: [{ name: 'body', type: 'text', required: true }] },
+      ],
+      options: { prune: true, dryRun: true, strictSchemas: true },
+      source: { repo: 'bffless/apps', path: 'apps/studio/.bffless/proxy-rules/studio', gitSha: 'abc123' },
+    });
+
+    expect(await validate(dto)).toEqual([]);
+  });
+
+  it('rejects a nested rule with a forbidden targetUrl', async () => {
+    const dto = plainToInstance(SyncProxyRuleSetDto, {
+      ruleSet: { name: 'studio' },
+      rules: [{ pathPattern: '/api/*', targetUrl: 'http://10.0.0.5/admin' }],
+    });
+
+    const errors = await validate(dto);
+    expect(errors.map((e) => e.property)).toContain('rules');
+  });
+
+  it('rejects a payload without ruleSet.name', async () => {
+    const dto = plainToInstance(SyncProxyRuleSetDto, {
+      ruleSet: {},
+      rules: [],
+    });
+
+    const errors = await validate(dto);
+    expect(errors.map((e) => e.property)).toContain('ruleSet');
+  });
+});

--- a/apps/backend/src/proxy-rules/dto/sync-proxy-rule-set.dto.ts
+++ b/apps/backend/src/proxy-rules/dto/sync-proxy-rule-set.dto.ts
@@ -1,0 +1,307 @@
+import { ApiProperty, ApiPropertyOptional, OmitType } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsBoolean,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  Validate,
+  ValidateNested,
+  ValidationArguments,
+  ValidatorConstraint,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { CreateProxyRuleDto, IsValidTargetUrlOrPath } from './create-proxy-rule.dto';
+import { CreateProxyRuleSetDto } from './proxy-rule-set.dto';
+import { SchemaFieldDto } from '../../pipelines/dto/create-pipeline-schema.dto';
+import type { ProxyType } from '../../db/schema/proxy-rules.schema';
+
+/**
+ * DTOs for the idempotent sync endpoint
+ * (`PUT /api/proxy-rule-sets/project/:projectId/sync`) — Task 7 of the
+ * proxy-rules-as-code Phase 1 plan
+ * (`docs/plans/proxy-rules-as-code-phase1-implementation.md`).
+ */
+
+/**
+ * Target-URL validator for sync payloads. Wraps {@link IsValidTargetUrlOrPath}
+ * (closing the SSRF gap the plan doc calls out — import's laxness is
+ * pre-existing and out of scope) with one sync-specific adjustment:
+ * **CLI-parity proxyType inference**. Canonical payloads elide an inferable
+ * `proxyType` (the CLI decompiler strips it when `pipelineConfig` /
+ * `emailHandlerConfig` presence implies it), so the base validator's
+ * pipeline/email exemptions must fire on the INFERRED type too — mirroring
+ * `inferProxyType` in `sync-plan.util.ts`. Without this, an explicit
+ * `targetUrl: "http://internal/pipeline"` on an elided pipeline rule would be
+ * rejected as a non-internal HTTP URL even though the rule never proxies to it.
+ *
+ * An ABSENT `targetUrl` is handled by `@IsOptional` on the property (validators
+ * are skipped entirely), so elided pipeline rules that omit `targetUrl` pass
+ * without touching this class; normalization fills `http://internal/pipeline`
+ * later (see `normalizeRule` in `sync-plan.util.ts`).
+ */
+@ValidatorConstraint({ name: 'isValidSyncTargetUrl', async: false })
+export class IsValidSyncTargetUrl extends IsValidTargetUrlOrPath {
+  validate(value: string, args: ValidationArguments): boolean {
+    const obj = args.object as {
+      proxyType?: ProxyType;
+      pipelineConfig?: unknown;
+      emailHandlerConfig?: unknown;
+    };
+    // Inferred pipeline / email_form_handler: targetUrl is unused for these
+    // types, exactly like the base validator's explicit-proxyType exemptions.
+    if (!obj.proxyType && (obj.pipelineConfig || obj.emailHandlerConfig)) {
+      return true;
+    }
+    return super.validate(value, args);
+  }
+}
+
+/**
+ * One rule in a sync payload. Mirrors the import rule DTO
+ * (`CreateProxyRuleInSetDto`) field-for-field — including the `method` /
+ * `methods` `@IsIn` HTTP-method whitelists, which also protect the
+ * `(pathPattern, method)` match key — except `targetUrl`, which is:
+ *
+ * - **optional** — elided canonical payloads omit it on pipeline rules
+ *   (defaults-normalization fills `http://internal/pipeline` later), and
+ * - validated by {@link IsValidSyncTargetUrl} when present (SSRF gap closure:
+ *   HTTPS anywhere, HTTP only for `*.svc` / localhost, path-only for internal
+ *   rewrites; pipeline/email rules — explicit or inferred — are exempt).
+ */
+export class SyncProxyRuleDto extends OmitType(CreateProxyRuleDto, [
+  'ruleSetId',
+  'targetUrl',
+] as const) {
+  @ApiPropertyOptional({
+    description:
+      'Target URL to forward requests to. Must be HTTPS, or HTTP for internal K8s services ' +
+      '(*.svc, localhost); a path starting with "/" for internal rewrites. Optional: omitted ' +
+      'on pipeline rules in canonical payloads (defaults to http://internal/pipeline).',
+    example: 'https://api.example.com',
+  })
+  @IsOptional()
+  @Validate(IsValidSyncTargetUrl)
+  targetUrl?: string;
+}
+
+/**
+ * A bundled schema definition in a sync payload — same shape as the export
+ * envelope's `schemas[]` entries. Resolved by NAME against the target project
+ * (non-interactive, unlike import's `ImportSchemaResolutionDto`).
+ */
+export class SyncSchemaDto {
+  @ApiProperty({ description: 'Source schema id as referenced by the payload rules' })
+  @IsUUID()
+  id: string;
+
+  @ApiProperty({ description: 'Schema name (the identity in the target project)' })
+  @IsString()
+  @MaxLength(255)
+  name: string;
+
+  @ApiProperty({ type: [SchemaFieldDto], description: 'Schema field definitions' })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SchemaFieldDto)
+  fields: SchemaFieldDto[];
+}
+
+export class SyncOptionsDto {
+  @ApiPropertyOptional({
+    description: 'Delete live rules absent from the payload (default: report them as pruneCandidates)',
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  prune?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Compute and return the full change plan without writing anything',
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  dryRun?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Fail with 400 when a name-reused schema has mismatched field definitions (default: warn)',
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  strictSchemas?: boolean;
+}
+
+/**
+ * Caller-supplied provenance, stamped onto the rule set's `source` column
+ * together with the server-computed `syncedAt` / `contentHash`.
+ */
+export class SyncSourceDto {
+  @ApiPropertyOptional({ description: 'Source repository', example: 'bffless/apps' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  repo?: string;
+
+  @ApiPropertyOptional({
+    description: 'Rule-set directory path within the repo',
+    example: 'apps/studio/.bffless/proxy-rules/studio',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  path?: string;
+
+  @ApiPropertyOptional({ description: 'Commit SHA the payload was built from' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  gitSha?: string;
+}
+
+/**
+ * Request body for the idempotent sync endpoint. `ruleSet.name` is the set's
+ * identity within the project (trimmed server-side, import parity); rules match
+ * live rows on `(pathPattern, method ?? null)`.
+ *
+ * `version` / `exportedAt` / `kind` are accepted but ignored (import parity —
+ * a raw export envelope plus options can be PUT without stripping; the global
+ * ValidationPipe runs with `forbidNonWhitelisted`).
+ */
+export class SyncProxyRuleSetDto {
+  @ApiPropertyOptional({ description: 'Export format version (ignored)', example: 2 })
+  @IsOptional()
+  @IsInt()
+  version?: number;
+
+  @ApiPropertyOptional({ description: 'ISO timestamp the payload was built (ignored)' })
+  @IsOptional()
+  @IsString()
+  exportedAt?: string;
+
+  @ApiPropertyOptional({ description: 'Export kind discriminator (ignored)' })
+  @IsOptional()
+  @IsString()
+  kind?: string;
+
+  @ApiProperty({ type: CreateProxyRuleSetDto, description: 'Rule set metadata; name is the identity' })
+  @ValidateNested()
+  @Type(() => CreateProxyRuleSetDto)
+  ruleSet: CreateProxyRuleSetDto;
+
+  @ApiProperty({ type: [SyncProxyRuleDto], description: 'The desired rules (full declarative state)' })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SyncProxyRuleDto)
+  rules: SyncProxyRuleDto[];
+
+  @ApiPropertyOptional({
+    type: [SyncSchemaDto],
+    description: 'Schema definitions the pipeline rules depend on, resolved by name',
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SyncSchemaDto)
+  schemas?: SyncSchemaDto[];
+
+  @ApiPropertyOptional({ type: SyncOptionsDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SyncOptionsDto)
+  options?: SyncOptionsDto;
+
+  @ApiPropertyOptional({ type: SyncSourceDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SyncSourceDto)
+  source?: SyncSourceDto;
+}
+
+/** A `(pathPattern, method)` rule reference in the sync response. */
+export class SyncRuleRefDto {
+  @ApiProperty({ description: 'Path pattern of the rule', example: '/api/*' })
+  pathPattern: string;
+
+  @ApiProperty({
+    description: 'HTTP method of the rule (null = any method)',
+    nullable: true,
+    example: 'GET',
+  })
+  method: string | null;
+}
+
+/** One entry of `schemaResolutions[]` — see `SchemaResolution` in schema-sync.util. */
+export class SyncSchemaResolutionDto {
+  @ApiProperty({ description: 'Schema name' })
+  name: string;
+
+  @ApiProperty({ enum: ['reuse', 'create'], description: 'How the schema was resolved' })
+  action: 'reuse' | 'create';
+
+  @ApiProperty({
+    nullable: true,
+    description: 'Resolved schema id in the target project (null for a dryRun create)',
+  })
+  targetSchemaId: string | null;
+
+  @ApiProperty({ description: 'Whether the reused schema has mismatched field definitions' })
+  fieldMismatch: boolean;
+}
+
+/**
+ * Sync response — also the dryRun plan. Shape pinned by the Phase 1 plan doc
+ * (cross-cutting definitions). Arrays are deterministically ordered (sorted by
+ * pathPattern then method) so CI output is byte-stable.
+ */
+export class SyncProxyRuleSetResponseDto {
+  @ApiProperty({
+    nullable: true,
+    description: 'The synced rule set id (null on a dryRun of a set that does not exist yet)',
+  })
+  ruleSetId: string | null;
+
+  @ApiProperty({ type: [SyncRuleRefDto], description: 'Rules created (or planned under dryRun)' })
+  created: SyncRuleRefDto[];
+
+  @ApiProperty({ type: [SyncRuleRefDto], description: 'Rules updated (or planned under dryRun)' })
+  updated: SyncRuleRefDto[];
+
+  @ApiProperty({
+    type: [SyncRuleRefDto],
+    description: 'Live-only rules deleted; only non-empty when options.prune',
+  })
+  deleted: SyncRuleRefDto[];
+
+  @ApiProperty({ type: [SyncRuleRefDto], description: 'Rules that matched their live form exactly' })
+  unchanged: SyncRuleRefDto[];
+
+  @ApiProperty({
+    type: [SyncRuleRefDto],
+    description: 'Live-only rules NOT deleted because options.prune is false',
+  })
+  pruneCandidates: SyncRuleRefDto[];
+
+  @ApiProperty({ type: [SyncSchemaResolutionDto], description: 'How each bundled schema was resolved' })
+  schemaResolutions: SyncSchemaResolutionDto[];
+
+  @ApiProperty({
+    type: [String],
+    description:
+      'Referenced {{secrets.NAME}} names with no project secret, plus blank header-add names ' +
+      'on new rules (nothing live to preserve). Warning-level — never fails the sync.',
+  })
+  missingSecrets: string[];
+
+  @ApiProperty({ type: [String], description: 'Non-fatal warnings (schema mismatches, nginx failures)' })
+  warnings: string[];
+
+  @ApiProperty({ description: 'Whether this was a dry run (nothing was written)' })
+  dryRun: boolean;
+
+  @ApiProperty({ description: 'Whether the rule set was created (or would be, under dryRun)' })
+  setCreated: boolean;
+}

--- a/apps/backend/src/proxy-rules/export-cli-equivalence.spec.ts
+++ b/apps/backend/src/proxy-rules/export-cli-equivalence.spec.ts
@@ -1,0 +1,470 @@
+/**
+ * CLI-equivalence drift guard for the server export endpoint (Task 2, #448).
+ *
+ * Imports the CLI canonicalizer (`packages/cli/src/format/canonical.ts`) — the
+ * export-format ground truth — DIRECTLY from source and asserts that
+ * `ProxyRuleSetsService.exportRuleSet()` output is accepted byte-identically by
+ * it. No golden fixture to regenerate: if either side drifts (a key dropped
+ * from the server serializer, a key added to the CLI's RULE_KEY_ORDER, changed
+ * null-stripping semantics, …) this suite fails immediately.
+ *
+ * The cross-package TS import works because backend Jest maps relative
+ * `./x.js` ESM specifiers back to their TS sources (`moduleNameMapper` in
+ * apps/backend/package.json) and ts-jest transforms everything outside
+ * node_modules. This is a test-only import — the backend has NO runtime
+ * dependency on packages/cli (see export-format.util.ts, which duplicates the
+ * constants for runtime use).
+ *
+ * The fixture below is a kitchen-sink rule set covering every RULE_KEY_ORDER
+ * key (asserted below, so a 19th key can't be added without extending it):
+ * `methods` (the field #448 dropped), pipeline rules with schema refs in step
+ * configs, header `add` secrets, falsy-but-present values (false/0/''), and
+ * nested nulls inside a step config (which must survive verbatim).
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProxyRuleSetsService } from './proxy-rule-sets.service';
+import { ProxyRulesService } from './proxy-rules.service';
+import { PermissionsService } from '../permissions/permissions.service';
+import { NginxRegenerationService } from '../domains/nginx-regeneration.service';
+import { PipelineSchemasService } from '../pipelines/pipeline-schemas.service';
+import {
+  RULE_KEY_ORDER as BACKEND_RULE_KEY_ORDER,
+  ENVELOPE_KEY_ORDER as BACKEND_ENVELOPE_KEY_ORDER,
+} from './export-format.util';
+import {
+  canonicalizeExport,
+  exportsEquivalent,
+  stringifyExport,
+} from '../../../../packages/cli/src/format/canonical';
+import {
+  RULE_KEY_ORDER as CLI_RULE_KEY_ORDER,
+  ENVELOPE_KEY_ORDER as CLI_ENVELOPE_KEY_ORDER,
+} from '../../../../packages/cli/src/format/types';
+import type { RuleSetExport as CliRuleSetExport } from '../../../../packages/cli/src/format/types';
+
+// Mock the db client - using factory function for hoisting
+jest.mock('../db/client', () => {
+  const mockResults: { data: unknown[] }[] = [];
+  let callIdx = 0;
+
+  const chainable = {
+    select: jest.fn(() => chainable),
+    from: jest.fn(() => chainable),
+    where: jest.fn(() => chainable),
+    limit: jest.fn(() => {
+      const result = mockResults[callIdx]?.data || [];
+      callIdx++;
+      return Promise.resolve(result);
+    }),
+    __setResults: (results: unknown[][]) => {
+      mockResults.length = 0;
+      results.forEach((r) => mockResults.push({ data: r }));
+      callIdx = 0;
+    },
+    __reset: () => {
+      mockResults.length = 0;
+      callIdx = 0;
+    },
+  };
+
+  return { db: chainable };
+});
+
+import { db } from '../db/client';
+const mockDb = db as unknown as {
+  __setResults: (results: unknown[][]) => void;
+  __reset: () => void;
+};
+
+// ==================== Kitchen-sink fixture ====================
+
+const ruleSetRow = {
+  id: 'rule-set-1',
+  projectId: 'project-1',
+  name: 'kitchen-sink',
+  description: 'Covers every exportable rule field',
+  environment: 'production',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-02T00:00:00Z'),
+};
+
+const serverManaged = {
+  ruleSetId: 'rule-set-1',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-02T00:00:00Z'),
+};
+
+/** DB rows as getRulesByRuleSetId returns them (decrypted headerConfig). */
+const dbRules = [
+  {
+    ...serverManaged,
+    id: 'rule-1',
+    pathPattern: '/api/external/*',
+    method: null,
+    methods: ['GET', 'POST'], // ← the field #448 dropped
+    targetUrl: 'https://api.example.com/v1',
+    stripPrefix: false, // non-default false
+    order: 0,
+    timeout: 5000,
+    preserveHost: true,
+    forwardCookies: true,
+    headerConfig: {
+      forward: ['authorization', 'accept'],
+      strip: ['cookie'],
+      add: { 'X-Api-Key': 'sk_live_super_secret', Authorization: 'Bearer live-token' },
+    },
+    authTransform: { type: 'cookie-to-bearer', cookieName: 'sAccessToken' },
+    internalRewrite: false,
+    proxyType: 'external_proxy',
+    emailHandlerConfig: null,
+    pipelineConfig: null,
+    isEnabled: true,
+    debugEnabled: true,
+    description: 'external proxy with everything set',
+  },
+  {
+    ...serverManaged,
+    id: 'rule-2',
+    pathPattern: '/api/comments',
+    method: 'GET',
+    methods: null,
+    targetUrl: 'http://internal/pipeline',
+    stripPrefix: true,
+    order: 1,
+    timeout: 30000,
+    preserveHost: false,
+    forwardCookies: false,
+    headerConfig: null,
+    authTransform: null,
+    internalRewrite: false,
+    proxyType: 'pipeline',
+    emailHandlerConfig: null,
+    pipelineConfig: {
+      name: 'list-comments',
+      description: 'query the comments table',
+      steps: [
+        {
+          id: 'step-1',
+          name: 'query',
+          handlerType: 'data_query',
+          config: {
+            schemaId: 'schema-comments', // schema ref → bundled
+            limit: 0, // falsy 0 survives
+            includeDeleted: false, // falsy false survives
+            cursor: '', // falsy '' survives
+            nested: { value: null }, // nested null inside step config survives verbatim
+          },
+          isEnabled: true,
+        },
+      ],
+      postSteps: [
+        {
+          name: 'persist',
+          handlerType: 'ai',
+          config: { persistMessagesSchemaId: 'schema-messages' }, // second ref key flavor
+        },
+      ],
+      validators: [{ type: 'auth_required' }],
+    },
+    isEnabled: true,
+    debugEnabled: false,
+    description: null,
+  },
+  {
+    ...serverManaged,
+    id: 'rule-3',
+    pathPattern: '/legacy/*',
+    method: 'POST',
+    methods: null,
+    targetUrl: '/public/myorg/myrepo/alias/production',
+    stripPrefix: true,
+    order: 2,
+    timeout: 30000,
+    preserveHost: false,
+    forwardCookies: false,
+    headerConfig: null,
+    authTransform: null,
+    internalRewrite: true,
+    proxyType: 'internal_rewrite',
+    emailHandlerConfig: null,
+    pipelineConfig: null,
+    isEnabled: false, // non-default false
+    debugEnabled: false,
+    description: '', // empty string is a value, not an absence
+  },
+  {
+    ...serverManaged,
+    id: 'rule-4',
+    pathPattern: '/api/contact',
+    method: 'POST',
+    methods: null,
+    targetUrl: 'http://internal/email',
+    stripPrefix: true,
+    order: 3,
+    timeout: 30000,
+    preserveHost: false,
+    forwardCookies: false,
+    headerConfig: null,
+    authTransform: null,
+    internalRewrite: false,
+    proxyType: 'email_form_handler',
+    emailHandlerConfig: {
+      destinationEmail: 'ops@example.com',
+      subjectTemplate: 'New contact: {{name}}',
+      rateLimitPerHour: 0,
+    },
+    pipelineConfig: null,
+    isEnabled: true,
+    debugEnabled: false,
+    description: 'contact form',
+  },
+];
+
+const schemaRows: Record<string, unknown> = {
+  'schema-comments': {
+    id: 'schema-comments',
+    projectId: 'project-1',
+    name: 'comments',
+    fields: [
+      { name: 'body', type: 'string', required: true },
+      { name: 'score', type: 'number', required: false },
+    ],
+  },
+  'schema-messages': {
+    id: 'schema-messages',
+    projectId: 'project-1',
+    name: 'messages',
+    fields: [{ name: 'content', type: 'string', required: true }],
+  },
+};
+
+/**
+ * The EXPECTED envelope, written out by hand as the independent statement of
+ * what those DB rows mean on the wire. If the server serializer drops or
+ * renames any field, the comparison against this literal fails.
+ */
+const expectedEnvelope: CliRuleSetExport = {
+  version: 2,
+  exportedAt: 'REPLACED_PER_TEST',
+  kind: 'bffless-proxy-rule-set',
+  ruleSet: {
+    name: 'kitchen-sink',
+    description: 'Covers every exportable rule field',
+    environment: 'production',
+  },
+  rules: [
+    {
+      pathPattern: '/api/external/*',
+      methods: ['GET', 'POST'],
+      targetUrl: 'https://api.example.com/v1',
+      stripPrefix: false,
+      order: 0,
+      timeout: 5000,
+      preserveHost: true,
+      forwardCookies: true,
+      headerConfig: {
+        forward: ['authorization', 'accept'],
+        strip: ['cookie'],
+        add: { 'X-Api-Key': '', Authorization: '' }, // secrets blanked
+      },
+      authTransform: { type: 'cookie-to-bearer', cookieName: 'sAccessToken' },
+      internalRewrite: false,
+      proxyType: 'external_proxy',
+      isEnabled: true,
+      debugEnabled: true,
+      description: 'external proxy with everything set',
+    },
+    {
+      pathPattern: '/api/comments',
+      method: 'GET',
+      targetUrl: 'http://internal/pipeline',
+      stripPrefix: true,
+      order: 1,
+      timeout: 30000,
+      preserveHost: false,
+      forwardCookies: false,
+      internalRewrite: false,
+      proxyType: 'pipeline',
+      pipelineConfig: {
+        name: 'list-comments',
+        description: 'query the comments table',
+        steps: [
+          {
+            id: 'step-1',
+            name: 'query',
+            handlerType: 'data_query',
+            config: {
+              schemaId: 'schema-comments',
+              limit: 0,
+              includeDeleted: false,
+              cursor: '',
+              nested: { value: null },
+            },
+            isEnabled: true,
+          },
+        ],
+        postSteps: [
+          {
+            name: 'persist',
+            handlerType: 'ai',
+            config: { persistMessagesSchemaId: 'schema-messages' },
+          },
+        ],
+        validators: [{ type: 'auth_required' }],
+      },
+      isEnabled: true,
+      debugEnabled: false,
+    },
+    {
+      pathPattern: '/legacy/*',
+      method: 'POST',
+      targetUrl: '/public/myorg/myrepo/alias/production',
+      stripPrefix: true,
+      order: 2,
+      timeout: 30000,
+      preserveHost: false,
+      forwardCookies: false,
+      internalRewrite: true,
+      proxyType: 'internal_rewrite',
+      isEnabled: false,
+      debugEnabled: false,
+      description: '',
+    },
+    {
+      pathPattern: '/api/contact',
+      method: 'POST',
+      targetUrl: 'http://internal/email',
+      stripPrefix: true,
+      order: 3,
+      timeout: 30000,
+      preserveHost: false,
+      forwardCookies: false,
+      internalRewrite: false,
+      proxyType: 'email_form_handler',
+      emailHandlerConfig: {
+        destinationEmail: 'ops@example.com',
+        subjectTemplate: 'New contact: {{name}}',
+        rateLimitPerHour: 0,
+      },
+      isEnabled: true,
+      debugEnabled: false,
+      description: 'contact form',
+    },
+  ],
+  schemas: [
+    {
+      id: 'schema-comments',
+      name: 'comments',
+      fields: [
+        { name: 'body', type: 'string', required: true },
+        { name: 'score', type: 'number', required: false },
+      ],
+    },
+    {
+      id: 'schema-messages',
+      name: 'messages',
+      fields: [{ name: 'content', type: 'string', required: true }],
+    },
+  ],
+};
+
+describe('server export ↔ CLI canonicalizer equivalence (#448 drift guard)', () => {
+  let service: ProxyRuleSetsService;
+  let rulesServiceMock: { getRulesByRuleSetId: jest.Mock };
+
+  beforeEach(async () => {
+    mockDb.__reset();
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProxyRuleSetsService,
+        {
+          provide: PermissionsService,
+          useValue: { enforceApiKeyProjectScope: jest.fn(), requireProjectAccess: jest.fn() },
+        },
+        {
+          provide: ProxyRulesService,
+          useValue: (rulesServiceMock = {
+            getRulesByRuleSetId: jest.fn().mockResolvedValue(dbRules),
+          }),
+        },
+        { provide: NginxRegenerationService, useValue: {} },
+        {
+          provide: PipelineSchemasService,
+          useValue: {
+            getById: jest.fn((id: string) => Promise.resolve(schemaRows[id] ?? null)),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ProxyRuleSetsService>(ProxyRuleSetsService);
+    mockDb.__setResults([[ruleSetRow]]);
+  });
+
+  it('backend key-order constants are byte-identical to the CLI ground truth', () => {
+    expect([...BACKEND_RULE_KEY_ORDER]).toEqual([...CLI_RULE_KEY_ORDER]);
+    expect([...BACKEND_ENVELOPE_KEY_ORDER]).toEqual([...CLI_ENVELOPE_KEY_ORDER]);
+  });
+
+  it('the fixture exercises every RULE_KEY_ORDER key (extend it when a key is added)', () => {
+    const covered = new Set(expectedEnvelope.rules.flatMap((r) => Object.keys(r)));
+    for (const key of CLI_RULE_KEY_ORDER) {
+      expect(covered).toContain(key);
+    }
+  });
+
+  it('exportRuleSet output is accepted byte-identically by the CLI canonicalizer', async () => {
+    const serverExport = (await service.exportRuleSet('rule-set-1')) as unknown as CliRuleSetExport;
+
+    // canonicalizeExport throws on any key outside the CLI contract, so this
+    // also proves the server emits no unknown keys.
+    const expected = { ...expectedEnvelope, exportedAt: serverExport.exportedAt };
+    expect(stringifyExport(serverExport)).toBe(stringifyExport(expected));
+
+    // The server export is ALREADY canonical — the CLI canonicalizer is a
+    // byte-level no-op on it (key order, null stripping, rule sort all match).
+    // The RAW stringification must equal the canonicalized one (comparing two
+    // canonicalizeExport calls would be a tautology).
+    expect(JSON.stringify(serverExport, null, 2) + '\n').toBe(stringifyExport(serverExport));
+  });
+
+  it('stays byte-canonical when the DB hands back rules in non-canonical order', async () => {
+    // Reversed rows simulate an insertion-order/tie-break-free DB read; the
+    // envelope must still come out CLI-sorted ((order, pathPattern, method) for
+    // rules, name for schemas) so raw stringification equals stringifyExport.
+    rulesServiceMock.getRulesByRuleSetId.mockResolvedValue([...dbRules].reverse());
+    const serverExport = (await service.exportRuleSet('rule-set-1')) as unknown as CliRuleSetExport;
+
+    expect(JSON.stringify(serverExport, null, 2) + '\n').toBe(stringifyExport(serverExport));
+    const expected = { ...expectedEnvelope, exportedAt: serverExport.exportedAt };
+    expect(stringifyExport(serverExport)).toBe(stringifyExport(expected));
+  });
+
+  it('is semantically equivalent under the CLI diff contract (exportsEquivalent)', async () => {
+    const serverExport = (await service.exportRuleSet('rule-set-1')) as unknown as CliRuleSetExport;
+
+    const { equal, diffs } = exportsEquivalent(serverExport, expectedEnvelope);
+    expect(diffs).toEqual([]);
+    expect(equal).toBe(true);
+  });
+
+  it('would catch a dropped field (the #448 failure mode)', async () => {
+    const serverExport = (await service.exportRuleSet('rule-set-1')) as unknown as CliRuleSetExport;
+
+    // Simulate the #448 bug: an exporter that forgets `methods`
+    const mutilated: CliRuleSetExport = {
+      ...serverExport,
+      rules: serverExport.rules.map((r) => {
+        const clone: Record<string, unknown> = { ...r };
+        delete clone.methods;
+        return clone as unknown as (typeof serverExport.rules)[number];
+      }),
+    };
+
+    const { equal, diffs } = exportsEquivalent(mutilated, expectedEnvelope);
+    expect(equal).toBe(false);
+    expect(diffs.join('\n')).toContain('methods');
+  });
+});

--- a/apps/backend/src/proxy-rules/export-format.util.spec.ts
+++ b/apps/backend/src/proxy-rules/export-format.util.spec.ts
@@ -263,9 +263,38 @@ describe('export-format.util', () => {
       expect(Object.keys(kept.ruleSet)).toEqual(['name', 'description', 'environment']);
     });
 
-    it('passes already-serialized rules through verbatim', () => {
+    it('passes already-serialized rules through content-verbatim (individual rules unmodified)', () => {
       const out = buildExportEnvelope({ ruleSet: { name: 'api' }, rules, exportedAt });
-      expect(out.rules).toBe(rules);
+      expect(out.rules).toEqual(rules);
+      expect(out.rules[0]).toBe(rules[0]); // rules themselves are not cloned, only re-ordered
+    });
+
+    it('sorts rules canonically by (order, pathPattern, method) — CLI sortRules parity', () => {
+      const mk = (pathPattern: string, order: number, method?: string) =>
+        serializeRuleForExport(makeRuleRow({ pathPattern, order, method: method ?? null, methods: null }));
+      const unsorted = [mk('/b', 1), mk('/a', 1, 'POST'), mk('/a', 1, 'GET'), mk('/z', 0)];
+      const out = buildExportEnvelope({ ruleSet: { name: 'api' }, rules: unsorted, exportedAt });
+      expect(out.rules.map((r) => [r.pathPattern, r.order, r.method ?? null])).toEqual([
+        ['/z', 0, null],
+        ['/a', 1, 'GET'],
+        ['/a', 1, 'POST'],
+        ['/b', 1, null],
+      ]);
+      // Input array order untouched (non-mutating sort).
+      expect(unsorted.map((r) => r.pathPattern)).toEqual(['/b', '/a', '/a', '/z']);
+    });
+
+    it('sorts bundled schemas by name — CLI sortSchemas parity', () => {
+      const out = buildExportEnvelope({
+        ruleSet: { name: 'api' },
+        rules,
+        schemas: [
+          { id: 's2', name: 'zebra', fields: [] },
+          { id: 's1', name: 'alpha', fields: [] },
+        ],
+        exportedAt,
+      });
+      expect(out.schemas!.map((s) => s.name)).toEqual(['alpha', 'zebra']);
     });
   });
 });

--- a/apps/backend/src/proxy-rules/export-format.util.spec.ts
+++ b/apps/backend/src/proxy-rules/export-format.util.spec.ts
@@ -209,11 +209,12 @@ describe('export-format.util', () => {
       expect(serializeRuleForExport(makeRuleRow({ description: 'hi' })).description).toBe('hi');
     });
 
-    it('keeps falsy-but-real values: empty-string description and an empty methods array', () => {
+    it('keeps falsy-but-real values (empty-string description) but drops an empty methods array', () => {
       const out = serializeRuleForExport(makeRuleRow({ description: '', methods: [] }));
       expect(out.description).toBe('');
-      // DB semantics: methods [] means "fall back to method" but it is real data — export it.
-      expect(out.methods).toEqual([]);
+      // methods [] ≡ absent (fall back to method); sync normalizes [] to null,
+      // so exporting [] would be permanent diff drift a push can never fix.
+      expect(out).not.toHaveProperty('methods');
     });
   });
 

--- a/apps/backend/src/proxy-rules/export-format.util.spec.ts
+++ b/apps/backend/src/proxy-rules/export-format.util.spec.ts
@@ -1,0 +1,271 @@
+import {
+  ENVELOPE_KEY_ORDER,
+  RULE_KEY_ORDER,
+  buildExportEnvelope,
+  sanitizeHeaderConfigForExport,
+  serializeRuleForExport,
+} from './export-format.util';
+import type { ProxyRule } from '../db/schema/proxy-rules.schema';
+
+/** Builds a fully-populated DB-shaped rule row, overridable per test. */
+function makeRuleRow(overrides: Partial<ProxyRule> = {}): Partial<ProxyRule> {
+  return {
+    id: 'rule-uuid-1',
+    ruleSetId: 'set-uuid-1',
+    pathPattern: '/api/*',
+    method: 'GET',
+    methods: ['GET', 'HEAD'],
+    targetUrl: 'https://api.example.com',
+    stripPrefix: true,
+    order: 0,
+    timeout: 30000,
+    preserveHost: false,
+    forwardCookies: false,
+    headerConfig: { forward: ['accept'], strip: ['cookie'], add: { 'X-API-Key': 'sk_live_secret' } },
+    authTransform: { type: 'cookie-to-bearer', cookieName: 'sAccessToken' },
+    internalRewrite: false,
+    proxyType: 'external_proxy',
+    emailHandlerConfig: { destinationEmail: 'a@b.c' },
+    pipelineConfig: { name: 'p', steps: [{ name: 's', handlerType: 'data_query', config: {} }] },
+    isEnabled: true,
+    debugEnabled: false,
+    description: 'a rule',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-02T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('export-format.util', () => {
+  describe('key-order constants (ground truth: packages/cli/src/format/types.ts)', () => {
+    it('RULE_KEY_ORDER is the 18-key CLI order, including methods', () => {
+      expect([...RULE_KEY_ORDER]).toEqual([
+        'pathPattern',
+        'method',
+        'methods',
+        'targetUrl',
+        'stripPrefix',
+        'order',
+        'timeout',
+        'preserveHost',
+        'forwardCookies',
+        'headerConfig',
+        'authTransform',
+        'internalRewrite',
+        'proxyType',
+        'emailHandlerConfig',
+        'pipelineConfig',
+        'isEnabled',
+        'debugEnabled',
+        'description',
+      ]);
+    });
+
+    it('ENVELOPE_KEY_ORDER matches the CLI envelope order', () => {
+      expect([...ENVELOPE_KEY_ORDER]).toEqual([
+        'version',
+        'exportedAt',
+        'kind',
+        'ruleSet',
+        'rules',
+        'schemas',
+      ]);
+    });
+  });
+
+  describe('sanitizeHeaderConfigForExport', () => {
+    it('returns undefined for null and undefined input', () => {
+      expect(sanitizeHeaderConfigForExport(null)).toBeUndefined();
+      expect(sanitizeHeaderConfigForExport(undefined)).toBeUndefined();
+    });
+
+    it('blanks every add value to the empty string', () => {
+      const out = sanitizeHeaderConfigForExport({
+        add: { 'X-API-Key': 'sk_live_abc123', Authorization: 'Bearer tok' },
+      });
+      expect(out).toEqual({ add: { 'X-API-Key': '', Authorization: '' } });
+    });
+
+    it('passes forward/strip arrays through untouched (same references)', () => {
+      const forward = ['accept', 'content-type'];
+      const strip = ['cookie'];
+      const out = sanitizeHeaderConfigForExport({ forward, strip, add: { 'X-K': 'v' } });
+      expect(out!.forward).toBe(forward);
+      expect(out!.strip).toBe(strip);
+      expect(out!.add).toEqual({ 'X-K': '' });
+    });
+
+    it('returns a config without add as-is', () => {
+      const cfg = { forward: ['accept'] };
+      expect(sanitizeHeaderConfigForExport(cfg)).toBe(cfg);
+    });
+
+    it('does not mutate the input', () => {
+      const cfg = { add: { 'X-K': 'secret' } };
+      sanitizeHeaderConfigForExport(cfg);
+      expect(cfg.add['X-K']).toBe('secret');
+    });
+
+    it('preserves an empty add map and passes a nested null add through verbatim', () => {
+      expect(sanitizeHeaderConfigForExport({ forward: ['accept'], add: {} })).toEqual({
+        forward: ['accept'],
+        add: {},
+      });
+      const withNullAdd = { forward: ['accept'], add: null } as unknown as {
+        forward: string[];
+        add: Record<string, string>;
+      };
+      expect(sanitizeHeaderConfigForExport(withNullAdd)).toBe(withNullAdd);
+    });
+  });
+
+  describe('serializeRuleForExport', () => {
+    it('emits exactly the RULE_KEY_ORDER keys, in order, for a fully-populated row', () => {
+      const out = serializeRuleForExport(makeRuleRow());
+      expect(Object.keys(out)).toEqual([...RULE_KEY_ORDER]);
+    });
+
+    it('includes methods when set (#448 regression test)', () => {
+      const out = serializeRuleForExport(makeRuleRow({ method: null, methods: ['GET', 'HEAD'] }));
+      expect(out.methods).toEqual(['GET', 'HEAD']);
+      expect(out).not.toHaveProperty('method');
+    });
+
+    it('includes method and omits methods when only method is set', () => {
+      const out = serializeRuleForExport(makeRuleRow({ method: 'POST', methods: null }));
+      expect(out.method).toBe('POST');
+      expect(out).not.toHaveProperty('methods');
+    });
+
+    it('never emits server-managed fields (id, ruleSetId, createdAt, updatedAt)', () => {
+      const out = serializeRuleForExport(makeRuleRow()) as unknown as Record<string, unknown>;
+      expect(out).not.toHaveProperty('id');
+      expect(out).not.toHaveProperty('ruleSetId');
+      expect(out).not.toHaveProperty('createdAt');
+      expect(out).not.toHaveProperty('updatedAt');
+    });
+
+    it('drops null/undefined at the rule top level only', () => {
+      const out = serializeRuleForExport(
+        makeRuleRow({
+          method: null,
+          methods: null,
+          headerConfig: null,
+          authTransform: null,
+          emailHandlerConfig: null,
+          pipelineConfig: null,
+          description: null,
+        }),
+      );
+      expect(Object.keys(out)).toEqual([
+        'pathPattern',
+        'targetUrl',
+        'stripPrefix',
+        'order',
+        'timeout',
+        'preserveHost',
+        'forwardCookies',
+        'internalRewrite',
+        'proxyType',
+        'isEnabled',
+        'debugEnabled',
+      ]);
+    });
+
+    it('passes nested objects through verbatim — a null inside a pipeline step config survives', () => {
+      const pipelineConfig = {
+        name: 'p',
+        description: undefined,
+        steps: [{ name: 's', handlerType: 'ai', config: { systemPrompt: null, temperature: 0.2 } }],
+      };
+      const out = serializeRuleForExport(makeRuleRow({ pipelineConfig }));
+      expect(out.pipelineConfig).toBe(pipelineConfig);
+      expect(
+        (out.pipelineConfig!.steps[0].config as Record<string, unknown>).systemPrompt,
+      ).toBeNull();
+    });
+
+    it('passes authTransform and emailHandlerConfig through verbatim', () => {
+      const authTransform = { type: 'cookie-to-bearer' as const, cookieName: 'sAccessToken' };
+      const emailHandlerConfig = { destinationEmail: 'a@b.c', subject: 'Hi' };
+      const out = serializeRuleForExport(makeRuleRow({ authTransform, emailHandlerConfig }));
+      expect(out.authTransform).toBe(authTransform);
+      expect(out.emailHandlerConfig).toBe(emailHandlerConfig);
+    });
+
+    it('blanks headerConfig.add secret values via the sanitizer', () => {
+      const out = serializeRuleForExport(
+        makeRuleRow({
+          headerConfig: { forward: ['accept'], add: { 'X-API-Key': 'sk_live_abc', Auth: 'tok' } },
+        }),
+      );
+      expect(out.headerConfig).toEqual({ forward: ['accept'], add: { 'X-API-Key': '', Auth: '' } });
+    });
+
+    it('omits description when null and keeps it when present', () => {
+      expect(serializeRuleForExport(makeRuleRow({ description: null }))).not.toHaveProperty(
+        'description',
+      );
+      expect(serializeRuleForExport(makeRuleRow({ description: 'hi' })).description).toBe('hi');
+    });
+
+    it('keeps falsy-but-real values: empty-string description and an empty methods array', () => {
+      const out = serializeRuleForExport(makeRuleRow({ description: '', methods: [] }));
+      expect(out.description).toBe('');
+      // DB semantics: methods [] means "fall back to method" but it is real data — export it.
+      expect(out.methods).toEqual([]);
+    });
+  });
+
+  describe('buildExportEnvelope', () => {
+    const rules = [serializeRuleForExport(makeRuleRow())];
+    const schemas = [
+      { id: 'sch-1', name: 'comments', fields: [{ name: 'body', type: 'string' as const, required: true }] },
+    ];
+    const exportedAt = '2026-07-11T00:00:00.000Z';
+
+    it('emits envelope keys in ENVELOPE_KEY_ORDER when schemas are present', () => {
+      const out = buildExportEnvelope({ ruleSet: { name: 'api' }, rules, schemas, exportedAt });
+      expect(Object.keys(out)).toEqual([...ENVELOPE_KEY_ORDER]);
+    });
+
+    it('sets version 2, the kind constant, and the given exportedAt', () => {
+      const out = buildExportEnvelope({ ruleSet: { name: 'api' }, rules, exportedAt });
+      expect(out.version).toBe(2);
+      expect(out.kind).toBe('bffless-proxy-rule-set');
+      expect(out.exportedAt).toBe(exportedAt);
+    });
+
+    it('omits the schemas key entirely when the list is empty or undefined', () => {
+      expect(
+        buildExportEnvelope({ ruleSet: { name: 'api' }, rules, schemas: [], exportedAt }),
+      ).not.toHaveProperty('schemas');
+      expect(
+        buildExportEnvelope({ ruleSet: { name: 'api' }, rules, exportedAt }),
+      ).not.toHaveProperty('schemas');
+    });
+
+    it('strips null/undefined ruleSet description/environment and keeps present values', () => {
+      const stripped = buildExportEnvelope({
+        ruleSet: { name: 'api', description: null, environment: undefined },
+        rules,
+        exportedAt,
+      });
+      expect(stripped.ruleSet).toEqual({ name: 'api' });
+      expect(Object.keys(stripped.ruleSet)).toEqual(['name']);
+
+      const kept = buildExportEnvelope({
+        ruleSet: { name: 'api', description: 'd', environment: 'prod' },
+        rules,
+        exportedAt,
+      });
+      expect(kept.ruleSet).toEqual({ name: 'api', description: 'd', environment: 'prod' });
+      expect(Object.keys(kept.ruleSet)).toEqual(['name', 'description', 'environment']);
+    });
+
+    it('passes already-serialized rules through verbatim', () => {
+      const out = buildExportEnvelope({ ruleSet: { name: 'api' }, rules, exportedAt });
+      expect(out.rules).toBe(rules);
+    });
+  });
+});

--- a/apps/backend/src/proxy-rules/export-format.util.ts
+++ b/apps/backend/src/proxy-rules/export-format.util.ts
@@ -159,9 +159,29 @@ export interface BuildExportEnvelopeInput {
 }
 
 /**
+ * Canonical rule sort — mirrors `sortRules` in `packages/cli/src/format/canonical.ts`:
+ * `(order ?? 0, pathPattern, method ?? '')`. The DB query's `asc(order)` alone has no
+ * tie-break, so without this the envelope byte-order would depend on insertion order.
+ */
+function canonicalRuleCompare(a: ExportedRule, b: ExportedRule): number {
+  const oa = a.order ?? 0;
+  const ob = b.order ?? 0;
+  if (oa !== ob) return oa - ob;
+  if (a.pathPattern !== b.pathPattern) return a.pathPattern < b.pathPattern ? -1 : 1;
+  const ma = a.method ?? '';
+  const mb = b.method ?? '';
+  if (ma !== mb) return ma < mb ? -1 : 1;
+  return 0;
+}
+
+/**
  * Build the v2 export envelope with keys in `ENVELOPE_KEY_ORDER`. `ruleSet`
  * keys with `null`/`undefined` values are stripped (structural level); the
  * `schemas` key is omitted entirely when the list is empty or undefined.
+ *
+ * The output is byte-canonical per the CLI canonicalizer: rules are sorted by
+ * `(order, pathPattern, method)` and schemas by name, so
+ * `canonicalizeExport(envelope)` is a no-op on it.
  */
 export function buildExportEnvelope(input: BuildExportEnvelopeInput): RuleSetExport {
   const ruleSet: RuleSetExport['ruleSet'] = { name: input.ruleSet.name };
@@ -177,10 +197,13 @@ export function buildExportEnvelope(input: BuildExportEnvelopeInput): RuleSetExp
     exportedAt: input.exportedAt,
     kind: 'bffless-proxy-rule-set',
     ruleSet,
-    rules: input.rules,
+    rules: [...input.rules].sort(canonicalRuleCompare),
   };
   if (input.schemas && input.schemas.length > 0) {
-    envelope.schemas = input.schemas;
+    // CLI canonical form sorts bundled schemas by name (sortSchemas).
+    envelope.schemas = [...input.schemas].sort((a, b) =>
+      a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+    );
   }
   return envelope;
 }

--- a/apps/backend/src/proxy-rules/export-format.util.ts
+++ b/apps/backend/src/proxy-rules/export-format.util.ts
@@ -1,0 +1,186 @@
+import type {
+  AuthTransformConfig,
+  EmailHandlerConfig,
+  PipelineConfig,
+  ProxyHeaderConfig,
+  ProxyRule,
+  ProxyType,
+} from '../db/schema/proxy-rules.schema';
+import type { SchemaField } from '../db/schema/pipeline-schemas.schema';
+
+/**
+ * Canonical proxy-rule-set export format (server side).
+ *
+ * GROUND TRUTH: `packages/cli/src/format/types.ts` — the key-order constants and
+ * exported shapes below must stay byte-identical with the CLI's `RULE_KEY_ORDER` /
+ * `ENVELOPE_KEY_ORDER` so a server export is accepted verbatim by the CLI
+ * canonicalizer. The types are duplicated (not imported) because the backend must
+ * not depend on the CLI package at runtime.
+ *
+ * Null/undefined stripping applies at structural levels only (rule top level,
+ * ruleSet keys, envelope keys). Values nested *inside* those keys (headerConfig
+ * internals, authTransform, emailHandlerConfig, pipelineConfig, step configs) are
+ * free-form user data and pass through verbatim, nulls included — mirroring
+ * `packages/cli/src/format/canonical.ts`.
+ */
+
+/** Exported rule key order. 18 keys — `methods` inclusion is the #448 fix. */
+export const RULE_KEY_ORDER = [
+  'pathPattern',
+  'method',
+  'methods',
+  'targetUrl',
+  'stripPrefix',
+  'order',
+  'timeout',
+  'preserveHost',
+  'forwardCookies',
+  'headerConfig',
+  'authTransform',
+  'internalRewrite',
+  'proxyType',
+  'emailHandlerConfig',
+  'pipelineConfig',
+  'isEnabled',
+  'debugEnabled',
+  'description',
+] as const;
+
+/** Envelope key order. `schemas` is last and omitted entirely when empty. */
+export const ENVELOPE_KEY_ORDER = [
+  'version',
+  'exportedAt',
+  'kind',
+  'ruleSet',
+  'rules',
+  'schemas',
+] as const;
+
+/** Bundled schema definition (name + fields only, no data rows). */
+export interface ExportedSchema {
+  id: string;
+  name: string;
+  fields: SchemaField[];
+}
+
+/**
+ * A single rule in the export envelope. Mirrors the CLI's `ExportedRule`:
+ * only portable config — server-managed fields (`id`, `ruleSetId`, timestamps)
+ * never appear.
+ */
+export interface ExportedRule {
+  pathPattern: string;
+  method?: string;
+  methods?: string[];
+  targetUrl: string;
+  stripPrefix?: boolean;
+  order?: number;
+  timeout?: number;
+  preserveHost?: boolean;
+  forwardCookies?: boolean;
+  headerConfig?: ProxyHeaderConfig;
+  authTransform?: AuthTransformConfig;
+  internalRewrite?: boolean;
+  proxyType?: ProxyType;
+  emailHandlerConfig?: EmailHandlerConfig;
+  pipelineConfig?: PipelineConfig;
+  isEnabled?: boolean;
+  debugEnabled?: boolean;
+  description?: string;
+}
+
+/** The v2 export envelope. Mirrors the CLI's `RuleSetExport`. */
+export interface RuleSetExport {
+  version: 2;
+  exportedAt: string;
+  kind: 'bffless-proxy-rule-set';
+  ruleSet: { name: string; description?: string; environment?: string };
+  rules: ExportedRule[];
+  schemas?: ExportedSchema[];
+}
+
+/**
+ * Header `add` values can hold secrets (API keys, bearer tokens) and reach this
+ * code DECRYPTED (`getRulesByRuleSetId` decrypts them). We deliberately do NOT
+ * export their values — exports keep the header names but blank every value to
+ * `''`, so the user re-enters secrets after import (sync preserves live values
+ * for blanked entries — decision 1 in the Phase 1 plan). `forward`/`strip`
+ * arrays pass through untouched; `null`/`undefined` input → `undefined` output
+ * so the key is dropped at the rule top level.
+ */
+export function sanitizeHeaderConfigForExport(
+  headerConfig: ProxyHeaderConfig | null | undefined,
+): ProxyHeaderConfig | undefined {
+  if (headerConfig === null || headerConfig === undefined) return undefined;
+  if (!headerConfig.add) return headerConfig;
+  const blankedAdd: Record<string, string> = {};
+  for (const key of Object.keys(headerConfig.add)) {
+    blankedAdd[key] = '';
+  }
+  return { ...headerConfig, add: blankedAdd };
+}
+
+/**
+ * Serialize a DB proxy-rule row into its canonical exported form: emit exactly
+ * the `RULE_KEY_ORDER` keys, in that order, dropping `null`/`undefined` at the
+ * rule top level only. `headerConfig` goes through
+ * {@link sanitizeHeaderConfigForExport}; all other nested objects
+ * (`pipelineConfig`, `authTransform`, `emailHandlerConfig`) pass through
+ * verbatim, including any nested nulls. Server-managed fields (`id`,
+ * `ruleSetId`, `createdAt`, `updatedAt`) are never emitted.
+ */
+export function serializeRuleForExport(rule: Partial<ProxyRule>): ExportedRule {
+  const out: Record<string, unknown> = {};
+  for (const key of RULE_KEY_ORDER) {
+    const value =
+      key === 'headerConfig'
+        ? sanitizeHeaderConfigForExport(rule.headerConfig)
+        : (rule as Record<string, unknown>)[key];
+    if (value === null || value === undefined) continue;
+    out[key] = value;
+  }
+  return out as unknown as ExportedRule;
+}
+
+export interface BuildExportEnvelopeInput {
+  /** Rule set metadata; `description`/`environment` may be null (DB shape) and are stripped. */
+  ruleSet: { name: string; description?: string | null; environment?: string | null };
+  /**
+   * ALREADY-SERIALIZED rules — the caller runs each DB row through
+   * {@link serializeRuleForExport} first (Task 2 needs the serialized form for
+   * `collectSchemaIds` anyway). Passed through verbatim; raw DB rows are NOT
+   * accepted here.
+   */
+  rules: ExportedRule[];
+  /** Bundled schema definitions; the `schemas` key is omitted when empty/undefined. */
+  schemas?: ExportedSchema[];
+  /** ISO-8601 timestamp for the export. */
+  exportedAt: string;
+}
+
+/**
+ * Build the v2 export envelope with keys in `ENVELOPE_KEY_ORDER`. `ruleSet`
+ * keys with `null`/`undefined` values are stripped (structural level); the
+ * `schemas` key is omitted entirely when the list is empty or undefined.
+ */
+export function buildExportEnvelope(input: BuildExportEnvelopeInput): RuleSetExport {
+  const ruleSet: RuleSetExport['ruleSet'] = { name: input.ruleSet.name };
+  if (input.ruleSet.description !== null && input.ruleSet.description !== undefined) {
+    ruleSet.description = input.ruleSet.description;
+  }
+  if (input.ruleSet.environment !== null && input.ruleSet.environment !== undefined) {
+    ruleSet.environment = input.ruleSet.environment;
+  }
+
+  const envelope: RuleSetExport = {
+    version: 2,
+    exportedAt: input.exportedAt,
+    kind: 'bffless-proxy-rule-set',
+    ruleSet,
+    rules: input.rules,
+  };
+  if (input.schemas && input.schemas.length > 0) {
+    envelope.schemas = input.schemas;
+  }
+  return envelope;
+}

--- a/apps/backend/src/proxy-rules/export-format.util.ts
+++ b/apps/backend/src/proxy-rules/export-format.util.ts
@@ -137,6 +137,10 @@ export function serializeRuleForExport(rule: Partial<ProxyRule>): ExportedRule {
         ? sanitizeHeaderConfigForExport(rule.headerConfig)
         : (rule as Record<string, unknown>)[key];
     if (value === null || value === undefined) continue;
+    // methods [] means "fall back to method" (see proxy-rules.schema.ts) — the
+    // same as absent. Sync normalizes [] ≡ null, so exporting a literal []
+    // would be permanent, push-unfixable drift for diff. Drop it.
+    if (key === 'methods' && Array.isArray(value) && value.length === 0) continue;
     out[key] = value;
   }
   return out as unknown as ExportedRule;

--- a/apps/backend/src/proxy-rules/export-format.util.ts
+++ b/apps/backend/src/proxy-rules/export-format.util.ts
@@ -162,8 +162,9 @@ export interface BuildExportEnvelopeInput {
  * Canonical rule sort — mirrors `sortRules` in `packages/cli/src/format/canonical.ts`:
  * `(order ?? 0, pathPattern, method ?? '')`. The DB query's `asc(order)` alone has no
  * tie-break, so without this the envelope byte-order would depend on insertion order.
+ * Exported for the sync endpoint's `contentHash` (same canonical order there).
  */
-function canonicalRuleCompare(a: ExportedRule, b: ExportedRule): number {
+export function canonicalRuleCompare(a: ExportedRule, b: ExportedRule): number {
   const oa = a.order ?? 0;
   const ob = b.order ?? 0;
   if (oa !== ob) return oa - ob;

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.controller.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.controller.spec.ts
@@ -1,12 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
-import { PATH_METADATA, METHOD_METADATA } from '@nestjs/common/constants';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PATH_METADATA, METHOD_METADATA, GUARDS_METADATA } from '@nestjs/common/constants';
 import { RequestMethod } from '@nestjs/common';
 import { ProxyRuleSetsController } from './proxy-rule-sets.controller';
 import { ProxyRuleSetsService } from './proxy-rule-sets.service';
 import { ProxyRulesService } from './proxy-rules.service';
+import { ApiKeyGuard } from '../auth/api-key.guard';
 import { CurrentUserData } from '../auth/decorators/current-user.decorator';
 import type { RuleSetExport } from './export-format.util';
+import type { SyncProxyRuleSetDto, SyncProxyRuleSetResponseDto } from './dto';
 
 describe('ProxyRuleSetsController', () => {
   let controller: ProxyRuleSetsController;
@@ -38,6 +40,7 @@ describe('ProxyRuleSetsController', () => {
       copy: jest.fn(),
       importRuleSet: jest.fn(),
       exportRuleSet: jest.fn(),
+      syncRuleSet: jest.fn(),
     } as unknown as jest.Mocked<ProxyRuleSetsService>;
 
     mockProxyRulesService = {
@@ -99,6 +102,89 @@ describe('ProxyRuleSetsController', () => {
       mockProxyRuleSetsService.getById.mockResolvedValue(null);
 
       await expect(controller.getById('missing', mockUser)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('sync', () => {
+    const syncDto = {
+      ruleSet: { name: 'studio' },
+      rules: [{ pathPattern: '/api/*', targetUrl: 'https://api.example.com' }],
+      options: { dryRun: true },
+    } as SyncProxyRuleSetDto;
+
+    const syncResponse: SyncProxyRuleSetResponseDto = {
+      ruleSetId: 'rule-set-1',
+      created: [],
+      updated: [],
+      deleted: [],
+      unchanged: [{ pathPattern: '/api/*', method: null }],
+      pruneCandidates: [],
+      schemaResolutions: [],
+      missingSecrets: [],
+      warnings: [],
+      dryRun: true,
+      setCreated: false,
+    };
+
+    it('delegates to the service with the full user context', async () => {
+      mockProxyRuleSetsService.syncRuleSet.mockResolvedValue(syncResponse);
+
+      const result = await controller.sync('project-1', syncDto, mockUser);
+
+      expect(result).toBe(syncResponse);
+      expect(mockProxyRuleSetsService.syncRuleSet).toHaveBeenCalledWith(
+        'project-1',
+        syncDto,
+        'user-1',
+        'admin',
+        'project-1',
+      );
+    });
+
+    it("defaults the role to 'user' when the current user has none", async () => {
+      mockProxyRuleSetsService.syncRuleSet.mockResolvedValue(syncResponse);
+
+      await controller.sync('project-1', syncDto, { ...mockUser, role: undefined });
+
+      expect(mockProxyRuleSetsService.syncRuleSet).toHaveBeenCalledWith(
+        'project-1',
+        syncDto,
+        'user-1',
+        'user',
+        'project-1',
+      );
+    });
+
+    it('is wired as PUT project/:projectId/sync', () => {
+      expect(Reflect.getMetadata(PATH_METADATA, controller.sync)).toBe('project/:projectId/sync');
+      expect(Reflect.getMetadata(METHOD_METADATA, controller.sync)).toBe(RequestMethod.PUT);
+    });
+
+    it('inherits the class-level ApiKeyGuard', () => {
+      const guards = Reflect.getMetadata(GUARDS_METADATA, ProxyRuleSetsController) as unknown[];
+      expect(guards).toContain(ApiKeyGuard);
+      // No method-level override that could weaken the class guard
+      expect(Reflect.getMetadata(GUARDS_METADATA, controller.sync)).toBeUndefined();
+    });
+
+    it('passes validation-type errors (400) through from the service', async () => {
+      mockProxyRuleSetsService.syncRuleSet.mockRejectedValue(
+        new BadRequestException('Duplicate rule for path pattern "/api/*"'),
+      );
+
+      await expect(controller.sync('project-1', syncDto, mockUser)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('passes NotFoundException through when the project is missing', async () => {
+      mockProxyRuleSetsService.syncRuleSet.mockRejectedValue(
+        new NotFoundException('Project project-1 not found'),
+      );
+
+      await expect(controller.sync('project-1', syncDto, mockUser)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.controller.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.controller.spec.ts
@@ -1,0 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { PATH_METADATA, METHOD_METADATA } from '@nestjs/common/constants';
+import { RequestMethod } from '@nestjs/common';
+import { ProxyRuleSetsController } from './proxy-rule-sets.controller';
+import { ProxyRuleSetsService } from './proxy-rule-sets.service';
+import { ProxyRulesService } from './proxy-rules.service';
+import { CurrentUserData } from '../auth/decorators/current-user.decorator';
+import type { RuleSetExport } from './export-format.util';
+
+describe('ProxyRuleSetsController', () => {
+  let controller: ProxyRuleSetsController;
+  let mockProxyRuleSetsService: jest.Mocked<ProxyRuleSetsService>;
+  let mockProxyRulesService: jest.Mocked<ProxyRulesService>;
+
+  const mockUser: CurrentUserData = {
+    id: 'user-1',
+    email: 'test@example.com',
+    role: 'admin',
+    apiKeyProjectId: 'project-1',
+  };
+
+  const mockEnvelope: RuleSetExport = {
+    version: 2,
+    exportedAt: '2026-07-11T00:00:00.000Z',
+    kind: 'bffless-proxy-rule-set',
+    ruleSet: { name: 'api-backend' },
+    rules: [{ pathPattern: '/api/*', targetUrl: 'https://api.example.com' }],
+  };
+
+  beforeEach(async () => {
+    mockProxyRuleSetsService = {
+      listByProject: jest.fn(),
+      getById: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      copy: jest.fn(),
+      importRuleSet: jest.fn(),
+      exportRuleSet: jest.fn(),
+    } as unknown as jest.Mocked<ProxyRuleSetsService>;
+
+    mockProxyRulesService = {
+      getRulesByRuleSetId: jest.fn(),
+      create: jest.fn(),
+      reorder: jest.fn(),
+    } as unknown as jest.Mocked<ProxyRulesService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProxyRuleSetsController],
+      providers: [
+        { provide: ProxyRuleSetsService, useValue: mockProxyRuleSetsService },
+        { provide: ProxyRulesService, useValue: mockProxyRulesService },
+      ],
+    }).compile();
+
+    controller = module.get<ProxyRuleSetsController>(ProxyRuleSetsController);
+  });
+
+  describe('export', () => {
+    it('returns the export envelope from the service', async () => {
+      mockProxyRuleSetsService.exportRuleSet.mockResolvedValue(mockEnvelope);
+
+      const result = await controller.export('rule-set-1', mockUser);
+
+      expect(result).toBe(mockEnvelope);
+      expect(mockProxyRuleSetsService.exportRuleSet).toHaveBeenCalledWith(
+        'rule-set-1',
+        'project-1',
+      );
+    });
+
+    it('passes NotFoundException through from the service', async () => {
+      mockProxyRuleSetsService.exportRuleSet.mockRejectedValue(
+        new NotFoundException('Rule set missing not found'),
+      );
+
+      await expect(controller.export('missing', mockUser)).rejects.toThrow(NotFoundException);
+    });
+
+    it('is wired as GET :id/export', () => {
+      expect(Reflect.getMetadata(PATH_METADATA, controller.export)).toBe(':id/export');
+      expect(Reflect.getMetadata(METHOD_METADATA, controller.export)).toBe(RequestMethod.GET);
+    });
+
+    it('is declared before GET :id so the static segment is never shadowed', () => {
+      // Nest registers routes in declaration order; ':id/export' must register
+      // before ':id' (belt-and-braces — Express matches ':id/export' anyway
+      // because of the extra path segment, but declaration order keeps this
+      // unambiguous).
+      const methodNames = Object.getOwnPropertyNames(ProxyRuleSetsController.prototype);
+      expect(methodNames.indexOf('export')).toBeGreaterThan(-1);
+      expect(methodNames.indexOf('export')).toBeLessThan(methodNames.indexOf('getById'));
+    });
+  });
+
+  describe('getById', () => {
+    it('throws NotFoundException when the service returns null', async () => {
+      mockProxyRuleSetsService.getById.mockResolvedValue(null);
+
+      await expect(controller.getById('missing', mockUser)).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.controller.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.controller.ts
@@ -32,6 +32,7 @@ import {
   ProxyRuleResponseDto,
   ProxyRulesListResponseDto,
   ImportProxyRuleSetDto,
+  ExportProxyRuleSetResponseDto,
 } from './dto';
 import { ApiKeyGuard } from '../auth/api-key.guard';
 import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
@@ -108,6 +109,36 @@ export class ProxyRuleSetsController {
       user.role || 'user',
       user.apiKeyProjectId,
     );
+  }
+
+  // NOTE: declared before GET ':id' — Nest registers routes in declaration
+  // order, so the static '/export' segment must come first to guarantee it is
+  // never shadowed by the plain ':id' route.
+  @Get(':id/export')
+  @ApiOperation({
+    summary: 'Export a rule set as the canonical v2 envelope',
+    description:
+      'Server-side export (closes #448 — the export format is no longer a frontend contract). ' +
+      'Returns the v2 envelope accepted verbatim by the bffless CLI: rule keys in canonical ' +
+      'order (including methods), header add secret values blanked to empty strings, and the ' +
+      'schema definitions referenced by pipeline rules bundled under schemas (omitted when none).',
+  })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiResponse({
+    status: 200,
+    description: 'The v2 export envelope',
+    type: ExportProxyRuleSetResponseDto,
+  })
+  @ApiResponse({ status: 403, description: 'Not authorized' })
+  @ApiResponse({ status: 404, description: 'Rule set not found' })
+  async export(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: CurrentUserData,
+  ): Promise<ExportProxyRuleSetResponseDto> {
+    const envelope = await this.proxyRuleSetsService.exportRuleSet(id, user.apiKeyProjectId);
+    // RuleSetExport is the runtime shape (db schema types); the DTO class only
+    // exists for Swagger — same bridging cast as the other rule responses.
+    return envelope as unknown as ExportProxyRuleSetResponseDto;
   }
 
   @Get(':id')

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.controller.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.controller.ts
@@ -33,6 +33,8 @@ import {
   ProxyRulesListResponseDto,
   ImportProxyRuleSetDto,
   ExportProxyRuleSetResponseDto,
+  SyncProxyRuleSetDto,
+  SyncProxyRuleSetResponseDto,
 } from './dto';
 import { ApiKeyGuard } from '../auth/api-key.guard';
 import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
@@ -103,6 +105,40 @@ export class ProxyRuleSetsController {
     @CurrentUser() user: CurrentUserData,
   ): Promise<ProxyRuleSetWithRulesResponseDto> {
     return this.proxyRuleSetsService.importRuleSet(
+      projectId,
+      dto,
+      user.id,
+      user.role || 'user',
+      user.apiKeyProjectId,
+    );
+  }
+
+  @Put('project/:projectId/sync')
+  @ApiOperation({
+    summary: 'Idempotently sync a rule set from a rules-as-code payload',
+    description:
+      'Declarative counterpart of import (Phase 1 of proxy-rules-as-code). The payload is the ' +
+      'desired state: rules match live rows on (pathPattern, method); only real differences are ' +
+      'written, live-only rules are deleted only under options.prune, bundled schemas resolve by ' +
+      'name, and blank header add values preserve the live secret. options.dryRun returns the ' +
+      'full change plan without writing. Stamps source (syncedAt/contentHash + caller-supplied ' +
+      'repo/path/gitSha) on the set and regenerates nginx when anything changed.',
+  })
+  @ApiParam({ name: 'projectId', type: 'string' })
+  @ApiResponse({
+    status: 200,
+    description: 'The sync change report (also the dryRun plan)',
+    type: SyncProxyRuleSetResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid payload (duplicate rule keys, forbidden targetUrl, strict schema mismatch)' })
+  @ApiResponse({ status: 403, description: 'Not authorized' })
+  @ApiResponse({ status: 404, description: 'Project not found' })
+  async sync(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Body() dto: SyncProxyRuleSetDto,
+    @CurrentUser() user: CurrentUserData,
+  ): Promise<SyncProxyRuleSetResponseDto> {
+    return this.proxyRuleSetsService.syncRuleSet(
       projectId,
       dto,
       user.id,

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
@@ -1,0 +1,353 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ProxyRuleSetsService } from './proxy-rule-sets.service';
+import { ProxyRulesService } from './proxy-rules.service';
+import { PermissionsService } from '../permissions/permissions.service';
+import { NginxRegenerationService } from '../domains/nginx-regeneration.service';
+import { PipelineSchemasService } from '../pipelines/pipeline-schemas.service';
+import { ENVELOPE_KEY_ORDER, RULE_KEY_ORDER } from './export-format.util';
+
+// Mock the db client - using factory function for hoisting
+jest.mock('../db/client', () => {
+  const mockResults: { data: unknown[] }[] = [];
+  let callIdx = 0;
+
+  const chainable = {
+    select: jest.fn(() => chainable),
+    from: jest.fn(() => chainable),
+    where: jest.fn(() => chainable),
+    orderBy: jest.fn(() => {
+      const result = mockResults[callIdx]?.data || [];
+      callIdx++;
+      return Promise.resolve(result);
+    }),
+    limit: jest.fn(() => {
+      const result = mockResults[callIdx]?.data || [];
+      callIdx++;
+      return Promise.resolve(result);
+    }),
+    insert: jest.fn(() => chainable),
+    values: jest.fn(() => chainable),
+    returning: jest.fn(() => {
+      const result = mockResults[callIdx]?.data || [{ id: 'test-id' }];
+      callIdx++;
+      return Promise.resolve(result);
+    }),
+    update: jest.fn(() => chainable),
+    set: jest.fn(() => chainable),
+    delete: jest.fn(() => chainable),
+    __setResults: (results: unknown[][]) => {
+      mockResults.length = 0;
+      results.forEach((r) => mockResults.push({ data: r }));
+      callIdx = 0;
+    },
+    __reset: () => {
+      mockResults.length = 0;
+      callIdx = 0;
+    },
+  };
+
+  return { db: chainable };
+});
+
+import { db } from '../db/client';
+const mockDb = db as unknown as {
+  __setResults: (results: unknown[][]) => void;
+  __reset: () => void;
+};
+
+describe('ProxyRuleSetsService', () => {
+  let service: ProxyRuleSetsService;
+
+  const mockPermissionsService = {
+    requireProjectAccess: jest.fn().mockResolvedValue(undefined),
+    enforceApiKeyProjectScope: jest.fn(),
+  };
+
+  const mockProxyRulesService = {
+    getRulesByRuleSetId: jest.fn(),
+    encryptHeaderConfigForStorage: jest.fn((hc: unknown) => hc),
+  };
+
+  const mockNginxRegenerationService = {
+    regenerateForRuleSet: jest.fn().mockResolvedValue(undefined),
+    regenerateForAlias: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockPipelineSchemasService = {
+    getById: jest.fn(),
+    getByProjectId: jest.fn(),
+    create: jest.fn(),
+  };
+
+  const createMockRuleSet = (overrides: Record<string, unknown> = {}) => ({
+    id: 'rule-set-1',
+    projectId: 'project-1',
+    name: 'api-backend',
+    description: 'API proxy rules',
+    environment: 'production',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-02T00:00:00Z'),
+    ...overrides,
+  });
+
+  // DB-shaped rule row as getRulesByRuleSetId returns it (headerConfig decrypted)
+  const createMockRule = (overrides: Record<string, unknown> = {}) => ({
+    id: 'rule-1',
+    ruleSetId: 'rule-set-1',
+    pathPattern: '/api/*',
+    method: null,
+    methods: null,
+    targetUrl: 'https://api.example.com',
+    stripPrefix: true,
+    order: 0,
+    timeout: 30000,
+    preserveHost: false,
+    forwardCookies: false,
+    headerConfig: null,
+    authTransform: null,
+    internalRewrite: false,
+    proxyType: 'external_proxy' as const,
+    emailHandlerConfig: null,
+    pipelineConfig: null,
+    isEnabled: true,
+    description: null,
+    debugEnabled: false,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-02T00:00:00Z'),
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    mockDb.__reset();
+    jest.clearAllMocks();
+    mockPermissionsService.requireProjectAccess.mockResolvedValue(undefined);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProxyRuleSetsService,
+        { provide: PermissionsService, useValue: mockPermissionsService },
+        { provide: ProxyRulesService, useValue: mockProxyRulesService },
+        { provide: NginxRegenerationService, useValue: mockNginxRegenerationService },
+        { provide: PipelineSchemasService, useValue: mockPipelineSchemasService },
+      ],
+    }).compile();
+
+    service = module.get<ProxyRuleSetsService>(ProxyRuleSetsService);
+  });
+
+  describe('exportRuleSet', () => {
+    it('returns the canonical v2 envelope with keys in ENVELOPE_KEY_ORDER', async () => {
+      mockDb.__setResults([[createMockRuleSet()]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([createMockRule()]);
+
+      const before = Date.now();
+      const result = await service.exportRuleSet('rule-set-1');
+      const after = Date.now();
+
+      expect(result.version).toBe(2);
+      expect(result.kind).toBe('bffless-proxy-rule-set');
+      expect(result.ruleSet).toEqual({
+        name: 'api-backend',
+        description: 'API proxy rules',
+        environment: 'production',
+      });
+      // No schemas referenced → schemas key omitted entirely
+      expect(Object.keys(result)).toEqual(
+        ENVELOPE_KEY_ORDER.filter((k) => k !== 'schemas'),
+      );
+      // Fresh exportedAt: valid ISO timestamp within this test's window
+      const exportedAt = Date.parse(result.exportedAt);
+      expect(exportedAt).toBeGreaterThanOrEqual(before);
+      expect(exportedAt).toBeLessThanOrEqual(after);
+    });
+
+    it('serializes rules with all populated RULE_KEY_ORDER keys, including methods (#448)', async () => {
+      mockDb.__setResults([[createMockRuleSet()]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([
+        createMockRule({
+          method: 'GET',
+          methods: ['GET', 'POST'],
+          headerConfig: { forward: ['accept'] },
+          authTransform: { type: 'cookie-to-bearer' },
+          emailHandlerConfig: { destinationEmail: 'a@b.c' },
+          pipelineConfig: { name: 'p', steps: [{ name: 's', handlerType: 'data_query', config: {} }] },
+          description: 'a rule',
+        }),
+      ]);
+
+      const result = await service.exportRuleSet('rule-set-1');
+
+      expect(result.rules).toHaveLength(1);
+      const rule = result.rules[0];
+      // Every RULE_KEY_ORDER key populated → all 18 present, in canonical order
+      expect(Object.keys(rule)).toEqual([...RULE_KEY_ORDER]);
+      expect(rule.methods).toEqual(['GET', 'POST']);
+      // Server-managed fields never appear
+      expect(rule).not.toHaveProperty('id');
+      expect(rule).not.toHaveProperty('ruleSetId');
+      expect(rule).not.toHaveProperty('createdAt');
+      expect(rule).not.toHaveProperty('updatedAt');
+    });
+
+    it('drops null-valued keys at the rule top level', async () => {
+      mockDb.__setResults([[createMockRuleSet()]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([createMockRule()]);
+
+      const result = await service.exportRuleSet('rule-set-1');
+
+      const rule = result.rules[0];
+      expect(rule).not.toHaveProperty('method');
+      expect(rule).not.toHaveProperty('methods');
+      expect(rule).not.toHaveProperty('headerConfig');
+      expect(rule).not.toHaveProperty('description');
+    });
+
+    it('blanks header add secret values to empty strings', async () => {
+      mockDb.__setResults([[createMockRuleSet()]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([
+        createMockRule({
+          headerConfig: {
+            forward: ['accept'],
+            strip: ['cookie'],
+            add: { 'X-API-Key': 'sk_live_secret', Authorization: 'Bearer token' },
+          },
+        }),
+      ]);
+
+      const result = await service.exportRuleSet('rule-set-1');
+
+      expect(result.rules[0].headerConfig).toEqual({
+        forward: ['accept'],
+        strip: ['cookie'],
+        add: { 'X-API-Key': '', Authorization: '' },
+      });
+      expect(JSON.stringify(result)).not.toContain('sk_live_secret');
+      expect(JSON.stringify(result)).not.toContain('Bearer token');
+    });
+
+    it('bundles referenced schemas as {id, name, fields}', async () => {
+      mockDb.__setResults([[createMockRuleSet()]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([
+        createMockRule({
+          proxyType: 'pipeline',
+          targetUrl: 'http://internal/pipeline',
+          pipelineConfig: {
+            name: 'comments',
+            steps: [{ name: 'query', handlerType: 'data_query', config: { schemaId: 'schema-1' } }],
+          },
+        }),
+      ]);
+      mockPipelineSchemasService.getById.mockResolvedValue({
+        id: 'schema-1',
+        projectId: 'project-1',
+        name: 'comments',
+        fields: [{ name: 'body', type: 'string', required: true }],
+        version: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await service.exportRuleSet('rule-set-1');
+
+      expect(mockPipelineSchemasService.getById).toHaveBeenCalledWith('schema-1');
+      expect(result.schemas).toEqual([
+        {
+          id: 'schema-1',
+          name: 'comments',
+          fields: [{ name: 'body', type: 'string', required: true }],
+        },
+      ]);
+      // schemas is the last envelope key
+      expect(Object.keys(result)).toEqual([...ENVELOPE_KEY_ORDER]);
+    });
+
+    it('skips missing schemas silently (frontend export parity)', async () => {
+      mockDb.__setResults([[createMockRuleSet()]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([
+        createMockRule({
+          proxyType: 'pipeline',
+          targetUrl: 'http://internal/pipeline',
+          pipelineConfig: {
+            name: 'comments',
+            steps: [{ name: 'query', handlerType: 'data_query', config: { schemaId: 'schema-gone' } }],
+          },
+        }),
+      ]);
+      mockPipelineSchemasService.getById.mockResolvedValue(null);
+
+      const result = await service.exportRuleSet('rule-set-1');
+
+      // Left as an unbundled reference; schemas key omitted entirely
+      expect(result).not.toHaveProperty('schemas');
+      expect(result.rules[0].pipelineConfig).toEqual({
+        name: 'comments',
+        steps: [{ name: 'query', handlerType: 'data_query', config: { schemaId: 'schema-gone' } }],
+      });
+    });
+
+    it('skips schemas belonging to another project', async () => {
+      mockDb.__setResults([[createMockRuleSet()]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([
+        createMockRule({
+          proxyType: 'pipeline',
+          targetUrl: 'http://internal/pipeline',
+          pipelineConfig: {
+            name: 'comments',
+            steps: [{ name: 'query', handlerType: 'data_query', config: { schemaId: 'schema-other' } }],
+          },
+        }),
+      ]);
+      mockPipelineSchemasService.getById.mockResolvedValue({
+        id: 'schema-other',
+        projectId: 'project-OTHER',
+        name: 'foreign',
+        fields: [{ name: 'x', type: 'string' }],
+      });
+
+      const result = await service.exportRuleSet('rule-set-1');
+
+      expect(result).not.toHaveProperty('schemas');
+    });
+
+    it('throws NotFoundException when the rule set does not exist', async () => {
+      mockDb.__setResults([[]]);
+
+      await expect(service.exportRuleSet('missing-set')).rejects.toThrow(NotFoundException);
+      expect(mockProxyRulesService.getRulesByRuleSetId).not.toHaveBeenCalled();
+    });
+
+    it('enforces API key project scope against the rule set project (getById parity)', async () => {
+      mockDb.__setResults([[createMockRuleSet()]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([]);
+
+      await service.exportRuleSet('rule-set-1', 'project-1');
+
+      expect(mockPermissionsService.enforceApiKeyProjectScope).toHaveBeenCalledWith(
+        'project-1',
+        'project-1',
+      );
+    });
+
+    it('propagates scope-enforcement failures before loading rules', async () => {
+      mockDb.__setResults([[createMockRuleSet()]]);
+      mockPermissionsService.enforceApiKeyProjectScope.mockImplementationOnce(() => {
+        throw new ForbiddenException('API key is scoped to a different project');
+      });
+
+      await expect(service.exportRuleSet('rule-set-1', 'other-project')).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockProxyRulesService.getRulesByRuleSetId).not.toHaveBeenCalled();
+    });
+
+    it('omits null description/environment from ruleSet metadata', async () => {
+      mockDb.__setResults([[createMockRuleSet({ description: null, environment: null })]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([]);
+
+      const result = await service.exportRuleSet('rule-set-1');
+
+      expect(result.ruleSet).toEqual({ name: 'api-backend' });
+    });
+  });
+});

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
@@ -36,6 +36,13 @@ jest.mock('../db/client', () => {
     update: jest.fn(() => chainable),
     set: jest.fn(() => chainable),
     delete: jest.fn(() => chainable),
+    // Transaction mock: invokes the callback with the SAME chainable as the tx
+    // handle, so writes inside a transaction register on the shared jest.fns
+    // and the mockResults slot accounting continues seamlessly. A throw inside
+    // the callback propagates out (real drizzle rolls the transaction back on
+    // throw — the rollback test asserts the error escapes un-swallowed and no
+    // post-commit effect runs).
+    transaction: jest.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(chainable)),
     __setResults: (results: unknown[][]) => {
       mockResults.length = 0;
       results.forEach((r) => mockResults.push({ data: r }));
@@ -54,6 +61,14 @@ import { db } from '../db/client';
 const mockDb = db as unknown as {
   __setResults: (results: unknown[][]) => void;
   __reset: () => void;
+  insert: jest.Mock;
+  values: jest.Mock;
+  returning: jest.Mock;
+  update: jest.Mock;
+  set: jest.Mock;
+  delete: jest.Mock;
+  where: jest.Mock;
+  transaction: jest.Mock;
 };
 
 describe('ProxyRuleSetsService', () => {
@@ -620,6 +635,509 @@ describe('ProxyRuleSetsService', () => {
         ),
       ).rejects.toThrow(BadRequestException);
       expect(mockPipelineSchemasService.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('syncRuleSet', () => {
+    const mockProject = { id: 'project-1', name: 'Project One' };
+
+    /** Minimal incoming rule matching createMockRule() once defaults apply. */
+    const baseRule = () => ({
+      pathPattern: '/api/*',
+      targetUrl: 'https://api.example.com',
+    });
+
+    const syncDto = (overrides: Record<string, unknown> = {}) => ({
+      ruleSet: { name: 'api-backend', description: 'API proxy rules', environment: 'production' },
+      rules: [baseRule()],
+      ...overrides,
+    });
+
+    const sync = (dto: Record<string, unknown>) =>
+      service.syncRuleSet(
+        'project-1',
+        dto as unknown as Parameters<typeof service.syncRuleSet>[1],
+        'user-1',
+        'admin',
+        'project-1',
+      );
+
+    beforeEach(() => {
+      // Tag encrypted values so specs can assert the exact encrypted form
+      // (in particular: blank-secret preservation encrypts the LIVE value).
+      mockProxyRulesService.encryptHeaderConfigForStorage.mockImplementation(
+        (hc: { add?: Record<string, string> } | null) => {
+          if (!hc) return null;
+          if (!hc.add) return { ...hc };
+          return {
+            ...hc,
+            add: Object.fromEntries(
+              Object.entries(hc.add).map(([k, v]) => [k, `enc(${v})`]),
+            ),
+          };
+        },
+      );
+      mockPipelineSchemasService.getByProjectId.mockResolvedValue([]);
+    });
+
+    it('throws NotFoundException when the project does not exist', async () => {
+      mockDb.__setResults([[]]);
+
+      await expect(sync(syncDto())).rejects.toThrow(NotFoundException);
+      expect(mockDb.transaction).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent: re-syncing a payload whose live rules already match writes no rules but re-stamps source', async () => {
+      // Live rules mocked as the DB result of having synced this very payload
+      mockDb.__setResults([[mockProject], [createMockRuleSet()]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([createMockRule()]);
+
+      const result = await sync(syncDto());
+
+      expect(mockPermissionsService.requireProjectAccess).toHaveBeenCalledWith(
+        'project-1',
+        'user-1',
+        'admin',
+        'contributor',
+        'project-1',
+      );
+      expect(result).toMatchObject({
+        ruleSetId: 'rule-set-1',
+        created: [],
+        updated: [],
+        deleted: [],
+        unchanged: [{ pathPattern: '/api/*', method: null }],
+        pruneCandidates: [],
+        missingSecrets: [],
+        warnings: [],
+        dryRun: false,
+        setCreated: false,
+      });
+
+      // NO rule writes …
+      expect(mockDb.insert).not.toHaveBeenCalled();
+      expect(mockDb.delete).not.toHaveBeenCalled();
+      // … but ONE transaction whose only write re-stamps source on the set row
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+      expect(mockDb.update).toHaveBeenCalledTimes(1);
+      const stamped = mockDb.set.mock.calls[0][0];
+      expect(stamped.source.contentHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(Date.parse(stamped.source.syncedAt)).not.toBeNaN();
+      // Unchanged metadata is not rewritten
+      expect(stamped.description).toBeUndefined();
+      expect(stamped.environment).toBeUndefined();
+      // Nothing changed → no nginx regeneration
+      expect(mockNginxRegenerationService.regenerateForRuleSet).not.toHaveBeenCalled();
+    });
+
+    it('stamps the same contentHash for the same payload on consecutive syncs', async () => {
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([createMockRule()]);
+
+      mockDb.__setResults([[mockProject], [createMockRuleSet()]]);
+      await sync(syncDto());
+      mockDb.__setResults([[mockProject], [createMockRuleSet()]]);
+      await sync(syncDto());
+
+      const calls = mockDb.set.mock.calls;
+      expect(calls).toHaveLength(2);
+      expect(calls[0][0].source.contentHash).toBe(calls[1][0].source.contentHash);
+    });
+
+    it('creates the set and all rules from scratch, stamping source and regenerating nginx once', async () => {
+      mockDb.__setResults([
+        [mockProject],
+        [], // findByName: no existing set
+        [createMockRuleSet({ id: 'new-set-id', name: 'api-backend' })], // insert … returning
+      ]);
+
+      const result = await sync(
+        syncDto({
+          rules: [{ ...baseRule(), headerConfig: { add: { 'X-Api-Key': 'secretv' } } }],
+          source: { repo: 'bffless/apps', path: 'apps/studio/.bffless/proxy-rules/studio', gitSha: 'abc123' },
+        }),
+      );
+
+      expect(result).toMatchObject({
+        ruleSetId: 'new-set-id',
+        created: [{ pathPattern: '/api/*', method: null }],
+        updated: [],
+        deleted: [],
+        unchanged: [],
+        dryRun: false,
+        setCreated: true,
+      });
+
+      // First values() call: the set row, with caller source + server stamp merged
+      const setValues = mockDb.values.mock.calls[0][0];
+      expect(setValues).toMatchObject({
+        projectId: 'project-1',
+        name: 'api-backend',
+        description: 'API proxy rules',
+        environment: 'production',
+      });
+      expect(setValues.source).toMatchObject({
+        repo: 'bffless/apps',
+        path: 'apps/studio/.bffless/proxy-rules/studio',
+        gitSha: 'abc123',
+      });
+      expect(setValues.source.contentHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(Date.parse(setValues.source.syncedAt)).not.toBeNaN();
+
+      // Second values() call: the rule row, defaults applied, header add encrypted
+      const ruleValues = mockDb.values.mock.calls[1][0];
+      expect(ruleValues).toMatchObject({
+        ruleSetId: 'new-set-id',
+        pathPattern: '/api/*',
+        method: null,
+        targetUrl: 'https://api.example.com',
+        stripPrefix: true,
+        order: 0,
+        timeout: 30000,
+        proxyType: 'external_proxy',
+        isEnabled: true,
+      });
+      expect(ruleValues.headerConfig.add).toEqual({ 'X-Api-Key': 'enc(secretv)' });
+
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+      expect(mockNginxRegenerationService.regenerateForRuleSet).toHaveBeenCalledTimes(1);
+      expect(mockNginxRegenerationService.regenerateForRuleSet).toHaveBeenCalledWith('new-set-id');
+    });
+
+    it('preserves live secret values for blank incoming header adds on update, without mutating the DTO', async () => {
+      mockDb.__setResults([[mockProject], [createMockRuleSet()]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([
+        createMockRule({ headerConfig: { add: { 'X-K': 'livesecret' } } }),
+      ]);
+
+      const incomingRule = {
+        ...baseRule(),
+        forwardCookies: true, // a real field change
+        headerConfig: { add: { 'X-K': '', 'X-N': 'newval' } },
+      };
+      const result = await sync(syncDto({ rules: [incomingRule] }));
+
+      expect(result.updated).toEqual([{ pathPattern: '/api/*', method: null }]);
+      // Blank on an UPDATED rule is preserved from live, not reported missing
+      expect(result.missingSecrets).toEqual([]);
+
+      // The rule update (the set() call carrying pathPattern) holds the LIVE
+      // value for X-K — in encrypted form — and the new value for X-N
+      const ruleUpdate = mockDb.set.mock.calls.find((call) => call[0].pathPattern)?.[0];
+      expect(ruleUpdate).toBeDefined();
+      expect(ruleUpdate.headerConfig.add).toEqual({
+        'X-K': 'enc(livesecret)',
+        'X-N': 'enc(newval)',
+      });
+      expect(ruleUpdate.forwardCookies).toBe(true);
+
+      // The request DTO objects were never mutated
+      expect(incomingRule.headerConfig.add['X-K']).toBe('');
+      expect(incomingRule.headerConfig.add['X-N']).toBe('newval');
+    });
+
+    it('reports live-only rules as pruneCandidates (no delete, no nginx) when prune is off', async () => {
+      mockDb.__setResults([[mockProject], [createMockRuleSet()]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([
+        createMockRule(),
+        createMockRule({ id: 'rule-2', pathPattern: '/old/*' }),
+      ]);
+
+      const result = await sync(syncDto());
+
+      expect(result.pruneCandidates).toEqual([{ pathPattern: '/old/*', method: null }]);
+      expect(result.deleted).toEqual([]);
+      expect(mockDb.delete).not.toHaveBeenCalled();
+      // Unchanged + pruneCandidates only → nothing changed → no nginx
+      expect(mockNginxRegenerationService.regenerateForRuleSet).not.toHaveBeenCalled();
+    });
+
+    it('deletes live-only rules when prune is on', async () => {
+      mockDb.__setResults([[mockProject], [createMockRuleSet()]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([
+        createMockRule(),
+        createMockRule({ id: 'rule-2', pathPattern: '/old/*' }),
+      ]);
+
+      const result = await sync(syncDto({ options: { prune: true } }));
+
+      expect(result.deleted).toEqual([{ pathPattern: '/old/*', method: null }]);
+      expect(result.pruneCandidates).toEqual([]);
+      expect(mockDb.delete).toHaveBeenCalledTimes(1);
+      expect(mockNginxRegenerationService.regenerateForRuleSet).toHaveBeenCalledTimes(1);
+    });
+
+    it('dryRun of a nonexistent set: full plan, ruleSetId null, ZERO writes, no nginx', async () => {
+      mockDb.__setResults([[mockProject], []]);
+
+      const result = await sync(syncDto({ options: { dryRun: true } }));
+
+      expect(result).toMatchObject({
+        ruleSetId: null,
+        created: [{ pathPattern: '/api/*', method: null }],
+        dryRun: true,
+        setCreated: true,
+      });
+      expect(mockDb.transaction).not.toHaveBeenCalled();
+      expect(mockDb.insert).not.toHaveBeenCalled();
+      expect(mockDb.update).not.toHaveBeenCalled();
+      expect(mockDb.delete).not.toHaveBeenCalled();
+      expect(mockNginxRegenerationService.regenerateForRuleSet).not.toHaveBeenCalled();
+    });
+
+    it('dryRun of an existing set returns its id and writes nothing (no source re-stamp)', async () => {
+      mockDb.__setResults([[mockProject], [createMockRuleSet()]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([createMockRule()]);
+
+      const result = await sync(syncDto({ options: { dryRun: true, prune: true } }));
+
+      expect(result.ruleSetId).toBe('rule-set-1');
+      expect(result.unchanged).toEqual([{ pathPattern: '/api/*', method: null }]);
+      expect(mockDb.transaction).not.toHaveBeenCalled();
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it('reports missing {{secrets.NAME}} references and new-rule blank header names, deduped and sorted', async () => {
+      mockDb.__setResults([
+        [mockProject],
+        [], // findByName
+        [{ name: 'BAR' }], // project_secrets names
+      ]);
+
+      const result = await sync(
+        syncDto({
+          rules: [
+            {
+              pathPattern: '/api/ai',
+              method: 'POST',
+              pipelineConfig: {
+                name: 'ai',
+                steps: [
+                  {
+                    handlerType: 'ai',
+                    config: { apiKey: '{{secrets.FOO}}', other: '{{ secrets.BAR }}' },
+                  },
+                ],
+              },
+            },
+            {
+              pathPattern: '/api/h',
+              targetUrl: 'https://x.example.com',
+              headerConfig: { add: { 'X-New-Key': '' } },
+            },
+          ],
+          options: { dryRun: true },
+        }),
+      );
+
+      // FOO has no project secret; BAR exists; the new rule's blank header
+      // add name is reported (nothing live to preserve — decision 1)
+      expect(result.missingSecrets).toEqual(['FOO', 'X-New-Key']);
+    });
+
+    it('reports blank headers on UPDATED rules only when no live value exists to preserve', async () => {
+      mockDb.__setResults([
+        [mockProject],
+        [createMockRuleSet()], // findByName → existing set
+      ]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([
+        createMockRule({
+          headerConfig: { add: { 'X-Kept': 'livesecret' } },
+        }),
+      ]);
+
+      const result = await sync(
+        syncDto({
+          rules: [
+            {
+              pathPattern: '/api/*',
+              targetUrl: 'https://api.example.com',
+              forwardCookies: true, // real change → toUpdate
+              headerConfig: { add: { 'X-Kept': '', 'X-Fresh': '' } },
+            },
+          ],
+          options: { dryRun: true },
+        }),
+      );
+
+      // X-Kept has a live value that will be preserved; X-Fresh is a brand-new
+      // blank header on an updated rule and would be stored as '' — report it.
+      expect(result.missingSecrets).toEqual(['X-Fresh']);
+    });
+
+    it('strictSchemas mismatch → 400 before any write', async () => {
+      mockDb.__setResults([[mockProject]]);
+      mockPipelineSchemasService.getByProjectId.mockResolvedValue([
+        {
+          id: 'existing-comments-id',
+          projectId: 'project-1',
+          name: 'comments',
+          fields: [{ name: 'body', type: 'text', required: true }],
+        },
+      ]);
+
+      await expect(
+        sync(
+          syncDto({
+            schemas: [{ id: 'src-1', name: 'comments', fields: [{ name: 'body', type: 'string' }] }],
+            options: { strictSchemas: true },
+          }),
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockDb.transaction).not.toHaveBeenCalled();
+      expect(mockDb.insert).not.toHaveBeenCalled();
+      expect(mockDb.update).not.toHaveBeenCalled();
+      expect(mockPipelineSchemasService.create).not.toHaveBeenCalled();
+    });
+
+    it('surfaces the computeSyncPlan duplicate-key error as a 400, before schema resolution', async () => {
+      mockDb.__setResults([[mockProject]]);
+
+      await expect(
+        sync(
+          syncDto({
+            rules: [baseRule(), { ...baseRule() }],
+            // Schemas present to prove the early duplicate check precedes
+            // resolution (which would otherwise create schemas outside the
+            // rule transaction before the 400)
+            schemas: [{ id: 'src-1', name: 'brand-new', fields: [] }],
+          }),
+        ),
+      ).rejects.toThrow(/Duplicate rule for path pattern "\/api\/\*"/);
+
+      expect(mockPipelineSchemasService.getByProjectId).not.toHaveBeenCalled();
+      expect(mockDb.transaction).not.toHaveBeenCalled();
+    });
+
+    it('rolls back on a mid-transaction write failure: error propagates, no nginx', async () => {
+      mockDb.__setResults([[mockProject], [createMockRuleSet()]]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([
+        createMockRule({ pathPattern: '/old/*' }),
+      ]);
+      // The last write of this sync is the prune delete — make it fail. The
+      // transaction mock lets the throw escape the callback, which is exactly
+      // what real drizzle does before rolling back every statement issued on tx.
+      mockDb.delete.mockImplementationOnce(() => {
+        throw new Error('write failed');
+      });
+
+      await expect(sync(syncDto({ rules: [], options: { prune: true } }))).rejects.toThrow(
+        'write failed',
+      );
+
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+      expect(mockNginxRegenerationService.regenerateForRuleSet).not.toHaveBeenCalled();
+    });
+
+    it('appends a warning (not a 500) when nginx regeneration fails after commit', async () => {
+      mockDb.__setResults([
+        [mockProject],
+        [],
+        [createMockRuleSet({ id: 'new-set-id', name: 'api-backend' })],
+      ]);
+      mockNginxRegenerationService.regenerateForRuleSet.mockRejectedValueOnce(
+        new Error('nginx down'),
+      );
+
+      const result = await sync(syncDto());
+
+      expect(result.ruleSetId).toBe('new-set-id');
+      expect(result.created).toHaveLength(1);
+      expect(result.warnings).toEqual([
+        expect.stringMatching(/nginx regeneration failed after sync: nginx down/),
+      ]);
+    });
+
+    it('returns response arrays sorted by (pathPattern, method) for byte-stable CI output', async () => {
+      mockDb.__setResults([[mockProject], []]);
+
+      const result = await sync(
+        syncDto({
+          rules: [
+            { pathPattern: '/b', targetUrl: 'https://api.example.com' },
+            { pathPattern: '/a', method: 'GET', targetUrl: 'https://api.example.com' },
+            { pathPattern: '/a', targetUrl: 'https://api.example.com' },
+          ],
+          options: { dryRun: true },
+        }),
+      );
+
+      expect(result.created).toEqual([
+        { pathPattern: '/a', method: null },
+        { pathPattern: '/a', method: 'GET' },
+        { pathPattern: '/b', method: null },
+      ]);
+    });
+
+    it('updates description/environment on the existing set when they actually changed', async () => {
+      mockDb.__setResults([
+        [mockProject],
+        [createMockRuleSet({ description: 'old desc', environment: 'staging' })],
+      ]);
+      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([createMockRule()]);
+
+      await sync(syncDto());
+
+      const stamped = mockDb.set.mock.calls[0][0];
+      expect(stamped.description).toBe('API proxy rules');
+      expect(stamped.environment).toBe('production');
+      // Metadata-only change: rule sets' description/environment don't reach
+      // nginx configs, so no regeneration
+      expect(mockNginxRegenerationService.regenerateForRuleSet).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty (whitespace-only) ruleSet.name with a 400', async () => {
+      mockDb.__setResults([[mockProject]]);
+
+      await expect(sync(syncDto({ ruleSet: { name: '   ' } }))).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(mockDb.transaction).not.toHaveBeenCalled();
+    });
+
+    it('resolves schemas by name and remaps rule schema refs before planning', async () => {
+      mockDb.__setResults([[mockProject], []]);
+      mockPipelineSchemasService.getByProjectId.mockResolvedValue([
+        {
+          id: 'target-comments-id',
+          projectId: 'project-1',
+          name: 'comments',
+          fields: [{ name: 'body', type: 'text', required: true }],
+        },
+      ]);
+
+      const result = await sync(
+        syncDto({
+          rules: [
+            {
+              pathPattern: '/api/comments',
+              method: 'GET',
+              pipelineConfig: {
+                name: 'q',
+                steps: [{ handlerType: 'data_query', config: { schemaId: 'src-schema-id' } }],
+              },
+            },
+          ],
+          schemas: [
+            {
+              id: 'src-schema-id',
+              name: ' comments ', // trimmed before resolution
+              fields: [{ name: 'body', type: 'text', required: true }],
+            },
+          ],
+          options: { dryRun: true },
+        }),
+      );
+
+      expect(result.schemaResolutions).toEqual([
+        {
+          name: 'comments',
+          action: 'reuse',
+          targetSchemaId: 'target-comments-id',
+          fieldMismatch: false,
+        },
+      ]);
+      expect(result.created).toEqual([{ pathPattern: '/api/comments', method: 'GET' }]);
     });
   });
 });

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { ProxyRuleSetsService } from './proxy-rule-sets.service';
 import { ProxyRulesService } from './proxy-rules.service';
 import { PermissionsService } from '../permissions/permissions.service';
@@ -348,6 +348,278 @@ describe('ProxyRuleSetsService', () => {
       const result = await service.exportRuleSet('rule-set-1');
 
       expect(result.ruleSet).toEqual({ name: 'api-backend' });
+    });
+  });
+
+  describe('resolveSchemasByName', () => {
+    // The helper is private (only the sync path calls it); tests reach it via
+    // a structural cast rather than widening its visibility.
+    type IncomingSchema = {
+      id: string;
+      name: string;
+      fields: { name: string; type: string; required?: boolean }[];
+    };
+    type Resolution = {
+      name: string;
+      action: 'reuse' | 'create';
+      targetSchemaId: string | null;
+      fieldMismatch: boolean;
+    };
+    const resolve = (
+      schemas: IncomingSchema[] | undefined,
+      options: { strictSchemas: boolean; dryRun: boolean } = {
+        strictSchemas: false,
+        dryRun: false,
+      },
+    ) =>
+      (
+        service as unknown as {
+          resolveSchemasByName: (
+            projectId: string,
+            schemas: IncomingSchema[] | undefined,
+            options: { strictSchemas: boolean; dryRun: boolean },
+            userId: string,
+            userRole: string,
+            apiKeyProjectId?: string | null,
+          ) => Promise<{
+            idMap: Map<string, string>;
+            resolutions: Resolution[];
+            warnings: string[];
+          }>;
+        }
+      ).resolveSchemasByName('project-1', schemas, options, 'user-1', 'admin', 'project-1');
+
+    const existingComments = {
+      id: 'existing-comments-id',
+      projectId: 'project-1',
+      name: 'comments',
+      fields: [{ name: 'body', type: 'text', required: true }],
+      version: 1,
+      recordCount: 0,
+    };
+
+    beforeEach(() => {
+      mockPipelineSchemasService.getByProjectId.mockResolvedValue([existingComments]);
+      mockPipelineSchemasService.create.mockImplementation(
+        (dto: { name: string }) => Promise.resolve({ id: `created-${dto.name}`, ...dto }),
+      );
+    });
+
+    it('reuses a name match with identical fields: mapped id, no warning, no mismatch', async () => {
+      const result = await resolve([
+        {
+          id: 'src-1',
+          name: 'comments',
+          fields: [{ name: 'body', type: 'text', required: true }],
+        },
+      ]);
+
+      expect(mockPipelineSchemasService.getByProjectId).toHaveBeenCalledWith(
+        'project-1',
+        'project-1',
+      );
+      expect(result.idMap.get('src-1')).toBe('existing-comments-id');
+      expect(result.resolutions).toEqual([
+        {
+          name: 'comments',
+          action: 'reuse',
+          targetSchemaId: 'existing-comments-id',
+          fieldMismatch: false,
+        },
+      ]);
+      expect(result.warnings).toEqual([]);
+      expect(mockPipelineSchemasService.create).not.toHaveBeenCalled();
+    });
+
+    it('reuses a name match despite field mismatch: warning + fieldMismatch, no throw when not strict', async () => {
+      const result = await resolve([
+        {
+          id: 'src-1',
+          name: 'comments',
+          fields: [{ name: 'body', type: 'string', required: false }],
+        },
+      ]);
+
+      expect(result.idMap.get('src-1')).toBe('existing-comments-id');
+      expect(result.resolutions[0]).toEqual({
+        name: 'comments',
+        action: 'reuse',
+        targetSchemaId: 'existing-comments-id',
+        fieldMismatch: true,
+      });
+      expect(result.warnings).toEqual([
+        'Schema "comments": field "body": type string (incoming) vs text (existing)',
+        'Schema "comments": field "body": required false (incoming) vs true (existing)',
+      ]);
+    });
+
+    it('strictSchemas: throws 400 listing every mismatch, before any creation side effect', async () => {
+      mockPipelineSchemasService.getByProjectId.mockResolvedValue([
+        existingComments,
+        {
+          ...existingComments,
+          id: 'existing-votes-id',
+          name: 'votes',
+          fields: [{ name: 'score', type: 'number', required: true }],
+        },
+      ]);
+
+      const schemas: IncomingSchema[] = [
+        { id: 'src-1', name: 'comments', fields: [{ name: 'body', type: 'json', required: true }] },
+        // A pending create sandwiched between two mismatched reuses — it must
+        // NOT be created when strict fails
+        { id: 'src-2', name: 'brand-new', fields: [{ name: 'x', type: 'string' }] },
+        { id: 'src-3', name: 'votes', fields: [{ name: 'score', type: 'string', required: true }] },
+      ];
+
+      await expect(resolve(schemas, { strictSchemas: true, dryRun: false })).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(resolve(schemas, { strictSchemas: true, dryRun: false })).rejects.toThrow(
+        /comments.*type json \(incoming\) vs text \(existing\).*votes.*type string \(incoming\) vs number \(existing\)/s,
+      );
+      expect(mockPipelineSchemasService.create).not.toHaveBeenCalled();
+    });
+
+    it('creates a missing schema live with the EXACT name (no auto-suffixing)', async () => {
+      const result = await resolve([
+        { id: 'src-1', name: 'brand-new', fields: [{ name: 'x', type: 'string' }] },
+      ]);
+
+      expect(mockPipelineSchemasService.create).toHaveBeenCalledTimes(1);
+      expect(mockPipelineSchemasService.create).toHaveBeenCalledWith(
+        {
+          projectId: 'project-1',
+          name: 'brand-new',
+          fields: [{ name: 'x', type: 'string' }],
+        },
+        'user-1',
+        'admin',
+        'project-1',
+      );
+      expect(result.idMap.get('src-1')).toBe('created-brand-new');
+      expect(result.resolutions).toEqual([
+        {
+          name: 'brand-new',
+          action: 'create',
+          targetSchemaId: 'created-brand-new',
+          fieldMismatch: false,
+        },
+      ]);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('dryRun: plans the create with targetSchemaId null and never calls create', async () => {
+      const result = await resolve(
+        [{ id: 'src-1', name: 'brand-new', fields: [{ name: 'x', type: 'string' }] }],
+        { strictSchemas: false, dryRun: true },
+      );
+
+      expect(mockPipelineSchemasService.create).not.toHaveBeenCalled();
+      expect(result.resolutions).toEqual([
+        { name: 'brand-new', action: 'create', targetSchemaId: null, fieldMismatch: false },
+      ]);
+      expect(result.idMap.has('src-1')).toBe(false);
+    });
+
+    it('handles a mixed batch: clean reuse + mismatched reuse + create, in payload order', async () => {
+      mockPipelineSchemasService.getByProjectId.mockResolvedValue([
+        existingComments,
+        {
+          ...existingComments,
+          id: 'existing-votes-id',
+          name: 'votes',
+          fields: [{ name: 'score', type: 'number', required: false }],
+        },
+      ]);
+
+      const result = await resolve([
+        { id: 'src-1', name: 'comments', fields: [{ name: 'body', type: 'text', required: true }] },
+        { id: 'src-2', name: 'votes', fields: [{ name: 'score', type: 'string' }] },
+        { id: 'src-3', name: 'brand-new', fields: [{ name: 'x', type: 'string' }] },
+      ]);
+
+      expect(result.resolutions).toEqual([
+        {
+          name: 'comments',
+          action: 'reuse',
+          targetSchemaId: 'existing-comments-id',
+          fieldMismatch: false,
+        },
+        { name: 'votes', action: 'reuse', targetSchemaId: 'existing-votes-id', fieldMismatch: true },
+        {
+          name: 'brand-new',
+          action: 'create',
+          targetSchemaId: 'created-brand-new',
+          fieldMismatch: false,
+        },
+      ]);
+      expect(result.warnings).toEqual([
+        'Schema "votes": field "score": type string (incoming) vs number (existing)',
+      ]);
+      expect(result.idMap).toEqual(
+        new Map([
+          ['src-1', 'existing-comments-id'],
+          ['src-2', 'existing-votes-id'],
+          ['src-3', 'created-brand-new'],
+        ]),
+      );
+      expect(mockPipelineSchemasService.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects duplicate schema names within the payload before touching the DB', async () => {
+      await expect(
+        resolve([
+          { id: 'src-1', name: 'comments', fields: [] },
+          { id: 'src-2', name: 'comments', fields: [] },
+        ]),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockPipelineSchemasService.getByProjectId).not.toHaveBeenCalled();
+      expect(mockPipelineSchemasService.create).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty result for empty or undefined schemas with no DB access', async () => {
+      for (const schemas of [[], undefined] as (IncomingSchema[] | undefined)[]) {
+        const result = await resolve(schemas);
+        expect(result.idMap.size).toBe(0);
+        expect(result.resolutions).toEqual([]);
+        expect(result.warnings).toEqual([]);
+      }
+      expect(mockPipelineSchemasService.getByProjectId).not.toHaveBeenCalled();
+      expect(mockPipelineSchemasService.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects duplicate source ids within the payload (refs remap by id)', async () => {
+      await expect(
+        resolve([
+          { id: 'src-1', name: 'comments', fields: [] },
+          { id: 'src-1', name: 'messages', fields: [] },
+        ]),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockPipelineSchemasService.getByProjectId).not.toHaveBeenCalled();
+      expect(mockPipelineSchemasService.create).not.toHaveBeenCalled();
+    });
+
+    it('dryRun reuse still resolves the real target id and populates the idMap', async () => {
+      const result = await resolve(
+        [{ id: 'src-1', name: 'comments', fields: [{ name: 'body', type: 'text', required: true }] }],
+        { strictSchemas: false, dryRun: true },
+      );
+      expect(result.resolutions).toEqual([
+        { name: 'comments', action: 'reuse', targetSchemaId: 'existing-comments-id', fieldMismatch: false },
+      ]);
+      expect(result.idMap.get('src-1')).toBe('existing-comments-id');
+      expect(mockPipelineSchemasService.create).not.toHaveBeenCalled();
+    });
+
+    it('strictSchemas mismatch throws 400 even under dryRun (CI must fail loudly)', async () => {
+      await expect(
+        resolve(
+          [{ id: 'src-1', name: 'comments', fields: [{ name: 'body', type: 'number' }] }],
+          { strictSchemas: true, dryRun: true },
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockPipelineSchemasService.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
@@ -7,9 +7,17 @@ import {
   Inject,
   forwardRef,
 } from '@nestjs/common';
-import { eq, and, inArray } from 'drizzle-orm';
+import { eq, and, inArray, isNull } from 'drizzle-orm';
+import * as crypto from 'crypto';
 import { db } from '../db/client';
-import { proxyRuleSets, proxyRules, projects, aliasProxyRuleSets, deploymentAliases } from '../db/schema';
+import {
+  proxyRuleSets,
+  proxyRules,
+  projects,
+  aliasProxyRuleSets,
+  deploymentAliases,
+  projectSecrets,
+} from '../db/schema';
 import { PermissionsService } from '../permissions/permissions.service';
 import { NginxRegenerationService } from '../domains/nginx-regeneration.service';
 import { PipelineSchemasService } from '../pipelines/pipeline-schemas.service';
@@ -19,8 +27,12 @@ import {
   ProxyRuleSetResponseDto,
   ProxyRuleSetWithRulesResponseDto,
   ImportProxyRuleSetDto,
+  SyncProxyRuleSetDto,
+  SyncProxyRuleSetResponseDto,
+  SyncRuleRefDto,
 } from './dto';
-import type { PipelineConfig, ProxyType } from '../db/schema/proxy-rules.schema';
+import type { PipelineConfig, ProxyHeaderConfig, ProxyType } from '../db/schema/proxy-rules.schema';
+import type { ProxyRuleSetSource } from '../db/schema/proxy-rule-sets.schema';
 import { ProxyRulesService } from './proxy-rules.service';
 import { collectSchemaIds, remapSchemaIds } from './schema-refs.util';
 import {
@@ -30,10 +42,27 @@ import {
 } from './schema-sync.util';
 import {
   buildExportEnvelope,
+  canonicalRuleCompare,
   serializeRuleForExport,
   type ExportedSchema,
   type RuleSetExport,
 } from './export-format.util';
+import {
+  computeSyncPlan,
+  normalizeSyncRules,
+  type LiveSyncRule,
+  type NormalizedSyncRule,
+  type SyncPlan,
+  type SyncRuleInput,
+  type SyncRuleRef,
+} from './sync-plan.util';
+
+/**
+ * `{{secrets.NAME}}` reference pattern, matching the pipeline execution layer's
+ * interpolation (`pipelines/execution/expression-evaluator.ts`). Used to report
+ * referenced-but-missing project secrets at sync time (warning-level only).
+ */
+const SECRET_REF_PATTERN = /\{\{\s*secrets\.([A-Za-z0-9_-]+)\s*\}\}/g;
 
 @Injectable()
 export class ProxyRuleSetsService {
@@ -586,6 +615,443 @@ export class ProxyRuleSetsService {
     }
 
     return { idMap, resolutions, warnings };
+  }
+
+  /**
+   * Idempotently sync a rule set from a rules-as-code payload
+   * (`PUT project/:projectId/sync` — Task 7 of the Phase 1 plan).
+   *
+   * The payload is the desired declarative state: rules match live rows on
+   * `(pathPattern, method ?? null)` via {@link computeSyncPlan}; matched rules
+   * are updated only when a portable field actually differs, live-only rules
+   * are deleted only under `options.prune` (otherwise reported as
+   * `pruneCandidates`), and bundled schemas resolve by NAME
+   * ({@link resolveSchemasByName} — decision 4: mismatches warn, or 400 under
+   * `options.strictSchemas`).
+   *
+   * Blank-secret handling (decision 1): an incoming empty-string
+   * `headerConfig.add` value means "keep the live value" — the live decrypted
+   * value is substituted before re-encryption on updates; on NEW rules there
+   * is nothing to preserve, so `''` is stored and the header name reported in
+   * `missingSecrets[]`. The plan's rule objects (which may alias the request
+   * DTO) are never mutated — fresh headerConfig objects are built instead.
+   *
+   * `options.dryRun` returns the full response with ZERO writes: no set
+   * create, no schema create, no rule writes, no source stamp, no nginx.
+   * Note: under dryRun the schema idMap has no entries for to-be-created
+   * schemas, so rules referencing them keep their source ids in the dry-run
+   * diff — tolerated, since those rules are creates anyway.
+   *
+   * Live syncs perform ALL rule-set/rule writes in ONE `db.transaction`
+   * (schema creation runs before it, outside — see resolveSchemasByName's
+   * ordering guarantee), then regenerate nginx for the set (a synced set may
+   * be attached to live aliases, unlike import); a regeneration failure is
+   * appended to `warnings[]`, never a 500, because the DB state is already
+   * committed. `source` is re-stamped (fresh `syncedAt`/`contentHash`) on
+   * every non-dryRun sync, even a no-op one.
+   *
+   * Response arrays are sorted by `(pathPattern, method)` so CI output is
+   * byte-stable.
+   */
+  async syncRuleSet(
+    projectId: string,
+    dto: SyncProxyRuleSetDto,
+    userId: string,
+    userRole: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<SyncProxyRuleSetResponseDto> {
+    // Verify project exists (import parity)
+    const [project] = await db
+      .select()
+      .from(projects)
+      .where(eq(projects.id, projectId))
+      .limit(1);
+
+    if (!project) {
+      throw new NotFoundException(`Project ${projectId} not found`);
+    }
+
+    await this.permissionsService.requireProjectAccess(
+      projectId,
+      userId,
+      userRole,
+      'contributor',
+      apiKeyProjectId,
+    );
+
+    const name = dto.ruleSet.name?.trim();
+    if (!name) {
+      throw new BadRequestException('ruleSet.name must be a non-empty string');
+    }
+
+    const prune = dto.options?.prune ?? false;
+    const dryRun = dto.options?.dryRun ?? false;
+    const strictSchemas = dto.options?.strictSchemas ?? false;
+
+    // Same bridging as importRuleSet: the DTO config classes are structural
+    // mirrors of the schema's config types.
+    const dtoRules = (dto.rules ?? []) as unknown as SyncRuleInput[];
+
+    // Early duplicate-(pathPattern, method) detection: against an empty live
+    // set the only possible computeSyncPlan throw is the duplicate-key error,
+    // and catching it HERE (before schema resolution) keeps a 400 payload from
+    // creating schemas first — schema creation runs outside the rule
+    // transaction, so it would otherwise survive the failure.
+    try {
+      computeSyncPlan([], dtoRules, { prune: false });
+    } catch (error) {
+      throw new BadRequestException((error as Error).message);
+    }
+
+    const { idMap, resolutions, warnings } = await this.resolveSchemasByName(
+      projectId,
+      dto.schemas?.map((schema) => ({
+        id: schema.id,
+        name: schema.name.trim(),
+        fields: schema.fields,
+      })),
+      { strictSchemas, dryRun },
+      userId,
+      userRole,
+      apiKeyProjectId,
+    );
+
+    // Remap schema references to target-project ids. remapSchemaIds deep-clones;
+    // with an empty idMap the rules still alias the request DTO, so downstream
+    // code must not mutate them in place.
+    const incomingRules = idMap.size > 0 ? remapSchemaIds(dtoRules, idMap) : dtoRules;
+
+    const existing = await this.findByName(projectId, name);
+    const setCreated = !existing;
+    const liveRules = existing ? await this.proxyRulesService.getRulesByRuleSetId(existing.id) : [];
+
+    let plan: SyncPlan;
+    try {
+      plan = computeSyncPlan(liveRules, incomingRules, { prune });
+    } catch (error) {
+      // Belt-and-braces: duplicates are already rejected above.
+      throw new BadRequestException((error as Error).message);
+    }
+
+    const missingSecrets = await this.collectMissingSecrets(projectId, incomingRules, plan, liveRules);
+    const contentHash = this.computeSyncContentHash(
+      { name, description: dto.ruleSet.description, environment: dto.ruleSet.environment },
+      incomingRules,
+    );
+
+    const buildResponse = (ruleSetId: string | null): SyncProxyRuleSetResponseDto => ({
+      ruleSetId,
+      created: this.sortRuleRefs(plan.toCreate),
+      updated: this.sortRuleRefs(plan.toUpdate),
+      deleted: this.sortRuleRefs(plan.toDelete),
+      unchanged: this.sortRuleRefs(plan.unchanged),
+      pruneCandidates: this.sortRuleRefs(plan.pruneCandidates),
+      schemaResolutions: resolutions,
+      missingSecrets,
+      warnings,
+      dryRun,
+      setCreated,
+    });
+
+    if (dryRun) {
+      return buildResponse(existing?.id ?? null);
+    }
+
+    const syncedAt = new Date();
+    const source: ProxyRuleSetSource = {
+      syncedAt: syncedAt.toISOString(),
+      contentHash,
+    };
+    if (dto.source?.repo !== undefined) source.repo = dto.source.repo;
+    if (dto.source?.path !== undefined) source.path = dto.source.path;
+    if (dto.source?.gitSha !== undefined) source.gitSha = dto.source.gitSha;
+
+    // Decrypted live rules by match key, for blank-secret preservation on updates
+    const liveByKey = new Map(
+      liveRules.map((rule) => [
+        JSON.stringify([rule.pathPattern, rule.method ?? null]),
+        rule,
+      ]),
+    );
+
+    let ruleSetId = existing?.id ?? '';
+    await db.transaction(async (tx) => {
+      if (!existing) {
+        const [created] = await tx
+          .insert(proxyRuleSets)
+          .values({
+            projectId,
+            name,
+            description: dto.ruleSet.description,
+            environment: dto.ruleSet.environment,
+            source,
+          })
+          .returning();
+        ruleSetId = created.id;
+      } else {
+        // Source is re-stamped on EVERY live sync (fresh syncedAt/contentHash),
+        // even when all rules are unchanged; description/environment only when
+        // provided and actually different.
+        const setUpdate: Partial<typeof proxyRuleSets.$inferInsert> = {
+          source,
+          updatedAt: syncedAt,
+        };
+        if (dto.ruleSet.description !== undefined && dto.ruleSet.description !== existing.description) {
+          setUpdate.description = dto.ruleSet.description;
+        }
+        if (dto.ruleSet.environment !== undefined && dto.ruleSet.environment !== existing.environment) {
+          setUpdate.environment = dto.ruleSet.environment;
+        }
+        await tx.update(proxyRuleSets).set(setUpdate).where(eq(proxyRuleSets.id, existing.id));
+      }
+
+      for (const entry of plan.toCreate) {
+        // New rule: blank add values are stored as-is (encrypted '') and the
+        // header names surface in missingSecrets — nothing live to preserve.
+        await tx.insert(proxyRules).values({
+          ruleSetId,
+          ...this.syncRuleToRowValues(entry.rule, entry.rule.headerConfig),
+        });
+      }
+
+      for (const entry of plan.toUpdate) {
+        const live = liveByKey.get(JSON.stringify([entry.pathPattern, entry.method]));
+        const headerConfig = this.preserveBlankHeaderValues(
+          entry.rule.headerConfig,
+          live?.headerConfig,
+        );
+        const where = entry.liveId
+          ? eq(proxyRules.id, entry.liveId)
+          : and(
+              eq(proxyRules.ruleSetId, ruleSetId),
+              eq(proxyRules.pathPattern, entry.pathPattern),
+              entry.method === null
+                ? isNull(proxyRules.method)
+                : eq(proxyRules.method, entry.method),
+            );
+        await tx
+          .update(proxyRules)
+          .set({ ...this.syncRuleToRowValues(entry.rule, headerConfig), updatedAt: syncedAt })
+          .where(where);
+      }
+
+      for (const ref of plan.toDelete) {
+        await tx
+          .delete(proxyRules)
+          .where(
+            and(
+              eq(proxyRules.ruleSetId, ruleSetId),
+              eq(proxyRules.pathPattern, ref.pathPattern),
+              ref.method === null ? isNull(proxyRules.method) : eq(proxyRules.method, ref.method),
+            ),
+          );
+      }
+    });
+
+    const changed =
+      setCreated ||
+      plan.toCreate.length > 0 ||
+      plan.toUpdate.length > 0 ||
+      plan.toDelete.length > 0;
+
+    if (changed) {
+      // Post-commit: a synced set may be attached to live aliases. Failure is a
+      // warning, not a 500 — the DB state is committed; regeneration happens on
+      // the next config change or restart.
+      try {
+        await this.nginxRegenerationService.regenerateForRuleSet(ruleSetId);
+      } catch (error) {
+        const message = `nginx regeneration failed after sync: ${(error as Error).message}. Rule changes are saved; regeneration will run on the next configuration change or restart.`;
+        warnings.push(message);
+        this.logger.warn(`Rule set ${ruleSetId}: ${message}`);
+      }
+    }
+
+    this.logger.log(
+      `Synced proxy rule set "${name}" (${ruleSetId}) for project ${projectId}: ` +
+        `${plan.toCreate.length} created, ${plan.toUpdate.length} updated, ` +
+        `${plan.toDelete.length} deleted, ${plan.unchanged.length} unchanged` +
+        (setCreated ? ' (set created)' : ''),
+    );
+
+    return buildResponse(ruleSetId);
+  }
+
+  /**
+   * Insert/update column values for a plan-normalized rule (defaults already
+   * applied by computeSyncPlan). `headerConfig` is passed separately — updates
+   * substitute preserved live values first — and is encrypted here via
+   * ProxyRulesService.encryptHeaderConfigForStorage (write-side counterpart of
+   * the decrypted read). Never mutates `rule`.
+   */
+  private syncRuleToRowValues(
+    rule: NormalizedSyncRule,
+    headerConfig: ProxyHeaderConfig | null,
+  ): Omit<typeof proxyRules.$inferInsert, 'id' | 'ruleSetId' | 'createdAt' | 'updatedAt'> {
+    return {
+      pathPattern: rule.pathPattern,
+      method: rule.method,
+      methods: rule.methods,
+      targetUrl: rule.targetUrl,
+      stripPrefix: rule.stripPrefix,
+      order: rule.order,
+      timeout: rule.timeout,
+      preserveHost: rule.preserveHost,
+      forwardCookies: rule.forwardCookies,
+      headerConfig: this.proxyRulesService.encryptHeaderConfigForStorage(headerConfig),
+      authTransform: rule.authTransform,
+      internalRewrite: rule.internalRewrite,
+      proxyType: rule.proxyType,
+      emailHandlerConfig: rule.emailHandlerConfig,
+      pipelineConfig: rule.pipelineConfig,
+      isEnabled: rule.isEnabled,
+      debugEnabled: rule.debugEnabled,
+      description: rule.description,
+    };
+  }
+
+  /**
+   * Blank-secret preservation (decision 1): build a FRESH headerConfig whose
+   * empty-string `add` values are replaced by the live decrypted value for the
+   * same header name, when one exists. Non-empty incoming values win; a blank
+   * with no live counterpart stays blank. The incoming object (which may alias
+   * the request DTO) is never mutated.
+   */
+  private preserveBlankHeaderValues(
+    incoming: ProxyHeaderConfig | null,
+    live: ProxyHeaderConfig | null | undefined,
+  ): ProxyHeaderConfig | null {
+    if (!incoming) return null;
+    if (!incoming.add) return { ...incoming };
+    const add: Record<string, string> = {};
+    for (const [header, value] of Object.entries(incoming.add)) {
+      const liveValue = live?.add?.[header];
+      add[header] = value === '' && typeof liveValue === 'string' && liveValue !== '' ? liveValue : value;
+    }
+    return { ...incoming, add };
+  }
+
+  /**
+   * `missingSecrets[]` (warning-level, never fatal):
+   * (a) every `{{secrets.NAME}}` reference in the (schema-remapped) incoming
+   *     rules whose name has no `project_secrets` row for this project, and
+   * (b) for NEW rules only (plan.toCreate), header `add` names whose incoming
+   *     value is `''` — decision 1: there is nothing live to preserve, so the
+   *     blank is stored and the operator is told to fill it in.
+   * Deduplicated and sorted. The secrets table is only queried when (a) found
+   * at least one reference.
+   */
+  private async collectMissingSecrets(
+    projectId: string,
+    incomingRules: SyncRuleInput[],
+    plan: SyncPlan,
+    liveRules: LiveSyncRule[],
+  ): Promise<string[]> {
+    const referenced = new Set<string>();
+    for (const match of JSON.stringify(incomingRules).matchAll(SECRET_REF_PATTERN)) {
+      referenced.add(match[1]);
+    }
+
+    const missing = new Set<string>();
+    if (referenced.size > 0) {
+      const rows = await db
+        .select({ name: projectSecrets.name })
+        .from(projectSecrets)
+        .where(eq(projectSecrets.projectId, projectId))
+        .orderBy(projectSecrets.name);
+      const existingNames = new Set(rows.map((row) => row.name));
+      for (const secretName of referenced) {
+        if (!existingNames.has(secretName)) missing.add(secretName);
+      }
+    }
+
+    // Blank header add values that will be stored as '' (decision 1): every
+    // blank on a NEW rule, and — on updated rules — blanks whose header name
+    // has no non-empty live value to preserve.
+    for (const entry of plan.toCreate) {
+      const add = entry.rule.headerConfig?.add;
+      if (!add) continue;
+      for (const [header, value] of Object.entries(add)) {
+        if (value === '') missing.add(header);
+      }
+    }
+    const liveAddByKey = new Map<string, Record<string, string>>();
+    for (const live of liveRules) {
+      const add = live.headerConfig?.add;
+      if (add) {
+        liveAddByKey.set(JSON.stringify([live.pathPattern, live.method ?? null]), add);
+      }
+    }
+    for (const entry of plan.toUpdate) {
+      const add = entry.rule.headerConfig?.add;
+      if (!add) continue;
+      const liveAdd = liveAddByKey.get(JSON.stringify([entry.pathPattern, entry.method]));
+      for (const [header, value] of Object.entries(add)) {
+        if (value === '' && !liveAdd?.[header]) missing.add(header);
+      }
+    }
+
+    return [...missing].sort();
+  }
+
+  /**
+   * `source.contentHash` — exact recipe (pinned by the Phase 1 plan doc,
+   * cross-cutting definitions):
+   *
+   *   sha256 hex over `JSON.stringify({ ruleSet, rules })` where
+   *   - `ruleSet` = `{ name, description?, environment? }` in that key order,
+   *     null/undefined values stripped;
+   *   - `rules` = the defaults-normalized incoming rules
+   *     ({@link normalizeSyncRules} — same normalization the sync plan
+   *     compares with, including proxyType/targetUrl inference), each
+   *     serialized through {@link serializeRuleForExport} (canonical
+   *     RULE_KEY_ORDER, null keys dropped, header `add` values blanked — so
+   *     secrets are excluded by construction), sorted by
+   *     `(order, pathPattern, method)` ({@link canonicalRuleCompare}).
+   *
+   * Schemas are excluded (project-level, not part of the set's content).
+   * Computed server-side on every sync, stored in `source.contentHash`.
+   *
+   * Reproducibility caveat: the hash covers REMAPPED schema ids inside
+   * pipelineConfig, so it is stable within one target project but not
+   * reproducible from the git payload alone across projects. Phase 1 drift
+   * detection uses `exportsEquivalent` (rules diff), not this hash.
+   */
+  private computeSyncContentHash(
+    meta: { name: string; description?: string | null; environment?: string | null },
+    incomingRules: SyncRuleInput[],
+  ): string {
+    const ruleSet: Record<string, string> = { name: meta.name };
+    if (meta.description !== undefined && meta.description !== null) {
+      ruleSet.description = meta.description;
+    }
+    if (meta.environment !== undefined && meta.environment !== null) {
+      ruleSet.environment = meta.environment;
+    }
+
+    const rules = normalizeSyncRules(incomingRules)
+      .map((rule) => serializeRuleForExport(rule))
+      .sort(canonicalRuleCompare);
+
+    return crypto
+      .createHash('sha256')
+      .update(JSON.stringify({ ruleSet, rules }))
+      .digest('hex');
+  }
+
+  /**
+   * Project plan refs to response DTOs, sorted by `(pathPattern, method ?? '')`
+   * with plain code-unit comparison (locale-independent → byte-stable for CI).
+   */
+  private sortRuleRefs(refs: SyncRuleRef[]): SyncRuleRefDto[] {
+    return refs
+      .map(({ pathPattern, method }) => ({ pathPattern, method }))
+      .sort((a, b) => {
+        if (a.pathPattern !== b.pathPattern) return a.pathPattern < b.pathPattern ? -1 : 1;
+        const ma = a.method ?? '';
+        const mb = b.method ?? '';
+        return ma === mb ? 0 : ma < mb ? -1 : 1;
+      });
   }
 
   /**

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
@@ -22,7 +22,13 @@ import {
 } from './dto';
 import type { PipelineConfig, ProxyType } from '../db/schema/proxy-rules.schema';
 import { ProxyRulesService } from './proxy-rules.service';
-import { remapSchemaIds } from './schema-refs.util';
+import { collectSchemaIds, remapSchemaIds } from './schema-refs.util';
+import {
+  buildExportEnvelope,
+  serializeRuleForExport,
+  type ExportedSchema,
+  type RuleSetExport,
+} from './export-format.util';
 
 @Injectable()
 export class ProxyRuleSetsService {
@@ -76,6 +82,54 @@ export class ProxyRuleSetsService {
       ...ruleSet,
       rules: rules as ProxyRuleSetWithRulesResponseDto['rules'],
     };
+  }
+
+  /**
+   * Export a rule set as the canonical v2 envelope (`GET :id/export`).
+   *
+   * Same authorization as getById: any authenticated caller whose API key
+   * scope (if any) matches the rule set's project. Rules are serialized via
+   * export-format.util — header `add` secret values are blanked there, so no
+   * secret ever leaves this method. Schema definitions referenced by pipeline
+   * rules are bundled as `{id, name, fields}` for portability; a referenced
+   * schema that is missing or belongs to another project is skipped silently,
+   * leaving an unbundled reference (parity with the frontend exporter this
+   * endpoint replaces — closes #448, where the frontend copy dropped
+   * `methods`).
+   */
+  async exportRuleSet(id: string, apiKeyProjectId?: string | null): Promise<RuleSetExport> {
+    const ruleSet = await this.findById(id);
+    if (!ruleSet) {
+      throw new NotFoundException(`Rule set ${id} not found`);
+    }
+
+    this.permissionsService.enforceApiKeyProjectScope(apiKeyProjectId, ruleSet.projectId);
+
+    // Decrypted headerConfig — serializeRuleForExport blanks the add values
+    const rules = await this.proxyRulesService.getRulesByRuleSetId(id);
+    const serializedRules = rules.map((rule) => serializeRuleForExport(rule));
+
+    // Bundle the schema definitions the pipeline rules depend on (definitions
+    // only — name + fields, never data rows)
+    const schemas: ExportedSchema[] = [];
+    for (const schemaId of collectSchemaIds(serializedRules)) {
+      const schema = await this.pipelineSchemasService.getById(schemaId);
+      // Skip silently: missing refs stay unbundled; never bundle another
+      // project's schema definition
+      if (!schema || schema.projectId !== ruleSet.projectId) continue;
+      schemas.push({ id: schema.id, name: schema.name, fields: schema.fields });
+    }
+
+    return buildExportEnvelope({
+      ruleSet: {
+        name: ruleSet.name,
+        description: ruleSet.description,
+        environment: ruleSet.environment,
+      },
+      rules: serializedRules,
+      schemas,
+      exportedAt: new Date().toISOString(),
+    });
   }
 
   /**

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
@@ -24,6 +24,11 @@ import type { PipelineConfig, ProxyType } from '../db/schema/proxy-rules.schema'
 import { ProxyRulesService } from './proxy-rules.service';
 import { collectSchemaIds, remapSchemaIds } from './schema-refs.util';
 import {
+  compareSchemaFields,
+  type ComparableSchemaField,
+  type SchemaResolution,
+} from './schema-sync.util';
+import {
   buildExportEnvelope,
   serializeRuleForExport,
   type ExportedSchema,
@@ -457,6 +462,130 @@ export class ProxyRuleSetsService {
       ...newRuleSet,
       rules: insertedRules as ProxyRuleSetWithRulesResponseDto['rules'],
     };
+  }
+
+  /**
+   * Resolve bundled schema definitions against the target project by NAME —
+   * the non-interactive counterpart of importRuleSet's resolution block, for
+   * the sync path (Task 6/7 of the Phase 1 plan). No `ImportSchemaResolutionDto`
+   * choices anywhere: the name IS the identity.
+   *
+   * Per bundled schema `{id, name, fields}`:
+   * - A project schema with the same name exists → `action: 'reuse'`, map
+   *   `sourceId → existing.id`. Field definitions are compared
+   *   (compareSchemaFields); a divergence sets `fieldMismatch: true` and
+   *   appends `Schema "<name>": <mismatch>` entries to `warnings[]` (design
+   *   decision 4: warnings by default).
+   * - No name match → `action: 'create'`. Live: created via
+   *   `pipelineSchemasService.create` with the EXACT name (no auto-suffixing,
+   *   unlike import — the name is the identity). Under `dryRun`, nothing is
+   *   created and `targetSchemaId` stays `null`.
+   *
+   * `strictSchemas` turns field mismatches into a single BadRequestException
+   * listing EVERY mismatched schema (CI wants the full list, not the first).
+   * ORDERING GUARANTEE: the strict throw happens after ALL schemas are
+   * examined but BEFORE any schema creation, so a failed strict sync has zero
+   * side effects — the sync endpoint (Task 7) relies on this to keep dry
+   * failures write-free even though schema creation runs outside the rule
+   * transaction.
+   *
+   * Duplicate names WITHIN the incoming schemas → 400 (ambiguous payload).
+   * Empty/undefined schemas → empty result with no DB access.
+   */
+  private async resolveSchemasByName(
+    projectId: string,
+    schemas: { id: string; name: string; fields: ComparableSchemaField[] }[] | undefined,
+    options: { strictSchemas: boolean; dryRun: boolean },
+    userId: string,
+    userRole: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<{ idMap: Map<string, string>; resolutions: SchemaResolution[]; warnings: string[] }> {
+    const idMap = new Map<string, string>();
+    const resolutions: SchemaResolution[] = [];
+    const warnings: string[] = [];
+
+    if (!schemas || schemas.length === 0) {
+      return { idMap, resolutions, warnings };
+    }
+
+    const seenNames = new Set<string>();
+    const seenIds = new Set<string>();
+    for (const schema of schemas) {
+      if (seenNames.has(schema.name)) {
+        throw new BadRequestException(
+          `Duplicate schema name "${schema.name}" in payload: schema names identify schemas, so each may appear only once`,
+        );
+      }
+      seenNames.add(schema.name);
+      if (seenIds.has(schema.id)) {
+        throw new BadRequestException(
+          `Duplicate schema id "${schema.id}" in payload: rule schema-refs remap by source id, so each may appear only once`,
+        );
+      }
+      seenIds.add(schema.id);
+    }
+
+    const existingSchemas = await this.pipelineSchemasService.getByProjectId(
+      projectId,
+      apiKeyProjectId,
+    );
+    const existingByName = new Map(existingSchemas.map((s) => [s.name, s]));
+
+    // Pass 1 — examine everything (reuse resolutions + pending creates) so the
+    // strict throw can list ALL mismatches and precede ANY creation.
+    const pendingCreates: { schema: (typeof schemas)[number]; resolution: SchemaResolution }[] = [];
+    const strictFailures: string[] = [];
+    for (const schema of schemas) {
+      const existing = existingByName.get(schema.name);
+      if (existing) {
+        const { match, mismatches } = compareSchemaFields(schema.fields, existing.fields);
+        idMap.set(schema.id, existing.id);
+        resolutions.push({
+          name: schema.name,
+          action: 'reuse',
+          targetSchemaId: existing.id,
+          fieldMismatch: !match,
+        });
+        for (const mismatch of mismatches) {
+          warnings.push(`Schema "${schema.name}": ${mismatch}`);
+          strictFailures.push(`Schema "${schema.name}": ${mismatch}`);
+        }
+      } else {
+        const resolution: SchemaResolution = {
+          name: schema.name,
+          action: 'create',
+          targetSchemaId: null,
+          fieldMismatch: false,
+        };
+        resolutions.push(resolution);
+        pendingCreates.push({ schema, resolution });
+      }
+    }
+
+    // Strict failures throw even under dryRun: CI's --strict-schemas --dry-run
+    // must fail the check loudly, not return a green-looking report.
+    if (options.strictSchemas && strictFailures.length > 0) {
+      throw new BadRequestException(
+        `Schema field mismatch (strictSchemas): ${strictFailures.join('; ')}`,
+      );
+    }
+
+    // Pass 2 — perform creations (live sync only; dryRun reports the plan with
+    // targetSchemaId null and touches nothing).
+    if (!options.dryRun) {
+      for (const { schema, resolution } of pendingCreates) {
+        const created = await this.pipelineSchemasService.create(
+          { projectId, name: schema.name, fields: schema.fields },
+          userId,
+          userRole,
+          apiKeyProjectId,
+        );
+        idMap.set(schema.id, created.id);
+        resolution.targetSchemaId = created.id;
+      }
+    }
+
+    return { idMap, resolutions, warnings };
   }
 
   /**

--- a/apps/backend/src/proxy-rules/schema-sync.util.spec.ts
+++ b/apps/backend/src/proxy-rules/schema-sync.util.spec.ts
@@ -1,0 +1,100 @@
+import { compareSchemaFields, type ComparableSchemaField } from './schema-sync.util';
+import type { SchemaField } from '../db/schema/pipeline-schemas.schema';
+
+describe('schema-sync.util', () => {
+  describe('compareSchemaFields', () => {
+    const existing: SchemaField[] = [
+      { name: 'body', type: 'text', required: true },
+      { name: 'score', type: 'string', required: false },
+    ];
+
+    it('matches identical field lists', () => {
+      expect(compareSchemaFields(existing, existing)).toEqual({ match: true, mismatches: [] });
+    });
+
+    it('matches identical fields regardless of order', () => {
+      const reordered: SchemaField[] = [
+        { name: 'score', type: 'string', required: false },
+        { name: 'body', type: 'text', required: true },
+      ];
+      expect(compareSchemaFields(reordered, existing)).toEqual({ match: true, mismatches: [] });
+    });
+
+    it('treats an absent required as false (bundled exports may omit it)', () => {
+      const incoming: ComparableSchemaField[] = [
+        { name: 'body', type: 'text', required: true },
+        { name: 'score', type: 'string' }, // required omitted ≡ false
+      ];
+      expect(compareSchemaFields(incoming, existing)).toEqual({ match: true, mismatches: [] });
+    });
+
+    it('reports a field only present in the incoming definition', () => {
+      const incoming: SchemaField[] = [...existing, { name: 'extra', type: 'number', required: false }];
+      const result = compareSchemaFields(incoming, existing);
+      expect(result.match).toBe(false);
+      expect(result.mismatches).toEqual(['field "extra" is only in the incoming definition']);
+    });
+
+    it('reports a field only present in the existing schema', () => {
+      const incoming: SchemaField[] = [{ name: 'body', type: 'text', required: true }];
+      const result = compareSchemaFields(incoming, existing);
+      expect(result.match).toBe(false);
+      expect(result.mismatches).toEqual(['field "score" is only in the existing schema']);
+    });
+
+    it('reports a type difference on a common field', () => {
+      const incoming: SchemaField[] = [
+        { name: 'body', type: 'text', required: true },
+        { name: 'score', type: 'number', required: false },
+      ];
+      const result = compareSchemaFields(incoming, existing);
+      expect(result.match).toBe(false);
+      expect(result.mismatches).toEqual([
+        'field "score": type number (incoming) vs string (existing)',
+      ]);
+    });
+
+    it('reports a required difference on a common field', () => {
+      const incoming: SchemaField[] = [
+        { name: 'body', type: 'text', required: false },
+        { name: 'score', type: 'string', required: false },
+      ];
+      const result = compareSchemaFields(incoming, existing);
+      expect(result.match).toBe(false);
+      expect(result.mismatches).toEqual([
+        'field "body": required false (incoming) vs true (existing)',
+      ]);
+    });
+
+    it('reports both type and required differences on the same field', () => {
+      const incoming: SchemaField[] = [
+        { name: 'body', type: 'string', required: false },
+        { name: 'score', type: 'string', required: false },
+      ];
+      const result = compareSchemaFields(incoming, existing);
+      expect(result.match).toBe(false);
+      expect(result.mismatches).toEqual([
+        'field "body": type string (incoming) vs text (existing)',
+        'field "body": required false (incoming) vs true (existing)',
+      ]);
+    });
+
+    it('collects every mismatch across a batch of differences', () => {
+      const incoming: SchemaField[] = [
+        { name: 'body', type: 'json', required: true },
+        { name: 'added', type: 'boolean', required: false },
+      ];
+      const result = compareSchemaFields(incoming, existing);
+      expect(result.match).toBe(false);
+      expect(result.mismatches).toEqual([
+        'field "body": type json (incoming) vs text (existing)',
+        'field "added" is only in the incoming definition',
+        'field "score" is only in the existing schema',
+      ]);
+    });
+
+    it('matches two empty field lists', () => {
+      expect(compareSchemaFields([], [])).toEqual({ match: true, mismatches: [] });
+    });
+  });
+});

--- a/apps/backend/src/proxy-rules/schema-sync.util.ts
+++ b/apps/backend/src/proxy-rules/schema-sync.util.ts
@@ -1,0 +1,89 @@
+import type { SchemaField } from '../db/schema/pipeline-schemas.schema';
+
+/**
+ * A schema field as it arrives in a sync/export payload. Identical to the DB
+ * `SchemaField` except `required` is optional — bundled export entries (and
+ * `SchemaFieldDto`) may omit it, and the backend treats an absent `required`
+ * as `false` (`PipelineSchemasService.create` normalizes `required ?? false`
+ * before insert). DB rows (`required: boolean`) are assignable as-is.
+ */
+export interface ComparableSchemaField {
+  name: string;
+  type: SchemaField['type'];
+  required?: boolean;
+  default?: unknown;
+}
+
+/**
+ * One entry of the sync response's `schemaResolutions[]` (Phase 1 plan,
+ * cross-cutting definitions): how a bundled schema was resolved against the
+ * target project, by name.
+ *
+ * - `action: 'reuse'` — a project schema with the same name exists;
+ *   `targetSchemaId` is its id and `fieldMismatch` reports whether its field
+ *   definitions diverge from the incoming ones (see compareSchemaFields).
+ * - `action: 'create'` — no name match; `targetSchemaId` is the freshly
+ *   created schema's id, or `null` under dryRun (nothing was created).
+ */
+export interface SchemaResolution {
+  name: string;
+  action: 'reuse' | 'create';
+  targetSchemaId: string | null;
+  fieldMismatch: boolean;
+}
+
+/**
+ * Compare two schema field lists by field NAME as identity, order-insensitively.
+ *
+ * Reports, as precise human-readable strings (schema-agnostic — the caller
+ * prefixes the schema name):
+ * - fields only in `incoming` / only in `existing`;
+ * - per common field, a `type` difference and/or a `required` difference.
+ *
+ * `required` is normalized with `?? false` on BOTH sides before comparing —
+ * bundled export entries may omit it and the backend treats absent as `false`
+ * (matching `PipelineSchemasService.create`). `default` is deliberately NOT
+ * compared: it does not participate in the DB schema identity and exports may
+ * carry or drop it freely.
+ *
+ * Mismatch order is deterministic: common-field diffs and incoming-only fields
+ * in `incoming` order, then existing-only fields in `existing` order. Duplicate
+ * names within a list are not expected (DB uniqueness / payload validation);
+ * if present, the last occurrence wins.
+ */
+export function compareSchemaFields(
+  incoming: ComparableSchemaField[],
+  existing: ComparableSchemaField[],
+): { match: boolean; mismatches: string[] } {
+  const existingByName = new Map(existing.map((f) => [f.name, f]));
+  const incomingNames = new Set(incoming.map((f) => f.name));
+  const mismatches: string[] = [];
+
+  for (const field of incoming) {
+    const match = existingByName.get(field.name);
+    if (!match) {
+      mismatches.push(`field "${field.name}" is only in the incoming definition`);
+      continue;
+    }
+    if (field.type !== match.type) {
+      mismatches.push(
+        `field "${field.name}": type ${field.type} (incoming) vs ${match.type} (existing)`,
+      );
+    }
+    const incomingRequired = field.required ?? false;
+    const existingRequired = match.required ?? false;
+    if (incomingRequired !== existingRequired) {
+      mismatches.push(
+        `field "${field.name}": required ${incomingRequired} (incoming) vs ${existingRequired} (existing)`,
+      );
+    }
+  }
+
+  for (const field of existing) {
+    if (!incomingNames.has(field.name)) {
+      mismatches.push(`field "${field.name}" is only in the existing schema`);
+    }
+  }
+
+  return { match: mismatches.length === 0, mismatches };
+}

--- a/apps/backend/src/proxy-rules/sync-plan.util.spec.ts
+++ b/apps/backend/src/proxy-rules/sync-plan.util.spec.ts
@@ -1,0 +1,599 @@
+import { computeSyncPlan, LiveSyncRule, SyncRuleInput } from './sync-plan.util';
+
+describe('sync-plan.util', () => {
+  /**
+   * A live DB row (decrypted) whose portable fields sit exactly on the DB
+   * import defaults, plus the server-managed fields the plan must ignore.
+   */
+  const liveBase: LiveSyncRule = {
+    id: 'rule-live-1',
+    ruleSetId: 'rs-1',
+    pathPattern: '/api/*',
+    method: null,
+    methods: null,
+    targetUrl: 'https://api.example.com',
+    stripPrefix: true,
+    order: 0,
+    timeout: 30000,
+    preserveHost: false,
+    forwardCookies: false,
+    headerConfig: null,
+    authTransform: null,
+    internalRewrite: false,
+    proxyType: 'external_proxy',
+    emailHandlerConfig: null,
+    pipelineConfig: null,
+    isEnabled: true,
+    debugEnabled: false,
+    description: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-02T00:00:00Z'),
+  };
+
+  /** Minimal incoming rule equivalent to liveBase once DB defaults are applied. */
+  const incomingBase: SyncRuleInput = {
+    pathPattern: '/api/*',
+    targetUrl: 'https://api.example.com',
+  };
+
+  const live = (overrides: Partial<LiveSyncRule> = {}): LiveSyncRule => ({
+    ...liveBase,
+    ...overrides,
+  });
+  const incoming = (overrides: Partial<SyncRuleInput> = {}): SyncRuleInput => ({
+    ...incomingBase,
+    ...overrides,
+  });
+
+  describe('bucketing', () => {
+    it('creates every incoming rule when there are no live rules', () => {
+      const plan = computeSyncPlan(
+        [],
+        [incoming(), incoming({ pathPattern: '/other', method: 'POST', timeout: 5000 })],
+        { prune: false },
+      );
+
+      expect(plan.toCreate).toHaveLength(2);
+      expect(plan.toUpdate).toEqual([]);
+      expect(plan.unchanged).toEqual([]);
+      expect(plan.toDelete).toEqual([]);
+      expect(plan.pruneCandidates).toEqual([]);
+
+      expect(plan.toCreate[0]).toMatchObject({ pathPattern: '/api/*', method: null });
+      expect(plan.toCreate[1]).toMatchObject({ pathPattern: '/other', method: 'POST' });
+    });
+
+    it('applies the DB import defaults to created rules (absent-means-default)', () => {
+      const plan = computeSyncPlan([], [{ pathPattern: '/api/*' }], { prune: false });
+
+      expect(plan.toCreate[0].rule).toEqual({
+        pathPattern: '/api/*',
+        method: null,
+        methods: null,
+        targetUrl: '',
+        stripPrefix: true,
+        order: 0, // fallback: index in evaluation order
+        timeout: 30000,
+        preserveHost: false,
+        forwardCookies: false,
+        headerConfig: null,
+        authTransform: null,
+        internalRewrite: false,
+        proxyType: 'external_proxy',
+        emailHandlerConfig: null,
+        pipelineConfig: null,
+        isEnabled: true,
+        debugEnabled: false,
+        description: null,
+      });
+    });
+
+    it('marks live-only rules toDelete when prune is on', () => {
+      const plan = computeSyncPlan(
+        [live(), live({ pathPattern: '/legacy', method: 'GET' })],
+        [],
+        { prune: true },
+      );
+
+      expect(plan.toDelete).toEqual([
+        { pathPattern: '/api/*', method: null },
+        { pathPattern: '/legacy', method: 'GET' },
+      ]);
+      expect(plan.pruneCandidates).toEqual([]);
+    });
+
+    it('marks live-only rules pruneCandidates when prune is off', () => {
+      const plan = computeSyncPlan(
+        [live(), live({ pathPattern: '/legacy', method: 'GET' })],
+        [],
+        { prune: false },
+      );
+
+      expect(plan.pruneCandidates).toEqual([
+        { pathPattern: '/api/*', method: null },
+        { pathPattern: '/legacy', method: 'GET' },
+      ]);
+      expect(plan.toDelete).toEqual([]);
+    });
+
+    it('reports an identical rule as unchanged', () => {
+      const plan = computeSyncPlan([live()], [incoming()], { prune: true });
+
+      expect(plan.unchanged).toEqual([{ pathPattern: '/api/*', method: null }]);
+      expect(plan.toCreate).toEqual([]);
+      expect(plan.toUpdate).toEqual([]);
+      expect(plan.toDelete).toEqual([]);
+    });
+
+    it('handles a mixed create/update/unchanged/prune-candidate batch', () => {
+      const liveRules = [
+        live(), // will be unchanged
+        live({ id: 'rule-live-2', pathPattern: '/changed', order: 1 }), // will be updated
+        live({ id: 'rule-live-3', pathPattern: '/gone', order: 2 }), // live-only
+      ];
+      const incomingRules = [
+        incoming({ order: 0 }),
+        incoming({ pathPattern: '/changed', order: 1, timeout: 60000 }),
+        incoming({ pathPattern: '/new', order: 2 }),
+      ];
+
+      const plan = computeSyncPlan(liveRules, incomingRules, { prune: false });
+
+      expect(plan.unchanged).toEqual([{ pathPattern: '/api/*', method: null }]);
+      expect(plan.toUpdate).toMatchObject([{ pathPattern: '/changed', method: null }]);
+      expect(plan.toCreate).toMatchObject([{ pathPattern: '/new', method: null }]);
+      expect(plan.pruneCandidates).toEqual([{ pathPattern: '/gone', method: null }]);
+      expect(plan.toDelete).toEqual([]);
+    });
+  });
+
+  describe('match key (pathPattern, method ?? null)', () => {
+    it('treats method null and method "GET" on the same path as distinct rules', () => {
+      const plan = computeSyncPlan(
+        [live({ method: null })],
+        [incoming({ method: 'GET' })],
+        { prune: false },
+      );
+
+      expect(plan.toCreate).toMatchObject([{ pathPattern: '/api/*', method: 'GET' }]);
+      expect(plan.pruneCandidates).toEqual([{ pathPattern: '/api/*', method: null }]);
+    });
+
+    it('matches same-path rules with different methods independently', () => {
+      const plan = computeSyncPlan(
+        [live({ method: 'GET' }), live({ id: 'rule-live-2', method: 'POST', order: 1 })],
+        [
+          incoming({ method: 'GET' }),
+          incoming({ method: 'POST', order: 1, timeout: 60000 }),
+        ],
+        { prune: true },
+      );
+
+      expect(plan.unchanged).toEqual([{ pathPattern: '/api/*', method: 'GET' }]);
+      expect(plan.toUpdate).toMatchObject([{ pathPattern: '/api/*', method: 'POST' }]);
+      expect(plan.toDelete).toEqual([]);
+    });
+  });
+
+  describe('defaults normalization', () => {
+    it.each([
+      ['targetUrl empty string', { targetUrl: '' }, { targetUrl: undefined }],
+      ['stripPrefix true', { stripPrefix: true }, { stripPrefix: true }],
+      ['timeout 30000', { timeout: 30000 }, { timeout: 30000 }],
+      ['preserveHost false', { preserveHost: false }, { preserveHost: false }],
+      ['forwardCookies false', { forwardCookies: false }, { forwardCookies: false }],
+      ['internalRewrite false', { internalRewrite: false }, { internalRewrite: false }],
+      ['proxyType external_proxy', { proxyType: 'external_proxy' }, { proxyType: 'external_proxy' }],
+      ['isEnabled true', { isEnabled: true }, { isEnabled: true }],
+      ['debugEnabled false', { debugEnabled: false }, { debugEnabled: false }],
+    ] as Array<[string, Partial<LiveSyncRule>, Partial<SyncRuleInput>]>)(
+      'explicit incoming default equals live default: %s',
+      (_label, liveOverride, incomingExplicit) => {
+        // Explicit default value in the payload...
+        const explicit = computeSyncPlan([live(liveOverride)], [incoming(incomingExplicit)], {
+          prune: false,
+        });
+        expect(explicit.unchanged).toHaveLength(1);
+        expect(explicit.toUpdate).toEqual([]);
+
+        // ...and the field absent entirely both compare unchanged.
+        const absentIncoming = { ...incoming() };
+        for (const key of Object.keys(incomingExplicit)) {
+          delete (absentIncoming as Record<string, unknown>)[key];
+        }
+        if ('targetUrl' in incomingExplicit) absentIncoming.targetUrl = undefined;
+        const absent = computeSyncPlan([live(liveOverride)], [absentIncoming], { prune: false });
+        expect(absent.unchanged).toHaveLength(1);
+        expect(absent.toUpdate).toEqual([]);
+      },
+    );
+
+    it('treats a legacy live row with proxyType null as external_proxy', () => {
+      const plan = computeSyncPlan([live({ proxyType: null })], [incoming()], { prune: false });
+      expect(plan.unchanged).toHaveLength(1);
+    });
+
+    it('treats absent incoming description as equal to live null description', () => {
+      const plan = computeSyncPlan([live({ description: null })], [incoming()], { prune: false });
+      expect(plan.unchanged).toHaveLength(1);
+    });
+
+    it('ignores server-managed fields (id, ruleSetId, timestamps) in the comparison', () => {
+      const plan = computeSyncPlan(
+        [
+          live({
+            id: 'totally-different-id',
+            ruleSetId: 'another-set',
+            createdAt: new Date('1999-12-31T23:59:59Z'),
+            updatedAt: new Date('2026-06-06T06:06:06Z'),
+          }),
+        ],
+        [incoming()],
+        { prune: false },
+      );
+      expect(plan.unchanged).toHaveLength(1);
+    });
+
+    it('assigns fallback order by import-parity sorted index, not payload position', () => {
+      // Import sorts by (order ?? 0) then falls back to the sorted index:
+      // B has order 5, A has none -> sorted [A, B] -> A gets order 0.
+      const liveRules = [
+        live({ order: 0 }),
+        live({ id: 'rule-live-2', pathPattern: '/b', order: 5 }),
+      ];
+      const incomingRules = [
+        incoming({ pathPattern: '/b', order: 5 }),
+        incoming(), // no order -> fallback 0 -> matches live order 0
+      ];
+
+      const plan = computeSyncPlan(liveRules, incomingRules, { prune: false });
+      expect(plan.unchanged).toHaveLength(2);
+      expect(plan.toUpdate).toEqual([]);
+    });
+  });
+
+  describe('field changes', () => {
+    it.each([
+      ['targetUrl', { targetUrl: 'https://other.example.com' }],
+      ['order only', { order: 7 }],
+      ['methods array', { methods: ['GET', 'HEAD'] }],
+      ['timeout', { timeout: 60000 }],
+      ['isEnabled', { isEnabled: false }],
+      ['authTransform', { authTransform: { type: 'cookie-to-bearer' as const, cookieName: 'sAccessToken' } }],
+    ] as Array<[string, Partial<SyncRuleInput>]>)('%s change lands in toUpdate', (_label, override) => {
+      const plan = computeSyncPlan([live()], [incoming(override)], { prune: false });
+      expect(plan.toUpdate).toHaveLength(1);
+      expect(plan.unchanged).toEqual([]);
+    });
+
+    it('treats removing a live description as a change', () => {
+      const plan = computeSyncPlan(
+        [live({ description: 'kept for docs' })],
+        [incoming()], // description absent -> null
+        { prune: false },
+      );
+      expect(plan.toUpdate).toHaveLength(1);
+    });
+
+    it('treats a methods change from an array to absent as a change', () => {
+      const plan = computeSyncPlan([live({ methods: ['GET'] })], [incoming()], { prune: false });
+      expect(plan.toUpdate).toHaveLength(1);
+    });
+  });
+
+  describe('headerConfig comparison and blank-secret semantics', () => {
+    const liveWithSecret = () =>
+      live({ headerConfig: { add: { 'X-API-Key': 'sk_live_secret' } } });
+
+    it('blank incoming value compares equal to any live value for that header (decision 1)', () => {
+      const plan = computeSyncPlan(
+        [liveWithSecret()],
+        [incoming({ headerConfig: { add: { 'X-API-Key': '' } } })],
+        { prune: false },
+      );
+      expect(plan.unchanged).toHaveLength(1);
+      expect(plan.toUpdate).toEqual([]);
+    });
+
+    it('blank incoming value for a header the live rule lacks is a change (header added)', () => {
+      const plan = computeSyncPlan(
+        [liveWithSecret()],
+        [incoming({ headerConfig: { add: { 'X-API-Key': '', 'X-New': '' } } })],
+        { prune: false },
+      );
+      expect(plan.toUpdate).toHaveLength(1);
+    });
+
+    it('a live header name absent from the incoming add map is a change (removal)', () => {
+      const plan = computeSyncPlan(
+        [live({ headerConfig: { add: { 'X-API-Key': 'sk_live_secret', 'X-Extra': 'v' } } })],
+        [incoming({ headerConfig: { add: { 'X-API-Key': '' } } })],
+        { prune: false },
+      );
+      expect(plan.toUpdate).toHaveLength(1);
+    });
+
+    it('non-empty incoming values compare normally (equal -> unchanged, different -> update)', () => {
+      const equal = computeSyncPlan(
+        [liveWithSecret()],
+        [incoming({ headerConfig: { add: { 'X-API-Key': 'sk_live_secret' } } })],
+        { prune: false },
+      );
+      expect(equal.unchanged).toHaveLength(1);
+
+      const different = computeSyncPlan(
+        [liveWithSecret()],
+        [incoming({ headerConfig: { add: { 'X-API-Key': 'sk_live_other' } } })],
+        { prune: false },
+      );
+      expect(different.toUpdate).toHaveLength(1);
+    });
+
+    it('forward arrays compare order-sensitively', () => {
+      const plan = computeSyncPlan(
+        [live({ headerConfig: { forward: ['accept', 'content-type'] } })],
+        [incoming({ headerConfig: { forward: ['content-type', 'accept'] } })],
+        { prune: false },
+      );
+      expect(plan.toUpdate).toHaveLength(1);
+    });
+
+    it('identical forward/strip arrays compare equal', () => {
+      const hc = { forward: ['accept'], strip: ['cookie'], add: { 'X-K': 'v' } };
+      const plan = computeSyncPlan(
+        [live({ headerConfig: hc })],
+        [incoming({ headerConfig: { ...hc, add: { 'X-K': '' } } })],
+        { prune: false },
+      );
+      expect(plan.unchanged).toHaveLength(1);
+    });
+
+    it('a strip change is a change', () => {
+      const plan = computeSyncPlan(
+        [live({ headerConfig: { strip: ['cookie'] } })],
+        [incoming({ headerConfig: { strip: ['cookie', 'authorization'] } })],
+        { prune: false },
+      );
+      expect(plan.toUpdate).toHaveLength(1);
+    });
+
+    it('headerConfig null vs an object is a change', () => {
+      const plan = computeSyncPlan(
+        [live({ headerConfig: null })],
+        [incoming({ headerConfig: { add: { 'X-K': 'v' } } })],
+        { prune: false },
+      );
+      expect(plan.toUpdate).toHaveLength(1);
+    });
+
+    it('tolerates add: null on either side without crashing (null ≡ empty map)', () => {
+      // add: null passes DTO validation and is stored verbatim, so live rows can carry it.
+      const nullAdd = { add: null } as unknown as { add: Record<string, string> };
+
+      const liveNull = computeSyncPlan(
+        [live({ headerConfig: nullAdd })],
+        [incoming({ headerConfig: { add: { 'X-K': 'v' } } })],
+        { prune: false },
+      );
+      expect(liveNull.toUpdate).toHaveLength(1);
+
+      const incomingNull = computeSyncPlan(
+        [live({ headerConfig: { add: { 'X-K': 'v' } } })],
+        [incoming({ headerConfig: nullAdd })],
+        { prune: false },
+      );
+      expect(incomingNull.toUpdate).toHaveLength(1);
+
+      const bothNull = computeSyncPlan(
+        [live({ headerConfig: nullAdd })],
+        [incoming({ headerConfig: { add: null } as never })],
+        { prune: false },
+      );
+      expect(bothNull.unchanged).toHaveLength(1);
+    });
+
+    it('same-size add maps with different header names are a change even when the incoming value is blank', () => {
+      const plan = computeSyncPlan(
+        [live({ headerConfig: { add: { 'X-Old': 'x' } } })],
+        [incoming({ headerConfig: { add: { 'X-New': '' } } })],
+        { prune: false },
+      );
+      expect(plan.toUpdate).toHaveLength(1);
+    });
+  });
+
+  describe('proxyType/targetUrl inference (CLI parity for elided canonical payloads)', () => {
+    const pipelineConfig = () => ({
+      name: 'p',
+      steps: [{ name: 'q', handlerType: 'data_query', config: { schemaId: 'A' } }],
+    });
+
+    it('an elided pipeline rule (no proxyType, no targetUrl) is unchanged against its live form', () => {
+      const plan = computeSyncPlan(
+        [
+          live({
+            proxyType: 'pipeline',
+            targetUrl: 'http://internal/pipeline',
+            pipelineConfig: pipelineConfig(),
+          }),
+        ],
+        [{ pathPattern: '/api/*', pipelineConfig: pipelineConfig() as never }],
+        { prune: false },
+      );
+      expect(plan.unchanged).toHaveLength(1);
+      expect(plan.toUpdate).toEqual([]);
+    });
+
+    it('toCreate infers pipeline proxyType and the internal pipeline targetUrl', () => {
+      const plan = computeSyncPlan(
+        [],
+        [{ pathPattern: '/api/x', pipelineConfig: pipelineConfig() as never }],
+        { prune: false },
+      );
+      expect(plan.toCreate[0].rule.proxyType).toBe('pipeline');
+      expect(plan.toCreate[0].rule.targetUrl).toBe('http://internal/pipeline');
+    });
+
+    it('infers email_form_handler from emailHandlerConfig presence', () => {
+      const plan = computeSyncPlan(
+        [],
+        [{ pathPattern: '/api/contact', emailHandlerConfig: { destinationEmail: 'a@b.c' } as never }],
+        { prune: false },
+      );
+      expect(plan.toCreate[0].rule.proxyType).toBe('email_form_handler');
+      expect(plan.toCreate[0].rule.targetUrl).toBe('');
+    });
+
+    it('an explicit proxyType always wins over inference', () => {
+      const plan = computeSyncPlan(
+        [],
+        [
+          {
+            pathPattern: '/api/x',
+            proxyType: 'external_proxy',
+            targetUrl: 'https://api.example.com',
+            pipelineConfig: pipelineConfig() as never,
+          },
+        ],
+        { prune: false },
+      );
+      expect(plan.toCreate[0].rule.proxyType).toBe('external_proxy');
+    });
+  });
+
+  describe('methods [] ≡ null normalization', () => {
+    it('live methods [] compares unchanged against an absent incoming methods', () => {
+      const plan = computeSyncPlan([live({ methods: [] })], [incoming()], { prune: false });
+      expect(plan.unchanged).toHaveLength(1);
+    });
+
+    it('incoming methods [] normalizes to null on created rules', () => {
+      const plan = computeSyncPlan([], [incoming({ methods: [] })], { prune: false });
+      expect(plan.toCreate[0].rule.methods).toBeNull();
+    });
+  });
+
+  describe('deep equality of nested config', () => {
+    const pipeline = () => ({
+      name: 'p',
+      steps: [
+        {
+          name: 'q',
+          handlerType: 'data_query',
+          config: { schemaId: 'A', pageSize: 10, filter: null },
+        },
+      ],
+    });
+
+    it('is key-order-insensitive for nested objects', () => {
+      const reordered = {
+        steps: [
+          {
+            config: { filter: null, pageSize: 10, schemaId: 'A' },
+            handlerType: 'data_query',
+            name: 'q',
+          },
+        ],
+        name: 'p',
+      };
+      const plan = computeSyncPlan(
+        [live({ proxyType: 'pipeline', pipelineConfig: pipeline() })],
+        [incoming({ proxyType: 'pipeline', pipelineConfig: reordered as never })],
+        { prune: false },
+      );
+      expect(plan.unchanged).toHaveLength(1);
+    });
+
+    it('is value-exact: a nested null is not the same as an absent key', () => {
+      const withoutNull = pipeline();
+      delete (withoutNull.steps[0].config as Record<string, unknown>).filter;
+      const plan = computeSyncPlan(
+        [live({ proxyType: 'pipeline', pipelineConfig: pipeline() })],
+        [incoming({ proxyType: 'pipeline', pipelineConfig: withoutNull as never })],
+        { prune: false },
+      );
+      expect(plan.toUpdate).toHaveLength(1);
+    });
+
+    it('detects a nested value change inside pipelineConfig', () => {
+      const changed = pipeline();
+      changed.steps[0].config.pageSize = 25;
+      const plan = computeSyncPlan(
+        [live({ proxyType: 'pipeline', pipelineConfig: pipeline() })],
+        [incoming({ proxyType: 'pipeline', pipelineConfig: changed as never })],
+        { prune: false },
+      );
+      expect(plan.toUpdate).toHaveLength(1);
+    });
+  });
+
+  describe('duplicate incoming match keys', () => {
+    it('throws a clear error naming the duplicate (pathPattern, method)', () => {
+      expect(() =>
+        computeSyncPlan([], [incoming({ method: 'GET' }), incoming({ method: 'GET' })], {
+          prune: false,
+        }),
+      ).toThrow('Duplicate rule for path pattern "/api/*" and method "GET"');
+    });
+
+    it('treats an absent method and an explicit null method as the same key', () => {
+      expect(() =>
+        computeSyncPlan([], [incoming(), incoming({ method: null })], { prune: false }),
+      ).toThrow('Duplicate rule for path pattern "/api/*" and method (any)');
+    });
+
+    it('does not throw for the same path with distinct methods', () => {
+      expect(() =>
+        computeSyncPlan([], [incoming({ method: 'GET' }), incoming({ method: 'POST' })], {
+          prune: false,
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('plan entry payloads', () => {
+    it('toUpdate carries the live rule id and the normalized incoming rule (blanks intact)', () => {
+      const plan = computeSyncPlan(
+        [live({ headerConfig: { add: { 'X-API-Key': 'sk_live_secret' } } })],
+        [incoming({ timeout: 60000, headerConfig: { add: { 'X-API-Key': '' } } })],
+        { prune: false },
+      );
+
+      expect(plan.toUpdate).toHaveLength(1);
+      const entry = plan.toUpdate[0];
+      expect(entry.liveId).toBe('rule-live-1');
+      expect(entry.rule.timeout).toBe(60000);
+      // Blank secret stays blank in the plan; Task 7's executor preserves the live value.
+      expect(entry.rule.headerConfig).toEqual({ add: { 'X-API-Key': '' } });
+    });
+
+    it('toCreate carries blank add values intact for missingSecrets reporting', () => {
+      const plan = computeSyncPlan(
+        [],
+        [incoming({ headerConfig: { add: { 'X-API-Key': '' } } })],
+        { prune: false },
+      );
+      expect(plan.toCreate[0].rule.headerConfig).toEqual({ add: { 'X-API-Key': '' } });
+    });
+
+    it('toUpdate omits liveId when the live row has no id', () => {
+      const noId = live({ timeout: 1000 });
+      delete (noId as Record<string, unknown>).id;
+      const plan = computeSyncPlan([noId], [incoming()], { prune: false });
+      expect(plan.toUpdate).toHaveLength(1);
+      expect(plan.toUpdate[0].liveId).toBeUndefined();
+    });
+
+    it('does not mutate its inputs', () => {
+      const liveRules = [live()];
+      const incomingRules = [incoming({ order: 3 }), incoming({ pathPattern: '/z' })];
+      const liveSnapshot = JSON.parse(JSON.stringify(liveRules));
+      const incomingSnapshot = JSON.parse(JSON.stringify(incomingRules));
+
+      computeSyncPlan(liveRules, incomingRules, { prune: true });
+
+      expect(JSON.parse(JSON.stringify(liveRules))).toEqual(liveSnapshot);
+      expect(JSON.parse(JSON.stringify(incomingRules))).toEqual(incomingSnapshot);
+    });
+  });
+});

--- a/apps/backend/src/proxy-rules/sync-plan.util.spec.ts
+++ b/apps/backend/src/proxy-rules/sync-plan.util.spec.ts
@@ -549,6 +549,19 @@ describe('sync-plan.util', () => {
         }),
       ).not.toThrow();
     });
+
+    it('throws when LIVE rules share a (pathPattern, null) key (method-list variants)', () => {
+      // PG's unique index treats NULL methods as distinct, so a methods-split
+      // set is legal live state. Last-wins matching would silently overwrite
+      // one variant and orphan the other — must fail loudly instead.
+      const liveVariants = [
+        live({ methods: ['GET'] }),
+        live({ id: 'rule-live-2', methods: ['POST'], order: 1 }),
+      ];
+      expect(() => computeSyncPlan(liveVariants, [incoming()], { prune: false })).toThrow(
+        'Live rule set has multiple rules for path pattern "/api/*" and method (any)',
+      );
+    });
   });
 
   describe('plan entry payloads', () => {

--- a/apps/backend/src/proxy-rules/sync-plan.util.spec.ts
+++ b/apps/backend/src/proxy-rules/sync-plan.util.spec.ts
@@ -1,4 +1,4 @@
-import { computeSyncPlan, LiveSyncRule, SyncRuleInput } from './sync-plan.util';
+import { computeSyncPlan, normalizeSyncRules, LiveSyncRule, SyncRuleInput } from './sync-plan.util';
 
 describe('sync-plan.util', () => {
   /**
@@ -594,6 +594,42 @@ describe('sync-plan.util', () => {
 
       expect(JSON.parse(JSON.stringify(liveRules))).toEqual(liveSnapshot);
       expect(JSON.parse(JSON.stringify(incomingRules))).toEqual(incomingSnapshot);
+    });
+  });
+
+  describe('normalizeSyncRules', () => {
+    it('applies the same defaults and fallback order as computeSyncPlan', () => {
+      const rules = [
+        incoming({ pathPattern: '/b', order: 5 }),
+        incoming({ pathPattern: '/a' }), // no order → fallback index 0 in the (order ?? 0)-sorted list
+        incoming({ pathPattern: '/pipe', targetUrl: undefined, pipelineConfig: { name: 'p', steps: [] } }),
+      ];
+
+      const normalized = normalizeSyncRules(rules);
+
+      expect(normalized[0]).toMatchObject({ pathPattern: '/b', order: 5 });
+      expect(normalized[1]).toMatchObject({
+        pathPattern: '/a',
+        order: 0,
+        stripPrefix: true,
+        timeout: 30000,
+        proxyType: 'external_proxy',
+      });
+      // CLI-parity inference, exactly as the plan applies it
+      expect(normalized[2]).toMatchObject({
+        pathPattern: '/pipe',
+        proxyType: 'pipeline',
+        targetUrl: 'http://internal/pipeline',
+      });
+      // Positional: output order mirrors input order, not sorted order
+      expect(normalized.map((r) => r.pathPattern)).toEqual(['/b', '/a', '/pipe']);
+    });
+
+    it('does not mutate its inputs', () => {
+      const rules = [incoming({ pathPattern: '/x' })];
+      const snapshot = JSON.parse(JSON.stringify(rules));
+      normalizeSyncRules(rules);
+      expect(JSON.parse(JSON.stringify(rules))).toEqual(snapshot);
     });
   });
 });

--- a/apps/backend/src/proxy-rules/sync-plan.util.ts
+++ b/apps/backend/src/proxy-rules/sync-plan.util.ts
@@ -160,6 +160,32 @@ function normalizeRule(rule: SyncRuleInput, fallbackOrder: number): NormalizedSy
   };
 }
 
+/**
+ * Import-parity fallback order per rule: its index within the
+ * `(order ?? 0)`-sorted list, keyed by object identity. Shared by
+ * {@link computeSyncPlan} and {@link normalizeSyncRules} so both apply
+ * identical defaults.
+ */
+function computeFallbackOrders(rules: SyncRuleInput[]): Map<SyncRuleInput, number> {
+  const fallbackOrder = new Map<SyncRuleInput, number>();
+  [...rules]
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+    .forEach((rule, i) => fallbackOrder.set(rule, i));
+  return fallbackOrder;
+}
+
+/**
+ * Defaults-normalize a whole incoming payload, exactly as {@link computeSyncPlan}
+ * does before comparison (same inference, same import-parity fallback `order`).
+ * Used by the sync executor (Task 7) to compute the `source.contentHash` over
+ * the plan-normalized rules — including the unchanged ones, which the plan
+ * itself only returns as refs. Pure; inputs are not mutated.
+ */
+export function normalizeSyncRules(rules: SyncRuleInput[]): NormalizedSyncRule[] {
+  const fallbackOrder = computeFallbackOrders(rules);
+  return rules.map((rule) => normalizeRule(rule, fallbackOrder.get(rule)!));
+}
+
 /** Object keys whose value is not `undefined` (undefined-valued keys count as absent). */
 function definedKeys(obj: Record<string, unknown>): string[] {
   return Object.keys(obj).filter((k) => obj[k] !== undefined);
@@ -291,10 +317,7 @@ export function computeSyncPlan(
   options: SyncPlanOptions,
 ): SyncPlan {
   // Import-parity fallback order: index within the (order ?? 0)-sorted list.
-  const fallbackOrder = new Map<SyncRuleInput, number>();
-  [...incomingRules]
-    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
-    .forEach((rule, i) => fallbackOrder.set(rule, i));
+  const fallbackOrder = computeFallbackOrders(incomingRules);
 
   const liveByKey = new Map<string, { row: LiveSyncRule; normalized: NormalizedSyncRule }>();
   for (const row of liveRules) {

--- a/apps/backend/src/proxy-rules/sync-plan.util.ts
+++ b/apps/backend/src/proxy-rules/sync-plan.util.ts
@@ -321,8 +321,23 @@ export function computeSyncPlan(
 
   const liveByKey = new Map<string, { row: LiveSyncRule; normalized: NormalizedSyncRule }>();
   for (const row of liveRules) {
+    const key = matchKeyOf(row);
+    // PG's unique index treats NULL methods as distinct, so two live rules can
+    // legally share (pathPattern, null) and differ only by their methods[]
+    // lists. The plan addresses rules by (pathPattern, method) — a last-wins
+    // map here would silently overwrite one variant and orphan the other, so
+    // fail loudly instead. Folding a methods signature into the match key is
+    // the Phase 2 fix.
+    if (liveByKey.has(key)) {
+      throw new Error(
+        `Live rule set has multiple rules for path pattern "${row.pathPattern}" and method ${describeMethod(
+          row.method,
+        )} (method-list variants); sync cannot address them by (pathPattern, method) yet — ` +
+          `edit this set via the dashboard, or give each variant a distinct method`,
+      );
+    }
     // Live rows always carry a concrete order (NOT NULL column); fallback is inert.
-    liveByKey.set(matchKeyOf(row), { row, normalized: normalizeRule(row, 0) });
+    liveByKey.set(key, { row, normalized: normalizeRule(row, 0) });
   }
 
   const plan: SyncPlan = {

--- a/apps/backend/src/proxy-rules/sync-plan.util.ts
+++ b/apps/backend/src/proxy-rules/sync-plan.util.ts
@@ -1,0 +1,354 @@
+import type {
+  AuthTransformConfig,
+  EmailHandlerConfig,
+  PipelineConfig,
+  ProxyHeaderConfig,
+  ProxyType,
+} from '../db/schema/proxy-rules.schema';
+
+/**
+ * The 18 portable rule fields shared with the export format (RULE_KEY_ORDER in
+ * `packages/cli/src/format/types.ts`). Server-managed fields (`id`, `ruleSetId`,
+ * timestamps) are deliberately excluded so they can never affect sync comparison.
+ */
+export interface SyncRuleInput {
+  pathPattern: string;
+  method?: string | null;
+  methods?: string[] | null;
+  targetUrl?: string | null;
+  stripPrefix?: boolean | null;
+  order?: number | null;
+  timeout?: number | null;
+  preserveHost?: boolean | null;
+  forwardCookies?: boolean | null;
+  headerConfig?: ProxyHeaderConfig | null;
+  authTransform?: AuthTransformConfig | null;
+  internalRewrite?: boolean | null;
+  proxyType?: string | null;
+  emailHandlerConfig?: EmailHandlerConfig | null;
+  pipelineConfig?: PipelineConfig | null;
+  isEnabled?: boolean | null;
+  debugEnabled?: boolean | null;
+  description?: string | null;
+}
+
+/**
+ * A live DB rule row, already DECRYPTED (`headerConfig.add` holds plaintext,
+ * as returned by `ProxyRulesService.getRulesByRuleSetId`). Extra server-managed
+ * fields (ruleSetId, createdAt, ...) are tolerated and ignored; `id`, when
+ * present, is threaded onto matching `toUpdate` entries for the executor.
+ */
+export interface LiveSyncRule extends SyncRuleInput {
+  id?: string;
+  [serverManaged: string]: unknown;
+}
+
+/**
+ * A rule with the DB import defaults applied (absent-means-default), matching
+ * the defaults table in `ProxyRuleSetsService.importRuleSet`. Every portable
+ * field is present; nullable fields are explicitly `null`.
+ */
+export interface NormalizedSyncRule {
+  pathPattern: string;
+  method: string | null;
+  methods: string[] | null;
+  targetUrl: string;
+  stripPrefix: boolean;
+  order: number;
+  timeout: number;
+  preserveHost: boolean;
+  forwardCookies: boolean;
+  headerConfig: ProxyHeaderConfig | null;
+  authTransform: AuthTransformConfig | null;
+  internalRewrite: boolean;
+  proxyType: ProxyType;
+  emailHandlerConfig: EmailHandlerConfig | null;
+  pipelineConfig: PipelineConfig | null;
+  isEnabled: boolean;
+  debugEnabled: boolean;
+  description: string | null;
+}
+
+/** The (pathPattern, method) match key identifying a rule within a set. */
+export interface SyncRuleRef {
+  pathPattern: string;
+  method: string | null;
+}
+
+export interface SyncPlanCreate extends SyncRuleRef {
+  /** Defaults-normalized incoming rule, ready for insert (blank `add` values intact). */
+  rule: NormalizedSyncRule;
+}
+
+export interface SyncPlanUpdate extends SyncRuleRef {
+  /**
+   * Defaults-normalized incoming rule. Blank (`''`) `headerConfig.add` values are
+   * carried through as-is — the sync executor (Task 7) preserves the live value
+   * for those header names and reports new-rule blanks in `missingSecrets[]`.
+   */
+  rule: NormalizedSyncRule;
+  /** The live row's id, when the caller provided one. */
+  liveId?: string;
+}
+
+export interface SyncPlan {
+  toCreate: SyncPlanCreate[];
+  toUpdate: SyncPlanUpdate[];
+  unchanged: SyncRuleRef[];
+  /** Live-only rules removed by this sync (only populated when `options.prune`). */
+  toDelete: SyncRuleRef[];
+  /** Live-only rules kept because `options.prune` is false. */
+  pruneCandidates: SyncRuleRef[];
+}
+
+export interface SyncPlanOptions {
+  /** When true, live-only rules go to `toDelete`; otherwise to `pruneCandidates`. */
+  prune: boolean;
+}
+
+/** Mirrors `PIPELINE_TARGET_URL_DEFAULT` in `packages/cli/src/format/defaults.ts`. */
+const PIPELINE_TARGET_URL_DEFAULT = 'http://internal/pipeline';
+
+/**
+ * CLI-parity proxyType inference (`inferProxyType` in
+ * `packages/cli/src/format/defaults.ts`): explicit proxyType always wins;
+ * otherwise config-shape presence decides. Without this, a canonical payload
+ * with elided defaults (the CLI decompiler strips an inferable `proxyType`)
+ * would normalize a working pipeline rule to a dead `external_proxy`.
+ */
+function inferProxyType(rule: SyncRuleInput): ProxyType {
+  if (rule.proxyType) return rule.proxyType as ProxyType;
+  if (rule.pipelineConfig) return 'pipeline';
+  if (rule.emailHandlerConfig) return 'email_form_handler';
+  return 'external_proxy';
+}
+
+/**
+ * Apply the DB import defaults (import parity: see `importRuleSet`) to a rule.
+ * `??` intentionally treats explicit `null` like absent for fields whose DB
+ * default is non-null, exactly as import does.
+ *
+ * Two deliberate divergences from import's raw defaults, both CLI-parity
+ * (`applyRuleDefaults`): `proxyType` is inferred from config shape when absent,
+ * and an absent `targetUrl` on a pipeline rule defaults to the internal
+ * pipeline URL instead of `''`. One semantic smoothing: `methods: []` means
+ * "fall back to `method`" (see the column comment in proxy-rules.schema.ts),
+ * so it normalizes to `null` — a dashboard-created `[]` never registers as
+ * drift against a git-authored absence.
+ */
+function normalizeRule(rule: SyncRuleInput, fallbackOrder: number): NormalizedSyncRule {
+  const proxyType = inferProxyType(rule);
+  return {
+    pathPattern: rule.pathPattern,
+    method: rule.method ?? null,
+    methods: rule.methods && rule.methods.length > 0 ? rule.methods : null,
+    targetUrl: rule.targetUrl ?? (proxyType === 'pipeline' ? PIPELINE_TARGET_URL_DEFAULT : ''),
+    stripPrefix: rule.stripPrefix ?? true,
+    order: rule.order ?? fallbackOrder,
+    timeout: rule.timeout ?? 30000,
+    preserveHost: rule.preserveHost ?? false,
+    forwardCookies: rule.forwardCookies ?? false,
+    headerConfig: rule.headerConfig ?? null,
+    authTransform: rule.authTransform ?? null,
+    internalRewrite: rule.internalRewrite ?? false,
+    proxyType,
+    emailHandlerConfig: rule.emailHandlerConfig ?? null,
+    pipelineConfig: rule.pipelineConfig ?? null,
+    isEnabled: rule.isEnabled ?? true,
+    debugEnabled: rule.debugEnabled ?? false,
+    description: rule.description ?? null,
+  };
+}
+
+/** Object keys whose value is not `undefined` (undefined-valued keys count as absent). */
+function definedKeys(obj: Record<string, unknown>): string[] {
+  return Object.keys(obj).filter((k) => obj[k] !== undefined);
+}
+
+/**
+ * Deep equality: key-order-insensitive for objects, order-sensitive for arrays,
+ * value-exact otherwise (a nested `null` is NOT equal to an absent key; an
+ * `undefined`-valued key IS treated as absent).
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((item, i) => deepEqual(item, b[i]));
+  }
+  if (a && b && typeof a === 'object' && typeof b === 'object') {
+    const aObj = a as Record<string, unknown>;
+    const bObj = b as Record<string, unknown>;
+    const aKeys = definedKeys(aObj);
+    if (aKeys.length !== definedKeys(bObj).length) return false;
+    return aKeys.every((k) => deepEqual(aObj[k], bObj[k]));
+  }
+  return false;
+}
+
+/**
+ * Compare `headerConfig.add` maps with blank-secret semantics (design decision 1):
+ * the key sets must match exactly (a live header name missing from the incoming
+ * map is a removal; an incoming name missing live is an addition — even when its
+ * value is `''`), and per key an incoming `''` compares equal to ANY live value
+ * (exports blank secrets, so a blanked value never makes a rule "changed").
+ * Non-empty incoming values compare exactly.
+ */
+function addMapsEqual(live: Record<string, string>, incoming: Record<string, string>): boolean {
+  const liveNames = Object.keys(live);
+  const incomingNames = Object.keys(incoming);
+  if (liveNames.length !== incomingNames.length) return false;
+  return incomingNames.every(
+    (name) => name in live && (incoming[name] === '' || incoming[name] === live[name]),
+  );
+}
+
+/**
+ * Compare header configs. `forward`/`strip` compare exactly and ORDER-SENSITIVELY —
+ * they are emitted verbatim into the proxy/nginx layer, so a reorder is treated as
+ * a real change rather than second-guessing downstream semantics. `add` uses
+ * blank-secret semantics (see addMapsEqual). `null` vs an object is a change.
+ */
+function headerConfigEqual(live: ProxyHeaderConfig | null, incoming: ProxyHeaderConfig | null): boolean {
+  if (live === null || incoming === null) return live === incoming;
+  const liveObj = live as Record<string, unknown>;
+  const incomingObj = incoming as Record<string, unknown>;
+  const liveKeys = definedKeys(liveObj);
+  const incomingKeys = definedKeys(incomingObj);
+  if (liveKeys.length !== incomingKeys.length) return false;
+  return incomingKeys.every((key) => {
+    if (!(key in liveObj) || liveObj[key] === undefined) return false;
+    if (key === 'add') {
+      // `add: null` passes DTO validation (@IsOptional skips null) and is stored
+      // verbatim, so live and incoming maps must both tolerate it: null ≡ {}.
+      return addMapsEqual(
+        (liveObj[key] ?? {}) as Record<string, string>,
+        (incomingObj[key] ?? {}) as Record<string, string>,
+      );
+    }
+    return deepEqual(liveObj[key], incomingObj[key]);
+  });
+}
+
+/** Portable fields compared with plain deep equality (headerConfig handled separately). */
+const PLAIN_COMPARE_KEYS = [
+  'pathPattern',
+  'method',
+  'methods',
+  'targetUrl',
+  'stripPrefix',
+  'order',
+  'timeout',
+  'preserveHost',
+  'forwardCookies',
+  'authTransform',
+  'internalRewrite',
+  'proxyType',
+  'emailHandlerConfig',
+  'pipelineConfig',
+  'isEnabled',
+  'debugEnabled',
+  'description',
+] as const satisfies readonly (keyof NormalizedSyncRule)[];
+
+function rulesEqual(live: NormalizedSyncRule, incoming: NormalizedSyncRule): boolean {
+  return (
+    PLAIN_COMPARE_KEYS.every((key) => deepEqual(live[key], incoming[key])) &&
+    headerConfigEqual(live.headerConfig, incoming.headerConfig)
+  );
+}
+
+function matchKeyOf(rule: SyncRuleInput): string {
+  return JSON.stringify([rule.pathPattern, rule.method ?? null]);
+}
+
+function describeMethod(method: string | null | undefined): string {
+  return method != null ? `"${method}"` : '(any)';
+}
+
+/**
+ * Compute the idempotent sync plan between the live rules of a set and an
+ * incoming rules-as-code payload.
+ *
+ * Pure and side-effect free: no DB access, inputs are not mutated. Rules match
+ * on `(pathPattern, method ?? null)` — the set's DB unique key. Before
+ * comparison both sides are normalized to the 18 portable export fields with
+ * the DB import defaults applied, so absent-means-default payloads compare
+ * equal to freshly-imported rows and server-managed fields never register as
+ * drift. `order` differences DO count as changes (they affect evaluation
+ * order). Incoming rules without `order` receive the same fallback import
+ * uses: their index within the (order ?? 0)-sorted incoming list.
+ *
+ * Live rules must arrive DECRYPTED so blank-secret comparison (decision 1)
+ * can work; see headerConfigEqual/addMapsEqual for those semantics.
+ *
+ * @throws Error when two incoming rules share a match key (the caller should
+ *   surface this as a 400 — the DB unique index would reject it anyway).
+ */
+export function computeSyncPlan(
+  liveRules: LiveSyncRule[],
+  incomingRules: SyncRuleInput[],
+  options: SyncPlanOptions,
+): SyncPlan {
+  // Import-parity fallback order: index within the (order ?? 0)-sorted list.
+  const fallbackOrder = new Map<SyncRuleInput, number>();
+  [...incomingRules]
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+    .forEach((rule, i) => fallbackOrder.set(rule, i));
+
+  const liveByKey = new Map<string, { row: LiveSyncRule; normalized: NormalizedSyncRule }>();
+  for (const row of liveRules) {
+    // Live rows always carry a concrete order (NOT NULL column); fallback is inert.
+    liveByKey.set(matchKeyOf(row), { row, normalized: normalizeRule(row, 0) });
+  }
+
+  const plan: SyncPlan = {
+    toCreate: [],
+    toUpdate: [],
+    unchanged: [],
+    toDelete: [],
+    pruneCandidates: [],
+  };
+
+  const seenIncoming = new Set<string>();
+  const matchedLive = new Set<string>();
+
+  for (const raw of incomingRules) {
+    const key = matchKeyOf(raw);
+    if (seenIncoming.has(key)) {
+      throw new Error(
+        `Duplicate rule for path pattern "${raw.pathPattern}" and method ${describeMethod(
+          raw.method,
+        )}: each (pathPattern, method) pair must be unique within the payload`,
+      );
+    }
+    seenIncoming.add(key);
+
+    const rule = normalizeRule(raw, fallbackOrder.get(raw)!);
+    const ref: SyncRuleRef = { pathPattern: rule.pathPattern, method: rule.method };
+    const liveMatch = liveByKey.get(key);
+
+    if (!liveMatch) {
+      plan.toCreate.push({ ...ref, rule });
+    } else {
+      matchedLive.add(key);
+      if (rulesEqual(liveMatch.normalized, rule)) {
+        plan.unchanged.push(ref);
+      } else {
+        plan.toUpdate.push({
+          ...ref,
+          rule,
+          ...(liveMatch.row.id !== undefined ? { liveId: liveMatch.row.id } : {}),
+        });
+      }
+    }
+  }
+
+  for (const row of liveRules) {
+    if (matchedLive.has(matchKeyOf(row))) continue;
+    const ref: SyncRuleRef = { pathPattern: row.pathPattern, method: row.method ?? null };
+    (options.prune ? plan.toDelete : plan.pruneCandidates).push(ref);
+  }
+
+  return plan;
+}

--- a/apps/frontend/src/components/proxy-rules/EditRuleSetDialog.test.tsx
+++ b/apps/frontend/src/components/proxy-rules/EditRuleSetDialog.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { EditRuleSetDialog } from './EditRuleSetDialog';
+import { MANAGED_FROM_GIT_WARNING } from './ManagedFromGitBadge';
+import { api } from '@/services/api';
+import type { ProxyRuleSet } from '@/services/proxyRulesApi';
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+const baseRuleSet: ProxyRuleSet = {
+  id: 'rs-1',
+  projectId: 'proj-1',
+  name: 'My API Rules',
+  description: null,
+  environment: null,
+  source: null,
+  createdAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+};
+
+function renderDialog(ruleSet: ProxyRuleSet) {
+  const store = configureStore({
+    reducer: { [api.reducerPath]: api.reducer },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+  });
+  return render(
+    <Provider store={store}>
+      <EditRuleSetDialog ruleSet={ruleSet} open={true} onOpenChange={() => {}} />
+    </Provider>,
+  );
+}
+
+describe('EditRuleSetDialog managed-from-git warning', () => {
+  it('shows an inline alert when the set is managed from git', () => {
+    renderDialog({
+      ...baseRuleSet,
+      source: {
+        repo: 'bffless/apps',
+        gitSha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+        syncedAt: '2026-07-10T00:00:00.000Z',
+        contentHash: 'sha256:deadbeef',
+      },
+    });
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Managed from git')).toBeInTheDocument();
+    expect(screen.getByText(MANAGED_FROM_GIT_WARNING)).toBeInTheDocument();
+  });
+
+  it('shows no alert for an unmanaged set', () => {
+    renderDialog(baseRuleSet);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByText(MANAGED_FROM_GIT_WARNING)).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/proxy-rules/EditRuleSetDialog.tsx
+++ b/apps/frontend/src/components/proxy-rules/EditRuleSetDialog.tsx
@@ -10,8 +10,11 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { GitBranch } from 'lucide-react';
 import { useUpdateRuleSetMutation, type ProxyRuleSet } from '@/services/proxyRulesApi';
 import { useToast } from '@/hooks/use-toast';
+import { MANAGED_FROM_GIT_WARNING } from '@/components/proxy-rules/ManagedFromGitBadge';
 
 interface EditRuleSetDialogProps {
   ruleSet: ProxyRuleSet;
@@ -98,6 +101,14 @@ export function EditRuleSetDialog({ ruleSet, open, onOpenChange }: EditRuleSetDi
             Update the name, environment, or description for this rule set.
           </DialogDescription>
         </DialogHeader>
+
+        {ruleSet.source && (
+          <Alert className="mt-2">
+            <GitBranch className="h-4 w-4" />
+            <AlertTitle>Managed from git</AlertTitle>
+            <AlertDescription>{MANAGED_FROM_GIT_WARNING}</AlertDescription>
+          </Alert>
+        )}
 
         <form onSubmit={handleSubmit} className="space-y-4 mt-4">
           <div className="space-y-2">

--- a/apps/frontend/src/components/proxy-rules/ManagedFromGitBadge.test.tsx
+++ b/apps/frontend/src/components/proxy-rules/ManagedFromGitBadge.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ManagedFromGitBadge } from './ManagedFromGitBadge';
+import type { ProxyRuleSetSource } from '@/services/proxyRulesApi';
+
+const fullSource: ProxyRuleSetSource = {
+  repo: 'bffless/apps',
+  path: 'apps/studio/proxy-rules',
+  gitSha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+  syncedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2 hours ago
+  contentHash: 'sha256:deadbeef',
+};
+
+describe('ManagedFromGitBadge', () => {
+  it('renders label, repo@shortSha, and relative synced time for a full source', () => {
+    render(<ManagedFromGitBadge source={fullSource} />);
+
+    expect(screen.getByText('Managed from git')).toBeInTheDocument();
+    // First 7 chars of the gitSha
+    expect(screen.getByText('bffless/apps@a1b2c3d')).toBeInTheDocument();
+    expect(screen.getByText('synced 2 hours ago')).toBeInTheDocument();
+  });
+
+  it('renders nothing without a source', () => {
+    const { container: withNull } = render(<ManagedFromGitBadge source={null} />);
+    expect(withNull).toBeEmptyDOMElement();
+
+    const { container: withUndefined } = render(<ManagedFromGitBadge />);
+    expect(withUndefined).toBeEmptyDOMElement();
+  });
+
+  it('degrades gracefully when source has only syncedAt/contentHash', () => {
+    render(
+      <ManagedFromGitBadge
+        source={{
+          syncedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+          contentHash: 'sha256:cafef00d',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Managed from git')).toBeInTheDocument();
+    expect(screen.getByText('synced 3 days ago')).toBeInTheDocument();
+    // No origin fragment at all
+    expect(screen.queryByText(/@/)).not.toBeInTheDocument();
+  });
+
+  it('shows repo alone when gitSha is absent', () => {
+    render(
+      <ManagedFromGitBadge
+        source={{
+          repo: 'bffless/apps',
+          syncedAt: new Date().toISOString(),
+          contentHash: 'sha256:cafef00d',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('bffless/apps')).toBeInTheDocument();
+  });
+
+  it('shows @shortSha alone when repo is absent', () => {
+    render(
+      <ManagedFromGitBadge
+        source={{
+          gitSha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+          syncedAt: new Date().toISOString(),
+          contentHash: 'sha256:cafef00d',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('@a1b2c3d')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/proxy-rules/ManagedFromGitBadge.tsx
+++ b/apps/frontend/src/components/proxy-rules/ManagedFromGitBadge.tsx
@@ -1,0 +1,52 @@
+import { GitBranch } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { cn, formatRelativeTime } from '@/lib/utils';
+import type { ProxyRuleSetSource } from '@/services/proxyRulesApi';
+
+/**
+ * Warning shown when a user edits a git-managed rule set (decision 2 of the
+ * proxy-rules-as-code plan): edits stay allowed and `source` is never
+ * cleared — we only warn that the next deploy will overwrite manual changes.
+ */
+export const MANAGED_FROM_GIT_WARNING =
+  'This rule set is managed from git — manual edits will be overwritten on the next deploy. ' +
+  'Run bffless rules pull to keep this change.';
+
+interface ManagedFromGitBadgeProps {
+  source?: ProxyRuleSetSource | null;
+  className?: string;
+}
+
+/**
+ * ManagedFromGitBadge - Provenance badge for rule sets synced from git.
+ *
+ * Renders "Managed from git" with `repo@shortSha` (whichever parts are
+ * present — a sync may carry only syncedAt/contentHash) and a relative
+ * synced time. Renders nothing when the set has no `source`.
+ */
+export function ManagedFromGitBadge({ source, className }: ManagedFromGitBadgeProps) {
+  if (!source) return null;
+
+  const shortSha = source.gitSha ? source.gitSha.slice(0, 7) : undefined;
+  const origin =
+    source.repo && shortSha
+      ? `${source.repo}@${shortSha}`
+      : source.repo || (shortSha ? `@${shortSha}` : undefined);
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn('text-xs font-normal gap-1 items-center', className)}
+      title={MANAGED_FROM_GIT_WARNING}
+    >
+      <GitBranch className="h-3 w-3 shrink-0" aria-hidden="true" />
+      <span>Managed from git</span>
+      {origin && <span className="text-muted-foreground">{origin}</span>}
+      {source.syncedAt && (
+        <span className="text-muted-foreground">
+          synced {formatRelativeTime(source.syncedAt)}
+        </span>
+      )}
+    </Badge>
+  );
+}

--- a/apps/frontend/src/components/proxy-rules/RuleSetCard.tsx
+++ b/apps/frontend/src/components/proxy-rules/RuleSetCard.tsx
@@ -1,12 +1,15 @@
 import { Link } from 'react-router-dom';
 import { Badge } from '@/components/ui/badge';
 import { ChevronRight, Settings } from 'lucide-react';
+import { ManagedFromGitBadge } from '@/components/proxy-rules/ManagedFromGitBadge';
+import type { ProxyRuleSetSource } from '@/services/proxyRulesApi';
 
 interface RuleSetCardProps {
   id: string;
   name: string;
   description: string | null;
   environment: string | null;
+  source?: ProxyRuleSetSource | null;
   isDefault: boolean;
   href: string;
 }
@@ -19,6 +22,7 @@ export function RuleSetCard({
   name,
   description,
   environment,
+  source,
   isDefault,
   href,
 }: RuleSetCardProps) {
@@ -42,6 +46,7 @@ export function RuleSetCard({
                 Default
               </Badge>
             )}
+            <ManagedFromGitBadge source={source} />
           </div>
           {description && (
             <p className="text-sm text-muted-foreground mt-1">{description}</p>

--- a/apps/frontend/src/pages/ProxyRuleSetsPage.test.tsx
+++ b/apps/frontend/src/pages/ProxyRuleSetsPage.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { configureStore } from '@reduxjs/toolkit';
+import { ProxyRuleSetsPage } from './ProxyRuleSetsPage';
+import { api } from '@/services/api';
+import type { ProxyRuleSetExport } from '@/services/proxyRulesApi';
+
+// Radix dropdown menus don't open reliably in happy-dom; render items inline
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: (e: React.MouseEvent) => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+// The create/import dialogs have their own concerns; stub them out
+vi.mock('@/components/proxy-rules/CreateRuleSetDialog', () => ({
+  CreateRuleSetDialog: () => null,
+}));
+vi.mock('@/components/proxy-rules/ImportRuleSetDialog', () => ({
+  ImportRuleSetDialog: () => null,
+}));
+
+// Mock useToast
+const mockToast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+// Mock useProjectRole so the actions menu renders
+vi.mock('@/hooks/useProjectRole', () => ({
+  useProjectRole: () => ({
+    role: 'owner',
+    isLoading: false,
+    canEdit: true,
+    canAdmin: true,
+    isOwner: true,
+  }),
+}));
+
+const project = { id: 'proj-1', owner: 'acme', name: 'site', defaultProxyRuleSetId: null };
+
+const ruleSetsList = {
+  ruleSets: [
+    {
+      id: 'rs-1',
+      projectId: 'proj-1',
+      name: 'My API Rules!',
+      description: null,
+      environment: null,
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+    },
+  ],
+};
+
+// Canonical server envelope: the client must download this verbatim.
+// exportedAt is server-stamped; headerConfig.add values arrive already blanked.
+const serverEnvelope: ProxyRuleSetExport = {
+  version: 2,
+  exportedAt: '2026-07-11T12:34:56.000Z',
+  kind: 'bffless-proxy-rule-set',
+  ruleSet: { name: 'My API Rules!', description: 'demo rules' },
+  rules: [
+    {
+      pathPattern: '/api/*',
+      methods: ['GET', 'POST'],
+      targetUrl: 'https://upstream.example',
+      headerConfig: { add: { 'X-Api-Key': '' } },
+    },
+    { pathPattern: '/other/*', targetUrl: 'https://other.example' },
+  ],
+  schemas: [{ id: 'schema-1', name: 'comments', fields: [] }],
+};
+
+// The `schemas` key is omitted when no schemas are bundled; no secrets note
+const envelopeNoSchemas: ProxyRuleSetExport = {
+  version: 2,
+  exportedAt: '2026-07-11T12:34:56.000Z',
+  kind: 'bffless-proxy-rule-set',
+  ruleSet: { name: 'My API Rules!' },
+  rules: [{ pathPattern: '/api/*', targetUrl: 'https://upstream.example' }],
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function createTestStore() {
+  return configureStore({
+    reducer: {
+      [api.reducerPath]: api.reducer,
+    },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+  });
+}
+
+function renderPage() {
+  const store = createTestStore();
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/repo/acme/site/proxy-rules']}>
+        <Routes>
+          <Route path="/repo/:owner/:repo/proxy-rules" element={<ProxyRuleSetsPage />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+describe('ProxyRuleSetsPage export', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let exportEnvelope: ProxyRuleSetExport | null;
+  let exportStatus: number;
+  let createdBlobs: Blob[];
+  let downloadNames: string[];
+
+  beforeEach(() => {
+    mockToast.mockClear();
+    exportEnvelope = serverEnvelope;
+    exportStatus = 200;
+    createdBlobs = [];
+    downloadNames = [];
+
+    fetchMock = vi.fn(async (input: Request | string) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('/api/projects/acme/site')) return jsonResponse(project);
+      if (url.includes('/api/proxy-rule-sets/project/proj-1')) return jsonResponse(ruleSetsList);
+      if (url.includes('/api/proxy-rule-sets/rs-1/export')) {
+        return exportStatus === 200
+          ? jsonResponse(exportEnvelope)
+          : jsonResponse({ message: 'boom' }, exportStatus);
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    URL.createObjectURL = vi.fn((blob: Blob) => {
+      createdBlobs.push(blob);
+      return 'blob:mock-url';
+    }) as typeof URL.createObjectURL;
+    URL.revokeObjectURL = vi.fn();
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      downloadNames.push(this.download);
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  async function clickExport() {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByRole('button', { name: 'Export' }));
+  }
+
+  it('downloads the server export envelope verbatim', async () => {
+    await clickExport();
+
+    await waitFor(() => expect(createdBlobs).toHaveLength(1));
+
+    // Fetched from the export endpoint (not client-side assembly)
+    const exportCall = fetchMock.mock.calls.find(([input]) =>
+      (typeof input === 'string' ? input : (input as Request).url).includes(
+        '/api/proxy-rule-sets/rs-1/export',
+      ),
+    );
+    expect(exportCall).toBeDefined();
+
+    // Payload is the server envelope, pretty-printed, byte-for-byte — no
+    // re-ordering, no re-stamped exportedAt, no reshaping
+    const downloaded = await createdBlobs[0].text();
+    expect(downloaded).toBe(JSON.stringify(serverEnvelope, null, 2));
+    expect(createdBlobs[0].type).toBe('application/json');
+
+    // Filename derives from the envelope's rule set name via the safeName regex
+    expect(downloadNames).toEqual(['My-API-Rules.proxy-rules.json']);
+  });
+
+  it('derives the toast counts and secrets note from the payload', async () => {
+    await clickExport();
+
+    await waitFor(() => expect(mockToast).toHaveBeenCalled());
+    expect(mockToast).toHaveBeenCalledWith({
+      title: 'Rule set exported',
+      description:
+        'Exported "My API Rules!" with 2 rules and 1 schema.' +
+        ' Added-header secret values were not included.',
+    });
+  });
+
+  it('omits the schema count and secrets note when the payload has neither', async () => {
+    exportEnvelope = envelopeNoSchemas;
+    await clickExport();
+
+    await waitFor(() => expect(mockToast).toHaveBeenCalled());
+    expect(mockToast).toHaveBeenCalledWith({
+      title: 'Rule set exported',
+      description: 'Exported "My API Rules!" with 1 rule.',
+    });
+  });
+
+  it('shows a destructive toast when the export request fails', async () => {
+    exportStatus = 500;
+    await clickExport();
+
+    await waitFor(() => expect(mockToast).toHaveBeenCalled());
+    expect(mockToast).toHaveBeenCalledWith({
+      title: 'Export failed',
+      description: 'Could not export the rule set. Please try again.',
+      variant: 'destructive',
+    });
+    expect(createdBlobs).toHaveLength(0);
+  });
+});

--- a/apps/frontend/src/pages/ProxyRuleSetsPage.test.tsx
+++ b/apps/frontend/src/pages/ProxyRuleSetsPage.test.tsx
@@ -235,3 +235,61 @@ describe('ProxyRuleSetsPage export', () => {
     expect(createdBlobs).toHaveLength(0);
   });
 });
+
+describe('ProxyRuleSetsPage managed-from-git badge', () => {
+  const managedSource = {
+    repo: 'bffless/apps',
+    path: 'apps/studio/proxy-rules',
+    gitSha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+    syncedAt: '2026-07-10T00:00:00.000Z',
+    contentHash: 'sha256:deadbeef',
+  };
+
+  let listBody: unknown;
+
+  beforeEach(() => {
+    mockToast.mockClear();
+    listBody = ruleSetsList;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: Request | string) => {
+        const url = typeof input === 'string' ? input : input.url;
+        if (url.includes('/api/projects/acme/site')) return jsonResponse(project);
+        if (url.includes('/api/proxy-rule-sets/project/proj-1')) return jsonResponse(listBody);
+        throw new Error(`Unexpected fetch: ${url}`);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('shows the badge with repo@shortSha on sets that carry a source', async () => {
+    listBody = {
+      ruleSets: [
+        { ...ruleSetsList.ruleSets[0], source: managedSource },
+        {
+          ...ruleSetsList.ruleSets[0],
+          id: 'rs-2',
+          name: 'Manual Rules',
+          source: null,
+        },
+      ],
+    };
+    renderPage();
+
+    expect(await screen.findByText('Managed from git')).toBeInTheDocument();
+    expect(screen.getByText('bffless/apps@a1b2c3d')).toBeInTheDocument();
+    // Only the managed set gets a badge
+    expect(screen.getAllByText('Managed from git')).toHaveLength(1);
+  });
+
+  it('shows no badge when no set has a source', async () => {
+    renderPage();
+
+    expect(await screen.findByText('My API Rules!')).toBeInTheDocument();
+    expect(screen.queryByText('Managed from git')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/pages/ProxyRuleSetsPage.tsx
+++ b/apps/frontend/src/pages/ProxyRuleSetsPage.tsx
@@ -248,6 +248,7 @@ export function ProxyRuleSetsPage() {
                     name={ruleSet.name}
                     description={ruleSet.description}
                     environment={ruleSet.environment}
+                    source={ruleSet.source}
                     isDefault={project?.defaultProxyRuleSetId === ruleSet.id}
                     href={routes.ruleSet(owner!, repo!, ruleSet.id)}
                   />

--- a/apps/frontend/src/pages/ProxyRuleSetsPage.tsx
+++ b/apps/frontend/src/pages/ProxyRuleSetsPage.tsx
@@ -24,37 +24,15 @@ import {
   useGetProjectRuleSetsQuery,
   useDeleteRuleSetMutation,
   useCopyRuleSetMutation,
-  useLazyGetRuleSetQuery,
-  type ProxyRuleSetExport,
-  type ExportedProxyRule,
-  type ExportedSchema,
-  type HeaderConfig,
+  useLazyGetRuleSetExportQuery,
 } from '@/services/proxyRulesApi';
-import { useLazyGetSchemaQuery } from '@/services/pipelineSchemasApi';
 import { useGetProjectQuery } from '@/services/projectsApi';
 import { useProjectRole } from '@/hooks/useProjectRole';
 import { useToast } from '@/hooks/use-toast';
-import { collectSchemaIds } from '@/utils/proxyRuleSchemaRefs';
 import { CreateRuleSetDialog } from '@/components/proxy-rules/CreateRuleSetDialog';
 import { ImportRuleSetDialog } from '@/components/proxy-rules/ImportRuleSetDialog';
 import { RuleSetCard } from '@/components/proxy-rules/RuleSetCard';
 import { routes } from '@/utils/routes';
-
-/**
- * Header `add` values can hold secrets (API keys, bearer tokens). We deliberately
- * do NOT export their values — exports keep the header names but blank the values,
- * so the user re-enters secrets after import. This is a known export/import gap
- * until inline secrets move to project-level `secrets.<name>` references
- * (see stories/tasks/migrate-inline-pipeline-secrets-to-project-secrets.md).
- */
-function sanitizeHeaderConfigForExport(headerConfig: HeaderConfig | null): HeaderConfig | null {
-  if (!headerConfig?.add) return headerConfig;
-  const blankedAdd: Record<string, string> = {};
-  for (const key of Object.keys(headerConfig.add)) {
-    blankedAdd[key] = '';
-  }
-  return { ...headerConfig, add: blankedAdd };
-}
 
 /**
  * ProxyRuleSetsPage - Content for the Proxy Rules tab showing all rule sets.
@@ -93,65 +71,22 @@ export function ProxyRuleSetsPage() {
   const [copyRuleSet, { isLoading: isCopying }] = useCopyRuleSetMutation();
 
   // Export / import
-  const [fetchRuleSet, { isFetching: isExporting }] = useLazyGetRuleSetQuery();
-  const [fetchSchema] = useLazyGetSchemaQuery();
+  const [fetchExport, { isFetching: isExporting }] = useLazyGetRuleSetExportQuery();
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
 
   const handleExport = async (ruleSetId: string) => {
     try {
-      const ruleSet = await fetchRuleSet(ruleSetId).unwrap();
+      // The server assembles the canonical export envelope (bundled schema
+      // definitions, blanked added-header secret values, null-stripping, key
+      // order) — download it verbatim, no client-side reshaping.
+      const envelope = await fetchExport(ruleSetId).unwrap();
 
-      // Bundle the schema definitions the pipelines depend on so the export is
-      // portable across projects. Definitions only (name + fields), no data rows.
-      const schemaIds = [...collectSchemaIds(ruleSet.rules)];
-      const schemas: ExportedSchema[] = [];
-      for (const id of schemaIds) {
-        try {
-          const schema = await fetchSchema(id).unwrap();
-          schemas.push({ id: schema.id, name: schema.name, fields: schema.fields });
-        } catch {
-          // Schema missing/inaccessible — leave it as an unbundled reference
-        }
-      }
-
-      const exportData: ProxyRuleSetExport = {
-        version: 2,
-        exportedAt: new Date().toISOString(),
-        kind: 'bffless-proxy-rule-set',
-        ruleSet: {
-          name: ruleSet.name,
-          description: ruleSet.description,
-          environment: ruleSet.environment,
-        },
-        // Strip server-managed fields; keep only portable rule config
-        rules: ruleSet.rules.map(
-          (rule): ExportedProxyRule => ({
-            pathPattern: rule.pathPattern,
-            method: rule.method,
-            targetUrl: rule.targetUrl,
-            stripPrefix: rule.stripPrefix,
-            order: rule.order,
-            timeout: rule.timeout,
-            preserveHost: rule.preserveHost,
-            forwardCookies: rule.forwardCookies,
-            headerConfig: sanitizeHeaderConfigForExport(rule.headerConfig),
-            authTransform: rule.authTransform,
-            internalRewrite: rule.internalRewrite,
-            proxyType: rule.proxyType,
-            emailHandlerConfig: rule.emailHandlerConfig,
-            pipelineConfig: rule.pipelineConfig,
-            isEnabled: rule.isEnabled,
-            debugEnabled: rule.debugEnabled,
-            description: rule.description,
-          }),
-        ),
-        schemas: schemas.length > 0 ? schemas : undefined,
-      };
-
-      const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
+      const blob = new Blob([JSON.stringify(envelope, null, 2)], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
-      const safeName = ruleSet.name.replace(/[^a-zA-Z0-9-_]+/g, '-').replace(/^-+|-+$/g, '');
+      const safeName = envelope.ruleSet.name
+        .replace(/[^a-zA-Z0-9-_]+/g, '-')
+        .replace(/^-+|-+$/g, '');
       link.href = url;
       link.download = `${safeName || 'proxy-rule-set'}.proxy-rules.json`;
       document.body.appendChild(link);
@@ -159,16 +94,17 @@ export function ProxyRuleSetsPage() {
       document.body.removeChild(link);
       URL.revokeObjectURL(url);
 
-      const hadSecrets = ruleSet.rules.some(
+      const ruleCount = envelope.rules.length;
+      const schemaCount = envelope.schemas?.length ?? 0;
+      // Blanked `add` entries in the payload mean the live rules had secret values
+      const hadSecrets = envelope.rules.some(
         (rule) => rule.headerConfig?.add && Object.keys(rule.headerConfig.add).length > 0,
       );
       toast({
         title: 'Rule set exported',
         description:
-          `Exported "${ruleSet.name}" with ${ruleSet.rules.length} rule${ruleSet.rules.length !== 1 ? 's' : ''}` +
-          (schemas.length > 0
-            ? ` and ${schemas.length} schema${schemas.length !== 1 ? 's' : ''}.`
-            : '.') +
+          `Exported "${envelope.ruleSet.name}" with ${ruleCount} rule${ruleCount !== 1 ? 's' : ''}` +
+          (schemaCount > 0 ? ` and ${schemaCount} schema${schemaCount !== 1 ? 's' : ''}.` : '.') +
           (hadSecrets ? ' Added-header secret values were not included.' : ''),
       });
     } catch {

--- a/apps/frontend/src/pages/RuleEditorPage.test.tsx
+++ b/apps/frontend/src/pages/RuleEditorPage.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { configureStore } from '@reduxjs/toolkit';
+import { RuleEditorPage } from './RuleEditorPage';
+import { api } from '@/services/api';
+
+// The full rule form has its own concerns; stub it with a submit button that
+// exercises the page's save callback (the path that must warn on managed sets).
+vi.mock('@/components/proxy-rules/ExpandedProxyRuleForm', () => ({
+  ExpandedProxyRuleForm: ({
+    onSubmit,
+  }: {
+    onSubmit: (data: unknown) => Promise<void>;
+  }) => (
+    <button onClick={() => void onSubmit({ pathPattern: '/api/*', order: 5 })}>
+      stub-save-rule
+    </button>
+  ),
+}));
+
+const mockToast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock('@/hooks/useProjectRole', () => ({
+  useProjectRole: () => ({
+    role: 'owner',
+    isLoading: false,
+    canEdit: true,
+    canAdmin: true,
+    isOwner: true,
+  }),
+}));
+
+const managedSource = {
+  repo: 'bffless/apps',
+  gitSha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+  syncedAt: '2026-07-10T00:00:00.000Z',
+  contentHash: 'sha256:deadbeef',
+};
+
+function ruleSetBody(source: typeof managedSource | null) {
+  return {
+    id: 'rs-1',
+    projectId: 'proj-1',
+    name: 'My API Rules',
+    description: null,
+    environment: null,
+    source,
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    rules: [],
+  };
+}
+
+const ruleBody = {
+  id: 'rule-1',
+  ruleSetId: 'rs-1',
+  pathPattern: '/api/*',
+  method: null,
+  targetUrl: 'https://api.example.com',
+  stripPrefix: true,
+  order: 0,
+  timeout: 30000,
+  preserveHost: false,
+  forwardCookies: false,
+  headerConfig: null,
+  authTransform: null,
+  internalRewrite: false,
+  proxyType: 'external_proxy',
+  emailHandlerConfig: null,
+  pipelineConfig: null,
+  isEnabled: true,
+  debugEnabled: false,
+  description: null,
+  createdAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function renderPage() {
+  const store = configureStore({
+    reducer: { [api.reducerPath]: api.reducer },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+  });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/repo/acme/site/proxy-rules/rs-1/rule-1']}>
+        <Routes>
+          <Route
+            path="/repo/:owner/:repo/proxy-rules/:ruleSetId/:ruleId"
+            element={<RuleEditorPage />}
+          />
+          <Route path="*" element={<div>elsewhere</div>} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+const managedWarningCalls = () =>
+  mockToast.mock.calls.filter(([args]) => args?.title === 'Managed from git');
+
+describe('RuleEditorPage managed-from-git warning', () => {
+  let setBody: ReturnType<typeof ruleSetBody>;
+
+  beforeEach(() => {
+    mockToast.mockClear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: Request | string) => {
+        const url = typeof input === 'string' ? input : input.url;
+        const method = typeof input === 'string' ? 'GET' : input.method;
+        if (url.includes('/api/proxy-rules/rule-1') && method === 'PATCH') {
+          return jsonResponse(ruleBody);
+        }
+        if (url.includes('/api/proxy-rules/rule-1')) return jsonResponse(ruleBody);
+        if (url.includes('/api/proxy-rule-sets/rs-1')) return jsonResponse(setBody);
+        throw new Error(`Unexpected fetch: ${method} ${url}`);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('warns once when saving a rule in a managed set (covers edits and order changes)', async () => {
+    setBody = ruleSetBody(managedSource);
+    renderPage();
+
+    const save = await screen.findByText('stub-save-rule');
+    await userEvent.click(save);
+    await waitFor(() => expect(managedWarningCalls()).toHaveLength(1));
+
+    // Second save on the same visit does not re-warn.
+    await userEvent.click(save);
+    await waitFor(() =>
+      expect(mockToast.mock.calls.some(([args]) => args?.title === 'Rule updated')).toBe(true),
+    );
+    expect(managedWarningCalls()).toHaveLength(1);
+  });
+
+  it('does not warn when saving a rule in an unmanaged set', async () => {
+    setBody = ruleSetBody(null);
+    renderPage();
+
+    await userEvent.click(await screen.findByText('stub-save-rule'));
+    await waitFor(() =>
+      expect(mockToast.mock.calls.some(([args]) => args?.title === 'Rule updated')).toBe(true),
+    );
+    expect(managedWarningCalls()).toHaveLength(0);
+  });
+});

--- a/apps/frontend/src/pages/RuleEditorPage.tsx
+++ b/apps/frontend/src/pages/RuleEditorPage.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent } from '@/components/ui/card';
@@ -21,6 +22,7 @@ import {
 import { useProjectRole } from '@/hooks/useProjectRole';
 import { useToast } from '@/hooks/use-toast';
 import { ExpandedProxyRuleForm } from '@/components/proxy-rules/ExpandedProxyRuleForm';
+import { MANAGED_FROM_GIT_WARNING } from '@/components/proxy-rules/ManagedFromGitBadge';
 import { routes } from '@/utils/routes';
 
 /**
@@ -64,7 +66,21 @@ export function RuleEditorPage() {
   const [createRule, { isLoading: isCreating }] = useCreateRuleInSetMutation();
   const [updateRule, { isLoading: isUpdating }] = useUpdateProxyRuleMutation();
 
+  // One-time (per page visit) warning when saving into a git-managed set
+  // (decision 2: warn, never block, never clear `source`). Covers rule edits
+  // AND order changes — the Priority field saves through this page too.
+  const managedEditWarnedRef = useRef(false);
+  const warnIfManaged = () => {
+    if (!ruleSet?.source || managedEditWarnedRef.current) return;
+    managedEditWarnedRef.current = true;
+    toast({
+      title: 'Managed from git',
+      description: MANAGED_FROM_GIT_WARNING,
+    });
+  };
+
   const handleSubmit = async (data: CreateProxyRuleDto) => {
+    warnIfManaged();
     try {
       if (isCreateMode) {
         const newRule = await createRule({ ruleSetId: ruleSetId!, rule: data }).unwrap();

--- a/apps/frontend/src/pages/RuleSetDetailPage.test.tsx
+++ b/apps/frontend/src/pages/RuleSetDetailPage.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { configureStore } from '@reduxjs/toolkit';
+import { RuleSetDetailPage } from './RuleSetDetailPage';
+import { api } from '@/services/api';
+import { MANAGED_FROM_GIT_WARNING } from '@/components/proxy-rules/ManagedFromGitBadge';
+
+// The rules list has its own concerns (log counts, dialogs, switches); stub it
+// with plain buttons that exercise the page's update/delete callbacks.
+vi.mock('@/components/proxy-rules/RulesList', () => ({
+  RulesList: ({
+    onUpdateRule,
+    onDeleteRule,
+  }: {
+    onUpdateRule: (id: string, updates: unknown) => Promise<void>;
+    onDeleteRule: (id: string) => Promise<void>;
+  }) => (
+    <div>
+      <button onClick={() => void onUpdateRule('rule-1', { isEnabled: false })}>
+        stub-update-rule
+      </button>
+      <button onClick={() => void onDeleteRule('rule-1')}>stub-delete-rule</button>
+    </div>
+  ),
+}));
+
+// The set edit dialog carries its own inline managed-from-git alert,
+// covered by its own test file.
+vi.mock('@/components/proxy-rules/EditRuleSetDialog', () => ({
+  EditRuleSetDialog: () => null,
+}));
+
+const mockToast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock('@/hooks/useProjectRole', () => ({
+  useProjectRole: () => ({
+    role: 'owner',
+    isLoading: false,
+    canEdit: true,
+    canAdmin: true,
+    isOwner: true,
+  }),
+}));
+
+const managedSource = {
+  repo: 'bffless/apps',
+  path: 'apps/studio/proxy-rules',
+  gitSha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+  syncedAt: '2026-07-10T00:00:00.000Z',
+  contentHash: 'sha256:deadbeef',
+};
+
+function ruleSetBody(source: typeof managedSource | null) {
+  return {
+    id: 'rs-1',
+    projectId: 'proj-1',
+    name: 'My API Rules',
+    description: null,
+    environment: 'production',
+    source,
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    rules: [],
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function renderPage() {
+  const store = configureStore({
+    reducer: { [api.reducerPath]: api.reducer },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+  });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/repo/acme/site/proxy-rules/rs-1']}>
+        <Routes>
+          <Route
+            path="/repo/:owner/:repo/proxy-rules/:ruleSetId"
+            element={<RuleSetDetailPage />}
+          />
+          <Route path="*" element={<div>elsewhere</div>} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+const managedWarningCalls = () =>
+  mockToast.mock.calls.filter(([args]) => args?.title === 'Managed from git');
+
+describe('RuleSetDetailPage managed-from-git', () => {
+  let setBody: ReturnType<typeof ruleSetBody>;
+
+  beforeEach(() => {
+    mockToast.mockClear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: Request | string) => {
+        const url = typeof input === 'string' ? input : input.url;
+        const method = typeof input === 'string' ? 'GET' : input.method;
+        if (url.includes('/api/proxy-rule-sets/rs-1')) return jsonResponse(setBody);
+        if (url.includes('/api/proxy-rules/rule-1') && method === 'PATCH') {
+          return jsonResponse({ id: 'rule-1' });
+        }
+        if (url.includes('/api/proxy-rules/rule-1') && method === 'DELETE') {
+          return jsonResponse({ success: true });
+        }
+        throw new Error(`Unexpected fetch: ${method} ${url}`);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('shows the banner in the header for a managed set', async () => {
+    setBody = ruleSetBody(managedSource);
+    renderPage();
+
+    expect(await screen.findByText('Managed from git')).toBeInTheDocument();
+    expect(screen.getByText('bffless/apps@a1b2c3d')).toBeInTheDocument();
+  });
+
+  it('shows no banner for an unmanaged set', async () => {
+    setBody = ruleSetBody(null);
+    renderPage();
+
+    // Name renders in both the breadcrumb and the card title
+    expect(await screen.findAllByText('My API Rules')).not.toHaveLength(0);
+    expect(screen.queryByText('Managed from git')).not.toBeInTheDocument();
+  });
+
+  it('warns once per visit when mutating rules in a managed set', async () => {
+    setBody = ruleSetBody(managedSource);
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByText('stub-update-rule'));
+
+    await waitFor(() => expect(managedWarningCalls()).toHaveLength(1));
+    expect(managedWarningCalls()[0][0]).toEqual({
+      title: 'Managed from git',
+      description: MANAGED_FROM_GIT_WARNING,
+    });
+
+    // A second edit affordance in the same visit does not re-warn
+    await user.click(screen.getByText('stub-delete-rule'));
+    await waitFor(() =>
+      expect(mockToast.mock.calls.some(([args]) => args?.title === 'Rule deleted')).toBe(true),
+    );
+    expect(managedWarningCalls()).toHaveLength(1);
+  });
+
+  it('warns when opening the Add Rule flow on a managed set', async () => {
+    setBody = ruleSetBody(managedSource);
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: /Add Rule/ }));
+
+    expect(managedWarningCalls()).toHaveLength(1);
+  });
+
+  it('never warns for an unmanaged set', async () => {
+    setBody = ruleSetBody(null);
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByText('stub-update-rule'));
+    await waitFor(() =>
+      expect(mockToast.mock.calls.some(([args]) => args?.title === 'Rule updated')).toBe(true),
+    );
+    expect(managedWarningCalls()).toHaveLength(0);
+  });
+});

--- a/apps/frontend/src/pages/RuleSetDetailPage.tsx
+++ b/apps/frontend/src/pages/RuleSetDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -23,6 +23,10 @@ import { useProjectRole } from '@/hooks/useProjectRole';
 import { useToast } from '@/hooks/use-toast';
 import { RulesList } from '@/components/proxy-rules/RulesList';
 import { EditRuleSetDialog } from '@/components/proxy-rules/EditRuleSetDialog';
+import {
+  ManagedFromGitBadge,
+  MANAGED_FROM_GIT_WARNING,
+} from '@/components/proxy-rules/ManagedFromGitBadge';
 import { routes } from '@/utils/routes';
 
 /**
@@ -52,7 +56,21 @@ export function RuleSetDetailPage() {
   // Edit dialog state
   const [editDialogOpen, setEditDialogOpen] = useState(false);
 
+  // One-time (per page visit) warning when mutating a git-managed set
+  // (decision 2: warn, never block, never clear `source`). The set edit
+  // dialog carries its own inline alert, so it's excluded here.
+  const managedEditWarnedRef = useRef(false);
+  const warnIfManaged = () => {
+    if (!ruleSet?.source || managedEditWarnedRef.current) return;
+    managedEditWarnedRef.current = true;
+    toast({
+      title: 'Managed from git',
+      description: MANAGED_FROM_GIT_WARNING,
+    });
+  };
+
   const handleUpdateRule = async (id: string, updates: UpdateProxyRuleDto) => {
+    warnIfManaged();
     try {
       await updateRule({ id, updates }).unwrap();
       toast({
@@ -72,6 +90,7 @@ export function RuleSetDetailPage() {
   };
 
   const handleDeleteRule = async (id: string) => {
+    warnIfManaged();
     try {
       await deleteRule(id).unwrap();
       toast({
@@ -172,6 +191,7 @@ export function RuleSetDetailPage() {
               {ruleSet.environment && (
                 <Badge variant="outline">{ruleSet.environment}</Badge>
               )}
+              <ManagedFromGitBadge source={ruleSet.source} />
               {canEdit && (
                 <Button
                   variant="ghost"
@@ -192,7 +212,10 @@ export function RuleSetDetailPage() {
             <Button
               size="sm"
               className="gap-2"
-              onClick={() => navigate(routes.newRule(owner!, repo!, ruleSetId!))}
+              onClick={() => {
+                warnIfManaged();
+                navigate(routes.newRule(owner!, repo!, ruleSetId!));
+              }}
             >
               <Plus className="h-4 w-4" />
               Add Rule

--- a/apps/frontend/src/services/pipelineSchemasApi.ts
+++ b/apps/frontend/src/services/pipelineSchemasApi.ts
@@ -340,7 +340,6 @@ export const {
   // Schemas
   useGetProjectSchemasQuery,
   useGetSchemaQuery,
-  useLazyGetSchemaQuery,
   useCreateSchemaMutation,
   useUpdateSchemaMutation,
   useDeleteSchemaMutation,

--- a/apps/frontend/src/services/proxyRulesApi.ts
+++ b/apps/frontend/src/services/proxyRulesApi.ts
@@ -148,11 +148,30 @@ export interface UpdateProxyRuleDto {
   debugEnabled?: boolean;
 }
 
-// A single proxy rule as represented in an export file (no server-managed fields)
-export type ExportedProxyRule = Omit<
-  ProxyRule,
-  'id' | 'ruleSetId' | 'createdAt' | 'updatedAt'
->;
+// A single proxy rule as represented in an export file (no server-managed fields).
+// Mirrors the server's canonical export shape (`export-format.util.ts` /
+// `ExportedProxyRuleDto`): null keys are stripped server-side, so everything but
+// `pathPattern`/`targetUrl` is optional. Includes `methods` (the #448 fix).
+export interface ExportedProxyRule {
+  pathPattern: string;
+  method?: HttpMethod;
+  methods?: HttpMethod[];
+  targetUrl: string;
+  stripPrefix?: boolean;
+  order?: number;
+  timeout?: number;
+  preserveHost?: boolean;
+  forwardCookies?: boolean;
+  headerConfig?: HeaderConfig;
+  authTransform?: AuthTransformConfig;
+  internalRewrite?: boolean;
+  proxyType?: ProxyType;
+  emailHandlerConfig?: EmailHandlerConfig;
+  pipelineConfig?: PipelineConfig;
+  isEnabled?: boolean;
+  debugEnabled?: boolean;
+  description?: string;
+}
 
 // A schema dependency bundled in an export (definitions only — name + fields).
 // `id` is the original (source-project) schema id as referenced in the rules.
@@ -164,6 +183,9 @@ export interface ExportedSchema {
 
 // Portable export envelope for a proxy rule set, its rules, and schema deps.
 // version 1: no `schemas`. version 2: bundles referenced schema definitions.
+// This is the server's canonical envelope (GET /api/proxy-rule-sets/:id/export);
+// null-valued ruleSet keys are stripped and `schemas` is omitted when empty
+// (`| null` remains for older client-assembled export files fed to import).
 export interface ProxyRuleSetExport {
   version: number;
   exportedAt: string;
@@ -349,6 +371,16 @@ export const proxyRulesApi = api.injectEndpoints({
       invalidatesTags: ['ProxyRuleSet', 'ProxyRule'],
     }),
 
+    // Get the canonical export envelope for a rule set. The server assembles it
+    // (schema bundling, secret blanking, null-stripping, key order) — clients
+    // download the payload verbatim. Deliberately untagged and uncached: each
+    // Export click is a fresh lazy fetch, and tags would make unrelated
+    // invalidations background-refetch the heavy export assembly.
+    getRuleSetExport: builder.query<ProxyRuleSetExport, string>({
+      query: (id) => `/api/proxy-rule-sets/${id}/export`,
+      keepUnusedDataFor: 0,
+    }),
+
     // Import a rule set (with rules) from an exported JSON definition
     importRuleSet: builder.mutation<
       ProxyRuleSetWithRules,
@@ -504,10 +536,10 @@ export const {
   useGetProjectRuleSetsQuery,
   useCreateRuleSetMutation,
   useGetRuleSetQuery,
-  useLazyGetRuleSetQuery,
   useUpdateRuleSetMutation,
   useDeleteRuleSetMutation,
   useCopyRuleSetMutation,
+  useLazyGetRuleSetExportQuery,
   useImportRuleSetMutation,
   // Rules within a Rule Set
   useGetRuleSetRulesQuery,

--- a/apps/frontend/src/services/proxyRulesApi.ts
+++ b/apps/frontend/src/services/proxyRulesApi.ts
@@ -76,6 +76,18 @@ export interface ProxyRule {
   updatedAt: string;
 }
 
+// Provenance metadata for a rule set managed from git via the sync endpoint
+// (PUT /api/proxy-rule-sets/project/:projectId/sync). repo/path/gitSha are
+// caller-supplied best-effort; syncedAt and contentHash are stamped
+// server-side on every successful sync. Null/absent for sets never synced.
+export interface ProxyRuleSetSource {
+  repo?: string;
+  path?: string;
+  gitSha?: string;
+  syncedAt: string;
+  contentHash: string;
+}
+
 // Proxy rule set response from API
 export interface ProxyRuleSet {
   id: string;
@@ -83,6 +95,9 @@ export interface ProxyRuleSet {
   name: string;
   description: string | null;
   environment: string | null;
+  // Present when the set is managed from git (rules-as-code sync); kept even
+  // after manual edits — the UI warns instead of clearing it.
+  source?: ProxyRuleSetSource | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/docs/plans/proxy-rules-as-code-phase1-implementation.md
+++ b/docs/plans/proxy-rules-as-code-phase1-implementation.md
@@ -343,13 +343,36 @@ accurate; stub error gone.
 
 ## Status
 
-- [ ] Task 1 — export-format module
-- [ ] Task 2 — export endpoint + equivalence test (#448)
-- [ ] Task 3 — frontend export switch
-- [ ] Task 4 — `source` schema edit (+ operator migration)
-- [ ] Task 5 — sync plan computation
-- [ ] Task 6 — schema resolution by name
-- [ ] Task 7 — sync service + endpoint
-- [ ] Task 8 — UI banner + MCP field
-- [ ] Task 9 — CLI pull/push/diff
-- [ ] Task 10 — final review + verify
+- [x] Task 1 — export-format module (`f2e20ba`; canonical sorting added post-review in `ad2c7e6`)
+- [x] Task 2 — export endpoint + equivalence test (#448) (`ad2c7e6`; CLI-import route via Jest moduleNameMapper)
+- [x] Task 3 — frontend export switch (`e0333c3`)
+- [x] Task 4 — `source` schema edit + DTO (`0114ce9`, `3346e3d`) + operator migration `drizzle/0038` (`7f8561e`)
+- [x] Task 5 — sync plan computation (`8d4e19f`; post-review: add-null guard, CLI-parity proxyType/targetUrl inference, methods [] ≡ null)
+- [x] Task 6 — schema resolution by name (`8a93dc2`; post-review: duplicate-id rejection, strict-under-dryRun pinned)
+- [x] Task 7 — sync service + endpoint (`c444819`; post-review: missingSecrets covers update-path blanks)
+- [x] Task 8 — UI banner + MCP field (`039c390`; post-review: RuleEditorPage save-path warning)
+- [x] Task 9 — CLI pull/push/diff (`ed754e2`; post-review: diff schema-id alignment, targetUrl ''-normalization, validator config {})
+- [x] Task 10 — final whole-branch review + verify (fresh-context adversarial review of
+      `origin/main...HEAD`; verdict "fix-first, then ship" — both fixes taken: fail-loud
+      guard on duplicate live `(pathPattern, null)` match keys from methods-split rules,
+      and `methods: []` dropped at export so it can't become push-unfixable diff drift.
+      Verification: backend 1659 passed / 107 suites, frontend 469 / 42 files,
+      CLI 298 / 20 files, all three `tsc --noEmit` clean.)
+
+## Known limitations (Phase 1, documented not fixed)
+
+- **Methods-split sets can't sync yet.** Two live rules sharing `(pathPattern, method:
+  null)` and differing only by `methods[]` are legal (PG unique index treats NULLs as
+  distinct) but the sync/diff match key can't address them; sync now fails loudly (400)
+  instead of silently overwriting one variant. Phase 2: fold a methods signature into
+  the match key.
+- **Set metadata is not declarative.** Sync writes `description`/`environment` only when
+  provided — removing one from `ruleset.yaml` preserves the live value, and `rules diff`
+  will keep reporting that drift. Workaround: set the field explicitly (empty string) or
+  edit once in the dashboard.
+- **`source.contentHash` is intra-project only** — it covers remapped schema ids, so it
+  is stable within a target project but not reproducible from the git payload alone.
+  Phase 1 drift detection uses `exportsEquivalent`, not the hash.
+- **Pre-existing, filed as follow-up:** `copy()` inserts decrypted `headerConfig` without
+  re-encrypting (plaintext at rest for copies) — present on `main`, not a Phase 1
+  regression.

--- a/docs/plans/proxy-rules-as-code-phase1-implementation.md
+++ b/docs/plans/proxy-rules-as-code-phase1-implementation.md
@@ -1,0 +1,355 @@
+# Proxy Rules as Code — Phase 1 Implementation Plan
+
+CE backend sync surface: server export endpoint (closes #448), idempotent sync endpoint,
+`source` tracking + managed-from-git banner, CLI live `pull`/`push`/`diff`.
+
+Companion to `proxy-rules-as-code.md` (§4 spec) and `proxy-rules-as-code-phase1-kickoff.md`
+(status handoff). Branch: `feat/proxy-rules-phase1` off `main@469e35d`.
+
+Date: 2026-07-11
+
+## Resolved design decisions (operator, 2026-07-11)
+
+1. **Sync secret handling — preserve live values.** An incoming empty-string
+   `headerConfig.add` value means "keep whatever the live rule has". If the rule is new
+   (no live value), store `''` and report the header name in `missingSecrets[]`. Non-empty
+   incoming values overwrite. Content comparison ignores blanked values (a blank incoming
+   value never makes a rule "changed").
+2. **Drift policy — keep `source`, warn.** Manual dashboard/MCP edits to a git-managed set
+   leave `source` intact; the UI warns edits will be overwritten on next deploy. Drift is
+   detected by contentHash / `rules diff`, not by clearing state.
+3. **Banner scope — UI banner + MCP field.** Frontend banner + edit warning; MCP includes
+   `source` in proxy-rule-set tool responses (no bespoke MCP warning logic).
+4. **Schema mismatch — warnings + opt-in strict.** Field mismatches on a name-reused schema
+   always land in `warnings[]`; `options.strictSchemas: true` turns them into a 400 (the
+   transaction guarantees no partial write). CLI exposes `--strict-schemas`.
+
+## Ground truth & key facts
+
+- **The CLI canonicalizer is the export-format reference**:
+  `packages/cli/src/format/{types,canonical,defaults}.ts`. `RULE_KEY_ORDER` (18 keys,
+  including `methods` — the #448 fix), `ENVELOPE_KEY_ORDER`, null/undefined stripping at
+  structural levels only, `schemas` key omitted when empty.
+- Backend already has `collectSchemaIds`/`remapSchemaIds` (`schema-refs.util.ts`) — the
+  frontend's copies mirror them.
+- `ProxyRulesService.getRulesByRuleSetId()` returns rules with **decrypted**
+  `headerConfig.add`; `encryptHeaderConfigForStorage()` is the write-side counterpart.
+- `sanitizeHeaderConfigForExport` currently exists **only in the frontend** — the backend
+  needs its own (blank `add` values to `''`).
+- Rule matching key: unique `(ruleSetId, pathPattern, method)`; `method` is nullable
+  (NULLs distinct in PG — matching logic must treat `null`/absent consistently).
+  Set matching key: unique `(projectId, name)`. Schemas: unique `(projectId, name)`.
+- DB rule defaults (import parity): `stripPrefix:true, order:i, timeout:30000,
+  preserveHost:false, forwardCookies:false, internalRewrite:false,
+  proxyType:'external_proxy', isEnabled:true, debugEnabled:false, targetUrl:''`.
+- **Sync must regenerate nginx** — unlike import (fresh sets are unattached), a synced set
+  may be attached to live aliases. `NginxRegenerationService.regenerateForRuleSet(ruleSetId)`
+  exists and does exactly this. Call after a non-dryRun sync that changed anything.
+- SSRF gap: import skips the `IsValidTargetUrlOrPath` validation that
+  `ProxyRulesService.create` enforces. The sync DTO must apply it per rule.
+- `db.transaction` precedent: `traffic/blocklist.service.ts`, `deployments/deployments.service.ts`.
+- Secrets interpolation (`{{secrets.NAME}}`) is a pipeline-execution concept
+  (`pipelines/execution/expression-evaluator.ts`); `project_secrets` has unique
+  `(projectId, name)`. `missingSecrets[]` = referenced names with no matching secret row.
+- MCP tools: `apps/backend/src/mcp/tools/proxy-rules.tools.ts`.
+- CLI stubs to replace: `packages/cli/src/commands/pull.ts:32` errors with
+  "live pull requires a server export endpoint (Phase 1)". `push`/`diff` don't exist yet.
+  CLI config (`.bffless/config.json`): `{ apiUrl?, project?, ruleSets? }`.
+- Backend tests are Jest (`cd apps/backend && pnpm test`); CLI tests are in
+  `packages/cli` (`pnpm test` there); frontend is Vitest.
+
+## Cross-cutting definitions
+
+**Canonical rule serialization (server)**: emit keys in `RULE_KEY_ORDER`, dropping
+`null`/`undefined` at the rule top level (nested config objects pass through verbatim).
+This matches the CLI's `canonicalizeRule` on the wire.
+
+**contentHash**: sha256 hex over `JSON.stringify` of the defaults-normalized, canonically
+key-ordered `{ ruleSet: {name, description?, environment?}, rules: [...] }` of the synced
+payload (schemas excluded — they're project-level; secrets excluded by construction since
+exports blank them). Computed server-side at sync time, stored in `source.contentHash`.
+Documented so `rules diff` / CI can reproduce it later if useful; Phase 1 diff uses
+`exportsEquivalent`, not the hash.
+
+**Sync response shape** (also the dryRun plan):
+
+```jsonc
+{
+  "ruleSetId": "…",            // null on dryRun-create
+  "created": [{ "pathPattern": "/api/x", "method": "GET" }],
+  "updated": [{ "pathPattern": "/api/y", "method": null }],
+  "deleted": [],                // only non-empty when options.prune
+  "unchanged": [{ "pathPattern": "/api/z", "method": "POST" }],
+  "pruneCandidates": [],        // live-only rules NOT deleted because prune=false
+  "schemaResolutions": [{ "name": "comments", "action": "reuse" | "create", "targetSchemaId": "…|null", "fieldMismatch": false }],
+  "missingSecrets": ["OPENAI_API_KEY"],
+  "warnings": ["…"],
+  "dryRun": false,
+  "setCreated": false
+}
+```
+
+## Process
+
+Subagent-driven, mirroring Phase 0: a **fresh implementer subagent per task** (TDD: tests
+first, then code, run the suite), an **independent adversarial review subagent per task**
+(reviews the diff with intent to refute correctness/completeness), fixes applied before
+moving on, and a **final whole-branch review**. The orchestrator arbitrates and keeps this
+doc's checkboxes current.
+
+Operator constraints: no commit/push without explicit approval; `db:generate`/`db:migrate`
+are interactive and operator-run (Task 4); the agent edits the schema file and reviews the
+generated SQL.
+
+Task order is dependency order. Tasks 1–3 are the export track (shippable alone, closes
+#448). Task 4 is a tiny schema edit whose interactive migration can be generated any time
+before merge — it does not block 5–7 (backend unit tests mock the DB). Tasks 5–7 are the
+sync track. Task 8 is UI/MCP. Task 9 is the CLI. Task 10 is the final review.
+
+---
+
+## Task 1 — Backend export-format module (pure functions)
+
+**Files**: new `apps/backend/src/proxy-rules/export-format.util.ts` + `.spec.ts`.
+
+Pure helpers, no DB:
+
+- `sanitizeHeaderConfigForExport(headerConfig)` — blank every `add` value to `''`;
+  pass `forward`/`strip` through; `null`/`undefined` in → `undefined` out.
+- `serializeRuleForExport(rule)` — DB row → exported rule: pick the 18 `RULE_KEY_ORDER`
+  keys in order, drop `null`/`undefined` at rule top level, run headerConfig through the
+  sanitizer. Nested objects (`pipelineConfig`, `authTransform`, …) verbatim.
+- `buildExportEnvelope({ ruleSet, rules, schemas, exportedAt })` — v2 envelope in
+  `ENVELOPE_KEY_ORDER`; `ruleSet` keys `{name, description?, environment?}` stripped of
+  null/undefined; `schemas` key omitted when empty.
+
+**TDD**: spec first — key order (assert via `Object.keys`), `methods` included when set
+(#448 regression test), null stripping at structural levels only (a `null` inside a step
+`config` survives), secret blanking, `schemas` omission, envelope key order.
+
+**Done when**: spec passes; no imports from frontend; types locally defined or shared.
+
+## Task 2 — Export endpoint + CLI-equivalence test (closes #448)
+
+**Files**: `proxy-rule-sets.service.ts` (`exportRuleSet`), `proxy-rule-sets.controller.ts`
+(`GET :id/export`), DTO in `dto/`, service spec.
+
+- `exportRuleSet(id, apiKeyProjectId)` — load set (404 if missing), enforce the same
+  authorization as `getById` (`enforceApiKeyProjectScope`), load decrypted rules via
+  `getRulesByRuleSetId`, serialize via Task 1, `collectSchemaIds` over the serialized
+  rules, fetch each schema (`{id, name, fields}`; skip silently if missing — parity with
+  the frontend's tolerance), envelope with fresh `exportedAt`.
+- Controller: `GET :id/export`, Swagger docs, same guard story as `getById`.
+- **Equivalence test**: assert the server export is accepted verbatim by the CLI's
+  canonicalizer contract. Preferred: import `exportsEquivalent`/`canonicalizeExport` from
+  `packages/cli` in the backend spec (workspace devDependency). If Jest/ESM interop makes
+  that painful, fall back to a golden-fixture test: a fixture set covering every rule field
+  (incl. `methods`, pipeline rules with schema refs, header add secrets) whose expected
+  canonical JSON was produced by the CLI's `stringifyExport` and committed under
+  `apps/backend/test/fixtures/`. Either way the test must fail if a field is dropped
+  (i.e. it would have caught #448).
+
+**Done when**: endpoint returns the canonical envelope; equivalence test green; controller
+spec covers 404 + happy path.
+
+## Task 3 — Frontend consumes the export endpoint
+
+**Files**: `apps/frontend/src/services/proxyRulesApi.ts`, `apps/frontend/src/pages/ProxyRuleSetsPage.tsx`,
+frontend tests.
+
+- Add an RTK Query (lazy) endpoint for `GET /api/proxy-rule-sets/:id/export`.
+- `handleExport` fetches the envelope from the server, downloads it as
+  `<safeName>.proxy-rules.json` (keep the filename + toast logic; counts come from the
+  payload). Delete the client-side assembly (`collectSchemaIds` walk, per-rule mapper,
+  `sanitizeHeaderConfigForExport`) and any now-unused frontend copies of those helpers —
+  the export format ceases to be a frontend contract.
+- Keep `ExportedProxyRule`/envelope types only where the import dialog still needs them.
+
+**Done when**: export flows through the server; dead code removed; frontend tests +
+`tsc --noEmit` pass.
+
+## Task 4 — `source` column (schema edit now; interactive migration operator-run)
+
+**Files**: `apps/backend/src/db/schema/proxy-rule-sets.schema.ts`, `dto/` response DTOs.
+
+- Add nullable `source` jsonb: `{ repo?: string; path?: string; gitSha?: string;
+  syncedAt: string; contentHash: string }` (typed via `.$type<ProxyRuleSetSource>()`).
+- Expose `source` on `ProxyRuleSetResponseDto` / `ProxyRuleSetWithRulesResponseDto`.
+- **Migration is interactive**: the operator runs `cd apps/backend && pnpm db:generate`
+  (then `db:migrate`); the agent reviews the generated SQL. NEVER hand-write migration SQL.
+- Unit tests mock the DB, so Tasks 5–7 proceed on the schema edit alone; the migration
+  must exist before merge.
+
+**Done when**: schema + DTOs updated, backend typecheck passes; migration generation
+requested from the operator (tracked, not blocking).
+
+## Task 5 — Sync plan computation (pure)
+
+**Files**: new `apps/backend/src/proxy-rules/sync-plan.util.ts` + `.spec.ts`.
+
+Pure function: `computeSyncPlan(liveRules, incomingRules, { prune })` →
+`{ toCreate[], toUpdate[], unchanged[], toDelete[], pruneCandidates[] }`.
+
+- **Match key**: `(pathPattern, method ?? null)`. Duplicate match keys in the incoming
+  payload are a validation error surfaced by the caller (the DB unique key would reject
+  them anyway — fail fast with a clear message).
+- **Normalization before comparison**: apply the DB import defaults to the incoming rule
+  (absent-means-default, same table as `importRuleSet`), and compare against the live row
+  projected through Task 1's `serializeRuleForExport`-style canonical form so
+  server-managed fields (`id`, timestamps, `ruleSetId`) never count.
+- **Blank-secret semantics** (decision 1): an incoming `headerConfig.add` value of `''`
+  compares equal to any live value for that header name, and on update the live value is
+  preserved. A header name present live but absent from the incoming `add` map is a real
+  change (removal). Non-empty incoming values compare/overwrite normally.
+- `toDelete` = live-only rules when `prune`; otherwise they land in `pruneCandidates`.
+- `order` changes count as changes (they affect evaluation order).
+
+**TDD**: table-driven spec — creates/updates/unchanged/deletes/pruneCandidates; blank-vs-set
+secret cases; default-vs-explicit equivalence (`timeout: 30000` vs absent); method
+null-vs-string keying; order-only change; duplicate incoming keys → error.
+
+**Done when**: spec passes; function is side-effect-free and DB-free.
+
+## Task 6 — Non-interactive schema resolution by name
+
+**Files**: `proxy-rule-sets.service.ts` (private helper) or new
+`schema-sync.util.ts` + service glue; specs.
+
+`resolveSchemasByName(projectId, schemas, { strictSchemas, dryRun }, …auth)` →
+`{ idMap, resolutions, warnings }`.
+
+- For each bundled schema `{id, name, fields}`: if a project schema with that `name`
+  exists → `action:'reuse'`, map `sourceId → existing.id`; compare `fields` (by field
+  `name` + `type` + `required`, order-insensitive) — mismatch appends to `warnings[]`
+  with a precise message, and under `strictSchemas` the whole sync fails 400.
+- Missing → `action:'create'`. **Under `dryRun`, do not create** — report the plan with
+  `targetSchemaId: null`. (Live sync creates via `pipelineSchemasService.create` with the
+  exact name — no auto-suffixing; the name is the identity, unlike import.)
+- No interactive `ImportSchemaResolutionDto` choices anywhere in this path.
+
+**TDD**: reuse (identical fields), reuse (mismatched fields → warning; strict → throws),
+create, dryRun-create (no service call — assert with mock), mixed batch.
+
+**Done when**: spec passes; behavior matches decision 4.
+
+## Task 7 — Sync service + endpoint
+
+**Files**: `proxy-rule-sets.service.ts` (`syncRuleSet`), controller
+(`PUT project/:projectId/sync`), new DTOs (`SyncProxyRuleSetDto`,
+`SyncProxyRuleSetResponseDto`), specs.
+
+**DTO**: `{ ruleSet: {name, description?, environment?}, rules: SyncRuleDto[],
+schemas?: {id, name, fields}[], options?: { prune?, dryRun?, strictSchemas? },
+source?: { repo?, path?, gitSha? } }`. `SyncRuleDto` mirrors the import rule DTO **plus
+`IsValidTargetUrlOrPath` on `targetUrl`** (closes the SSRF gap; import's laxness is
+pre-existing and out of scope to change here).
+
+**Service flow** (`syncRuleSet(projectId, dto, userId, userRole, apiKeyProjectId)`):
+
+1. Project exists (404) + `requireProjectAccess(…, 'contributor', …)` — import parity.
+2. Resolve schemas (Task 6) → `idMap`; `remapSchemaIds` over incoming rules.
+3. Find set by `(projectId, name)`; absent → plan a create (`setCreated: true`).
+4. Load live rules decrypted (empty for a new set); `computeSyncPlan` (Task 5).
+5. Collect `{{secrets.NAME}}` references (regex over the JSON-stringified incoming rules),
+   check against `project_secrets` names → `missingSecrets[]` (warning-level, never fatal).
+   Also add new-rule blank header `add` names to `missingSecrets[]` (decision 1).
+6. `dryRun` → return the full response with no writes at all (no set create, no schema
+   create, no rule writes, no source stamp).
+7. Otherwise, in **one `db.transaction`**: upsert the set (create, or update
+   description/environment when changed), insert `toCreate` (defaults + encrypted headers),
+   update `toUpdate` (preserving live header values where incoming is blank, encrypting
+   fresh values), delete `toDelete`, stamp `source` (`{...dto.source, syncedAt: now,
+   contentHash}`).
+8. Post-commit: if anything changed, `nginxRegenerationService.regenerateForRuleSet(id)`
+   (failure logged as warning in `warnings[]`, not a 500 — the DB state is committed).
+9. Return the response shape above.
+
+**Controller**: `PUT project/:projectId/sync`, `ApiKeyGuard` (class-level), Swagger.
+
+**TDD**: service spec with mocked db/services — idempotency (second sync of same payload →
+all `unchanged`, no writes, but `source` re-stamped), create-from-scratch, update+preserve
+secret, prune on/off, dryRun writes nothing (assert on mocks), missingSecrets, strictSchemas
+400 before any write, transaction rollback on mid-flight error, nginx called once on change /
+not called when all unchanged. Controller spec: guard + happy path + validation error.
+
+**Done when**: all specs pass; `pnpm test` (backend) green; response is byte-stable for CI
+consumption.
+
+## Task 8 — Managed-from-git banner (UI) + MCP `source` field
+
+**Files**: frontend `ProxyRuleSetsPage.tsx` (+ the set detail/rules page), `proxyRulesApi.ts`
+types; backend `mcp/tools/proxy-rules.tools.ts`.
+
+- Frontend: sets with `source` show a banner/badge "Managed from git
+  (`repo@shortSha`, synced `<relative time>`)". Opening an edit dialog / mutating a rule in
+  a managed set shows the warning "This set is managed from git — manual edits will be
+  overwritten on next deploy. Run `bffless rules pull` to keep this change." Edits stay
+  allowed; `source` is never cleared (decision 2).
+- MCP: include `source` in rule-set responses (list/get) so agents can see the managed state; no
+  extra warning logic (decision 3).
+
+**TDD**: frontend component tests (banner renders with/without `source`; warning shown);
+MCP tool spec asserts `source` passthrough.
+
+**Done when**: tests + `tsc --noEmit` pass on both apps.
+
+## Task 9 — CLI live `pull` / `push` / `diff`
+
+**Files**: `packages/cli/src/` — new `api/client.ts` (fetch wrapper), `commands/push.ts`,
+`commands/diff.ts`, rework `commands/pull.ts`, `index.ts` wiring, tests.
+
+- **Client**: base URL from `--api-url` flag > `BFFLESS_API_URL` env > config `apiUrl`;
+  key from `--api-key` flag > `BFFLESS_API_KEY` env (never in config.json). Sends
+  `X-API-Key`. Inject `fetch` for tests. Clear errors on 401/403/404.
+- **Set resolution**: the API is UUID-addressed; resolve by listing
+  `GET /api/proxy-rule-sets/project/:projectId` and matching `name`. `projectId` from
+  config `project` / flag. If `project` holds a name rather than a UUID, resolve via the
+  projects list endpoint (implementer: check `projects` controller for the right call) —
+  error messages must say exactly what was tried.
+- **`rules pull <set-name>`**: resolve → `GET :id/export` → existing `decompileExport` /
+  `writeDecompiled` (keep `--from-file` path working; `--decompile` stays default-on
+  semantics for live pulls — live pull always decompiles).
+- **`rules push [dirs…]`**: `build` in-memory → optional `--name-suffix pr-42` (rename
+  `ruleSet.name` to `<name>-pr-42`) → attach `source` metadata (repo from
+  `GITHUB_REPOSITORY` env or `git remote get-url origin`; gitSha from `GITHUB_SHA` or
+  `git rev-parse HEAD`; path = rule-set dir relative to repo root; all best-effort) →
+  `PUT project/:projectId/sync` with `--dry-run`, `--prune`, `--strict-schemas` flags →
+  print the change report (created/updated/deleted/unchanged counts + lists,
+  pruneCandidates, missingSecrets, warnings). Exit non-zero on HTTP error or strict
+  failure; missingSecrets is a warning, exit 0.
+- **`rules diff [dirs…]`**: build local + fetch live export → `exportsEquivalent` →
+  print diffs, exit 1 on drift, 0 on clean (CI contract).
+- Replace the Phase-1 stub error in `pull.ts`.
+
+**TDD**: client tests (headers, error mapping) with injected fetch; command tests with a
+stubbed client — pull happy path, push dry-run report rendering, push name-suffix, diff
+exit codes. Reuse Phase 0's fixtures.
+
+**Done when**: `pnpm test` in `packages/cli` green; `bffless rules pull|push|diff --help`
+accurate; stub error gone.
+
+## Task 10 — Final whole-branch review + verification
+
+- Independent adversarial review of the entire branch diff vs `main` (fresh subagent, no
+  implementation context): correctness, the four decisions honored, #448 actually fixed,
+  SSRF validation present, transaction + nginx regeneration correct, no secret leaks in
+  exports or logs, no drive-by regressions to import/copy.
+- Verification: backend `pnpm test`, frontend tests, `packages/cli` tests, both
+  `tsc --noEmit` typechecks. Exercise an end-to-end flow if feasible (backend up locally,
+  real export→decompile→build→push round-trip).
+- Review the operator-generated migration SQL (Task 4) before merge.
+- Update the kickoff doc's status section; note the follow-ups (Phase 2 CI action, reader
+  conversion, revisions in Phase 3).
+
+## Status
+
+- [ ] Task 1 — export-format module
+- [ ] Task 2 — export endpoint + equivalence test (#448)
+- [ ] Task 3 — frontend export switch
+- [ ] Task 4 — `source` schema edit (+ operator migration)
+- [ ] Task 5 — sync plan computation
+- [ ] Task 6 — schema resolution by name
+- [ ] Task 7 — sync service + endpoint
+- [ ] Task 8 — UI banner + MCP field
+- [ ] Task 9 — CLI pull/push/diff
+- [ ] Task 10 — final review + verify

--- a/docs/plans/proxy-rules-as-code-phase1-kickoff.md
+++ b/docs/plans/proxy-rules-as-code-phase1-kickoff.md
@@ -1,0 +1,132 @@
+# Proxy Rules as Code — Phase 1 Kickoff & Status Handoff
+
+Status doc for resuming after a context clear. Phase 0 is shipped; this doc is the
+starting point for **Phase 1 (CE backend: export + sync endpoints)**.
+
+Date: 2026-07-11
+
+## Where things stand
+
+**Phase 0 — DONE, merged.**
+- The `bffless` CLI (`packages/cli`) shipped in **bffless/ce#449** (commit `469e35d` on `main`):
+  a compiler/decompiler between a file-per-rule authoring layout and the existing
+  `bffless-proxy-rule-set` v2 export JSON, plus a `node:vm` handler test harness
+  (`bffless/harness`), an ESLint preset (`bffless/eslint`), and
+  `bffless rules build | validate | test | pull --from-file`. 232 tests. No CE backend changes.
+- The design doc is `docs/plans/proxy-rules-as-code.md` (merged in #447). §4 is the Phase 1 spec.
+- The Phase 0 implementation plan + reader-pilot report are
+  `docs/plans/proxy-rules-cli-phase0-implementation.md` and `…-phase0-pilot.md`.
+- **Round-trip proven on real data:** the reader pilot decompiled reader's live export
+  (13 rules, 21 handlers) and rebuilt it byte-faithfully (`exportsEquivalent` equal, 0 diffs,
+  all 21 `function_handler` code strings identical).
+
+**Reader pilot output — open PR, non-blocking.** bffless/**apps**#228 carries reader's
+decompiled authoring layout (`apps/reader/.bffless/proxy-rules/reader/**`), additive
+(the raw `reader.proxy-rules.json` backup is kept). It is a review artifact; the full
+reader conversion is Phase 2. **Does not block Phase 1.** Leave open until Phase 2, or merge
+as a reference — either is fine.
+
+**Related bug — bffless/ce#448 (fold into Phase 1).** The frontend exporter silently drops
+the `methods` field (`apps/frontend/src/pages/ProxyRuleSetsPage.tsx`, the `handleExport`
+mapper ~lines 127-147 omits `methods` though the DB column, DTO, and the `ExportedProxyRule`
+type all carry it). Fix it as part of the Phase 1 server-side export endpoint (task 1 below).
+
+**Auth-proxy fix — already released**, unrelated to this work: bffless/ce#444, in release 0.1.105.
+
+## Phase 1 scope (from design doc §4)
+
+Four deliverables, in dependency order. Tasks 1–2 are the substance; 3 needs a DB migration;
+4 wires the already-shipped CLI to the new endpoints.
+
+### Task 1 — Server-side export endpoint (small, ship first; closes #448)
+`GET /api/proxy-rule-sets/:id/export`. Move the export-envelope assembly out of the frontend
+(`ProxyRuleSetsPage.tsx` `handleExport`, ~lines 100-181) into `ProxyRuleSetsService`; frontend
+and the CLI both consume it. **Include the #448 fix** — emit `methods`.
+- Envelope (v2, unchanged): keys `version:2, exportedAt, kind:'bffless-proxy-rule-set',
+  ruleSet:{name,description?,environment?}, rules[], schemas?[]` (schemas key omitted when empty).
+- Per-rule serialized fields (the CLI's `RULE_KEY_ORDER` is the reference, in
+  `packages/cli/src/format/types.ts`): `pathPattern, method, methods, targetUrl, stripPrefix,
+  order, timeout, preserveHost, forwardCookies, headerConfig, authTransform, internalRewrite,
+  proxyType, emailHandlerConfig, pipelineConfig, isEnabled, debugEnabled, description`.
+- `schemas[]` = `{ id, name, fields }` from `collectSchemaIds` walk; `sanitizeHeaderConfigForExport`
+  blanks `headerConfig.add` values to `''` (secret stripping).
+- **Verify against the CLI:** the CLI's `exportsEquivalent`/`canonicalizeExport`
+  (`packages/cli/src/format/canonical.ts`) defines correct output; a good test is
+  `exportsEquivalent(serverExport, cliRoundTrip)`.
+
+### Task 2 — Idempotent sync endpoint (the real unlock)
+`PUT /api/proxy-rule-sets/project/:projectId/sync`.
+- Match the set **by name** (existing unique key `(projectId, name)`); create if absent —
+  this replaces the create-only import (`proxy-rule-sets.service.ts:273-408`, which suffixes
+  `… (Imported)` at ~345-355).
+- Match rules by **`(pathPattern, method)`** (existing unique key
+  `(ruleSetId, pathPattern, method)`): update changed (content-hash for cheap no-ops), insert
+  new, delete removed **only when `options.prune`** (default off).
+- Auto-resolve `schemas[]` **by name** per target project (reuse if a schema with that name
+  exists, else create) — today's `ImportSchemaResolutionDto` needs explicit per-schema choices
+  CI can't answer; sync must be non-interactive. Rewrite refs via `remapSchemaIds`.
+- Body: `{ ruleSet, rules[], schemas[], options: { prune, dryRun } }`.
+  Response: `{ created[], updated[], deleted[], unchanged[], schemaResolutions[],
+  missingSecrets[], warnings[] }`. `dryRun` returns the plan without writing (CI posts it as a
+  PR comment).
+- Guard: `ApiKeyGuard` + `contributor` (same as import). **Add SSRF re-validation of
+  `targetUrl`s** — import currently skips the `IsValidTargetUrlOrPath` check that
+  `ProxyRulesService.create` enforces (gap at ~`:378`); close it here.
+- **Transaction** per set so a failed push can't leave a half-updated set serving traffic.
+- Collect `{{secrets.NAME}}` references, verify against `project_secrets`, return
+  `missingSecrets[]`.
+
+### Task 3 — Source tracking + drift banner (needs a migration)
+- Nullable `source` jsonb on `proxy_rule_sets`: `{ repo, path, gitSha, syncedAt, contentHash }`,
+  written by sync.
+- **MIGRATION IS INTERACTIVE — the operator runs it, not the agent:**
+  `cd apps/backend && pnpm db:generate` (after editing the schema file
+  `src/db/schema/proxy-rule-sets.schema.ts`), then `pnpm db:migrate`. Do NOT hand-write SQL
+  migrations (breaks Drizzle snapshots).
+- Admin UI + MCP show a "Managed from git (repo@sha)" banner on such sets; edits warn
+  "will be overwritten on next deploy".
+
+### Task 4 — Wire the CLI to the endpoints
+In `packages/cli` (already on `main`): implement live `rules pull` (from the export endpoint),
+`rules push` (to the sync endpoint — `--dry-run`, `--prune`, `--name-suffix pr-42`), and
+`rules diff` (compiled vs live, nonzero exit on drift). Auth via `X-API-Key`. These currently
+error with "requires a server export endpoint (Phase 1)".
+
+## Key grounding facts (so you don't re-derive them)
+
+- **Export/import code:** frontend assembly `apps/frontend/src/pages/ProxyRuleSetsPage.tsx`
+  (`handleExport` ~100-181); envelope types `apps/frontend/src/services/proxyRulesApi.ts:152-178`;
+  import service `apps/backend/src/proxy-rules/proxy-rule-sets.service.ts` (`importRuleSet`
+  ~273-408); controller `…/proxy-rule-sets.controller.ts` (`ApiKeyGuard` class-level,
+  `requireProjectAccess(…, 'contributor')`).
+- **DB:** `apps/backend/src/db/schema/proxy-rule-sets.schema.ts` (set: unique `(projectId, name)`;
+  no `source` column yet) and `proxy-rules.schema.ts` (rule: unique
+  `(ruleSetId, pathPattern, method)`; defaults `stripPrefix:true, timeout:30000,
+  preserveHost:false, forwardCookies:false, internalRewrite:false, isEnabled:true,
+  debugEnabled:false, proxyType:'external_proxy'`). Schemas: `pipeline-schemas.schema.ts`,
+  unique `(projectId, name)`.
+- **Schema ref keys** (used by both the CLI and the backend's `schema-refs.util.ts`):
+  `schemaId, persistMessagesSchemaId, persistConversationsSchemaId, conversationsSchemaId,
+  messagesSchemaId`.
+- **The CLI is the export-format reference.** `packages/cli/src/format/{types,canonical,defaults}.ts`
+  encode exactly what a correct v2 export/round-trip looks like. When in doubt about a field or
+  ordering, the CLI's canonicalizer is ground truth; make the server endpoint agree with it.
+- **Handler-type strings** are the canonical union in `apps/backend/src/pipelines/types.ts`
+  (`data_query`, `function_handler`, `response_handler`, `ai_handler`, …).
+
+## How to run this
+
+Use **superpowers subagent-driven-development** again (it worked well for Phase 0): write an
+implementation plan (`docs/plans/proxy-rules-as-code-phase1-implementation.md`) with bite-sized
+TDD tasks, then dispatch a fresh implementer per task + an independent adversarial review per
+task + a final whole-branch review. Backend is Jest (`cd apps/backend && pnpm test`).
+
+Work on branch **`feat/proxy-rules-phase1`** (already created off `main`@`469e35d`, where this
+doc lives). Confirm `git log origin/main` still has #449 as an ancestor before starting.
+
+## Operator constraints (from the repo CLAUDE.md)
+
+- Never commit/push without explicit approval; never force-push; branch off `main`.
+- `db:generate`/`db:migrate` are **interactive** — the operator runs them; the agent edits the
+  schema file and reviews the generated SQL.
+- Deploying to prod / touching live tenants / DB migrations are high-stakes — pause and confirm.

--- a/docs/plans/proxy-rules-as-code-phase1-kickoff.md
+++ b/docs/plans/proxy-rules-as-code-phase1-kickoff.md
@@ -5,6 +5,16 @@ starting point for **Phase 1 (CE backend: export + sync endpoints)**.
 
 Date: 2026-07-11
 
+> **UPDATE 2026-07-12 — Phase 1 is implemented on `feat/proxy-rules-phase1`** (not yet
+> pushed/merged). All four deliverables landed with per-task adversarial reviews and a
+> final whole-branch review: export endpoint (closes #448), sync endpoint, `source`
+> tracking + migration (`drizzle/0038`) + UI banner + MCP field, and live CLI
+> `pull`/`push`/`diff`. See `proxy-rules-as-code-phase1-implementation.md` for the
+> task-by-task status, commit SHAs, resolved design decisions, and the documented
+> Phase 1 limitations (methods-split sets, non-declarative set metadata, contentHash
+> scope, pre-existing `copy()` plaintext headerConfig follow-up). Next: PR + Phase 2
+> (CI action, apps-repo conversion, PR-preview rule sets).
+
 ## Where things stand
 
 **Phase 0 — DONE, merged.**

--- a/packages/cli/src/api/client.ts
+++ b/packages/cli/src/api/client.ts
@@ -1,0 +1,174 @@
+/**
+ * Minimal HTTP client for the BFFless backend API (Phase 1 live `pull`/`push`/`diff`).
+ *
+ * Base-URL resolution: `--api-url` flag > `BFFLESS_API_URL` env > `apiUrl` in the nearest
+ * `.bffless/config.json`.
+ *
+ * API-key resolution: `--api-key` flag > `BFFLESS_API_KEY` env — and NOTHING else.
+ * The key is deliberately never read from `.bffless/config.json`: that file is meant to be
+ * committed to the repo (it carries `apiUrl`/`project`/`ruleSets` for the whole team), so
+ * supporting a key there would invite committing credentials. Keys stay in flags/env only.
+ *
+ * Auth is the backend's `ApiKeyGuard`, which reads the `X-API-Key` request header.
+ *
+ * `fetch` is injectable for tests. No retries — a CI drift check or deploy push should fail
+ * fast and loudly rather than mask a flaky endpoint.
+ */
+import { findConfig, type BfflessConfig } from '../config.js';
+
+/** Error thrown for any failed request; `status` is 0 for network-level failures. */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly url: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
+
+export interface ClientFlags {
+  apiUrl?: string;
+  apiKey?: string;
+}
+
+export interface ClientDeps {
+  fetchImpl?: FetchLike;
+  env?: Record<string, string | undefined>;
+  /** Pre-loaded config (tests / callers that already ran `findConfig`); when absent the
+   *  nearest `.bffless/config.json` above `cwd` is used. */
+  config?: BfflessConfig | null;
+}
+
+/** Extract a human-readable message from an error-response body (NestJS `message` field,
+ *  which may be a string or an array of validation messages). */
+function parseErrorDetail(bodyText: string): string | undefined {
+  if (!bodyText) return undefined;
+  try {
+    const parsed = JSON.parse(bodyText) as { message?: unknown };
+    if (typeof parsed.message === 'string') return parsed.message;
+    if (Array.isArray(parsed.message)) return parsed.message.map(String).join('; ');
+  } catch {
+    // Non-JSON body — fall through to a truncated raw snippet.
+  }
+  const trimmed = bodyText.trim();
+  return trimmed.length > 0 ? trimmed.slice(0, 300) : undefined;
+}
+
+export class ApiClient {
+  private readonly base: string;
+  private readonly apiKey: string;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(init: { apiUrl: string; apiKey: string; fetchImpl?: FetchLike }) {
+    this.base = init.apiUrl.replace(/\/+$/, '');
+    this.apiKey = init.apiKey;
+    this.fetchImpl = init.fetchImpl ?? ((url, opts) => fetch(url, opts));
+  }
+
+  /** Absolute URL for an API path (path must start with `/`). */
+  url(apiPath: string): string {
+    return this.base + apiPath;
+  }
+
+  /**
+   * Perform a JSON request. `lookup` describes what a 404 means for this call so the error
+   * says what was looked up (e.g. `rule set "studio" export`), not just the URL.
+   */
+  private async request<T>(
+    method: string,
+    apiPath: string,
+    opts?: { body?: unknown; lookup?: string },
+  ): Promise<T> {
+    const url = this.url(apiPath);
+    let res: Response;
+    try {
+      res = await this.fetchImpl(url, {
+        method,
+        headers: {
+          'X-API-Key': this.apiKey,
+          Accept: 'application/json',
+          ...(opts?.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+        },
+        ...(opts?.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new ApiError(`request failed: ${method} ${url} — ${msg}`, 0, url);
+    }
+
+    if (!res.ok) {
+      let bodyText = '';
+      try {
+        bodyText = await res.text();
+      } catch {
+        // Ignore body-read failures; the status alone still makes a useful error.
+      }
+      const detail = parseErrorDetail(bodyText);
+      const suffix = detail ? ` — ${detail}` : '';
+      if (res.status === 401 || res.status === 403) {
+        throw new ApiError(
+          `HTTP ${res.status} ${method} ${url}: authentication failed${suffix}. ` +
+            `The API key is sent as the X-API-Key header — pass --api-key or set BFFLESS_API_KEY ` +
+            `to a key with access to this project.`,
+          res.status,
+          url,
+        );
+      }
+      if (res.status === 404) {
+        throw new ApiError(
+          `HTTP 404 ${method} ${url}: ${opts?.lookup ?? 'resource'} not found${suffix}`,
+          res.status,
+          url,
+        );
+      }
+      throw new ApiError(`HTTP ${res.status} ${method} ${url}${suffix}`, res.status, url);
+    }
+
+    try {
+      return (await res.json()) as T;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new ApiError(`invalid JSON response from ${method} ${url} — ${msg}`, res.status, url);
+    }
+  }
+
+  get<T>(apiPath: string, lookup?: string): Promise<T> {
+    return this.request<T>('GET', apiPath, { lookup });
+  }
+
+  put<T>(apiPath: string, body: unknown, lookup?: string): Promise<T> {
+    return this.request<T>('PUT', apiPath, { body, lookup });
+  }
+}
+
+/**
+ * Build a client from CLI flags + env + config, applying the documented precedence.
+ * Throws a plain Error (caller prints it, no stack) naming every source that was tried.
+ */
+export function createClient(flags: ClientFlags, cwd: string, deps?: ClientDeps): ApiClient {
+  const env = deps?.env ?? process.env;
+  const config = deps?.config !== undefined ? deps.config : (findConfig(cwd)?.config ?? null);
+
+  const apiUrl = flags.apiUrl ?? env.BFFLESS_API_URL ?? config?.apiUrl;
+  if (!apiUrl) {
+    throw new Error(
+      'no API URL configured — pass --api-url, set BFFLESS_API_URL, ' +
+        'or add "apiUrl" to .bffless/config.json',
+    );
+  }
+
+  // Key precedence is flag > env ONLY — never config.json (a committed file; see module doc).
+  const apiKey = flags.apiKey ?? env.BFFLESS_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'no API key configured — pass --api-key or set BFFLESS_API_KEY ' +
+        '(API keys are never read from .bffless/config.json, which is committed to the repo)',
+    );
+  }
+
+  return new ApiClient({ apiUrl, apiKey, fetchImpl: deps?.fetchImpl });
+}

--- a/packages/cli/src/api/git-source.ts
+++ b/packages/cli/src/api/git-source.ts
@@ -1,0 +1,85 @@
+/**
+ * Best-effort `source` provenance for `rules push` — stamped by the server onto the rule
+ * set's `source` column so the UI can show "managed from git".
+ *
+ * Every field degrades independently and silently (a push from a laptop without git, or a
+ * CI without the GitHub env vars, still works — it just carries less provenance):
+ *
+ * - `repo`: `GITHUB_REPOSITORY` env (`owner/repo`), else `git remote get-url origin`
+ *   parsed to `owner/repo`.
+ * - `gitSha`: `GITHUB_SHA` env, else `git rev-parse HEAD`.
+ * - `path`: the rule-set directory relative to the repo root (`git rev-parse --show-toplevel`).
+ *
+ * `execGit` is injectable so tests never depend on the host repo's actual git state.
+ */
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+export type ExecGit = (args: string[], cwd: string) => string;
+
+export interface GitSourceDeps {
+  env?: Record<string, string | undefined>;
+  execGit?: ExecGit;
+}
+
+export interface SourceMetadata {
+  repo?: string;
+  path?: string;
+  gitSha?: string;
+}
+
+const defaultExecGit: ExecGit = (args, cwd) =>
+  execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+
+/** Parse a git remote URL (scp-like, ssh://, https://) to `owner/repo`. */
+export function parseRepoFromRemoteUrl(url: string): string | undefined {
+  // scp-like: git@github.com:owner/repo.git
+  let m = /^[^@/]+@[^:/]+:(.+?)(?:\.git)?\/?$/.exec(url);
+  // URL-style: https://host/owner/repo(.git), ssh://git@host/owner/repo.git
+  if (!m) m = /^[a-z][a-z0-9+.-]*:\/\/[^/]+\/(.+?)(?:\.git)?\/?$/i.exec(url);
+  if (!m) return undefined;
+  const parts = m[1].split('/').filter((p) => p.length > 0);
+  if (parts.length < 2) return undefined;
+  return parts.slice(-2).join('/');
+}
+
+/** `undefined` when nothing could be determined at all (the `source` key is then omitted). */
+export function collectSourceMetadata(setDir: string, deps?: GitSourceDeps): SourceMetadata | undefined {
+  const env = deps?.env ?? process.env;
+  const execGit = deps?.execGit ?? defaultExecGit;
+  const tryGit = (args: string[]): string | undefined => {
+    try {
+      const out = execGit(args, setDir);
+      return out.length > 0 ? out : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
+  const source: SourceMetadata = {};
+
+  const envRepo = env.GITHUB_REPOSITORY;
+  if (envRepo) {
+    source.repo = envRepo;
+  } else {
+    const remoteUrl = tryGit(['remote', 'get-url', 'origin']);
+    if (remoteUrl) {
+      const parsed = parseRepoFromRemoteUrl(remoteUrl);
+      if (parsed) source.repo = parsed;
+    }
+  }
+
+  const gitSha = env.GITHUB_SHA ?? tryGit(['rev-parse', 'HEAD']);
+  if (gitSha) source.gitSha = gitSha;
+
+  const repoRoot = tryGit(['rev-parse', '--show-toplevel']);
+  if (repoRoot) {
+    const rel = path.relative(repoRoot, path.resolve(setDir));
+    // A setDir outside the repo root (or the root itself) carries no useful path.
+    if (rel.length > 0 && !rel.startsWith('..') && !path.isAbsolute(rel)) {
+      source.path = rel.split(path.sep).join('/');
+    }
+  }
+
+  return Object.keys(source).length > 0 ? source : undefined;
+}

--- a/packages/cli/src/api/resolve.ts
+++ b/packages/cli/src/api/resolve.ts
@@ -1,0 +1,99 @@
+/**
+ * Name → id resolution against the backend's UUID-addressed API.
+ *
+ * - Projects: `GET /api/projects` lists the caller's projects (`{id, owner, name}` each).
+ *   The config `project` value (or `--project` flag) may be a UUID (used directly), an
+ *   `owner/name` pair, or a bare project name (errors if two owners share it).
+ * - Rule sets: `GET /api/proxy-rule-sets/project/:projectId` lists `{ruleSets: [{id, name}]}`;
+ *   matched by exact name.
+ *
+ * Every failure message states exactly what was tried (URL + name) and what IS available,
+ * so a typo'd name is a one-glance fix.
+ */
+import { UUID_RE } from '../format/routes.js';
+import type { ApiClient } from './client.js';
+
+export interface ProjectListItem {
+  id: string;
+  owner: string;
+  name: string;
+}
+
+export interface RuleSetListItem {
+  id: string;
+  name: string;
+}
+
+/** Resolve a project identifier (UUID | `owner/name` | bare name) to its UUID. */
+export async function resolveProjectId(client: ApiClient, project: string): Promise<string> {
+  if (UUID_RE.test(project)) return project;
+
+  const listPath = '/api/projects';
+  const projects = await client.get<ProjectListItem[]>(listPath, 'project list');
+  const available = projects.map((p) => `${p.owner}/${p.name}`).sort();
+
+  let matches: ProjectListItem[];
+  if (project.includes('/')) {
+    const [owner, name] = project.split('/', 2);
+    matches = projects.filter((p) => p.owner === owner && p.name === name);
+  } else {
+    matches = projects.filter((p) => p.name === project);
+  }
+
+  if (matches.length === 1) return matches[0].id;
+  const tried = `project "${project}" via GET ${client.url(listPath)}`;
+  if (matches.length === 0) {
+    throw new Error(
+      `${tried}: no match. Available projects: ${available.length > 0 ? available.join(', ') : '(none)'}`,
+    );
+  }
+  const candidates = matches.map((p) => `${p.owner}/${p.name}`).join(', ');
+  throw new Error(`${tried}: ambiguous — matches ${candidates}. Use owner/name or the project UUID.`);
+}
+
+/** Find a rule set by exact name within a project; `null` when the project has no set by
+ *  that name (callers decide whether that's an error — `diff` treats it as drift). */
+export async function findRuleSetByName(
+  client: ApiClient,
+  projectId: string,
+  setName: string,
+): Promise<RuleSetListItem | null> {
+  const listPath = `/api/proxy-rule-sets/project/${projectId}`;
+  const { ruleSets } = await client.get<{ ruleSets: RuleSetListItem[] }>(
+    listPath,
+    `rule sets for project ${projectId}`,
+  );
+  return ruleSets.find((s) => s.name === setName) ?? null;
+}
+
+/** Resolve a rule-set name to its UUID, erroring with the names that DO exist. */
+export async function resolveRuleSetId(
+  client: ApiClient,
+  projectId: string,
+  setName: string,
+): Promise<string> {
+  const listPath = `/api/proxy-rule-sets/project/${projectId}`;
+  const { ruleSets } = await client.get<{ ruleSets: RuleSetListItem[] }>(
+    listPath,
+    `rule sets for project ${projectId}`,
+  );
+  const match = ruleSets.find((s) => s.name === setName);
+  if (match) return match.id;
+  const available = ruleSets.map((s) => s.name).sort();
+  throw new Error(
+    `rule set "${setName}" not found via GET ${client.url(listPath)}. ` +
+      `Available rule sets: ${available.length > 0 ? available.join(', ') : '(none)'}`,
+  );
+}
+
+/** The project to operate on: `--project` flag > config `project`. Throws when neither is set. */
+export function requireProject(flagProject: string | undefined, configProject: string | undefined): string {
+  const project = flagProject ?? configProject;
+  if (!project) {
+    throw new Error(
+      'no project configured — pass --project <uuid|owner/name|name> ' +
+        'or add "project" to .bffless/config.json',
+    );
+  }
+  return project;
+}

--- a/packages/cli/src/api/sync-types.ts
+++ b/packages/cli/src/api/sync-types.ts
@@ -1,0 +1,40 @@
+/**
+ * Wire types for `PUT /api/proxy-rule-sets/project/:projectId/sync` — mirrors
+ * `SyncProxyRuleSetDto` / `SyncProxyRuleSetResponseDto` in the backend and the
+ * "Sync response shape" cross-cutting definition of the Phase 1 plan doc.
+ */
+import type { ExportedRule, ExportedSchema } from '../format/types.js';
+
+export interface SyncRuleRef {
+  pathPattern: string;
+  method: string | null;
+}
+
+export interface SyncSchemaResolution {
+  name: string;
+  action: 'reuse' | 'create';
+  targetSchemaId: string | null;
+  fieldMismatch: boolean;
+}
+
+export interface SyncRequestBody {
+  ruleSet: { name: string; description?: string; environment?: string };
+  rules: ExportedRule[];
+  schemas?: ExportedSchema[];
+  options?: { prune?: boolean; dryRun?: boolean; strictSchemas?: boolean };
+  source?: { repo?: string; path?: string; gitSha?: string };
+}
+
+export interface SyncResponse {
+  ruleSetId: string | null;
+  created: SyncRuleRef[];
+  updated: SyncRuleRef[];
+  deleted: SyncRuleRef[];
+  unchanged: SyncRuleRef[];
+  pruneCandidates: SyncRuleRef[];
+  schemaResolutions: SyncSchemaResolution[];
+  missingSecrets: string[];
+  warnings: string[];
+  dryRun: boolean;
+  setCreated: boolean;
+}

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -1,0 +1,123 @@
+/**
+ * `rules diff` orchestration — the CI drift-check contract:
+ *
+ * Compile the local rule-set directory in-memory, fetch the live export for the set with
+ * the same name, and compare with `exportsEquivalent` (defaults-normalized, exportedAt
+ * ignored — the same equivalence the round-trip tests use).
+ *
+ * Outcomes (the caller maps these to exit codes — documented in `--help`):
+ * - `clean` (exit 0): local and live are equivalent.
+ * - `drift` (exit 1): differences found, or the set does not exist on the server at all
+ *   (a missing set IS drift — the git state says it should exist).
+ * - `error` (exit 2): compile/auth/network failure — distinguishable from drift in CI.
+ */
+import { buildRuleSet } from '../compile/build.js';
+import { exportsEquivalent } from '../format/canonical.js';
+import { walkSchemaRefs } from '../format/schema-refs.js';
+import { createClient, ApiError, type ClientDeps } from '../api/client.js';
+import { resolveProjectId, requireProject, findRuleSetByName } from '../api/resolve.js';
+import { findConfig } from '../config.js';
+import type { RuleSetExport } from '../format/types.js';
+
+/**
+ * Align the LOCAL export's schema identity to the LIVE export's, by NAME — mirroring what the
+ * server does on push (`resolveSchemasByName` + `remapSchemaIds` in
+ * `apps/backend/src/proxy-rules/proxy-rule-sets.service.ts`): schemas are resolved by name in
+ * the target project and every step-config schema ref is rewritten to the project's DB ids.
+ * So a locally-derived schema id (uuidv5(name) from `build.ts`, or an authored one) that
+ * differs from the live DB id is NOT drift as long as the names match — without this
+ * alignment, `rules diff` would report permanent false drift on sets that push cleanly as
+ * "unchanged".
+ *
+ * Returns a deep copy of `local` where, for every local schema whose name also exists live
+ * (with a different id), `schemas[].id` is substituted with the live id and every schema ref
+ * in the rules (`walkSchemaRefs`, same key list as the backend's `SCHEMA_REF_KEYS`) is
+ * rewritten localId → liveId. Everything else is left untouched, so it surfaces as genuine
+ * drift: schemas present on only one side, name mismatches, and differing schema fields.
+ */
+function alignLocalSchemaIdsToLive(local: RuleSetExport, live: RuleSetExport): RuleSetExport {
+  const localSchemas = local.schemas ?? [];
+  const liveSchemas = live.schemas ?? [];
+  if (localSchemas.length === 0 || liveSchemas.length === 0) return local;
+
+  const liveIdByName = new Map(liveSchemas.map((s) => [s.name, s.id] as const));
+  const idMap = new Map<string, string>();
+  for (const s of localSchemas) {
+    const liveId = liveIdByName.get(s.name);
+    if (liveId !== undefined && liveId !== s.id) idMap.set(s.id, liveId);
+  }
+  if (idMap.size === 0) return local;
+
+  const aligned = structuredClone(local);
+  for (const s of aligned.schemas ?? []) {
+    const mapped = idMap.get(s.id);
+    if (mapped !== undefined) s.id = mapped;
+  }
+  walkSchemaRefs(aligned.rules, (ref, set) => {
+    const mapped = idMap.get(ref);
+    if (mapped !== undefined) set(mapped);
+  });
+  return aligned;
+}
+
+export interface DiffOptions {
+  apiUrl?: string;
+  apiKey?: string;
+  project?: string;
+}
+
+export type DiffDeps = ClientDeps;
+
+export interface DiffOutcome {
+  status: 'clean' | 'drift' | 'error';
+  /** Set name the comparison ran for (when compilation succeeded). */
+  setName?: string;
+  message?: string;
+  diffs?: string[];
+}
+
+export async function runDiffOne(
+  setDir: string,
+  opts: DiffOptions,
+  cwd: string,
+  deps?: DiffDeps,
+): Promise<DiffOutcome> {
+  let local: RuleSetExport;
+  try {
+    local = (await buildRuleSet(setDir)).export;
+  } catch (err) {
+    return { status: 'error', message: err instanceof Error ? err.message : String(err) };
+  }
+  const setName = local.ruleSet.name;
+
+  let live: RuleSetExport;
+  try {
+    const config = deps?.config !== undefined ? deps.config : (findConfig(cwd)?.config ?? null);
+    const client = createClient(opts, cwd, { ...deps, config });
+    const project = requireProject(opts.project, config?.project);
+    const projectId = await resolveProjectId(client, project);
+    const match = await findRuleSetByName(client, projectId, setName);
+    if (!match) {
+      return {
+        status: 'drift',
+        setName,
+        message:
+          `rule set "${setName}" does not exist on the server (project ${projectId}) — ` +
+          `local state has it; run \`bffless rules push\` to create it`,
+      };
+    }
+    live = await client.get<RuleSetExport>(
+      `/api/proxy-rule-sets/${match.id}/export`,
+      `rule set "${setName}" (${match.id}) export`,
+    );
+  } catch (err) {
+    if (err instanceof ApiError || err instanceof Error) {
+      return { status: 'error', setName, message: err.message };
+    }
+    return { status: 'error', setName, message: String(err) };
+  }
+
+  const { equal, diffs } = exportsEquivalent(alignLocalSchemaIdsToLive(local, live), live);
+  if (equal) return { status: 'clean', setName, message: `${setName}: in sync` };
+  return { status: 'drift', setName, message: `${setName}: drift detected (local != live)`, diffs };
+}

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -1,16 +1,26 @@
 /**
- * `rules pull` orchestration. Phase 0 only supports pulling from a local export file
- * (`--from-file`) and decompiling it to the authoring layout — there is no server export
- * endpoint yet, so a live pull (no `--from-file`) is a hard error pointing at Phase 1.
+ * `rules pull` orchestration — two modes:
  *
- * `--decompile` is required alongside `--from-file` in Phase 0: it is the only supported
- * output mode (there is no "just fetch the raw export" mode yet), so rather than silently
- * decompiling regardless of the flag, an explicit omission is treated the same as a missing
- * `--from-file` — a clear Phase-0-scope error instead of silently guessing intent.
+ * - **Live pull** (Phase 1): `rules pull <set-name>` resolves the set by name within the
+ *   configured project, fetches `GET /api/proxy-rule-sets/:id/export`, and decompiles the
+ *   envelope to the authoring layout. A live pull ALWAYS decompiles — there is no "raw
+ *   fetch" mode, so no `--decompile` flag is needed (it stays accepted for compatibility
+ *   but is a no-op here).
+ *
+ * - **From-file** (Phase 0, kept 100% backward-compatible): `--from-file <file> --decompile`
+ *   reads a local export JSON instead of the server. `--decompile` remains REQUIRED with
+ *   `--from-file` — the Phase 0 semantics were an explicit-opt-in decompile, and silently
+ *   changing that would surprise existing scripts.
+ *
+ * Both modes share the output logic: `--output` wins, else
+ * `.bffless/proxy-rules/<ruleSet.name>/`; non-empty targets need `--force`.
  */
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { decompileExport, writeDecompiled } from '../compile/decompile.js';
+import { createClient, ApiError, type ClientDeps } from '../api/client.js';
+import { resolveProjectId, resolveRuleSetId, requireProject } from '../api/resolve.js';
+import { findConfig } from '../config.js';
 import type { RuleSetExport } from '../format/types.js';
 
 export interface PullOptions {
@@ -18,6 +28,9 @@ export interface PullOptions {
   decompile?: boolean;
   output?: string;
   force?: boolean;
+  apiUrl?: string;
+  apiKey?: string;
+  project?: string;
 }
 
 export interface PullOutcome {
@@ -27,26 +40,65 @@ export interface PullOutcome {
   error?: string;
 }
 
-export async function runPull(opts: PullOptions, cwd: string): Promise<PullOutcome> {
-  if (!opts.fromFile) {
-    return { ok: false, error: 'live pull requires a server export endpoint (Phase 1)' };
-  }
-  if (!opts.decompile) {
-    return { ok: false, error: '--decompile is required alongside --from-file (Phase 0 supports no other pull output)' };
-  }
+export type PullDeps = ClientDeps;
 
+export async function runPull(
+  setName: string | undefined,
+  opts: PullOptions,
+  cwd: string,
+  deps?: PullDeps,
+): Promise<PullOutcome> {
   let exp: RuleSetExport;
-  try {
-    const raw = readFileSync(path.resolve(cwd, opts.fromFile), 'utf8');
-    exp = JSON.parse(raw) as RuleSetExport;
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+
+  if (opts.fromFile) {
+    if (setName !== undefined) {
+      return {
+        ok: false,
+        error: 'a set name and --from-file are mutually exclusive (--from-file names the source already)',
+      };
+    }
+    if (!opts.decompile) {
+      return {
+        ok: false,
+        error: '--decompile is required alongside --from-file (Phase 0 supports no other pull output)',
+      };
+    }
+    try {
+      const raw = readFileSync(path.resolve(cwd, opts.fromFile), 'utf8');
+      exp = JSON.parse(raw) as RuleSetExport;
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  } else {
+    if (!setName) {
+      return {
+        ok: false,
+        error: 'a set name is required for a live pull (bffless rules pull <set-name>), or use --from-file <file>',
+      };
+    }
+    try {
+      const config = deps?.config !== undefined ? deps.config : (findConfig(cwd)?.config ?? null);
+      const client = createClient(opts, cwd, { ...deps, config });
+      const project = requireProject(opts.project, config?.project);
+      const projectId = await resolveProjectId(client, project);
+      const ruleSetId = await resolveRuleSetId(client, projectId, setName);
+      exp = await client.get<RuleSetExport>(
+        `/api/proxy-rule-sets/${ruleSetId}/export`,
+        `rule set "${setName}" (${ruleSetId}) export`,
+      );
+    } catch (err) {
+      if (err instanceof ApiError || err instanceof Error) return { ok: false, error: err.message };
+      return { ok: false, error: String(err) };
+    }
   }
 
-  const outDir = opts.output ? path.resolve(cwd, opts.output) : path.resolve(cwd, '.bffless', 'proxy-rules', exp.ruleSet.name);
+  const outDir = opts.output
+    ? path.resolve(cwd, opts.output)
+    : path.resolve(cwd, '.bffless', 'proxy-rules', exp.ruleSet.name);
 
-  const result = decompileExport(exp);
+  let result;
   try {
+    result = decompileExport(exp);
     await writeDecompiled(result, outDir, { force: opts.force });
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -1,0 +1,130 @@
+/**
+ * `rules push` orchestration: compile a rule-set directory in-memory (same compiler as
+ * `rules build`, nothing written to `dist/`), then `PUT /api/proxy-rule-sets/project/
+ * :projectId/sync` and render the server's change report.
+ *
+ * - `--name-suffix pr-42` renames the compiled set to `<name>-pr-42` before syncing —
+ *   the preview-deploy pattern (a PR gets its own live set without touching production's).
+ * - `source` metadata (repo/gitSha/path) is attached best-effort from the GitHub Actions
+ *   env or local git (see api/git-source.ts) so the server can stamp provenance.
+ * - Exit semantics (enforced by the caller via `ok`): any HTTP or compile error is a
+ *   failure; `missingSecrets` alone is a WARNING (exit 0) — a fresh set legitimately has
+ *   blank secret placeholders until someone fills the project secrets.
+ */
+import { buildRuleSet } from '../compile/build.js';
+import { createClient, ApiError, type ClientDeps } from '../api/client.js';
+import { resolveProjectId, requireProject } from '../api/resolve.js';
+import { collectSourceMetadata, type ExecGit } from '../api/git-source.js';
+import { findConfig } from '../config.js';
+import type { SyncRequestBody, SyncResponse, SyncRuleRef } from '../api/sync-types.js';
+
+export interface PushOptions {
+  nameSuffix?: string;
+  prune?: boolean;
+  dryRun?: boolean;
+  strictSchemas?: boolean;
+  apiUrl?: string;
+  apiKey?: string;
+  project?: string;
+}
+
+export interface PushDeps extends ClientDeps {
+  execGit?: ExecGit;
+}
+
+export interface PushOutcome {
+  ok: boolean;
+  /** The rendered change report (present on success). */
+  report?: string;
+  response?: SyncResponse;
+  error?: string;
+}
+
+function formatRef(ref: SyncRuleRef): string {
+  return `${ref.method ?? 'ANY'} ${ref.pathPattern}`;
+}
+
+/** Render the sync response as a human/CI-readable change report. */
+export function formatSyncReport(setName: string, res: SyncResponse): string {
+  const lines: string[] = [];
+  const mode = res.dryRun ? ' (dry run — nothing was written)' : '';
+  const created = res.setCreated ? (res.dryRun ? ' [set would be created]' : ' [set created]') : '';
+  lines.push(
+    `${setName}: ${res.created.length} created, ${res.updated.length} updated, ` +
+      `${res.deleted.length} deleted, ${res.unchanged.length} unchanged${created}${mode}`,
+  );
+
+  const bucket = (label: string, refs: SyncRuleRef[], marker: string) => {
+    if (refs.length === 0) return;
+    lines.push(`  ${label}:`);
+    for (const ref of refs) lines.push(`    ${marker} ${formatRef(ref)}`);
+  };
+  bucket('created', res.created, '+');
+  bucket('updated', res.updated, '~');
+  bucket('deleted', res.deleted, '-');
+
+  if (res.pruneCandidates.length > 0) {
+    lines.push(`  would prune (live-only rules; pass --prune to delete):`);
+    for (const ref of res.pruneCandidates) lines.push(`    ! ${formatRef(ref)}`);
+  }
+
+  if (res.missingSecrets.length > 0) {
+    lines.push(
+      `  MISSING SECRETS (${res.missingSecrets.length}) — set these in the project's secrets: ` +
+        res.missingSecrets.join(', '),
+    );
+  }
+
+  for (const w of res.warnings) lines.push(`  warning: ${w}`);
+
+  return lines.join('\n');
+}
+
+export async function runPushOne(
+  setDir: string,
+  opts: PushOptions,
+  cwd: string,
+  deps?: PushDeps,
+): Promise<PushOutcome> {
+  let built;
+  try {
+    built = await buildRuleSet(setDir);
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  const exp = built.export;
+  const ruleSet = opts.nameSuffix
+    ? { ...exp.ruleSet, name: `${exp.ruleSet.name}-${opts.nameSuffix}` }
+    : exp.ruleSet;
+
+  const source = collectSourceMetadata(setDir, { env: deps?.env, execGit: deps?.execGit });
+
+  const body: SyncRequestBody = {
+    ruleSet,
+    rules: exp.rules,
+    ...(exp.schemas && exp.schemas.length > 0 ? { schemas: exp.schemas } : {}),
+    options: {
+      prune: opts.prune ?? false,
+      dryRun: opts.dryRun ?? false,
+      strictSchemas: opts.strictSchemas ?? false,
+    },
+    ...(source ? { source } : {}),
+  };
+
+  try {
+    const config = deps?.config !== undefined ? deps.config : (findConfig(cwd)?.config ?? null);
+    const client = createClient(opts, cwd, { ...deps, config });
+    const project = requireProject(opts.project, config?.project);
+    const projectId = await resolveProjectId(client, project);
+    const response = await client.put<SyncResponse>(
+      `/api/proxy-rule-sets/project/${projectId}/sync`,
+      body,
+      `project ${projectId} (sync target)`,
+    );
+    return { ok: true, report: formatSyncReport(ruleSet.name, response), response };
+  } catch (err) {
+    if (err instanceof ApiError || err instanceof Error) return { ok: false, error: err.message };
+    return { ok: false, error: String(err) };
+  }
+}

--- a/packages/cli/src/compile/build.ts
+++ b/packages/cli/src/compile/build.ts
@@ -320,6 +320,15 @@ export async function buildRuleSet(setDir: string, opts?: { exportedAt?: string 
     if (pipelineConfig) {
       // $file: refs inside pipeline step configs (pipeline sugar path already handled `code:`).
       pipelineConfig = resolveFileRefs(pipelineConfig, setDir, d.manifestDir, d.manifestPath) as PipelineConfig;
+      // The backend's PipelineValidatorDto declares `config` as @IsObject() WITHOUT @IsOptional
+      // (apps/backend/src/proxy-rules/dto/create-proxy-rule.dto.ts), so a validator authored
+      // without `config:` (allowed by the zod manifest schema) would 400 the entire sync on
+      // push. Normalize an absent validator config to `{}` in the compiled output.
+      if (pipelineConfig.validators !== undefined) {
+        pipelineConfig.validators = pipelineConfig.validators.map((v) =>
+          v.config === undefined ? { ...v, config: {} } : v,
+        );
+      }
       // Resolve $schema: refs (and warn on raw UUIDs) in place.
       walkSchemaRefs(pipelineConfig, (ref, set) => {
         if (ref.startsWith('$schema:')) {

--- a/packages/cli/src/format/canonical.ts
+++ b/packages/cli/src/format/canonical.ts
@@ -196,10 +196,22 @@ function diffValue(a: unknown, b: unknown, path: string, diffs: string[]): void 
  * `debugEnabled`) are emitted at all vs. explicit `false`. Absent-means-default is the DB import's
  * own semantics (Task 3), so equivalence must be judged on each rule's defaults-complete form, not
  * raw key presence.
+ *
+ * `targetUrl` gets the same DB-default alignment: the sync/import layer stores an absent
+ * `targetUrl` as `''` for non-pipeline rules (the DB column default — see `normalizeRule` in
+ * `apps/backend/src/proxy-rules/sync-plan.util.ts`) and the server export returns that `''`, so
+ * a rule authored without `targetUrl` (e.g. an email_form_handler) must compare equal to the
+ * live `targetUrl: ""`. `applyRuleDefaults` already fills the pipeline URL for pipeline rules;
+ * for everything else an absent `targetUrl` is normalized to `''` here — comparison-only, the
+ * build output is untouched.
  */
 function normalizeRulesForComparison(rules: unknown): unknown {
   if (!Array.isArray(rules)) return rules;
-  return rules.map((r) => applyRuleDefaults(r as Partial<ExportedRule> & { pathPattern: string }));
+  return rules.map((r) => {
+    const full = applyRuleDefaults(r as Partial<ExportedRule> & { pathPattern: string }) as ExportedRule;
+    if (full.targetUrl === undefined) full.targetUrl = '';
+    return full;
+  });
 }
 
 export function exportsEquivalent(a: RuleSetExport, b: RuleSetExport): { equal: boolean; diffs: string[] } {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,8 @@ import { buildOne } from './commands/build.js';
 import { validateRuleSet, type Issue } from './commands/validate.js';
 import { runFnTests } from './commands/test.js';
 import { runPull } from './commands/pull.js';
+import { runPushOne } from './commands/push.js';
+import { runDiffOne } from './commands/diff.js';
 
 /** `<file>:<line> <message>` when `line` is present, `<file> <message>` otherwise. */
 function formatIssue(issue: Issue): string {
@@ -23,7 +25,9 @@ function resolveDirsOrReport(dirs: string[]): string[] | null {
 }
 
 const program = new Command('bffless').description('BFFless CLI');
-const rules = program.command('rules').description('Proxy rule sets as code (build, validate, test, pull)');
+const rules = program
+  .command('rules')
+  .description('Proxy rule sets as code (build, validate, test, pull, push, diff)');
 
 rules
   .command('build')
@@ -107,20 +111,129 @@ rules
 
 rules
   .command('pull')
-  .description('Pull a rule set (Phase 0: from a local export file only) and decompile it to the authoring layout')
-  .option('--from-file <file>', 'path to a RuleSetExport JSON file (required in Phase 0)')
-  .option('--decompile', 'decompile the export to the authoring layout (the only supported mode in Phase 0)')
+  .description(
+    'Pull a rule set from the server (by name) and decompile it to the authoring layout. ' +
+      'Alternatively pull from a local export file with --from-file <file> --decompile.',
+  )
+  .argument('[set-name]', 'rule set name within the configured project (required unless --from-file)')
+  .option('--from-file <file>', 'path to a local RuleSetExport JSON file instead of the server')
+  .option('--decompile', 'decompile the export to the authoring layout (required with --from-file; live pulls always decompile)')
   .option('-o, --output <dir>', 'output directory (default: .bffless/proxy-rules/<ruleSet.name>/)')
   .option('--force', 'overwrite a non-empty output directory')
-  .action(async (opts: { fromFile?: string; decompile?: boolean; output?: string; force?: boolean }) => {
-    const result = await runPull(opts, process.cwd());
-    if (!result.ok) {
-      console.error(result.error);
-      process.exitCode = 1;
+  .option('--api-url <url>', 'API base URL (overrides BFFLESS_API_URL and config apiUrl)')
+  .option('--api-key <key>', 'API key (overrides BFFLESS_API_KEY; sent as X-API-Key)')
+  .option('--project <idOrName>', 'project UUID, owner/name, or name (overrides config project)')
+  .action(
+    async (
+      setName: string | undefined,
+      opts: {
+        fromFile?: string;
+        decompile?: boolean;
+        output?: string;
+        force?: boolean;
+        apiUrl?: string;
+        apiKey?: string;
+        project?: string;
+      },
+    ) => {
+      const result = await runPull(setName, opts, process.cwd());
+      if (!result.ok) {
+        console.error(result.error);
+        process.exitCode = 1;
+        return;
+      }
+      console.log(result.outDir);
+      for (const w of result.warnings ?? []) console.warn(`warning: ${w}`);
+    },
+  );
+
+rules
+  .command('push')
+  .description(
+    'Compile rule-set directories and idempotently sync them to the server ' +
+      '(PUT /api/proxy-rule-sets/project/:projectId/sync), printing the change report. ' +
+      'Missing secrets are reported as warnings (exit 0); HTTP/compile errors exit 1.',
+  )
+  .argument('[dirs...]', 'rule-set directories (defaults to .bffless/config.json ruleSets)')
+  .option('--dry-run', 'compute and print the change plan without writing anything')
+  .option('--prune', 'delete live rules that are absent from the local rule set')
+  .option('--strict-schemas', 'fail when a name-reused schema has mismatched field definitions')
+  .option('--name-suffix <suffix>', 'rename the set to <name>-<suffix> before syncing (e.g. pr-42 previews)')
+  .option('--api-url <url>', 'API base URL (overrides BFFLESS_API_URL and config apiUrl)')
+  .option('--api-key <key>', 'API key (overrides BFFLESS_API_KEY; sent as X-API-Key)')
+  .option('--project <idOrName>', 'project UUID, owner/name, or name (overrides config project)')
+  .action(
+    async (
+      dirs: string[],
+      opts: {
+        dryRun?: boolean;
+        prune?: boolean;
+        strictSchemas?: boolean;
+        nameSuffix?: string;
+        apiUrl?: string;
+        apiKey?: string;
+        project?: string;
+      },
+    ) => {
+      const resolved = resolveDirsOrReport(dirs);
+      if (!resolved) {
+        process.exitCode = 1;
+        return;
+      }
+      const multi = resolved.length > 1;
+      let ok = true;
+      for (const dir of resolved) {
+        if (multi) console.log(`\n${dir}:`);
+        const result = await runPushOne(dir, opts, process.cwd());
+        if (!result.ok) {
+          ok = false;
+          console.error(result.error);
+          continue;
+        }
+        console.log(result.report);
+      }
+      if (!ok) process.exitCode = 1;
+    },
+  );
+
+rules
+  .command('diff')
+  .description(
+    'Compare local rule-set directories against the live server state (CI drift check). ' +
+      'Exit codes: 0 = in sync, 1 = drift (including a set missing on the server), 2 = error ' +
+      '(compile/auth/network failure).',
+  )
+  .argument('[dirs...]', 'rule-set directories (defaults to .bffless/config.json ruleSets)')
+  .option('--api-url <url>', 'API base URL (overrides BFFLESS_API_URL and config apiUrl)')
+  .option('--api-key <key>', 'API key (overrides BFFLESS_API_KEY; sent as X-API-Key)')
+  .option('--project <idOrName>', 'project UUID, owner/name, or name (overrides config project)')
+  .action(async (dirs: string[], opts: { apiUrl?: string; apiKey?: string; project?: string }) => {
+    const resolved = resolveDirsOrReport(dirs);
+    if (!resolved) {
+      process.exitCode = 2;
       return;
     }
-    console.log(result.outDir);
-    for (const w of result.warnings ?? []) console.warn(`warning: ${w}`);
+    const multi = resolved.length > 1;
+    let hasDrift = false;
+    let hasError = false;
+    for (const dir of resolved) {
+      if (multi) console.log(`\n${dir}:`);
+      const result = await runDiffOne(dir, opts, process.cwd());
+      if (result.status === 'error') {
+        hasError = true;
+        console.error(result.message);
+        continue;
+      }
+      if (result.status === 'drift') {
+        hasDrift = true;
+        console.error(result.message);
+        for (const d of result.diffs ?? []) console.error(`  ${d}`);
+        continue;
+      }
+      console.log(result.message);
+    }
+    if (hasError) process.exitCode = 2;
+    else if (hasDrift) process.exitCode = 1;
   });
 
 program.parseAsync().catch((err) => {

--- a/packages/cli/test/build.test.ts
+++ b/packages/cli/test/build.test.ts
@@ -274,4 +274,42 @@ describe('buildRuleSet', () => {
     expect(res.warnings).toEqual([expect.stringContaining('multiple rules share order 2')]);
     expect(res.warnings[0]).toMatch(/api\/a\/get\.rule\.yaml.*api\/c\/get\.rule\.yaml/);
   });
+
+  it('(p) normalizes an absent validator config to {} (backend PipelineValidatorDto.config is required); a set config is untouched', async () => {
+    const dir = scratchSet({
+      'ruleset.yaml': 'name: s\n',
+      'rules/api/x/post.rule.yaml':
+        'pipeline:\n' +
+        '  steps:\n' +
+        '    - name: fn\n' +
+        '      handler: function_handler\n' +
+        '      config: { code: "x" }\n' +
+        '  validators:\n' +
+        '    - type: auth_required\n' + // no config: → must compile to config: {}
+        '    - type: rate_limit\n' +
+        '      config: { maxRequests: 5 }\n',
+    });
+    const res = await buildRuleSet(dir, { exportedAt: EXPORTED_AT });
+    expect(res.export.rules[0].pipelineConfig?.validators).toEqual([
+      { type: 'auth_required', config: {} },
+      { type: 'rate_limit', config: { maxRequests: 5 } },
+    ]);
+  });
+
+  it('(p2) validator config normalization also applies on the verbatim pipelineConfig: path', async () => {
+    const dir = scratchSet({
+      'ruleset.yaml': 'name: s\n',
+      'rules/api/x/post.rule.yaml':
+        'pipelineConfig:\n' +
+        '  name: p\n' +
+        '  steps:\n' +
+        '    - name: fn\n' +
+        '      handlerType: function_handler\n' +
+        '      config: { code: "x" }\n' +
+        '  validators:\n' +
+        '    - type: auth_required\n',
+    });
+    const res = await buildRuleSet(dir, { exportedAt: EXPORTED_AT });
+    expect(res.export.rules[0].pipelineConfig?.validators).toEqual([{ type: 'auth_required', config: {} }]);
+  });
 });

--- a/packages/cli/test/canonical.test.ts
+++ b/packages/cli/test/canonical.test.ts
@@ -122,4 +122,22 @@ describe('exportsEquivalent', () => {
     expect(r.equal).toBe(false);
     expect(r.diffs.some((d) => d.includes('debugEnabled'))).toBe(true);
   });
+  it('treats an absent targetUrl on a non-pipeline rule as equal to the DB default "" (server stores/export "")', () => {
+    // e.g. an email_form_handler authored without targetUrl: the sync import stores '' (DB
+    // column default — apps/backend sync-plan.util.ts normalizeRule) and the export returns ''.
+    const emailNoTarget: RuleSetExport = {
+      ...structuredClone(mini),
+      rules: [{ pathPattern: '/contact', method: 'POST', emailHandlerConfig: { to: 't@e.com' } } as any],
+    };
+    const emailEmptyTarget = structuredClone(emailNoTarget);
+    (emailEmptyTarget.rules[0] as any).targetUrl = '';
+    expect(exportsEquivalent(emailNoTarget, emailEmptyTarget).equal).toBe(true);
+
+    // A REAL targetUrl difference is still drift.
+    const emailRealTarget = structuredClone(emailNoTarget);
+    (emailRealTarget.rules[0] as any).targetUrl = 'https://mailer.example.com';
+    const r = exportsEquivalent(emailNoTarget, emailRealTarget);
+    expect(r.equal).toBe(false);
+    expect(r.diffs.some((d) => d.includes('targetUrl'))).toBe(true);
+  });
 });

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -107,10 +107,10 @@ describe('bffless rules test', () => {
 });
 
 describe('bffless rules pull', () => {
-  it('without --from-file exits 1 with the Phase 1 message', () => {
+  it('without --from-file and without a set name exits 1 with a usage error', () => {
     const result = run(['rules', 'pull']);
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain('live pull requires a server export endpoint (Phase 1)');
+    expect(result.stderr).toContain('a set name is required for a live pull');
   });
 
   it('--from-file <expected.json> --decompile -o <tmp> recreates the authoring layout, and a follow-up build round-trips', () => {

--- a/packages/cli/test/client.test.ts
+++ b/packages/cli/test/client.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { ApiClient, ApiError, createClient, type FetchLike } from '../src/api/client.js';
+
+interface RecordedCall {
+  url: string;
+  init?: RequestInit;
+}
+
+/** A fetch stub that records calls and answers from a `METHOD url` → response map. */
+function stubFetch(
+  routes: Record<string, { status?: number; body?: unknown; text?: string }>,
+): { fetchImpl: FetchLike; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const fetchImpl: FetchLike = async (url, init) => {
+    calls.push({ url, init });
+    const key = `${init?.method ?? 'GET'} ${url}`;
+    const route = routes[key];
+    if (!route) throw new Error(`stubFetch: no route for ${key}`);
+    const text = route.text ?? JSON.stringify(route.body ?? {});
+    return new Response(text, {
+      status: route.status ?? 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+  return { fetchImpl, calls };
+}
+
+describe('ApiClient', () => {
+  it('sends the X-API-Key header and Accept: application/json on GET', async () => {
+    const { fetchImpl, calls } = stubFetch({ 'GET https://api.test/api/projects': { body: [] } });
+    const client = new ApiClient({ apiUrl: 'https://api.test', apiKey: 'k-123', fetchImpl });
+    await client.get('/api/projects');
+    expect(calls).toHaveLength(1);
+    const headers = calls[0].init?.headers as Record<string, string>;
+    expect(headers['X-API-Key']).toBe('k-123');
+    expect(headers.Accept).toBe('application/json');
+  });
+
+  it('PUT serializes the body as JSON with Content-Type', async () => {
+    const { fetchImpl, calls } = stubFetch({ 'PUT https://api.test/api/x': { body: { ok: true } } });
+    const client = new ApiClient({ apiUrl: 'https://api.test', apiKey: 'k', fetchImpl });
+    const out = await client.put<{ ok: boolean }>('/api/x', { a: 1 });
+    expect(out).toEqual({ ok: true });
+    const headers = calls[0].init?.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(calls[0].init?.body).toBe('{"a":1}');
+  });
+
+  it('normalizes a trailing slash on the base URL', async () => {
+    const { fetchImpl, calls } = stubFetch({ 'GET https://api.test/api/projects': { body: [] } });
+    const client = new ApiClient({ apiUrl: 'https://api.test/', apiKey: 'k', fetchImpl });
+    await client.get('/api/projects');
+    expect(calls[0].url).toBe('https://api.test/api/projects');
+  });
+
+  it('401 maps to an auth error naming X-API-Key and BFFLESS_API_KEY', async () => {
+    const { fetchImpl } = stubFetch({
+      'GET https://api.test/api/projects': { status: 401, body: { message: 'Invalid API key' } },
+    });
+    const client = new ApiClient({ apiUrl: 'https://api.test', apiKey: 'bad', fetchImpl });
+    await expect(client.get('/api/projects')).rejects.toThrow(/X-API-Key/);
+    await expect(client.get('/api/projects')).rejects.toThrow(/BFFLESS_API_KEY/);
+    await expect(client.get('/api/projects')).rejects.toThrow(/Invalid API key/);
+  });
+
+  it('403 maps to the same auth guidance', async () => {
+    const { fetchImpl } = stubFetch({ 'GET https://api.test/api/x': { status: 403, body: {} } });
+    const client = new ApiClient({ apiUrl: 'https://api.test', apiKey: 'k', fetchImpl });
+    await expect(client.get('/api/x')).rejects.toThrow(/HTTP 403 .*authentication failed.*X-API-Key/s);
+  });
+
+  it('404 names what was looked up and the URL', async () => {
+    const { fetchImpl } = stubFetch({ 'GET https://api.test/api/rs/abc/export': { status: 404, body: {} } });
+    const client = new ApiClient({ apiUrl: 'https://api.test', apiKey: 'k', fetchImpl });
+    await expect(client.get('/api/rs/abc/export', 'rule set "studio" export')).rejects.toThrow(
+      /HTTP 404 GET https:\/\/api\.test\/api\/rs\/abc\/export: rule set "studio" export not found/,
+    );
+  });
+
+  it('other non-2xx includes the status and the parsed message field (array form joined)', async () => {
+    const { fetchImpl } = stubFetch({
+      'PUT https://api.test/api/x': { status: 400, body: { message: ['rules.0.targetUrl invalid', 'nope'] } },
+    });
+    const client = new ApiClient({ apiUrl: 'https://api.test', apiKey: 'k', fetchImpl });
+    await expect(client.put('/api/x', {})).rejects.toThrow(
+      /HTTP 400 PUT https:\/\/api\.test\/api\/x — rules\.0\.targetUrl invalid; nope/,
+    );
+  });
+
+  it('a network-level failure is wrapped with the method and URL', async () => {
+    const fetchImpl: FetchLike = async () => {
+      throw new Error('ECONNREFUSED');
+    };
+    const client = new ApiClient({ apiUrl: 'https://api.test', apiKey: 'k', fetchImpl });
+    const err = await client.get('/api/x').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(0);
+    expect((err as ApiError).message).toMatch(/request failed: GET https:\/\/api\.test\/api\/x — ECONNREFUSED/);
+  });
+});
+
+describe('createClient — precedence and sourcing rules', () => {
+  const okFetch = stubFetch({ 'GET https://flag.test/api/x': { body: {} } }).fetchImpl;
+
+  it('--api-url flag beats BFFLESS_API_URL env beats config apiUrl', async () => {
+    const { fetchImpl, calls } = stubFetch({
+      'GET https://flag.test/api/x': { body: {} },
+      'GET https://env.test/api/x': { body: {} },
+      'GET https://config.test/api/x': { body: {} },
+    });
+    const env = { BFFLESS_API_URL: 'https://env.test', BFFLESS_API_KEY: 'k' };
+    const config = { apiUrl: 'https://config.test' };
+
+    await createClient({ apiUrl: 'https://flag.test' }, '/nowhere', { env, config, fetchImpl }).get('/api/x');
+    expect(calls.at(-1)?.url).toBe('https://flag.test/api/x');
+
+    await createClient({}, '/nowhere', { env, config, fetchImpl }).get('/api/x');
+    expect(calls.at(-1)?.url).toBe('https://env.test/api/x');
+
+    await createClient({}, '/nowhere', { env: { BFFLESS_API_KEY: 'k' }, config, fetchImpl }).get('/api/x');
+    expect(calls.at(-1)?.url).toBe('https://config.test/api/x');
+  });
+
+  it('errors when no API URL is available anywhere, naming all three sources', () => {
+    expect(() => createClient({}, '/nowhere', { env: {}, config: null })).toThrow(
+      /--api-url.*BFFLESS_API_URL.*apiUrl/s,
+    );
+  });
+
+  it('--api-key flag beats BFFLESS_API_KEY env', async () => {
+    const { fetchImpl, calls } = stubFetch({ 'GET https://a.test/api/x': { body: {} } });
+    const env = { BFFLESS_API_KEY: 'env-key' };
+    await createClient({ apiUrl: 'https://a.test', apiKey: 'flag-key' }, '/nowhere', {
+      env,
+      config: null,
+      fetchImpl,
+    }).get('/api/x');
+    expect((calls[0].init?.headers as Record<string, string>)['X-API-Key']).toBe('flag-key');
+
+    await createClient({ apiUrl: 'https://a.test' }, '/nowhere', { env, config: null, fetchImpl }).get('/api/x');
+    expect((calls[1].init?.headers as Record<string, string>)['X-API-Key']).toBe('env-key');
+  });
+
+  it('the API key is NEVER read from config.json — a config-only setup errors', () => {
+    // The config schema has no apiKey field at all; even a fully-populated config cannot
+    // supply a key. The error explains where keys may come from and why config is excluded.
+    const config = { apiUrl: 'https://config.test', project: 'p' };
+    expect(() => createClient({}, '/nowhere', { env: {}, config, fetchImpl: okFetch })).toThrow(
+      /--api-key or set BFFLESS_API_KEY.*never read from \.bffless\/config\.json/s,
+    );
+  });
+});

--- a/packages/cli/test/diff.test.ts
+++ b/packages/cli/test/diff.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { runDiffOne } from '../src/commands/diff.js';
+import type { DiffDeps } from '../src/commands/diff.js';
+import { buildRuleSet, uuidv5, SCHEMA_NAMESPACE } from '../src/compile/build.js';
+import { API_URL, PROJECT_UUID, SET_UUID, basicSrcDir, happyRoutes, readBasicExpected, stubFetch } from './live-helpers.js';
+import type { RuleSetExport } from '../src/format/types.js';
+
+const config = { apiUrl: API_URL, project: PROJECT_UUID };
+const env = { BFFLESS_API_KEY: 'k-test' };
+
+function deps(routes: Parameters<typeof stubFetch>[0]): DiffDeps {
+  const { fetchImpl } = stubFetch(routes);
+  return { fetchImpl, env, config };
+}
+
+describe('rules diff', () => {
+  it('clean: local compile matches the live export → status clean ("in sync", exit 0 contract)', async () => {
+    const result = await runDiffOne(basicSrcDir, {}, '/nowhere', deps(happyRoutes(readBasicExpected())));
+    expect(result.status).toBe('clean');
+    expect(result.message).toBe('basic: in sync');
+  });
+
+  it('drift: a live rule differs → status drift with populated diffs (exit 1 contract)', async () => {
+    const live = readBasicExpected();
+    (live.rules[0] as { timeout?: number }).timeout = 12345;
+    const result = await runDiffOne(basicSrcDir, {}, '/nowhere', deps(happyRoutes(live)));
+    expect(result.status).toBe('drift');
+    expect(result.message).toContain('drift detected');
+    expect(result.diffs && result.diffs.length).toBeGreaterThan(0);
+    expect(result.diffs!.join('\n')).toContain('timeout');
+  });
+
+  it('set missing on the server is drift (exit 1), with a clear push hint', async () => {
+    const routes = happyRoutes(readBasicExpected());
+    routes[`GET ${API_URL}/api/proxy-rule-sets/project/${PROJECT_UUID}`] = { body: { ruleSets: [] } };
+    const result = await runDiffOne(basicSrcDir, {}, '/nowhere', deps(routes));
+    expect(result.status).toBe('drift');
+    expect(result.message).toMatch(/rule set "basic" does not exist on the server .*rules push/);
+    expect(result.diffs).toBeUndefined();
+  });
+
+  it('an equivalent live export with elided defaults still compares clean (defaults-normalized)', async () => {
+    // Strip a default-valued key from a live rule; exportsEquivalent must not call it drift.
+    const live = readBasicExpected() as RuleSetExport;
+    const rule = live.rules.find((r) => r.timeout === 30000);
+    if (rule) delete (rule as { timeout?: number }).timeout;
+    const result = await runDiffOne(basicSrcDir, {}, '/nowhere', deps(happyRoutes(live)));
+    expect(result.status).toBe('clean');
+  });
+
+  it('auth failure is an error (exit 2 contract), not drift', async () => {
+    const routes = happyRoutes(readBasicExpected());
+    routes[`GET ${API_URL}/api/proxy-rule-sets/project/${PROJECT_UUID}`] = { status: 401, body: {} };
+    const result = await runDiffOne(basicSrcDir, {}, '/nowhere', deps(routes));
+    expect(result.status).toBe('error');
+    expect(result.message).toMatch(/X-API-Key/);
+  });
+
+  it('a compile failure is an error (exit 2 contract)', async () => {
+    const result = await runDiffOne('/not/a/rule-set', {}, '/nowhere', deps({}));
+    expect(result.status).toBe('error');
+    expect(result.message).toMatch(/no ruleset\.yaml/);
+  });
+});
+
+// ==================== schema-id alignment (server remaps refs by NAME on push) ====================
+
+const LOCAL_SCHEMA_ID = '11111111-2222-4333-8444-555555555555'; // explicit id in basic's items.schema.yaml
+const DB_SCHEMA_ID = '99999999-8888-4777-a666-555544443333'; // a made-up target-project DB id
+
+/** Simulate what the server exports after a clean push: DB schema ids, refs remapped. */
+function liveWithDbSchemaIds(fromId: string, toId: string): RuleSetExport {
+  const live = readBasicExpected();
+  return JSON.parse(JSON.stringify(live).replaceAll(fromId, toId)) as RuleSetExport;
+}
+
+describe('rules diff — schema-id alignment by name', () => {
+  it('live export with DB schema ids (refs remapped by the server) is clean, not permanent drift', async () => {
+    const result = await runDiffOne(basicSrcDir, {}, '/nowhere', deps(happyRoutes(liveWithDbSchemaIds(LOCAL_SCHEMA_ID, DB_SCHEMA_ID))));
+    expect(result.status).toBe('clean');
+  });
+
+  it('a genuinely different schema field is still drift even when ids differ', async () => {
+    const live = liveWithDbSchemaIds(LOCAL_SCHEMA_ID, DB_SCHEMA_ID);
+    live.schemas![0].fields[0].type = 'number'; // was string
+    const result = await runDiffOne(basicSrcDir, {}, '/nowhere', deps(happyRoutes(live)));
+    expect(result.status).toBe('drift');
+    expect(result.diffs!.join('\n')).toContain('fields');
+  });
+
+  it('a schema name mismatch is drift (no alignment without a name match)', async () => {
+    const live = liveWithDbSchemaIds(LOCAL_SCHEMA_ID, DB_SCHEMA_ID);
+    live.schemas![0].name = 'items-renamed';
+    const result = await runDiffOne(basicSrcDir, {}, '/nowhere', deps(happyRoutes(live)));
+    expect(result.status).toBe('drift');
+  });
+
+  it('a schema missing from the live export is drift', async () => {
+    const live = readBasicExpected();
+    delete (live as { schemas?: unknown }).schemas;
+    const result = await runDiffOne(basicSrcDir, {}, '/nowhere', deps(happyRoutes(live)));
+    expect(result.status).toBe('drift');
+  });
+
+  it('a schema present live but not locally is drift', async () => {
+    const live = readBasicExpected();
+    live.schemas!.push({ id: DB_SCHEMA_ID, name: 'extra', fields: [{ name: 'x', type: 'string' }] });
+    const result = await runDiffOne(basicSrcDir, {}, '/nowhere', deps(happyRoutes(live)));
+    expect(result.status).toBe('drift');
+  });
+});
+
+// ==================== uuidv5-derived ids + email rule without targetUrl (end-to-end) ====================
+
+/** A rule set whose schema manifest has NO explicit id (compiler derives uuidv5(name)) plus an
+ *  email_form_handler rule authored without targetUrl (server stores/export the DB default ''). */
+function scratchEmailSet(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'bffless-diff-test-'));
+  const files: Record<string, string> = {
+    'ruleset.yaml': 'name: mail\n',
+    'schemas/leads.schema.yaml': 'name: leads\nfields:\n  - name: email\n    type: string\n',
+    'rules/api/leads/get.rule.yaml':
+      'pipeline:\n  steps:\n    - name: query\n      handler: data_query\n      config:\n        schemaId: "$schema:leads"\n',
+    'rules/api/contact/post.rule.yaml':
+      'emailHandlerConfig:\n  to: team@example.com\n',
+  };
+  for (const [rel, contents] of Object.entries(files)) {
+    const full = path.join(dir, rel);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, contents, 'utf8');
+  }
+  return dir;
+}
+
+function routesFor(setName: string, exportBody: unknown): Record<string, { status?: number; body?: unknown }> {
+  return {
+    [`GET ${API_URL}/api/projects`]: { body: [{ id: PROJECT_UUID, owner: 'me', name: 'proj' }] },
+    [`GET ${API_URL}/api/proxy-rule-sets/project/${PROJECT_UUID}`]: {
+      body: { ruleSets: [{ id: SET_UUID, name: setName }] },
+    },
+    [`GET ${API_URL}/api/proxy-rule-sets/${SET_UUID}/export`]: { body: exportBody },
+  };
+}
+
+describe('rules diff — uuidv5 local ids and DB-default targetUrl', () => {
+  it('uuidv5(name) local schema id vs live DB id + email rule without targetUrl vs live "" → clean', async () => {
+    const dir = scratchEmailSet();
+    const localId = uuidv5('leads', SCHEMA_NAMESPACE);
+    const built = (await buildRuleSet(dir)).export;
+    expect(JSON.stringify(built)).toContain(localId); // precondition: id really is uuidv5-derived
+
+    // Live counterpart, exactly as the server would export it after a clean push:
+    // schema refs/ids remapped to the DB id, absent targetUrl stored as ''.
+    const live = JSON.parse(JSON.stringify(built).replaceAll(localId, DB_SCHEMA_ID)) as RuleSetExport;
+    const emailRule = live.rules.find((r) => r.proxyType === 'email_form_handler')!;
+    expect(emailRule.targetUrl).toBeUndefined(); // precondition: local build emits no targetUrl
+    emailRule.targetUrl = '';
+
+    const result = await runDiffOne(dir, {}, '/nowhere', deps(routesFor('mail', live)));
+    expect(result.status).toBe('clean');
+  });
+
+  it('a real targetUrl change on the email rule is still drift', async () => {
+    const dir = scratchEmailSet();
+    const built = (await buildRuleSet(dir)).export;
+    const live = structuredClone(built);
+    const emailRule = live.rules.find((r) => r.proxyType === 'email_form_handler')!;
+    emailRule.targetUrl = 'https://mailer.example.com';
+
+    const result = await runDiffOne(dir, {}, '/nowhere', deps(routesFor('mail', live)));
+    expect(result.status).toBe('drift');
+    expect(result.diffs!.join('\n')).toContain('targetUrl');
+  });
+});

--- a/packages/cli/test/git-source.test.ts
+++ b/packages/cli/test/git-source.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { collectSourceMetadata, parseRepoFromRemoteUrl } from '../src/api/git-source.js';
+
+const throwingGit = () => {
+  throw new Error('git: command not found');
+};
+
+describe('parseRepoFromRemoteUrl', () => {
+  it('parses scp-like, https, and ssh remotes to owner/repo', () => {
+    expect(parseRepoFromRemoteUrl('git@github.com:bffless/ce.git')).toBe('bffless/ce');
+    expect(parseRepoFromRemoteUrl('https://github.com/bffless/ce.git')).toBe('bffless/ce');
+    expect(parseRepoFromRemoteUrl('https://github.com/bffless/ce')).toBe('bffless/ce');
+    expect(parseRepoFromRemoteUrl('ssh://git@github.com/bffless/ce.git')).toBe('bffless/ce');
+  });
+
+  it('returns undefined for unparseable values', () => {
+    expect(parseRepoFromRemoteUrl('not a url')).toBeUndefined();
+    expect(parseRepoFromRemoteUrl('https://github.com/onlyowner')).toBeUndefined();
+  });
+});
+
+describe('collectSourceMetadata', () => {
+  it('prefers GITHUB_REPOSITORY / GITHUB_SHA env over git commands', () => {
+    const source = collectSourceMetadata('/repo/apps/x/.bffless/proxy-rules/x', {
+      env: { GITHUB_REPOSITORY: 'bffless/apps', GITHUB_SHA: 'abc123' },
+      execGit: (args) => {
+        if (args.includes('--show-toplevel')) return '/repo';
+        throw new Error(`unexpected git call: ${args.join(' ')}`);
+      },
+    });
+    expect(source).toEqual({
+      repo: 'bffless/apps',
+      gitSha: 'abc123',
+      path: 'apps/x/.bffless/proxy-rules/x',
+    });
+  });
+
+  it('falls back to git remote/rev-parse when the GitHub env is absent', () => {
+    const source = collectSourceMetadata('/repo/sets/a', {
+      env: {},
+      execGit: (args) => {
+        if (args.join(' ') === 'remote get-url origin') return 'git@github.com:me/proj.git';
+        if (args.join(' ') === 'rev-parse HEAD') return 'deadbeef';
+        if (args.join(' ') === 'rev-parse --show-toplevel') return '/repo';
+        throw new Error('unexpected');
+      },
+    });
+    expect(source).toEqual({ repo: 'me/proj', gitSha: 'deadbeef', path: 'sets/a' });
+  });
+
+  it('returns undefined when git is unavailable and no env vars are set', () => {
+    expect(collectSourceMetadata('/somewhere', { env: {}, execGit: throwingGit })).toBeUndefined();
+  });
+
+  it('degrades per-field: env sha only, no repo/path, still yields a partial source', () => {
+    const source = collectSourceMetadata('/somewhere', {
+      env: { GITHUB_SHA: 'cafef00d' },
+      execGit: throwingGit,
+    });
+    expect(source).toEqual({ gitSha: 'cafef00d' });
+  });
+
+  it('omits path when the set dir is outside the repo root', () => {
+    const source = collectSourceMetadata('/elsewhere/sets/a', {
+      env: { GITHUB_REPOSITORY: 'o/r', GITHUB_SHA: 's' },
+      execGit: (args) => {
+        if (args.includes('--show-toplevel')) return path.resolve('/repo');
+        throw new Error('unexpected');
+      },
+    });
+    expect(source).toEqual({ repo: 'o/r', gitSha: 's' });
+  });
+});

--- a/packages/cli/test/live-helpers.ts
+++ b/packages/cli/test/live-helpers.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared helpers for the live-command tests (pull/push/diff/resolve): a recording fetch
+ * stub and the canonical fixture constants. Not a test file itself (no `.test.ts`).
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import type { FetchLike } from '../src/api/client.js';
+import type { RuleSetExport } from '../src/format/types.js';
+
+export const API_URL = 'https://api.test';
+export const PROJECT_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+export const SET_UUID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+export const basicSrcDir = path.resolve('test/fixtures/synthetic/basic');
+
+export function readBasicExpected(): RuleSetExport {
+  return JSON.parse(readFileSync(path.join(basicSrcDir, 'expected.json'), 'utf8')) as RuleSetExport;
+}
+
+export interface RecordedCall {
+  url: string;
+  init?: RequestInit;
+}
+
+export interface StubRoute {
+  status?: number;
+  body?: unknown;
+}
+
+/** A fetch stub answering from a `METHOD url` → response map, recording every call. */
+export function stubFetch(routes: Record<string, StubRoute>): {
+  fetchImpl: FetchLike;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  const fetchImpl: FetchLike = async (url, init) => {
+    calls.push({ url, init });
+    const key = `${init?.method ?? 'GET'} ${url}`;
+    const route = routes[key];
+    if (!route) throw new Error(`stubFetch: no route for ${key}`);
+    return new Response(JSON.stringify(route.body ?? {}), {
+      status: route.status ?? 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+  return { fetchImpl, calls };
+}
+
+/** Standard happy-path routes: project list, rule-set list, export. */
+export function happyRoutes(exportBody: unknown): Record<string, StubRoute> {
+  return {
+    [`GET ${API_URL}/api/projects`]: {
+      body: [{ id: PROJECT_UUID, owner: 'me', name: 'proj' }],
+    },
+    [`GET ${API_URL}/api/proxy-rule-sets/project/${PROJECT_UUID}`]: {
+      body: { ruleSets: [{ id: SET_UUID, name: 'basic' }] },
+    },
+    [`GET ${API_URL}/api/proxy-rule-sets/${SET_UUID}/export`]: { body: exportBody },
+  };
+}

--- a/packages/cli/test/pull-live.test.ts
+++ b/packages/cli/test/pull-live.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { runPull } from '../src/commands/pull.js';
+import { API_URL, PROJECT_UUID, SET_UUID, happyRoutes, readBasicExpected, stubFetch } from './live-helpers.js';
+import type { PullDeps } from '../src/commands/pull.js';
+
+const config = { apiUrl: API_URL, project: 'proj' };
+const env = { BFFLESS_API_KEY: 'k-test' };
+
+function deps(routes: Parameters<typeof stubFetch>[0]): PullDeps & { calls: ReturnType<typeof stubFetch>['calls'] } {
+  const { fetchImpl, calls } = stubFetch(routes);
+  return { fetchImpl, env, config, calls };
+}
+
+function scratchDir(): string {
+  return mkdtempSync(path.join(tmpdir(), 'bffless-pull-live-'));
+}
+
+describe('rules pull — live path', () => {
+  it('happy path: resolves project by name, set by name, fetches the export, and writes the authoring layout', async () => {
+    const d = deps(happyRoutes(readBasicExpected()));
+    const outDir = path.join(scratchDir(), 'out');
+    const result = await runPull('basic', { output: outDir }, '/nowhere', d);
+
+    expect(result.error).toBeUndefined();
+    expect(result.ok).toBe(true);
+    expect(result.outDir).toBe(path.resolve('/nowhere', outDir));
+    expect(existsSync(path.join(outDir, 'ruleset.yaml'))).toBe(true);
+    expect(existsSync(path.join(outDir, 'rules'))).toBe(true);
+    expect(existsSync(path.join(outDir, 'schemas', 'items.schema.yaml'))).toBe(true);
+
+    // Verify the live pull hit exactly the three expected endpoints, with the API key.
+    expect(d.calls.map((c) => c.url)).toEqual([
+      `${API_URL}/api/projects`,
+      `${API_URL}/api/proxy-rule-sets/project/${PROJECT_UUID}`,
+      `${API_URL}/api/proxy-rule-sets/${SET_UUID}/export`,
+    ]);
+    for (const call of d.calls) {
+      expect((call.init?.headers as Record<string, string>)['X-API-Key']).toBe('k-test');
+    }
+  });
+
+  it('defaults the output dir to <cwd>/.bffless/proxy-rules/<ruleSet.name>', async () => {
+    const d = deps(happyRoutes(readBasicExpected()));
+    const cwd = scratchDir();
+    const result = await runPull('basic', {}, cwd, d);
+    expect(result.ok, result.error).toBe(true);
+    expect(result.outDir).toBe(path.join(cwd, '.bffless', 'proxy-rules', 'basic'));
+    expect(existsSync(path.join(cwd, '.bffless', 'proxy-rules', 'basic', 'ruleset.yaml'))).toBe(true);
+  });
+
+  it('a project UUID in config skips the projects list endpoint', async () => {
+    const routes = happyRoutes(readBasicExpected());
+    delete routes[`GET ${API_URL}/api/projects`]; // stubFetch would throw if it were called
+    const { fetchImpl } = stubFetch(routes);
+    const outDir = path.join(scratchDir(), 'out');
+    const result = await runPull(
+      'basic',
+      { output: outDir },
+      '/nowhere',
+      { fetchImpl, env, config: { apiUrl: API_URL, project: PROJECT_UUID } },
+    );
+    expect(result.ok, result.error).toBe(true);
+  });
+
+  it('an unknown set name fails, naming the URL tried and the available sets', async () => {
+    const d = deps(happyRoutes(readBasicExpected()));
+    const result = await runPull('missing-set', { output: path.join(scratchDir(), 'out') }, '/nowhere', d);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/rule set "missing-set" not found via GET .*Available rule sets: basic/);
+  });
+
+  it('a 403 on export surfaces the auth hint (X-API-Key / BFFLESS_API_KEY)', async () => {
+    const routes = happyRoutes(readBasicExpected());
+    routes[`GET ${API_URL}/api/proxy-rule-sets/${SET_UUID}/export`] = { status: 403, body: {} };
+    const d = deps(routes);
+    const result = await runPull('basic', { output: path.join(scratchDir(), 'out') }, '/nowhere', d);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/X-API-Key/);
+  });
+
+  it('without an API key the error explains the flag/env sources', async () => {
+    const result = await runPull('basic', {}, '/nowhere', {
+      fetchImpl: stubFetch({}).fetchImpl,
+      env: {},
+      config,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/--api-key or set BFFLESS_API_KEY/);
+  });
+
+  it('refuses a non-empty output dir without --force, honors --force', async () => {
+    const outDir = path.join(scratchDir(), 'out');
+    const first = await runPull('basic', { output: outDir }, '/nowhere', deps(happyRoutes(readBasicExpected())));
+    expect(first.ok, first.error).toBe(true);
+
+    const second = await runPull('basic', { output: outDir }, '/nowhere', deps(happyRoutes(readBasicExpected())));
+    expect(second.ok).toBe(false);
+    expect(second.error).toMatch(/non-empty directory/);
+
+    const forced = await runPull(
+      'basic',
+      { output: outDir, force: true },
+      '/nowhere',
+      deps(happyRoutes(readBasicExpected())),
+    );
+    expect(forced.ok, forced.error).toBe(true);
+  });
+});
+
+describe('rules pull — from-file backward compatibility (unit level)', () => {
+  it('still requires --decompile with --from-file', async () => {
+    const result = await runPull(undefined, { fromFile: 'x.json' }, '/nowhere', { env: {}, config: null });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/--decompile is required alongside --from-file/);
+  });
+
+  it('rejects combining a set name with --from-file', async () => {
+    const result = await runPull('basic', { fromFile: 'x.json', decompile: true }, '/nowhere', {
+      env: {},
+      config: null,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/mutually exclusive/);
+  });
+
+  it('without a set name and without --from-file explains both usages', async () => {
+    const result = await runPull(undefined, {}, '/nowhere', { env: {}, config: null });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/set name is required for a live pull.*--from-file/s);
+  });
+});

--- a/packages/cli/test/push.test.ts
+++ b/packages/cli/test/push.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { runPushOne, formatSyncReport } from '../src/commands/push.js';
+import type { PushDeps } from '../src/commands/push.js';
+import type { SyncResponse, SyncRequestBody } from '../src/api/sync-types.js';
+import { API_URL, PROJECT_UUID, SET_UUID, basicSrcDir, stubFetch } from './live-helpers.js';
+
+const SYNC_URL = `${API_URL}/api/proxy-rule-sets/project/${PROJECT_UUID}/sync`;
+const config = { apiUrl: API_URL, project: PROJECT_UUID };
+const env = { BFFLESS_API_KEY: 'k-test' };
+const noGit: PushDeps['execGit'] = () => {
+  throw new Error('git unavailable');
+};
+
+function syncResponse(overrides?: Partial<SyncResponse>): SyncResponse {
+  return {
+    ruleSetId: SET_UUID,
+    created: [],
+    updated: [],
+    deleted: [],
+    unchanged: [],
+    pruneCandidates: [],
+    schemaResolutions: [],
+    missingSecrets: [],
+    warnings: [],
+    dryRun: false,
+    setCreated: false,
+    ...overrides,
+  };
+}
+
+function pushDeps(
+  response: SyncResponse | { status: number; body?: unknown },
+  extra?: Partial<PushDeps>,
+): PushDeps & { sentBody: () => SyncRequestBody } {
+  const route = 'status' in response ? response : { body: response };
+  const { fetchImpl, calls } = stubFetch({ [`PUT ${SYNC_URL}`]: route });
+  return {
+    fetchImpl,
+    env,
+    config,
+    execGit: noGit,
+    ...extra,
+    sentBody: () => JSON.parse(calls[0].init?.body as string) as SyncRequestBody,
+  };
+}
+
+describe('rules push', () => {
+  it('dry run: sends options.dryRun, exits ok, and renders the change report with METHOD /path refs', async () => {
+    const d = pushDeps(
+      syncResponse({
+        ruleSetId: null,
+        created: [
+          { pathPattern: '/api/items', method: 'GET' },
+          { pathPattern: '/api/items/*', method: null },
+        ],
+        updated: [{ pathPattern: '/api/feeds/remove', method: 'POST' }],
+        unchanged: [],
+        dryRun: true,
+        setCreated: true,
+      }),
+    );
+    const result = await runPushOne(basicSrcDir, { dryRun: true }, '/nowhere', d);
+    expect(result.error).toBeUndefined();
+    expect(result.ok).toBe(true);
+
+    const body = d.sentBody();
+    expect(body.options).toEqual({ prune: false, dryRun: true, strictSchemas: false });
+    expect(body.ruleSet.name).toBe('basic');
+    expect(Array.isArray(body.rules)).toBe(true);
+    expect(body.rules.length).toBeGreaterThan(0);
+    expect(body.schemas?.map((s) => s.name)).toContain('items');
+    expect(body.source).toBeUndefined(); // env has no GITHUB_*, git unavailable
+
+    expect(result.report).toContain('basic: 2 created, 1 updated, 0 deleted, 0 unchanged');
+    expect(result.report).toContain('[set would be created]');
+    expect(result.report).toContain('(dry run — nothing was written)');
+    expect(result.report).toContain('+ GET /api/items');
+    expect(result.report).toContain('+ ANY /api/items/*'); // null method renders as ANY
+    expect(result.report).toContain('~ POST /api/feeds/remove');
+  });
+
+  it('--prune and --strict-schemas are forwarded in options', async () => {
+    const d = pushDeps(syncResponse({ deleted: [{ pathPattern: '/api/old', method: null }] }));
+    const result = await runPushOne(basicSrcDir, { prune: true, strictSchemas: true }, '/nowhere', d);
+    expect(result.ok, result.error).toBe(true);
+    expect(d.sentBody().options).toEqual({ prune: true, dryRun: false, strictSchemas: true });
+    expect(result.report).toContain('- ANY /api/old');
+  });
+
+  it('--name-suffix renames the set in the payload and the report', async () => {
+    const d = pushDeps(syncResponse({ setCreated: true }));
+    const result = await runPushOne(basicSrcDir, { nameSuffix: 'pr-42' }, '/nowhere', d);
+    expect(result.ok, result.error).toBe(true);
+    expect(d.sentBody().ruleSet.name).toBe('basic-pr-42');
+    expect(result.report).toContain('basic-pr-42:');
+    expect(result.report).toContain('[set created]');
+  });
+
+  it('pruneCandidates are called out as would-prune hints', async () => {
+    const d = pushDeps(syncResponse({ pruneCandidates: [{ pathPattern: '/api/legacy', method: 'DELETE' }] }));
+    const result = await runPushOne(basicSrcDir, {}, '/nowhere', d);
+    expect(result.ok, result.error).toBe(true);
+    expect(result.report).toMatch(/would prune .*--prune/);
+    expect(result.report).toContain('! DELETE /api/legacy');
+  });
+
+  it('missingSecrets alone is a WARNING: ok stays true, report calls them out prominently', async () => {
+    const d = pushDeps(syncResponse({ missingSecrets: ['OPENAI_API_KEY'], warnings: ['schema "items" fields differ'] }));
+    const result = await runPushOne(basicSrcDir, {}, '/nowhere', d);
+    expect(result.ok).toBe(true); // exit 0 semantics
+    expect(result.report).toContain('MISSING SECRETS (1)');
+    expect(result.report).toContain('OPENAI_API_KEY');
+    expect(result.report).toContain('warning: schema "items" fields differ');
+  });
+
+  it('HTTP 403 fails with the auth hint (nonzero exit path)', async () => {
+    const d = pushDeps({ status: 403, body: { message: 'Forbidden' } });
+    const result = await runPushOne(basicSrcDir, {}, '/nowhere', d);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/HTTP 403 .*X-API-Key.*BFFLESS_API_KEY/s);
+  });
+
+  it('HTTP 400 (e.g. strict schema failure) fails with the server message', async () => {
+    const d = pushDeps({ status: 400, body: { message: 'schema "items" field mismatch (strictSchemas)' } });
+    const result = await runPushOne(basicSrcDir, { strictSchemas: true }, '/nowhere', d);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('schema "items" field mismatch');
+  });
+
+  it('a compile error fails before any HTTP call', async () => {
+    const { fetchImpl, calls } = stubFetch({});
+    const result = await runPushOne('/definitely/not/a/rule-set', {}, '/nowhere', {
+      fetchImpl,
+      env,
+      config,
+      execGit: noGit,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/no ruleset\.yaml/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('source metadata: GitHub Actions env wins; path comes from the git repo root', async () => {
+    const d = pushDeps(syncResponse(), {
+      env: { ...env, GITHUB_REPOSITORY: 'bffless/ce', GITHUB_SHA: 'abc123' },
+      execGit: (args) => {
+        if (args.join(' ') === 'rev-parse --show-toplevel') return '/repo';
+        throw new Error('unexpected git call');
+      },
+    });
+    // basicSrcDir is not under /repo, so path degrades away while repo/gitSha survive.
+    const result = await runPushOne(basicSrcDir, {}, '/nowhere', d);
+    expect(result.ok, result.error).toBe(true);
+    expect(d.sentBody().source).toEqual({ repo: 'bffless/ce', gitSha: 'abc123' });
+  });
+
+  it('source metadata: falls back to git commands, and to nothing when git is unavailable', async () => {
+    const withGit = pushDeps(syncResponse(), {
+      execGit: (args) => {
+        const cmd = args.join(' ');
+        if (cmd === 'remote get-url origin') return 'git@github.com:me/proj.git';
+        if (cmd === 'rev-parse HEAD') return 'deadbeef';
+        if (cmd === 'rev-parse --show-toplevel') return basicSrcDir; // set dir == repo root → no path
+        throw new Error('unexpected');
+      },
+    });
+    const ok = await runPushOne(basicSrcDir, {}, '/nowhere', withGit);
+    expect(ok.ok, ok.error).toBe(true);
+    expect(withGit.sentBody().source).toEqual({ repo: 'me/proj', gitSha: 'deadbeef' });
+
+    const without = pushDeps(syncResponse());
+    const stillOk = await runPushOne(basicSrcDir, {}, '/nowhere', without);
+    expect(stillOk.ok, stillOk.error).toBe(true); // push proceeds without provenance
+    expect(without.sentBody().source).toBeUndefined();
+  });
+
+  it('a validator authored without config is sent on the wire with config: {} (backend DTO requires config)', async () => {
+    // PipelineValidatorDto.config is @IsObject() without @IsOptional (apps/backend
+    // dto/create-proxy-rule.dto.ts): omitting it 400s the whole sync.
+    const dir = mkdtempSync(path.join(tmpdir(), 'bffless-push-test-'));
+    mkdirSync(path.join(dir, 'rules/api/x'), { recursive: true });
+    writeFileSync(path.join(dir, 'ruleset.yaml'), 'name: v\n', 'utf8');
+    writeFileSync(
+      path.join(dir, 'rules/api/x/post.rule.yaml'),
+      'pipeline:\n  steps:\n    - name: fn\n      handler: function_handler\n      config: { code: "x" }\n  validators:\n    - type: auth_required\n',
+      'utf8',
+    );
+    const d = pushDeps(syncResponse());
+    const result = await runPushOne(dir, {}, '/nowhere', d);
+    expect(result.ok, result.error).toBe(true);
+    expect(d.sentBody().rules[0].pipelineConfig?.validators).toEqual([{ type: 'auth_required', config: {} }]);
+  });
+});
+
+describe('formatSyncReport', () => {
+  it('an all-unchanged sync is a single summary line', () => {
+    const report = formatSyncReport(
+      'basic',
+      syncResponse({ unchanged: [{ pathPattern: '/api/items', method: 'GET' }] }),
+    );
+    expect(report).toBe('basic: 0 created, 0 updated, 0 deleted, 1 unchanged');
+  });
+});

--- a/packages/cli/test/resolve.test.ts
+++ b/packages/cli/test/resolve.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { ApiClient } from '../src/api/client.js';
+import { resolveProjectId, resolveRuleSetId, findRuleSetByName, requireProject } from '../src/api/resolve.js';
+import { API_URL, PROJECT_UUID, SET_UUID, stubFetch } from './live-helpers.js';
+
+function clientWith(routes: Parameters<typeof stubFetch>[0]): ApiClient {
+  const { fetchImpl } = stubFetch(routes);
+  return new ApiClient({ apiUrl: API_URL, apiKey: 'k', fetchImpl });
+}
+
+describe('resolveProjectId', () => {
+  const twoProjects = {
+    [`GET ${API_URL}/api/projects`]: {
+      body: [
+        { id: PROJECT_UUID, owner: 'me', name: 'proj' },
+        { id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', owner: 'other', name: 'demo' },
+      ],
+    },
+  };
+
+  it('a UUID is used directly without hitting the list endpoint', async () => {
+    const { fetchImpl, calls } = stubFetch({});
+    const client = new ApiClient({ apiUrl: API_URL, apiKey: 'k', fetchImpl });
+    expect(await resolveProjectId(client, PROJECT_UUID)).toBe(PROJECT_UUID);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('a bare name resolves via GET /api/projects', async () => {
+    expect(await resolveProjectId(clientWith(twoProjects), 'proj')).toBe(PROJECT_UUID);
+  });
+
+  it('an owner/name pair resolves', async () => {
+    expect(await resolveProjectId(clientWith(twoProjects), 'other/demo')).toBe(
+      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+    );
+  });
+
+  it('a miss errors with what was tried (name + URL) and the available names', async () => {
+    await expect(resolveProjectId(clientWith(twoProjects), 'nope')).rejects.toThrow(
+      /project "nope" via GET https:\/\/api\.test\/api\/projects: no match\. Available projects: me\/proj, other\/demo/,
+    );
+  });
+
+  it('an ambiguous bare name errors listing the owner/name candidates', async () => {
+    const dup = {
+      [`GET ${API_URL}/api/projects`]: {
+        body: [
+          { id: PROJECT_UUID, owner: 'me', name: 'proj' },
+          { id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', owner: 'other', name: 'proj' },
+        ],
+      },
+    };
+    await expect(resolveProjectId(clientWith(dup), 'proj')).rejects.toThrow(
+      /ambiguous — matches me\/proj, other\/proj/,
+    );
+  });
+});
+
+describe('resolveRuleSetId / findRuleSetByName', () => {
+  const routes = {
+    [`GET ${API_URL}/api/proxy-rule-sets/project/${PROJECT_UUID}`]: {
+      body: { ruleSets: [{ id: SET_UUID, name: 'basic' }] },
+    },
+  };
+
+  it('resolves an existing set name to its id', async () => {
+    expect(await resolveRuleSetId(clientWith(routes), PROJECT_UUID, 'basic')).toBe(SET_UUID);
+  });
+
+  it('a miss errors with the URL tried and the sets that DO exist', async () => {
+    await expect(resolveRuleSetId(clientWith(routes), PROJECT_UUID, 'nope')).rejects.toThrow(
+      /rule set "nope" not found via GET https:\/\/api\.test\/api\/proxy-rule-sets\/project\/.*Available rule sets: basic/,
+    );
+  });
+
+  it('findRuleSetByName returns null (not an error) when absent', async () => {
+    expect(await findRuleSetByName(clientWith(routes), PROJECT_UUID, 'nope')).toBeNull();
+  });
+});
+
+describe('requireProject', () => {
+  it('flag beats config; missing both is a clear error', () => {
+    expect(requireProject('flag-p', 'cfg-p')).toBe('flag-p');
+    expect(requireProject(undefined, 'cfg-p')).toBe('cfg-p');
+    expect(() => requireProject(undefined, undefined)).toThrow(/--project.*\.bffless\/config\.json/s);
+  });
+});


### PR DESCRIPTION
Phase 1 of proxy-rules-as-code (#446), building on the Phase 0 CLI (#449). Closes #448.

## What this adds

**Server-side export endpoint** — `GET /api/proxy-rule-sets/:id/export` assembles the v2 envelope in the backend (canonical key order, secret blanking, schema bundling). The frontend downloads it verbatim; the export format stops being a frontend contract. This also fixes #448 — the client-side exporter silently dropped `methods`. A cross-package equivalence spec imports the actual CLI canonicalizer (`packages/cli/src/format`) and asserts the server output is byte-canonical, with a mutation test proving a dropped field fails CI.

**Idempotent sync endpoint** — `PUT /api/proxy-rule-sets/project/:projectId/sync`:
- Set matched by `(projectId, name)`, created if absent; rules matched by `(pathPattern, method)` — update changed, insert new, delete removed only with `options.prune`.
- Schema deps resolved **by name** non-interactively (reuse or create); field mismatches land in `warnings[]`, or 400 with `options.strictSchemas` (thrown before any side effect, even under `dryRun`).
- **Blank-secret preservation**: exports blank header `add` values to `''`; on sync an incoming `''` keeps the live value (encrypted once, request DTO never mutated). New blanks are reported in `missingSecrets[]` along with unresolved `{{secrets.NAME}}` refs.
- All writes in one transaction; `dryRun` returns the full change report with zero writes (CI posts it as a PR comment).
- Closes the SSRF gap import had: `targetUrl` is validated (with CLI-parity proxyType inference so elided pipeline payloads pass without widening what an explicit proxyType allows).
- Nginx regenerates post-commit when anything changed (synced sets can be live-attached, unlike imports).

**Source tracking + managed-from-git UX** — nullable `source` jsonb on `proxy_rule_sets` (`{repo, path, gitSha, syncedAt, contentHash}`, migration `drizzle/0038`), stamped by sync and kept (not cleared) on manual edits. The dashboard shows a "Managed from git (repo@sha)" badge and warns on every mutation path that edits will be overwritten on next deploy; MCP rule-set responses include `source`.

**Live CLI** — `bffless rules pull` (export → decompile), `rules push` (`--dry-run`, `--prune`, `--name-suffix pr-42`, `--strict-schemas`; best-effort git provenance from CI env or git), `rules diff` (exit 0 in sync / 1 drift / 2 error — the CI drift contract). Auth via `X-API-Key` (flag > `BFFLESS_API_KEY`; never config.json). `diff` aligns schema ids by name before comparing, mirroring the server, so push and diff agree about the same state.

## Process & verification

Built subagent-driven: fresh implementer per task, an independent adversarial review per task (fixes folded in — including a fail-loud guard so sync can't silently overwrite methods-split rule variants), and a final whole-branch review. Plan + resolved design decisions + known limitations: `docs/plans/proxy-rules-as-code-phase1-implementation.md`.

- Backend: 107 suites, 1659 tests passing
- Frontend: 42 files, 469 tests passing
- CLI: 20 files, 298 tests passing
- `tsc --noEmit` clean on all three

## Known limitations (documented in the plan doc)

- Methods-split sets (two rules sharing `(pathPattern, method: null)`) 400 on sync instead of syncing — Phase 2 folds a methods signature into the match key.
- Set `description`/`environment` are only written when provided (omission preserves the live value).
- `source.contentHash` is intra-project (covers remapped schema ids); drift detection uses `exportsEquivalent`.

Follow-up filed separately: pre-existing `copy()` plaintext headerConfig at rest (present on `main`, not a regression here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnjMn4rUnS1FRbgapjkV3h
