### PR TITLE
fix(backend): exclude spec files from nest build (unbreaks Docker image build)

### DIFF
--- a/apps/backend/nest-cli.json
+++ b/apps/backend/nest-cli.json
@@ -3,6 +3,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
+    "tsConfigPath": "tsconfig.build.json",
     "deleteOutDir": true,
     "assets": [
       {

--- a/apps/backend/tsconfig.build.json
+++ b/apps/backend/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "test", "**/*.spec.ts"]
+}


### PR DESCRIPTION
The v0.2.0 release's Docker image build failed (https://github.com/bffless/ce/actions/runs/29202471623): `nest build` compiles `*.spec.ts` because `tsconfig.json` has no spec exclude and `nest-cli.json` pinned no tsconfig. The Phase 1 spec `export-cli-equivalence.spec.ts` deep-imports `packages/cli/src/*`, which `docker/backend.Dockerfile` never copies into the build context → TS2307 inside the image build. PR CI passes because the full checkout has `packages/cli`.

Fix = the standard NestJS layout: `apps/backend/tsconfig.build.json` (extends tsconfig.json, excludes `**/*.spec.ts`), pinned via `compilerOptions.tsConfigPath` in `nest-cli.json`. Spec files no longer ship toward the production image at all.

Verified locally: `pnpm --filter backend build` green; `dist/` contains zero `*.spec.js` and zero `packages/cli` references; `dist/main.js` and modules intact. Type checking in PR CI (`tsc --noEmit` over `tsconfig.json`) still covers spec files — only `nest build` output changes.

Note: v0.2.0's images were never pushed (only the tag/release exist). After this merges, release-please cuts **v0.2.1** — deploy that to j5s.dev instead of v0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HwQGvUTxoN7oCp3k1b6nB