### PR TITLE
fix(docker): copy tsconfig.build.json into backend image builds

### DIFF
--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -21,6 +21,7 @@ RUN pnpm install --frozen-lockfile
 # Copy specific files and directories to avoid conflicts with installed node_modules
 COPY apps/backend/src ./apps/backend/src
 COPY apps/backend/tsconfig.json ./apps/backend/
+COPY apps/backend/tsconfig.build.json ./apps/backend/
 COPY apps/backend/nest-cli.json ./apps/backend/
 COPY apps/backend/drizzle.config.ts ./apps/backend/
 COPY apps/backend/drizzle ./apps/backend/drizzle

--- a/docker/backend.umbrel.Dockerfile
+++ b/docker/backend.umbrel.Dockerfile
@@ -27,6 +27,7 @@ RUN pnpm install --frozen-lockfile
 # Copy specific files and directories to avoid conflicts with installed node_modules
 COPY apps/backend/src ./apps/backend/src
 COPY apps/backend/tsconfig.json ./apps/backend/
+COPY apps/backend/tsconfig.build.json ./apps/backend/
 COPY apps/backend/nest-cli.json ./apps/backend/
 COPY apps/backend/drizzle.config.ts ./apps/backend/
 COPY apps/backend/drizzle ./apps/backend/drizzle


### PR DESCRIPTION
Follow-up to #455. `nest build` now points at `tsconfig.build.json`, but both backend Dockerfiles (`docker/backend.Dockerfile`, `docker/backend.umbrel.Dockerfile`) copy an explicit file list that didn't include the new file — so the v0.2.1 release's image build failed with `Could not find TypeScript configuration file "tsconfig.build.json"` (https://github.com/bffless/ce/actions/runs/29202890535).

One `COPY` line added to each Dockerfile.

**Verified inside the image this time**: `docker build --target builder -f docker/backend.Dockerfile .` completes — i.e. `pnpm --filter backend build` succeeds in the exact context that failed, not just on a full local checkout.

After merge: release-please cuts **v0.2.2** — that's the version to deploy to j5s.dev (contains 0.2.0's sync endpoints + DTO transform, plus the two build fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HwQGvUTxoN7oCp3k1b6nB