### PR TITLE
docs: mark proxy-rules-as-code Phase 3 shipped

### DIFF
--- a/docs/plans/proxy-rules-as-code-phase3-implementation.md
+++ b/docs/plans/proxy-rules-as-code-phase3-implementation.md
@@ -907,7 +907,7 @@ content, verify every documented flag/command against the actual CLI source (`gi
 `packages/cli/src/index.ts`), since D/E were written from plan contracts. Fix rounds +
 re-review until clean.
 
-### - [ ] Task G2 — release checklist (operator-gated, in order)
+### - [x] Task G2 — release checklist (operator-gated, in order)
 
 1. **Operator**: `cd repos/ce/apps/backend && pnpm db:generate` (expect one new migration
    creating `proxy_rule_set_revisions`; name suggestion: accept default or

--- a/docs/plans/proxy-rules-as-code-phase3-kickoff.md
+++ b/docs/plans/proxy-rules-as-code-phase3-kickoff.md
@@ -6,6 +6,15 @@ skills-as-synced-resources evaluation, public docs + skill)**.
 
 Date: 2026-07-12
 
+> **STATUS UPDATE 2026-07-12 — PHASE 3 SHIPPED.** Everything below is historical context.
+> Shipped: CE v0.2.3 on j5s.dev (revisions + rollback live-verified on a scratch set),
+> `bffless@0.2.0` on npm (first CI publish via release-please component `bffless`, ce#463/#467),
+> docs-public recipe live (/recipes/proxy-rules-as-code/), skills plugin v1.11.0
+> (`bffless:rules-as-code`). Plan of record with review results:
+> `proxy-rules-as-code-phase3-implementation.md`. Follow-ups filed: ce#464 (generator
+> services bypass revision capture), ce#465 (8-char revision ids vs `--to` UUID), ce#466
+> (stale missingSecrets doc bullet), apps#233/#234 (drift-check pin bump).
+
 ## Where things stand
 
 **Phases 0–1 — DONE** (see `proxy-rules-as-code-phase2-kickoff.md` for that history).


### PR DESCRIPTION
Docs-only: adds the shipped status note to the Phase 3 kickoff doc and checks off G1/G2 in the implementation plan. Live verification record is in the plan/PR #463 trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HwQGvUTxoN7oCp3k1b6nB