### PR TITLE
fix(cli): decompile a dual method/methods rule under the any stem

### DIFF
--- a/packages/cli/src/compile/decompile.ts
+++ b/packages/cli/src/compile/decompile.ts
@@ -158,7 +158,15 @@ export function decompileExport(exp: RuleSetExport): DecompileResult {
     const segments = patternToRelPath(clone.pathPattern);
     const isCustom = segments === null;
     const baseSegments = isCustom ? ['_custom', slugForPattern(clone.pathPattern)] : segments!;
-    const stem = clone.method ? clone.method.toLowerCase() : 'any';
+    // A `methods:` list is only legal under an `any` stem, so it decides the stem — a rule
+    // carrying both (legacy dual-field rules) would otherwise land in a `<method>` stem whose
+    // manifest the compiler rejects. `methods[]` also wins at match time (backend
+    // method-match.ts), so the redundant `method` this drops is not load-bearing.
+    const stem = clone.methods?.length
+      ? 'any'
+      : clone.method
+        ? clone.method.toLowerCase()
+        : 'any';
 
     // 3. Directory shape iff any function_handler step exists.
     const allSteps: PipelineStep[] = clone.pipelineConfig

--- a/packages/cli/test/decompile.test.ts
+++ b/packages/cli/test/decompile.test.ts
@@ -119,6 +119,40 @@ describe('decompileExport', () => {
     expect(manifest.pathPattern).toBe('/api/*.json');
   });
 
+  it('(b2) writes a rule carrying both method and methods under the any stem, and it recompiles', async () => {
+    // The live `handoff` set holds a legacy dual-field rule (bffless/ce#469). `methods[]` wins at
+    // match time (backend method-match.ts), so the only layout that can carry it is an `any` stem
+    // with `methods:` — a method stem would emit a manifest the compiler rejects.
+    const exp: RuleSetExport = {
+      version: 2,
+      exportedAt: EXPORTED_AT,
+      kind: 'bffless-proxy-rule-set',
+      ruleSet: { name: 'dual' },
+      rules: [
+        {
+          pathPattern: '/r/*',
+          method: 'GET',
+          methods: ['GET', 'HEAD'],
+          targetUrl: 'http://b',
+          proxyType: 'external_proxy',
+        },
+      ],
+    };
+    const { files } = decompileExport(exp);
+    const rel = 'rules/r/[...path]/any.rule.yaml';
+    expect([...files.keys()]).toContain(rel);
+    const manifest = parseYaml(files.get(rel)!) as Record<string, unknown>;
+    expect(manifest.methods).toEqual(['GET', 'HEAD']);
+    expect(manifest.method).toBeUndefined();
+
+    // …and the layout the decompiler emitted must survive its own compiler.
+    const dir = mkdtempSync(path.join(tmpdir(), 'bffless-decompile-dual-'));
+    writeFiles(dir, files);
+    const { export: out } = await buildRuleSet(dir, { exportedAt: EXPORTED_AT });
+    expect(out.rules[0].pathPattern).toBe('/r/*');
+    expect(out.rules[0].methods).toEqual(['GET', 'HEAD']);
+  });
+
   it('(d) warns on an unknown schema UUID and leaves it untouched', () => {
     const unknownId = '99999999-8888-4777-8666-555555555555';
     const exp: RuleSetExport = {


### PR DESCRIPTION
Fixes #469.

## Problem

`bffless rules pull` could emit an authoring directory that its own `bffless rules validate` immediately rejected, so the pull → validate → push round-trip was broken for any rule carrying **both** a `method` and a `methods` list (the live `handoff` set has one: `{ pathPattern: "/r/*", method: "GET", methods: ["GET","HEAD"] }`).

The decompiler derived the directory stem from `method` alone, so the rule landed in a `get` stem while `methods:` survived into the manifest body — a combination `build.ts` explicitly rejects:

```
rules/r/[...path]/get/rule.yaml 'methods:' is only allowed in an 'any' rule (found in get/rule.yaml)
```

## Fix

A non-empty `methods` list now decides the stem (`any`), falling back to `method`, then `any`.

Dropping the redundant `method` this implies is semantically lossless: `apps/backend/src/proxy-rules/method-match.ts` gives a non-empty `methods[]` strict precedence and ignores `method` entirely when it is set. The rule round-trips as `any/rule.yaml` + `methods: [GET, HEAD]`, which is what the export JSON (`method: null`, `methods: [...]`) already represents.

## Tests

New `decompile.test.ts` case `(b2)` covers the dual-field rule and asserts both halves of the round trip: the manifest lands under `any.rule.yaml` with `methods` and no `method`, **and** the emitted layout recompiles through `buildRuleSet`. Written test-first — it failed on the `get` stem before the change.

Full CLI suite passes (342 tests); `tsc` clean. The issue's repro was also run end-to-end through the built CLI (`rules pull --from-file --decompile` → `rules validate`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)