### PR TITLE
fix(cli): let `rules rollback --to` accept the short revision ids the table prints

### DIFF
--- a/packages/cli/docs/reference.md
+++ b/packages/cli/docs/reference.md
@@ -314,8 +314,9 @@ a1b2c3d4  2h ago   sync       12     current  bffless/ce@a1b2c3d
 e5f6a7b8  1d ago   rule_edit  11
 ```
 
-- **ID** — the first 8 characters of the revision's uuid (pass the full id, from this table
-  or `rules revisions` output, to `rules rollback --to`).
+- **ID** — the first 8 characters of the revision's uuid. Paste it straight into `rules
+  rollback --to`: any unique prefix of a revision's uuid resolves client-side against this
+  same list (an ambiguous prefix errors with the full ids that matched).
 - **CURRENT** — set when the revision's stored `contentHash` matches a hash of the live rule
   set, computed fresh per request (not a stored flag).
 - **SOURCE** — `repo@shortSha` when the revision carries rules-as-code provenance (i.e. it
@@ -328,11 +329,14 @@ identical `formatSyncReport` change-report — a rollback IS a sync. It never re
 current name (a warning is appended if they differ), and pruning is always on (`prune:
 true`) so rules absent from the snapshot are removed.
 
-**Target selection.** `--to <revisionId>` targets that revision explicitly (no extra network
-call — it goes straight to the rollback endpoint). Without `--to`, the default is **the
-newest revision with `current: false`** — i.e. "undo the most recent change." If every
-captured revision is already current (nothing to roll back to), the command fails with a
-message pointing at `--to` instead of guessing.
+**Target selection.** `--to <revisionId>` targets that revision explicitly. A full uuid goes
+straight to the rollback endpoint (no extra network call); anything shorter — the 8-char id
+from the table, or any other unique prefix — is expanded against `/revisions` first, because
+the rollback route parses `:revisionId` as a uuid and would otherwise reject it. A prefix
+matching no revision, or more than one, fails client-side without touching the endpoint.
+Without `--to`, the default is **the newest revision with `current: false`** — i.e. "undo the
+most recent change." If every captured revision is already current (nothing to roll back to),
+the command fails with a message pointing at `--to` instead of guessing.
 
 **`--dry-run`** computes and prints the change plan (`{"dryRun": true}` in the request body)
 without writing anything; a non-dry-run rollback additionally captures one new revision with

--- a/packages/cli/src/commands/rollback.ts
+++ b/packages/cli/src/commands/rollback.ts
@@ -8,10 +8,15 @@
  * list is already newest-first, so that's simply the first non-current entry — erroring
  * loudly when there isn't one beats guessing (the only non-current revision to roll back to
  * IS the live state, i.e. there's nothing to revert).
+ *
+ * `--to` accepts either a full uuid (used as-is, no extra network call) or any unique prefix
+ * of one — notably the 8-char short id `rules revisions` prints, which is otherwise
+ * unusable because the rollback route guards `:revisionId` with a `ParseUUIDPipe`.
  */
 import { createClient, ApiError, type ClientDeps } from '../api/client.js';
 import { requireProject, resolveProjectId, resolveRuleSetId } from '../api/resolve.js';
 import { findConfig } from '../config.js';
+import { UUID_RE } from '../format/routes.js';
 import type { RevisionListItem, RevisionListResponse, SyncResponse } from '../api/sync-types.js';
 
 export interface RollbackOptions {
@@ -35,6 +40,32 @@ export function pickDefaultRollbackTarget(revisions: RevisionListItem[]): Revisi
   return revisions.find((r) => !r.current) ?? null;
 }
 
+/** Expand a `--to` value to a full revision uuid against the fetched list. A prefix that
+ *  matches exactly one revision wins; zero or several is an error naming the short ids that
+ *  DO exist, so a mistyped or stale id is a one-glance fix. Comparison is case-insensitive
+ *  because a uuid pasted from anywhere may be upper-cased. */
+export function resolveRevisionId(to: string, revisions: RevisionListItem[]): string {
+  if (to === '')
+    throw new Error(
+      '--to needs a revision id (a full uuid or a unique prefix, e.g. the 8-char id from `rules revisions`)',
+    );
+  const prefix = to.toLowerCase();
+  const matches = revisions.filter((r) => r.id.toLowerCase().startsWith(prefix));
+  if (matches.length === 1) return matches[0].id;
+
+  const available = revisions.map((r) => r.id.slice(0, 8));
+  if (matches.length === 0) {
+    throw new Error(
+      `revision "${to}" not found. Available revisions: ` +
+        `${available.length > 0 ? available.join(', ') : '(none captured yet)'}`,
+    );
+  }
+  const candidates = matches.map((r) => r.id).join(', ');
+  throw new Error(
+    `revision "${to}" is ambiguous — matches ${candidates}. Use a longer prefix or the full uuid.`,
+  );
+}
+
 export async function runRollback(
   setName: string,
   opts: RollbackOptions,
@@ -48,24 +79,33 @@ export async function runRollback(
     const projectId = await resolveProjectId(client, project);
     const ruleSetId = await resolveRuleSetId(client, projectId, setName);
 
-    let revisionId = opts.to;
-    if (!revisionId) {
+    // A full uuid goes straight to the rollback endpoint; anything else (a short id, a
+    // partial paste) has to be expanded against the list first — the route's ParseUUIDPipe
+    // rejects a prefix with a 400 before the handler ever runs.
+    const to = opts.to?.trim();
+    let revisionId = to;
+    if (to === undefined || !UUID_RE.test(to)) {
       const { revisions } = await client.get<RevisionListResponse>(
         `/api/proxy-rule-sets/${ruleSetId}/revisions`,
         `rule set "${setName}" (${ruleSetId}) revisions`,
       );
-      const target = pickDefaultRollbackTarget(revisions);
-      if (!target) {
-        return {
-          ok: false,
-          error:
-            `rule set "${setName}" has no non-current revision to roll back to — the current ` +
-            `state already IS the newest captured revision, so there is nothing to revert to. ` +
-            `Pass --to <revisionId> to target a specific revision explicitly (see \`bffless ` +
-            `rules revisions ${setName}\`).`,
-        };
+
+      if (to !== undefined) {
+        revisionId = resolveRevisionId(to, revisions);
+      } else {
+        const target = pickDefaultRollbackTarget(revisions);
+        if (!target) {
+          return {
+            ok: false,
+            error:
+              `rule set "${setName}" has no non-current revision to roll back to — the current ` +
+              `state already IS the newest captured revision, so there is nothing to revert to. ` +
+              `Pass --to <revisionId> to target a specific revision explicitly (see \`bffless ` +
+              `rules revisions ${setName}\`).`,
+          };
+        }
+        revisionId = target.id;
       }
-      revisionId = target.id;
     }
 
     const response = await client.post<SyncResponse>(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -267,7 +267,11 @@ rules
       'revision with current: false; --to targets a specific revision id instead.',
   )
   .argument('<set-name>', 'rule set name within the configured project')
-  .option('--to <revisionId>', 'revision id to roll back to (default: newest non-current revision)')
+  .option(
+    '--to <revisionId>',
+    'revision to roll back to — a full uuid or any unique prefix, e.g. the 8-char id ' +
+      '`rules revisions` prints (default: newest non-current revision)',
+  )
   .option('--dry-run', 'compute and print the rollback change plan without writing anything')
   .option('--api-url <url>', 'API base URL (overrides BFFLESS_API_URL and config apiUrl)')
   .option('--api-key <key>', 'API key (overrides BFFLESS_API_KEY; sent as X-API-Key)')

--- a/packages/cli/test/rollback.test.ts
+++ b/packages/cli/test/rollback.test.ts
@@ -91,6 +91,50 @@ describe('rules rollback', () => {
     expect(calls.some((c) => c.url === REVISIONS_URL)).toBe(false);
   });
 
+  it('--to accepts the 8-char short id the revisions table prints, expanding it to the full uuid', async () => {
+    const rollbackUrl = `${API_URL}/api/proxy-rule-sets/${SET_UUID}/rollback/${REV_OLDER_NONCURRENT}`;
+    const { fetchImpl, calls } = stubFetch({
+      ...setListRoute(),
+      [`GET ${REVISIONS_URL}`]: { body: { revisions: threeRevisions() } },
+      [`POST ${rollbackUrl}`]: { body: syncResponse() },
+    });
+    const shortId = REV_OLDER_NONCURRENT.slice(0, 8);
+    const result = await runRollback('basic', { to: shortId }, '/nowhere', { fetchImpl, env, config });
+    expect(result.ok, result.error).toBe(true);
+    expect(result.revisionId).toBe(REV_OLDER_NONCURRENT);
+    // The prefix must never reach the endpoint — the route's ParseUUIDPipe would 400 it.
+    expect(calls.some((c) => c.url.endsWith(`/rollback/${shortId}`))).toBe(false);
+  });
+
+  it('an ambiguous --to prefix fails client-side, naming the matches, with no rollback POST', async () => {
+    const revisions = [
+      { ...threeRevisions()[1], id: 'abcd1111-1111-4111-8111-111111111111' },
+      { ...threeRevisions()[2], id: 'abcd2222-2222-4222-8222-222222222222' },
+    ];
+    const { fetchImpl, calls } = stubFetch({
+      ...setListRoute(),
+      [`GET ${REVISIONS_URL}`]: { body: { revisions } },
+    });
+    const result = await runRollback('basic', { to: 'abcd' }, '/nowhere', { fetchImpl, env, config });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/ambiguous/i);
+    expect(result.error).toContain('abcd1111-1111-4111-8111-111111111111');
+    expect(result.error).toContain('abcd2222-2222-4222-8222-222222222222');
+    expect(calls.some((c) => (c.init?.method ?? 'GET') === 'POST')).toBe(false);
+  });
+
+  it('a --to prefix matching no revision fails client-side, listing the short ids that do exist', async () => {
+    const { fetchImpl, calls } = stubFetch({
+      ...setListRoute(),
+      [`GET ${REVISIONS_URL}`]: { body: { revisions: threeRevisions() } },
+    });
+    const result = await runRollback('basic', { to: 'deadbeef' }, '/nowhere', { fetchImpl, env, config });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+    expect(result.error).toContain(REV_CURRENT.slice(0, 8));
+    expect(calls.some((c) => (c.init?.method ?? 'GET') === 'POST')).toBe(false);
+  });
+
   it('no non-current revision exists: ok false with a helpful message, and no rollback POST is made', async () => {
     const { fetchImpl, calls } = stubFetch({
       ...setListRoute(),


### PR DESCRIPTION
Fixes #465.

## The bug

`rules revisions` truncates revision ids to 8 chars in its table, but `rules rollback --to <id>` posted its value straight into a route guarded by `@Param('revisionId', ParseUUIDPipe)`. So an id copied from the table was rejected with a 400 before the handler ever ran — the table's own output was unusable with the flag it exists to feed. `docs/reference.md` compounded it by saying "pass the full id, from this table", which the table cannot provide.

Default rollback (no `--to`) resolves a full uuid internally and was never affected.

## The fix

Prefix resolution client-side (option 1 in the issue), rather than widening the table to full UUIDs — this keeps the table scannable *and* makes copy-paste work.

`--to` now accepts **a full uuid or any unique prefix**:

- A full uuid still short-circuits straight to the rollback endpoint, no extra network call (existing behavior and its test preserved).
- Anything shorter fetches `/revisions` and is expanded by the new exported `resolveRevisionId()`, matching case-insensitively.
- A prefix matching **no** revision errors listing the short ids that *do* exist; an **ambiguous** prefix errors listing the full uuids that matched. Both fail before any POST is issued, so a bad id never reaches the endpoint.
- `--to ""` is now rejected instead of silently falling through to the default target.

The error idiom follows the existing `resolveProjectId` in `src/api/resolve.ts` (same "here's what you tried, here's what's available" shape). `resolveRevisionId` lives in `rollback.ts` since it's the only consumer.

## Docs

- The **ID** bullet now says the printed short id is directly pasteable and that any unique prefix resolves client-side.
- The **Target selection** paragraph's blanket "no extra network call" claim is scoped to the full-uuid path.
- The Commander `--to` help text matches.

## Verification

Three tests added to `test/rollback.test.ts`: the exact repro (8-char short id expands to the full uuid, and asserts the prefix never reaches the endpoint), the ambiguous prefix, and the unknown prefix.

- Full CLI suite: **344 tests / 25 files passing**
- `tsc --noEmit` clean; `rollback.ts` prettier-clean

Note: `src/index.ts` and `test/rollback.test.ts` already failed `prettier --check` on `main` before this branch, so I formatted only `rollback.ts` (which my change had broken) rather than sweeping unrelated reformatting into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEskaYtc3akG5rbbQ6KScC