### PR TITLE
fix(backend): capture a revision when a schema generator writes proxy rules

### DIFF
--- a/apps/backend/src/pipelines/chat-schema-generator.service.ts
+++ b/apps/backend/src/pipelines/chat-schema-generator.service.ts
@@ -6,6 +6,8 @@ import { ProjectAISettingsService, AIProviderType } from '../projects/project-ai
 import { GenerateChatSchemaDto, GenerateChatSchemaResponseDto } from './dto/generate-chat-schema.dto';
 import type { SchemaField } from '../db/schema/pipeline-schemas.schema';
 import type { PipelineConfig, PipelineStepConfig } from '../db/schema/proxy-rules.schema';
+import type { ProxyRuleSet } from '../db/schema/proxy-rule-sets.schema';
+import { SchemaGeneratorRevisionsService } from './schema-generator-revisions.service';
 import { eq, and } from 'drizzle-orm';
 
 /**
@@ -19,6 +21,7 @@ export class ChatSchemaGeneratorService {
   constructor(
     private readonly permissionsService: PermissionsService,
     private readonly projectAISettingsService: ProjectAISettingsService,
+    private readonly revisions: SchemaGeneratorRevisionsService,
   ) {}
 
   /**
@@ -127,7 +130,7 @@ export class ChatSchemaGeneratorService {
     this.logger.log(`Created messages schema '${messagesName}' (${messagesSchema.id})`);
 
     // Use existing rule set or create a new one
-    let ruleSet: { id: string; name: string };
+    let ruleSet: ProxyRuleSet;
 
     if (dto.ruleSetId) {
       // Verify the rule set exists and belongs to this project
@@ -163,6 +166,11 @@ export class ChatSchemaGeneratorService {
       ruleSet = newRuleSet;
       this.logger.log(`Created rule set '${ruleSet.name}' (${ruleSet.id})`);
     }
+
+    // Backfill, pre-mutation: adding rules to an existing set is destructive
+    // for revision-history purposes, so snapshot its pre-generate state if it
+    // has none yet. No-ops for the set we just created (it has no rules).
+    await this.revisions.backfill(ruleSet, userId);
 
     // Create /api/chat pipelines (GET + POST)
     const pipelines: { id: string; path: string; method: string }[] = [];
@@ -212,6 +220,10 @@ export class ChatSchemaGeneratorService {
     pipelines.push({ id: chatRule.id, path: chatPath, method: 'POST' });
 
     this.logger.log(`Created chat pipelines for '${dto.name}'`);
+
+    // Post-write, best-effort: capture the generated state so a later rollback
+    // can't restore a revision that predates these rules and prune them away.
+    await this.revisions.capture(ruleSet, dto.ruleSetId ? 'rule_edit' : 'create', userId);
 
     return {
       conversationsSchema: {

--- a/apps/backend/src/pipelines/pipelines.module.ts
+++ b/apps/backend/src/pipelines/pipelines.module.ts
@@ -6,6 +6,7 @@ import { PipelineDataService } from './pipeline-data.service';
 import { StateSchemaGeneratorService } from './state-schema-generator.service';
 import { ChatSchemaGeneratorService } from './chat-schema-generator.service';
 import { UploadSchemaGeneratorService } from './upload-schema-generator.service';
+import { SchemaGeneratorRevisionsService } from './schema-generator-revisions.service';
 import { UploadRecordService } from './upload-record.service';
 import {
   PipelineExecutionService,
@@ -18,6 +19,7 @@ import { PermissionsModule } from '../permissions/permissions.module';
 import { SettingsModule } from '../settings/settings.module';
 import { ProjectsModule } from '../projects/projects.module';
 import { CacheRulesModule } from '../cache-rules/cache-rules.module';
+import { ProxyRulesModule } from '../proxy-rules/proxy-rules.module';
 // Step handlers
 import {
   FormHandler,
@@ -85,6 +87,11 @@ import {
     forwardRef(() => ProjectsModule),
     CacheRulesModule,
     forwardRef(() => IntegrationsModule),
+    // forwardRef: ProxyRulesModule already imports PipelinesModule (for the
+    // execution service). The schema generators need the reverse edge —
+    // ProxyRulesService + ProxyRuleSetRevisionsService — to capture a revision
+    // for the rule sets they write.
+    forwardRef(() => ProxyRulesModule),
   ],
   controllers: [
     PipelineSchemasController,
@@ -98,6 +105,8 @@ import {
     StateSchemaGeneratorService,
     ChatSchemaGeneratorService,
     UploadSchemaGeneratorService,
+    // Revision capture shared by the three generators above
+    SchemaGeneratorRevisionsService,
     // Shared upload bookkeeping (used by file_upload + register_upload handlers)
     UploadRecordService,
     // Execution engine

--- a/apps/backend/src/pipelines/schema-generator-revisions.service.spec.ts
+++ b/apps/backend/src/pipelines/schema-generator-revisions.service.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SchemaGeneratorRevisionsService } from './schema-generator-revisions.service';
+import { ProxyRulesService } from '../proxy-rules/proxy-rules.service';
+import { ProxyRuleSetRevisionsService } from '../proxy-rules/proxy-rule-set-revisions.service';
+import type { ProxyRuleSet } from '../db/schema/proxy-rule-sets.schema';
+import type { ProxyRule } from '../db/schema/proxy-rules.schema';
+
+describe('SchemaGeneratorRevisionsService', () => {
+  let service: SchemaGeneratorRevisionsService;
+
+  const ruleSet = { id: 'set-1', name: 'chat_pipelines' } as ProxyRuleSet;
+  const rules = [{ id: 'rule-1', ruleSetId: 'set-1' }] as ProxyRule[];
+
+  const mockProxyRulesService = {
+    getRulesByRuleSetId: jest.fn().mockResolvedValue(rules),
+  };
+
+  const mockRevisionsService = {
+    capture: jest.fn().mockResolvedValue(undefined),
+    captureIfUnrevisioned: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SchemaGeneratorRevisionsService,
+        { provide: ProxyRulesService, useValue: mockProxyRulesService },
+        { provide: ProxyRuleSetRevisionsService, useValue: mockRevisionsService },
+      ],
+    }).compile();
+
+    service = module.get(SchemaGeneratorRevisionsService);
+    jest.clearAllMocks();
+    mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue(rules);
+  });
+
+  describe('backfill', () => {
+    it('passes the set and its decrypted rules to captureIfUnrevisioned', async () => {
+      await service.backfill(ruleSet, 'user-1');
+
+      expect(mockProxyRulesService.getRulesByRuleSetId).toHaveBeenCalledWith('set-1');
+      expect(mockRevisionsService.captureIfUnrevisioned).toHaveBeenCalledWith({
+        ruleSet,
+        rules,
+        userId: 'user-1',
+      });
+    });
+
+    it('swallows a failure so a revision problem never fails generation', async () => {
+      mockProxyRulesService.getRulesByRuleSetId.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(service.backfill(ruleSet, 'user-1')).resolves.toBeUndefined();
+      expect(mockRevisionsService.captureIfUnrevisioned).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('capture', () => {
+    it('captures the post-write state under the given trigger', async () => {
+      await service.capture(ruleSet, 'create', 'user-1');
+
+      expect(mockRevisionsService.capture).toHaveBeenCalledWith({
+        ruleSet,
+        rules,
+        trigger: 'create',
+        userId: 'user-1',
+      });
+    });
+
+    it('swallows a failure so a revision problem never fails generation', async () => {
+      mockProxyRulesService.getRulesByRuleSetId.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(service.capture(ruleSet, 'rule_edit', 'user-1')).resolves.toBeUndefined();
+      expect(mockRevisionsService.capture).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/pipelines/schema-generator-revisions.service.ts
+++ b/apps/backend/src/pipelines/schema-generator-revisions.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
+import { ProxyRulesService } from '../proxy-rules/proxy-rules.service';
+import { ProxyRuleSetRevisionsService } from '../proxy-rules/proxy-rule-set-revisions.service';
+import type { ProxyRuleSet } from '../db/schema/proxy-rule-sets.schema';
+import type { RevisionTrigger } from '../db/schema/proxy-rule-set-revisions.schema';
+
+/**
+ * Revision capture for the schema-generator services (state/chat/upload).
+ *
+ * The generators insert rule sets and rules straight through `db` rather than
+ * going via `ProxyRulesService`, so they have to run the same capture pattern
+ * its rule-level mutations do: back-fill the pre-write state of a set that has
+ * no revisions yet, then capture the post-write state. Without the post-write
+ * capture, a default `bffless rules rollback` right after a generator adds
+ * rules to an already-revisioned set restores a revision that predates them
+ * and (with prune) deletes the generated rules.
+ *
+ * Both calls are best-effort: a revision failure must never fail generation,
+ * so nothing here throws.
+ */
+@Injectable()
+export class SchemaGeneratorRevisionsService {
+  private readonly logger = new Logger(SchemaGeneratorRevisionsService.name);
+
+  constructor(
+    @Inject(forwardRef(() => ProxyRulesService))
+    private readonly proxyRulesService: ProxyRulesService,
+    @Inject(forwardRef(() => ProxyRuleSetRevisionsService))
+    private readonly revisionsService: ProxyRuleSetRevisionsService,
+  ) {}
+
+  /**
+   * Pre-write backfill. No-ops for a rule set the generator just created (no
+   * rules yet) and for a set that already has revision history.
+   */
+  async backfill(ruleSet: ProxyRuleSet, userId?: string): Promise<void> {
+    try {
+      const rules = await this.proxyRulesService.getRulesByRuleSetId(ruleSet.id);
+      await this.revisionsService.captureIfUnrevisioned({ ruleSet, rules, userId });
+    } catch (error) {
+      this.logger.warn(
+        `Failed to backfill pre-generate revision for rule set ${ruleSet.id}: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  /** Post-write capture of the generated state. */
+  async capture(ruleSet: ProxyRuleSet, trigger: RevisionTrigger, userId?: string): Promise<void> {
+    try {
+      const rules = await this.proxyRulesService.getRulesByRuleSetId(ruleSet.id);
+      await this.revisionsService.capture({ ruleSet, rules, trigger, userId });
+    } catch (error) {
+      this.logger.warn(
+        `Failed to capture ${trigger} revision for rule set ${ruleSet.id}: ${(error as Error).message}`,
+      );
+    }
+  }
+}

--- a/apps/backend/src/pipelines/schema-generators.revisions.spec.ts
+++ b/apps/backend/src/pipelines/schema-generators.revisions.spec.ts
@@ -1,0 +1,248 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StateSchemaGeneratorService } from './state-schema-generator.service';
+import { ChatSchemaGeneratorService } from './chat-schema-generator.service';
+import { UploadSchemaGeneratorService } from './upload-schema-generator.service';
+import { SchemaGeneratorRevisionsService } from './schema-generator-revisions.service';
+import { PermissionsService } from '../permissions/permissions.service';
+import { ProjectAISettingsService } from '../projects/project-ai-settings.service';
+
+// Mock the db client - sequenced results, consumed by .limit() / .returning()
+jest.mock('../db/client', () => {
+  const mockResults: unknown[][] = [];
+  let callIdx = 0;
+
+  const chainable = {
+    select: jest.fn(() => chainable),
+    from: jest.fn(() => chainable),
+    where: jest.fn(() => chainable),
+    limit: jest.fn(() => Promise.resolve(mockResults[callIdx++] ?? [])),
+    insert: jest.fn(() => chainable),
+    values: jest.fn(() => chainable),
+    returning: jest.fn(() => Promise.resolve(mockResults[callIdx++] ?? [{ id: 'test-id' }])),
+    __setResults: (results: unknown[][]) => {
+      mockResults.length = 0;
+      results.forEach((r) => mockResults.push(r));
+      callIdx = 0;
+    },
+  };
+
+  return { db: chainable };
+});
+
+import { db } from '../db/client';
+import { proxyRules } from '../db/schema';
+
+const mockDb = db as unknown as {
+  __setResults: (results: unknown[][]) => void;
+  insert: jest.Mock;
+};
+
+/**
+ * The generators write rule sets + rules straight through `db`, so these tests
+ * assert the CALL SITES: a pre-write backfill (before any rule insert) and a
+ * post-write capture (after every rule insert), with the trigger that matches
+ * whether the set was created here ('create') or already existed ('rule_edit').
+ * Capture internals live in proxy-rule-set-revisions.service.spec.ts.
+ */
+describe('schema generators — revision capture', () => {
+  const userId = 'user-1';
+  const projectId = 'project-1';
+  const existingRuleSet = { id: 'set-existing', name: 'existing_set', projectId };
+  const newRuleSet = { id: 'set-new', name: 'generated_pipelines', projectId };
+
+  const schemaRow = (id: string, name: string) => ({
+    id,
+    name,
+    projectId,
+    fields: [{ name: 'key', type: 'string', required: true }],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  // Number of rules inserted so far — lets us pin backfill/capture either side
+  // of the rule writes.
+  const ruleInsertCount = () =>
+    mockDb.insert.mock.calls.filter(([table]) => table === proxyRules).length;
+
+  let ruleInsertsAtBackfill: number;
+  let ruleInsertsAtCapture: number;
+
+  const mockRevisions = {
+    backfill: jest.fn(),
+    capture: jest.fn(),
+  };
+
+  const mockPermissionsService = {
+    requireProjectAccess: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockProjectAISettingsService = {
+    getProviderConfig: jest
+      .fn()
+      .mockResolvedValue({ provider: 'openai', defaultModel: 'gpt-4o', apiKey: 'sk-test' }),
+  };
+
+  let stateGenerator: StateSchemaGeneratorService;
+  let chatGenerator: ChatSchemaGeneratorService;
+  let uploadGenerator: UploadSchemaGeneratorService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StateSchemaGeneratorService,
+        ChatSchemaGeneratorService,
+        UploadSchemaGeneratorService,
+        { provide: SchemaGeneratorRevisionsService, useValue: mockRevisions },
+        { provide: PermissionsService, useValue: mockPermissionsService },
+        { provide: ProjectAISettingsService, useValue: mockProjectAISettingsService },
+      ],
+    }).compile();
+
+    stateGenerator = module.get(StateSchemaGeneratorService);
+    chatGenerator = module.get(ChatSchemaGeneratorService);
+    uploadGenerator = module.get(UploadSchemaGeneratorService);
+
+    jest.clearAllMocks();
+    ruleInsertsAtBackfill = -1;
+    ruleInsertsAtCapture = -1;
+    mockRevisions.backfill.mockImplementation(async () => {
+      ruleInsertsAtBackfill = ruleInsertCount();
+    });
+    mockRevisions.capture.mockImplementation(async () => {
+      ruleInsertsAtCapture = ruleInsertCount();
+    });
+  });
+
+  describe('StateSchemaGeneratorService', () => {
+    it('backfills before the rule writes and captures a "rule_edit" revision after them, for an existing set', async () => {
+      mockDb.__setResults([
+        [], // no schema with this name yet
+        [schemaRow('schema-1', 'counter')], // insert schema
+        [existingRuleSet], // lookup dto.ruleSetId
+        [{ id: 'rule-get' }],
+        [{ id: 'rule-post' }],
+      ]);
+
+      await stateGenerator.generateStateSchema(
+        { projectId, name: 'counter', scope: 'global', ruleSetId: existingRuleSet.id },
+        userId,
+        'admin',
+      );
+
+      expect(mockRevisions.backfill).toHaveBeenCalledWith(existingRuleSet, userId);
+      expect(ruleInsertsAtBackfill).toBe(0);
+
+      expect(mockRevisions.capture).toHaveBeenCalledWith(existingRuleSet, 'rule_edit', userId);
+      expect(ruleInsertsAtCapture).toBe(2);
+    });
+
+    it('captures a "create" revision when it creates the rule set itself', async () => {
+      mockDb.__setResults([
+        [],
+        [schemaRow('schema-1', 'counter')],
+        [newRuleSet], // insert rule set
+        [{ id: 'rule-get' }],
+        [{ id: 'rule-post' }],
+      ]);
+
+      await stateGenerator.generateStateSchema(
+        { projectId, name: 'counter', scope: 'global' },
+        userId,
+        'admin',
+      );
+
+      expect(mockRevisions.capture).toHaveBeenCalledWith(newRuleSet, 'create', userId);
+      expect(ruleInsertsAtCapture).toBe(2);
+    });
+  });
+
+  describe('UploadSchemaGeneratorService', () => {
+    it('backfills before the rule writes and captures a "rule_edit" revision after them, for an existing set', async () => {
+      mockDb.__setResults([
+        [],
+        [schemaRow('schema-2', 'docs')],
+        [existingRuleSet],
+        [{ id: 'rule-post' }],
+        [{ id: 'rule-get' }],
+      ]);
+
+      await uploadGenerator.generateUploadSchema(
+        { projectId, name: 'docs', subDir: 'docs', ruleSetId: existingRuleSet.id },
+        userId,
+        'admin',
+      );
+
+      expect(mockRevisions.backfill).toHaveBeenCalledWith(existingRuleSet, userId);
+      expect(ruleInsertsAtBackfill).toBe(0);
+
+      expect(mockRevisions.capture).toHaveBeenCalledWith(existingRuleSet, 'rule_edit', userId);
+      expect(ruleInsertsAtCapture).toBe(2);
+    });
+
+    it('captures a "create" revision when it creates the rule set itself', async () => {
+      mockDb.__setResults([
+        [],
+        [schemaRow('schema-2', 'docs')],
+        [newRuleSet],
+        [{ id: 'rule-post' }],
+        [{ id: 'rule-get' }],
+      ]);
+
+      await uploadGenerator.generateUploadSchema(
+        { projectId, name: 'docs', subDir: 'docs' },
+        userId,
+        'admin',
+      );
+
+      expect(mockRevisions.capture).toHaveBeenCalledWith(newRuleSet, 'create', userId);
+      expect(ruleInsertsAtCapture).toBe(2);
+    });
+  });
+
+  describe('ChatSchemaGeneratorService', () => {
+    it('backfills before the rule writes and captures a "rule_edit" revision after them, for an existing set', async () => {
+      mockDb.__setResults([
+        [], // no conversations schema
+        [], // no messages schema
+        [schemaRow('schema-conv', 'support_conversations')],
+        [schemaRow('schema-msg', 'support_messages')],
+        [existingRuleSet],
+        [{ id: 'rule-get' }],
+        [{ id: 'rule-post' }],
+      ]);
+
+      await chatGenerator.generateChatSchema(
+        { projectId, name: 'support', scope: 'user', ruleSetId: existingRuleSet.id },
+        userId,
+        'admin',
+      );
+
+      expect(mockRevisions.backfill).toHaveBeenCalledWith(existingRuleSet, userId);
+      expect(ruleInsertsAtBackfill).toBe(0);
+
+      expect(mockRevisions.capture).toHaveBeenCalledWith(existingRuleSet, 'rule_edit', userId);
+      expect(ruleInsertsAtCapture).toBe(2);
+    });
+
+    it('captures a "create" revision when it creates the rule set itself', async () => {
+      mockDb.__setResults([
+        [],
+        [],
+        [schemaRow('schema-conv', 'support_conversations')],
+        [schemaRow('schema-msg', 'support_messages')],
+        [newRuleSet],
+        [{ id: 'rule-get' }],
+        [{ id: 'rule-post' }],
+      ]);
+
+      await chatGenerator.generateChatSchema(
+        { projectId, name: 'support', scope: 'user' },
+        userId,
+        'admin',
+      );
+
+      expect(mockRevisions.capture).toHaveBeenCalledWith(newRuleSet, 'create', userId);
+      expect(ruleInsertsAtCapture).toBe(2);
+    });
+  });
+});

--- a/apps/backend/src/pipelines/state-schema-generator.service.ts
+++ b/apps/backend/src/pipelines/state-schema-generator.service.ts
@@ -5,6 +5,8 @@ import { PermissionsService } from '../permissions/permissions.service';
 import { GenerateStateSchemaDto, GenerateStateSchemaResponseDto } from './dto';
 import type { SchemaField } from '../db/schema/pipeline-schemas.schema';
 import type { PipelineConfig, PipelineStepConfig } from '../db/schema/proxy-rules.schema';
+import type { ProxyRuleSet } from '../db/schema/proxy-rule-sets.schema';
+import { SchemaGeneratorRevisionsService } from './schema-generator-revisions.service';
 import { eq, and } from 'drizzle-orm';
 
 /**
@@ -15,7 +17,10 @@ import { eq, and } from 'drizzle-orm';
 export class StateSchemaGeneratorService {
   private readonly logger = new Logger(StateSchemaGeneratorService.name);
 
-  constructor(private readonly permissionsService: PermissionsService) {}
+  constructor(
+    private readonly permissionsService: PermissionsService,
+    private readonly revisions: SchemaGeneratorRevisionsService,
+  ) {}
 
   /**
    * Generate a state schema with GET and POST pipelines.
@@ -72,7 +77,7 @@ export class StateSchemaGeneratorService {
     this.logger.log(`Created state schema '${dto.name}' (${schema.id})`);
 
     // Use existing rule set or create a new one
-    let ruleSet: { id: string; name: string };
+    let ruleSet: ProxyRuleSet;
 
     if (dto.ruleSetId) {
       // Verify the rule set exists and belongs to this project
@@ -108,6 +113,11 @@ export class StateSchemaGeneratorService {
       ruleSet = newRuleSet;
       this.logger.log(`Created rule set '${ruleSet.name}' (${ruleSet.id})`);
     }
+
+    // Backfill, pre-mutation: adding rules to an existing set is destructive
+    // for revision-history purposes, so snapshot its pre-generate state if it
+    // has none yet. No-ops for the set we just created (it has no rules).
+    await this.revisions.backfill(ruleSet, userId);
 
     // Create GET and POST pipelines
     const pipelines: { id: string; path: string; method: string }[] = [];
@@ -160,6 +170,10 @@ export class StateSchemaGeneratorService {
     });
 
     this.logger.log(`Created ${pipelines.length} pipelines for state schema '${dto.name}'`);
+
+    // Post-write, best-effort: capture the generated state so a later rollback
+    // can't restore a revision that predates these rules and prune them away.
+    await this.revisions.capture(ruleSet, dto.ruleSetId ? 'rule_edit' : 'create', userId);
 
     return {
       schema: {

--- a/apps/backend/src/pipelines/upload-schema-generator.service.ts
+++ b/apps/backend/src/pipelines/upload-schema-generator.service.ts
@@ -8,7 +8,9 @@ import {
 } from './dto/generate-upload-schema.dto';
 import type { SchemaField } from '../db/schema/pipeline-schemas.schema';
 import type { PipelineConfig, PipelineStepConfig } from '../db/schema/proxy-rules.schema';
+import type { ProxyRuleSet } from '../db/schema/proxy-rule-sets.schema';
 import type { ValidatorConfig } from './types';
+import { SchemaGeneratorRevisionsService } from './schema-generator-revisions.service';
 import { eq, and } from 'drizzle-orm';
 
 /**
@@ -19,7 +21,10 @@ import { eq, and } from 'drizzle-orm';
 export class UploadSchemaGeneratorService {
   private readonly logger = new Logger(UploadSchemaGeneratorService.name);
 
-  constructor(private readonly permissionsService: PermissionsService) {}
+  constructor(
+    private readonly permissionsService: PermissionsService,
+    private readonly revisions: SchemaGeneratorRevisionsService,
+  ) {}
 
   /**
    * Generate an upload schema with POST (upload) and GET (serve) pipelines.
@@ -84,7 +89,7 @@ export class UploadSchemaGeneratorService {
     this.logger.log(`Created upload schema '${dto.name}' (${schema.id})`);
 
     // Use existing rule set or create a new one
-    let ruleSet: { id: string; name: string };
+    let ruleSet: ProxyRuleSet;
 
     if (dto.ruleSetId) {
       const [existingRuleSet] = await db
@@ -120,6 +125,11 @@ export class UploadSchemaGeneratorService {
       ruleSet = newRuleSet;
       this.logger.log(`Created rule set '${ruleSet.name}' (${ruleSet.id})`);
     }
+
+    // Backfill, pre-mutation: adding rules to an existing set is destructive
+    // for revision-history purposes, so snapshot its pre-generate state if it
+    // has none yet. No-ops for the set we just created (it has no rules).
+    await this.revisions.backfill(ruleSet, userId);
 
     // Create POST and GET pipelines
     const pipelines: { id: string; path: string; method: string }[] = [];
@@ -175,6 +185,10 @@ export class UploadSchemaGeneratorService {
     this.logger.log(
       `Created ${pipelines.length} pipelines for upload schema '${dto.name}'`,
     );
+
+    // Post-write, best-effort: capture the generated state so a later rollback
+    // can't restore a revision that predates these rules and prune them away.
+    await this.revisions.capture(ruleSet, dto.ruleSetId ? 'rule_edit' : 'create', userId);
 
     return {
       schema: {

--- a/packages/cli/docs/reference.md
+++ b/packages/cli/docs/reference.md
@@ -175,12 +175,18 @@ config? }[]`, unchanged from the canonical shape.
   `schemas/*.schema.yaml`.
 - **`{{secrets.NAME}}`** — a literal placeholder left in any string value (e.g.
   `targetUrl`, a `pipeline:` step's `config`). The compiler only *collects* every referenced
-  secret name (surfaced in `rules build`'s summary line, e.g. `1 secrets referenced`) — it
-  does not resolve or verify them against a live instance; that's a Phase 1 concern (see
-  below).
+  secret name (surfaced in `rules build`'s summary line, e.g. `1 secrets referenced`); it
+  never resolves the value locally. Verification happens server-side on `rules push`: the
+  sync endpoint checks the referenced names against the target project's `project_secrets`
+  and returns any with no matching row as `missingSecrets[]`, which `rules push` renders as a
+  `MISSING SECRETS (n) — set these in the project's secrets: …` line in the change report.
+  It is a **warning, not a failure** (exit `0`) — a fresh set legitimately has unfilled
+  placeholders until someone sets the secrets on the project.
 - **`headerConfig.add` secret placeholders** — committed as an **empty string**
   (`Authorization: ""`), not a `$secret:`/template form; a non-empty value is a hard build
-  error (see the table above).
+  error (see the table above). Blank header names land in the same `missingSecrets[]` list:
+  always for a newly created rule, and for an updated rule only when the live rule has no
+  non-empty value left to preserve.
 
 **The method escape hatch.** The filename/directory stem (`get`, `post`, …, `any`) is
 normally the sole source of a rule's HTTP method(s). `method:` inside a method-stem file
@@ -517,10 +523,12 @@ Per [the design doc's phasing](../../../docs/plans/proxy-rules-as-code.md#6-phas
 following are **planned but not implemented** in this package — do not write CI or docs
 that assume they exist:
 
-- **Secret verification** — the compiler collects `{{secrets.NAME}}` references (see the
-  manifest reference above) but never checks them against a target instance's
-  `project_secrets`; that check (`missingSecrets[]`, `--require-secrets`) is part of the
-  planned sync endpoint.
+- **Failing a push on missing secrets** — secret verification itself shipped: the sync
+  endpoint checks `{{secrets.NAME}}` references (and blank `headerConfig.add` values)
+  against the target project's `project_secrets` and `rules push` reports the misses (see
+  `{{secrets.NAME}}` in the manifest reference above). What does *not* exist is the design
+  doc's `--require-secrets` flag to escalate that warning: a push with unfilled secrets
+  always exits `0` today.
 - **`$secret: NAME` header placeholders** — the design doc's plan for `headerConfig.add`
   used a `$secret: NAME` reference form; what's actually implemented (see the manifest
   reference above) is a plain empty-string placeholder convention (`Authorization: ""`),


### PR DESCRIPTION
Closes #464.

## The bug

`state`/`chat`/`upload-schema-generator.service.ts` insert proxy rule sets — and, via the `dto.ruleSetId` path, rules into an **existing** set — straight through `db`, never calling `ProxyRuleSetRevisionsService.capture`/`captureIfUnrevisioned`.

So after a generator added rules to an already-revisioned set, the newest revision predated those rules. A default `bffless rules rollback` (prune on, target = newest non-current revision) right afterwards silently deleted the just-generated rules.

## The fix

New `SchemaGeneratorRevisionsService` — a small shared helper running the same pattern the rule-level mutations in `ProxyRulesService` already use:

- **pre-write** `captureIfUnrevisioned` backfill (a no-op for a set the generator just created, since it has no rules yet, and for a set that already has history);
- **post-write** `capture` once both rules are inserted, under trigger `create` when the generator created the set and `rule_edit` when it wrote into an existing one;
- both best-effort — a revision failure must never fail generation.

It loads rules through `ProxyRulesService.getRulesByRuleSetId` so header configs are decrypted exactly as the other capture call sites see them.

`PipelinesModule` gains `forwardRef(() => ProxyRulesModule)`; the reverse edge (`ProxyRulesModule` → `PipelinesModule`) already existed, so this closes the cycle the standard Nest way.

## Verification

- **DI graph boots.** Built the backend and ran it against a throwaway pgvector Postgres: `Nest application successfully started` (the only errors are the expected nginx/ACME filesystem ones from running outside Docker). This was the main risk of the new module cycle.
- **Behavior, against a live DB.** Drove the real path with the real revision services: seed a rule set holding one hand-authored rule plus the revision a rule edit would have left, run the state generator against it, then read `proxy_rule_set_revisions`. Post-fix the newest revision holds all three rules (legacy + two generated), so a rollback restores instead of pruning. With the new `capture` call commented out, the same check fails with the reported symptom exactly — a single revision containing only `/api/legacy`. That scaffold isn't committed; CI's unit suite has no database.
- **Unit tests:** 10 new (capture call sites per generator: backfill lands before any rule insert, capture after both, with the right trigger; helper passes decrypted rules through and swallows failures). Existing `src/proxy-rules` + `src/pipelines` suites still green (604 tests). `tsc --noEmit` clean.

## Not changed (possible follow-ups)

The generators still don't regenerate nginx configs after inserting rules (unlike `ProxyRulesService.create`), and they still write schema + set + rules without a transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEskaYtc3akG5rbbQ6KScC
