### PR TITLE
fix(cli): resolve owner/name projects via the access-scoped endpoint

### DIFF
--- a/packages/cli/.claude/skills/verify/SKILL.md
+++ b/packages/cli/.claude/skills/verify/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: verify
+description: Verify a change to the bffless CLI (packages/cli) by driving the built binary against a stub backend.
+---
+
+# Verifying a `packages/cli` change
+
+The CLI's surface is the terminal. Verification = run `dist/index.js` and read what it prints.
+The live commands (`pull`/`push`/`diff`/`revisions`/`rollback`/`dev`) all talk to the backend
+over HTTP, so a stub HTTP server is enough — no Postgres, MinIO, or backend needed.
+
+## Build
+
+```bash
+cd packages/cli
+pnpm install   # a fresh git worktree has no node_modules; ~7s from the pnpm store
+pnpm build     # tsc -> dist/index.js  (the `bin`)
+```
+
+`pnpm build` is required after every source edit — `dist/` is what the `bffless` bin runs.
+
+## Drive
+
+```bash
+node dist/index.js rules revisions <set-name> \
+  --api-url http://127.0.0.1:8791 --api-key testkey --project <uuid|owner/name|name>
+```
+
+`rules revisions` is the cheapest command that exercises the full resolve chain
+(project → rule set → request), so it's a good probe for anything in `src/api/`.
+Auth/URL/project all have flags, so no `.bffless/config.json` is needed.
+
+## Stub backend
+
+Stand up a `node:http` server that answers the endpoints the command walks, and **log every
+request** — the request path is usually the thing you're actually verifying:
+
+| Endpoint | Shape | Note |
+|---|---|---|
+| `GET /api/projects` | `[{id, owner, name}]` | **creator-scoped** (`projects.createdBy`) — only projects the key's user created |
+| `GET /api/projects/:owner/:name` | `{id, owner, name}` | **access-scoped** (`RequireProjectRole('viewer')`) — works for any member |
+| `GET /api/proxy-rule-sets/project/:projectId` | `{ruleSets: [{id, name}]}` | |
+| `GET /api/proxy-rule-sets/:id/revisions` | `{revisions: [{id, createdAt, trigger, ruleCount, current}]}` | |
+
+Gotchas that cost time:
+
+- **A missing project is HTTP 400, not 404.** `ProjectPermissionGuard` catches the service's
+  NotFound and rethrows `BadRequestException('Project not found')`. Treat 400 and 404 alike;
+  403 is the distinct "exists but no role" case.
+- `formatRevisionsTable` indexes every cell unguarded, so a stub revision missing `trigger` or
+  `ruleCount` dies with `Cannot read properties of undefined (reading 'length')`. That's the
+  stub, not the CLI.
+- To show a fix *does* something, run the same command against the same stub with the old file
+  (`git show HEAD:packages/cli/src/api/foo.ts > src/api/foo.ts`, rebuild, run, restore, rebuild).
+
+## Don't
+
+Don't `pnpm vitest` as verification — CI does that. Don't import from `src/` and call the
+function; the resolver's behaviour (which URL it hits) is only observable at the binary.
+
+## Shell notes (zsh)
+
+- `pkill -f stub-backend.mjs` **kills your own shell** (the pattern matches the command line).
+  Use `fuser -k 8791/tcp`.
+- zsh doesn't word-split unquoted vars, so `B="node dist/... "; $B --flag` fails with
+  "no such file or directory". Use a shell function.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -31,6 +31,9 @@ when `[dirs...]` is omitted.
 - API URL: `--api-url` > `BFFLESS_API_URL` env > `.bffless/config.json`'s `apiUrl`.
 - API key: `--api-key` > `BFFLESS_API_KEY` env only (never read from config, so it's safe to commit).
 - Project: `--project` > `.bffless/config.json`'s `project` (UUID, `owner/name`, or bare name).
+  Prefer a UUID or `owner/name`: both resolve for any user with a role on the project. A bare
+  name has to be matched against `GET /api/projects`, which lists only the projects the API
+  key's user *created* — so it won't find a project that was merely shared with them.
 
 `.bffless/config.json` (`{ apiUrl?, project?, ruleSets? }`) is discovered by walking up from
 the current directory and is safe to commit — it never holds secrets.

--- a/packages/cli/src/api/resolve.ts
+++ b/packages/cli/src/api/resolve.ts
@@ -1,9 +1,13 @@
 /**
  * Name → id resolution against the backend's UUID-addressed API.
  *
- * - Projects: `GET /api/projects` lists the caller's projects (`{id, owner, name}` each).
- *   The config `project` value (or `--project` flag) may be a UUID (used directly), an
- *   `owner/name` pair, or a bare project name (errors if two owners share it).
+ * - Projects: the config `project` value (or `--project` flag) may be a UUID (used directly),
+ *   an `owner/name` pair, or a bare project name.
+ *   `owner/name` resolves through `GET /api/projects/:owner/:name`, which is access-scoped
+ *   (`RequireProjectRole('viewer')`). A bare name has no such endpoint, so it falls back to
+ *   `GET /api/projects` — but that list is *creator*-scoped (`projects.createdBy`), so a key
+ *   whose user was granted a role on a project they didn't create sees nothing there. Bare
+ *   names are therefore best-effort; `owner/name` is the form that works for any member.
  * - Rule sets: `GET /api/proxy-rule-sets/project/:projectId` lists `{ruleSets: [{id, name}]}`;
  *   matched by exact name.
  *
@@ -11,7 +15,7 @@
  * so a typo'd name is a one-glance fix.
  */
 import { UUID_RE } from '../format/routes.js';
-import type { ApiClient } from './client.js';
+import { ApiError, type ApiClient } from './client.js';
 
 export interface ProjectListItem {
   id: string;
@@ -24,31 +28,78 @@ export interface RuleSetListItem {
   name: string;
 }
 
+const LIST_PATH = '/api/projects';
+
 /** Resolve a project identifier (UUID | `owner/name` | bare name) to its UUID. */
 export async function resolveProjectId(client: ApiClient, project: string): Promise<string> {
   if (UUID_RE.test(project)) return project;
 
-  const listPath = '/api/projects';
-  const projects = await client.get<ProjectListItem[]>(listPath, 'project list');
-  const available = projects.map((p) => `${p.owner}/${p.name}`).sort();
+  const slash = project.indexOf('/');
+  if (slash === -1) return resolveBareName(client, project);
+  return resolveOwnerName(client, project, project.slice(0, slash), project.slice(slash + 1));
+}
 
-  let matches: ProjectListItem[];
-  if (project.includes('/')) {
-    const [owner, name] = project.split('/', 2);
-    matches = projects.filter((p) => p.owner === owner && p.name === name);
-  } else {
-    matches = projects.filter((p) => p.name === project);
+/**
+ * `owner/name` → the access-scoped `GET /api/projects/:owner/:name`, so a key belonging to any
+ * member (not just the project's creator) resolves it.
+ *
+ * A project that doesn't exist surfaces as 400 from `ProjectPermissionGuard` ("Project not
+ * found") rather than 404, so both statuses mean "no such project" here. A 403 — the key's user
+ * exists but has no role — is a genuinely different failure and propagates untouched.
+ */
+async function resolveOwnerName(
+  client: ApiClient,
+  project: string,
+  owner: string,
+  name: string,
+): Promise<string> {
+  const path = `${LIST_PATH}/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+  try {
+    const found = await client.get<ProjectListItem>(path, `project "${project}"`);
+    if (!found?.id) throw new Error(`GET ${client.url(path)} returned no project id`);
+    return found.id;
+  } catch (err) {
+    if (err instanceof ApiError && (err.status === 400 || err.status === 404)) {
+      throw new Error(
+        `project "${project}" via GET ${client.url(path)}: no match — it does not exist, ` +
+          `or the API key's user has no role on it.${await createdProjectsHint(client)}`,
+      );
+    }
+    throw err;
   }
+}
 
+/** A bare name can only be matched client-side, against the creator-scoped project list. */
+async function resolveBareName(client: ApiClient, project: string): Promise<string> {
+  const projects = await client.get<ProjectListItem[]>(LIST_PATH, 'project list');
+  const matches = projects.filter((p) => p.name === project);
   if (matches.length === 1) return matches[0].id;
-  const tried = `project "${project}" via GET ${client.url(listPath)}`;
+
+  const tried = `project "${project}" via GET ${client.url(LIST_PATH)}`;
   if (matches.length === 0) {
+    const available = projects.map((p) => `${p.owner}/${p.name}`).sort();
     throw new Error(
-      `${tried}: no match. Available projects: ${available.length > 0 ? available.join(', ') : '(none)'}`,
+      `${tried}: no match. That endpoint lists only projects created by the API key's user — ` +
+        `use owner/name (or the project UUID) to reach a project shared with them. ` +
+        `Available projects: ${available.length > 0 ? available.join(', ') : '(none)'}`,
     );
   }
   const candidates = matches.map((p) => `${p.owner}/${p.name}`).join(', ');
   throw new Error(`${tried}: ambiguous — matches ${candidates}. Use owner/name or the project UUID.`);
+}
+
+/** Best-effort " Projects created by …: a/b, c/d" suffix for a failed owner/name lookup — a
+ *  typo'd name is the likeliest cause, and this names the near-misses. Silent when the list
+ *  is empty or itself fails: the caller already has a complete error without it. */
+async function createdProjectsHint(client: ApiClient): Promise<string> {
+  try {
+    const projects = await client.get<ProjectListItem[]>(LIST_PATH, 'project list');
+    const available = projects.map((p) => `${p.owner}/${p.name}`).sort();
+    if (available.length === 0) return '';
+    return ` Projects created by the API key's user: ${available.join(', ')}`;
+  } catch {
+    return '';
+  }
 }
 
 /** Find a rule set by exact name within a project; `null` when the project has no set by

--- a/packages/cli/test/resolve.test.ts
+++ b/packages/cli/test/resolve.test.ts
@@ -9,16 +9,20 @@ function clientWith(routes: Parameters<typeof stubFetch>[0]): ApiClient {
 }
 
 describe('resolveProjectId', () => {
+  const OTHER_UUID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
   const twoProjects = {
     [`GET ${API_URL}/api/projects`]: {
       body: [
         { id: PROJECT_UUID, owner: 'me', name: 'proj' },
-        { id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', owner: 'other', name: 'demo' },
+        { id: OTHER_UUID, owner: 'other', name: 'demo' },
       ],
+    },
+    [`GET ${API_URL}/api/projects/other/demo`]: {
+      body: { id: OTHER_UUID, owner: 'other', name: 'demo' },
     },
   };
 
-  it('a UUID is used directly without hitting the list endpoint', async () => {
+  it('a UUID is used directly without hitting the API', async () => {
     const { fetchImpl, calls } = stubFetch({});
     const client = new ApiClient({ apiUrl: API_URL, apiKey: 'k', fetchImpl });
     expect(await resolveProjectId(client, PROJECT_UUID)).toBe(PROJECT_UUID);
@@ -29,15 +33,43 @@ describe('resolveProjectId', () => {
     expect(await resolveProjectId(clientWith(twoProjects), 'proj')).toBe(PROJECT_UUID);
   });
 
-  it('an owner/name pair resolves', async () => {
-    expect(await resolveProjectId(clientWith(twoProjects), 'other/demo')).toBe(
-      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+  it('an owner/name pair resolves via the access-scoped GET /api/projects/:owner/:name', async () => {
+    const { fetchImpl, calls } = stubFetch(twoProjects);
+    const client = new ApiClient({ apiUrl: API_URL, apiKey: 'k', fetchImpl });
+    expect(await resolveProjectId(client, 'other/demo')).toBe(OTHER_UUID);
+    expect(calls.map((c) => c.url)).toEqual([`${API_URL}/api/projects/other/demo`]);
+  });
+
+  // The bug this endpoint switch fixes: GET /api/projects is creator-scoped, so a key whose
+  // user was granted a role on a project they did NOT create lists nothing — yet owner/name
+  // must still resolve.
+  it('an owner/name pair resolves for a project absent from the creator-scoped list', async () => {
+    const notCreatedByMe = {
+      [`GET ${API_URL}/api/projects`]: { body: [] },
+      [`GET ${API_URL}/api/projects/other/demo`]: { body: { id: OTHER_UUID, owner: 'other', name: 'demo' } },
+    };
+    expect(await resolveProjectId(clientWith(notCreatedByMe), 'other/demo')).toBe(OTHER_UUID);
+  });
+
+  // A project that doesn't exist trips ProjectPermissionGuard's "Project not found", which is
+  // a 400 — not the 404 you'd expect. Both must read as "no match".
+  it.each([400, 404])('an owner/name miss (HTTP %i) errors with the URL tried and near-misses', async (status) => {
+    const routes = { ...twoProjects, [`GET ${API_URL}/api/projects/me/typo`]: { status, body: {} } };
+    await expect(resolveProjectId(clientWith(routes), 'me/typo')).rejects.toThrow(
+      /project "me\/typo" via GET https:\/\/api\.test\/api\/projects\/me\/typo: no match .*Projects created by the API key's user: me\/proj, other\/demo/s,
     );
   });
 
-  it('a miss errors with what was tried (name + URL) and the available names', async () => {
+  it('an owner/name 403 surfaces as the access failure it is, not as "no match"', async () => {
+    const routes = { ...twoProjects, [`GET ${API_URL}/api/projects/other/demo`]: { status: 403, body: {} } };
+    await expect(resolveProjectId(clientWith(routes), 'other/demo')).rejects.toThrow(
+      /HTTP 403 .*authentication failed/,
+    );
+  });
+
+  it('a bare-name miss errors with the available names and points at owner/name', async () => {
     await expect(resolveProjectId(clientWith(twoProjects), 'nope')).rejects.toThrow(
-      /project "nope" via GET https:\/\/api\.test\/api\/projects: no match\. Available projects: me\/proj, other\/demo/,
+      /project "nope" via GET https:\/\/api\.test\/api\/projects: no match\..*use owner\/name.*Available projects: me\/proj, other\/demo/s,
     );
   });
 
@@ -46,7 +78,7 @@ describe('resolveProjectId', () => {
       [`GET ${API_URL}/api/projects`]: {
         body: [
           { id: PROJECT_UUID, owner: 'me', name: 'proj' },
-          { id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', owner: 'other', name: 'proj' },
+          { id: OTHER_UUID, owner: 'other', name: 'proj' },
         ],
       },
     };


### PR DESCRIPTION
Fixes #460.

## The bug

`resolveProjectId` resolved every non-UUID project by listing `GET /api/projects` and filtering client-side. That endpoint is **creator-scoped** (`projects.createdBy = the API key's owning user`), not access-scoped — so a key belonging to a user who was *granted a role* on a project they didn't create resolved nothing, and every live command (`pull`/`push`/`diff`/`revisions`/`rollback`/`dev`) failed with "no match" even at viewer+.

## The fix

An `owner/name` pair now goes straight to `GET /api/projects/:owner/:name` (`RequireProjectRole('viewer')`), which any member can read. A bare name has no such endpoint, so it keeps the list fallback — and its miss message now says the list is creator-scoped and points at `owner/name`, rather than insisting the project doesn't exist.

Two details worth a reviewer's eye:

- **A nonexistent project is HTTP 400, not 404.** `ProjectPermissionGuard` catches the service's NotFound and rethrows `BadRequestException('Project not found')`, so both statuses are treated as "no such project". A **403** — user exists, has no role — is a genuinely different failure and propagates untouched, so a permission problem never masquerades as a typo.
- **`a/b/c` is now rejected instead of silently truncated.** The old `split('/', 2)` discarded the trailing segment, so `a/b/c` would match a real, *different* project `a/b`. Segments are percent-encoded now, so it 400s honestly. This is a behavior change slightly beyond the issue's scope.

The failed-lookup path costs one extra round trip: it re-requests the list to build a "Projects created by the API key's user: …" hint, so a typo still shows near-misses. It's best-effort and silent on failure, so it can't mask the real error.

## Verification

Beyond the unit tests, I drove the built binary against a stub backend whose `/api/projects` list deliberately **omits** the shared project, reproducing the bug's exact shape. Same command, same stub, before vs. after:

```
BEFORE: project "other/demo" via GET .../api/projects: no match. Available projects: me/proj   (exit 1)
AFTER:  ID        AGE     TRIGGER  RULES  CURRENT  SOURCE
        11111111  1h ago  push     3      current                                              (exit 0)
```

The stub's request log confirms the success path makes **zero** calls to the creator-scoped list. Also exercised: 400/404/403 handling, the bare-name fallback (both hit and miss), and encoding probes (`a/b/c` → `/api/projects/a/b%2Fc`, spaces → `%20`).

Full CLI suite (349 tests) and `tsc --noEmit` are clean.

## Note on the second commit

`chore(cli): add a verify skill …` is tooling, not part of the fix — it records the build-and-drive recipe (stub endpoint shapes, the 400-not-404 quirk) so the next CLI change skips the cold start. Happy to drop it if you'd rather keep this PR to the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYLAWauJdKfkEFLVPjGfus