### PR TITLE
fix(proxy-rules): re-encrypt header add secrets when copying a rule set

### DIFF
--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
@@ -921,24 +921,41 @@ describe('ProxyRuleSetsService', () => {
   });
 
   describe('copy', () => {
-    it('captures a revision with trigger "copy" carrying the copied rules (not the source set)', async () => {
+    /**
+     * Wires the DB-mock slots and the source/read-back halves of
+     * getRulesByRuleSetId for a single-rule copy. The read-back is what the
+     * response and the revision snapshot are built from, so it returns the
+     * DECRYPTED copy of the rule, exactly like the real service.
+     */
+    const arrangeCopy = (sourceRule: ReturnType<typeof createMockRule>) => {
       const existingRuleSet = createMockRuleSet();
-      const existingRule = createMockRule();
       const newRuleSet = createMockRuleSet({ id: 'copy-set-id', name: 'api-backend (Copy)' });
-      const copiedRule = createMockRule({ id: 'copied-rule-1', ruleSetId: 'copy-set-id' });
+      const copiedRule = createMockRule({
+        ...sourceRule,
+        id: 'copied-rule-1',
+        ruleSetId: 'copy-set-id',
+      });
 
       mockDb.__setResults([
         [existingRuleSet], // findById
         [], // findByName uniqueness probe: no collision
         [newRuleSet], // insert rule set … returning
-        [copiedRule], // insert rule … returning
       ]);
-      mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([existingRule]);
+      mockProxyRulesService.getRulesByRuleSetId
+        .mockResolvedValueOnce([sourceRule]) // source rules (decrypted)
+        .mockResolvedValueOnce([copiedRule]); // read-back of the inserted copies
+
+      return { newRuleSet, copiedRule };
+    };
+
+    it('captures a revision with trigger "copy" carrying the copied rules (not the source set)', async () => {
+      const { newRuleSet, copiedRule } = arrangeCopy(createMockRule());
 
       const result = await service.copy('rule-set-1', 'user-1', 'admin', 'project-1');
 
       expect(result.id).toBe('copy-set-id');
       expect(result.rules).toEqual([copiedRule]);
+      expect(mockProxyRulesService.getRulesByRuleSetId).toHaveBeenNthCalledWith(2, 'copy-set-id');
       expect(mockProxyRuleSetRevisionsService.capture).toHaveBeenCalledTimes(1);
       expect(mockProxyRuleSetRevisionsService.capture).toHaveBeenCalledWith({
         ruleSet: newRuleSet,
@@ -946,6 +963,28 @@ describe('ProxyRuleSetsService', () => {
         trigger: 'copy',
         userId: 'user-1',
       });
+    });
+
+    // Regression: copy() used to insert rule.headerConfig verbatim. Source rules
+    // arrive DECRYPTED from getRulesByRuleSetId, so that stored header `add`
+    // secrets as plaintext at rest (#452).
+    it('re-encrypts header add values before storing the copied rules', async () => {
+      const decryptedHeaderConfig = { add: { 'X-Api-Key': 'super-secret' }, remove: [] };
+      const encryptedHeaderConfig = { add: { 'X-Api-Key': 'iv:ciphertext' }, remove: [] };
+      mockProxyRulesService.encryptHeaderConfigForStorage.mockReturnValueOnce(
+        encryptedHeaderConfig,
+      );
+      arrangeCopy(createMockRule({ headerConfig: decryptedHeaderConfig }));
+
+      await service.copy('rule-set-1', 'user-1', 'admin', 'project-1');
+
+      expect(mockProxyRulesService.encryptHeaderConfigForStorage).toHaveBeenCalledWith(
+        decryptedHeaderConfig,
+      );
+      // values() call 0 is the rule set insert; call 1 is the rule insert.
+      const insertedRule = mockDb.values.mock.calls[1][0] as { headerConfig: unknown };
+      expect(insertedRule.headerConfig).toEqual(encryptedHeaderConfig);
+      expect(insertedRule.headerConfig).not.toEqual(decryptedHeaderConfig);
     });
   });
 

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
@@ -522,36 +522,39 @@ export class ProxyRuleSetsService {
       })
       .returning();
 
-    // Copy all rules from the original rule set
-    const copiedRules: (typeof proxyRules.$inferSelect)[] = [];
+    // Copy all rules from the original rule set. existingRules arrive DECRYPTED
+    // (getRulesByRuleSetId decrypts header `add` values), so they must be
+    // re-encrypted on the way back into storage — same as importRuleSet.
     for (const rule of existingRules) {
-      const [newRule] = await db
-        .insert(proxyRules)
-        .values({
-          ruleSetId: newRuleSet.id,
-          pathPattern: rule.pathPattern,
-          method: rule.method,
-          methods: rule.methods ?? null,
-          targetUrl: rule.targetUrl,
-          stripPrefix: rule.stripPrefix,
-          order: rule.order,
-          timeout: rule.timeout,
-          preserveHost: rule.preserveHost,
-          forwardCookies: rule.forwardCookies,
-          headerConfig: rule.headerConfig,
-          authTransform: rule.authTransform,
-          internalRewrite: rule.internalRewrite,
-          proxyType: rule.proxyType,
-          emailHandlerConfig: rule.emailHandlerConfig,
-          pipelineConfig: rule.pipelineConfig,
-          isEnabled: rule.isEnabled,
-          description: rule.description,
-        })
-        .returning();
-      copiedRules.push(newRule);
+      await db.insert(proxyRules).values({
+        ruleSetId: newRuleSet.id,
+        pathPattern: rule.pathPattern,
+        method: rule.method,
+        methods: rule.methods ?? null,
+        targetUrl: rule.targetUrl,
+        stripPrefix: rule.stripPrefix,
+        order: rule.order,
+        timeout: rule.timeout,
+        preserveHost: rule.preserveHost,
+        forwardCookies: rule.forwardCookies,
+        headerConfig: this.proxyRulesService.encryptHeaderConfigForStorage(rule.headerConfig),
+        authTransform: rule.authTransform,
+        internalRewrite: rule.internalRewrite,
+        proxyType: rule.proxyType,
+        emailHandlerConfig: rule.emailHandlerConfig,
+        pipelineConfig: rule.pipelineConfig,
+        isEnabled: rule.isEnabled,
+        description: rule.description,
+      });
     }
 
-    this.logger.log(`Copied proxy rule set ${id} to ${newRuleSet.id} with ${copiedRules.length} rules`);
+    this.logger.log(
+      `Copied proxy rule set ${id} to ${newRuleSet.id} with ${existingRules.length} rules`,
+    );
+
+    // Read the rules back decrypted: both the revision snapshot and the API
+    // response carry plaintext header values, not the stored ciphertext.
+    const copiedRules = await this.proxyRulesService.getRulesByRuleSetId(newRuleSet.id);
 
     // Post-commit, best-effort: snapshot the copy's own rules (not the
     // source set's revisions — the copy is a new set with its own history).


### PR DESCRIPTION
Fixes #452.

## The bug

`ProxyRuleSetsService.copy()` read the source rules through `getRulesByRuleSetId()` — which **decrypts** header `add` values — and inserted them straight back, so every copy of a rule set carrying header secrets (API keys, bearer tokens) stored them as **plaintext** in `proxy_rules.header_config`. Nothing broke at runtime because `decryptHeaderConfig()` returns values it can't parse as-is, which is why this went unnoticed.

## The fix

Encrypt on insert via `encryptHeaderConfigForStorage()`, then re-read the rules with `getRulesByRuleSetId()` so the API response and the `copy` revision snapshot still carry **decrypted** values. That last half matters: the inserted rows now hold ciphertext, so returning the `.returning()` rows directly (as the old code did) would have leaked ciphertext into both surfaces. This is exactly the shape `importRuleSet()` already uses.

## Tests

- New regression test asserts the stored `headerConfig` is the encrypted value and **not** the plaintext one. Verified it fails against the pre-fix code (`Expected: {"add": {"X-Api-Key": "super-secret"}, ...}`) and passes after.
- Existing `copy` revision-capture test updated for the read-back, and it still pins that the snapshot carries decrypted rules.
- `src/proxy-rules` suite: 320 passed / 14 suites. `tsc --noEmit` clean.

## Not in scope

Item 2 of the issue (a data fix for rows *already* copied with plaintext) is deliberately left out. Those rows keep working, and re-saving an affected rule re-encrypts it; a backfill script can follow separately if we want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYLAWauJdKfkEFLVPjGfus