### PR TITLE
fix(projects): allow the user global role to create projects

### DIFF
--- a/apps/backend/src/projects/projects.controller.spec.ts
+++ b/apps/backend/src/projects/projects.controller.spec.ts
@@ -1,0 +1,18 @@
+import { ROLES_KEY } from '../auth/roles.guard';
+import { ProjectsController } from './projects.controller';
+
+describe('ProjectsController', () => {
+  describe('createProject role gating (#441)', () => {
+    const handler = ProjectsController.prototype.createProject;
+
+    it('allows the admin and user global roles (members stay blocked)', () => {
+      expect(Reflect.getMetadata(ROLES_KEY, handler)).toEqual(['admin', 'user']);
+    });
+
+    it('is guarded: handler declares ApiKeyGuard + RolesGuard', () => {
+      const guards = Reflect.getMetadata('__guards__', handler) ?? [];
+      const guardNames = guards.map((g: any) => g.name);
+      expect(guardNames).toEqual(expect.arrayContaining(['ApiKeyGuard', 'RolesGuard']));
+    });
+  });
+});

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -546,10 +546,13 @@ export class ProjectsController {
 
   @Post()
   @UseGuards(ApiKeyGuard, RolesGuard)
-  @Roles('admin')
+  @Roles('admin', 'user')
   @ApiOperation({ summary: 'Create a new project' })
   @ApiResponse({ status: 201, description: 'Project created', type: ProjectResponseDto })
-  @ApiResponse({ status: 403, description: 'Members cannot create projects' })
+  @ApiResponse({
+    status: 403,
+    description: 'Requires the admin or user global role; members cannot create projects',
+  })
   async createProject(
     @Body() dto: CreateProjectDto,
     @CurrentUser('id') userId: string,

--- a/apps/frontend/src/components/repositories/ActivityFeed.tsx
+++ b/apps/frontend/src/components/repositories/ActivityFeed.tsx
@@ -17,7 +17,7 @@ export function ActivityFeed() {
   );
 
   const { data: sessionData } = useGetSessionQuery();
-  const canCreateRepo = sessionData?.user?.role === 'admin';
+  const canCreateRepo = sessionData?.user?.role !== 'member';
 
   const { data, isLoading, error, refetch } = useGetRepositoryFeedQuery({
     page: currentPage,

--- a/apps/frontend/src/components/repositories/RepositorySidebar.tsx
+++ b/apps/frontend/src/components/repositories/RepositorySidebar.tsx
@@ -19,7 +19,7 @@ export function RepositorySidebar() {
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
 
   const { data: sessionData } = useGetSessionQuery();
-  const canCreateRepo = sessionData?.user?.role === 'admin';
+  const canCreateRepo = sessionData?.user?.role !== 'member';
 
   const { data, isLoading, error } = useGetMyRepositoriesQuery();
 

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -67,9 +67,10 @@ export function HomePage() {
   };
 
   // Show onboarding modal if user hasn't completed onboarding
-  // Only show for admin role since they can create repos (the modal guides through repo creation)
+  // Only show for admin/user roles since they can create repos (the modal guides through repo creation)
+  // Members cannot create repos, so skip the modal for them
   useEffect(() => {
-    const canCreateRepos = sessionData?.user?.role === 'admin';
+    const canCreateRepos = sessionData?.user?.role === 'admin' || sessionData?.user?.role === 'user';
     if (sessionData?.user && !hasCompletedOnboarding && canCreateRepos) {
       setShowOnboarding(true);
     }


### PR DESCRIPTION
## Summary

Implements **Option B** from #441 (refs, intentionally not closing via keyword): reverts `dbcd288` so the global `user` role can create projects again, matching the role-capability table (`PROJECT_ROLES_BY_GLOBAL_ROLE`), the public docs (`authorization.md` never followed the restriction), and GitHub-like expectations. `member` stays blocked.

## Changes

- **Backend**: `@Roles('admin')` → `@Roles('admin', 'user')` on `POST /api/projects`; fixed the stale 403 Swagger description (Inconsistency 1 in the issue)
- **Frontend**: exact reverts of `dbcd288` — create-repo buttons (`ActivityFeed`, `RepositorySidebar`) back to `role !== 'member'`, onboarding modal (`HomePage`) back to admin-or-user
- **Test**: new `projects.controller.spec.ts` locks in the role metadata and the `ApiKeyGuard + RolesGuard` chain on the create handler

## Safety notes

- Self-signup can't reach this: new accounts default to `member`; `user` is only granted by deliberate admin promotion
- API keys unaffected: `RolesGuard` resolves the key owner's DB role, and keys are admin-managed
- **Namespace behavior is intentional**: `owner` is not enforced per-user — all users in a workspace may create projects under any namespace (decision recorded on #441)

## Verification

- `pnpm --filter backend exec tsc --noEmit` ✅
- `pnpm --filter frontend exec tsc --noEmit` ✅
- `pnpm test -- projects.controller.spec` ✅ (2/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEskaYtc3akG5rbbQ6KScC