### PR TITLE
fix(ci): make the root release-please component match the grouped release branch

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
     ".": {
       "changelog-path": "CHANGELOG.md",
       "release-type": "node",
+      "package-name": "",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,


### PR DESCRIPTION
## Why

PR #483 (`chore: release main`, v0.2.9) merged cleanly, bumped `.release-please-manifest.json` to `0.2.9` and wrote the changelog — but **created no release**. No `v0.2.9` tag, no GitHub release, and because `release_created` came back false, both `Build Docker Images` and `Publish CLI to npm` were skipped.

[Run 29327255891](https://github.com/bffless/ce/actions/runs/29327255891) shows why:

```
⚠ PR component: undefined does not match configured component: ce
⚠ PR component: undefined does not match configured component: bffless
```

The root package has `include-component-in-tag: false`, so its section in the release-PR body is written with an empty component — just `<details><summary>0.2.9</summary>`, with no `ce:` label. When a grouped manifest PR body contains **exactly one** unlabeled section, release-please assumes it is a *standalone* single-component PR and requires the branch name to carry the component ([`base.ts:656`](https://github.com/googleapis/release-please/blob/v17.3.0/src/strategies/base.ts#L656)). A grouped PR branches from `release-please--branches--main`, which has no component in it, so the check compares `undefined` against the root's branch component (`ce`, derived from the `@bffless/ce` package.json name), mismatches, and bails.

It only bit now because #482 was the first root-only change in a while. Every earlier release PR — e.g. #481, which released fine (`✔ Creating 2 releases for pull #481`) — also carried a `bffless: x.y.z` section, so the body had two sections and took the multi-component path instead. The bug is still present in the latest release-please (v17.10.3), so bumping the action does not help.

## The fix

Pin the root `package-name` to an empty string. `getBranchComponent()` resolves it to `""` instead of `"ce"`, which matches the componentless grouped branch, so the standalone check passes and the release is built.

Deliberately narrow — nothing else moves:

- **Tags are unchanged.** `include-component-in-tag` is already `false` for the root, so `getComponent()` returns `""` regardless and root tags stay `vX.Y.Z`.
- **`package.json` is not touched.** The `PackageJson` updater only ever writes the `version` field, never `name`.
- **`packages/cli` is unaffected** — it keeps its explicit `component: bffless` and `include-component-in-tag: true`.

The alternative was `separate-pull-requests: true` (which this repo used historically, hence the old `release-please--branches--main--components--ce` branches). That also works, but it costs a second release PR every time both packages change.

## Verification

This commit is a `fix`, so merging it produces a **root-only** release PR — exactly the single-section shape that failed. If that PR merges and tags `v0.2.10`, the fix is confirmed end to end.

v0.2.9 itself has been recovered by hand: tag pushed, [release created](https://github.com/bffless/ce/releases/tag/v0.2.9), images built, and #483 relabelled `autorelease: tagged` so release-please stops aborting with *"There are untagged, merged release PRs outstanding"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
