### PR TITLE
feat(cli): add rules init --schema scaffold command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,6 +16,7 @@ pnpm add -D bffless              # or pin it as a devDependency
 
 ## Commands
 
+- `bffless rules init --schema <name> [dir]` — scaffold `schemas/<name>.schema.yaml` in a rule-set directory (schemas sync by name on push; no pre-created server id needed).
 - `bffless rules build [dirs...]` — compile an authoring rule-set directory to a canonical export JSON.
 - `bffless rules validate [dirs...]` — validate an authoring rule-set directory.
 - `bffless rules test [dirs...]` — run declarative handler fixtures (`*.fn.test.yaml`).

--- a/packages/cli/docs/reference.md
+++ b/packages/cli/docs/reference.md
@@ -121,6 +121,31 @@ file** (`get.rule.yaml`) for a rule with no extracted code, or a **directory**
 its manifest. `rules pull --decompile` picks the directory form automatically, exactly when
 a rule's pipeline has at least one `function_handler` step.
 
+## `rules init` — scaffolding
+
+`rules init --schema <name> [dir]` writes `schemas/<name>.schema.yaml` into a rule-set
+directory (`[dir]` defaults to the nearest config's `ruleSets` — it must resolve to exactly
+one set, since a schema belongs to one set). There is **no chicken-and-egg step**: the
+generated manifest has no `id`, because schemas sync **by name** on `rules push` — the
+server creates a missing schema (assigning its real id) and reuses an existing same-name
+one. Reference it from a rule pipeline as `$schema:<name>`.
+
+```console
+$ npx bffless rules init --schema comments --field author:string:required --field body:text
+/path/to/project/.bffless/proxy-rules/basic/schemas/comments.schema.yaml
+reference it from a rule pipeline as $schema:comments
+```
+
+- `--field <name>:<type>[:required|optional]` — repeatable; types are
+  `string | number | boolean | email | text | datetime | json`. Omitted modifier means
+  optional. With no `--field` at all, the file gets `fields: []` plus a commented example.
+- `--force` — overwrite an existing `schemas/<name>.schema.yaml`.
+
+One sharp edge the generated header comment also warns about: **push never changes the
+fields of an existing live schema** — the live definition wins (a mismatch is a warning,
+or a hard error under `push --strict-schemas`). Settle fields before the first push; after
+that, live field changes happen in the dashboard.
+
 ## Rule manifest reference (`*.rule.yaml` / `rule.yaml`)
 
 Every key is optional except where a stem/escape hatch fills it in; unknown keys are a

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,140 @@
+/**
+ * `rules init` — scaffold authoring files in a rule-set directory.
+ *
+ * Currently only `--schema <name>`: generates `schemas/<name>.schema.yaml`. Schemas are
+ * synced BY NAME on `rules push` (created in the project when missing, reused when a
+ * same-name schema exists), so no pre-created server id is ever needed — the generated
+ * manifest deliberately has no `id`. The one sharp edge worth scaffolding around: push
+ * never changes the fields of an existing live schema (the live definition wins; a
+ * mismatch warns, or fails under `--strict-schemas`), so the generated header comment
+ * tells the author to settle fields before the first push.
+ */
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { stringify as stringifyYaml } from 'yaml';
+import { resolveRuleSetDirs } from '../config.js';
+
+export interface InitOptions {
+  schema?: string;
+  field?: string[];
+  force?: boolean;
+}
+
+export interface InitOutcome {
+  ok: boolean;
+  outFile?: string;
+  hint?: string;
+  error?: string;
+}
+
+/** Field types accepted by pipeline schemas (mirrors the backend's `SchemaFieldType`). */
+export const SCHEMA_FIELD_TYPES = ['string', 'number', 'boolean', 'email', 'text', 'datetime', 'json'] as const;
+
+/** Schema names become filenames (`schemas/<name>.schema.yaml`), so keep them path-safe. */
+const SCHEMA_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const FIELD_NAME_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+
+interface ParsedField {
+  name: string;
+  type: string;
+  required: boolean;
+}
+
+/** Parse a `--field <name>:<type>[:required|optional]` spec; returns an error string on failure. */
+function parseFieldSpec(spec: string): ParsedField | string {
+  const parts = spec.split(':');
+  if (parts.length < 2 || parts.length > 3) {
+    return `--field "${spec}": expected <name>:<type> or <name>:<type>:required`;
+  }
+  const [name, type, flag] = parts;
+  if (!FIELD_NAME_RE.test(name)) {
+    return `--field "${spec}": invalid field name "${name}"`;
+  }
+  if (!(SCHEMA_FIELD_TYPES as readonly string[]).includes(type)) {
+    return `--field "${spec}": unknown type "${type}" (expected ${SCHEMA_FIELD_TYPES.join(' | ')})`;
+  }
+  if (flag !== undefined && flag !== 'required' && flag !== 'optional') {
+    return `--field "${spec}": trailing modifier must be "required" or "optional"`;
+  }
+  return { name, type, required: flag === 'required' };
+}
+
+function schemaYaml(name: string, fields: ParsedField[]): string {
+  const header = [
+    `# Pipeline schema "${name}" — reference it from rules as \`$schema:${name}\`.`,
+    '#',
+    '# Synced by name on `rules push`: created in the project when missing, reused when a',
+    '# schema with this name already exists — no id needed, the name is the identity.',
+    '# NOTE: push never changes the fields of an existing live schema (the live definition',
+    '# wins; a mismatch warns, or fails under --strict-schemas). Settle fields before the',
+    '# first push; edit live fields in the dashboard.',
+    '#',
+    `# Field types: ${SCHEMA_FIELD_TYPES.join(' | ')}`,
+  ].join('\n');
+  const body = stringifyYaml({ name, fields }, { blockQuote: 'literal', lineWidth: 0 });
+  const example =
+    fields.length > 0
+      ? ''
+      : [
+          '# Example:',
+          '# fields:',
+          '#   - name: title',
+          '#     type: string',
+          '#     required: true',
+          '#   - name: body',
+          '#     type: text',
+          '#     required: false',
+          '',
+        ].join('\n');
+  return `${header}\n${body}${example}`;
+}
+
+export function runInit(dir: string | undefined, opts: InitOptions, cwd: string): InitOutcome {
+  if (!opts.schema) {
+    return { ok: false, error: 'rules init currently only scaffolds schemas — pass --schema <name>' };
+  }
+  const name = opts.schema;
+  if (name.length > 100 || !SCHEMA_NAME_RE.test(name)) {
+    return {
+      ok: false,
+      error: `invalid schema name "${name}" — letters, digits, ".", "_", "-" only (must start with a letter or digit)`,
+    };
+  }
+
+  const fields: ParsedField[] = [];
+  for (const spec of opts.field ?? []) {
+    const parsed = parseFieldSpec(spec);
+    if (typeof parsed === 'string') return { ok: false, error: parsed };
+    fields.push(parsed);
+  }
+  const seen = new Set<string>();
+  for (const f of fields) {
+    if (seen.has(f.name)) return { ok: false, error: `duplicate field name "${f.name}"` };
+    seen.add(f.name);
+  }
+
+  let setDir: string;
+  try {
+    const resolved = resolveRuleSetDirs(cwd, dir ? [dir] : []);
+    if (resolved.length !== 1) {
+      const listed = resolved.map((d) => path.relative(cwd, d) || '.').join(', ');
+      return {
+        ok: false,
+        error:
+          `${resolved.length} rule sets resolved${listed ? ` (${listed})` : ''} — ` +
+          'a schema belongs to one set; pass its directory explicitly',
+      };
+    }
+    setDir = resolved[0];
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  const outFile = path.join(setDir, 'schemas', `${name}.schema.yaml`);
+  if (existsSync(outFile) && !opts.force) {
+    return { ok: false, error: `${path.relative(cwd, outFile)} already exists (use --force to overwrite)` };
+  }
+  mkdirSync(path.dirname(outFile), { recursive: true });
+  writeFileSync(outFile, schemaYaml(name, fields), 'utf8');
+  return { ok: true, outFile, hint: `reference it from a rule pipeline as $schema:${name}` };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,7 @@ import { runDiffOne } from './commands/diff.js';
 import { runRevisionsList, formatRevisionsTable } from './commands/revisions.js';
 import { runRollback } from './commands/rollback.js';
 import { runDev, type DevOptions } from './commands/dev.js';
+import { runInit } from './commands/init.js';
 
 /** `<file>:<line> <message>` when `line` is present, `<file> <message>` otherwise. */
 function formatIssue(issue: Issue): string {
@@ -30,7 +31,39 @@ function resolveDirsOrReport(dirs: string[]): string[] | null {
 const program = new Command('bffless').description('BFFless CLI');
 const rules = program
   .command('rules')
-  .description('Proxy rule sets as code (build, validate, test, pull, push, diff, revisions, rollback, dev)');
+  .description('Proxy rule sets as code (init, build, validate, test, pull, push, diff, revisions, rollback, dev)');
+
+/** Commander option collector for repeatable flags. */
+function collect(value: string, previous: string[]): string[] {
+  return previous.concat(value);
+}
+
+rules
+  .command('init')
+  .description(
+    'Scaffold authoring files in a rule-set directory. Currently: --schema <name> writes ' +
+      'schemas/<name>.schema.yaml — schemas sync by name on `rules push` (created in the ' +
+      'project when missing), so no pre-created server id is needed.',
+  )
+  .argument('[dir]', 'rule-set directory (defaults to the single .bffless/config.json ruleSets match)')
+  .option('--schema <name>', 'generate schemas/<name>.schema.yaml')
+  .option(
+    '--field <name:type[:required]>',
+    'schema field, repeatable; types: string|number|boolean|email|text|datetime|json',
+    collect,
+    [],
+  )
+  .option('--force', 'overwrite an existing file')
+  .action((dir: string | undefined, opts: { schema?: string; field?: string[]; force?: boolean }) => {
+    const result = runInit(dir, opts, process.cwd());
+    if (!result.ok) {
+      console.error(result.error);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(result.outFile);
+    if (result.hint) console.log(result.hint);
+  });
 
 rules
   .command('build')

--- a/packages/cli/src/lib.ts
+++ b/packages/cli/src/lib.ts
@@ -23,6 +23,8 @@ export { runRollback, pickDefaultRollbackTarget } from './commands/rollback.js';
 export type { RollbackOptions, RollbackOutcome } from './commands/rollback.js';
 export { runDev } from './commands/dev.js';
 export type { DevOptions, DevDeps, DevWatcher } from './commands/dev.js';
+export { runInit, SCHEMA_FIELD_TYPES } from './commands/init.js';
+export type { InitOptions, InitOutcome } from './commands/init.js';
 export { decompileExport, writeDecompiled } from './compile/decompile.js';
 export { canonicalizeExport, stringifyExport, exportsEquivalent } from './format/canonical.js';
 export type { RuleSetExport, ExportedRule, ExportedSchema } from './format/types.js';

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { runInit } from '../src/commands/init.js';
+import { SchemaManifestSchema } from '../src/format/manifest.js';
+import { validateRuleSet } from '../src/commands/validate.js';
+
+function scratchSet(files: Record<string, string>): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'bffless-init-test-'));
+  for (const [rel, contents] of Object.entries(files)) {
+    const full = path.join(dir, rel);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, contents, 'utf8');
+  }
+  return dir;
+}
+
+describe('runInit --schema — happy path', () => {
+  it('writes schemas/<name>.schema.yaml with parsed fields and no id', () => {
+    const dir = scratchSet({ 'ruleset.yaml': 'name: s\n' });
+    const result = runInit(dir, { schema: 'comments', field: ['author:string:required', 'body:text'] }, dir);
+    expect(result.ok).toBe(true);
+    expect(result.outFile).toBe(path.join(dir, 'schemas', 'comments.schema.yaml'));
+    expect(result.hint).toContain('$schema:comments');
+
+    const raw = readFileSync(result.outFile!, 'utf8');
+    const parsed = SchemaManifestSchema.parse(parseYaml(raw));
+    expect(parsed).toEqual({
+      name: 'comments',
+      fields: [
+        { name: 'author', type: 'string', required: true },
+        { name: 'body', type: 'text', required: false },
+      ],
+    });
+    expect(parsed.id).toBeUndefined();
+    // The header must carry the two facts that make the flow self-explanatory.
+    expect(raw).toContain('Synced by name');
+    expect(raw).toContain('--strict-schemas');
+  });
+
+  it('accepts an explicit :optional modifier', () => {
+    const dir = scratchSet({ 'ruleset.yaml': 'name: s\n' });
+    const result = runInit(dir, { schema: 'items', field: ['note:text:optional'] }, dir);
+    expect(result.ok).toBe(true);
+    const parsed = SchemaManifestSchema.parse(parseYaml(readFileSync(result.outFile!, 'utf8')));
+    expect(parsed.fields).toEqual([{ name: 'note', type: 'text', required: false }]);
+  });
+
+  it('with no --field, writes fields: [] plus a commented example', () => {
+    const dir = scratchSet({ 'ruleset.yaml': 'name: s\n' });
+    const result = runInit(dir, { schema: 'drafts' }, dir);
+    expect(result.ok).toBe(true);
+    const raw = readFileSync(result.outFile!, 'utf8');
+    expect(SchemaManifestSchema.parse(parseYaml(raw)).fields).toEqual([]);
+    expect(raw).toContain('# Example:');
+  });
+
+  it('produces a set that validateRuleSet accepts, including a $schema ref to the new schema', async () => {
+    const dir = scratchSet({
+      'ruleset.yaml': 'name: s\n',
+      'rules/api/comments/post.rule.yaml': [
+        'pipeline:',
+        '  steps:',
+        '    - name: save',
+        '      handler: data_create',
+        '      config:',
+        '        schemaId: $schema:comments',
+        '',
+      ].join('\n'),
+    });
+    const result = runInit(dir, { schema: 'comments', field: ['author:string:required'] }, dir);
+    expect(result.ok).toBe(true);
+    const { errors } = await validateRuleSet(dir);
+    expect(errors).toEqual([]);
+  });
+});
+
+describe('runInit — directory resolution', () => {
+  it('resolves the single ruleSets config match when no dir is given', () => {
+    const root = scratchSet({
+      '.bffless/config.json': JSON.stringify({ ruleSets: ['.bffless/proxy-rules/*'] }),
+      '.bffless/proxy-rules/reader/ruleset.yaml': 'name: reader\n',
+    });
+    const result = runInit(undefined, { schema: 'feeds' }, root);
+    expect(result.ok).toBe(true);
+    expect(result.outFile).toBe(path.join(root, '.bffless', 'proxy-rules', 'reader', 'schemas', 'feeds.schema.yaml'));
+  });
+
+  it('errors when the config resolves multiple rule sets', () => {
+    const root = scratchSet({
+      '.bffless/config.json': JSON.stringify({ ruleSets: ['.bffless/proxy-rules/*'] }),
+      '.bffless/proxy-rules/a/ruleset.yaml': 'name: a\n',
+      '.bffless/proxy-rules/b/ruleset.yaml': 'name: b\n',
+    });
+    const result = runInit(undefined, { schema: 'feeds' }, root);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('2 rule sets resolved');
+    expect(result.error).toContain('pass its directory explicitly');
+  });
+
+  it('errors on an explicit dir that is not a rule set', () => {
+    const dir = scratchSet({ 'notes.txt': 'x\n' });
+    const result = runInit(dir, { schema: 'feeds' }, dir);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('no ruleset.yaml');
+  });
+});
+
+describe('runInit — guardrails', () => {
+  it('requires --schema', () => {
+    const dir = scratchSet({ 'ruleset.yaml': 'name: s\n' });
+    const result = runInit(dir, {}, dir);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('--schema <name>');
+  });
+
+  it('rejects a path-unsafe schema name', () => {
+    const dir = scratchSet({ 'ruleset.yaml': 'name: s\n' });
+    const result = runInit(dir, { schema: '../evil' }, dir);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('invalid schema name');
+  });
+
+  it('rejects an unknown field type, a malformed spec, and a duplicate field name', () => {
+    const dir = scratchSet({ 'ruleset.yaml': 'name: s\n' });
+    expect(runInit(dir, { schema: 's1', field: ['a:uuid'] }, dir).error).toContain('unknown type "uuid"');
+    expect(runInit(dir, { schema: 's2', field: ['justaname'] }, dir).error).toContain('expected <name>:<type>');
+    expect(runInit(dir, { schema: 's3', field: ['a:string:maybe'] }, dir).error).toContain('"required" or "optional"');
+    expect(runInit(dir, { schema: 's4', field: ['a:string', 'a:number'] }, dir).error).toContain(
+      'duplicate field name "a"',
+    );
+  });
+
+  it('refuses to overwrite an existing file without --force, overwrites with it', () => {
+    const dir = scratchSet({
+      'ruleset.yaml': 'name: s\n',
+      'schemas/comments.schema.yaml': 'name: comments\nfields: []\n',
+    });
+    const blocked = runInit(dir, { schema: 'comments' }, dir);
+    expect(blocked.ok).toBe(false);
+    expect(blocked.error).toContain('already exists');
+    expect(blocked.error).toContain('--force');
+
+    const forced = runInit(dir, { schema: 'comments', field: ['author:string:required'], force: true }, dir);
+    expect(forced.ok).toBe(true);
+    expect(existsSync(forced.outFile!)).toBe(true);
+    const parsed = SchemaManifestSchema.parse(parseYaml(readFileSync(forced.outFile!, 'utf8')));
+    expect(parsed.fields).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `bffless rules init --schema <name> [dir]` — a scaffold command that writes `schemas/<name>.schema.yaml` into a rule-set directory, making the greenfield schema flow explicit: **schemas sync by name on `rules push`** (`resolveSchemasByName` creates missing ones server-side), so users never need to pre-create a schema in the dashboard to obtain an id.

- `[dir]` defaults to the config's `ruleSets` resolution and must resolve to exactly one set (a schema belongs to one set); multiple matches error with the candidates listed.
- `--field <name>:<type>[:required|optional]`, repeatable, validated against the backend's `SchemaFieldType` set (`string | number | boolean | email | text | datetime | json`); omitted modifier means optional. No `--field` → `fields: []` plus a commented example.
- `--force` to overwrite an existing manifest.
- The generated header comment documents the two non-obvious facts: name is the identity (no id needed), and push never changes the fields of an existing live schema (live wins; warning, or hard error under `push --strict-schemas`) — so fields should be settled before the first push.
- Registered as the first `rules` subcommand, exported from `bffless/lib`, documented in the README command list and a new `docs/reference.md` section.

## Testing

- 11 new tests in `test/init.test.ts` (happy paths, config/dir resolution, all guardrails); full suite passes 368/368.
- Drove the built binary end-to-end in a scratch project: `init` (via config resolution) → `validate` (clean) → `build` (compiled export carries the derived UUIDv5 `schemaId` — no server round-trip), plus overwrite guard, all `--field` error paths, multi-set ambiguity, path-unsafe names, help output, and exit codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)