### PR TITLE
fix(cli): treat pipeline step name as optional, matching the server

### DIFF
--- a/packages/cli/src/compile/build.ts
+++ b/packages/cli/src/compile/build.ts
@@ -178,7 +178,8 @@ async function compilePipeline(
           config.code = readFileSync(file, 'utf8');
         }
       }
-      const out: PipelineStep = { name: step.name, handlerType: step.handler, config };
+      const out: PipelineStep = { handlerType: step.handler, config };
+      if (step.name !== undefined) out.name = step.name;
       if (step.id !== undefined) out.id = step.id;
       if (step.isEnabled !== undefined) out.isEnabled = step.isEnabled;
       converted.push(out);

--- a/packages/cli/src/compile/decompile.ts
+++ b/packages/cli/src/compile/decompile.ts
@@ -77,14 +77,16 @@ function stepToSugar(
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   if (step.id !== undefined) out.id = step.id;
-  out.name = step.name;
+  if (step.name !== undefined) out.name = step.name;
   out.handler = step.handlerType;
 
   const config: Record<string, unknown> = { ...(step.config ?? {}) };
   if (step.handlerType === 'function_handler' && typeof config.code === 'string') {
     const code = config.code;
     delete config.code;
-    let base = sanitizeFileBase(step.id ?? step.name);
+    // id/name are both optional; a step with neither still needs a stable filename,
+    // and the collision loop below disambiguates if more than one lands on it.
+    let base = sanitizeFileBase(step.id ?? step.name ?? 'handler');
     let fname = `${base}.fn.js`;
     let n = 1;
     while (usedFnNames.has(fname)) {

--- a/packages/cli/src/format/manifest.ts
+++ b/packages/cli/src/format/manifest.ts
@@ -35,11 +35,17 @@ const PipelineValidatorSchema = z
   })
   .strict();
 
-/** Canonical pipeline step shape (matches `PipelineStep` in src/format/types.ts) — used for `pipelineConfig:`. */
+/**
+ * Canonical pipeline step shape (matches `PipelineStep` in src/format/types.ts) — used for
+ * `pipelineConfig:`. `name` is optional to match the server, which treats it as an optional
+ * display label (`CreateProxyRuleDto`, `@IsOptional()`). Steps authored in the dashboard can
+ * legitimately have none, and requiring it here would make `pull` emit manifests that
+ * `validate`/`diff`/`push` then reject.
+ */
 const PipelineStepCanonicalSchema = z
   .object({
     id: z.string().optional(),
-    name: z.string(),
+    name: z.string().optional(),
     handlerType: z.string(),
     config: z.record(z.unknown()),
     isEnabled: z.boolean().optional(),
@@ -63,11 +69,12 @@ const PipelineConfigSchema = z
  * convenience for supplying handler code out-of-line instead of inline in `config.code`. A
  * `.ts` ref is bundled (esbuild) at build time — see "TypeScript handlers" in reference.md;
  * a `.js` ref is inlined byte-verbatim as before. A step may not set both `code`/`config.code`.
+ * `name` is optional, matching the server — see `PipelineStepCanonicalSchema` above.
  */
 const PipelineStepManifestSchema = z
   .object({
     id: z.string().optional(),
-    name: z.string(),
+    name: z.string().optional(),
     handler: z.string(),
     config: z.record(z.unknown()).optional(),
     code: z.string().regex(/\.(js|ts)$/, 'code must be a relative path ending in .js or .ts').optional(),

--- a/packages/cli/src/format/types.ts
+++ b/packages/cli/src/format/types.ts
@@ -1,7 +1,8 @@
 export interface SchemaField { name: string; type: string; required?: boolean; [k: string]: unknown }
 export interface ExportedSchema { id: string; name: string; fields: SchemaField[] }
 export interface PipelineValidator { type: 'auth_required' | 'rate_limit'; config?: Record<string, unknown> }
-export interface PipelineStep { id?: string; name: string; handlerType: string; config: Record<string, unknown>; isEnabled?: boolean }
+/** `name` is an optional display label — the server treats it as optional, and dashboard-authored steps may omit it. */
+export interface PipelineStep { id?: string; name?: string; handlerType: string; config: Record<string, unknown>; isEnabled?: boolean }
 export interface PipelineConfig { name: string; description?: string; steps: PipelineStep[]; postSteps?: PipelineStep[]; validators?: PipelineValidator[] }
 export interface HeaderConfig { forward?: string[]; strip?: string[]; add?: Record<string, string> }
 export type ProxyType = 'external_proxy' | 'internal_rewrite' | 'email_form_handler' | 'pipeline';

--- a/packages/cli/test/fixtures/real/legacy-unnamed-step.proxy-rules.json
+++ b/packages/cli/test/fixtures/real/legacy-unnamed-step.proxy-rules.json
@@ -1,0 +1,96 @@
+{
+  "version": 2,
+  "kind": "bffless-proxy-rule-set",
+  "exportedAt": "2026-07-16T12:00:00.000Z",
+  "ruleSet": {
+    "name": "legacy-unnamed-step",
+    "description": "A set in the shape the dashboard produces, which the CLI did not author. Step `name` is optional server-side, so steps may carry none: here an email_handler step with an id but no name, and a function_handler step with an id but no name (its handler filename must fall back to the id). Guards adoption of pre-existing sets via pull --decompile.",
+    "environment": "production"
+  },
+  "schemas": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "name": "signups",
+      "fields": [
+        { "name": "name", "type": "string", "required": true },
+        { "name": "email", "type": "email", "required": true }
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "pathPattern": "/api/signup-form",
+      "targetUrl": "",
+      "stripPrefix": true,
+      "order": 0,
+      "timeout": 30000,
+      "preserveHost": false,
+      "forwardCookies": false,
+      "headerConfig": null,
+      "authTransform": null,
+      "internalRewrite": false,
+      "proxyType": "pipeline",
+      "emailHandlerConfig": null,
+      "isEnabled": true,
+      "debugEnabled": false,
+      "description": null,
+      "pipelineConfig": {
+        "name": "signup form",
+        "description": "validate, store, notify",
+        "steps": [
+          {
+            "id": "step_1700000000000_aaaaaaa",
+            "name": "form_validation",
+            "config": { "fields": { "name": { "type": "string", "required": true } } },
+            "isEnabled": true,
+            "handlerType": "form_handler"
+          },
+          {
+            "id": "step_1700000000001_bbbbbbb",
+            "name": "create record",
+            "config": {
+              "fields": { "name": "input.name", "email": "input.email" },
+              "schemaId": "00000000-0000-4000-8000-000000000001"
+            },
+            "isEnabled": true,
+            "handlerType": "data_create"
+          },
+          {
+            "id": "step_1700000000002_ccccccc",
+            "config": { "to": "someone@example.com", "subject": "New signup" },
+            "isEnabled": true,
+            "handlerType": "email_handler"
+          }
+        ]
+      }
+    },
+    {
+      "pathPattern": "/api/shape",
+      "method": "GET",
+      "targetUrl": "pipeline",
+      "stripPrefix": true,
+      "order": 1,
+      "timeout": 30000,
+      "preserveHost": false,
+      "forwardCookies": false,
+      "headerConfig": null,
+      "authTransform": null,
+      "internalRewrite": false,
+      "proxyType": "pipeline",
+      "emailHandlerConfig": null,
+      "isEnabled": true,
+      "debugEnabled": false,
+      "description": null,
+      "pipelineConfig": {
+        "name": "shape",
+        "steps": [
+          {
+            "id": "shape",
+            "config": { "code": "function handler({ steps }) {\n  return { ok: true };\n}" },
+            "handlerType": "function_handler"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/cli/test/validate.test.ts
+++ b/packages/cli/test/validate.test.ts
@@ -222,3 +222,47 @@ describe('validateRuleSet — skills cross-ref', () => {
     expect(warnings).toEqual([]);
   });
 });
+
+/**
+ * Step `name` is an optional display label server-side (`CreateProxyRuleDto`, `@IsOptional()`),
+ * so a set authored in the dashboard can hold steps that have none. Requiring it here made
+ * `pull --decompile` emit manifests that `validate`/`diff`/`push` then rejected — a set that
+ * was live and serving traffic could not be adopted into git. The round-trip fixtures never
+ * caught it because all three were CLI-authored, and the CLI forced a name.
+ */
+describe('validateRuleSet — pipeline steps without a name', () => {
+  it('accepts a nameless step in `pipeline:` (authoring shape)', async () => {
+    const dir = scratchSet({
+      'ruleset.yaml': 'name: myset\n',
+      'rules/api/x/post.rule.yaml': [
+        'pipeline:',
+        '  steps:',
+        '    - handler: response_handler',
+        '      config:',
+        '        status: 200',
+        '',
+      ].join('\n'),
+    });
+    const { errors, warnings } = await validateRuleSet(dir);
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('accepts a nameless step in `pipelineConfig:` (canonical shape)', async () => {
+    const dir = scratchSet({
+      'ruleset.yaml': 'name: myset\n',
+      'rules/api/y/post.rule.yaml': [
+        'pipelineConfig:',
+        '  name: p',
+        '  steps:',
+        '    - handlerType: response_handler',
+        '      config:',
+        '        status: 200',
+        '',
+      ].join('\n'),
+    });
+    const { errors, warnings } = await validateRuleSet(dir);
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

`name` on a pipeline step is now optional in the CLI, matching the server.

## Why

`rules pull --decompile` produced manifests that the CLI's own `rules validate`, `diff` and `push` then **rejected**:

```
rules/api/pricing-form/any.rule.yaml: pipeline.steps[2].name — Required
```

Step `name` is an optional display label server-side — `CreateProxyRuleDto` marks it `@IsOptional()` — and a set authored in the dashboard can legitimately have steps without one. The CLI was stricter than the server, so **a live rule set with an unnamed step could not be adopted into git at all**: pull emitted it, validate refused it. That's the whole rules-as-code on-ramp for any set the CLI didn't author.

Found while adopting an existing dashboard-managed set in `bffless/platform`.

## How

- `name: z.string().optional()` in both `PipelineStepCanonicalSchema` (`pipelineConfig:`) and `PipelineStepManifestSchema` (`pipeline:`), plus `PipelineStep.name` in `types.ts`.
- The type change then surfaced two places that had silently assumed a name existed:
  - `build.ts` wrote `name: step.name` unconditionally — now only set when defined, matching how `id`/`isEnabled` are already handled.
  - `decompile.ts` emitted `out.name = step.name` (i.e. `name: undefined` into the YAML), and derived the `.fn.js` filename from `step.id ?? step.name` — which is `undefined` for a step with neither. Now falls back to `handler`, with the existing collision loop disambiguating.

## Why the round-trip suite didn't catch it

`roundtrip.test.ts` is described as "the make-or-break gate", and it passed — because all three real fixtures (`reader`, `handoff`, `studio-blog`) were authored *through the CLI*, which forces a name. The dashboard-authored shape was never represented.

Adds `legacy-unnamed-step.proxy-rules.json` in the shape the dashboard produces: an `email_handler` step with an id but no name, and a `function_handler` step with no name whose handler filename must fall back to its id. Reverting `src/` makes 4 tests fail, the round-trip ones with the exact original error.

## Verification

- 372 tests pass (26 files); `tsc --noEmit` clean.
- Guard confirmed to fail without the fix: `git checkout HEAD~1 -- src/` → 4 failures, including `pipeline.steps[2].name — Required`.
- **Against live data**: with this build, `rules diff` of a raw `pull --decompile` of a real production set reports `in sync` — exit 0, zero drift across 12 rules and 9 schemas. Unpatched, the same command exits 2 and refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mx52MrKyPMRndoSnhp1Uvr