### PR TITLE
fix(ai-settings): refresh Anthropic fallbacks and surface live-lookup failures

### DIFF
--- a/apps/backend/src/projects/project-ai-settings.service.spec.ts
+++ b/apps/backend/src/projects/project-ai-settings.service.spec.ts
@@ -1,0 +1,192 @@
+import { ConfigService } from '@nestjs/config';
+import { ProjectAISettingsService } from './project-ai-settings.service';
+
+describe('ProjectAISettingsService', () => {
+  const buildService = () => {
+    const key = Buffer.alloc(32, 7).toString('base64');
+    const configService = {
+      get: jest.fn().mockReturnValue(key),
+    } as unknown as ConfigService;
+    return new ProjectAISettingsService(configService);
+  };
+
+  /** Stub /v1/models with the given ids. */
+  const mockModelsResponse = (ids: string[]) => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: ids.map((id) => ({ id })) }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    return fetchMock;
+  };
+
+  // Distinct keys per test so the per-key models cache never bleeds across cases.
+  let keySeq = 0;
+  const uniqueKey = () => `sk-ant-test-key-${keySeq++}`;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('previewProviderModels — live Anthropic model ids', () => {
+    it('strips the dated suffix from a two-segment version', async () => {
+      mockModelsResponse(['claude-haiku-4-5-20251001']);
+      const service = buildService();
+
+      const result = await service.previewProviderModels('anthropic', uniqueKey());
+
+      expect(result.models.map((m) => m.id)).toEqual(['claude-haiku-4-5']);
+    });
+
+    it('strips the dated suffix from a single-segment gen-5 version', async () => {
+      mockModelsResponse(['claude-sonnet-5-20260101']);
+      const service = buildService();
+
+      const result = await service.previewProviderModels('anthropic', uniqueKey());
+
+      expect(result.models.map((m) => m.id)).toEqual(['claude-sonnet-5']);
+    });
+
+    it('strips the dated suffix from a single-segment fable id', async () => {
+      mockModelsResponse(['claude-fable-5-20260301']);
+      const service = buildService();
+
+      const result = await service.previewProviderModels('anthropic', uniqueKey());
+
+      expect(result.models.map((m) => m.id)).toEqual(['claude-fable-5']);
+    });
+
+    it('leaves a dated gen-4 single-segment id untouched (its alias is -0, not bare)', async () => {
+      mockModelsResponse(['claude-opus-4-20250514']);
+      const service = buildService();
+
+      const result = await service.previewProviderModels('anthropic', uniqueKey());
+
+      expect(result.models.map((m) => m.id)).toEqual(['claude-opus-4-20250514']);
+    });
+
+    it('leaves a legacy 3.x id untouched', async () => {
+      mockModelsResponse(['claude-3-5-sonnet-20241022']);
+      const service = buildService();
+
+      const result = await service.previewProviderModels('anthropic', uniqueKey());
+
+      expect(result.models.map((m) => m.id)).toEqual(['claude-3-5-sonnet-20241022']);
+    });
+
+    it('dedupes an alias and its dated snapshot down to one entry', async () => {
+      mockModelsResponse(['claude-sonnet-5', 'claude-sonnet-5-20260101']);
+      const service = buildService();
+
+      const result = await service.previewProviderModels('anthropic', uniqueKey());
+
+      expect(result.models.map((m) => m.id)).toEqual(['claude-sonnet-5']);
+    });
+
+    it('classifies families into tiers', async () => {
+      mockModelsResponse(['claude-opus-4-8', 'claude-sonnet-5', 'claude-haiku-4-5']);
+      const service = buildService();
+
+      const result = await service.previewProviderModels('anthropic', uniqueKey());
+
+      expect(result.models.map((m) => [m.id, m.tier])).toEqual([
+        ['claude-opus-4-8', 'premium'],
+        ['claude-sonnet-5', 'balanced'],
+        ['claude-haiku-4-5', 'economy'],
+      ]);
+    });
+  });
+
+  describe('previewProviderModels — reporting live vs fallback', () => {
+    it('reports live:true when the provider list is fetched successfully', async () => {
+      mockModelsResponse(['claude-opus-4-8']);
+      const service = buildService();
+
+      const result = await service.previewProviderModels('anthropic', uniqueKey());
+
+      expect(result.live).toBe(true);
+    });
+
+    it('reports live:false and falls back when the fetch throws', async () => {
+      global.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error('getaddrinfo ENOTFOUND api.anthropic.com')) as unknown as typeof fetch;
+      const service = buildService();
+
+      const result = await service.previewProviderModels('anthropic', uniqueKey());
+
+      expect(result.live).toBe(false);
+      expect(result.models.length).toBeGreaterThan(0);
+    });
+
+    it('reports live:false and falls back on a non-200 response', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue({ ok: false, status: 401 }) as unknown as typeof fetch;
+      const service = buildService();
+
+      const result = await service.previewProviderModels('anthropic', uniqueKey());
+
+      expect(result.live).toBe(false);
+      expect(result.models.length).toBeGreaterThan(0);
+    });
+
+    it('reports live:false without calling the provider when no key is supplied', async () => {
+      const fetchMock = mockModelsResponse([]);
+      const service = buildService();
+
+      const result = await service.previewProviderModels('anthropic', '');
+
+      expect(result.live).toBe(false);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('reports live:false for providers with no live listing implemented', async () => {
+      const fetchMock = mockModelsResponse([]);
+      const service = buildService();
+
+      const result = await service.previewProviderModels('openai', uniqueKey());
+
+      expect(result.live).toBe(false);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('previewProviderModels — distinguishing why a fallback was used', () => {
+    it('blames the fetch when the provider is reachable but errors', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue({ ok: false, status: 500 }) as unknown as typeof fetch;
+      const service = buildService();
+
+      const result = await service.previewProviderModels('anthropic', uniqueKey());
+
+      expect(result.fallbackReason).toBe('fetch_failed');
+    });
+
+    it('blames the missing key, not the fetch, when no key is supplied', async () => {
+      const service = buildService();
+
+      const result = await service.previewProviderModels('anthropic', '');
+
+      expect(result.fallbackReason).toBe('no_key');
+    });
+
+    it('blames the provider, not the fetch, when live listing is unsupported', async () => {
+      const service = buildService();
+
+      const result = await service.previewProviderModels('openai', uniqueKey());
+
+      expect(result.fallbackReason).toBe('unsupported_provider');
+    });
+
+    it('reports no fallbackReason on a live list', async () => {
+      mockModelsResponse(['claude-opus-4-8']);
+      const service = buildService();
+
+      const result = await service.previewProviderModels('anthropic', uniqueKey());
+
+      expect(result.fallbackReason).toBeUndefined();
+    });
+  });
+});

--- a/apps/backend/src/projects/project-ai-settings.service.ts
+++ b/apps/backend/src/projects/project-ai-settings.service.ts
@@ -31,6 +31,25 @@ export interface ModelInfo {
 }
 
 /**
+ * Why a model list fell back to the built-in catalog. Only 'fetch_failed' is
+ * an actual problem — the other two are expected states the UI shouldn't alarm
+ * the user about.
+ */
+export type ModelListFallbackReason = 'no_key' | 'unsupported_provider' | 'fetch_failed';
+
+/**
+ * A resolved model list plus whether it came from the provider's live catalog.
+ * `live: false` means these are the built-in suggestions; `fallbackReason` says
+ * why, so callers can distinguish a broken lookup from a provider that simply
+ * has no live listing.
+ */
+export interface ProviderModelList {
+  models: ModelInfo[];
+  live: boolean;
+  fallbackReason?: ModelListFallbackReason;
+}
+
+/**
  * Metadata for AI providers
  */
 export const AI_PROVIDER_METADATA: Record<
@@ -57,12 +76,14 @@ export const AI_PROVIDER_METADATA: Record<
   },
   anthropic: {
     name: 'Anthropic',
-    description: 'Claude Opus 4.6, Sonnet 4.6, and Haiku 4.5',
+    // Fallback only — the live list from /v1/models supersedes this whenever a
+    // key is available (see fetchAnthropicModels). One representative per tier.
+    description: 'Claude Opus 4.8, Sonnet 5, and Haiku 4.5',
     models: [
       // Premium tier
-      { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', tier: 'premium', description: 'Most intelligent for agents and coding' },
+      { id: 'claude-opus-4-8', name: 'Claude Opus 4.8', tier: 'premium', description: 'Most intelligent for agents and coding' },
       // Balanced tier
-      { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', tier: 'balanced', description: 'Best balance of speed and intelligence' },
+      { id: 'claude-sonnet-5', name: 'Claude Sonnet 5', tier: 'balanced', description: 'Best balance of speed and intelligence' },
       // Economy tier
       { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', tier: 'economy', description: 'Fastest with near-frontier intelligence' },
     ],
@@ -450,7 +471,7 @@ export class ProjectAISettingsService {
           // hardcoded metadata if the fetch fails.
           const suggestedModels =
             p.provider === 'anthropic'
-              ? await this.fetchAnthropicModels(config.apiKey)
+              ? (await this.fetchAnthropicModels(config.apiKey)).models
               : meta?.models || [];
 
           return {
@@ -502,10 +523,13 @@ export class ProjectAISettingsService {
    * Falls back to the hardcoded metadata list (no key, unsupported provider, or
    * a failed fetch) so the picker is never empty.
    */
-  async previewProviderModels(provider: AIProviderType, apiKey: string): Promise<ModelInfo[]> {
+  async previewProviderModels(
+    provider: AIProviderType,
+    apiKey: string,
+  ): Promise<ProviderModelList> {
     const fallback = AI_PROVIDER_METADATA[provider]?.models || [];
     if (!apiKey?.trim()) {
-      return fallback;
+      return { models: fallback, live: false, fallbackReason: 'no_key' };
     }
 
     if (provider === 'anthropic') {
@@ -513,7 +537,7 @@ export class ProjectAISettingsService {
     }
 
     // OpenAI/Google live listing not implemented yet — return the static catalog.
-    return fallback;
+    return { models: fallback, live: false, fallbackReason: 'unsupported_provider' };
   }
 
   /**
@@ -524,16 +548,20 @@ export class ProjectAISettingsService {
    * TTL, and any failure falls back to the hardcoded catalog so the UI never
    * ends up with an empty model list.
    */
-  private async fetchAnthropicModels(apiKey: string): Promise<ModelInfo[]> {
-    const fallback = AI_PROVIDER_METADATA.anthropic.models;
+  private async fetchAnthropicModels(apiKey: string): Promise<ProviderModelList> {
+    const fallback: ProviderModelList = {
+      models: AI_PROVIDER_METADATA.anthropic.models,
+      live: false,
+      fallbackReason: 'fetch_failed',
+    };
     if (!apiKey) {
-      return fallback;
+      return { ...fallback, fallbackReason: 'no_key' };
     }
 
     const cacheKey = crypto.createHash('sha256').update(apiKey).digest('hex');
     const cached = this.modelsCache.get(cacheKey);
     if (cached && cached.expires > Date.now()) {
-      return cached.models;
+      return { models: cached.models, live: true };
     }
 
     try {
@@ -576,7 +604,7 @@ export class ProjectAISettingsService {
         models,
         expires: Date.now() + this.MODELS_CACHE_TTL_MS,
       });
-      return models;
+      return { models, live: true };
     } catch (error) {
       this.logger.warn(
         `Anthropic models fetch error; using fallback list: ${(error as Error)?.message}`,
@@ -591,12 +619,23 @@ export class ProjectAISettingsService {
    * claude-haiku-4-5), so the picker is consistent regardless of whether the
    * API returns the aliased or dated id.
    *
-   * Restricted to the modern "family-major-minor-date" shape: older 3.x ids
-   * (e.g. claude-3-5-sonnet-20241022), whose stripped form is NOT a valid
-   * alias, and single-segment ids (claude-opus-4-20250514) are left untouched.
+   * Only strips when the result is a real alias:
+   *  - "family-major-minor-date" always is (claude-haiku-4-5-20251001).
+   *  - "family-major-date" is only from generation 5 on, where the bare form is
+   *    the alias (claude-sonnet-5, claude-fable-5). Generation 4 aliases to a
+   *    "-0" suffix instead (claude-opus-4-20250514 → claude-opus-4-0), so
+   *    stripping would yield the invalid "claude-opus-4" — left untouched.
+   *
+   * Legacy 3.x ids (claude-3-5-sonnet-20241022) match neither shape, since the
+   * family name trails the version, and are likewise left untouched.
    */
   private normalizeAnthropicModelId(id: string): string {
-    return id.replace(/^(claude-(?:opus|sonnet|haiku|fable)-\d+-\d+)-20\d{6}$/, '$1');
+    const match = id.match(/^(claude-(?:opus|sonnet|haiku|fable|mythos)-(\d+)(?:-(\d+))?)-20\d{6}$/);
+    if (!match) return id;
+
+    const [, alias, major, minor] = match;
+    if (minor !== undefined) return alias;
+    return Number(major) >= 5 ? alias : id;
   }
 
   /**

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -173,12 +173,14 @@ export class ProjectsController {
   async previewProviderModels(
     @Param('provider') provider: AIProviderEnum,
     @Body() body: { apiKey?: string },
-  ): Promise<{ models: ModelInfoDto[] }> {
-    const models = await this.aiSettingsService.previewProviderModels(
+  ): Promise<{ models: ModelInfoDto[]; live: boolean; fallbackReason?: string }> {
+    const { models, live, fallbackReason } = await this.aiSettingsService.previewProviderModels(
       provider as AIProviderType,
       body?.apiKey ?? '',
     );
-    return { models };
+    // `live: false` means these are the built-in suggestions, not the provider's
+    // catalog — the client surfaces that rather than silently showing stale models.
+    return { models, live, fallbackReason };
   }
 
   @Get(':id/ai/skills')

--- a/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
+++ b/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
@@ -579,6 +579,10 @@ function AddProviderDialog({
   const [isDefault, setIsDefault] = useState(isFirstProvider);
   // Live model list fetched with the entered key (overrides the static catalog)
   const [liveModels, setLiveModels] = useState<ModelInfo[] | null>(null);
+  // Set when the provider *has* a live catalog but we couldn't reach it, so the
+  // picker is showing built-in suggestions that may be out of date. Only a
+  // genuine lookup failure sets this — a provider with no live listing doesn't.
+  const [lookupFailed, setLookupFailed] = useState(false);
 
   const [previewModels, { isLoading: isLoadingModels }] = usePreviewProviderModelsMutation();
 
@@ -589,6 +593,7 @@ function AddProviderDialog({
   useEffect(() => {
     if (!selectedProvider || apiKey.trim().length < 8) {
       setLiveModels(null);
+      setLookupFailed(false);
       return;
     }
     const handle = setTimeout(async () => {
@@ -598,9 +603,13 @@ function AddProviderDialog({
           provider: selectedProvider,
           apiKey: apiKey.trim(),
         }).unwrap();
-        setLiveModels(result.models?.length ? result.models : null);
+        setLiveModels(result.live && result.models?.length ? result.models : null);
+        setLookupFailed(result.fallbackReason === 'fetch_failed');
       } catch {
-        setLiveModels(null); // fall back to the static catalog
+        // Fall back to the static catalog, but say so rather than passing stale
+        // models off as the key's real list.
+        setLiveModels(null);
+        setLookupFailed(true);
       }
     }, 500);
     return () => clearTimeout(handle);
@@ -712,13 +721,21 @@ function AddProviderDialog({
                     suggestedModels={modelOptions}
                   />
                 </div>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  {isLoadingModels
-                    ? 'Fetching available models for this key…'
-                    : liveModels
-                      ? 'Showing models available to this API key. You can also type any model ID.'
-                      : 'Choose a suggested model or type any model ID. Can be overridden per-pipeline.'}
-                </p>
+                {lookupFailed && !isLoadingModels ? (
+                  <p className="mt-1 text-xs text-destructive">
+                    Couldn't reach {selectedProviderInfo?.displayName ?? 'the provider'} to list
+                    models for this key, so these are built-in suggestions and may be out of date.
+                    Check the server's outbound network access. You can also type any model ID.
+                  </p>
+                ) : (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {isLoadingModels
+                      ? 'Fetching available models for this key…'
+                      : liveModels
+                        ? 'Showing models available to this API key. You can also type any model ID.'
+                        : 'Choose a suggested model or type any model ID. Can be overridden per-pipeline.'}
+                  </p>
+                )}
               </div>
 
               {/* Only show checkbox when adding additional providers */}

--- a/apps/frontend/src/services/projectsApi.ts
+++ b/apps/frontend/src/services/projectsApi.ts
@@ -278,7 +278,11 @@ export const projectsApi = api.injectEndpoints({
     }),
 
     previewProviderModels: builder.mutation<
-      { models: ModelInfo[] },
+      {
+        models: ModelInfo[];
+        live: boolean;
+        fallbackReason?: 'no_key' | 'unsupported_provider' | 'fetch_failed';
+      },
       { projectId: string; provider: AIProviderType; apiKey: string }
     >({
       query: ({ projectId, provider, apiKey }) => ({


### PR DESCRIPTION
## Problem

A new BFFless server on `bffless.dev` was offering **Claude Sonnet 4.6** when creating an Anthropic connection from project settings.

The live `/v1/models` fetch added in #326 works, but two things hid it:

1. It only runs **after** an API key is typed (8+ chars, 500ms debounce). Before that the dialog shows the built-in catalog — which had drifted two generations stale (Opus 4.6 / Sonnet 4.6).
2. On **any** failure it silently falls back to that same catalog. The fetch is made by the backend, so a server without outbound access to `api.anthropic.com` shows stale models with no indication anything is wrong — `catch { setLiveModels(null) }` swallowed it on the frontend too.

## Changes

**Refresh the fallback catalog** — Opus 4.8 / Sonnet 5 / Haiku 4.5, keeping the existing one-representative-per-tier shape. Fable 5 is deliberately excluded: it's priced above the Opus tier, so it's a considered choice rather than a sensible default. Added a comment marking the block fallback-only, since that wasn't obvious and is what let it rot unnoticed.

**Fix `normalizeAnthropicModelId` for single-segment ids** — it only matched `family-major-minor-date`, so `claude-sonnet-5-20260101` kept its dated suffix while `claude-haiku-4-5-20251001` normalized correctly.

The subtlety: you can't just make the minor segment optional. `claude-opus-4-20250514` and `claude-sonnet-5-20260101` are the same shape, but gen-4 aliases to a `-0` suffix (`claude-opus-4-0`) while gen-5 aliases to the bare form (`claude-sonnet-5`). A blanket strip would produce the invalid `claude-opus-4`. So: two-segment always strips, single-segment only from gen 5 on. Also recognizes the `mythos` family.

**Surface the failure** — `previewProviderModels` now returns `{ models, live, fallbackReason }`. `fallbackReason` separates a real `fetch_failed` from `no_key` and `unsupported_provider`, so OpenAI/Google (no live listing by design) don't show a false error. The dialog now shows a destructive-styled message pointing at outbound network access instead of presenting built-in suggestions as the key's real list.

## Testing

Adds `project-ai-settings.service.spec.ts` — the service's first spec — with **16 tests** covering id normalization (including the gen-4 and legacy-3.x exclusions), tier classification, alias/snapshot dedupe, and every fallback path.

Worth noting: the gen-4 and legacy-3.x exclusion tests **passed before the regex change**, which is what confirmed those guards were real rather than incidental.

- Full backend suite: 113 suites / 1790 tests passing
- `tsc --noEmit` clean on both apps; ESLint clean on changed frontend files
- Not yet verified against a live instance. If blocked egress is the root cause on `bffless.dev`, the new message is what should now appear.

## Deliberately out of scope

- `ai.handler.ts:757` still defaults to `claude-sonnet-4-6` when a pipeline step omits `model`. Not cosmetic — changing it alters runtime behavior for pipelines relying on the default, so it deserves its own decision.
- `proxy-rules.tools.ts:62` hardcodes the old three models into an MCP tool description string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
