### PR TITLE
feat(mcp): add traffic-splitting tools (weights + routing rules)

### DIFF
--- a/apps/backend/src/mcp/tools/domain.tools.spec.ts
+++ b/apps/backend/src/mcp/tools/domain.tools.spec.ts
@@ -1,0 +1,160 @@
+import { DomainTools, setTrafficWeightsParameters } from './domain.tools';
+
+describe('traffic-splitting MCP tools', () => {
+  const stubUser = () =>
+    jest
+      .spyOn(
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require('../helpers/user-context.helper'),
+        'getUserContext',
+      )
+      .mockResolvedValue({ id: 'u1', role: 'admin', apiKeyProjectId: null });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('set_traffic_weights parameters schema', () => {
+    it('accepts weights that sum to 100', () => {
+      const parsed = setTrafficWeightsParameters.parse({
+        domainId: 'd1',
+        weights: [
+          { alias: 'production', weight: 50 },
+          { alias: 'red', weight: 50 },
+        ],
+      });
+      expect(parsed.weights).toHaveLength(2);
+    });
+
+    it('rejects weights that do not sum to 100 with a clear message', () => {
+      const result = setTrafficWeightsParameters.safeParse({
+        domainId: 'd1',
+        weights: [
+          { alias: 'production', weight: 60 },
+          { alias: 'red', weight: 30 },
+        ],
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toMatch(/sum to 100/i);
+      }
+    });
+
+    it('rejects an empty weights array', () => {
+      expect(
+        setTrafficWeightsParameters.safeParse({ domainId: 'd1', weights: [] }).success,
+      ).toBe(false);
+    });
+
+    it('preserves the optional per-weight path', () => {
+      const parsed = setTrafficWeightsParameters.parse({
+        domainId: 'd1',
+        weights: [
+          { alias: 'production', weight: 50, path: 'site-v0/dist' },
+          { alias: 'red', weight: 50, path: 'site-v1/dist' },
+        ],
+      });
+      expect(parsed.weights[0].path).toBe('site-v0/dist');
+    });
+  });
+
+  describe('setTrafficWeights', () => {
+    it('forwards domainId, dto, and userId to TrafficRoutingService', async () => {
+      const setTrafficWeights = jest.fn().mockResolvedValue({ weights: [] });
+      const tools = new DomainTools(
+        {} as any,
+        { setTrafficWeights } as any,
+        {} as any,
+        {} as any,
+      );
+      stubUser();
+
+      await tools.setTrafficWeights(
+        {
+          domainId: 'd1',
+          weights: [
+            { alias: 'production', weight: 50 },
+            { alias: 'red', weight: 50 },
+          ],
+          stickySessionsEnabled: true,
+        } as any,
+        {} as any,
+        { user: { id: 'u1' } } as any,
+      );
+
+      expect(setTrafficWeights).toHaveBeenCalledWith(
+        'd1',
+        expect.objectContaining({
+          weights: expect.arrayContaining([expect.objectContaining({ alias: 'red', weight: 50 })]),
+          stickySessionsEnabled: true,
+        }),
+        'u1',
+      );
+      // domainId must be split out of the dto forwarded to the service.
+      expect(setTrafficWeights.mock.calls[0][1].domainId).toBeUndefined();
+    });
+  });
+
+  describe('createTrafficRule', () => {
+    it('splits domainId out and forwards the rule dto plus userId', async () => {
+      const create = jest.fn().mockResolvedValue({ id: 'r1' });
+      const tools = new DomainTools(
+        {} as any,
+        {} as any,
+        { create } as any,
+        {} as any,
+      );
+      stubUser();
+
+      await tools.createTrafficRule(
+        {
+          domainId: 'd1',
+          alias: 'canary',
+          conditionType: 'query_param',
+          conditionKey: 'v',
+          conditionValue: 'canary',
+          priority: 10,
+        } as any,
+        {} as any,
+        { user: { id: 'u1' } } as any,
+      );
+
+      expect(create).toHaveBeenCalledWith(
+        'd1',
+        expect.objectContaining({
+          alias: 'canary',
+          conditionType: 'query_param',
+          conditionKey: 'v',
+          conditionValue: 'canary',
+          priority: 10,
+        }),
+        'u1',
+      );
+      expect(create.mock.calls[0][1].domainId).toBeUndefined();
+    });
+  });
+
+  describe('updateTrafficRule', () => {
+    it('forwards ruleId separately from the patch dto', async () => {
+      const update = jest.fn().mockResolvedValue({ id: 'r1' });
+      const tools = new DomainTools(
+        {} as any,
+        {} as any,
+        { update } as any,
+        {} as any,
+      );
+      stubUser();
+
+      await tools.updateTrafficRule(
+        { ruleId: 'r1', priority: 5, isActive: false } as any,
+        {} as any,
+        { user: { id: 'u1' } } as any,
+      );
+
+      expect(update).toHaveBeenCalledWith(
+        'r1',
+        expect.objectContaining({ priority: 5, isActive: false }),
+        'u1',
+      );
+      expect(update.mock.calls[0][1].ruleId).toBeUndefined();
+    });
+  });
+});

--- a/apps/backend/src/mcp/tools/domain.tools.ts
+++ b/apps/backend/src/mcp/tools/domain.tools.ts
@@ -3,13 +3,65 @@ import { Tool, Context } from '@rekog/mcp-nest';
 import { z } from 'zod';
 import { Request } from 'express';
 import { DomainsService } from '../../domains/domains.service';
+import { TrafficRoutingService } from '../../domains/traffic-routing.service';
+import { TrafficRulesService } from '../../domains/traffic-rules.service';
 import { AuthService } from '../../auth/auth.service';
 import { getUserContext } from '../helpers/user-context.helper';
+
+/**
+ * Parameters for the `set_traffic_weights` tool. Exported so the schema (and the
+ * sum-to-100 refinement) can be unit-tested independently of the NestJS wiring.
+ *
+ * The per-weight `path` is optional and falls back to the domain mapping's path
+ * (`public.controller.ts` uses `variantSelection?.selectedPath ?? mapping.path`),
+ * so agents rarely need to set it.
+ */
+export const setTrafficWeightsParameters = z
+  .object({
+    domainId: z.string().describe('Domain mapping ID (UUID) to configure'),
+    weights: z
+      .array(
+        z.object({
+          alias: z.string().describe('Deployment alias to receive traffic (e.g. "production")'),
+          weight: z
+            .number()
+            .int()
+            .min(0)
+            .max(100)
+            .describe('Weight percentage (0–100); all weights must sum to 100'),
+          path: z
+            .string()
+            .optional()
+            .describe(
+              'Optional path override within the deployment for this alias (e.g. "site-v1/dist"). Falls back to the domain mapping path when omitted.',
+            ),
+        }),
+      )
+      .min(1)
+      .describe('Weighted alias distribution; weights must sum to 100'),
+    stickySessionsEnabled: z
+      .boolean()
+      .optional()
+      .describe('Pin a visitor to their first-selected variant via the __bffless_variant cookie (default true)'),
+    stickySessionDuration: z
+      .number()
+      .int()
+      .min(0)
+      .max(2592000)
+      .optional()
+      .describe('Sticky session cookie lifetime in seconds; 0 = no expiration, max 30 days (default 86400)'),
+  })
+  .refine((v) => v.weights.reduce((sum, w) => sum + w.weight, 0) === 100, {
+    message: 'Traffic weights must sum to 100. Use clear_traffic_weights to return to a single alias.',
+    path: ['weights'],
+  });
 
 @Injectable()
 export class DomainTools {
   constructor(
     private readonly domainsService: DomainsService,
+    private readonly trafficRoutingService: TrafficRoutingService,
+    private readonly trafficRulesService: TrafficRulesService,
     private readonly authService: AuthService,
   ) {}
 
@@ -196,6 +248,202 @@ export class DomainTools {
   ) {
     const user = await getUserContext(request, this.authService);
     const result = await this.domainsService.remove(id, user.id, undefined, user.apiKeyProjectId);
+    return JSON.stringify(result);
+  }
+
+  // =====================
+  // Traffic Splitting: Weights
+  // =====================
+
+  @Tool({
+    name: 'get_traffic_config',
+    description:
+      'Get the traffic-splitting configuration for a domain: weighted alias distribution plus sticky-session settings ({ weights[], stickySessionsEnabled, stickySessionDuration }). Empty weights means the domain serves its single alias.',
+    parameters: z.object({
+      domainId: z.string().describe('Domain mapping ID (UUID)'),
+    }),
+  })
+  async getTrafficConfig(
+    { domainId }: { domainId: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.trafficRoutingService.getTrafficConfig(domainId, user.id);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'set_traffic_weights',
+    description:
+      'Configure weighted traffic splitting (A/B testing / canary) across deployment aliases for a domain. Weights must sum to 100. Replaces any existing weights. Optionally set sticky sessions so a visitor stays on their first-selected variant. Per-weight "path" is optional and falls back to the domain mapping path. Requires admin role.',
+    parameters: setTrafficWeightsParameters,
+  })
+  async setTrafficWeights(
+    args: z.infer<typeof setTrafficWeightsParameters>,
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const { domainId, ...dto } = args;
+    const result = await this.trafficRoutingService.setTrafficWeights(domainId, dto, user.id);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'clear_traffic_weights',
+    description:
+      'Clear traffic splitting for a domain, returning it to serving its single alias. Requires admin role.',
+    parameters: z.object({
+      domainId: z.string().describe('Domain mapping ID (UUID)'),
+    }),
+    annotations: { destructiveHint: true },
+  })
+  async clearTrafficWeights(
+    { domainId }: { domainId: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.trafficRoutingService.clearTrafficWeights(domainId, user.id);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'list_traffic_aliases',
+    description:
+      'List the deployment aliases available to weight for a domain (the aliases that exist on the domain\'s project). Use this to discover valid alias names before calling set_traffic_weights.',
+    parameters: z.object({
+      domainId: z.string().describe('Domain mapping ID (UUID)'),
+    }),
+  })
+  async listTrafficAliases(
+    { domainId }: { domainId: string },
+    _context: Context,
+    request: Request,
+  ) {
+    await getUserContext(request, this.authService);
+    const result = await this.trafficRoutingService.getAvailableAliases(domainId);
+    return JSON.stringify(result);
+  }
+
+  // =====================
+  // Traffic Splitting: Rules (override weights; first match wins by priority)
+  // =====================
+
+  @Tool({
+    name: 'list_traffic_rules',
+    description:
+      'List traffic routing rules for a domain, ordered by priority. Rules force a specific alias when a query param, cookie, or header matches, overriding the weighted split.',
+    parameters: z.object({
+      domainId: z.string().describe('Domain mapping ID (UUID)'),
+    }),
+  })
+  async listTrafficRules(
+    { domainId }: { domainId: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.trafficRulesService.findByDomain(domainId, user.id);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'create_traffic_rule',
+    description:
+      'Create a traffic routing rule that forces a specific alias when a request matches a condition (query param, cookie, or header). Rules override the weighted split; lower priority is evaluated first, first match wins. Requires admin role.',
+    parameters: z.object({
+      domainId: z.string().describe('Domain mapping ID (UUID)'),
+      alias: z.string().describe('Alias to force when the condition matches (e.g. "canary")'),
+      conditionType: z
+        .enum(['query_param', 'cookie', 'header'])
+        .describe('What part of the request to match against'),
+      conditionKey: z
+        .string()
+        .describe('Name of the query param, cookie, or header to match (e.g. "v", "token")'),
+      conditionValue: z.string().describe('Value the key must equal for the rule to match'),
+      priority: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe('Lower is evaluated first (default 100)'),
+      label: z.string().optional().describe('Optional human-readable label for the rule'),
+    }),
+  })
+  async createTrafficRule(
+    args: {
+      domainId: string;
+      alias: string;
+      conditionType: 'query_param' | 'cookie' | 'header';
+      conditionKey: string;
+      conditionValue: string;
+      priority?: number;
+      label?: string;
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const { domainId, ...dto } = args;
+    const result = await this.trafficRulesService.create(domainId, dto, user.id);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'update_traffic_rule',
+    description:
+      'Update a traffic routing rule by ID. Any omitted field is left unchanged. Requires admin role.',
+    parameters: z.object({
+      ruleId: z.string().describe('Traffic rule ID (UUID) to update'),
+      alias: z.string().optional().describe('Alias to force when the condition matches'),
+      conditionType: z
+        .enum(['query_param', 'cookie', 'header'])
+        .optional()
+        .describe('What part of the request to match against'),
+      conditionKey: z.string().optional().describe('Name of the query param, cookie, or header'),
+      conditionValue: z.string().optional().describe('Value the key must equal'),
+      priority: z.number().int().min(0).optional().describe('Lower is evaluated first'),
+      isActive: z.boolean().optional().describe('Whether the rule is active'),
+      label: z.string().optional().describe('Human-readable label for the rule'),
+    }),
+  })
+  async updateTrafficRule(
+    args: {
+      ruleId: string;
+      alias?: string;
+      conditionType?: 'query_param' | 'cookie' | 'header';
+      conditionKey?: string;
+      conditionValue?: string;
+      priority?: number;
+      isActive?: boolean;
+      label?: string;
+    },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const { ruleId, ...dto } = args;
+    const result = await this.trafficRulesService.update(ruleId, dto, user.id);
+    return JSON.stringify(result);
+  }
+
+  @Tool({
+    name: 'delete_traffic_rule',
+    description: 'Delete a traffic routing rule by ID. Requires admin role.',
+    parameters: z.object({
+      ruleId: z.string().describe('Traffic rule ID (UUID) to delete'),
+    }),
+    annotations: { destructiveHint: true },
+  })
+  async deleteTrafficRule(
+    { ruleId }: { ruleId: string },
+    _context: Context,
+    request: Request,
+  ) {
+    const user = await getUserContext(request, this.authService);
+    const result = await this.trafficRulesService.remove(ruleId, user.id);
     return JSON.stringify(result);
   }
 }


### PR DESCRIPTION
Closes #497.

## Summary

The MCP server exposed domain CRUD but no tools for **traffic splitting** — the weighted alias distribution and query-param/cookie/header routing rules. Agents had to drop to raw REST calls against `admin.<host>/api/domains/...` or click through the admin UI.

This adds 8 thin MCP wrappers over the existing `TrafficRoutingService` / `TrafficRulesService` in `apps/backend/src/mcp/tools/domain.tools.ts`:

**Weights**
- `get_traffic_config(domainId)` → `GET :id/traffic`
- `set_traffic_weights(domainId, weights[], stickySessionsEnabled?, stickySessionDuration?)` → `PUT :id/traffic`
- `clear_traffic_weights(domainId)` → `DELETE :id/traffic`
- `list_traffic_aliases(domainId)` → `GET :id/traffic/aliases`

**Rules** (override weights; first match wins by priority)
- `list_traffic_rules(domainId)` → `GET :id/traffic/rules`
- `create_traffic_rule(domainId, alias, conditionType, conditionKey, conditionValue, priority?, label?)` → `POST :id/traffic/rules`
- `update_traffic_rule(ruleId, ...)` → `PATCH traffic/rules/:ruleId`
- `delete_traffic_rule(ruleId)` → `DELETE traffic/rules/:ruleId`

## Acceptance criteria

- ✅ **Sum-to-100 validation** — the exported `setTrafficWeightsParameters` schema `.refine`s weights to sum to 100, surfacing a clear error before the round-trip and backing up the server-side `validateWeights`.
- ✅ **`path` documented as optional** — tool description notes it falls back to the domain mapping path (`variantSelection?.selectedPath ?? mapping.path`).
- ✅ **Skill updated** — the `bffless:traffic-splitting` skill now references these tools (separate PR in `bffless/skills`).
- ✅ **Standalone MCP package** — N/A: CE has no separately-generated MCP server; `apps/backend/src/mcp` is the only surface.

## Notes

Like the existing REST endpoints, these tools pass only `userId` to the traffic services (which don't accept `apiKeyProjectId`), so behavior matches the current REST surface exactly. Tightening project-scoping would be a separate service-layer change.

## Testing

- New `domain.tools.spec.ts` — 7 tests: schema sum/empty/path validation + argument forwarding for weights, create-rule, update-rule.
- All MCP specs pass (13/13); backend `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)