### PR TITLE
fix(domains): accept wildcard source domains in the UI and API

### DIFF
--- a/apps/backend/src/domains/dto/create-domain.dto.ts
+++ b/apps/backend/src/domains/dto/create-domain.dto.ts
@@ -9,6 +9,12 @@ import {
   Matches,
   ValidateIf,
 } from 'class-validator';
+import {
+  HOSTNAME_PATTERN,
+  INVALID_DOMAIN_MESSAGE,
+  INVALID_REDIRECT_TARGET_MESSAGE,
+  SOURCE_DOMAIN_PATTERN,
+} from './domain-patterns';
 
 export class CreateDomainDto {
   @ApiPropertyOptional({
@@ -37,11 +43,12 @@ export class CreateDomainDto {
   path?: string;
 
   @ApiProperty({
-    description: 'Domain name (e.g., coverage.localhost, docs.example.com)',
+    description:
+      'Domain name (e.g., coverage.localhost, docs.example.com). May use a leading wildcard label to match every subdomain (e.g., *.example.com).',
   })
   @IsString()
-  @Matches(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/, {
-    message: 'Invalid domain format',
+  @Matches(SOURCE_DOMAIN_PATTERN, {
+    message: INVALID_DOMAIN_MESSAGE,
   })
   domain: string;
 
@@ -59,8 +66,8 @@ export class CreateDomainDto {
   })
   @ValidateIf((o) => o.domainType === 'redirect')
   @IsString()
-  @Matches(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/, {
-    message: 'Invalid redirect target domain format',
+  @Matches(HOSTNAME_PATTERN, {
+    message: INVALID_REDIRECT_TARGET_MESSAGE,
   })
   redirectTarget?: string;
 

--- a/apps/backend/src/domains/dto/create-redirect.dto.ts
+++ b/apps/backend/src/domains/dto/create-redirect.dto.ts
@@ -1,11 +1,15 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsEnum, IsOptional, IsString, IsBoolean, Matches } from 'class-validator';
+import { INVALID_DOMAIN_MESSAGE, SOURCE_DOMAIN_PATTERN } from './domain-patterns';
 
 export class CreateRedirectDto {
-  @ApiProperty({ description: 'Source domain that will redirect' })
+  @ApiProperty({
+    description:
+      'Source domain that will redirect. May use a leading wildcard label (e.g., *.example.com).',
+  })
   @IsString()
-  @Matches(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/, {
-    message: 'Invalid domain format',
+  @Matches(SOURCE_DOMAIN_PATTERN, {
+    message: INVALID_DOMAIN_MESSAGE,
   })
   sourceDomain: string;
 

--- a/apps/backend/src/domains/dto/domain-patterns.spec.ts
+++ b/apps/backend/src/domains/dto/domain-patterns.spec.ts
@@ -1,0 +1,91 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { CreateDomainDto } from './create-domain.dto';
+import { CreateRedirectDto } from './create-redirect.dto';
+import { SOURCE_DOMAIN_PATTERN, HOSTNAME_PATTERN } from './domain-patterns';
+
+describe('domain patterns', () => {
+  describe('SOURCE_DOMAIN_PATTERN', () => {
+    it.each([
+      'example.com',
+      'docs.example.com',
+      'localhost',
+      'a-b.example.com',
+      '*.example.com',
+      '*.docs.example.com',
+    ])('accepts %s', (domain) => {
+      expect(SOURCE_DOMAIN_PATTERN.test(domain)).toBe(true);
+    });
+
+    it.each([
+      '*',
+      '*example.com',
+      'foo.*.example.com',
+      '*.*.example.com',
+      'Example.com',
+      '-example.com',
+      'example-.com',
+      'exam ple.com',
+      '',
+    ])('rejects %s', (domain) => {
+      expect(SOURCE_DOMAIN_PATTERN.test(domain)).toBe(false);
+    });
+  });
+
+  describe('HOSTNAME_PATTERN', () => {
+    it('accepts a plain hostname', () => {
+      expect(HOSTNAME_PATTERN.test('example.com')).toBe(true);
+    });
+
+    it('rejects a wildcard, which is meaningless as a redirect target', () => {
+      expect(HOSTNAME_PATTERN.test('*.example.com')).toBe(false);
+    });
+  });
+
+  const errorsFor = async (dto: object, property: string) => {
+    const errors = await validate(dto as never);
+    return errors.filter((e) => e.property === property);
+  };
+
+  describe('CreateDomainDto', () => {
+    const base = {
+      domainType: 'redirect' as const,
+      redirectTarget: 'bffless.dev',
+      redirectType: '301' as const,
+    };
+
+    it('accepts a wildcard source domain for a redirect', async () => {
+      const dto = plainToInstance(CreateDomainDto, { ...base, domain: '*.bffless.com' });
+      expect(await errorsFor(dto, 'domain')).toHaveLength(0);
+    });
+
+    it('accepts a plain source domain for a redirect', async () => {
+      const dto = plainToInstance(CreateDomainDto, { ...base, domain: 'bffless.com' });
+      expect(await errorsFor(dto, 'domain')).toHaveLength(0);
+    });
+
+    it('rejects a bare asterisk source domain', async () => {
+      const dto = plainToInstance(CreateDomainDto, { ...base, domain: '*' });
+      expect(await errorsFor(dto, 'domain')).not.toHaveLength(0);
+    });
+
+    it('rejects a wildcard redirect target', async () => {
+      const dto = plainToInstance(CreateDomainDto, {
+        ...base,
+        domain: 'bffless.com',
+        redirectTarget: '*.bffless.dev',
+      });
+      expect(await errorsFor(dto, 'redirectTarget')).not.toHaveLength(0);
+    });
+  });
+
+  describe('CreateRedirectDto', () => {
+    it('accepts a wildcard source domain', async () => {
+      const dto = plainToInstance(CreateRedirectDto, {
+        sourceDomain: '*.bffless.com',
+        redirectType: '301',
+      });
+      expect(await errorsFor(dto, 'sourceDomain')).toHaveLength(0);
+    });
+  });
+});

--- a/apps/backend/src/domains/dto/domain-patterns.ts
+++ b/apps/backend/src/domains/dto/domain-patterns.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared domain-format patterns for domain mapping DTOs.
+ *
+ * Keep in sync with the frontend copy at
+ * `apps/frontend/src/components/domains/domainPatterns.ts` — the two apps have no
+ * shared package, so a change here needs the same change there or the form and the
+ * API will disagree about what a valid domain looks like.
+ */
+
+/** A plain hostname: `example.com`, `docs.example.com`, `localhost`. */
+export const HOSTNAME_PATTERN =
+  /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
+
+/**
+ * A hostname that may carry a leading `*.` wildcard label: `*.example.com`.
+ *
+ * Valid for a *source* domain, which becomes an nginx `server_name` and so can
+ * legitimately match every subdomain (e.g. redirecting all of `*.old-brand.com`).
+ * Deliberately NOT used for redirect targets — a wildcard has no meaning in a
+ * `Location:` header, so targets keep HOSTNAME_PATTERN.
+ *
+ * Only a single leading `*.` is accepted; nginx does not support wildcards in the
+ * middle of a name (`foo.*.example.com`) or a bare `*`.
+ */
+export const SOURCE_DOMAIN_PATTERN =
+  /^(\*\.)?[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
+
+export const INVALID_DOMAIN_MESSAGE =
+  'Invalid domain format. Use a hostname like example.com, optionally with a leading *. wildcard (e.g. *.example.com)';
+
+export const INVALID_REDIRECT_TARGET_MESSAGE =
+  'Invalid redirect target domain format. Use a hostname like example.com (wildcards are not allowed in a redirect target)';

--- a/apps/backend/src/domains/dto/update-domain.dto.ts
+++ b/apps/backend/src/domains/dto/update-domain.dto.ts
@@ -1,5 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsBoolean, IsEnum, IsIn, IsOptional, IsString, Matches } from 'class-validator';
+import { HOSTNAME_PATTERN, INVALID_REDIRECT_TARGET_MESSAGE } from './domain-patterns';
 
 export class UpdateDomainDto {
   @ApiPropertyOptional({ description: 'Deployment alias' })
@@ -71,8 +72,8 @@ export class UpdateDomainDto {
   })
   @IsOptional()
   @IsString()
-  @Matches(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/, {
-    message: 'Invalid redirect target domain format',
+  @Matches(HOSTNAME_PATTERN, {
+    message: INVALID_REDIRECT_TARGET_MESSAGE,
   })
   redirectTarget?: string;
 

--- a/apps/frontend/src/components/domains/DomainForm.tsx
+++ b/apps/frontend/src/components/domains/DomainForm.tsx
@@ -15,6 +15,11 @@ import type { CreateDomainDto, WwwBehavior } from '@/services/domainsApi';
 import { useFeatureFlags } from '@/services/featureFlagsApi';
 import { useGetPrimaryContentProjectsQuery } from '@/services/settingsApi';
 import { PathTypeahead } from './PathTypeahead';
+import {
+  HOSTNAME_PATTERN,
+  SOURCE_DOMAIN_PATTERN,
+  SUBDOMAIN_LABEL_PATTERN,
+} from './domainPatterns';
 
 interface DomainFormProps {
   projectId: string;
@@ -118,30 +123,31 @@ export function DomainForm({
   const validateForm = (): boolean => {
     const newErrors: { domain?: string; path?: string; redirectTarget?: string } = {};
 
-    const domainRegex = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
-
     // Validate domain
     if (domainType === 'subdomain') {
       if (!subdomain) {
         newErrors.domain = 'Subdomain is required';
-      } else if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(subdomain)) {
+      } else if (!SUBDOMAIN_LABEL_PATTERN.test(subdomain)) {
         newErrors.domain =
           'Subdomain must start and end with alphanumeric, can contain hyphens';
       }
     } else if (domainType === 'custom' || domainType === 'redirect') {
       if (!customDomain) {
         newErrors.domain = 'Domain is required';
-      } else if (!domainRegex.test(customDomain)) {
-        newErrors.domain = 'Invalid domain format';
+      } else if (!SOURCE_DOMAIN_PATTERN.test(customDomain)) {
+        newErrors.domain =
+          'Invalid domain format. Use a hostname like example.com, optionally with a leading *. wildcard';
       }
     }
 
-    // Validate redirect target for redirect domains
+    // Validate redirect target for redirect domains. Targets are plain hostnames —
+    // a wildcard is meaningless in a Location: header.
     if (domainType === 'redirect') {
       if (!redirectTarget) {
         newErrors.redirectTarget = 'Redirect target is required';
-      } else if (!domainRegex.test(redirectTarget)) {
-        newErrors.redirectTarget = 'Invalid redirect target format';
+      } else if (!HOSTNAME_PATTERN.test(redirectTarget)) {
+        newErrors.redirectTarget =
+          'Invalid redirect target format. Use a hostname like example.com (no wildcards)';
       } else if (redirectTarget === customDomain) {
         newErrors.redirectTarget = 'Redirect target cannot be the same as the source domain';
       }
@@ -258,8 +264,16 @@ export function DomainForm({
             />
           )}
         </div>
-        {errors.domain && (
+        {errors.domain ? (
           <p className="text-sm text-destructive mt-1">{errors.domain}</p>
+        ) : (
+          domainType !== 'subdomain' && (
+            <p className="text-xs text-muted-foreground mt-1">
+              Start with <code>*.</code> to match every subdomain (e.g.{' '}
+              <code>*.example.com</code>). An exact domain mapping always wins over a
+              wildcard.
+            </p>
+          )
         )}
       </div>
 

--- a/apps/frontend/src/components/domains/domainPatterns.test.ts
+++ b/apps/frontend/src/components/domains/domainPatterns.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  HOSTNAME_PATTERN,
+  SOURCE_DOMAIN_PATTERN,
+  SUBDOMAIN_LABEL_PATTERN,
+} from './domainPatterns';
+
+describe('SOURCE_DOMAIN_PATTERN', () => {
+  it.each([
+    'example.com',
+    'docs.example.com',
+    'localhost',
+    '*.example.com',
+    '*.bffless.com',
+    '*.docs.example.com',
+  ])('accepts %s', (domain) => {
+    expect(SOURCE_DOMAIN_PATTERN.test(domain)).toBe(true);
+  });
+
+  it.each(['*', '*example.com', 'foo.*.example.com', 'Example.com', '-example.com', ''])(
+    'rejects %s',
+    (domain) => {
+      expect(SOURCE_DOMAIN_PATTERN.test(domain)).toBe(false);
+    },
+  );
+});
+
+describe('HOSTNAME_PATTERN', () => {
+  it('accepts a plain hostname as a redirect target', () => {
+    expect(HOSTNAME_PATTERN.test('bffless.dev')).toBe(true);
+  });
+
+  it('rejects a wildcard redirect target', () => {
+    expect(HOSTNAME_PATTERN.test('*.bffless.dev')).toBe(false);
+  });
+});
+
+describe('SUBDOMAIN_LABEL_PATTERN', () => {
+  it('accepts a bare label', () => {
+    expect(SUBDOMAIN_LABEL_PATTERN.test('coverage')).toBe(true);
+  });
+
+  it('rejects a dotted label', () => {
+    expect(SUBDOMAIN_LABEL_PATTERN.test('a.b')).toBe(false);
+  });
+});

--- a/apps/frontend/src/components/domains/domainPatterns.ts
+++ b/apps/frontend/src/components/domains/domainPatterns.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared domain-format patterns for the domain mapping form.
+ *
+ * Keep in sync with the backend copy at
+ * `apps/backend/src/domains/dto/domain-patterns.ts` — the two apps have no shared
+ * package, so a change here needs the same change there or the form will accept
+ * values the API rejects (or block ones it would allow).
+ */
+
+/** A plain hostname: `example.com`, `docs.example.com`, `localhost`. */
+export const HOSTNAME_PATTERN =
+  /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
+
+/**
+ * A hostname that may carry a leading `*.` wildcard label: `*.example.com`.
+ *
+ * Valid for a *source* domain, which becomes an nginx `server_name` and so can
+ * legitimately match every subdomain. Deliberately NOT used for redirect targets —
+ * a wildcard has no meaning in a `Location:` header.
+ */
+export const SOURCE_DOMAIN_PATTERN =
+  /^(\*\.)?[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
+
+/** A single subdomain label, no dots: `docs`. */
+export const SUBDOMAIN_LABEL_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;


### PR DESCRIPTION
## Problem

Creating a domain mapping for `*.bffless.com` in the **Create Domain Mapping** dialog fails with `Invalid domain format`:

The domain-format regex has no wildcard branch:

```
/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/
```

…and it was copy-pasted in **five** places (`DomainForm.tsx`, `create-domain.dto.ts` ×2, `update-domain.dto.ts`, `create-redirect.dto.ts`). Fixing only the form would have traded the inline error for a 400 from `CreateDomainDto`.

Wildcard mappings are already in production use — `*.bffless.app` and `*.bffless.com` both redirect to `bffless.dev`. They could only be created over MCP, because `domain.tools.ts` declares `domain: z.string()` with no pattern and bypasses the DTO regex entirely.

## Change

Extract the patterns into a module per app and split them in two:

| Pattern | Allows `*.` | Used for |
|---|---|---|
| `SOURCE_DOMAIN_PATTERN` | yes | source domain (becomes an nginx `server_name`) |
| `HOSTNAME_PATTERN` | no | `redirectTarget` (a wildcard is meaningless in a `Location:` header) |

Both reject `*`, `*example.com` and `foo.*.example.com` — nginx doesn't support those either. Error messages now describe a valid value instead of just saying "Invalid domain format", and the field gained helper text so the wildcard is discoverable rather than trial-and-error.

The frontend and backend share no package, so the two copies carry sync notes pointing at each other.

## Verification

- 22 new backend tests (`domain-patterns.spec.ts`) — pass
- 16 new frontend tests (`domainPatterns.test.ts`) — pass
- existing `src/domains` suite — 126/126 pass
- `tsc --noEmit` clean on both apps

## Follow-ups (not in this PR)

- `UpdateDomainDto` has **no** `domain` field validation at all — it validates `redirectTarget` but never the domain itself.
- MCP `create_domain` / `update_domain` still use bare `z.string()`, so they accept domains the API layer would reject. Worth aligning with these patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

