### PR TITLE
fix(pipelines): make the `ne` filter null-safe (IS DISTINCT FROM)

### DIFF
--- a/apps/backend/src/pipelines/handlers/data-delete.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/data-delete.handler.spec.ts
@@ -151,6 +151,31 @@ describe('DataDeleteHandler', () => {
     expect(mockDb.delete).toHaveBeenCalled();
   });
 
+  it('ne is null-safe — a row missing the key is now IN SCOPE for deletion', async () => {
+    // NOTE: this WIDENS a destructive operation. `starred ne true` previously spared
+    // rows that had no `starred` key at all (NULL != 'true' is NULL); it now deletes
+    // them. That is the correct reading of "delete everything that isn't starred" —
+    // a row with no flag is not starred — but any delete-by-query relying on the old
+    // NULL-skipping behaviour to protect partially-populated rows will remove more.
+    const { handler } = buildHandler();
+    mockDb.__queue([{ id: 'no-flag-1' }]); // a legacy row with no `starred` key
+    mockDb.__queue([{ id: 'no-flag-1' }]); // delete .returning()
+
+    const result = await handler.execute(
+      context({}),
+      step({
+        schemaId: 'schema-1',
+        filters: { starred: { op: 'ne', value: 'true' } },
+      }),
+    );
+
+    expect(result.output).toEqual({ count: 1, deletedIds: ['no-flag-1'] });
+    const { sql, params } = selectWhereQuery();
+    expect(sql.toLowerCase()).toContain('is distinct from');
+    expect(sql).not.toContain('!=');
+    expect(params).toContain('true');
+  });
+
   it('returns count 0 without deleting when no rows match the predicate', async () => {
     const { handler } = buildHandler();
     mockDb.__queue([]); // select finds nothing

--- a/apps/backend/src/pipelines/handlers/data-delete.handler.ts
+++ b/apps/backend/src/pipelines/handlers/data-delete.handler.ts
@@ -110,7 +110,11 @@ export class DataDeleteHandler implements StepHandler<DataDeleteHandlerConfig> {
             filterConditions.push(sql`${fieldPath} = ${String(value)}`);
             break;
           case 'ne':
-            filterConditions.push(sql`${fieldPath} != ${String(value)}`);
+            // IS DISTINCT FROM, not !=: for a row whose JSONB lacks the key, `data->>'f'`
+            // is NULL and a bare `!=` yields NULL, silently EXCLUDING the row. Callers
+            // read `ne` as "everything that isn't this value", which must include rows
+            // where the field was never written (a flag added after the rows existed).
+            filterConditions.push(sql`${fieldPath} IS DISTINCT FROM ${String(value)}`);
             break;
           case 'gt':
             filterConditions.push(sql`(${fieldPath})::numeric > ${Number(value)}`);

--- a/apps/backend/src/pipelines/handlers/data-query.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/data-query.handler.spec.ts
@@ -88,6 +88,29 @@ describe('DataQueryHandler in operator', () => {
   });
 });
 
+describe('DataQueryHandler ne operator is null-safe', () => {
+  beforeEach(() => mockDb.__reset());
+
+  it('emits IS DISTINCT FROM so a row missing the key is kept', async () => {
+    // A bare `!=` compares against NULL for a row whose JSONB lacks the field and
+    // yields NULL, dropping the row. Adding a boolean flag to an existing table
+    // would then hide every pre-existing record from a `flag ne true` query.
+    const { handler } = buildHandler();
+    mockDb.__queue([]);
+    await handler.execute(
+      context({}),
+      step({
+        schemaId: 'schema-1',
+        filters: { archived: { op: 'ne', value: 'true' } },
+      }),
+    );
+    const { sql, params } = selectWhereQuery();
+    expect(sql.toLowerCase()).toContain('is distinct from');
+    expect(sql).not.toContain('!=');
+    expect(params).toEqual(expect.arrayContaining(['true']));
+  });
+});
+
 describe('DataQueryHandler output shape (array vs single object)', () => {
   beforeEach(() => mockDb.__reset());
 

--- a/apps/backend/src/pipelines/handlers/data-query.handler.ts
+++ b/apps/backend/src/pipelines/handlers/data-query.handler.ts
@@ -134,7 +134,11 @@ export class DataQueryHandler implements StepHandler<DataQueryHandlerConfig> {
             filterConditions.push(sql`${fieldPath} = ${String(value)}`);
             break;
           case 'ne':
-            filterConditions.push(sql`${fieldPath} != ${String(value)}`);
+            // IS DISTINCT FROM, not !=: for a row whose JSONB lacks the key, `data->>'f'`
+            // is NULL and a bare `!=` yields NULL, silently EXCLUDING the row. Callers
+            // read `ne` as "everything that isn't this value", which must include rows
+            // where the field was never written (a flag added after the rows existed).
+            filterConditions.push(sql`${fieldPath} IS DISTINCT FROM ${String(value)}`);
             break;
           case 'gt':
             filterConditions.push(sql`(${fieldPath})::numeric > ${Number(value)}`);

--- a/apps/backend/src/pipelines/handlers/data-update.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/data-update.handler.spec.ts
@@ -93,3 +93,30 @@ describe('DataUpdateHandler in operator', () => {
     );
   });
 });
+
+describe('DataUpdateHandler ne operator is null-safe', () => {
+  beforeEach(() => mockDb.__reset());
+
+  it('updates rows missing the key via IS DISTINCT FROM', async () => {
+    // This is what makes a backfill possible at all: `flag ne <value>` has to reach
+    // the rows that predate the flag, which is precisely where it needs writing.
+    const { handler } = buildHandler();
+    mockDb.__queue([{ id: 'i1', data: { guid: 'g1' } }]); // select matches (no `archived` key)
+    mockDb.__queue([{ id: 'i1', data: { guid: 'g1', archived: 'false' } }]); // update .returning()
+
+    const result = await handler.execute(
+      context({}),
+      step({
+        schemaId: 'schema-1',
+        filters: { archived: { op: 'ne', value: 'false' } },
+        fields: { archived: 'false' },
+      }),
+    );
+
+    expect((result.output as { count: number }).count).toBe(1);
+    const { sql, params } = new PgDialect().sqlToQuery(mockDb.where.mock.calls[0][0]);
+    expect(sql.toLowerCase()).toContain('is distinct from');
+    expect(sql).not.toContain('!=');
+    expect(params).toEqual(expect.arrayContaining(['false']));
+  });
+});

--- a/apps/backend/src/pipelines/handlers/data-update.handler.ts
+++ b/apps/backend/src/pipelines/handlers/data-update.handler.ts
@@ -114,7 +114,11 @@ export class DataUpdateHandler implements StepHandler<DataUpdateHandlerConfig> {
             filterConditions.push(sql`${fieldPath} = ${String(value)}`);
             break;
           case 'ne':
-            filterConditions.push(sql`${fieldPath} != ${String(value)}`);
+            // IS DISTINCT FROM, not !=: for a row whose JSONB lacks the key, `data->>'f'`
+            // is NULL and a bare `!=` yields NULL, silently EXCLUDING the row. Callers
+            // read `ne` as "everything that isn't this value", which must include rows
+            // where the field was never written (a flag added after the rows existed).
+            filterConditions.push(sql`${fieldPath} IS DISTINCT FROM ${String(value)}`);
             break;
           case 'in':
             filterConditions.push(buildInPredicate(fieldPath, value));

--- a/apps/backend/src/pipelines/handlers/db-aggregate.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/db-aggregate.handler.spec.ts
@@ -86,3 +86,27 @@ describe('DbAggregateHandler in operator', () => {
     );
   });
 });
+
+describe('DbAggregateHandler ne operator is null-safe', () => {
+  beforeEach(() => mockDb.__reset());
+
+  it('counts rows missing the key via IS DISTINCT FROM', async () => {
+    // Badge counts must include records written before the flag existed, otherwise
+    // adding a flag to a populated table silently zeroes every count that filters it.
+    const { handler } = buildHandler();
+    mockDb.__queue([{ result: '3' }]);
+    const result = await handler.execute(
+      context({}),
+      step({
+        schemaId: 'schema-1',
+        operation: 'count',
+        filters: { archived: { op: 'ne', value: 'true' } },
+      }),
+    );
+    expect(result.output).toEqual(expect.objectContaining({ result: 3 }));
+    const { sql, params } = new PgDialect().sqlToQuery(mockDb.where.mock.calls[0][0]);
+    expect(sql.toLowerCase()).toContain('is distinct from');
+    expect(sql).not.toContain('!=');
+    expect(params).toEqual(expect.arrayContaining(['true']));
+  });
+});

--- a/apps/backend/src/pipelines/handlers/db-aggregate.handler.ts
+++ b/apps/backend/src/pipelines/handlers/db-aggregate.handler.ts
@@ -108,7 +108,11 @@ export class DbAggregateHandler implements StepHandler<DbAggregateHandlerConfig>
             filterConditions.push(sql`${fieldPath} = ${String(value)}`);
             break;
           case 'ne':
-            filterConditions.push(sql`${fieldPath} != ${String(value)}`);
+            // IS DISTINCT FROM, not !=: for a row whose JSONB lacks the key, `data->>'f'`
+            // is NULL and a bare `!=` yields NULL, silently EXCLUDING the row. Callers
+            // read `ne` as "everything that isn't this value", which must include rows
+            // where the field was never written (a flag added after the rows existed).
+            filterConditions.push(sql`${fieldPath} IS DISTINCT FROM ${String(value)}`);
             break;
           case 'gt':
             filterConditions.push(sql`(${fieldPath})::numeric > ${Number(value)}`);

--- a/apps/backend/src/pipelines/pipeline-data.service.ts
+++ b/apps/backend/src/pipelines/pipeline-data.service.ts
@@ -106,7 +106,9 @@ export class PipelineDataService {
               conditions.push(sql`${fieldPath} = ${value}`);
               break;
             case 'ne':
-              conditions.push(sql`${fieldPath} != ${value}`);
+              // Null-safe, matching the pipeline handlers: a row whose JSONB lacks
+              // the key must count as "not equal", not drop out of the result set.
+              conditions.push(sql`${fieldPath} IS DISTINCT FROM ${value}`);
               break;
             case 'gt':
               conditions.push(sql`(${fieldPath})::numeric > ${Number(value)}`);


### PR DESCRIPTION
## The bug

`ne` compiled to a bare SQL `!=` against the JSONB field accessor:

```ts
case 'ne':
  filterConditions.push(sql`${fieldPath} != ${String(value)}`);
```

For a row whose `data` object lacks the key, `data->>'field'` is SQL `NULL`, so `NULL != 'true'` evaluates to `NULL`, and the `WHERE` clause rejects the row. `flag ne 'true'` therefore returned **only rows that already had the flag written** — the opposite of what "everything that isn't true" means to a caller.

The failure mode is invisible right up until someone adds a field to a table that already has rows in it, at which point every pre-existing record disappears from any query filtering on it.

That's what happened in bffless/apps#247: an `archived` flag was added to the reader's items table, and all 403 existing rows dropped out of `/api/items` and `/api/counts` — the item pane rendered empty while the sidebar, served by the flag-free `/api/feeds`, kept working fine. The pre-existing `starred ne 'true'` filters never exposed this because ingest writes `starred` explicitly on every row.

## The fix

`IS DISTINCT FROM` instead of `!=`, in all **five** filter builders — `data_query`, `db_aggregate`, `data_update`, `data_delete`, and the `pipeline-data` service behind the admin/MCP data views. Each carries its own independently duplicated copy of the operator switch, so all five needed it.

The other operators (`eq`, `like`, `in`, the `::numeric` comparisons) are equally NULL-propagating, but exclusion is the intuitive outcome there. `ne` is the only one where the NULL semantics surprise.

## ⚠️ Behaviour change: `data_delete` deletes more than it used to

A delete-by-query such as `starred ne 'true'` previously **spared** rows that had no `starred` key at all, and now removes them.

I believe that's the correct reading — a row with no flag is not starred — and it makes the operator consistent across handlers. But it widens a destructive operation, so anything that was implicitly relying on NULL-skipping to protect partially-populated rows will now delete more. This is the part of the PR worth the closest look. It's pinned by a test that spells out the semantics.

Worth noting the reader's own retention prune (`read eq true AND starred ne true AND fetchedAt lt cutoff`) is unaffected in practice, since every row there has `starred` written at ingest.

## Tests

A null-safety test per handler, asserting the generated SQL contains `IS DISTINCT FROM` and no bare `!=` — matching the existing SQL-assertion style in these specs. The `data_delete` one documents the widening explicitly rather than hiding it.

`289 passed` across the pipelines suite (25 suites); backend typecheck clean.

## Related

- bffless/apps#247 — where this surfaced. That PR carries its own app-side fix (stamping `archived=false` at ingest) so it doesn't depend on this release, but this is what heals the rows already in the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
