### PR TITLE
feat(frontend): support multiple conditional terminal response branches

### DIFF
--- a/apps/frontend/src/components/pipelines/PipelineConfig.terminalBranches.test.tsx
+++ b/apps/frontend/src/components/pipelines/PipelineConfig.terminalBranches.test.tsx
@@ -1,0 +1,214 @@
+import { useState } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PipelineConfig, type PipelineConfigData } from './PipelineConfig';
+
+vi.mock('@/services/setupApi', () => ({
+  useGetCurrentStorageConfigQuery: () => ({ data: { storageProvider: 's3' } }),
+}));
+
+vi.mock('@/services/projectsApi', () => ({
+  useGetProjectSecretsQuery: () => ({ data: { secrets: [] } }),
+}));
+
+/**
+ * The landing-episodes pattern: two conditional response handlers at the end
+ * of the pipeline (503 when the fetch failed, 200 when it succeeded). Authored
+ * via the CLI, so steps carry no `id`. The editor must round-trip both.
+ */
+const branchedConfig = (): Partial<PipelineConfigData> => ({
+  name: 'landing_episodes',
+  steps: [
+    { name: 'fetch_playlist', handlerType: 'http_request', config: { url: 'https://example.com', failOnError: false } },
+    { name: 'shape', handlerType: 'function_handler', config: { code: 'return 1;' } },
+    {
+      name: 'unavailable',
+      handlerType: 'response_handler',
+      config: {
+        condition: '!steps.fetch_playlist.ok',
+        status: 503,
+        contentType: 'application/json',
+        body: '{ "error": "playlist_unavailable" }',
+        headers: { 'Cache-Control': 'public, max-age=60' },
+      },
+    },
+    {
+      name: 'respond',
+      handlerType: 'response_handler',
+      config: {
+        condition: 'steps.fetch_playlist.ok',
+        status: 200,
+        contentType: 'application/json',
+        body: '{{{steps.shape.episodes}}}',
+        headers: { 'Cache-Control': 'public, max-age=3600' },
+      },
+    },
+  ],
+});
+
+const header = (name: string) => screen.getByRole('button', { name: new RegExp(`^${name}`) });
+
+const lastSteps = (onChange: ReturnType<typeof vi.fn>) =>
+  onChange.mock.calls.at(-1)![0].steps as PipelineConfigData['steps'];
+
+/** Mirrors how the real parent owns `config` and feeds edits back down. */
+function ControlledHarness({
+  onChange,
+  initial = branchedConfig,
+}: {
+  onChange?: (c: PipelineConfigData) => void;
+  initial?: () => Partial<PipelineConfigData>;
+}) {
+  const [config, setConfig] = useState<Partial<PipelineConfigData>>(initial);
+  return (
+    <PipelineConfig
+      config={config}
+      onChange={(next) => {
+        setConfig(next);
+        onChange?.(next);
+      }}
+      projectId="p1"
+    />
+  );
+}
+
+describe('PipelineConfig terminal response branches', () => {
+  it('renders every trailing response handler as a branch card', () => {
+    render(<PipelineConfig config={branchedConfig()} onChange={vi.fn()} projectId="p1" />);
+
+    expect(header('unavailable')).toBeInTheDocument();
+    expect(header('respond')).toBeInTheDocument();
+  });
+
+  it('shows each branch condition in the collapsed header', () => {
+    render(<PipelineConfig config={branchedConfig()} onChange={vi.fn()} projectId="p1" />);
+
+    expect(screen.getByText(/!steps\.fetch_playlist\.ok/)).toBeInTheDocument();
+    expect(screen.getByText(/^when steps\.fetch_playlist\.ok$/)).toBeInTheDocument();
+  });
+
+  it('emits both branches unchanged when the pipeline is renamed', () => {
+    const onChange = vi.fn();
+    render(<PipelineConfig config={branchedConfig()} onChange={onChange} projectId="p1" />);
+
+    fireEvent.change(screen.getByLabelText('Pipeline Name'), {
+      target: { value: 'landing_episodes_v2' },
+    });
+
+    const steps = lastSteps(onChange);
+    expect(steps).toHaveLength(4);
+    expect(steps[2]).toEqual(branchedConfig().steps![2]);
+    expect(steps[3]).toEqual(branchedConfig().steps![3]);
+  });
+
+  it('preserves a branch condition when its response editor mounts and edits', () => {
+    const onChange = vi.fn();
+    render(<ControlledHarness onChange={onChange} />);
+
+    // Expanding mounts ResponseHandlerConfig, whose mount-time onChange used to
+    // replace the config wholesale and strip `condition`.
+    fireEvent.click(header('unavailable'));
+
+    let steps = lastSteps(onChange);
+    expect(steps[2].config.condition).toBe('!steps.fetch_playlist.ok');
+    expect(steps[3]).toEqual(branchedConfig().steps![3]);
+
+    // A real edit must also keep the condition.
+    fireEvent.change(screen.getByDisplayValue('{ "error": "playlist_unavailable" }'), {
+      target: { value: '{ "error": "unavailable" }' },
+    });
+
+    steps = lastSteps(onChange);
+    expect(steps[2].config.condition).toBe('!steps.fetch_playlist.ok');
+    expect(steps[2].config.body).toBe('{ "error": "unavailable" }');
+    expect(steps[3]).toEqual(branchedConfig().steps![3]);
+  });
+
+  it('adds a new response branch via Add Branch', () => {
+    const onChange = vi.fn();
+    render(<ControlledHarness onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Add Branch/ }));
+
+    const steps = lastSteps(onChange);
+    expect(steps).toHaveLength(5);
+    expect(steps[4].handlerType).toBe('response_handler');
+  });
+
+  it('deletes only the confirmed branch', () => {
+    const onChange = vi.fn();
+    render(<ControlledHarness onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete unavailable' }));
+    fireEvent.click(screen.getByRole('button', { name: /^Delete$/ }));
+
+    const steps = lastSteps(onChange);
+    expect(steps).toHaveLength(3);
+    expect(steps[2]).toEqual(branchedConfig().steps![3]);
+  });
+
+  it('reorders branches with the move buttons', () => {
+    const onChange = vi.fn();
+    render(<ControlledHarness onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move respond up' }));
+
+    const steps = lastSteps(onChange);
+    expect(steps[2].name).toBe('respond');
+    expect(steps[3].name).toBe('unavailable');
+  });
+
+  it('does not mint ids onto id-less branches on unrelated edits', () => {
+    const onChange = vi.fn();
+    render(<PipelineConfig config={branchedConfig()} onChange={onChange} projectId="p1" />);
+
+    fireEvent.change(screen.getByLabelText('Pipeline Name'), {
+      target: { value: 'renamed' },
+    });
+
+    for (const step of lastSteps(onChange)) {
+      expect(step).not.toHaveProperty('id');
+    }
+  });
+
+  it('keeps a non-trailing response handler in the regular steps list', () => {
+    const onChange = vi.fn();
+    const config: Partial<PipelineConfigData> = {
+      name: 'early_responder',
+      steps: [
+        { name: 'maybe_reply', handlerType: 'response_handler', config: { status: 200, body: 'x' } },
+        { name: 'log', handlerType: 'function_handler', config: { code: 'return 1;' } },
+      ],
+    };
+    render(<PipelineConfig config={config} onChange={onChange} projectId="p1" />);
+
+    // Both steps visible; renaming the pipeline round-trips both.
+    expect(header('maybe_reply')).toBeInTheDocument();
+    expect(header('log')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Pipeline Name'), {
+      target: { value: 'renamed' },
+    });
+
+    const steps = lastSteps(onChange);
+    expect(steps.map((s) => s.name)).toEqual(['maybe_reply', 'log']);
+  });
+
+  it('still clears a single terminal step via the type dropdown', () => {
+    const onChange = vi.fn();
+    const single: Partial<PipelineConfigData> = {
+      name: 'single',
+      steps: [
+        { name: 'shape', handlerType: 'function_handler', config: { code: 'return 1;' } },
+        { name: 'respond', handlerType: 'response_handler', config: { status: 200, body: 'ok' } },
+      ],
+    };
+    render(<PipelineConfig config={single} onChange={onChange} projectId="p1" />);
+
+    fireEvent.click(screen.getByRole('combobox', { name: /terminal step type/i }));
+    fireEvent.click(screen.getByRole('option', { name: 'Default Response' }));
+
+    const steps = lastSteps(onChange);
+    expect(steps.map((s) => s.name)).toEqual(['shape']);
+  });
+});

--- a/apps/frontend/src/components/pipelines/PipelineConfig.tsx
+++ b/apps/frontend/src/components/pipelines/PipelineConfig.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, Fragment } from 'react';
+import { useState, useCallback, useMemo, useRef, Fragment } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -146,6 +146,11 @@ function swapIndexes(set: Set<number>, a: number, b: number): Set<number> {
 // Terminal step types
 type TerminalStepType = 'none' | 'response' | 'proxy';
 
+/** Handler types that produce the HTTP response and end the pipeline. */
+function isTerminalHandler(step: PipelineStep): boolean {
+  return step.handlerType === 'response_handler' || step.handlerType === 'proxy_forward';
+}
+
 /**
  * PipelineConfig - Full pipeline editor component.
  * Allows adding, removing, and reordering steps with their handler configs.
@@ -168,7 +173,8 @@ export function PipelineConfig({
   const [expandedPostSteps, setExpandedPostSteps] = useState<Set<number>>(new Set());
   const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
   const [deletePostConfirm, setDeletePostConfirm] = useState<number | null>(null);
-  const [terminalExpanded, setTerminalExpanded] = useState(false);
+  const [deleteTerminalConfirm, setDeleteTerminalConfirm] = useState<number | null>(null);
+  const [expandedTerminalSteps, setExpandedTerminalSteps] = useState<Set<number>>(new Set());
 
   // Direct-to-bucket uploads (presigned_upload) only work on object storage,
   // not local. Disable the option in the picker when storage can't presign.
@@ -184,19 +190,23 @@ export function PipelineConfig({
     ? {}
     : { presigned_upload: 'Requires S3, GCS, MinIO, or Azure storage (not local)' };
 
-  // Separate terminal steps (response_handler, proxy_forward) from regular steps
+  // The trailing contiguous run of response/proxy steps forms the terminal
+  // branches; each may carry a `condition` so the pipeline can answer
+  // differently per outcome (e.g. 503 when a fetch failed, 200 otherwise).
+  // A terminal-type step sitting before a non-terminal step is not part of the
+  // run and stays in the regular list so it remains visible and editable.
   const allSteps = config.steps || [];
-  const terminalStep = allSteps.find(
-    (s) => s.handlerType === 'response_handler' || s.handlerType === 'proxy_forward',
-  );
-  const steps = allSteps.filter(
-    (s) => s.handlerType !== 'response_handler' && s.handlerType !== 'proxy_forward',
-  );
+  let splitIndex = allSteps.length;
+  while (splitIndex > 0 && isTerminalHandler(allSteps[splitIndex - 1])) splitIndex--;
+  const steps = allSteps.slice(0, splitIndex);
+  const terminalSteps = allSteps.slice(splitIndex);
+  const terminalStep = terminalSteps[0];
 
   // Post-processing steps
   const postSteps = config.postSteps || [];
 
-  // Determine current terminal step type
+  // Terminal type drives the single-branch dropdown; with 2+ branches the
+  // dropdown is hidden, so it only needs to reflect the first branch.
   const terminalStepType: TerminalStepType = terminalStep
     ? terminalStep.handlerType === 'proxy_forward'
       ? 'proxy'
@@ -206,35 +216,31 @@ export function PipelineConfig({
   const name = config.name || '';
   const description = config.description || '';
 
-  // Combine steps with terminal step (terminal always goes last)
-  const getAllSteps = useCallback(
-    (regularSteps: PipelineStep[], termStep?: PipelineStep) => {
-      return termStep ? [...regularSteps, termStep] : regularSteps;
-    },
-    [],
-  );
+  // Latest values for the stable branch-edit callbacks below. Handler config
+  // editors emit onChange from a mount-time effect that depends on the
+  // callback's identity, so those callbacks must not be recreated per render.
+  const latest = useRef({ name, description, steps, terminalSteps, postSteps, onChange });
+  latest.current = { name, description, steps, terminalSteps, postSteps, onChange };
 
   const updateConfig = useCallback(
     (updates: Partial<PipelineConfigData>) => {
-      // If updating steps, we need to re-combine with terminal step
-      const newSteps = updates.steps !== undefined
-        ? getAllSteps(updates.steps, terminalStep)
-        : getAllSteps(steps, terminalStep);
+      const combine = (regularSteps: PipelineStep[]) => [...regularSteps, ...terminalSteps];
 
       onChange({
         name,
         description,
-        steps: newSteps,
+        steps: combine(updates.steps !== undefined ? updates.steps : steps),
         postSteps,
         ...updates,
         // Make sure steps is always the combined value
-        ...(updates.steps !== undefined ? { steps: getAllSteps(updates.steps, terminalStep) } : {}),
+        ...(updates.steps !== undefined ? { steps: combine(updates.steps) } : {}),
       });
     },
-    [name, description, steps, postSteps, terminalStep, onChange, getAllSteps],
+    [name, description, steps, postSteps, terminalSteps, onChange],
   );
 
-  // Change terminal step type
+  // Change terminal step type (single-branch mode only — the dropdown is
+  // hidden once there are multiple branches)
   const setTerminalType = useCallback(
     (type: TerminalStepType) => {
       if (type === 'none') {
@@ -245,7 +251,7 @@ export function PipelineConfig({
           steps: steps,
           postSteps,
         });
-        setTerminalExpanded(false);
+        setExpandedTerminalSteps(new Set());
       } else if (type === 'response') {
         // Add or replace with response_handler
         const newTerminalStep: PipelineStep = {
@@ -265,7 +271,7 @@ export function PipelineConfig({
           steps: [...steps, newTerminalStep],
           postSteps,
         });
-        setTerminalExpanded(true);
+        setExpandedTerminalSteps(new Set([0]));
       } else if (type === 'proxy') {
         // Add or replace with proxy_forward
         const newTerminalStep: PipelineStep = {
@@ -286,25 +292,105 @@ export function PipelineConfig({
           steps: [...steps, newTerminalStep],
           postSteps,
         });
-        setTerminalExpanded(true);
+        setExpandedTerminalSteps(new Set([0]));
       }
     },
     [name, description, steps, postSteps, terminalStep, onChange],
   );
 
-  // Update terminal step config
+  const updateTerminalStep = useCallback((index: number, updates: Partial<PipelineStep>) => {
+    const { name, description, steps, terminalSteps, postSteps, onChange } = latest.current;
+    onChange({
+      name,
+      description,
+      steps: [
+        ...steps,
+        ...terminalSteps.map((s, i) => (i === index ? { ...s, ...updates } : s)),
+      ],
+      postSteps,
+    });
+  }, []);
+
+  // Update a branch's handler config, preserving its run condition — the
+  // response/proxy editors emit only the fields they own.
   const updateTerminalConfig = useCallback(
-    (newConfig: ResponseConfig | ProxyConfig) => {
-      if (!terminalStep) return;
-      onChange({
-        name,
-        description,
-        steps: [...steps, { ...terminalStep, config: newConfig as unknown as Record<string, unknown> }],
-        postSteps,
+    (index: number, newConfig: ResponseConfig | ProxyConfig) => {
+      const branch = latest.current.terminalSteps[index];
+      if (!branch) return;
+      const currentCondition = (branch.config as Record<string, unknown>)?.condition;
+      updateTerminalStep(index, {
+        config: (currentCondition
+          ? { ...newConfig, condition: currentCondition }
+          : newConfig) as unknown as Record<string, unknown>,
       });
     },
-    [name, description, steps, postSteps, terminalStep, onChange],
+    [updateTerminalStep],
   );
+
+  // Stable per-branch onChange identities (see `latest` above). Depending on
+  // branch count, not contents: the handlers read current state via `latest`,
+  // and recreating them on every config change would refire the handler
+  // editors' mount effects in a feedback loop.
+  const terminalConfigHandlers = useMemo(
+    () =>
+      terminalSteps.map(
+        (_, i) => (cfg: ResponseConfig | ProxyConfig) => updateTerminalConfig(i, cfg),
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [terminalSteps.length, updateTerminalConfig],
+  );
+
+  const addTerminalBranch = useCallback(() => {
+    const { name, description, steps, terminalSteps, postSteps, onChange } = latest.current;
+    const newBranch: PipelineStep = {
+      id: generateId(),
+      name: generateStepName('response_handler', [...steps, ...terminalSteps, ...postSteps]),
+      handlerType: 'response_handler',
+      config: {
+        status: 200,
+        body: '',
+        contentType: 'application/json',
+      },
+      isEnabled: true,
+    };
+    onChange({
+      name,
+      description,
+      steps: [...steps, ...terminalSteps, newBranch],
+      postSteps,
+    });
+    setExpandedTerminalSteps((prev) => new Set([...prev, terminalSteps.length]));
+  }, []);
+
+  const removeTerminalBranch = (index: number) => {
+    onChange({
+      name,
+      description,
+      steps: [...steps, ...terminalSteps.filter((_, i) => i !== index)],
+      postSteps,
+    });
+    setExpandedTerminalSteps((prev) => removeIndex(prev, index));
+    setDeleteTerminalConfirm(null);
+  };
+
+  const moveTerminalBranch = (index: number, direction: 'up' | 'down') => {
+    const newIndex = direction === 'up' ? index - 1 : index + 1;
+    if (newIndex < 0 || newIndex >= terminalSteps.length) return;
+
+    const newTerminalSteps = [...terminalSteps];
+    [newTerminalSteps[index], newTerminalSteps[newIndex]] = [newTerminalSteps[newIndex], newTerminalSteps[index]];
+    onChange({
+      name,
+      description,
+      steps: [...steps, ...newTerminalSteps],
+      postSteps,
+    });
+    setExpandedTerminalSteps((prev) => swapIndexes(prev, index, newIndex));
+  };
+
+  const toggleTerminalExpanded = (index: number) => {
+    setExpandedTerminalSteps((prev) => toggleIndex(prev, index));
+  };
 
   // Calculate previous steps for response (all regular steps)
   const previousStepsForResponse: PreviousStep[] = useMemo(
@@ -432,25 +518,15 @@ export function PipelineConfig({
     setExpandedPostSteps((prev) => toggleIndex(prev, index));
   };
 
-  // Previous steps available for post-processing steps (all regular + terminal)
+  // Previous steps available for post-processing steps (all regular + terminal branches)
   const previousStepsForPost: PreviousStep[] = useMemo(
-    () => [
-      ...steps.map((s) => ({
+    () =>
+      [...steps, ...terminalSteps].map((s) => ({
         name: s.name || getHandlerDisplayName(s.handlerType),
         handlerType: s.handlerType,
         config: s.config,
       })),
-      ...(terminalStep
-        ? [
-            {
-              name: terminalStep.name || getHandlerDisplayName(terminalStep.handlerType),
-              handlerType: terminalStep.handlerType,
-              config: terminalStep.config,
-            },
-          ]
-        : []),
-    ],
-    [steps, terminalStep],
+    [steps, terminalSteps],
   );
 
   return (
@@ -694,107 +770,195 @@ export function PipelineConfig({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Send className="h-4 w-4 text-muted-foreground" />
-            <Label className="text-base">Terminal Step</Label>
+            <Label className="text-base">
+              {terminalSteps.length > 1 ? 'Terminal Branches' : 'Terminal Step'}
+            </Label>
           </div>
-          {!hasImplicitTerminal && (
-            <Select
-              value={terminalStepType}
-              onValueChange={(v) => setTerminalType(v as TerminalStepType)}
-            >
-              <SelectTrigger className="w-[200px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">Default Response</SelectItem>
-                <SelectItem value="response">Custom HTTP Response</SelectItem>
-                <SelectItem value="proxy">Forward Request (Proxy)</SelectItem>
-              </SelectContent>
-            </Select>
-          )}
-          {hasImplicitTerminal && (
-            <Badge variant="secondary" className="text-xs">
-              AI Chat (Streaming)
-            </Badge>
-          )}
+          <div className="flex items-center gap-2">
+            {!hasImplicitTerminal && terminalSteps.length <= 1 && (
+              <Select
+                value={terminalStepType}
+                onValueChange={(v) => setTerminalType(v as TerminalStepType)}
+              >
+                <SelectTrigger className="w-[200px]" aria-label="Terminal step type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">Default Response</SelectItem>
+                  <SelectItem value="response">Custom HTTP Response</SelectItem>
+                  <SelectItem value="proxy">Forward Request (Proxy)</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+            {!hasImplicitTerminal && terminalSteps.length >= 1 && (
+              <Button type="button" variant="outline" size="sm" onClick={addTerminalBranch}>
+                <Plus className="h-4 w-4 mr-1" />
+                Add Branch
+              </Button>
+            )}
+            {hasImplicitTerminal && (
+              <Badge variant="secondary" className="text-xs">
+                AI Chat (Streaming)
+              </Badge>
+            )}
+          </div>
         </div>
 
-        {terminalStepType === 'response' && terminalStep && (
-          // Custom Response Configuration
-          <Card className="border-primary/20 bg-primary/5">
-            <CardHeader className="py-3">
-              <button
-                type="button"
-                onClick={() => setTerminalExpanded(!terminalExpanded)}
-                className="flex items-center gap-2 text-left hover:text-primary w-full"
-              >
-                {terminalExpanded ? (
-                  <ChevronDown className="h-4 w-4" />
-                ) : (
-                  <ChevronRight className="h-4 w-4" />
-                )}
-                <CardTitle className="text-sm font-medium flex items-center gap-2">
-                  <Send className="h-4 w-4" />
-                  HTTP Response
-                </CardTitle>
-                <Badge variant="outline" className="text-xs">
-                  Terminal
-                </Badge>
-              </button>
-            </CardHeader>
-            {terminalExpanded && (
-              <CardContent className="pt-0 space-y-4">
-                <AvailableVariables
-                  previousSteps={previousStepsForResponse}
-                  syntax="template"
-                  className="mb-4"
-                />
-                <ResponseHandlerConfig
-                  config={terminalStep.config as Partial<ResponseConfig>}
-                  onChange={updateTerminalConfig}
-                  previousSteps={previousStepsForResponse}
-                />
-              </CardContent>
-            )}
-          </Card>
+        {terminalSteps.length > 1 && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/50 rounded-md px-3 py-2">
+            <Info className="h-3.5 w-3.5 shrink-0" />
+            <span>
+              Branches run in order; the response comes from the last branch whose condition
+              matches. A branch without a condition always matches.
+            </span>
+          </div>
         )}
 
-        {terminalStepType === 'proxy' && terminalStep && (
-          // Proxy Forward Configuration
-          <Card className="border-blue-500/20 bg-blue-500/5">
-            <CardHeader className="py-3">
-              <button
-                type="button"
-                onClick={() => setTerminalExpanded(!terminalExpanded)}
-                className="flex items-center gap-2 text-left hover:text-primary w-full"
-              >
-                {terminalExpanded ? (
-                  <ChevronDown className="h-4 w-4" />
-                ) : (
-                  <ChevronRight className="h-4 w-4" />
-                )}
-                <CardTitle className="text-sm font-medium flex items-center gap-2">
-                  <Send className="h-4 w-4" />
-                  Forward Request
-                </CardTitle>
-                <Badge variant="outline" className="text-xs bg-blue-500/10">
-                  Proxy
-                </Badge>
-              </button>
-            </CardHeader>
-            {terminalExpanded && (
-              <CardContent className="pt-0 space-y-4">
-                <AvailableVariables
-                  previousSteps={previousStepsForResponse}
-                  syntax="template"
-                  className="mb-4"
-                />
-                <ProxyForwardConfig
-                  config={terminalStep.config as Partial<ProxyConfig>}
-                  onChange={updateTerminalConfig}
-                />
-              </CardContent>
-            )}
-          </Card>
+        {terminalSteps.length >= 1 && (
+          <div className="space-y-3">
+            {terminalSteps.map((branch, index) => {
+              const isProxy = branch.handlerType === 'proxy_forward';
+              const isExpanded = expandedTerminalSteps.has(index);
+              const key = stepKey(branch, index);
+              const branchTitle =
+                branch.name || (isProxy ? 'Forward Request' : 'HTTP Response');
+              const condition = (branch.config as Record<string, unknown>)?.condition as
+                | string
+                | undefined;
+              const showBranchControls = terminalSteps.length > 1;
+              return (
+                <Card
+                  key={key}
+                  className={isProxy ? 'border-blue-500/20 bg-blue-500/5' : 'border-primary/20 bg-primary/5'}
+                >
+                  <CardHeader className="py-3">
+                    <div className="flex items-center gap-2">
+                      {showBranchControls && (
+                        <Badge variant="secondary" className="font-mono">
+                          T{index + 1}
+                        </Badge>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => toggleTerminalExpanded(index)}
+                        className="flex-1 flex items-center gap-2 text-left hover:text-primary min-w-0"
+                      >
+                        {isExpanded ? (
+                          <ChevronDown className="h-4 w-4" />
+                        ) : (
+                          <ChevronRight className="h-4 w-4" />
+                        )}
+                        <CardTitle className="text-sm font-medium flex items-center gap-2">
+                          <Send className="h-4 w-4" />
+                          {branchTitle}
+                        </CardTitle>
+                        <Badge
+                          variant="outline"
+                          className={isProxy ? 'text-xs bg-blue-500/10' : 'text-xs'}
+                        >
+                          {isProxy ? 'Proxy' : 'Terminal'}
+                        </Badge>
+                        {showBranchControls && (
+                          <Badge
+                            variant="secondary"
+                            className="text-xs font-mono max-w-[280px] truncate"
+                            title={condition ? `when ${condition}` : 'always'}
+                          >
+                            {condition ? `when ${condition}` : 'always'}
+                          </Badge>
+                        )}
+                      </button>
+                      {showBranchControls && (
+                        <>
+                          <div className="flex gap-1">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="h-7 w-7"
+                              disabled={index === 0}
+                              aria-label={`Move ${branch.name || 'branch'} up`}
+                              onClick={() => moveTerminalBranch(index, 'up')}
+                            >
+                              <ChevronUp className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="h-7 w-7"
+                              disabled={index === terminalSteps.length - 1}
+                              aria-label={`Move ${branch.name || 'branch'} down`}
+                              onClick={() => moveTerminalBranch(index, 'down')}
+                            >
+                              <ChevronDown className="h-4 w-4" />
+                            </Button>
+                          </div>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                            aria-label={`Delete ${branch.name || 'branch'}`}
+                            onClick={() => setDeleteTerminalConfirm(index)}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </>
+                      )}
+                    </div>
+                  </CardHeader>
+                  {isExpanded && (
+                    <CardContent className="pt-0 space-y-4">
+                      {/* Respond When (optional) */}
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2">
+                          <Filter className="h-4 w-4 text-muted-foreground" />
+                          <Label htmlFor={`terminal-${key}-condition`}>
+                            Respond When{' '}
+                            <span className="text-muted-foreground font-normal">(optional)</span>
+                          </Label>
+                        </div>
+                        <ExpressionInput
+                          value={condition || ''}
+                          onChange={(value) => {
+                            const currentConfig = (branch.config || {}) as Record<string, unknown>;
+                            updateTerminalStep(index, {
+                              config: { ...currentConfig, condition: value || undefined },
+                            });
+                          }}
+                          placeholder="e.g., steps.fetch.ok or !steps.check_exists"
+                          previousSteps={previousStepsForResponse}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          This response is only used when the expression is truthy. Leave empty to
+                          always respond.
+                        </p>
+                      </div>
+
+                      <AvailableVariables
+                        previousSteps={previousStepsForResponse}
+                        syntax="template"
+                        className="mb-4"
+                      />
+                      {isProxy ? (
+                        <ProxyForwardConfig
+                          config={branch.config as Partial<ProxyConfig>}
+                          onChange={terminalConfigHandlers[index]}
+                        />
+                      ) : (
+                        <ResponseHandlerConfig
+                          config={branch.config as Partial<ResponseConfig>}
+                          onChange={terminalConfigHandlers[index]}
+                          previousSteps={previousStepsForResponse}
+                        />
+                      )}
+                    </CardContent>
+                  )}
+                </Card>
+              );
+            })}
+          </div>
         )}
 
         {terminalStepType === 'none' && !hasImplicitTerminal && (
@@ -1072,6 +1236,30 @@ data: {"type":"text-delta","value":" world"}
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => deleteConfirm !== null && removeStep(deleteConfirm)}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Delete terminal branch confirmation dialog */}
+      <AlertDialog
+        open={deleteTerminalConfirm !== null}
+        onOpenChange={() => setDeleteTerminalConfirm(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Branch</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete this response branch? This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => deleteTerminalConfirm !== null && removeTerminalBranch(deleteTerminalConfirm)}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               Delete

--- a/apps/frontend/src/components/pipelines/handlers/ResponseHandlerConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/ResponseHandlerConfig.test.tsx
@@ -32,6 +32,17 @@ function Harness({
   return <ResponseHandlerConfig config={config} onChange={handleChange} />;
 }
 
+describe('ResponseHandlerConfig status code', () => {
+  it('shows a non-preset stored status instead of blanking it out', () => {
+    const sink = { current: {} as Record<string, unknown> };
+    render(<Harness initial={{ status: 503 }} sink={sink} />);
+
+    expect(screen.getByRole('combobox', { name: /status code/i })).toHaveTextContent('503');
+    // Untouched, so the emitted config must still carry the original value.
+    expect(sink.current.status).toBe(503);
+  });
+});
+
 describe('ResponseHandlerConfig content type', () => {
   it('defaults to application/json', () => {
     render(<Harness />);

--- a/apps/frontend/src/components/pipelines/handlers/ResponseHandlerConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/ResponseHandlerConfig.tsx
@@ -173,6 +173,10 @@ export function ResponseHandlerConfig({ config, onChange, previousSteps = [] }: 
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
+              {/* Keep a non-preset status (e.g. 503 authored via the CLI) visible instead of a blank trigger */}
+              {!STATUS_CODES.some((code) => code.value === String(status)) && (
+                <SelectItem value={String(status)}>{String(status)}</SelectItem>
+              )}
               {STATUS_CODES.map((code) => (
                 <SelectItem key={code.value} value={code.value}>
                   {code.label}

--- a/docs/superpowers/specs/2026-07-18-terminal-response-branches-design.md
+++ b/docs/superpowers/specs/2026-07-18-terminal-response-branches-design.md
@@ -1,0 +1,109 @@
+# Terminal Response Branches — Design
+
+**Date:** 2026-07-18
+**Repo:** bffless/ce (frontend only)
+**Motivating case:** `landing-episodes` `/api/episodes` rule — two conditional
+`response_handler` steps (`unavailable`: 503 when `!steps.fetch_playlist.ok`,
+`respond`: 200 when `steps.fetch_playlist.ok`).
+
+## Problem
+
+The pipeline editor (`apps/frontend/src/components/pipelines/PipelineConfig.tsx`)
+models "the Terminal Step" as a singleton:
+
+1. It `.find()`s the **first** `response_handler`/`proxy_forward` and shows it as
+   the Terminal Step; every other terminal-type step is filtered out and rendered
+   **nowhere**.
+2. Every `onChange` (even editing the pipeline name) recombines the steps array as
+   `[...regularSteps, theOneTerminalStep]`, **permanently deleting** the other
+   terminal steps on save.
+3. The terminal editor exposes no `condition` field, and `updateTerminalConfig`
+   replaces the step config wholesale — expanding the card fires
+   `ResponseHandlerConfig`'s mount-time `onChange` and **strips an existing
+   `condition`**.
+
+The backend has no single-terminal concept: steps run sequentially, each step's
+`config.condition` is evaluated (skipped when falsy, preserving the previous
+step's output), and the response is the output of the last step that ran.
+Multiple conditional response handlers are a valid, useful pattern. This is
+purely a frontend editor limitation.
+
+## Design (Option B — approved in conversation)
+
+### Data model / split logic
+
+No wire-format, API, or backend changes. In `PipelineConfig.tsx`:
+
+- **Terminal branches** = the *trailing contiguous run* of
+  `response_handler`/`proxy_forward` steps at the end of `config.steps`
+  (`terminalSteps: PipelineStep[]`, order preserved).
+- Any terminal-type step that appears **before** a non-terminal step is not part
+  of the trailing run; it renders as a **regular pipeline step**
+  (`HandlerConfigWrapper` already supports `response_handler`) instead of being
+  hidden and dropped.
+- **Recombine** everywhere as `[...regularSteps, ...terminalSteps]`. All update
+  paths (`updateConfig`, `setTerminalType`, branch edits, add/remove/move
+  branch) carry the full branch list. Round-tripping is lossless — untouched
+  branches pass through byte-identical (no minted `id`s, `condition` intact).
+
+### UI
+
+- **Zero branches:** unchanged — "Terminal Step" heading, type dropdown
+  (Default Response / Custom HTTP Response / Forward Request), default-response
+  preview card.
+- **One branch:** today's single card plus:
+  - a **"Respond When (optional)"** `ExpressionInput` at the top of the expanded
+    card body (reads/writes `config.condition`, autocomplete from prior steps);
+  - an **"Add Branch"** button beside the type dropdown.
+- **Two+ branches:** heading becomes "Terminal Branches"; the type dropdown is
+  replaced by the "Add Branch" button. Each branch renders as a card:
+  - collapsed header: number badge, step name (fallback "HTTP Response" /
+    "Forward Request"), Terminal/Proxy badge, a condition summary badge
+    (`when <expr>` or `always`), move up/down, delete (with confirm dialog),
+    enable/disable switch is *not* added (branches use conditions, and
+    `isEnabled` passes through untouched);
+  - expanded body: condition input + `AvailableVariables` +
+    `ResponseHandlerConfig`/`ProxyForwardConfig`.
+  - helper text under the heading: "Branches run in order; the response comes
+    from the last branch whose condition matches. A branch without a condition
+    always matches."
+- "Add Branch" appends a `response_handler` branch
+  (`{status: 200, body: '', contentType: 'application/json'}`, unique name,
+  minted `id` — same as `addStep`) and expands it.
+- Per-branch expansion state: `Set<number>` (replaces the single
+  `terminalExpanded` boolean), same index-shifting helpers as regular steps.
+- AI-chat streaming implicit terminal behavior unchanged.
+
+### Condition preservation
+
+Branch config edits follow the regular-step idiom already used at lines
+671-677: `condition ? { ...newConfig, condition } : newConfig`. The condition
+input itself writes `{ ...step.config, condition: value || undefined }`.
+
+### Post-steps / variables
+
+`previousStepsForPost` includes **all** terminal branches (not just the first).
+Each branch's condition/body autocomplete sees all regular steps.
+
+## Out of scope
+
+- Per-branch handler-type switch (delete + re-add covers it).
+- Backend validation changes (none needed).
+- Drag-and-drop reordering (move buttons match existing step UX).
+
+## Testing
+
+Vitest (`PipelineConfig.test.tsx` conventions — the fixture there is already the
+landing-episodes pipeline):
+
+1. Two conditional response handlers both render as branch cards; renaming the
+   pipeline (an `updateConfig` path) emits **both** branches unchanged.
+2. Expanding + editing one branch's body preserves its `condition` and does not
+   touch the other branch.
+3. Add Branch appends a response branch; delete (confirmed) removes only that
+   branch; move up/down swaps order in the emitted steps.
+4. Single-terminal pipeline: dropdown behavior unchanged (`none` clears it,
+   switching to proxy replaces it); no `id` minted onto id-less branches on
+   unrelated edits.
+5. A `response_handler` occurring before a non-terminal step renders in the
+   regular steps list and survives edits.


### PR DESCRIPTION
## Problem

The pipeline editor modeled the Terminal Step as a singleton, but the backend runs steps sequentially with per-step `condition`s and returns the last step that ran — so pipelines with **multiple conditional `response_handler` steps** (e.g. the landing-episodes rule: 503 when `!steps.fetch_playlist.ok`, 200 otherwise) are fully valid at runtime yet couldn't be represented in the UI:

- Only the **first** terminal-type step was shown; the rest rendered nowhere.
- Any `onChange` (even editing the pipeline name) recombined the steps array around that single step, **permanently deleting** the other terminal handlers on save.
- The terminal editor exposed no `condition`, and merely **expanding** the card stripped an existing condition (the response editor's mount-time onChange replaced the config wholesale).

## Change

- The **trailing contiguous run** of `response_handler`/`proxy_forward` steps now renders as ordered **Terminal Branches**: one card per branch with a `when <condition>` / `always` badge in the collapsed header, a "Respond When (optional)" expression input, Add Branch, reorder, and delete-with-confirm.
- Round-tripping is lossless: recombine always emits `[...regularSteps, ...allBranches]`, branch edits preserve `condition` (same idiom as regular steps), and no `id`s are minted onto CLI-authored steps.
- A terminal-type step that appears **before** a non-terminal step stays visible in the regular steps list instead of vanishing.
- Single-terminal pipelines keep the familiar dropdown UX (Default Response / Custom HTTP Response / Forward Request).
- Branch `onChange` callbacks are identity-stable — the response editor re-emits from a mount effect keyed on the callback identity, so per-render recreation risks a feedback loop.
- Bonus fix: a non-preset status code (e.g. **503**) rendered the Status Code dropdown blank; it now shows the stored value.

No backend/API/wire-format changes. Design spec included at `docs/superpowers/specs/2026-07-18-terminal-response-branches-design.md`.

## Testing

- 11 new Vitest tests: branch rendering, condition badges, lossless rename round-trip, condition preservation through mount + edit, add/delete/move branch, no minted ids, non-trailing response handler, single-terminal dropdown behavior, 503 display.
- Full frontend suite: 506 tests passing; `tsc --noEmit` clean; eslint adds no new warnings.
- Validated in a real headless browser against the landing-episodes fixture: edited one branch's body, confirmed the emitted steps kept all four steps, both conditions, and headers intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)