### PR TITLE
fix(frontend): mobile viewport overflow and crashes across admin pages

### DIFF
--- a/apps/frontend/PRODUCT.md
+++ b/apps/frontend/PRODUCT.md
@@ -1,0 +1,35 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Developers and small teams self-hosting BFFless CE: they deploy static frontends from CI, manage deployment aliases and custom domains, wire proxy rules / pipelines as their backend, and administer users. Context is task-driven work — usually desktop, but increasingly on a phone to check a deployment, inspect data-table records, or flip an alias while away from a desk. Admins of the hosted platform (bffless.app workspaces) use the identical UI per-workspace.
+
+## Product Purpose
+
+BFFless CE admin panel: the single UI for a self-contained static-hosting + backend-for-frontend platform (deployments, branches, aliases, domains, traffic splitting, proxy rules, pipelines, data tables, uploads, users/groups, instance settings). Success = an operator can find and complete any management task quickly and confidently, on any device, without docs.
+
+## Brand Personality
+
+Pragmatic, calm, trustworthy. A developer tool in the GitHub/Vercel/shadcn lineage: neutral surfaces, dense-but-legible data, no marketing flourish inside the app. The tool should disappear into the task.
+
+## Anti-references
+
+- Marketing-style landing flourishes (hero gradients, oversized display type) inside the admin.
+- Over-decorated dashboards (gradient stat cards, glassmorphism, decorative motion).
+- Anything that breaks the "boring is trustworthy" contract of infra tools.
+
+## Design Principles
+
+1. **Task first** — every screen answers "what is this and what can I do" within seconds; chrome never competes with data.
+2. **Same vocabulary everywhere** — one button, form, table, and empty-state grammar across all 30+ pages.
+3. **Works one-handed** — the admin is genuinely used from phones; responsive behavior is structural (collapsing nav, stacking tables), not an afterthought.
+4. **State is visible** — loading, empty, error, and success states are designed, not defaulted.
+5. **Earned familiarity** — follow the conventions of the best dev tools (GitHub, Vercel, Linear) rather than inventing affordances.
+
+## Accessibility & Inclusion
+
+WCAG 2.1 AA target: 4.5:1 body contrast, full keyboard operability (Radix primitives help), visible focus, labeled icons, `sr-only` support already present. Respect `prefers-reduced-motion` and `prefers-color-scheme` (light + dark themes are both first-class).

--- a/apps/frontend/e2e/fixtures/mobile-viewport-mocks.ts
+++ b/apps/frontend/e2e/fixtures/mobile-viewport-mocks.ts
@@ -1,0 +1,269 @@
+import { Page } from '@playwright/test';
+
+/**
+ * Full-surface API mocks for the mobile viewport regression suite
+ * (mobile-viewport.spec.ts).
+ *
+ * Unlike the per-page helpers in helpers/mock-api.ts, this module mocks the
+ * ENTIRE /api surface with one catch-all route so every admin page renders
+ * with realistic data and no backend. Fixtures deliberately include
+ * stress-test values (long unbroken domain names, long emails, long URLs,
+ * long alias/schema names) because unbreakable strings are the most common
+ * cause of horizontal overflow regressions.
+ *
+ * Route table semantics: first match (method + pathname regex) wins;
+ * unmatched GET /api requests are fulfilled with `{}`.
+ */
+
+const daysAgo = (d: number) => new Date(Date.now() - d * 864e5).toISOString();
+
+const session = {
+  session: { userId: 'user-1', handle: 'sess-1' },
+  user: { id: 'user-1', email: 'admin@example.com', role: 'admin' },
+  emailVerified: true,
+  emailVerificationRequired: false,
+};
+
+const project = {
+  id: 'proj-1',
+  owner: 'acme',
+  name: 'webapp',
+  displayName: 'Web Application',
+  description: 'Main web application frontend',
+  isPublic: false,
+  unauthorizedBehavior: 'redirect_login',
+  requiredRole: 'authenticated',
+  allowPublicSignup: false,
+  settings: null,
+  defaultProxyRuleSetId: 'rs-1',
+  defaultProxyRuleSetIds: ['rs-1'],
+  createdBy: 'user-1',
+  createdAt: daysAgo(120),
+  updatedAt: daysAgo(1),
+};
+
+const mkDeployment = (i: number, branch: string, desc: string) => ({
+  id: `dep-${i}`,
+  commitSha: `${i}bc4f2a9e8d7c6b5a4938271605f4e3d2c1b0a9${i}`.slice(0, 40),
+  shortSha: `${i}bc4f2a`,
+  branch,
+  description: desc,
+  deployedAt: daysAgo(i * 0.7),
+  fileCount: 120 + i,
+  totalSize: 9_100_000 + i * 250_000,
+  isPublic: i % 2 === 0,
+});
+const deployments = [
+  mkDeployment(1, 'main', 'feat(frontend): support multiple conditional terminal response branches (#502)'),
+  mkDeployment(2, 'main', 'fix(pipelines): make the `ne` filter null-safe (IS DISTINCT FROM) (#501)'),
+  mkDeployment(3, 'feat/pipeline-primitives', 'wip: schema editor validation for deeply nested field groups'),
+  mkDeployment(4, 'main', 'chore: release main (#499)'),
+  mkDeployment(5, 'fix/mobile-overflow', 'fix long unbroken words causing layout issues'),
+];
+
+const aliases = [
+  { id: 'al-1', name: 'production', commitSha: deployments[0].commitSha, shortSha: '1bc4f2a', branch: 'main', deploymentId: 'dep-1', createdAt: daysAgo(90), updatedAt: daysAgo(1), isPublic: true, isAutoPreview: false, proxyRuleSetIds: ['rs-1'] },
+  { id: 'al-2', name: 'staging', commitSha: deployments[1].commitSha, shortSha: '2bc4f2a', branch: 'main', deploymentId: 'dep-2', createdAt: daysAgo(60), updatedAt: daysAgo(2), isPublic: false, isAutoPreview: false, proxyRuleSetIds: ['rs-1'] },
+  { id: 'al-3', name: 'pr-42-preview-long-alias-name', commitSha: deployments[2].commitSha, shortSha: '3bc4f2a', branch: 'feat/pipeline-primitives', deploymentId: 'dep-3', createdAt: daysAgo(3), updatedAt: daysAgo(3), isPublic: false, isAutoPreview: true, basePath: 'pr-42', proxyRuleSetIds: [] },
+  { id: 'al-4', name: 'www', commitSha: deployments[0].commitSha, shortSha: '1bc4f2a', branch: 'main', deploymentId: 'dep-1', createdAt: daysAgo(30), updatedAt: daysAgo(1), isPublic: true, isAutoPreview: false, proxyRuleSetIds: ['rs-1'] },
+];
+
+const schemaFeedback = {
+  id: 'schema-1',
+  projectId: 'proj-1',
+  name: 'feedback',
+  version: 1,
+  fields: [
+    { name: 'name', type: 'string', required: true },
+    { name: 'email', type: 'email', required: true },
+    { name: 'message', type: 'text', required: true },
+    { name: 'rating', type: 'number', required: false, default: 5 },
+    { name: 'createdFrom', type: 'string', required: false },
+  ],
+  createdAt: daysAgo(2),
+  updatedAt: daysAgo(1),
+  recordCount: 3,
+};
+const schemas = [
+  schemaFeedback,
+  { id: 'schema-2', projectId: 'proj-1', name: 'chat-conversations', version: 2, fields: [{ name: 'title', type: 'string', required: true }, { name: 'userId', type: 'string', required: true }], createdAt: daysAgo(40), updatedAt: daysAgo(5), recordCount: 128 },
+  { id: 'schema-3', projectId: 'proj-1', name: 'upload-manifests-with-a-long-name', version: 1, fields: [{ name: 'key', type: 'string', required: true }, { name: 'size', type: 'number', required: true }, { name: 'meta', type: 'json', required: false }], createdAt: daysAgo(10), updatedAt: daysAgo(10), recordCount: 57 },
+];
+
+const records = [
+  { id: 'rec-1', projectId: 'proj-1', schemaId: 'schema-1', alias: null, version: 1, data: { name: 'Ada Lovelace', email: 'ada@example.com', message: 'Love the new deploy flow! The alias switcher saved us during the launch. One thing: the mobile admin overflows horizontally on my phone.', rating: 5, createdFrom: 'production' }, createdBy: 'guest-8f2', createdAt: daysAgo(0.4), updatedAt: daysAgo(0.4) },
+  { id: 'rec-2', projectId: 'proj-1', schemaId: 'schema-1', alias: 'production', version: 1, data: { name: 'Grace Hopper', email: 'grace.hopper+verylongemailaddress@example-company-domain.com', message: 'Short note.', rating: 4, createdFrom: 'production' }, createdBy: null, createdAt: daysAgo(1.3), updatedAt: daysAgo(1.3) },
+  { id: 'rec-3', projectId: 'proj-1', schemaId: 'schema-1', alias: 'staging', version: 1, data: { name: 'ThisIsAnUnbrokenSuperLongUserNameFromAnAPIWithoutSpaces', email: 't@e.io', message: 'https://very-long-url.example.com/deep/path/segment/that/never/wraps/because/it/has/no/spaces/at/all', rating: 3, createdFrom: 'staging' }, createdBy: 'user-1', createdAt: daysAgo(2.1), updatedAt: daysAgo(2.1) },
+];
+
+const ruleSets = [
+  { id: 'rs-1', projectId: 'proj-1', name: 'api', description: 'Primary API rule set for the production alias', environment: 'production', source: { repo: 'acme/webapp', path: 'proxy-rules/api.json', syncedAt: daysAgo(2) }, createdAt: daysAgo(80), updatedAt: daysAgo(2) },
+  { id: 'rs-2', projectId: 'proj-1', name: 'staging-experiments', description: null, environment: 'staging', source: null, createdAt: daysAgo(20), updatedAt: daysAgo(4) },
+];
+const mkRule = (i: number, pathPattern: string, method: string | null, targetUrl: string, proxyType: string, desc: string | null) => ({
+  id: `rule-${i}`,
+  ruleSetId: 'rs-1',
+  pathPattern,
+  method,
+  methods: method ? [method] : null,
+  targetUrl,
+  stripPrefix: true,
+  order: i,
+  timeout: 30000,
+  preserveHost: false,
+  forwardCookies: true,
+  headerConfig: null,
+  authTransform: null,
+  internalRewrite: false,
+  proxyType,
+  emailHandlerConfig: null,
+  pipelineConfig: proxyType === 'pipeline' ? { handlers: [{ type: 'data_insert' }, { type: 'respond' }] } : null,
+  isEnabled: i !== 3,
+  debugEnabled: i === 2,
+  description: desc,
+  createdAt: daysAgo(30),
+  updatedAt: daysAgo(2),
+});
+const rules = [
+  mkRule(1, '/api/contact', 'POST', 'pipeline://contact-form', 'pipeline', 'Contact form intake with email notification'),
+  mkRule(2, '/api/comments/*', null, 'pipeline://comments', 'pipeline', 'Live comment wall data table access'),
+  mkRule(3, '/api/search', 'GET', 'https://search-backend.internal.example.com:9200/indexes/site/query', 'http', null),
+  mkRule(4, '/api/chat', 'POST', 'pipeline://ai-chat-streaming-with-long-target-name', 'pipeline', 'Streaming AI chat completion relay'),
+];
+
+const users = [
+  { id: 'user-1', email: 'admin@example.com', role: 'admin', disabled: false, disabledAt: null, disabledBy: null, createdAt: daysAgo(300), updatedAt: daysAgo(1) },
+  { id: 'user-2', email: 'grace.hopper+team@example-company-domain.com', role: 'member', disabled: false, disabledAt: null, disabledBy: null, createdAt: daysAgo(120), updatedAt: daysAgo(9) },
+  { id: 'user-3', email: 'former.employee@example.com', role: 'member', disabled: true, disabledAt: daysAgo(30), disabledBy: 'user-1', createdAt: daysAgo(200), updatedAt: daysAgo(30) },
+];
+
+const groups = [
+  { id: 'grp-1', name: 'engineering', description: 'Full write access to app repos', createdBy: 'user-1', createdAt: daysAgo(100), updatedAt: daysAgo(10) },
+  { id: 'grp-2', name: 'contractors-read-only', description: null, createdBy: 'user-1', createdAt: daysAgo(50), updatedAt: daysAgo(50) },
+];
+
+const repositoriesMine = {
+  total: 3,
+  repositories: [
+    { id: 'proj-1', owner: 'acme', name: 'webapp', permissionType: 'owner', role: 'admin' },
+    { id: 'proj-2', owner: 'acme', name: 'docs', permissionType: 'direct', role: 'write' },
+    { id: 'proj-3', owner: 'acme', name: 'internal-analytics-service', permissionType: 'group', role: 'read' },
+  ],
+};
+const repositoriesFeed = {
+  page: 1,
+  limit: 10,
+  total: 3,
+  repositories: [
+    { id: 'proj-1', owner: 'acme', name: 'webapp', displayName: 'Web Application', description: 'Main web application frontend', isPublic: false, permissionType: 'owner', role: 'admin', stats: { deploymentCount: 42, storageBytes: 9_100_000, storageMB: 9.1, lastDeployedAt: daysAgo(0.5) }, createdAt: daysAgo(120), updatedAt: daysAgo(0.5) },
+    { id: 'proj-2', owner: 'acme', name: 'docs', displayName: 'Documentation', description: 'API documentation and guides', isPublic: true, permissionType: 'direct', role: 'write', stats: { deploymentCount: 15, storageBytes: 10_485_760, storageMB: 10, lastDeployedAt: daysAgo(12) }, createdAt: daysAgo(300), updatedAt: daysAgo(12) },
+    { id: 'proj-3', owner: 'acme', name: 'internal-analytics-service', displayName: null, description: null, isPublic: false, permissionType: 'group', role: 'read', stats: { deploymentCount: 8, storageBytes: 5_242_880, storageMB: 5, lastDeployedAt: daysAgo(40) }, createdAt: daysAgo(220), updatedAt: daysAgo(40) },
+  ],
+};
+
+const stats = {
+  repository: 'acme/webapp',
+  totalDeployments: 42,
+  totalStorageBytes: 9_100_000,
+  totalStorageMB: 9.1,
+  lastDeployedAt: daysAgo(0.5),
+  branchCount: 3,
+  aliasCount: 4,
+  isPublic: false,
+};
+
+const refs = {
+  aliases: aliases.map((a) => ({ name: a.name, commitSha: a.commitSha, updatedAt: a.updatedAt, isAutoPreview: a.isAutoPreview })),
+  branches: [
+    { name: 'main', latestCommit: deployments[0].commitSha, latestDeployedAt: daysAgo(0.5), fileCount: 121 },
+    { name: 'feat/pipeline-primitives', latestCommit: deployments[2].commitSha, latestDeployedAt: daysAgo(2), fileCount: 118 },
+    { name: 'fix/mobile-overflow-on-schema-detail-page', latestCommit: deployments[4].commitSha, latestDeployedAt: daysAgo(3.5), fileCount: 119 },
+  ],
+  recentCommits: deployments.map((d) => ({ sha: d.commitSha, shortSha: d.shortSha, branch: d.branch, description: d.description, deployedAt: d.deployedAt, parentShas: [] })),
+  pagination: { hasMore: false, total: 5 },
+};
+
+const schedules = [
+  { id: 'sched-1', projectId: 'proj-1', name: 'nightly-cleanup', targetProxyRuleId: 'rule-2', cronExpression: '0 3 * * *', timezone: 'America/New_York', enabled: true, lastRunAt: daysAgo(0.3), nextRunAt: daysAgo(-0.7), createdAt: daysAgo(30), updatedAt: daysAgo(0.3) },
+  { id: 'sched-2', projectId: 'proj-1', name: 'weekly-digest-email-with-long-name', targetProxyRuleId: 'rule-1', cronExpression: '0 9 * * MON', timezone: 'UTC', enabled: false, lastError: 'Timeout of 30000ms exceeded while calling pipeline handler chain', createdAt: daysAgo(60), updatedAt: daysAgo(7) },
+];
+
+const domains = [
+  { id: 'dom-1', projectId: 'proj-1', alias: 'production', domain: 'example.dev', domainType: 'custom', isActive: true, isPublic: true, isSpa: true, isPrimary: true, wwwBehavior: 'redirect-to-www', sslEnabled: true, sslExpiresAt: daysAgo(-60), dnsVerified: true, dnsVerifiedAt: daysAgo(90), createdBy: 'user-1', createdAt: daysAgo(90), updatedAt: daysAgo(1) },
+  // Long unbroken domain: regression stress for min-content overflow (grid/truncate)
+  { id: 'dom-2', projectId: 'proj-1', alias: 'staging', domain: 'staging.example-with-a-long-subdomain.dev', domainType: 'custom', isActive: true, isPublic: false, isSpa: true, isPrimary: false, sslEnabled: false, dnsVerified: false, createdBy: 'user-1', createdAt: daysAgo(10), updatedAt: daysAgo(10) },
+];
+
+type RouteEntry = [method: string, pathPattern: RegExp, body: unknown];
+
+const ROUTES: RouteEntry[] = [
+  ['GET', /\/api\/auth\/session$/, session],
+  ['GET', /\/api\/auth\/oauth\/providers/, { providers: [] }],
+  ['GET', /\/api\/auth\/registration-status/, { registrationEnabled: true, allowPublicSignups: false, emailPasswordEnabled: true, requireTosAcceptance: false, tosUrl: '' }],
+  ['GET', /\/api\/auth\/me\/login-methods/, { hasPassword: true }],
+  ['GET', /\/api\/setup\/status/, { isSetupComplete: true, hasAdminUser: true, storageProvider: 'minio', emailConfigured: true }],
+  ['GET', /\/api\/settings\/branding\/public/, { siteName: 'BFFless', hasHeaderLogo: false, hasAuthLogo: false }],
+  ['GET', /\/api\/settings\/branding/, { siteName: 'BFFless', headerLogoKey: null, authLogoKey: null }],
+  ['GET', /\/api\/settings\/primary-content\/projects/, { projects: [{ id: 'proj-1', owner: 'acme', name: 'webapp', aliases: ['production', 'staging', 'www'] }] }],
+  ['GET', /\/api\/settings\/primary-content/, { enabled: true, projectId: 'proj-1', projectOwner: 'acme', projectName: 'webapp', alias: 'production', path: null, wwwEnabled: true, wwwBehavior: 'redirect-to-www', isSpa: true, updatedAt: daysAgo(5) }],
+  ['GET', /\/api\/settings\/telemetry/, { enabled: true, forcedOffByEnv: false, lastSentAt: daysAgo(0.2) }],
+  ['GET', /\/api\/feature-flags\/client/, { flags: {} }],
+  ['GET', /\/api\/feature-flags\/grouped/, { groups: [] }],
+  ['GET', /\/api\/feature-flags$/, { flags: [] }],
+  ['GET', /\/api\/aliases\/[^/]+\/[^/]+\/visibility/, { projectId: 'proj-1', alias: 'production', effectiveVisibility: 'public', source: 'alias', aliasOverride: true, projectVisibility: false, effectiveUnauthorizedBehavior: 'redirect_login', effectiveRequiredRole: 'authenticated' }],
+  ['GET', /\/api\/proxy-rules\/[^/]+\/logs\/count/, { count: 12 }],
+  ['GET', /\/api\/proxy-rules\/[^/]+\/logs/, { logs: [], total: 0 }],
+  ['GET', /\/api\/repositories\/mine/, repositoriesMine],
+  ['GET', /\/api\/repositories\/feed/, repositoriesFeed],
+  ['GET', /\/api\/repo\/[^/]+\/[^/]+\/stats/, stats],
+  ['GET', /\/api\/repo\/[^/]+\/[^/]+\/refs/, refs],
+  ['GET', /\/api\/repo\/[^/]+\/[^/]+\/deployments/, { repository: 'acme/webapp', page: 1, limit: 20, total: 5, deployments }],
+  ['GET', /\/api\/repo\/[^/]+\/[^/]+\/aliases$/, { repository: 'acme/webapp', aliases }],
+  ['GET', /\/api\/projects\/[^/]+\/[^/]+\/permissions\/users/, { users: [] }],
+  ['GET', /\/api\/projects\/[^/]+\/[^/]+\/permissions\/groups/, { groups: [] }],
+  ['GET', /\/api\/projects\/[^/]+\/[^/]+\/permissions$/, { userPermissions: [{ id: 'perm-1', projectId: 'proj-1', userId: 'user-1', role: 'owner', grantedBy: null, grantedAt: daysAgo(120), user: { id: 'user-1', email: 'admin@example.com', name: null, role: 'admin' } }], groupPermissions: [] }],
+  ['GET', /\/api\/projects\/[^/]+\/[^/]+$/, project],
+  ['GET', /\/api\/projects$/, { projects: [project] }],
+  ['GET', /\/api\/pipeline-schemas\/schema-\d+\/data/, { records, total: 3, page: 1, pageSize: 20, totalPages: 1 }],
+  ['GET', /\/api\/pipeline-schemas\/schema-1/, schemaFeedback],
+  ['GET', /\/api\/pipeline-schemas\/schema-2/, schemas[1]],
+  ['GET', /\/api\/pipeline-schemas\/schema-3/, schemas[2]],
+  ['GET', /\/api\/pipeline-schemas/, { schemas }],
+  ['GET', /\/api\/proxy-rule-sets\/project\//, { ruleSets }],
+  ['GET', /\/api\/proxy-rule-sets\/rs-1/, { ...ruleSets[0], rules }],
+  ['GET', /\/api\/proxy-rule-sets\/rs-2/, { ...ruleSets[1], rules: [] }],
+  ['GET', /\/api\/pipeline-schedules\/projects\/[^/]+\/schedules/, { data: schedules }],
+  ['GET', /\/api\/pipeline-schedules\/projects\/[^/]+\/rules/, { data: [{ id: 'rule-1', name: 'Contact form intake', ruleSetId: 'rs-1', ruleSetName: 'api' }, { id: 'rule-2', name: 'Comments', ruleSetId: 'rs-1', ruleSetName: 'api' }] }],
+  ['GET', /\/api\/users/, { data: users, meta: { page: 1, limit: 20, total: 3, totalPages: 1 } }],
+  ['GET', /\/api\/user-groups/, { groups }],
+  ['GET', /\/api\/groups/, { groups }],
+  ['GET', /\/api\/domains\/ssl\/wildcard\/status/, { exists: true, isSelfSigned: false, issuer: "Let's Encrypt", expiresAt: daysAgo(-60), daysUntilExpiry: 60, isExpiringSoon: false }],
+  ['GET', /\/api\/domains\/config/, { primaryDomain: 'example.dev', wildcardEnabled: true }],
+  ['GET', /\/api\/domains\/[^/]+\/traffic$/, { domainId: 'dom-1', weights: [], stickySessionDuration: 86400 }],
+  ['GET', /\/api\/domains\/[^/]+\/traffic\/rules/, []],
+  ['GET', /\/api\/domains\/[^/]+\/redirects/, []],
+  ['GET', /\/api\/domains\/[^/]+\/path-redirects/, []],
+  ['GET', /\/api\/domains$/, domains],
+  ['GET', /\/api\/domains/, { domains: [] }],
+  ['GET', /\/api\/me\/projects/, { projects: [] }],
+  ['GET', /\/api\/api-keys/, { apiKeys: [] }],
+  ['GET', /\/api\/storage/, { totalBytes: 9_100_000, totalMB: 9.1 }],
+  ['GET', /\/api\/traffic/, { data: [], meta: { page: 1, limit: 50, total: 0, totalPages: 0 } }],
+];
+
+/**
+ * Mock the entire /api surface. Unmatched GET requests resolve to `{}` so
+ * pages never hang on a real network call.
+ */
+export async function mockAllApis(page: Page): Promise<void> {
+  await page.route('**/api/**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const hit = ROUTES.find(([method, pattern]) => method === request.method() && pattern.test(url.pathname));
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(hit ? hit[2] : {}),
+    });
+  });
+}

--- a/apps/frontend/e2e/mobile-viewport.spec.ts
+++ b/apps/frontend/e2e/mobile-viewport.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, Page } from '@playwright/test';
+import { mockAllApis } from './fixtures/mobile-viewport-mocks';
+
+/**
+ * Mobile viewport regression suite
+ *
+ * Guards against horizontal overflow at phone width: every admin route must
+ * lay out within a 375px viewport (document.scrollWidth === viewport width).
+ * This is the regression that shipped when the repo tab bar (7 non-wrapping
+ * tabs) forced every /repo/* page out to 641px, project settings to 1168px.
+ *
+ * The whole /api surface is mocked (see fixtures/mobile-viewport-mocks.ts),
+ * so the suite runs without a backend and with deliberately hostile data
+ * (long unbroken domains, emails, URLs, alias names).
+ *
+ * Run with: pnpm test:e2e mobile-viewport
+ */
+
+const VIEWPORT = { width: 375, height: 667 };
+
+interface RouteSpec {
+  name: string;
+  path: string;
+  /** Also capture with the dark theme applied */
+  dark?: boolean;
+}
+
+const ROUTES: RouteSpec[] = [
+  { name: 'home', path: '/', dark: true },
+  { name: 'repositories list', path: '/repo' },
+  { name: 'repo overview', path: '/repo/acme/webapp', dark: true },
+  { name: 'repo deployments', path: '/repo/acme/webapp/deployments' },
+  { name: 'repo branches', path: '/repo/acme/webapp/branches' },
+  { name: 'repo aliases', path: '/repo/acme/webapp/aliases' },
+  { name: 'repo proxy rules', path: '/repo/acme/webapp/proxy-rules' },
+  { name: 'repo rule set detail', path: '/repo/acme/webapp/proxy-rules/rs-1' },
+  { name: 'repo schedules', path: '/repo/acme/webapp/schedules' },
+  { name: 'repo data schemas', path: '/repo/acme/webapp/data' },
+  { name: 'repo schema detail', path: '/repo/acme/webapp/data/schema-1', dark: true },
+  { name: 'repo uploads', path: '/repo/acme/webapp/uploads' },
+  { name: 'project settings', path: '/repo/acme/webapp/settings' },
+  { name: 'user settings', path: '/settings' },
+  { name: 'admin settings', path: '/admin/settings' },
+  { name: 'users', path: '/users' },
+  { name: 'groups', path: '/groups' },
+  { name: 'domains', path: '/domains' },
+  { name: 'traffic', path: '/traffic' },
+];
+
+async function assertNoHorizontalOverflow(page: Page, path: string, theme: 'light' | 'dark') {
+  await page.addInitScript((t) => {
+    try {
+      localStorage.setItem('app-theme', t);
+    } catch {
+      /* storage unavailable */
+    }
+  }, theme);
+  await mockAllApis(page);
+
+  await page.goto(path, { waitUntil: 'networkidle' });
+  // Give post-load renders (charts, expanding lists) a beat to settle
+  await page.waitForTimeout(500);
+
+  const widths = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+    bodyScrollWidth: document.body.scrollWidth,
+  }));
+
+  expect(
+    widths.scrollWidth,
+    `${path} (${theme}) overflows horizontally: document is ${widths.scrollWidth}px in a ${widths.clientWidth}px viewport`,
+  ).toBeLessThanOrEqual(widths.clientWidth + 1);
+  expect(
+    widths.bodyScrollWidth,
+    `${path} (${theme}) body overflows horizontally`,
+  ).toBeLessThanOrEqual(widths.clientWidth + 1);
+}
+
+test.describe('Mobile viewport (375px) has no horizontal overflow', () => {
+  test.use({ viewport: VIEWPORT, hasTouch: true });
+
+  for (const route of ROUTES) {
+    test(`${route.name} fits the viewport`, async ({ page }) => {
+      await assertNoHorizontalOverflow(page, route.path, 'light');
+    });
+
+    if (route.dark) {
+      test(`${route.name} fits the viewport (dark)`, async ({ page }) => {
+        await assertNoHorizontalOverflow(page, route.path, 'dark');
+      });
+    }
+  }
+});

--- a/apps/frontend/src/components/ErrorBoundary.tsx
+++ b/apps/frontend/src/components/ErrorBoundary.tsx
@@ -70,10 +70,13 @@ export class ErrorBoundary extends Component<Props, State> {
               </p>
             </div>
 
-            {/* Show error details in development */}
+            {/* Show error details in development, collapsed by default */}
             {process.env.NODE_ENV === 'development' && this.state.error && (
-              <div className="rounded-md bg-muted p-4 text-left">
-                <p className="font-mono text-sm text-destructive break-all">
+              <details className="rounded-md bg-muted p-4 text-left">
+                <summary className="cursor-pointer text-sm font-medium text-muted-foreground">
+                  Show technical details
+                </summary>
+                <p className="mt-2 font-mono text-sm text-destructive break-all">
                   {this.state.error.message}
                 </p>
                 {this.state.errorInfo && (
@@ -81,7 +84,7 @@ export class ErrorBoundary extends Component<Props, State> {
                     {this.state.errorInfo.componentStack}
                   </pre>
                 )}
-              </div>
+              </details>
             )}
 
             <div className="flex justify-center gap-4">

--- a/apps/frontend/src/components/common/TabScroller.tsx
+++ b/apps/frontend/src/components/common/TabScroller.tsx
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+
+interface TabScrollerProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Horizontal scroll container for tab strips that can be wider than the viewport
+ * (e.g. the 7-tab repository nav at phone widths). Wraps the stock shadcn
+ * TabsList at the call site so the primitive stays unmodified.
+ *
+ * - scrolls the active trigger into view on mount
+ * - fades the clipped edges so hidden tabs are discoverable on touch screens
+ * - hides the scrollbar; the cut-off tab plus edge fade is the affordance
+ */
+export function TabScroller({ className, children }: TabScrollerProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [fade, setFade] = useState({ left: false, right: false });
+
+  const updateFade = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setFade({
+      left: el.scrollLeft > 4,
+      right: el.scrollLeft + el.clientWidth < el.scrollWidth - 4,
+    });
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    // Center the active trigger when the strip overflows
+    const active = el.querySelector<HTMLElement>('[data-state="active"], [aria-current="page"]');
+    if (active && el.scrollWidth > el.clientWidth) {
+      el.scrollLeft = Math.max(0, active.offsetLeft - (el.clientWidth - active.offsetWidth) / 2);
+    }
+    updateFade();
+    window.addEventListener('resize', updateFade);
+    return () => window.removeEventListener('resize', updateFade);
+  }, [updateFade]);
+
+  return (
+    <div className={cn('relative', className)}>
+      <div
+        ref={scrollRef}
+        onScroll={updateFade}
+        className="overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        {children}
+      </div>
+      <div
+        aria-hidden
+        className={cn(
+          'pointer-events-none absolute inset-y-0 left-0 w-6 bg-gradient-to-r from-background to-transparent transition-opacity',
+          fade.left ? 'opacity-100' : 'opacity-0',
+        )}
+      />
+      <div
+        aria-hidden
+        className={cn(
+          'pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-background to-transparent transition-opacity',
+          fade.right ? 'opacity-100' : 'opacity-0',
+        )}
+      />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/data/DataBrowser.tsx
+++ b/apps/frontend/src/components/data/DataBrowser.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { Fragment, useState, useEffect, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -352,8 +352,8 @@ export function DataBrowser({ schemaId, fields, canEdit }: DataBrowserProps) {
                   </TableHeader>
                   <TableBody>
                     {records.map((record) => (
-                      <>
-                        <TableRow key={record.id}>
+                      <Fragment key={record.id}>
+                        <TableRow>
                           {canEdit && (
                             <TableCell>
                               <Checkbox
@@ -387,7 +387,9 @@ export function DataBrowser({ schemaId, fields, canEdit }: DataBrowserProps) {
                                     className="flex items-center gap-1 hover:text-foreground text-muted-foreground transition-colors cursor-pointer"
                                     onClick={() => copyToClipboard(record.id)}
                                   >
-                                    <span>{record.id.slice(0, 8)}...</span>
+                                    <span className="whitespace-nowrap font-mono text-xs">
+                                      {record.id.slice(0, 8)}...
+                                    </span>
                                     {copiedId === record.id ? (
                                       <Check className="h-3 w-3 text-green-500" />
                                     ) : (
@@ -452,7 +454,7 @@ export function DataBrowser({ schemaId, fields, canEdit }: DataBrowserProps) {
                             </TableCell>
                           </TableRow>
                         )}
-                      </>
+                      </Fragment>
                     ))}
                   </TableBody>
                 </Table>

--- a/apps/frontend/src/components/data/SchemaFieldsTable.tsx
+++ b/apps/frontend/src/components/data/SchemaFieldsTable.tsx
@@ -13,13 +13,16 @@ interface SchemaFieldsTableProps {
   fields: SchemaField[];
 }
 
+// All field types share one badge weight: the type name is the information,
+// so mixed fill weights would read as false emphasis. "Required" keeps the
+// filled variant since it is the only genuinely load-bearing flag in the table.
 const FIELD_TYPE_LABELS: Record<string, { label: string; variant: 'default' | 'secondary' | 'outline' }> = {
   string: { label: 'String', variant: 'outline' },
   text: { label: 'Text', variant: 'outline' },
-  number: { label: 'Number', variant: 'secondary' },
-  boolean: { label: 'Boolean', variant: 'secondary' },
-  email: { label: 'Email', variant: 'default' },
-  datetime: { label: 'DateTime', variant: 'secondary' },
+  number: { label: 'Number', variant: 'outline' },
+  boolean: { label: 'Boolean', variant: 'outline' },
+  email: { label: 'Email', variant: 'outline' },
+  datetime: { label: 'DateTime', variant: 'outline' },
   json: { label: 'JSON', variant: 'outline' },
 };
 

--- a/apps/frontend/src/components/domains/DomainCard.tsx
+++ b/apps/frontend/src/components/domains/DomainCard.tsx
@@ -245,26 +245,26 @@ export function DomainCard({ domain, projectName, onEdit, onDelete }: DomainCard
   const sslExpiry = domain.sslExpiresAt ? formatExpiryDate(domain.sslExpiresAt) : null;
 
   return (
-    <Card>
+    <Card className="min-w-0">
       <CardHeader>
-        <div className="flex items-start justify-between">
-          <div className="flex-1">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
             {/* Project name as title for non-redirect domains */}
             {projectName && domain.domainType !== 'redirect' && (
               <p className="text-sm font-medium text-muted-foreground mb-1">
                 {projectName}
               </p>
             )}
-            <div className="flex items-center gap-2">
+            <div className="flex min-w-0 items-center gap-2">
               <a
                 href={fullUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-lg font-semibold hover:underline"
+                className="min-w-0 truncate text-lg font-semibold hover:underline"
               >
                 {domain.domain}
               </a>
-              <ExternalLink className="h-4 w-4 text-muted-foreground" />
+              <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground" />
             </div>
             <p className="text-xs text-muted-foreground mt-1">
               {domain.domainType === 'subdomain' ? 'Subdomain' : domain.domainType === 'redirect' ? 'Redirect Domain' : 'Custom Domain'}
@@ -288,7 +288,7 @@ export function DomainCard({ domain, projectName, onEdit, onDelete }: DomainCard
             )}
           </div>
 
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             {/* Phase B5: Visibility badge */}
             {visibilityInfo && (
               <Badge
@@ -337,14 +337,14 @@ export function DomainCard({ domain, projectName, onEdit, onDelete }: DomainCard
           )}
 
           {/* Phase C: Traffic split indicator - only for non-redirect domains */}
-          {domain.domainType !== 'redirect' && trafficConfig && trafficConfig.weights.length > 0 && (
+          {domain.domainType !== 'redirect' && (trafficConfig?.weights?.length ?? 0) > 0 && (
             <div className="flex items-center gap-2">
               <span className="font-medium flex items-center gap-1">
                 <Split className="h-3 w-3 text-purple-600" />
                 Traffic Split:
               </span>
               <div className="flex flex-wrap gap-1">
-                {trafficConfig.weights.map((w) => (
+                {trafficConfig?.weights?.map((w) => (
                   <Badge key={w.alias} variant="outline" className="text-xs">
                     {w.alias}: {w.weight}%
                   </Badge>
@@ -845,7 +845,7 @@ export function DomainCard({ domain, projectName, onEdit, onDelete }: DomainCard
         </div>
       </CardContent>
 
-      <CardFooter className="flex justify-end gap-2">
+      <CardFooter className="flex flex-wrap justify-end gap-2">
         {/* Verify/Re-check DNS button for custom and redirect domains */}
         {/* Hidden when external proxy (Cloudflare) handles DNS/routing */}
         {/* Note: In platform mode, subdomains have wildcard DNS, but custom domains still need manual verification */}

--- a/apps/frontend/src/components/proxy-rules/RuleSetCard.tsx
+++ b/apps/frontend/src/components/proxy-rules/RuleSetCard.tsx
@@ -31,10 +31,10 @@ export function RuleSetCard({
       to={href}
       className="flex items-center justify-between p-4 rounded-lg border hover:bg-accent transition-colors group"
     >
-      <div className="flex items-center gap-4">
-        <Settings className="h-5 w-5 text-muted-foreground" />
-        <div>
-          <div className="flex items-center gap-2">
+      <div className="flex min-w-0 items-center gap-4">
+        <Settings className="h-5 w-5 shrink-0 text-muted-foreground" />
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
             <span className="font-medium">{name}</span>
             {environment && (
               <Badge variant="outline" className="text-xs">

--- a/apps/frontend/src/components/repo/AliasesTab.tsx
+++ b/apps/frontend/src/components/repo/AliasesTab.tsx
@@ -199,24 +199,40 @@ function AliasRow({
         )}
       </div>
 
-      {/* Actions */}
-      <div className="flex items-center gap-1 justify-end md:justify-start">
-        <Button variant="ghost" size="sm" className="h-8 px-2" title="View alias" onClick={onView}>
-          <Eye className="h-3 w-3" />
+      {/* Actions - larger touch targets and wider gaps below sm so the
+          destructive delete is not a mis-tap away from edit */}
+      <div className="flex items-center gap-2 justify-end sm:gap-1 md:justify-start">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-11 w-11 p-0 sm:h-8 sm:w-auto sm:px-2"
+          title="View alias"
+          aria-label="View alias"
+          onClick={onView}
+        >
+          <Eye className="h-4 w-4 sm:h-3 sm:w-3" />
         </Button>
         {canEdit && (
           <>
-            <Button variant="ghost" size="sm" className="h-8 px-2" title="Edit alias" onClick={onEdit}>
-              <Pencil className="h-3 w-3" />
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-11 w-11 p-0 sm:h-8 sm:w-auto sm:px-2"
+              title="Edit alias"
+              aria-label="Edit alias"
+              onClick={onEdit}
+            >
+              <Pencil className="h-4 w-4 sm:h-3 sm:w-3" />
             </Button>
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 px-2 text-destructive hover:text-destructive"
+              className="h-11 w-11 p-0 text-destructive hover:text-destructive sm:h-8 sm:w-auto sm:px-2"
               title="Delete alias"
+              aria-label="Delete alias"
               onClick={onDelete}
             >
-              <Trash2 className="h-3 w-3" />
+              <Trash2 className="h-4 w-4 sm:h-3 sm:w-3" />
             </Button>
           </>
         )}

--- a/apps/frontend/src/components/repo/RepositoryStatsHeader.tsx
+++ b/apps/frontend/src/components/repo/RepositoryStatsHeader.tsx
@@ -48,68 +48,57 @@ const formatDate = (dateString: string | null): string => {
 };
 
 /**
- * RepositoryStatsHeader - Displays repository statistics in card format
+ * RepositoryStatsHeader - Displays repository statistics
  * Shows: Total Deployments, Storage Used, Branches, and Aliases
+ *
+ * Below `md` the four cards collapse into one compact 2x2 strip so the tab
+ * content (the reason the user navigated here) stays above the fold on phones.
  */
 export function RepositoryStatsHeader({ stats }: RepositoryStatsHeaderProps) {
+  const items = [
+    { label: 'Deployments', icon: Package, value: String(stats.totalDeployments) },
+    { label: 'Storage Used', icon: HardDrive, value: formatStorageSize(stats.totalStorageBytes) },
+    { label: 'Branches', icon: GitBranch, value: String(stats.branchCount) },
+    {
+      label: 'Aliases',
+      icon: Tag,
+      value: String(stats.aliasCount),
+      detail: `Last: ${formatDate(stats.lastDeployedAt)}`,
+    },
+  ];
+
   return (
-    <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-      {/* Deployments Card */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-sm font-medium flex items-center gap-2">
-            <Package className="h-4 w-4" />
-            Deployments
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{stats.totalDeployments}</div>
-        </CardContent>
-      </Card>
-
-      {/* Storage Card */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-sm font-medium flex items-center gap-2">
-            <HardDrive className="h-4 w-4" />
-            Storage Used
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">
-            {formatStorageSize(stats.totalStorageBytes)}
+    <>
+      {/* Mobile: compact 2x2 strip */}
+      <div className="grid grid-cols-2 gap-px overflow-hidden rounded-lg border bg-border md:hidden">
+        {items.map(({ label, icon: Icon, value }) => (
+          <div key={label} className="flex items-center gap-2.5 bg-card px-3 py-2.5">
+            <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <div className="min-w-0">
+              <div className="truncate text-xs text-muted-foreground">{label}</div>
+              <div className="text-sm font-semibold">{value}</div>
+            </div>
           </div>
-        </CardContent>
-      </Card>
+        ))}
+      </div>
 
-      {/* Branches Card */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-sm font-medium flex items-center gap-2">
-            <GitBranch className="h-4 w-4" />
-            Branches
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{stats.branchCount}</div>
-        </CardContent>
-      </Card>
-
-      {/* Aliases Card */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-sm font-medium flex items-center gap-2">
-            <Tag className="h-4 w-4" />
-            Aliases
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{stats.aliasCount}</div>
-          <p className="text-xs text-muted-foreground mt-1">
-            Last: {formatDate(stats.lastDeployedAt)}
-          </p>
-        </CardContent>
-      </Card>
-    </div>
+      {/* Desktop: card per stat */}
+      <div className="hidden gap-4 md:grid md:grid-cols-4">
+        {items.map(({ label, icon: Icon, value, detail }) => (
+          <Card key={label}>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm font-medium flex items-center gap-2">
+                <Icon className="h-4 w-4" />
+                {label}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{value}</div>
+              {detail && <p className="text-xs text-muted-foreground mt-1">{detail}</p>}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </>
   );
 }

--- a/apps/frontend/src/components/repositories/GlobalSearchBar.test.tsx
+++ b/apps/frontend/src/components/repositories/GlobalSearchBar.test.tsx
@@ -306,14 +306,42 @@ describe('GlobalSearchBar', () => {
     expect(clearButton).toHaveAttribute('type', 'button');
   });
 
-  it('displays keyboard shortcut hint in placeholder', () => {
+  it('hides the keyboard shortcut hint on narrow (touch) viewports', () => {
+    // The global matchMedia mock reports matches: false, i.e. below the sm breakpoint
     render(
       <ReduxWrapper store={store}>
         <GlobalSearchBar />
       </ReduxWrapper>
     );
 
-    const input = screen.getByPlaceholderText(/press \/ to focus/i);
+    const input = screen.getByPlaceholderText('Search all repositories...');
     expect(input).toBeInTheDocument();
+  });
+
+  it('displays keyboard shortcut hint in placeholder on wide viewports', () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = ((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+
+    try {
+      render(
+        <ReduxWrapper store={store}>
+          <GlobalSearchBar />
+        </ReduxWrapper>
+      );
+
+      const input = screen.getByPlaceholderText(/press \/ to focus/i);
+      expect(input).toBeInTheDocument();
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
   });
 });

--- a/apps/frontend/src/components/repositories/GlobalSearchBar.tsx
+++ b/apps/frontend/src/components/repositories/GlobalSearchBar.tsx
@@ -4,6 +4,7 @@ import { setFeedSearch } from '@/store/slices/repositoryListSlice';
 import { Input } from '@/components/ui/input';
 import { Search, X } from 'lucide-react';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 
 export function GlobalSearchBar() {
   const dispatch = useAppDispatch();
@@ -12,6 +13,8 @@ export function GlobalSearchBar() {
 
   // Local state for immediate UI update
   const [localSearch, setLocalSearch] = useState(feedSearch);
+  // The "/" shortcut hint only makes sense where a hardware keyboard is likely
+  const hasKeyboardViewport = useMediaQuery('(min-width: 640px)');
 
   // Debounced value for API call
   const debouncedSearch = useDebouncedValue(localSearch, 300);
@@ -67,7 +70,11 @@ export function GlobalSearchBar() {
       <Input
         ref={inputRef}
         type="search"
-        placeholder="Search all repositories... (press / to focus)"
+        placeholder={
+          hasKeyboardViewport
+            ? 'Search all repositories... (press / to focus)'
+            : 'Search all repositories...'
+        }
         value={localSearch}
         onChange={(e) => setLocalSearch(e.target.value)}
         className="pl-10 pr-10"

--- a/apps/frontend/src/components/settings/PrimaryContentSettings.tsx
+++ b/apps/frontend/src/components/settings/PrimaryContentSettings.tsx
@@ -89,7 +89,7 @@ export function PrimaryContentSettings() {
   }, [config]);
 
   // Get selected project's available aliases
-  const selectedProject = projectsData?.projects.find((p) => p.id === projectId);
+  const selectedProject = projectsData?.projects?.find((p) => p.id === projectId);
   const availableAliases = selectedProject?.aliases || [];
 
   // Reset alias when project changes

--- a/apps/frontend/src/components/ui/badge.tsx
+++ b/apps/frontend/src/components/ui/badge.tsx
@@ -27,10 +27,13 @@ export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
-function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  )
-}
+const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
+  ({ className, variant, ...props }, ref) => {
+    return (
+      <div ref={ref} className={cn(badgeVariants({ variant }), className)} {...props} />
+    )
+  }
+)
+Badge.displayName = "Badge"
 
 export { Badge, badgeVariants }

--- a/apps/frontend/src/pages/AdminSettingsPage.tsx
+++ b/apps/frontend/src/pages/AdminSettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, Link, Outlet, useLocation } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { TabScroller } from '@/components/common/TabScroller';
 import { ArrowLeft, Settings, Paintbrush, Shield, Mail, Server } from 'lucide-react';
 
 const TABS = [
@@ -52,16 +53,18 @@ export function AdminSettingsPage() {
 
       {/* Tabs Navigation */}
       <Tabs value={currentTab} className="w-full">
-        <TabsList>
-          {TABS.map(({ value, path, label, icon: Icon }) => (
-            <TabsTrigger key={value} value={value} asChild>
-              <Link to={path} className="gap-1.5">
-                <Icon className="h-4 w-4" />
-                {label}
-              </Link>
-            </TabsTrigger>
-          ))}
-        </TabsList>
+        <TabScroller>
+          <TabsList>
+            {TABS.map(({ value, path, label, icon: Icon }) => (
+              <TabsTrigger key={value} value={value} asChild>
+                <Link to={path} className="gap-1.5">
+                  <Icon className="h-4 w-4" />
+                  {label}
+                </Link>
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </TabScroller>
       </Tabs>
 
       {/* Tab Content - rendered via Outlet */}

--- a/apps/frontend/src/pages/DomainsPage.tsx
+++ b/apps/frontend/src/pages/DomainsPage.tsx
@@ -190,9 +190,9 @@ export function DomainsPage() {
 
   return (
     <div className="container mx-auto py-8">
-      <div className="flex items-center justify-between mb-8">
+      <div className="mb-8 flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h1 className="text-3xl font-bold">Domain Mappings</h1>
+          <h1 className="text-2xl font-bold">Domain Mappings</h1>
           <p className="text-muted-foreground mt-1">
             Manage custom domain mappings for your deployments
           </p>
@@ -279,13 +279,14 @@ export function DomainsPage() {
 
       {/* Domain List */}
       {isLoading ? (
-        <div className="grid gap-4">
+        <div className="grid gap-4" role="status" aria-live="polite">
+          <p className="text-sm text-muted-foreground">Loading domain mappings…</p>
           {[1, 2, 3].map((i) => (
             <Skeleton key={i} className="h-48 w-full" />
           ))}
         </div>
       ) : filteredDomains && filteredDomains.length > 0 ? (
-        <div className="grid gap-4">
+        <div className="grid grid-cols-[minmax(0,1fr)] gap-4">
           {filteredDomains.map((domain) => {
             const project = projects?.find((p) => p.id === domain.projectId);
             const projectName = project ? `${project.owner}/${project.name}` : undefined;

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -69,12 +69,17 @@ export function HomePage() {
   // Show onboarding modal if user hasn't completed onboarding
   // Only show for admin/user roles since they can create repos (the modal guides through repo creation)
   // Members cannot create repos, so skip the modal for them
+  // Also skip when repositories already exist: the local hasCompletedOnboarding flag is
+  // per-browser, so a new device/cleared storage must not re-trigger "create your first
+  // repository" over a workspace that already has repos. Wait for the query to resolve so
+  // the modal never flashes before the count is known.
   useEffect(() => {
     const canCreateRepos = sessionData?.user?.role === 'admin' || sessionData?.user?.role === 'user';
-    if (sessionData?.user && !hasCompletedOnboarding && canCreateRepos) {
+    const hasNoRepos = myRepos !== undefined && (myRepos.total ?? 0) === 0;
+    if (sessionData?.user && !hasCompletedOnboarding && canCreateRepos && hasNoRepos) {
       setShowOnboarding(true);
     }
-  }, [sessionData, hasCompletedOnboarding]);
+  }, [sessionData, hasCompletedOnboarding, myRepos]);
 
   // Check setup status first - redirect to setup if not complete
   if (!isSetupLoading && setupStatus && !setupStatus.isSetupComplete) {
@@ -107,7 +112,7 @@ export function HomePage() {
               />
             </div>
             <div className="text-center md:text-left">
-              <h1 className="text-3xl md:text-4xl font-bold text-[#3a3a3a] dark:text-foreground">
+              <h1 className="text-3xl md:text-4xl font-bold text-foreground">
                 Welcome{user ? `, ${user.email.split('@')[0]}` : ''}
               </h1>
               <p className="mt-2 text-lg text-[#4a4a4a] dark:text-muted-foreground">

--- a/apps/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/apps/frontend/src/pages/ProjectSettingsPage.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { TabScroller } from '@/components/common/TabScroller';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
@@ -101,7 +102,7 @@ export function ProjectSettingsPage() {
   // Check if current user has admin or owner role.
   // Global admins are treated as project Owner on every project (see docs: authorization.md).
   const isGlobalAdmin = currentUser?.role === 'admin';
-  const userPermission = permissions?.userPermissions.find(
+  const userPermission = permissions?.userPermissions?.find(
     (perm) => perm.userId === currentUser?.id,
   );
   const hasAdminAccess =
@@ -272,7 +273,8 @@ export function ProjectSettingsPage() {
       {/* Content */}
       <div className="p-8 max-w-6xl mx-auto">
         <Tabs value={currentTab} onValueChange={handleTabChange}>
-          <TabsList>
+          <TabScroller>
+            <TabsList>
             <TabsTrigger value="general">General</TabsTrigger>
             <TabsTrigger value="members">Members</TabsTrigger>
             <TabsTrigger value="invite-links">Invite Links</TabsTrigger>
@@ -285,7 +287,8 @@ export function ProjectSettingsPage() {
             <TabsTrigger value="share-links">Share Links</TabsTrigger>
             <TabsTrigger value="ai">AI</TabsTrigger>
             <TabsTrigger value="integrations">Integrations</TabsTrigger>
-          </TabsList>
+            </TabsList>
+          </TabScroller>
 
           {/* General Tab */}
           <TabsContent value="general" className="space-y-6 mt-6">

--- a/apps/frontend/src/pages/ProxyRuleSetsPage.tsx
+++ b/apps/frontend/src/pages/ProxyRuleSetsPage.tsx
@@ -204,13 +204,13 @@ export function ProxyRuleSetsPage() {
   return (
     <>
       <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
+        <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-3">
           <div>
             <CardTitle>Proxy Rule Sets</CardTitle>
             <CardDescription>Manage reusable proxy rule configurations</CardDescription>
           </div>
           {canEdit && (
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <Button
                 variant="outline"
                 size="sm"

--- a/apps/frontend/src/pages/RepositoryLayout.tsx
+++ b/apps/frontend/src/pages/RepositoryLayout.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { TabScroller } from '@/components/common/TabScroller';
 import { AlertCircle, RefreshCw, Settings } from 'lucide-react';
 import { RepositoryStatsHeader } from '@/components/repo/RepositoryStatsHeader';
 import { routes } from '@/utils/routes';
@@ -145,7 +146,8 @@ export function RepositoryLayout() {
 
         {/* Tabs Navigation */}
         <Tabs value={currentTab} className="w-full">
-          <TabsList>
+          <TabScroller>
+            <TabsList>
             <TabsTrigger value="deployments" asChild>
               <Link to={routes.deployments(owner!, repo!)}>Deployments</Link>
             </TabsTrigger>
@@ -167,7 +169,8 @@ export function RepositoryLayout() {
             <TabsTrigger value="uploads" asChild>
               <Link to={`/repo/${owner}/${repo}/uploads`}>Uploads</Link>
             </TabsTrigger>
-          </TabsList>
+            </TabsList>
+          </TabScroller>
         </Tabs>
 
         {/* Tab Content - rendered via Outlet */}

--- a/apps/frontend/src/pages/RuleSetDetailPage.tsx
+++ b/apps/frontend/src/pages/RuleSetDetailPage.tsx
@@ -185,9 +185,9 @@ export function RuleSetDetailPage() {
 
       {/* Rule Set Content */}
       <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
+        <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-3">
           <div>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <CardTitle>{ruleSet.name}</CardTitle>
               {ruleSet.environment && (
                 <Badge variant="outline">{ruleSet.environment}</Badge>

--- a/apps/frontend/src/pages/SchemaDetailPage.tsx
+++ b/apps/frontend/src/pages/SchemaDetailPage.tsx
@@ -137,15 +137,15 @@ export function SchemaDetailPage() {
     <>
       <div className="space-y-6">
         {/* Back link and actions */}
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <Link
             to={`/repo/${owner}/${repo}/data`}
-            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+            className="inline-flex items-center whitespace-nowrap text-sm text-muted-foreground hover:text-foreground"
           >
             <ArrowLeft className="h-4 w-4 mr-1" />
             Back to Schemas
           </Link>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <Button
               variant="outline"
               size="sm"

--- a/apps/frontend/src/pages/SchemasListPage.tsx
+++ b/apps/frontend/src/pages/SchemasListPage.tsx
@@ -148,13 +148,13 @@ export function SchemasListPage() {
   return (
     <>
       <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
+        <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-3">
           <div>
             <CardTitle>Data Schemas</CardTitle>
             <CardDescription>Manage data structures for pipeline handlers</CardDescription>
           </div>
           {canEdit && (
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <Button
                 variant="outline"
                 size="sm"

--- a/apps/frontend/src/pages/TrafficPage.tsx
+++ b/apps/frontend/src/pages/TrafficPage.tsx
@@ -57,11 +57,11 @@ export function TrafficPage() {
     <div className="container mx-auto px-4 py-8 max-w-7xl">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-[#3a3a3a] dark:text-foreground flex items-center gap-2">
+          <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
             <Activity className="h-6 w-6 text-[#d96459]" />
             Traffic
           </h1>
-          <p className="text-sm text-[#4a4a4a] dark:text-muted-foreground mt-1">
+          <p className="text-sm text-muted-foreground mt-1">
             Requests hitting this instance, as the application observes them
           </p>
         </div>
@@ -153,7 +153,7 @@ export function LiveTrafficTab() {
             <CardTitle className="text-base">Live requests</CardTitle>
             <ConnectionBadge state={connection} paused={paused} />
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
             <div className="flex items-center gap-2">
               <Switch id="show-all" checked={showAll} onCheckedChange={setShowAll} />
               <Label htmlFor="show-all" className="text-sm cursor-pointer">
@@ -177,7 +177,7 @@ export function LiveTrafficTab() {
           </div>
         </div>
         {!showAll && (
-          <p className="text-xs text-[#4a4a4a] dark:text-muted-foreground">
+          <p className="text-xs text-muted-foreground">
             Showing Unmatched and 4xx/5xx requests only
             {events.length > visibleEvents.length &&
               ` — ${events.length - visibleEvents.length} matched request${events.length - visibleEvents.length === 1 ? '' : 's'} hidden`}
@@ -263,7 +263,7 @@ function ConnectionBadge({ state, paused }: { state: ConnectionState; paused: bo
   }
   if (state === 'connecting') {
     return (
-      <Badge variant="outline" className="text-[#4a4a4a] dark:text-muted-foreground">
+      <Badge variant="outline" className="text-muted-foreground">
         Connecting…
       </Badge>
     );

--- a/apps/frontend/src/pages/UploadsListPage.tsx
+++ b/apps/frontend/src/pages/UploadsListPage.tsx
@@ -115,7 +115,7 @@ export function UploadsListPage() {
   return (
     <>
       <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
+        <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-3">
           <div>
             <CardTitle>Uploads</CardTitle>
             <CardDescription>Manage file uploads and uploaded files</CardDescription>
@@ -166,7 +166,7 @@ export function UploadsListPage() {
                   </h3>
                   <div className="flex items-center gap-2">
                     <Select value={selectedSchemaId} onValueChange={setSelectedSchemaId}>
-                      <SelectTrigger className="w-full">
+                      <SelectTrigger className="w-full min-w-0 flex-1">
                         <SelectValue placeholder="Select a schema to browse uploads..." />
                       </SelectTrigger>
                       <SelectContent>
@@ -179,6 +179,7 @@ export function UploadsListPage() {
                     </Select>
                     <Button
                       variant="outline"
+                      className="shrink-0"
                       disabled={!selectedSchemaId}
                       onClick={() => {
                         if (selectedSchemaId) {

--- a/apps/frontend/src/pages/UserGroupsPage.tsx
+++ b/apps/frontend/src/pages/UserGroupsPage.tsx
@@ -40,6 +40,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 
 /**
@@ -186,7 +187,7 @@ export function UserGroupsPage() {
       <div className="p-8 max-w-6xl mx-auto">
         <Card>
           <CardHeader>
-            <div className="flex items-center justify-between">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <CardTitle>Manage User Groups</CardTitle>
                 <CardDescription>
@@ -288,7 +289,7 @@ export function UserGroupsPage() {
                               setDeletingGroup(open ? group.id : null)
                             }
                           >
-                            <DialogTrigger asChild>
+                            <AlertDialogTrigger asChild>
                               <Button
                                 variant="ghost"
                                 size="sm"
@@ -296,7 +297,7 @@ export function UserGroupsPage() {
                               >
                                 <Trash2 className="h-4 w-4 text-destructive" />
                               </Button>
-                            </DialogTrigger>
+                            </AlertDialogTrigger>
                             <AlertDialogContent>
                               <AlertDialogHeader>
                                 <AlertDialogTitle>Delete Group</AlertDialogTitle>

--- a/apps/frontend/src/pages/UsersPage.tsx
+++ b/apps/frontend/src/pages/UsersPage.tsx
@@ -6,6 +6,7 @@ import {
   useDeleteUserMutation,
   useDisableUserMutation,
   useEnableUserMutation,
+  User,
   UserRole,
 } from '@/services/usersApi';
 import {
@@ -377,6 +378,129 @@ export function UsersPage() {
   const invitations = invitationsData?.invitations || [];
   const pendingCount = invitations.filter((i) => !i.acceptedAt && !i.isExpired).length;
 
+  // Shared between the desktop table rows and the mobile card list
+  const renderRoleBadge = (user: User) => (
+    <Badge
+      variant={user.role === 'admin' ? 'default' : user.role === 'member' ? 'outline' : 'secondary'}
+      className={
+        user.role === 'admin'
+          ? 'bg-[#d96459] hover:bg-[#c55449]'
+          : user.role === 'member'
+            ? 'text-muted-foreground'
+            : undefined
+      }
+    >
+      {user.role === 'admin' ? <Shield className="h-3 w-3 mr-1" /> : null}
+      {user.role}
+    </Badge>
+  );
+
+  const renderStatusBadge = (user: User) =>
+    user.disabled ? (
+      <Badge variant="destructive">
+        <UserX className="h-3 w-3 mr-1" />
+        Disabled
+      </Badge>
+    ) : (
+      <Badge variant="outline" className="text-green-600 border-green-600">
+        <UserCheck className="h-3 w-3 mr-1" />
+        Active
+      </Badge>
+    );
+
+  const renderUserActions = (user: User, isCurrentUser: boolean) => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm" aria-label={`Actions for ${user.email}`}>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {isCurrentUser ? (
+          <DropdownMenuItem disabled className="text-muted-foreground">
+            Cannot modify your own account
+          </DropdownMenuItem>
+        ) : (
+          <>
+            {user.role !== 'admin' && (
+              <DropdownMenuItem
+                onClick={() => handleRoleChange(user.id, 'admin')}
+                disabled={isUpdatingRole}
+              >
+                <Shield className="h-4 w-4 mr-2" />
+                Make Admin
+              </DropdownMenuItem>
+            )}
+            {user.role !== 'user' && (
+              <DropdownMenuItem
+                onClick={() => handleRoleChange(user.id, 'user')}
+                disabled={isUpdatingRole}
+              >
+                <UserCheck className="h-4 w-4 mr-2" />
+                Make User
+              </DropdownMenuItem>
+            )}
+            {user.role !== 'member' && (
+              <DropdownMenuItem
+                onClick={() => handleRoleChange(user.id, 'member')}
+                disabled={isUpdatingRole}
+              >
+                <UserX className="h-4 w-4 mr-2" />
+                Make Member
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuSeparator />
+            {user.disabled ? (
+              <DropdownMenuItem
+                onClick={() => handleToggleDisabled(user.id, true)}
+                disabled={isEnabling}
+              >
+                <UserCheck className="h-4 w-4 mr-2" />
+                Enable Account
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem
+                onClick={() => handleToggleDisabled(user.id, false)}
+                disabled={isDisabling}
+              >
+                <UserX className="h-4 w-4 mr-2" />
+                Disable Account
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={() => setDeletingUser({ id: user.id, email: user.email })}
+              className="text-destructive focus:text-destructive"
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              Delete User
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  const renderCopyUserId = (user: User) => (
+    <div className="flex items-center gap-1">
+      <code className="text-xs text-muted-foreground" title={user.id}>
+        {user.id.slice(0, 8)}...
+      </code>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-6 w-6 p-0"
+        onClick={async () => {
+          await navigator.clipboard.writeText(user.id);
+          toast({ title: 'Copied', description: 'User ID copied to clipboard' });
+        }}
+        title="Copy full User ID"
+      >
+        <Copy className="h-3 w-3" />
+      </Button>
+    </div>
+  );
+
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
@@ -424,7 +548,7 @@ export function UsersPage() {
           <TabsContent value="users">
             <Card>
               <CardHeader>
-                <div className="flex items-center justify-between">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <div>
                     <CardTitle>Manage Users</CardTitle>
                     <CardDescription>
@@ -432,7 +556,7 @@ export function UsersPage() {
                     </CardDescription>
                   </div>
                   <div className="flex items-center gap-2">
-                    <div className="relative">
+                    <div className="relative w-full sm:w-auto">
                       <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
                       <Input
                         placeholder="Search by email..."
@@ -441,7 +565,7 @@ export function UsersPage() {
                           setSearch(e.target.value);
                           setPage(1);
                         }}
-                        className="pl-9 w-64"
+                        className="pl-9 w-full sm:w-64"
                       />
                     </div>
                   </div>
@@ -473,6 +597,43 @@ export function UsersPage() {
                   </div>
                 ) : (
                   <>
+                    {/* Mobile: card per user (the table hides Role/Status/Actions off-canvas at phone widths) */}
+                    <div className="space-y-3 sm:hidden">
+                      {users.map((user) => {
+                        const isCurrentUser = user.id === currentUserId;
+                        return (
+                          <div
+                            key={user.id}
+                            className={`rounded-lg border p-4${user.disabled ? ' opacity-60' : ''}`}
+                          >
+                            <div className="flex items-start justify-between gap-2">
+                              <div className="min-w-0">
+                                <div className="flex flex-wrap items-center gap-2 font-medium">
+                                  <span className="truncate">{user.email}</span>
+                                  {isCurrentUser && (
+                                    <Badge variant="outline" className="text-xs">
+                                      You
+                                    </Badge>
+                                  )}
+                                </div>
+                                <div className="mt-1">{renderCopyUserId(user)}</div>
+                              </div>
+                              {renderUserActions(user, isCurrentUser)}
+                            </div>
+                            <div className="mt-3 flex flex-wrap items-center gap-2">
+                              {renderRoleBadge(user)}
+                              {renderStatusBadge(user)}
+                              <span className="text-sm text-muted-foreground">
+                                Joined {new Date(user.createdAt).toLocaleDateString()}
+                              </span>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+
+                    {/* Desktop: table */}
+                    <div className="hidden sm:block">
                     <Table>
                       <TableHeader>
                         <TableRow>
@@ -502,139 +663,25 @@ export function UsersPage() {
                                   )}
                                 </div>
                               </TableCell>
-                              <TableCell>
-                                <div className="flex items-center gap-1">
-                                  <code className="text-xs text-muted-foreground" title={user.id}>
-                                    {user.id.slice(0, 8)}...
-                                  </code>
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    className="h-6 w-6 p-0"
-                                    onClick={async () => {
-                                      await navigator.clipboard.writeText(user.id);
-                                      toast({ title: 'Copied', description: 'User ID copied to clipboard' });
-                                    }}
-                                    title="Copy full User ID"
-                                  >
-                                    <Copy className="h-3 w-3" />
-                                  </Button>
-                                </div>
-                              </TableCell>
-                              <TableCell>
-                                <Badge
-                                  variant={user.role === 'admin' ? 'default' : user.role === 'member' ? 'outline' : 'secondary'}
-                                  className={
-                                    user.role === 'admin'
-                                      ? 'bg-[#d96459] hover:bg-[#c55449]'
-                                      : user.role === 'member'
-                                        ? 'text-muted-foreground'
-                                        : undefined
-                                  }
-                                >
-                                  {user.role === 'admin' ? (
-                                    <Shield className="h-3 w-3 mr-1" />
-                                  ) : null}
-                                  {user.role}
-                                </Badge>
-                              </TableCell>
-                              <TableCell>
-                                {user.disabled ? (
-                                  <Badge variant="destructive">
-                                    <UserX className="h-3 w-3 mr-1" />
-                                    Disabled
-                                  </Badge>
-                                ) : (
-                                  <Badge variant="outline" className="text-green-600 border-green-600">
-                                    <UserCheck className="h-3 w-3 mr-1" />
-                                    Active
-                                  </Badge>
-                                )}
-                              </TableCell>
+                              <TableCell>{renderCopyUserId(user)}</TableCell>
+                              <TableCell>{renderRoleBadge(user)}</TableCell>
+                              <TableCell>{renderStatusBadge(user)}</TableCell>
                               <TableCell className="text-sm text-muted-foreground">
                                 {new Date(user.createdAt).toLocaleDateString()}
                               </TableCell>
                               <TableCell className="text-right">
-                                <DropdownMenu>
-                                  <DropdownMenuTrigger asChild>
-                                    <Button variant="ghost" size="sm">
-                                      <MoreHorizontal className="h-4 w-4" />
-                                    </Button>
-                                  </DropdownMenuTrigger>
-                                  <DropdownMenuContent align="end">
-                                    {isCurrentUser ? (
-                                      <DropdownMenuItem disabled className="text-muted-foreground">
-                                        Cannot modify your own account
-                                      </DropdownMenuItem>
-                                    ) : (
-                                      <>
-                                        {user.role !== 'admin' && (
-                                          <DropdownMenuItem
-                                            onClick={() => handleRoleChange(user.id, 'admin')}
-                                            disabled={isUpdatingRole}
-                                          >
-                                            <Shield className="h-4 w-4 mr-2" />
-                                            Make Admin
-                                          </DropdownMenuItem>
-                                        )}
-                                        {user.role !== 'user' && (
-                                          <DropdownMenuItem
-                                            onClick={() => handleRoleChange(user.id, 'user')}
-                                            disabled={isUpdatingRole}
-                                          >
-                                            <UserCheck className="h-4 w-4 mr-2" />
-                                            Make User
-                                          </DropdownMenuItem>
-                                        )}
-                                        {user.role !== 'member' && (
-                                          <DropdownMenuItem
-                                            onClick={() => handleRoleChange(user.id, 'member')}
-                                            disabled={isUpdatingRole}
-                                          >
-                                            <UserX className="h-4 w-4 mr-2" />
-                                            Make Member
-                                          </DropdownMenuItem>
-                                        )}
-                                        <DropdownMenuSeparator />
-                                        {user.disabled ? (
-                                          <DropdownMenuItem
-                                            onClick={() => handleToggleDisabled(user.id, true)}
-                                            disabled={isEnabling}
-                                          >
-                                            <UserCheck className="h-4 w-4 mr-2" />
-                                            Enable Account
-                                          </DropdownMenuItem>
-                                        ) : (
-                                          <DropdownMenuItem
-                                            onClick={() => handleToggleDisabled(user.id, false)}
-                                            disabled={isDisabling}
-                                          >
-                                            <UserX className="h-4 w-4 mr-2" />
-                                            Disable Account
-                                          </DropdownMenuItem>
-                                        )}
-                                        <DropdownMenuSeparator />
-                                        <DropdownMenuItem
-                                          onClick={() => setDeletingUser({ id: user.id, email: user.email })}
-                                          className="text-destructive focus:text-destructive"
-                                        >
-                                          <Trash2 className="h-4 w-4 mr-2" />
-                                          Delete User
-                                        </DropdownMenuItem>
-                                      </>
-                                    )}
-                                  </DropdownMenuContent>
-                                </DropdownMenu>
+                                {renderUserActions(user, isCurrentUser)}
                               </TableCell>
                             </TableRow>
                           );
                         })}
                       </TableBody>
                     </Table>
+                    </div>
 
                     {/* Pagination */}
                     {meta && meta.totalPages > 1 && (
-                      <div className="flex items-center justify-between mt-4">
+                      <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
                         <div className="text-sm text-muted-foreground">
                           Showing {(meta.page - 1) * meta.limit + 1} to{' '}
                           {Math.min(meta.page * meta.limit, meta.total)} of {meta.total} users


### PR DESCRIPTION
## Summary

A full mobile UX review of the admin (375×667, mocked API — no backend needed) found **13 of 20 routes overflowing horizontally**: every `/repo/*` page laid out at 641px (7-tab `TabsList` with no wrap/scroll), project settings at **1168px** (12 tabs), admin settings at 510px — matching the reported broken mobile rendering on the schema detail page. It also surfaced hard crashes reachable in production.

### Layout fixes
- **New `TabScroller`** (`components/common/TabScroller.tsx`): horizontal scroll wrapper for tab strips — hides the scrollbar, centers the active tab on load, fades clipped edges for discoverability. Applied at the three call sites; the shadcn `ui/tabs.tsx` primitive stays stock.
- **`RepositoryStatsHeader`**: four ~230px stat cards collapse to a compact 2×2 strip below `md`, so the tab content is above the fold on phones (desktop unchanged).
- **Users page**: responsive header, full-width search, card-per-user list below `sm` (desktop table unchanged); row badges/actions extracted into shared render helpers.
- **Wrapped overflowing action rows/headers** on schema detail, proxy rules, schemas, uploads, rule set detail, traffic, and domains.
- **Domains grid**: `grid-cols-[minmax(0,1fr)]` + `min-w-0` card — long unbroken domain names previously forced 529px min-content despite `truncate`.

### Crash fixes
- `/groups` crashed to the error boundary whenever a group existed: `DialogTrigger` inside `AlertDialog` → `AlertDialogTrigger` (`UserGroupsPage.tsx`).
- Unguarded `.find`/`.length` on optional API data in `PrimaryContentSettings`, `DomainCard`, `ProjectSettingsPage`.
- Onboarding modal no longer hijacks Home on a fresh device when repos already exist (gates on fetched repo count).
- `Badge` forwards refs (Radix `asChild` warning); `DataBrowser` fragment keys; dev error details behind a disclosure.

### Polish
44px touch targets for alias actions below `sm`, no mid-token record-ID wrapping, tokenized hard-coded hex text colors, unified schema field-type badge weight, keyboard-shortcut hint hidden on touch viewports, labeled loading state on Domains.

## New regression suite

`e2e/mobile-viewport.spec.ts` + `e2e/fixtures/mobile-viewport-mocks.ts`: asserts `scrollWidth ≤ viewport` on 19 routes at 375×667 (plus 3 dark-theme runs), with the entire `/api` surface mocked using deliberately hostile data (long unbroken domains/emails/URLs). Runs under the existing `webServer` config: `pnpm test:e2e mobile-viewport`.

## Verification

- All 25 mobile captures across 20 routes now lay out at exactly 375px (was: worst case 1168px)
- `tsc --noEmit` clean · vitest **507/507** · Playwright mobile suite **22/22**
- Screenshot sweep light + dark; visually spot-checked repo overview, users, groups, domains, schema detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaanGYwuqFuwWDJ2CZ1CY7