### PR TITLE
fix(frontend): mobile overflow in proxy-rules and pipeline editor

### DIFF
--- a/apps/frontend/e2e/fixtures/mobile-viewport-mocks.ts
+++ b/apps/frontend/e2e/fixtures/mobile-viewport-mocks.ts
@@ -97,7 +97,9 @@ const records = [
 ];
 
 const ruleSets = [
-  { id: 'rs-1', projectId: 'proj-1', name: 'api', description: 'Primary API rule set for the production alias', environment: 'production', source: { repo: 'acme/webapp', path: 'proxy-rules/api.json', syncedAt: daysAgo(2) }, createdAt: daysAgo(80), updatedAt: daysAgo(2) },
+  // Full provenance (repo + gitSha + syncedAt) so ManagedFromGitBadge renders
+  // its widest form — this overflowed cards on real data before it wrapped
+  { id: 'rs-1', projectId: 'proj-1', name: 'studio', description: 'Primary API rule set for the production alias', environment: 'production', source: { repo: 'bffless/apps', path: 'apps/studio/proxy-rules/studio.json', gitSha: '58d7cbf0aa11c2f9d8e7b6a5c4d3e2f1a0b9c8d7', syncedAt: daysAgo(5) }, createdAt: daysAgo(80), updatedAt: daysAgo(2) },
   { id: 'rs-2', projectId: 'proj-1', name: 'staging-experiments', description: null, environment: 'staging', source: null, createdAt: daysAgo(20), updatedAt: daysAgo(4) },
 ];
 const mkRule = (i: number, pathPattern: string, method: string | null, targetUrl: string, proxyType: string, desc: string | null) => ({
@@ -124,12 +126,34 @@ const mkRule = (i: number, pathPattern: string, method: string | null, targetUrl
   createdAt: daysAgo(30),
   updatedAt: daysAgo(2),
 });
+// Realistic pipeline config for the rule editor (steps + terminal), with a
+// long step name to stress the step-row truncation
+const uploadPipelineConfig = {
+  name: 'Upload youtube thumbnail',
+  description: 'Accept a thumbnail upload, store metadata, return the public URL',
+  steps: [
+    {
+      id: 'step-1',
+      name: 'upload-youtube-thumbnail-to-storage',
+      handlerType: 'file_upload_handler',
+      config: { schemaId: 'schema-3', subDir: 'youtube-thumbnail', accessControl: 'authenticated' },
+    },
+    {
+      id: 'step-2',
+      name: 'Return Upload Result',
+      handlerType: 'response_handler',
+      config: { statusCode: 200, body: '{"url":"{{steps.upload-youtube-thumbnail-to-storage.url}}"}' },
+    },
+  ],
+  postSteps: [],
+};
 const rules = [
   mkRule(1, '/api/contact', 'POST', 'pipeline://contact-form', 'pipeline', 'Contact form intake with email notification'),
   mkRule(2, '/api/comments/*', null, 'pipeline://comments', 'pipeline', 'Live comment wall data table access'),
   mkRule(3, '/api/search', 'GET', 'https://search-backend.internal.example.com:9200/indexes/site/query', 'http', null),
   mkRule(4, '/api/chat', 'POST', 'pipeline://ai-chat-streaming-with-long-target-name', 'pipeline', 'Streaming AI chat completion relay'),
 ];
+rules[0].pipelineConfig = uploadPipelineConfig as (typeof rules)[number]['pipelineConfig'];
 
 const users = [
   { id: 'user-1', email: 'admin@example.com', role: 'admin', disabled: false, disabledAt: null, disabledBy: null, createdAt: daysAgo(300), updatedAt: daysAgo(1) },
@@ -213,6 +237,7 @@ const ROUTES: RouteEntry[] = [
   ['GET', /\/api\/aliases\/[^/]+\/[^/]+\/visibility/, { projectId: 'proj-1', alias: 'production', effectiveVisibility: 'public', source: 'alias', aliasOverride: true, projectVisibility: false, effectiveUnauthorizedBehavior: 'redirect_login', effectiveRequiredRole: 'authenticated' }],
   ['GET', /\/api\/proxy-rules\/[^/]+\/logs\/count/, { count: 12 }],
   ['GET', /\/api\/proxy-rules\/[^/]+\/logs/, { logs: [], total: 0 }],
+  ['GET', /\/api\/proxy-rules\/rule-1$/, rules[0]],
   ['GET', /\/api\/repositories\/mine/, repositoriesMine],
   ['GET', /\/api\/repositories\/feed/, repositoriesFeed],
   ['GET', /\/api\/repo\/[^/]+\/[^/]+\/stats/, stats],

--- a/apps/frontend/e2e/mobile-viewport.spec.ts
+++ b/apps/frontend/e2e/mobile-viewport.spec.ts
@@ -34,6 +34,7 @@ const ROUTES: RouteSpec[] = [
   { name: 'repo aliases', path: '/repo/acme/webapp/aliases' },
   { name: 'repo proxy rules', path: '/repo/acme/webapp/proxy-rules' },
   { name: 'repo rule set detail', path: '/repo/acme/webapp/proxy-rules/rs-1' },
+  { name: 'repo rule editor (pipeline)', path: '/repo/acme/webapp/proxy-rules/rs-1/rule-1' },
   { name: 'repo schedules', path: '/repo/acme/webapp/schedules' },
   { name: 'repo data schemas', path: '/repo/acme/webapp/data' },
   { name: 'repo schema detail', path: '/repo/acme/webapp/data/schema-1', dark: true },
@@ -60,6 +61,13 @@ async function assertNoHorizontalOverflow(page: Page, path: string, theme: 'ligh
   await page.goto(path, { waitUntil: 'networkidle' });
   // Give post-load renders (charts, expanding lists) a beat to settle
   await page.waitForTimeout(500);
+
+  if (process.env.MOBILE_SHOTS) {
+    await page.screenshot({
+      path: `test-results/mobile-shots/${path.replace(/\W+/g, '-').replace(/^-|-$/g, '') || 'home'}${theme === 'dark' ? '.dark' : ''}.png`,
+      fullPage: true,
+    });
+  }
 
   const widths = await page.evaluate(() => ({
     scrollWidth: document.documentElement.scrollWidth,

--- a/apps/frontend/src/components/pipelines/PipelineConfig.tsx
+++ b/apps/frontend/src/components/pipelines/PipelineConfig.tsx
@@ -561,7 +561,7 @@ export function PipelineConfig({
 
       {/* Steps */}
       <div className="space-y-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <Label className="text-base">Pipeline Steps</Label>
           <Button type="button" variant="outline" size="sm" onClick={addStep}>
             <Plus className="h-4 w-4 mr-1" />
@@ -606,17 +606,18 @@ export function PipelineConfig({
                       <button
                         type="button"
                         onClick={() => toggleExpanded(index)}
-                        className="flex-1 flex items-center gap-2 text-left hover:text-primary"
+                        className="min-w-0 flex-1 flex items-center gap-2 text-left hover:text-primary"
                       >
                         {isExpanded ? (
-                          <ChevronDown className="h-4 w-4" />
+                          <ChevronDown className="h-4 w-4 shrink-0" />
                         ) : (
-                          <ChevronRight className="h-4 w-4" />
+                          <ChevronRight className="h-4 w-4 shrink-0" />
                         )}
-                        <CardTitle className="text-sm font-medium">
+                        <CardTitle className="min-w-0 truncate text-sm font-medium">
                           {step.name || getHandlerDisplayName(step.handlerType)}
                         </CardTitle>
-                        <span className="text-xs text-muted-foreground">
+                        {/* Secondary handler-type hint loses to the step name on phones */}
+                        <span className="hidden min-w-0 truncate text-xs text-muted-foreground sm:inline">
                           {step.name && `(${getHandlerDisplayName(step.handlerType)})`}
                         </span>
                       </button>
@@ -767,14 +768,14 @@ export function PipelineConfig({
 
       {/* Terminal Step Configuration */}
       <div className="space-y-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <div className="flex items-center gap-2">
             <Send className="h-4 w-4 text-muted-foreground" />
             <Label className="text-base">
               {terminalSteps.length > 1 ? 'Terminal Branches' : 'Terminal Step'}
             </Label>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             {!hasImplicitTerminal && terminalSteps.length <= 1 && (
               <Select
                 value={terminalStepType}
@@ -848,9 +849,9 @@ export function PipelineConfig({
                         ) : (
                           <ChevronRight className="h-4 w-4" />
                         )}
-                        <CardTitle className="text-sm font-medium flex items-center gap-2">
-                          <Send className="h-4 w-4" />
-                          {branchTitle}
+                        <CardTitle className="min-w-0 text-sm font-medium flex items-center gap-2">
+                          <Send className="h-4 w-4 shrink-0" />
+                          <span className="min-w-0 truncate">{branchTitle}</span>
                         </CardTitle>
                         <Badge
                           variant="outline"
@@ -1026,7 +1027,7 @@ data: {"type":"text-delta","value":" world"}
 
       {/* Post-Processing Steps */}
       <div className="space-y-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <Label className="text-base">Post-Processing Steps</Label>
           <Button type="button" variant="outline" size="sm" onClick={addPostStep}>
             <Plus className="h-4 w-4 mr-1" />
@@ -1075,17 +1076,18 @@ data: {"type":"text-delta","value":" world"}
                       <button
                         type="button"
                         onClick={() => togglePostExpanded(index)}
-                        className="flex-1 flex items-center gap-2 text-left hover:text-primary"
+                        className="min-w-0 flex-1 flex items-center gap-2 text-left hover:text-primary"
                       >
                         {isExpanded ? (
-                          <ChevronDown className="h-4 w-4" />
+                          <ChevronDown className="h-4 w-4 shrink-0" />
                         ) : (
-                          <ChevronRight className="h-4 w-4" />
+                          <ChevronRight className="h-4 w-4 shrink-0" />
                         )}
-                        <CardTitle className="text-sm font-medium">
+                        <CardTitle className="min-w-0 truncate text-sm font-medium">
                           {step.name || getHandlerDisplayName(step.handlerType)}
                         </CardTitle>
-                        <span className="text-xs text-muted-foreground">
+                        {/* Secondary handler-type hint loses to the step name on phones */}
+                        <span className="hidden min-w-0 truncate text-xs text-muted-foreground sm:inline">
                           {step.name && `(${getHandlerDisplayName(step.handlerType)})`}
                         </span>
                       </button>

--- a/apps/frontend/src/components/proxy-rules/ExpandedProxyRuleForm.tsx
+++ b/apps/frontend/src/components/proxy-rules/ExpandedProxyRuleForm.tsx
@@ -706,7 +706,7 @@ export function ExpandedProxyRuleForm({
       {/* Pipeline Configuration */}
       {isPipeline && (
         <Card>
-          <CardHeader className="flex flex-row items-start justify-between space-y-0">
+          <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-3 space-y-0">
             <div>
               <CardTitle>Pipeline Configuration</CardTitle>
               <CardDescription>Define the steps that process incoming requests</CardDescription>

--- a/apps/frontend/src/components/proxy-rules/ManagedFromGitBadge.tsx
+++ b/apps/frontend/src/components/proxy-rules/ManagedFromGitBadge.tsx
@@ -36,14 +36,14 @@ export function ManagedFromGitBadge({ source, className }: ManagedFromGitBadgePr
   return (
     <Badge
       variant="outline"
-      className={cn('text-xs font-normal gap-1 items-center', className)}
+      className={cn('max-w-full flex-wrap text-xs font-normal gap-1 items-center', className)}
       title={MANAGED_FROM_GIT_WARNING}
     >
       <GitBranch className="h-3 w-3 shrink-0" aria-hidden="true" />
-      <span>Managed from git</span>
-      {origin && <span className="text-muted-foreground">{origin}</span>}
+      <span className="whitespace-nowrap">Managed from git</span>
+      {origin && <span className="min-w-0 truncate text-muted-foreground">{origin}</span>}
       {source.syncedAt && (
-        <span className="text-muted-foreground">
+        <span className="whitespace-nowrap text-muted-foreground">
           synced {formatRelativeTime(source.syncedAt)}
         </span>
       )}

--- a/apps/frontend/src/components/proxy-rules/RuleSetCard.tsx
+++ b/apps/frontend/src/components/proxy-rules/RuleSetCard.tsx
@@ -31,7 +31,8 @@ export function RuleSetCard({
       to={href}
       className="flex items-center justify-between p-4 rounded-lg border hover:bg-accent transition-colors group"
     >
-      <div className="flex min-w-0 items-center gap-4">
+      {/* pr-9 keeps content clear of the actions menu the list page overlays at right-12 */}
+      <div className="flex min-w-0 items-center gap-4 pr-9">
         <Settings className="h-5 w-5 shrink-0 text-muted-foreground" />
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
@@ -54,7 +55,7 @@ export function RuleSetCard({
         </div>
       </div>
 
-      <ChevronRight className="h-5 w-5 text-muted-foreground group-hover:text-foreground transition-colors" />
+      <ChevronRight className="h-5 w-5 shrink-0 text-muted-foreground group-hover:text-foreground transition-colors" />
     </Link>
   );
 }

--- a/apps/frontend/src/components/proxy-rules/RulesList.tsx
+++ b/apps/frontend/src/components/proxy-rules/RulesList.tsx
@@ -147,7 +147,7 @@ export function RulesList({
           <div
             key={rule.id}
             onClick={canEdit ? () => onRuleClick(rule) : undefined}
-            className={`flex items-center gap-3 p-3 border rounded-md bg-background transition-colors ${
+            className={`flex flex-wrap items-center gap-x-3 gap-y-2 p-3 border rounded-md bg-background transition-colors ${
               canEdit ? 'cursor-pointer hover:bg-accent' : ''
             } ${!rule.isEnabled ? 'opacity-50' : ''}`}
           >
@@ -157,7 +157,7 @@ export function RulesList({
             >
               {rule.order}
             </div>
-            <div className="flex-1 min-w-0">
+            <div className="flex-1 basis-40 min-w-0">
               <div className="flex items-center gap-2 text-sm">
                 <code className="font-mono bg-muted px-2 py-0.5 rounded truncate">
                   {rule.pathPattern}
@@ -229,49 +229,53 @@ export function RulesList({
                 )}
               </div>
             </div>
-            {rule.proxyType === 'pipeline' && rule.debugEnabled && (
-              <LogCountBadge
-                ruleId={rule.id}
-                onClick={(e) => handleViewLogs(rule, e)}
-              />
-            )}
-            {canEdit && (
-              <>
-                {rule.proxyType === 'pipeline' && (
+            {/* Actions wrap to a second line as one group when the rule name
+                would otherwise be crushed at phone widths */}
+            <div className="ml-auto flex items-center gap-1">
+              {rule.proxyType === 'pipeline' && rule.debugEnabled && (
+                <LogCountBadge
+                  ruleId={rule.id}
+                  onClick={(e) => handleViewLogs(rule, e)}
+                />
+              )}
+              {canEdit && (
+                <>
+                  {rule.proxyType === 'pipeline' && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={(e) => handleToggleDebug(rule, e)}
+                      title={rule.debugEnabled ? 'Disable debug logging' : 'Enable debug logging'}
+                      className={rule.debugEnabled ? 'text-purple-500' : ''}
+                    >
+                      <Bug className="h-4 w-4" />
+                    </Button>
+                  )}
+                  <Switch
+                    checked={rule.isEnabled}
+                    onCheckedChange={() => {}}
+                    onClick={(e) => handleToggleEnabled(rule, e)}
+                    title={rule.isEnabled ? 'Disable rule' : 'Enable rule'}
+                  />
                   <Button
                     variant="ghost"
                     size="icon"
-                    onClick={(e) => handleToggleDebug(rule, e)}
-                    title={rule.debugEnabled ? 'Disable debug logging' : 'Enable debug logging'}
-                    className={rule.debugEnabled ? 'text-purple-500' : ''}
+                    onClick={(e) => handleEditClick(rule, e)}
+                    title="Edit rule"
                   >
-                    <Bug className="h-4 w-4" />
+                    <Edit2 className="h-4 w-4" />
                   </Button>
-                )}
-                <Switch
-                  checked={rule.isEnabled}
-                  onCheckedChange={() => {}}
-                  onClick={(e) => handleToggleEnabled(rule, e)}
-                  title={rule.isEnabled ? 'Disable rule' : 'Enable rule'}
-                />
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={(e) => handleEditClick(rule, e)}
-                  title="Edit rule"
-                >
-                  <Edit2 className="h-4 w-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={(e) => handleDeleteClick(rule, e)}
-                  title="Delete rule"
-                >
-                  <Trash2 className="h-4 w-4 text-destructive" />
-                </Button>
-              </>
-            )}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={(e) => handleDeleteClick(rule, e)}
+                    title="Delete rule"
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </>
+              )}
+            </div>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary

Real-data follow-up to #503. Four reported screenshots (admin.j5s.dev at 375px) showed the proxy-rules family still breaking — the rule editor wasn't covered by the mobile suite at all, and the fixtures were too gentle (no `gitSha` provenance, short names).

| Reported | Cause | Fix |
|---|---|---|
| Rule editor: `+` button clipped, page pans to 464px | Terminal Step row (`w-[200px]` select + Add Branch) never wraps | `flex-wrap` on the row + control group; same for Pipeline/Post-Processing Steps headers |
| Rule editor header crushed | Pipeline Configuration title vs Import/Export in one rigid row | header wraps |
| Rule set detail: rule names crushed to `Uplo…` | path badge + debug + toggle + edit + delete all on one line | actions wrap as one right-aligned group; step names truncate with `min-w-0`; the `(Handler Name)` hint hides below `sm` |
| Rule sets list: `Managed from git · repo@sha · synced …` overflows card, `⋯` overlaps | badge is a non-wrapping inline-flex; menu overlaid absolutely | badge wraps internally + truncates origin; `RuleSetCard` reserves `pr-9` for the overlay |

## Test coverage

- Mobile suite gains the **pipeline rule editor route** with a realistic `pipelineConfig` (upload handler with a long step name + response terminal), and the rule-set fixture now carries full git provenance.
- **Verified the guard bites**: with the fix stashed, the new test fails with `document is 464px in a 375px viewport` — matching the report exactly.
- `MOBILE_SHOTS=1` saves per-route full-page screenshots to `test-results/mobile-shots/` for visual review.

## Verification

- `tsc --noEmit` clean · vitest **507/507** · mobile suite **23/23**
- Screenshots of all four reported screens confirmed fixed at 375px

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaanGYwuqFuwWDJ2CZ1CY7