### PR TITLE
fix(frontend): always show Repositories card for roles that can create repos

### DIFF
--- a/apps/frontend/src/pages/HomePage.test.tsx
+++ b/apps/frontend/src/pages/HomePage.test.tsx
@@ -171,3 +171,57 @@ describe('HomePage — wildcard SSL banner', () => {
     expect(screen.getByText('Wildcard SSL Certificate Required')).toBeInTheDocument();
   });
 });
+
+describe('HomePage — Repositories card gating (#517)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockGetSetupStatus.mockReturnValue({ data: { isSetupComplete: true }, isLoading: false });
+    mockGetWildcardStatus.mockReturnValue({ data: undefined });
+    mockGetPrimarySslStatus.mockReturnValue({ data: undefined });
+  });
+
+  const sessionWithRole = (role: 'admin' | 'user' | 'member') => ({
+    data: { user: { email: `${role}@example.com`, role } },
+  });
+
+  it('shows the card for an admin with zero repos', () => {
+    mockGetSession.mockReturnValue(sessionWithRole('admin'));
+    mockGetMyRepositories.mockReturnValue({ data: { total: 0 } });
+    renderHomePage();
+
+    expect(screen.getByText('Repositories')).toBeInTheDocument();
+  });
+
+  it('shows the card for a user-role account with zero repos (can create projects)', () => {
+    mockGetSession.mockReturnValue(sessionWithRole('user'));
+    mockGetMyRepositories.mockReturnValue({ data: { total: 0 } });
+    renderHomePage();
+
+    expect(screen.getByText('Repositories')).toBeInTheDocument();
+  });
+
+  it('shows the card for a user-role account before the repositories query resolves', () => {
+    mockGetSession.mockReturnValue(sessionWithRole('user'));
+    mockGetMyRepositories.mockReturnValue({ data: undefined });
+    renderHomePage();
+
+    expect(screen.getByText('Repositories')).toBeInTheDocument();
+  });
+
+  it('hides the card for a member with zero repo memberships (cannot create projects)', () => {
+    mockGetSession.mockReturnValue(sessionWithRole('member'));
+    mockGetMyRepositories.mockReturnValue({ data: { total: 0 } });
+    renderHomePage();
+
+    expect(screen.queryByText('Repositories')).not.toBeInTheDocument();
+  });
+
+  it('shows the card for a member with at least one repo membership', () => {
+    mockGetSession.mockReturnValue(sessionWithRole('member'));
+    mockGetMyRepositories.mockReturnValue({ data: { total: 2 } });
+    renderHomePage();
+
+    expect(screen.getByText('Repositories')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -79,12 +79,16 @@ export function HomePage() {
   }, [certStatus?.expiresAt]);
 
   const user = sessionData?.user;
-  // Show the Repositories card when the user has at least one non-guest repo
-  // membership. The backend's /api/repositories/mine already filters out
-  // guest-only entries, so total > 0 means there is somewhere to navigate to.
-  // Admins always get a result here because the endpoint returns every repo.
+  // Show the Repositories card for roles that can create repositories
+  // (admin/user), even with zero memberships — /repo is their only path to
+  // "New Repository" once the onboarding modal has been dismissed (#517).
+  // Members can't create repos, so for them the card appears only when they
+  // have at least one non-guest repo membership. The backend's
+  // /api/repositories/mine already filters out guest-only entries, so
+  // total > 0 means there is somewhere to navigate to.
   const { data: myRepos } = useGetMyRepositoriesQuery(undefined, { skip: !user });
-  const showRepositoriesCard = (myRepos?.total ?? 0) > 0;
+  const canCreateRepos = user?.role === 'admin' || user?.role === 'user';
+  const showRepositoriesCard = canCreateRepos || (myRepos?.total ?? 0) > 0;
 
   const missingWildcard = certStatus?.exists === false;
   const showExpiryBanner = wildcardExpiring && !isExpiryBannerDismissed;
@@ -113,12 +117,11 @@ export function HomePage() {
   // repository" over a workspace that already has repos. Wait for the query to resolve so
   // the modal never flashes before the count is known.
   useEffect(() => {
-    const canCreateRepos = sessionData?.user?.role === 'admin' || sessionData?.user?.role === 'user';
     const hasNoRepos = myRepos !== undefined && (myRepos.total ?? 0) === 0;
     if (sessionData?.user && !hasCompletedOnboarding && canCreateRepos && hasNoRepos) {
       setShowOnboarding(true);
     }
-  }, [sessionData, hasCompletedOnboarding, myRepos]);
+  }, [sessionData, hasCompletedOnboarding, myRepos, canCreateRepos]);
 
   // Check setup status first - redirect to setup if not complete
   if (!isSetupLoading && setupStatus && !setupStatus.isSetupComplete) {


### PR DESCRIPTION
## Summary

Fixes #517 — a `user`/`admin` account with zero project memberships had no discoverable UI path to `/repo` or the "New Repository" button: the dashboard Repositories card was gated on `myRepos.total > 0`, and the only alternate entry point (the onboarding modal) fires once and is permanently suppressed by `localStorage['hasCompletedOnboarding']`.

## Changes

- `showRepositoriesCard` in `HomePage.tsx` is now `canCreateRepos || (myRepos?.total ?? 0) > 0`, where `canCreateRepos` = role `admin` or `user` (the roles that can create repositories per #441/#482). The card — and its link to `/repo` — always renders for them, even with 0 projects.
- `member` accounts keep the existing behavior (card only with ≥1 non-guest repo membership), since they cannot create projects and an empty `/repo` would be a dead end.
- The onboarding-modal effect reuses the same `canCreateRepos` const instead of duplicating the role check.

Deliberately **not** included (possible follow-ups from the issue): a re-openable onboarding modal and a dedicated `/repo/new` route. Restoring the always-present nav entry point alone unblocks the stuck path.

## Testing

- New `HomePage.test.tsx` describe block covering: admin with 0 repos (shown), `user` role with 0 repos (shown), `user` role before the repositories query resolves (shown), member with 0 repos (hidden), member with memberships (shown).
- `tsc --noEmit`, ESLint, and the full HomePage test file (14 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)