### PR TITLE
fix(bootstrap): redirect after apply only when the backend is ready, not on nginx's 502

### DIFF
--- a/apps/backend/src/setup/setup.controller.spec.ts
+++ b/apps/backend/src/setup/setup.controller.spec.ts
@@ -68,4 +68,16 @@ describe('SetupController', () => {
       expect(service.initialize).toHaveBeenCalledWith(mockDto);
     });
   });
+
+  describe('getReady', () => {
+    it('returns ready with wide-open CORS and no-store caching', () => {
+      const res = { setHeader: jest.fn() };
+
+      const result = controller.getReady(res as any);
+
+      expect(result).toEqual({ ready: true });
+      expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
+      expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+    });
+  });
 });

--- a/apps/backend/src/setup/setup.controller.ts
+++ b/apps/backend/src/setup/setup.controller.ts
@@ -6,13 +6,14 @@ import {
   HttpStatus,
   Post,
   Req,
+  Res,
   BadRequestException,
   UnauthorizedException,
   Logger,
   UseGuards,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 import { SessionContainer } from 'supertokens-node/recipe/session';
 import { SetupService } from './setup.service';
 import { SessionAuthGuard } from '../auth/session-auth.guard';
@@ -82,6 +83,26 @@ export class SetupController {
   })
   async getStatus(): Promise<SetupStatusResponseDto> {
     return this.setupService.getSetupStatus();
+  }
+
+  @Get('ready')
+  @ApiOperation({
+    summary: 'Readiness probe',
+    description:
+      'Answers 200 once the backend is fully booted. Served with Access-Control-Allow-Origin: * so ' +
+      'the bootstrap wizard can poll it from any origin (including a bare-IP page) across the apply ' +
+      'restart. Public; exposes nothing beyond process liveness.',
+  })
+  @ApiResponse({ status: 200, description: 'Backend is up and serving requests' })
+  getReady(@Res({ passthrough: true }) res: Response): { ready: boolean } {
+    // Overwrites the header the global CORS middleware set from its origin
+    // allowlist: this endpoint carries no credentials and nothing beyond
+    // "the process is up", so any origin may read it — that is what lets the
+    // wizard's post-apply poll work from the bare-IP page. no-store keeps
+    // any layer from replaying a stale "ready" mid-restart.
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Cache-Control', 'no-store');
+    return { ready: true };
   }
 
   @Get('constraints')

--- a/apps/frontend/src/components/setup/ApplyStep.tsx
+++ b/apps/frontend/src/components/setup/ApplyStep.tsx
@@ -82,20 +82,25 @@ export function ApplyStep() {
     pollRef.current = setInterval(async () => {
       if (doneRef.current) return;
       try {
-        // Readiness probe only — we never read the response, we just need to
-        // know the new origin answers. A `cors` fetch is BLOCKED here: this
-        // page is still on the bare IP (a different origin than adminUrl), and
-        // the restarted backend's CORS allowlist is the domain, not the IP —
-        // so res.ok was never readable and the redirect never fired (#510).
-        // `no-cors` yields an opaque response but still RESOLVES the moment the
-        // server answers, and rejects while it's still down / DNS is still
-        // propagating — exactly the reachability signal we need.
-        await fetch(`${adminUrl}/api/setup/status`, { mode: 'no-cors' });
-        if (doneRef.current) return;
-        doneRef.current = true;
-        if (pollRef.current) clearInterval(pollRef.current);
-        window.location.href = adminUrl;
-        return;
+        // Readiness probe. Reachability alone is a FALSE signal here: nginx
+        // (separate container) never goes down during the apply restart and
+        // answers 502 while the backend is dead — and an opaque no-cors fetch
+        // resolves on that 502, which used to redirect ~17s early into an
+        // "invalid credentials" login. /api/setup/ready replies with
+        // Access-Control-Allow-Origin: *, so this plain fetch is readable
+        // from ANY origin (bare-IP page included) and res.ok only goes true
+        // once the backend is genuinely up (Nest listens only after full
+        // bootstrap, so login works). While it isn't: cross-origin the 502
+        // lacks the ACAO header and the fetch throws; same-origin it reads
+        // as !ok. Either way we keep polling.
+        const res = await fetch(`${adminUrl}/api/setup/ready`);
+        if (res.ok) {
+          if (doneRef.current) return;
+          doneRef.current = true;
+          if (pollRef.current) clearInterval(pollRef.current);
+          window.location.href = adminUrl;
+          return;
+        }
       } catch {
         /* backend still restarting / DNS still propagating — keep polling */
       }

--- a/apps/frontend/src/components/setup/__tests__/ApplyStep.test.tsx
+++ b/apps/frontend/src/components/setup/__tests__/ApplyStep.test.tsx
@@ -262,14 +262,16 @@ describe('ApplyStep', () => {
     expect(screen.queryByText(/switching to/i)).not.toBeInTheDocument();
   });
 
-  it('polls the new origin, keeps polling while unreachable, and redirects once it responds', async () => {
+  it('polls readiness on the new origin, ignores not-ready answers, and redirects once ready', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const fetchMock = vi.fn();
-    // First poll: rejects (network/DNS not ready). Second poll: resolves — a
-    // no-cors probe yields an opaque response we never read, so any resolution
-    // means the new origin is reachable and we redirect.
+    // First poll: rejects (network/DNS not ready, or cross-origin 502 whose
+    // missing ACAO header makes the read throw). Second poll: reachable but
+    // not ready (same-origin nginx 502 → readable !ok) — must NOT redirect.
+    // Third poll: backend up (readable 200) — redirect.
     fetchMock.mockRejectedValueOnce(new Error('network error'));
-    fetchMock.mockResolvedValueOnce({});
+    fetchMock.mockResolvedValueOnce({ ok: false });
+    fetchMock.mockResolvedValueOnce({ ok: true });
     vi.stubGlobal('fetch', fetchMock);
 
     renderWithStore(<ApplyStep />, {
@@ -285,20 +287,24 @@ describe('ApplyStep', () => {
     // First poll tick: fetch rejects, no redirect yet.
     await vi.advanceTimersByTimeAsync(3000);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://admin.example.com/api/setup/status',
-      { mode: 'no-cors' }
-    );
+    expect(fetchMock).toHaveBeenCalledWith('https://admin.example.com/api/setup/ready');
     expect(window.location.href).toBe('https://old-origin.example/setup');
 
-    // Second poll tick: fetch resolves (opaque), redirect happens.
+    // Second poll tick: reachable 502 (ok:false) — still no redirect. This is
+    // the ~20s restart window where nginx is up but the backend is dead; the
+    // old no-cors probe redirected here (opaque responses resolve on 502).
     await vi.advanceTimersByTimeAsync(3000);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(window.location.href).toBe('https://old-origin.example/setup');
+
+    // Third poll tick: ready — redirect happens.
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(window.location.href).toBe('https://admin.example.com');
 
     // No further polling after a successful redirect.
     await vi.advanceTimersByTimeAsync(9000);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
 
     // The redirect-once guard doesn't break the happy path: exactly one
     // assignment, not zero and not more than one.
@@ -413,8 +419,8 @@ describe('ApplyStep', () => {
 
     // Both polls now resolve "simultaneously". Without the guard both
     // would assign window.location.href.
-    resolveFirst({});
-    resolveSecond({});
+    resolveFirst({ ok: true });
+    resolveSecond({ ok: true });
     await vi.advanceTimersByTimeAsync(0);
 
     expect(hrefAssignments).toEqual(['https://admin.example.com']);

--- a/docs/superpowers/plans/2026-07-24-apply-readiness-probe.md
+++ b/docs/superpowers/plans/2026-07-24-apply-readiness-probe.md
@@ -1,0 +1,228 @@
+# Apply Readiness Probe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the bootstrap wizard's post-apply redirect fire only when the restarted backend is actually ready, instead of on nginx's 502.
+
+**Architecture:** A new public `GET /api/setup/ready` endpoint answers 200 + `Access-Control-Allow-Origin: *` once Nest is fully booted (migrations/SuperTokens/nginx regen all precede `listen`). `ApplyStep.tsx` swaps its `no-cors` reachability probe (which resolves on nginx's 502 while the backend is dead) for a plain `cors` fetch of that endpoint, redirecting only on `res.ok`.
+
+**Tech Stack:** NestJS controller (backend, Jest), React + RTK (frontend, Vitest).
+
+**Spec:** `docs/superpowers/specs/2026-07-24-apply-readiness-probe-design.md`
+
+## Global Constraints
+
+- Branch: `specs/do-one-click-and-web-bootstrap`, worktree `.claude/worktrees/bootstrap-apply-readiness`.
+- Workspace rule: commits require the user's explicit sign-off — complete each task's code + tests, but hold the commit steps until sign-off is given.
+- ACAO header value must be exactly `*`; probe fetch must NOT send credentials (use fetch defaults — no `credentials: 'include'`).
+- Response body is exactly `{ ready: true }` — no setup-state details (that is why `status`'s CORS is not widened instead).
+
+---
+
+### Task 1: Backend `GET /api/setup/ready`
+
+**Files:**
+- Modify: `apps/backend/src/setup/setup.controller.ts` (imports at :1-15, new handler after `getStatus` at :85)
+- Test: `apps/backend/src/setup/setup.controller.spec.ts`
+
+**Interfaces:**
+- Produces: `GET /api/setup/ready` → 200 `{ ready: true }`, headers `Access-Control-Allow-Origin: *` and `Cache-Control: no-store`. Task 2 polls this route.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the top-level `describe('SetupController', ...)` block of `apps/backend/src/setup/setup.controller.spec.ts` (after the `initialize` describe):
+
+```ts
+describe('getReady', () => {
+  it('returns ready with wide-open CORS and no-store caching', () => {
+    const res = { setHeader: jest.fn() };
+
+    const result = controller.getReady(res as any);
+
+    expect(result).toEqual({ ready: true });
+    expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/backend && pnpm jest src/setup/setup.controller.spec.ts`
+Expected: FAIL — `controller.getReady is not a function`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/backend/src/setup/setup.controller.ts`:
+
+Add `Res` to the `@nestjs/common` import list (line 1-13) and widen the express import (line 15):
+
+```ts
+import { Request, Response } from 'express';
+```
+
+Insert after the `getStatus` handler (after line 85):
+
+```ts
+@Get('ready')
+@ApiOperation({
+  summary: 'Readiness probe',
+  description:
+    'Answers 200 once the backend is fully booted. Served with Access-Control-Allow-Origin: * so ' +
+    'the bootstrap wizard can poll it from any origin (including a bare-IP page) across the apply ' +
+    'restart. Public; exposes nothing beyond process liveness.',
+})
+@ApiResponse({ status: 200, description: 'Backend is up and serving requests' })
+getReady(@Res({ passthrough: true }) res: Response): { ready: boolean } {
+  // Overwrites the header the global CORS middleware set from its origin
+  // allowlist: this endpoint carries no credentials and nothing beyond
+  // "the process is up", so any origin may read it — that is what lets the
+  // wizard's post-apply poll work from the bare-IP page. no-store keeps
+  // any layer from replaying a stale "ready" mid-restart.
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Cache-Control', 'no-store');
+  return { ready: true };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/backend && pnpm jest src/setup/setup.controller.spec.ts`
+Expected: PASS (4 tests)
+
+Then type-check: `pnpm --filter backend exec tsc --noEmit` → no errors.
+
+- [ ] **Step 5: Commit (HOLD until user sign-off)**
+
+```bash
+git add apps/backend/src/setup/setup.controller.ts apps/backend/src/setup/setup.controller.spec.ts
+git commit -m "feat(setup): CORS-open /api/setup/ready readiness probe"
+```
+
+---
+
+### Task 2: `ApplyStep` polls readiness instead of reachability
+
+**Files:**
+- Modify: `apps/frontend/src/components/setup/ApplyStep.tsx:82-106` (poll body)
+- Test: `apps/frontend/src/components/setup/__tests__/ApplyStep.test.tsx`
+
+**Interfaces:**
+- Consumes: `GET ${adminUrl}/api/setup/ready` from Task 1 — readable 200 `{ready:true}` cross-origin; nginx's 502 (backend down) has no ACAO header, so a cross-origin fetch throws and a same-origin fetch reads `ok: false`.
+
+- [ ] **Step 1: Update the poll test + add the 502 regression test (failing first)**
+
+In `apps/frontend/src/components/setup/__tests__/ApplyStep.test.tsx`:
+
+Replace the body of `it('polls the new origin, keeps polling while unreachable, and redirects once it responds', ...)` (lines 265-306) with:
+
+```ts
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const fetchMock = vi.fn();
+    // First poll: rejects (network/DNS not ready, or cross-origin 502 whose
+    // missing ACAO header makes the read throw). Second poll: reachable but
+    // not ready (same-origin nginx 502 → readable !ok) — must NOT redirect.
+    // Third poll: backend up (readable 200) — redirect.
+    fetchMock.mockRejectedValueOnce(new Error('network error'));
+    fetchMock.mockResolvedValueOnce({ ok: false });
+    fetchMock.mockResolvedValueOnce({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderWithStore(<ApplyStep />, {
+      bootstrapDomain: 'example.com',
+      servingMode: 'cloudflare',
+      bootstrapSslMode: 'paste',
+    });
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: /finish setup/i }));
+
+    await waitFor(() => expect(screen.getByText(/switching to/i)).toBeInTheDocument());
+
+    // First poll tick: fetch rejects, no redirect yet.
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('https://admin.example.com/api/setup/ready');
+    expect(window.location.href).toBe('https://old-origin.example/setup');
+
+    // Second poll tick: reachable 502 (ok:false) — still no redirect. This is
+    // the ~20s restart window where nginx is up but the backend is dead; the
+    // old no-cors probe redirected here (opaque responses resolve on 502).
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(window.location.href).toBe('https://old-origin.example/setup');
+
+    // Third poll tick: ready — redirect happens.
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(window.location.href).toBe('https://admin.example.com');
+
+    // No further polling after a successful redirect.
+    await vi.advanceTimersByTimeAsync(9000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    // The redirect-once guard doesn't break the happy path: exactly one
+    // assignment, not zero and not more than one.
+    expect(hrefAssignments).toEqual(['https://admin.example.com']);
+```
+
+(The test name becomes `'polls readiness on the new origin, ignores not-ready answers, and redirects once ready'`.)
+
+In `it('guards against overlapping poll resolutions producing more than one redirect', ...)` change the two resolutions (lines 416-417) to ready responses:
+
+```ts
+    resolveFirst({ ok: true });
+    resolveSecond({ ok: true });
+```
+
+The unmount, hint, and manual-link tests need no changes (rejected fetches behave the same).
+
+- [ ] **Step 2: Run tests to verify the updated ones fail**
+
+Run: `cd apps/frontend && pnpm vitest run src/components/setup/__tests__/ApplyStep.test.tsx`
+Expected: FAIL — the poll test asserts URL `/api/setup/ready` (component still calls `/api/setup/status` with `{ mode: 'no-cors' }`) and asserts no redirect on `{ ok: false }` (component redirects on any resolution). Overlap test fails on the URL-argument change only if asserted; primarily the poll test fails.
+
+- [ ] **Step 3: Update the poll implementation**
+
+In `apps/frontend/src/components/setup/ApplyStep.tsx`, replace the `try { ... } catch { ... }` block inside the interval callback (lines 84-101) with:
+
+```ts
+      try {
+        // Readiness probe. Reachability alone is a FALSE signal here: nginx
+        // (separate container) never goes down during the apply restart and
+        // answers 502 while the backend is dead — and an opaque no-cors fetch
+        // resolves on that 502, which used to redirect ~17s early into an
+        // "invalid credentials" login. /api/setup/ready replies with
+        // Access-Control-Allow-Origin: *, so this plain fetch is readable
+        // from ANY origin (bare-IP page included) and res.ok only goes true
+        // once the backend is genuinely up (Nest listens only after full
+        // bootstrap, so login works). While it isn't: cross-origin the 502
+        // lacks the ACAO header and the fetch throws; same-origin it reads
+        // as !ok. Either way we keep polling.
+        const res = await fetch(`${adminUrl}/api/setup/ready`);
+        if (res.ok) {
+          if (doneRef.current) return;
+          doneRef.current = true;
+          if (pollRef.current) clearInterval(pollRef.current);
+          window.location.href = adminUrl;
+          return;
+        }
+      } catch {
+        /* backend still restarting / DNS still propagating — keep polling */
+      }
+```
+
+(The lines before/after — `if (doneRef.current) return;` at the top of the callback and the `elapsedMs` hint accounting — stay exactly as they are; a not-ready `res.ok === false` now falls through to the hint accounting.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/frontend && pnpm vitest run src/components/setup/__tests__/ApplyStep.test.tsx`
+Expected: PASS (17 tests)
+
+Then type-check: `pnpm --filter frontend exec tsc --noEmit` → no errors.
+
+- [ ] **Step 5: Commit (HOLD until user sign-off)**
+
+```bash
+git add apps/frontend/src/components/setup/ApplyStep.tsx apps/frontend/src/components/setup/__tests__/ApplyStep.test.tsx docs/superpowers/specs/2026-07-24-apply-readiness-probe-design.md docs/superpowers/plans/2026-07-24-apply-readiness-probe.md
+git commit -m "fix(bootstrap): redirect after apply only when the backend is ready, not on nginx's 502"
+```

--- a/docs/superpowers/specs/2026-07-24-apply-readiness-probe-design.md
+++ b/docs/superpowers/specs/2026-07-24-apply-readiness-probe-design.md
@@ -1,0 +1,85 @@
+# Apply readiness probe — redirect only when the restarted backend is actually up
+
+**Date:** 2026-07-24
+**Branch:** `specs/do-one-click-and-web-bootstrap` (PR #508)
+**Relates to:** issue #510 (supersedes its "skip the doomed poll" polish), live-testing follow-up
+
+## Problem
+
+After the bootstrap wizard's Apply step, the backend writes `instance.json` and
+`process.exit(0)`s so Docker restarts it under its new identity
+(`bootstrap-setup.controller.ts`). The restart takes ~20 s (Nest boot,
+migrations, nginx config regen). nginx runs in a separate container and never
+goes down; while the backend is dead, `location /api` proxy attempts fail and
+nginx answers **502**.
+
+The wizard's readiness probe (`ApplyStep.tsx`) is a `no-cors` fetch of
+`${adminUrl}/api/setup/status`. An opaque `no-cors` fetch **resolves on any
+HTTP answer — including that 502** — and only rejects on network/DNS failure.
+So the first poll tick (3 s) "succeeds" and redirects the user to
+`https://admin.<domain>` while the backend is still booting. Logging in
+immediately fails with a misleading "invalid credentials".
+
+The signal is structurally too weak: `no-cors` cannot distinguish "nginx up,
+backend down" from "ready". A fixed pre-redirect delay would only treat the
+symptom (slow droplets / long migrations overrun any constant; fast restarts
+make everyone wait).
+
+## Design
+
+### Backend — `GET /api/setup/ready`
+
+New endpoint on `SetupController` (`api/setup` route group), public like
+`status` (no guards). Behavior:
+
+- Returns `200` with body `{ "ready": true }` — unconditionally; if the
+  process can answer, Nest bootstrap has completed (migrations, SuperTokens
+  init, nginx config regen all happen before `listen`), so login genuinely
+  works.
+- Sets `Access-Control-Allow-Origin: *` via Nest's `@Header()` decorator.
+  The handler-level header is written after the global `enableCors`
+  middleware runs, overwriting its value — no duplicate-header conflict.
+- Sets `Cache-Control: no-store` so no layer caches a stale "ready".
+
+Why a dedicated endpoint instead of widening `status`'s CORS: `status`
+returns setup-state details; `ready` exposes nothing beyond "the process is
+up", so ACAO `*` is safe. No credentials are involved (the wizard polls with
+the fetch default `credentials: 'same-origin'`, which sends no cookies
+cross-origin, so ACAO `*` is valid; same-origin requests are exempt from CORS
+entirely).
+
+### Frontend — `ApplyStep.tsx` poll
+
+Replace the `no-cors` probe with a plain (`cors`) fetch of
+`${adminUrl}/api/setup/ready`; redirect only when `res.ok`. Failure modes all
+correctly mean "keep polling":
+
+| State | Probe result | Action |
+| --- | --- | --- |
+| Backend down, nginx up (502, no ACAO) | cross-origin: fetch throws; same-origin: `res.ok` false | keep polling |
+| DNS not propagated / conn refused | fetch throws | keep polling |
+| Backend up | readable `200` | redirect once |
+
+Keep: 3 s cadence, 30 s hint, manual "Open <url>" link, `doneRef` single-shot
+guard. The hint copy (DNS-propagation wording) is unchanged — it never had a
+"browser may be blocking" line; that wording only appeared in issue #510's
+description. With ACAO `*` the bare-IP origin can now read the probe, so
+auto-redirect works on the bare-IP path too (supersedes #510's proposed
+skip-the-poll workaround).
+
+## Testing
+
+- **Backend** (`setup.controller.spec.ts` or sibling): `ready` returns 200 +
+  `{ready: true}`; route metadata carries the two headers (assert via
+  supertest-style e2e if available, else reflect `@Header` metadata).
+- **Frontend** (`ApplyStep.test.tsx`): fetch rejecting → no redirect, hint
+  appears after 30 s of ticks; fetch resolving `ok: false` (nginx 502
+  same-origin case) → no redirect; fetch resolving `ok: true` → exactly one
+  redirect, poll cleared. Update existing no-cors assertions.
+
+## Out of scope
+
+- No fixed delay / countdown.
+- No identity check in the response body (the old backend exits ~100 ms
+  after apply's response; the first probe tick is 3 s later).
+- No gating of the manual link on readiness — it stays an escape hatch.


### PR DESCRIPTION
## Problem

After the bootstrap wizard's Apply step the backend `process.exit(0)`s and takes ~20s to restart, but nginx (a separate container) never goes down — it answers **502** for `/api/*` the whole time. The wizard's readiness probe was a `no-cors` fetch, and an opaque `no-cors` fetch resolves on *any* HTTP answer, 502 included. So the very first 3s poll tick "succeeded" and redirected the user to `https://admin.<domain>` while the backend was still booting — logging in immediately fails with a misleading "invalid credentials".

## Fix

Poll for **readiness**, not reachability:

- New public `GET /api/setup/ready` → `200 {ready:true}` with `Access-Control-Allow-Origin: *` and `Cache-Control: no-store`. Nest only listens after full bootstrap (migrations, SuperTokens init, nginx regen), so a readable 200 means login genuinely works. The endpoint exposes nothing beyond process liveness, which is why widening `status`'s CORS wasn't used instead.
- `ApplyStep` polls that endpoint with a plain readable fetch and redirects only on `res.ok`. While the backend is down, nginx's 502 has no ACAO header, so a cross-origin fetch throws (and a same-origin one reads `ok:false`) — either way polling continues. Poll cadence, the 30s hint, and the manual link are unchanged.

**Bonus:** with ACAO `*` the probe is readable from the **bare-IP** origin too, so the auto-redirect now works on the bare-IP path — superseding the skip-the-poll polish proposed in #510.

## Testing

- New regression test for the reachable-but-502 restart window (the exact failure users hit).
- Backend setup module 149/149, frontend setup components 65/65, both `tsc --noEmit` clean.
- Spec + plan under `docs/superpowers/specs|plans/2026-07-24-apply-readiness-probe*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
