### PR TITLE
feat(ssl): stage certs to a staging path; gate + discard staged certs in day-2 UI

### DIFF
--- a/apps/backend/src/domains/ssl-certificate.service.spec.ts
+++ b/apps/backend/src/domains/ssl-certificate.service.spec.ts
@@ -127,6 +127,40 @@ describe('SslCertificateService.requestPrimaryDomainCertificate', () => {
       const res = await service.requestPrimaryDomainCertificate('example.com', { target: 'staging' });
       expect(res.reused).toBe(true);
     });
+
+    it('clears a prior stage before writing (#514 F1) — stale wildcard copies do not survive a fresh staging-target issuance', async () => {
+      const service = new SslCertificateService();
+      // Seed a paste-like 4-file stage (garbage content — must never parse as
+      // a valid reusable cert, so the reuse check below is forced to issue).
+      fs.mkdirSync(path.join(sslDir, 'staging'), { recursive: true });
+      fs.writeFileSync(path.join(sslDir, 'staging', 'fullchain.pem'), 'STALE-FULLCHAIN');
+      fs.writeFileSync(path.join(sslDir, 'staging', 'privkey.pem'), 'STALE-PRIVKEY');
+      fs.writeFileSync(path.join(sslDir, 'staging', 'wildcard.example.com.crt'), 'STALE-WCERT');
+      fs.writeFileSync(path.join(sslDir, 'staging', 'wildcard.example.com.key'), 'STALE-WKEY');
+      // A REAL live DNS-01 wildcard is installed — installedWildcardIsReal()
+      // is true, so the fresh issuance must NOT write new wildcard copies
+      // either; the stale staged ones must simply be gone.
+      fs.writeFileSync(path.join(sslDir, 'wildcard.example.com.crt'), REAL_WILDCARD_CERT_PEM);
+      fs.writeFileSync(path.join(sslDir, 'wildcard.example.com.key'), REAL_WILDCARD_KEY_PEM);
+
+      await service.requestPrimaryDomainCertificate('example.com', { target: 'staging' });
+
+      const stagedFiles = fs.readdirSync(path.join(sslDir, 'staging')).sort();
+      expect(stagedFiles).toEqual(['fullchain.pem', 'privkey.pem']);
+    });
+
+    it("a staged fullchain.pem WITHOUT its matching privkey.pem is not reused for target 'staging' (#514 F2)", async () => {
+      const service = new SslCertificateService();
+      const first = await service.requestPrimaryDomainCertificate('example.com', { target: 'staging' });
+      expect(first.reused).toBeFalsy();
+      // Simulate a torn stage: drop the privkey but leave the fullchain.
+      fs.unlinkSync(path.join(sslDir, 'staging', 'privkey.pem'));
+
+      const res = await service.requestPrimaryDomainCertificate('example.com', { target: 'staging' });
+      expect(res.reused).toBeFalsy();
+      // A fresh, complete stage was written (F1's discard-before-write).
+      expect(fs.existsSync(path.join(sslDir, 'staging', 'privkey.pem'))).toBe(true);
+    });
   });
 });
 

--- a/apps/backend/src/domains/ssl-certificate.service.spec.ts
+++ b/apps/backend/src/domains/ssl-certificate.service.spec.ts
@@ -92,6 +92,42 @@ describe('SslCertificateService.requestPrimaryDomainCertificate', () => {
     const days = service.getPrimaryCertificateExpiryDays();
     expect(days).toBeGreaterThan(80); // mock certs are minted for 90 days
   });
+
+  describe('target (#514)', () => {
+    it("target 'staging' writes the issued cert under staging/, not live", async () => {
+      const service = new SslCertificateService();
+      const res = await service.requestPrimaryDomainCertificate('example.com', { target: 'staging' });
+      expect(res.success).toBe(true);
+      expect(fs.existsSync(path.join(sslDir, 'staging', 'fullchain.pem'))).toBe(true);
+      expect(fs.existsSync(path.join(sslDir, 'staging', 'privkey.pem'))).toBe(true);
+      expect(fs.existsSync(path.join(sslDir, 'fullchain.pem'))).toBe(false);
+    });
+
+    it('default target writes live (renewal-cron contract)', async () => {
+      const service = new SslCertificateService();
+      const res = await service.requestPrimaryDomainCertificate('example.com');
+      expect(res.success).toBe(true);
+      expect(fs.existsSync(path.join(sslDir, 'fullchain.pem'))).toBe(true);
+      expect(fs.existsSync(path.join(sslDir, 'staging'))).toBe(false);
+    });
+
+    it("a valid STAGED cert does NOT satisfy the reuse check for target 'live'", async () => {
+      const service = new SslCertificateService();
+      // Stage a valid covering cert...
+      await service.requestPrimaryDomainCertificate('example.com', { target: 'staging' });
+      // ...then a live-target request must still issue (not report reused).
+      const res = await service.requestPrimaryDomainCertificate('example.com');
+      expect(res.reused).toBeFalsy();
+      expect(fs.existsSync(path.join(sslDir, 'fullchain.pem'))).toBe(true);
+    });
+
+    it("a valid staged cert IS reused for target 'staging'", async () => {
+      const service = new SslCertificateService();
+      await service.requestPrimaryDomainCertificate('example.com', { target: 'staging' });
+      const res = await service.requestPrimaryDomainCertificate('example.com', { target: 'staging' });
+      expect(res.reused).toBe(true);
+    });
+  });
 });
 
 describe('SslCertificateService.checkWildcardCertificate', () => {

--- a/apps/backend/src/domains/ssl-certificate.service.ts
+++ b/apps/backend/src/domains/ssl-certificate.service.ts
@@ -10,7 +10,7 @@ import { eq, and } from 'drizzle-orm';
 import { db } from '../db/client';
 import { sslChallenges, SslChallenge } from '../db/schema';
 import { certPemHasWildcardSan } from './ssl-cert-utils';
-import { sslStagingDir } from '../setup/ssl-staging';
+import { sslStagingDir, discardStagedCertificates } from '../setup/ssl-staging';
 
 export interface DnsChallenge {
   domain: string;
@@ -599,9 +599,17 @@ export class SslCertificateService {
     sans: string[],
     target: 'live' | 'staging',
   ): { expiresAt: Date } | null {
+    // A staged fullchain.pem only counts as a usable candidate when its
+    // matching privkey.pem is also staged — a torn/partial stage (fullchain
+    // written, privkey not yet) must fall through to the live candidate
+    // instead of being reported as reusable (see stagingPartiallyPopulated).
+    const stagedFullchainUsable = fs.existsSync(join(sslStagingDir(), 'privkey.pem'));
     const candidates =
       target === 'staging'
-        ? [join(sslStagingDir(), 'fullchain.pem'), join(this.getSslPath(), 'fullchain.pem')]
+        ? [
+            ...(stagedFullchainUsable ? [join(sslStagingDir(), 'fullchain.pem')] : []),
+            join(this.getSslPath(), 'fullchain.pem'),
+          ]
         : [join(this.getSslPath(), 'fullchain.pem')];
     for (const certPath of candidates) {
       try {
@@ -629,6 +637,14 @@ export class SslCertificateService {
     target: 'live' | 'staging' = 'live',
   ): Promise<void> {
     const dir = target === 'staging' ? sslStagingDir() : this.getSslPath();
+    if (target === 'staging') {
+      // A stage overwrites any prior stage — no accumulation (#514 F1). Left
+      // unguarded, a stale staged wildcard pair from an earlier abandoned
+      // stage (e.g. a paste) could survive alongside this issuance's fresh
+      // generic pair and get promoted together as if it were one coherent
+      // set. The live dir is never touched here.
+      discardStagedCertificates();
+    }
     await mkdir(dir, { recursive: true });
     await writeFile(join(dir, 'fullchain.pem'), certificate, { mode: 0o644 });
     await writeFile(join(dir, 'privkey.pem'), key, { mode: 0o600 });

--- a/apps/backend/src/domains/ssl-certificate.service.ts
+++ b/apps/backend/src/domains/ssl-certificate.service.ts
@@ -10,6 +10,7 @@ import { eq, and } from 'drizzle-orm';
 import { db } from '../db/client';
 import { sslChallenges, SslChallenge } from '../db/schema';
 import { certPemHasWildcardSan } from './ssl-cert-utils';
+import { sslStagingDir } from '../setup/ssl-staging';
 
 export interface DnsChallenge {
   domain: string;
@@ -500,25 +501,31 @@ export class SslCertificateService {
    * (Task 4) holds — preview subdomains serve it with a hostname mismatch
    * until the optional DNS-01 wildcard flow replaces the copies.
    */
-  async requestPrimaryDomainCertificate(domain: string): Promise<{
+  async requestPrimaryDomainCertificate(
+    domain: string,
+    opts: { target?: 'live' | 'staging' } = {},
+  ): Promise<{
     success: boolean;
     error?: string;
     expiresAt?: Date;
     sans?: string[];
     reused?: boolean;
   }> {
+    const target = opts.target ?? 'live';
     const sans = [domain, `www.${domain}`, `admin.${domain}`];
 
-    // Idempotency: bootstrap wizard retries (and the renewal cron far from
-    // expiry) must not burn LE rate limit re-issuing a cert we already hold.
-    const staged = this.stagedPrimaryCertificate(sans);
+    // Idempotency (rate-limit protection). Target-scoped on purpose: the
+    // renewal cron (target 'live') must never be satisfied by a stale staged
+    // cert while the LIVE one approaches expiry; a user-driven staging
+    // request may reuse either a fresh stage or a still-valid live cert.
+    const staged = this.stagedPrimaryCertificate(sans, target);
     if (staged) {
       this.logger.log(`Primary cert already covers [${sans.join(', ')}] — reusing`);
       return { success: true, expiresAt: staged.expiresAt, sans, reused: true };
     }
 
     if (this.mockMode) {
-      return this.issueMockPrimaryCertificate(domain, sans);
+      return this.issueMockPrimaryCertificate(domain, sans, target);
     }
     if (!this.acmeClient) {
       return { success: false, error: 'ACME client not initialized' };
@@ -559,7 +566,7 @@ export class SslCertificateService {
         throw new Error(`Order did not become valid. Final status: ${validOrder.status}`);
       }
       const certificate = await this.acmeClient.getCertificate(validOrder);
-      await this.savePrimaryCertificate(domain, certificate, key);
+      await this.savePrimaryCertificate(domain, certificate, key, target);
       const expiresAt = this.parseCertificateExpiry(certificate);
       this.logger.log(`Primary domain certificate issued for [${sans.join(', ')}]`);
       return { success: true, expiresAt, sans };
@@ -583,35 +590,48 @@ export class SslCertificateService {
   /**
    * Returns the currently staged fullchain.pem's expiry when it already
    * covers every requested SAN with more than 30 days left — signals the
-   * caller to skip re-issuance entirely.
+   * caller to skip re-issuance entirely. Target-scoped: a 'live' target only
+   * ever consults the live cert (the renewal cron must never be satisfied by
+   * a stale staged cert), while a 'staging' target checks staging first,
+   * falling back to a still-valid live cert.
    */
-  private stagedPrimaryCertificate(sans: string[]): { expiresAt: Date } | null {
-    try {
-      const pem = fs.readFileSync(join(this.getSslPath(), 'fullchain.pem'));
-      const cert = new X509Certificate(pem);
-      const certSans = (cert.subjectAltName ?? '')
-        .split(',')
-        .map((s) => s.trim())
-        .filter((s) => s.startsWith('DNS:'))
-        .map((s) => s.slice(4));
-      const covers = sans.every((s) => certSans.includes(s));
-      const expiresAt = new Date(cert.validTo);
-      const daysLeft = (expiresAt.getTime() - Date.now()) / 86_400_000;
-      return covers && daysLeft > 30 ? { expiresAt } : null;
-    } catch {
-      return null;
+  private stagedPrimaryCertificate(
+    sans: string[],
+    target: 'live' | 'staging',
+  ): { expiresAt: Date } | null {
+    const candidates =
+      target === 'staging'
+        ? [join(sslStagingDir(), 'fullchain.pem'), join(this.getSslPath(), 'fullchain.pem')]
+        : [join(this.getSslPath(), 'fullchain.pem')];
+    for (const certPath of candidates) {
+      try {
+        const cert = new X509Certificate(fs.readFileSync(certPath));
+        const certSans = (cert.subjectAltName ?? '')
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s.startsWith('DNS:'))
+          .map((s) => s.slice(4));
+        const covers = sans.every((s) => certSans.includes(s));
+        const expiresAt = new Date(cert.validTo);
+        const daysLeft = (expiresAt.getTime() - Date.now()) / 86_400_000;
+        if (covers && daysLeft > 30) return { expiresAt };
+      } catch {
+        // try next candidate
+      }
     }
+    return null;
   }
 
   private async savePrimaryCertificate(
     domain: string,
     certificate: string,
     key: Buffer,
+    target: 'live' | 'staging' = 'live',
   ): Promise<void> {
-    const sslPath = this.getSslPath();
-    await mkdir(sslPath, { recursive: true });
-    await writeFile(join(sslPath, 'fullchain.pem'), certificate, { mode: 0o644 });
-    await writeFile(join(sslPath, 'privkey.pem'), key, { mode: 0o600 });
+    const dir = target === 'staging' ? sslStagingDir() : this.getSslPath();
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'fullchain.pem'), certificate, { mode: 0o644 });
+    await writeFile(join(dir, 'privkey.pem'), key, { mode: 0o600 });
     // The wildcard.* files are only a COPY of the primary cert (render-contract
     // filler for Task 4's nginx template). If a REAL DNS-01 wildcard is
     // installed — its SANs include *.<domain>, which an HTTP-01 primary cert
@@ -620,10 +640,12 @@ export class SslCertificateService {
     // *.<domain> SAN), which also correctly covers the mock path: a freshly
     // mock-issued primary cert has no prior wildcard.crt on disk yet, so the
     // guard is a no-op the first time and only ever blocks when a genuinely
-    // wildcard-carrying cert is already staged.
+    // wildcard-carrying cert is already staged. This guard stays pointed at
+    // the LIVE dir regardless of target — it decides whether wildcard copies
+    // may exist at all, and a real live wildcard must never be clobbered.
     if (!this.installedWildcardIsReal(domain)) {
-      await writeFile(join(sslPath, `wildcard.${domain}.crt`), certificate, { mode: 0o644 });
-      await writeFile(join(sslPath, `wildcard.${domain}.key`), key, { mode: 0o600 });
+      await writeFile(join(dir, `wildcard.${domain}.crt`), certificate, { mode: 0o644 });
+      await writeFile(join(dir, `wildcard.${domain}.key`), key, { mode: 0o600 });
     }
   }
 
@@ -648,9 +670,10 @@ export class SslCertificateService {
   private async issueMockPrimaryCertificate(
     domain: string,
     sans: string[],
+    target: 'live' | 'staging' = 'live',
   ): Promise<{ success: boolean; expiresAt?: Date; sans?: string[] }> {
     const certPem = this.selfSignWithForge(domain, [...sans, `*.${domain}`]);
-    await this.savePrimaryCertificate(domain, certPem, Buffer.from(this.mockPrimaryKeyPem!));
+    await this.savePrimaryCertificate(domain, certPem, Buffer.from(this.mockPrimaryKeyPem!), target);
     const expiresAt = new Date(Date.now() + 90 * 86_400_000);
     this.mockCertificates.set(domain, expiresAt);
     this.logger.log(`[MOCK] Primary domain certificate issued for [${sans.join(', ')}]`);

--- a/apps/backend/src/domains/ssl-info.service.ts
+++ b/apps/backend/src/domains/ssl-info.service.ts
@@ -3,6 +3,7 @@ import { X509Certificate } from 'crypto';
 import { readFile, access } from 'fs/promises';
 import { join } from 'path';
 import { certPemHasWildcardSan } from './ssl-cert-utils';
+import { sslStagingDir } from '../setup/ssl-staging';
 
 export interface SslCertificateInfo {
   type: 'wildcard' | 'individual';
@@ -106,10 +107,7 @@ export class SslInfoService {
    */
   async getStagedPrimaryCertInfo(): Promise<SslCertificateInfo | null> {
     try {
-      const certContent = await readFile(
-        join(this.getSslPath(), 'staging', 'fullchain.pem'),
-        'utf-8',
-      );
+      const certContent = await readFile(join(sslStagingDir(), 'fullchain.pem'), 'utf-8');
       return this.parseCertificate(certContent, 'individual');
     } catch {
       return null;

--- a/apps/backend/src/domains/ssl-info.service.ts
+++ b/apps/backend/src/domains/ssl-info.service.ts
@@ -100,6 +100,23 @@ export class SslInfoService {
   }
 
   /**
+   * Cert staged for the primary domain but not yet promoted by apply()
+   * (<SSL_CERT_PATH>/staging/fullchain.pem). Absence is the normal state,
+   * so unlike getServedPrimaryCertInfo this logs nothing on a miss.
+   */
+  async getStagedPrimaryCertInfo(): Promise<SslCertificateInfo | null> {
+    try {
+      const certContent = await readFile(
+        join(this.getSslPath(), 'staging', 'fullchain.pem'),
+        'utf-8',
+      );
+      return this.parseCertificate(certContent, 'individual');
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Get SSL certificate info for system app domains
    * These domains have individual certificates (not wildcard)
    */

--- a/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
@@ -1,6 +1,12 @@
 import { BadRequestException } from '@nestjs/common';
 import { BootstrapSetupController } from './bootstrap-setup.controller';
 import { ApplyBootstrapDto } from './setup.dto';
+import * as staging from './ssl-staging';
+
+jest.mock('./ssl-staging', () => ({
+  promoteStagedCertificates: jest.fn().mockReturnValue([]),
+  discardStagedCertificates: jest.fn(),
+}));
 
 describe('BootstrapSetupController', () => {
   let controller: BootstrapSetupController;
@@ -284,6 +290,41 @@ describe('BootstrapSetupController', () => {
       expect(res.adminUrl).toBe('https://admin.example.com');
       writeSpy.mockRestore();
     });
+
+    it('apply promotes staged certs BEFORE writing instance config (non-selfsigned)', async () => {
+      const writeSpy = jest
+        .spyOn(require('../bootstrap/instance-config'), 'writeInstanceConfig')
+        .mockImplementation(() => undefined);
+      // Pin explicitly (mockReturnValueOnce): an earlier test in this
+      // describe block ('applies a selfsigned proxy install...') leaves
+      // svc.validateApplyConfig permanently stubbed via mockReturnValue
+      // (no `Once`), so relying on the shared default dto-passthrough
+      // implementation here would be order-dependent.
+      svc.validateApplyConfig.mockReturnValueOnce({
+        proxyMode: 'cloudflare', sslMode: 'paste', port80: 'redirect', realIp: null,
+      });
+      await controller.apply({ domain: 'example.com', proxyMode: 'cloudflare', sslMode: 'paste' });
+      expect(staging.promoteStagedCertificates).toHaveBeenCalled();
+      const promoteOrder = (staging.promoteStagedCertificates as jest.Mock).mock.invocationCallOrder[0];
+      const writeOrder = writeSpy.mock.invocationCallOrder[0];
+      expect(promoteOrder).toBeLessThan(writeOrder);
+      writeSpy.mockRestore();
+    });
+
+    it('apply with selfsigned discards staging and does not promote', async () => {
+      const writeSpy = jest
+        .spyOn(require('../bootstrap/instance-config'), 'writeInstanceConfig')
+        .mockImplementation(() => undefined);
+      svc.validateApplyConfig.mockReturnValueOnce({
+        proxyMode: 'proxy', sslMode: 'selfsigned', port80: 'redirect', realIp: null,
+      });
+      await controller.apply({
+        domain: 'example.com', proxyMode: 'proxy', sslMode: 'selfsigned',
+      } as ApplyBootstrapDto);
+      expect(staging.discardStagedCertificates).toHaveBeenCalled();
+      expect(staging.promoteStagedCertificates).not.toHaveBeenCalled();
+      writeSpy.mockRestore();
+    });
   });
 
   describe('scheduleExit (real timer, not invoked through the mocked override)', () => {
@@ -341,7 +382,7 @@ describe('BootstrapSetupController', () => {
       });
       const res = await controller.issueCertificate({ domain: 'Example.com' });
       expect(svc.validateDomain).toHaveBeenCalledWith('Example.com');
-      expect(sslCert.requestPrimaryDomainCertificate).toHaveBeenCalledWith('example.com');
+      expect(sslCert.requestPrimaryDomainCertificate).toHaveBeenCalledWith('example.com', { target: 'staging' });
       expect(res).toEqual({ issued: true, sans: ['example.com', 'www.example.com', 'admin.example.com'] });
     });
 

--- a/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
@@ -6,6 +6,7 @@ import * as staging from './ssl-staging';
 jest.mock('./ssl-staging', () => ({
   promoteStagedCertificates: jest.fn().mockReturnValue([]),
   discardStagedCertificates: jest.fn(),
+  stagingPartiallyPopulated: jest.fn().mockReturnValue(false),
 }));
 
 describe('BootstrapSetupController', () => {
@@ -253,6 +254,20 @@ describe('BootstrapSetupController', () => {
       await expect(
         controller.apply({ domain: 'example.com', proxyMode: 'cloudflare', sslMode: 'paste' }),
       ).rejects.toThrow(/does not cover/i);
+      expect(writeSpy).not.toHaveBeenCalled();
+      expect(exitFn).not.toHaveBeenCalled();
+      writeSpy.mockRestore();
+    });
+
+    it('refuses when staging is partially populated (torn stage), before checking cert presence or writing config', async () => {
+      const writeSpy = jest
+        .spyOn(require('../bootstrap/instance-config'), 'writeInstanceConfig')
+        .mockImplementation(() => undefined);
+      (staging.stagingPartiallyPopulated as jest.Mock).mockReturnValueOnce(true);
+      await expect(
+        controller.apply({ domain: 'example.com', proxyMode: 'cloudflare', sslMode: 'paste' }),
+      ).rejects.toThrow(/incomplete/i);
+      expect(svc.certificatesPresent).not.toHaveBeenCalled();
       expect(writeSpy).not.toHaveBeenCalled();
       expect(exitFn).not.toHaveBeenCalled();
       writeSpy.mockRestore();

--- a/apps/backend/src/setup/bootstrap-setup.controller.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.ts
@@ -4,7 +4,7 @@ import { BootstrapSetupService } from './bootstrap-setup.service';
 import { BootstrapDnsPreflightService, PreflightResult } from './bootstrap-dns-preflight.service';
 import { SslCertificateService } from '../domains/ssl-certificate.service';
 import { writeInstanceConfig } from '../bootstrap/instance-config';
-import { discardStagedCertificates, promoteStagedCertificates } from './ssl-staging';
+import { discardStagedCertificates, promoteStagedCertificates, stagingPartiallyPopulated } from './ssl-staging';
 import { ApplyBootstrapDto, BootstrapDomainActionDto, UploadCertificatesDto } from './setup.dto';
 
 @ApiTags('Setup')
@@ -68,6 +68,12 @@ export class BootstrapSetupController {
     // check. Every other mode stages a real cert (paste) or has one issued
     // (letsencrypt, via issue-certificate) before apply.
     if (dto.sslMode !== 'selfsigned') {
+      // A torn stage (only one of fullchain.pem/privkey.pem present) must
+      // fail loudly rather than silently no-op-ing through promote — see
+      // stagingPartiallyPopulated's doc comment.
+      if (stagingPartiallyPopulated()) {
+        throw new BadRequestException('Staged certificate is incomplete — discard it and stage again');
+      }
       if (!this.bootstrap.certificatesPresent(dto.domain)) {
         throw new BadRequestException('Install certificates before applying');
       }

--- a/apps/backend/src/setup/bootstrap-setup.controller.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.ts
@@ -4,6 +4,7 @@ import { BootstrapSetupService } from './bootstrap-setup.service';
 import { BootstrapDnsPreflightService, PreflightResult } from './bootstrap-dns-preflight.service';
 import { SslCertificateService } from '../domains/ssl-certificate.service';
 import { writeInstanceConfig } from '../bootstrap/instance-config';
+import { discardStagedCertificates, promoteStagedCertificates } from './ssl-staging';
 import { ApplyBootstrapDto, BootstrapDomainActionDto, UploadCertificatesDto } from './setup.dto';
 
 @ApiTags('Setup')
@@ -89,6 +90,14 @@ export class BootstrapSetupController {
     // throws BadRequestException on any illegal combination before anything
     // is written or the process is marked for restart.
     const applied = this.bootstrap.validateApplyConfig(dto);
+    // #514: certs staged by uploadCertificates / issue-certificate go live
+    // here — after every validation gate, before the instance write whose
+    // watcher-triggered render flips SSL_MODE and starts serving them.
+    if (applied.sslMode === 'selfsigned') {
+      discardStagedCertificates();
+    } else {
+      promoteStagedCertificates();
+    }
     // Mark setup complete BEFORE writing instance.json + exiting: apply is the
     // bootstrap flow's terminal step, so the restarted backend should land the
     // user at login, not back in the normal-mode wizard. Must persist before
@@ -134,7 +143,7 @@ export class BootstrapSetupController {
       );
     }
     await this.sslCert.initialize();
-    const result = await this.sslCert.requestPrimaryDomainCertificate(domain);
+    const result = await this.sslCert.requestPrimaryDomainCertificate(domain, { target: 'staging' });
     if (!result.success) {
       throw new BadRequestException(`Certificate issuance failed: ${result.error}`);
     }

--- a/apps/backend/src/setup/bootstrap-setup.service.spec.ts
+++ b/apps/backend/src/setup/bootstrap-setup.service.spec.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { BootstrapSetupService } from './bootstrap-setup.service';
 import { ApplyBootstrapDto } from './setup.dto';
+import { promoteStagedCertificates } from './ssl-staging';
 
 interface MakeCertOpts {
   includeApex?: boolean;
@@ -535,16 +536,22 @@ describe('BootstrapSetupService', () => {
       expect(() => service.assertStagedCertificateCovers('example.com', 'cloudflare')).not.toThrow();
     });
 
-    it('rejects the change-of-mind sequence: upload A, upload B, apply A', () => {
-      // saveCertificates overwrites the generic fullchain.pem/privkey.pem on
-      // every upload, but leaves earlier domains' wildcard.* files behind —
-      // so certificatesPresent('example.com') still passes after the
-      // other.com upload while fullchain.pem now holds other.com's cert.
+    it('rejects the change-of-mind sequence: upload A, apply A (promotes to live), upload B, apply A again', () => {
+      // #514 F1: saveCertificates now clears any PRIOR STAGE before writing,
+      // so the classic "upload A, upload B" trap can no longer arise purely
+      // within staging/ (the B upload wipes A's staged files outright). The
+      // trap still arises across live + staging: promote A to live (a real
+      // apply()), then upload B for a different domain — live keeps A's
+      // wildcard.* files while staging's generic pair now holds B's
+      // material. certificatesPresent('example.com') still passes on the
+      // leftover live wildcard.example.com.* files while fullchain.pem
+      // (staging, unioned in by certificatesPresent) now holds B's cert.
       // Applying example.com at that point would put nginx up serving
       // example.com's vhosts with other.com's certificate.
       const a = makeCert('example.com', keyA);
       const b = makeCert('other.com', keyB);
       service.saveCertificates(a.certPem, a.keyPem, 'example.com');
+      promoteStagedCertificates(); // simulate apply() promoting A to live
       service.saveCertificates(b.certPem, b.keyPem, 'other.com');
 
       expect(service.certificatesPresent('example.com')).toBe(true); // the trap
@@ -594,6 +601,25 @@ describe('BootstrapSetupService', () => {
         expect(fs.existsSync(path.join(stagingDir(), f))).toBe(true);
         expect(fs.existsSync(path.join(sslDir, f))).toBe(false);
       }
+    });
+
+    it('saveCertificates clears any prior stage before writing (#514 F1) — no accumulation', () => {
+      const { certPem, keyPem } = makeCert('example.com', keyA);
+      // Seed a junk file plus a stale pair from an earlier, abandoned stage.
+      fs.mkdirSync(stagingDir(), { recursive: true });
+      fs.writeFileSync(path.join(stagingDir(), 'junk.txt'), 'JUNK');
+      fs.writeFileSync(path.join(stagingDir(), 'wildcard.stale.com.crt'), 'STALE');
+      fs.writeFileSync(path.join(stagingDir(), 'wildcard.stale.com.key'), 'STALE');
+
+      service.saveCertificates(certPem, keyPem, 'example.com');
+
+      const files = fs.readdirSync(stagingDir()).sort();
+      expect(files).toEqual([
+        'fullchain.pem',
+        'privkey.pem',
+        'wildcard.example.com.crt',
+        'wildcard.example.com.key',
+      ]);
     });
 
     it('certificatesPresent is a per-file union of staging and live', () => {

--- a/apps/backend/src/setup/bootstrap-setup.service.spec.ts
+++ b/apps/backend/src/setup/bootstrap-setup.service.spec.ts
@@ -340,7 +340,9 @@ describe('BootstrapSetupService', () => {
     it('saves the four cert files with correct permissions', () => {
       const { certPem, keyPem } = makeCert('example.com', keyA);
       service.saveCertificates(certPem, keyPem, 'example.com');
-      const mode = (f: string) => fs.statSync(path.join(sslDir, f)).mode & 0o777;
+      // #514: saveCertificates writes into staging/, not the live dir.
+      const stagingDir = path.join(sslDir, 'staging');
+      const mode = (f: string) => fs.statSync(path.join(stagingDir, f)).mode & 0o777;
       expect(mode('fullchain.pem')).toBe(0o644);
       expect(mode('privkey.pem')).toBe(0o600);
       expect(mode('wildcard.example.com.crt')).toBe(0o644);
@@ -350,16 +352,20 @@ describe('BootstrapSetupService', () => {
     it('writes exactly the expected file contents', () => {
       const { certPem, keyPem } = makeCert('example.com', keyA);
       service.saveCertificates(certPem, keyPem, 'example.com');
-      expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe(certPem);
-      expect(fs.readFileSync(path.join(sslDir, 'privkey.pem'), 'utf8')).toBe(keyPem);
-      expect(fs.readFileSync(path.join(sslDir, 'wildcard.example.com.crt'), 'utf8')).toBe(certPem);
-      expect(fs.readFileSync(path.join(sslDir, 'wildcard.example.com.key'), 'utf8')).toBe(keyPem);
+      // #514: saveCertificates writes into staging/, not the live dir.
+      const stagingDir = path.join(sslDir, 'staging');
+      expect(fs.readFileSync(path.join(stagingDir, 'fullchain.pem'), 'utf8')).toBe(certPem);
+      expect(fs.readFileSync(path.join(stagingDir, 'privkey.pem'), 'utf8')).toBe(keyPem);
+      expect(fs.readFileSync(path.join(stagingDir, 'wildcard.example.com.crt'), 'utf8')).toBe(certPem);
+      expect(fs.readFileSync(path.join(stagingDir, 'wildcard.example.com.key'), 'utf8')).toBe(keyPem);
     });
 
     it('leaves no stray .tmp files behind', () => {
       const { certPem, keyPem } = makeCert('example.com', keyA);
       service.saveCertificates(certPem, keyPem, 'example.com');
-      const stray = fs.readdirSync(sslDir).filter((f) => f.includes('.tmp'));
+      // #514: the atomic write's tmp files land (and get renamed away) in
+      // staging/, the dir saveCertificates now writes into.
+      const stray = fs.readdirSync(path.join(sslDir, 'staging')).filter((f) => f.includes('.tmp'));
       expect(stray).toEqual([]);
     });
 
@@ -377,9 +383,11 @@ describe('BootstrapSetupService', () => {
     it('writes lowercased wildcard filenames given a mixed-case domain', () => {
       const { certPem, keyPem } = makeCert('example.com', keyA);
       service.saveCertificates(certPem, keyPem, 'Example.com');
-      expect(fs.existsSync(path.join(sslDir, 'wildcard.example.com.crt'))).toBe(true);
-      expect(fs.existsSync(path.join(sslDir, 'wildcard.example.com.key'))).toBe(true);
-      expect(fs.existsSync(path.join(sslDir, 'wildcard.Example.com.crt'))).toBe(false);
+      // #514: saveCertificates writes into staging/, not the live dir.
+      const stagingDir = path.join(sslDir, 'staging');
+      expect(fs.existsSync(path.join(stagingDir, 'wildcard.example.com.crt'))).toBe(true);
+      expect(fs.existsSync(path.join(stagingDir, 'wildcard.example.com.key'))).toBe(true);
+      expect(fs.existsSync(path.join(stagingDir, 'wildcard.Example.com.crt'))).toBe(false);
     });
   });
 
@@ -573,6 +581,49 @@ describe('BootstrapSetupService', () => {
       expect(() => service.assertStagedCertificateCovers('example.com', 'cloudflare')).toThrow(
         /wildcard/i,
       );
+    });
+  });
+
+  describe('staging semantics (#514)', () => {
+    const stagingDir = () => path.join(sslDir, 'staging');
+
+    it('saveCertificates writes the four files into staging/, not the live dir', () => {
+      const { certPem, keyPem } = makeCert('example.com', keyA);
+      service.saveCertificates(certPem, keyPem, 'example.com');
+      for (const f of ['fullchain.pem', 'privkey.pem', 'wildcard.example.com.crt', 'wildcard.example.com.key']) {
+        expect(fs.existsSync(path.join(stagingDir(), f))).toBe(true);
+        expect(fs.existsSync(path.join(sslDir, f))).toBe(false);
+      }
+    });
+
+    it('certificatesPresent is a per-file union of staging and live', () => {
+      const { certPem, keyPem } = makeCert('example.com', keyA);
+      expect(service.certificatesPresent('example.com')).toBe(false);
+      // generic pair staged, wildcard pair live (the LE + real-DNS-01-wildcard case)
+      fs.mkdirSync(stagingDir(), { recursive: true });
+      fs.writeFileSync(path.join(stagingDir(), 'fullchain.pem'), certPem);
+      fs.writeFileSync(path.join(stagingDir(), 'privkey.pem'), keyPem);
+      fs.writeFileSync(path.join(sslDir, 'wildcard.example.com.crt'), certPem);
+      fs.writeFileSync(path.join(sslDir, 'wildcard.example.com.key'), keyPem);
+      expect(service.certificatesPresent('example.com')).toBe(true);
+    });
+
+    it('assertStagedCertificateCovers prefers the STAGED fullchain over the live one', () => {
+      const a = makeCert('aaa.com', keyA); // live: covers only aaa.com
+      const b = makeCert('bbb.com', keyB); // staged: covers only bbb.com
+      fs.writeFileSync(path.join(sslDir, 'fullchain.pem'), a.certPem);
+      fs.mkdirSync(stagingDir(), { recursive: true });
+      fs.writeFileSync(path.join(stagingDir(), 'fullchain.pem'), b.certPem);
+      // staged cert covers bbb.com → passes even though live covers only aaa.com
+      expect(() => service.assertStagedCertificateCovers('bbb.com', 'proxy')).not.toThrow();
+      // and correctly fails for aaa.com (staged takes precedence)
+      expect(() => service.assertStagedCertificateCovers('aaa.com', 'proxy')).toThrow(/does not cover/);
+    });
+
+    it('assertStagedCertificateCovers falls back to the live fullchain when nothing is staged', () => {
+      const a = makeCert('aaa.com', keyA);
+      fs.writeFileSync(path.join(sslDir, 'fullchain.pem'), a.certPem);
+      expect(() => service.assertStagedCertificateCovers('aaa.com', 'proxy')).not.toThrow();
     });
   });
 

--- a/apps/backend/src/setup/bootstrap-setup.service.ts
+++ b/apps/backend/src/setup/bootstrap-setup.service.ts
@@ -14,7 +14,7 @@ import {
   RealIpConfig,
   SHELL_SAFE_HEADER_RE,
 } from '../bootstrap/instance-config';
-import { sslLiveDir, sslStagingDir } from './ssl-staging';
+import { sslLiveDir, sslStagingDir, discardStagedCertificates } from './ssl-staging';
 
 /**
  * Plausible-hostname check for a bootstrap domain. This value is user-supplied
@@ -270,6 +270,13 @@ export class BootstrapSetupService {
    */
   saveCertificates(certPem: string, keyPem: string, domain: string): void {
     const validatedDomain = this.assertValidDomain(domain);
+    // A stage overwrites any prior stage — no accumulation. Without this, a
+    // stale staged file from an earlier (possibly abandoned) stage can
+    // survive alongside this upload's files, e.g. a stale wildcard.<domain>
+    // pair from a paste sitting next to a freshly-issued LE pair — mixed
+    // fullchain/privkey + wildcard.* material that promoteStagedCertificates
+    // would then promote as if it were one coherent set.
+    discardStagedCertificates();
     // #514: user-driven writes are provisional — they land in staging/ and
     // only apply() promotes them into the watched live dir.
     const dir = sslStagingDir();

--- a/apps/backend/src/setup/bootstrap-setup.service.ts
+++ b/apps/backend/src/setup/bootstrap-setup.service.ts
@@ -14,6 +14,7 @@ import {
   RealIpConfig,
   SHELL_SAFE_HEADER_RE,
 } from '../bootstrap/instance-config';
+import { sslLiveDir, sslStagingDir } from './ssl-staging';
 
 /**
  * Plausible-hostname check for a bootstrap domain. This value is user-supplied
@@ -57,13 +58,9 @@ export class BootstrapSetupService {
     await this.setupService.finalizeBootstrapSetup();
   }
 
-  /**
-   * Same resolution as `ssl-certificate.service.ts` `getSslPath()` (line ~1039):
-   * `SSL_CERT_PATH` env override, else the default nginx SSL volume path.
-   * Duplicated intentionally rather than importing the 1000+ line ACME service.
-   */
+  /** Live cert dir — delegates to ssl-staging.ts so there is one resolution. */
   private sslDir(): string {
-    return process.env.SSL_CERT_PATH || '/etc/nginx/ssl';
+    return sslLiveDir();
   }
 
   /**
@@ -245,9 +242,13 @@ export class BootstrapSetupService {
    */
   assertStagedCertificateCovers(domain: string, servingMode: ProxyMode): void {
     const validatedDomain = this.assertValidDomain(domain);
+    const stagedPath = path.join(sslStagingDir(), 'fullchain.pem');
+    const certPath = fs.existsSync(stagedPath)
+      ? stagedPath
+      : path.join(this.sslDir(), 'fullchain.pem');
     let cert: X509Certificate;
     try {
-      cert = new X509Certificate(fs.readFileSync(path.join(this.sslDir(), 'fullchain.pem')));
+      cert = new X509Certificate(fs.readFileSync(certPath));
     } catch {
       throw new BadRequestException(
         'Installed certificate could not be read — re-install the certificate for this domain',
@@ -269,7 +270,9 @@ export class BootstrapSetupService {
    */
   saveCertificates(certPem: string, keyPem: string, domain: string): void {
     const validatedDomain = this.assertValidDomain(domain);
-    const dir = this.sslDir();
+    // #514: user-driven writes are provisional — they land in staging/ and
+    // only apply() promotes them into the watched live dir.
+    const dir = sslStagingDir();
     fs.mkdirSync(dir, { recursive: true });
 
     const write = (name: string, content: string, mode: number) => {
@@ -303,12 +306,17 @@ export class BootstrapSetupService {
    */
   certificatesPresent(domain: string): boolean {
     const validatedDomain = this.assertValidDomain(domain);
-    const dir = this.sslDir();
+    // Per-file union of staging and live: after #514 a stage may hold only
+    // the generic pair (LE issuance with a real DNS-01 wildcard installed
+    // live), and after a promote everything is live — both must count.
+    const present = (name: string) =>
+      fs.existsSync(path.join(sslStagingDir(), name)) ||
+      fs.existsSync(path.join(this.sslDir(), name));
     return (
-      fs.existsSync(path.join(dir, 'fullchain.pem')) &&
-      fs.existsSync(path.join(dir, 'privkey.pem')) &&
-      fs.existsSync(path.join(dir, `wildcard.${validatedDomain}.crt`)) &&
-      fs.existsSync(path.join(dir, `wildcard.${validatedDomain}.key`))
+      present('fullchain.pem') &&
+      present('privkey.pem') &&
+      present(`wildcard.${validatedDomain}.crt`) &&
+      present(`wildcard.${validatedDomain}.key`)
     );
   }
 

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.controller.spec.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.controller.spec.ts
@@ -8,6 +8,7 @@ const makeSvc = () => ({
   apply: jest.fn().mockResolvedValue({ applied: true, kind: 'cert-only' }),
   confirm: jest.fn(),
   rollback: jest.fn(),
+  discardStaged: jest.fn().mockReturnValue({ discarded: true }),
 });
 
 describe('PrimarySslController', () => {
@@ -27,5 +28,12 @@ describe('PrimarySslController', () => {
     expect(svc.apply).toHaveBeenCalled();
     expect(svc.confirm).toHaveBeenCalled();
     expect(svc.rollback).toHaveBeenCalled();
+  });
+
+  it('DELETE staged delegates to discardStaged', () => {
+    const svc = makeSvc();
+    const c = new PrimarySslController(svc as any);
+    expect(c.discardStaged()).toEqual({ discarded: true });
+    expect(svc.discardStaged).toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.controller.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { SessionAuthGuard } from '../../auth/session-auth.guard';
 import { RolesGuard } from '../../auth/roles.guard';
@@ -41,4 +41,7 @@ export class PrimarySslController {
   @Post('rollback')
   @HttpCode(HttpStatus.OK)
   rollback() { this.svc.rollback(); return { rolledBack: true }; }
+
+  @Delete('staged')
+  discardStaged() { return this.svc.discardStaged(); }
 }

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.integration.service.spec.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.integration.service.spec.ts
@@ -29,6 +29,7 @@ const domain = 'a.com';
 // assertions below check actual file CONTENT rather than mere existence.
 let keyOld: forge.pki.rsa.KeyPair;
 let keyNew: forge.pki.rsa.KeyPair;
+let keyThird: forge.pki.rsa.KeyPair;
 
 function makeCert(d: string, keys: forge.pki.rsa.KeyPair) {
   const cert = forge.pki.createCertificate();
@@ -63,12 +64,16 @@ describe('PrimarySslService cert staging (real BootstrapSetupService + snapshot 
   let oldKeyPem: string;
   let newCertPem: string;
   let newKeyPem: string;
+  let thirdCertPem: string;
+  let thirdKeyPem: string;
 
   beforeAll(() => {
     keyOld = forge.pki.rsa.generateKeyPair(2048);
     keyNew = forge.pki.rsa.generateKeyPair(2048);
+    keyThird = forge.pki.rsa.generateKeyPair(2048);
     ({ certPem: oldCertPem, keyPem: oldKeyPem } = makeCert(domain, keyOld));
     ({ certPem: newCertPem, keyPem: newKeyPem } = makeCert(domain, keyNew));
+    ({ certPem: thirdCertPem, keyPem: thirdKeyPem } = makeCert(domain, keyThird));
   });
 
   beforeEach(() => {
@@ -108,12 +113,59 @@ describe('PrimarySslService cert staging (real BootstrapSetupService + snapshot 
   it('apply promotes the staged cert and rollback restores the OLD live cert', async () => {
     fs.writeFileSync(path.join(sslDir, 'fullchain.pem'), oldCertPem);
     fs.writeFileSync(path.join(sslDir, 'privkey.pem'), oldKeyPem);
+    // Seed the domain-specific wildcard pair too (a real prior bootstrap
+    // apply would have promoted these alongside the generic pair) so the
+    // round-trip below has an OLD value to roll back to.
+    fs.writeFileSync(path.join(sslDir, `wildcard.${domain}.crt`), oldCertPem);
+    fs.writeFileSync(path.join(sslDir, `wildcard.${domain}.key`), oldKeyPem);
     svc.stagePaste({ certificatePem: newCertPem, privateKeyPem: newKeyPem, servingMode: 'none' } as any);
     await svc.apply({ proxyMode: 'none', sslMode: 'paste', port80: 'redirect' } as any);
     expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe(newCertPem);
+    expect(fs.readFileSync(path.join(sslDir, `wildcard.${domain}.crt`), 'utf8')).toBe(newCertPem);
     expect(fs.existsSync(path.join(sslDir, 'staging'))).toBe(false);
     svc.rollback();
     expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe(oldCertPem);
+    expect(fs.readFileSync(path.join(sslDir, `wildcard.${domain}.crt`), 'utf8')).toBe(oldCertPem);
+  });
+
+  it('a second no-confirm-window apply re-baselines rollback to the LATEST pre-change cert, not the original (ce#511)', async () => {
+    // proxyMode 'cloudflare' means the origin cert isn't user-facing, so
+    // apply() commits immediately via markApplied() instead of opening a
+    // confirm window. Seed the instance config to match what apply() will
+    // produce so there is no reachability change either — both applies
+    // below take the no-confirm path.
+    writeInstanceConfig(
+      {
+        version: 2,
+        state: 'applied',
+        primaryDomain: domain,
+        proxyMode: 'cloudflare',
+        sslMode: 'paste',
+        port80: 'closed',
+        realIp: { preset: 'cloudflare' },
+      },
+      bootDir,
+    );
+    fs.writeFileSync(path.join(sslDir, 'fullchain.pem'), oldCertPem);
+    fs.writeFileSync(path.join(sslDir, 'privkey.pem'), oldKeyPem);
+
+    // Cycle 1: live C0 -> stage C1 -> apply (commits immediately, no confirm window).
+    svc.stagePaste({ certificatePem: newCertPem, privateKeyPem: newKeyPem, servingMode: 'cloudflare' } as any);
+    await svc.apply({ proxyMode: 'cloudflare', sslMode: 'paste', port80: 'closed' } as any);
+    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe(newCertPem);
+
+    // Cycle 2: stage C2 -> apply again (also commits immediately). This
+    // apply's snapshotForChangeCycle() re-baselines over the cycle-1
+    // snapshot (already marked applied) instead of leaving the original C0
+    // baseline in place.
+    svc.stagePaste({ certificatePem: thirdCertPem, privateKeyPem: thirdKeyPem, servingMode: 'cloudflare' } as any);
+    await svc.apply({ proxyMode: 'cloudflare', sslMode: 'paste', port80: 'closed' } as any);
+    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe(thirdCertPem);
+
+    // Rollback restores the LATEST pre-change state (C1), not the original
+    // C0 — the re-baseline guarantee.
+    svc.rollback();
+    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe(newCertPem);
   });
 
   it('discardStaged aborts a stage cleanly', () => {

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.integration.service.spec.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.integration.service.spec.ts
@@ -1,28 +1,75 @@
-// Integration test with the REAL PrimarySslSnapshotService (real instance-config
-// + real cert files on tmpdirs). This is the test the fully-mocked service spec
-// missed: it exercises the actual snapshot ORDERING across a stage→apply→rollback
-// cycle and asserts the LIVE cert bytes are restored to the pre-change value.
+// Integration test with the REAL BootstrapSetupService and the REAL
+// PrimarySslSnapshotService (real instance-config + real cert files on
+// tmpdirs, real staging dir under SSL_CERT_PATH/staging). This is the test
+// the fully-mocked service spec (primary-ssl.service.spec.ts) misses: it
+// exercises the actual stage -> apply(promote) -> rollback cycle through
+// ssl-staging.ts, with real X509 cert/key validation, and asserts the LIVE
+// cert bytes at each step.
 //
-// Deliberately NO `jest.mock('../../bootstrap/instance-config')` here (unlike
-// primary-ssl.service.spec.ts) so the real snapshot service reads/writes real
-// instance.json + cert bytes under BOOTSTRAP_DIR / SSL_CERT_PATH.
+// Deliberately NO `jest.mock('../../bootstrap/instance-config')` here
+// (unlike primary-ssl.service.spec.ts) so the real snapshot service
+// reads/writes real instance.json + cert bytes under BOOTSTRAP_DIR /
+// SSL_CERT_PATH.
+import * as forge from 'node-forge';
 import { PrimarySslService } from './primary-ssl.service';
 import { PrimarySslSnapshotService } from './primary-ssl-snapshot.service';
+import { BootstrapSetupService } from '../bootstrap-setup.service';
 import { writeInstanceConfig } from '../../bootstrap/instance-config';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
 const domain = 'a.com';
-const CERT_FILES = ['fullchain.pem', 'privkey.pem', `wildcard.${domain}.crt`, `wildcard.${domain}.key`];
 
-describe('PrimarySslService cert rollback (real snapshot service)', () => {
+// RSA keygen is the slow part of these tests; generate the two distinct key
+// pairs once in beforeAll and reuse them across every test instead of
+// generating fresh keys each time. Two DISTINCT pairs (not just two cert
+// variants of the same key) so the "old" and "new" cert PEMs — and their
+// wildcard siblings — are byte-for-byte distinguishable, letting the
+// assertions below check actual file CONTENT rather than mere existence.
+let keyOld: forge.pki.rsa.KeyPair;
+let keyNew: forge.pki.rsa.KeyPair;
+
+function makeCert(d: string, keys: forge.pki.rsa.KeyPair) {
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = '01';
+  cert.validity.notBefore = new Date(Date.now() - 86400_000);
+  cert.validity.notAfter = new Date(Date.now() + 365 * 86400_000);
+  const attrs = [{ name: 'commonName', value: d }];
+  cert.setSubject(attrs);
+  cert.setIssuer(attrs);
+  cert.setExtensions([
+    {
+      name: 'subjectAltName',
+      altNames: [
+        { type: 2, value: d },
+        { type: 2, value: `*.${d}` },
+      ],
+    },
+  ]);
+  cert.sign(keys.privateKey, forge.md.sha256.create());
+  return {
+    certPem: forge.pki.certificateToPem(cert),
+    keyPem: forge.pki.privateKeyToPem(keys.privateKey),
+  };
+}
+
+describe('PrimarySslService cert staging (real BootstrapSetupService + snapshot service)', () => {
   let bootDir: string;
   let sslDir: string;
+  let svc: PrimarySslService;
+  let oldCertPem: string;
+  let oldKeyPem: string;
+  let newCertPem: string;
+  let newKeyPem: string;
 
-  const seedLiveCert = (bytes: string) => {
-    for (const f of CERT_FILES) fs.writeFileSync(path.join(sslDir, f), bytes);
-  };
+  beforeAll(() => {
+    keyOld = forge.pki.rsa.generateKeyPair(2048);
+    keyNew = forge.pki.rsa.generateKeyPair(2048);
+    ({ certPem: oldCertPem, keyPem: oldKeyPem } = makeCert(domain, keyOld));
+    ({ certPem: newCertPem, keyPem: newKeyPem } = makeCert(domain, keyNew));
+  });
 
   beforeEach(() => {
     bootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boot-'));
@@ -34,88 +81,44 @@ describe('PrimarySslService cert rollback (real snapshot service)', () => {
       { version: 2, state: 'applied', primaryDomain: domain, proxyMode: 'none', sslMode: 'paste', port80: 'redirect', realIp: null },
       bootDir,
     );
+
+    const bootstrap = new BootstrapSetupService({} as any, {} as any);
+    const ssl = { requestPrimaryDomainCertificate: jest.fn() };
+    const preflight = { run: jest.fn().mockResolvedValue({ ok: true, checks: [] }) };
+    const info = { getWildcardCertInfo: jest.fn().mockResolvedValue(null) };
+    const snap = new PrimarySslSnapshotService();
+    svc = new PrimarySslService(bootstrap, ssl as any, preflight as any, info as any, snap);
   });
+
   afterEach(() => {
     delete process.env.BOOTSTRAP_DIR;
     delete process.env.SSL_CERT_PATH;
   });
 
-  const build = () => {
-    const snap = new PrimarySslSnapshotService();
-    const bootstrap = {
-      validateCertificatePair: jest.fn().mockReturnValue({ sans: [domain, `*.${domain}`], wildcardCovered: true }),
-      // The real behavior under test: writing a paste actually overwrites the
-      // LIVE cert files. If the snapshot wasn't taken first, C0 is already gone.
-      saveCertificates: jest.fn((certPem: string, keyPem: string) => {
-        fs.writeFileSync(path.join(sslDir, 'fullchain.pem'), certPem);
-        fs.writeFileSync(path.join(sslDir, 'privkey.pem'), keyPem);
-        fs.writeFileSync(path.join(sslDir, `wildcard.${domain}.crt`), certPem);
-        fs.writeFileSync(path.join(sslDir, `wildcard.${domain}.key`), keyPem);
-      }),
-      validateApplyConfig: jest.fn((d: any) => ({ proxyMode: d.proxyMode, sslMode: d.sslMode, port80: d.port80 ?? 'redirect', realIp: d.realIp ?? null })),
-      certificatesPresent: jest.fn().mockReturnValue(true),
-      assertStagedCertificateCovers: jest.fn(),
-    };
-    const ssl = { requestPrimaryDomainCertificate: jest.fn() };
-    const preflight = { run: jest.fn().mockResolvedValue({ ok: true, checks: [] }) };
-    const info = { getWildcardCertInfo: jest.fn().mockResolvedValue(null) };
-    const svc = new PrimarySslService(bootstrap as any, ssl as any, preflight as any, info as any, snap);
-    return { svc, snap };
-  };
-
-  it('rollback restores the pre-change (C0) cert after a paste+apply that installed C1', async () => {
-    const { svc } = build();
-
-    // Live known-good cert before any change.
-    seedLiveCert('C0');
-    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe('C0');
-
-    // Stage a new pasted cert C1 — this OVERWRITES the live cert files.
-    svc.stagePaste({ certificatePem: 'C1', privateKeyPem: 'C1', servingMode: 'none' } as any);
-    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe('C1');
-
-    // Apply the cert-only change (no reachability change → no pending revert).
-    const r = await svc.apply({ proxyMode: 'none', sslMode: 'paste', port80: 'redirect', realIp: undefined } as any);
-    expect(r.kind).toBe('cert-only');
-
-    // Roll back — must restore the ORIGINAL C0 cert, not the just-installed C1.
-    svc.rollback();
-    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe('C0');
-    expect(fs.readFileSync(path.join(sslDir, `wildcard.${domain}.crt`), 'utf8')).toBe('C0');
+  it('stagePaste leaves the live cert untouched until apply promotes it', () => {
+    // seed a live cert as the "currently served" one
+    fs.writeFileSync(path.join(sslDir, 'fullchain.pem'), oldCertPem);
+    fs.writeFileSync(path.join(sslDir, 'privkey.pem'), oldKeyPem);
+    svc.stagePaste({ certificatePem: newCertPem, privateKeyPem: newKeyPem, servingMode: 'proxy' } as any);
+    // live file unchanged; staged file holds the new cert
+    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe(oldCertPem);
+    expect(fs.readFileSync(path.join(sslDir, 'staging', 'fullchain.pem'), 'utf8')).toBe(newCertPem);
   });
 
-  it('chained applies re-baseline: rollback after the second apply restores the FIRST applied cert, not the original', async () => {
-    // Proxied (Cloudflare) config on both the baseline and every apply below,
-    // so no reachability/confirm window is involved — this test is purely
-    // about the ssl-snapshot re-baseline chain (ce#511).
-    writeInstanceConfig(
-      { version: 2, state: 'applied', primaryDomain: domain, proxyMode: 'cloudflare', sslMode: 'paste', port80: 'redirect', realIp: null },
-      bootDir,
-    );
-    const { svc } = build();
-
-    // Original live cert, before any staged change.
-    seedLiveCert('ORIG');
-
-    // Stage + apply cert A. Committed with no confirm window (proxied, no
-    // reachability change) -> markApplied() runs, no deadlineMs.
-    svc.stagePaste({ certificatePem: 'A', privateKeyPem: 'A', servingMode: 'cloudflare' } as any);
-    const r1 = await svc.apply({ proxyMode: 'cloudflare', sslMode: 'paste', port80: 'redirect', realIp: undefined } as any);
-    expect(r1.kind).toBe('cert-only');
-    expect(r1.deadlineMs).toBeUndefined();
-    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe('A');
-
-    // Stage + apply cert B. The stage re-baselines the (now-applied) snapshot
-    // over A -- so the snapshot goes from holding ORIG to holding A.
-    svc.stagePaste({ certificatePem: 'B', privateKeyPem: 'B', servingMode: 'cloudflare' } as any);
-    const r2 = await svc.apply({ proxyMode: 'cloudflare', sslMode: 'paste', port80: 'redirect', realIp: undefined } as any);
-    expect(r2.kind).toBe('cert-only');
-    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe('B');
-
-    // Roll back — must restore A (the last committed change before this one),
-    // NOT the original pre-chain ORIG cert.
+  it('apply promotes the staged cert and rollback restores the OLD live cert', async () => {
+    fs.writeFileSync(path.join(sslDir, 'fullchain.pem'), oldCertPem);
+    fs.writeFileSync(path.join(sslDir, 'privkey.pem'), oldKeyPem);
+    svc.stagePaste({ certificatePem: newCertPem, privateKeyPem: newKeyPem, servingMode: 'none' } as any);
+    await svc.apply({ proxyMode: 'none', sslMode: 'paste', port80: 'redirect' } as any);
+    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe(newCertPem);
+    expect(fs.existsSync(path.join(sslDir, 'staging'))).toBe(false);
     svc.rollback();
-    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe('A');
-    expect(fs.readFileSync(path.join(sslDir, `wildcard.${domain}.crt`), 'utf8')).toBe('A');
+    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe(oldCertPem);
+  });
+
+  it('discardStaged aborts a stage cleanly', () => {
+    svc.stagePaste({ certificatePem: newCertPem, privateKeyPem: newKeyPem, servingMode: 'proxy' } as any);
+    svc.discardStaged();
+    expect(fs.existsSync(path.join(sslDir, 'staging'))).toBe(false);
   });
 });

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
@@ -31,6 +31,7 @@ jest.mock('../../bootstrap/instance-config', () => ({
 
 jest.mock('../ssl-staging', () => ({
   stagingPopulated: jest.fn().mockReturnValue(false),
+  stagingPartiallyPopulated: jest.fn().mockReturnValue(false),
   promoteStagedCertificates: jest.fn().mockReturnValue([]),
   discardStagedCertificates: jest.fn(),
 }));
@@ -42,8 +43,20 @@ beforeEach(() => {
   // Module mocks persist across tests (no global resetMocks), so re-baseline
   // the staging module's defaults here — same reason mockCur is reset above.
   (staging.stagingPopulated as jest.Mock).mockReset().mockReturnValue(false);
-  (staging.promoteStagedCertificates as jest.Mock).mockReset().mockReturnValue([]);
-  (staging.discardStagedCertificates as jest.Mock).mockReset();
+  (staging.stagingPartiallyPopulated as jest.Mock).mockReset().mockReturnValue(false);
+  // Stateful (M1): promote/discard flip stagingPopulated() back to false when
+  // invoked, mirroring the real ssl-staging.ts module (a promoted or
+  // discarded stage is no longer populated). This makes certAffecting's
+  // ordering (must read stagingPopulated() BEFORE promote/discard runs)
+  // test-observable — computing it after would silently see `false` here,
+  // just as it would against the real filesystem.
+  (staging.promoteStagedCertificates as jest.Mock).mockReset().mockImplementation(() => {
+    (staging.stagingPopulated as jest.Mock).mockReturnValue(false);
+    return [];
+  });
+  (staging.discardStagedCertificates as jest.Mock).mockReset().mockImplementation(() => {
+    (staging.stagingPopulated as jest.Mock).mockReturnValue(false);
+  });
 });
 
 describe('PrimarySslService', () => {
@@ -199,6 +212,17 @@ describe('PrimarySslService.apply classification', () => {
     const res = await svc.apply({ proxyMode: 'none', sslMode: 'paste', port80: 'redirect' } as any);
     expect(res.deadlineMs).toBeDefined();
     expect(d.snap.writePendingRevert).toHaveBeenCalled();
+  });
+
+  it('rejects apply when staging is partially populated (torn stage), before promoting', async () => {
+    const { d, svc } = build();
+    (staging.stagingPartiallyPopulated as jest.Mock).mockReturnValue(true);
+    await expect(
+      svc.apply({ proxyMode: 'none', sslMode: 'paste', port80: 'redirect' } as any),
+    ).rejects.toThrow(/incomplete/i);
+    expect(staging.promoteStagedCertificates).not.toHaveBeenCalled();
+    expect(staging.discardStagedCertificates).not.toHaveBeenCalled();
+    expect(d.snap.snapshotForChangeCycle).not.toHaveBeenCalled();
   });
 
   it('discardStaged clears the staging dir', () => {

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
@@ -1,5 +1,6 @@
 import { ForbiddenException } from '@nestjs/common';
 import { PrimarySslService } from './primary-ssl.service';
+import * as staging from '../ssl-staging';
 
 const domain = 'a.com';
 
@@ -18,6 +19,7 @@ const makeDeps = () => ({
   info: {
     getWildcardCertInfo: jest.fn().mockResolvedValue({ type: 'wildcard', expiresAt: new Date(), isValid: true }),
     getServedPrimaryCertInfo: jest.fn().mockResolvedValue({ type: 'individual', expiresAt: new Date(), isValid: true }),
+    getStagedPrimaryCertInfo: jest.fn().mockResolvedValue(null),
   },
   snap: { snapshot: jest.fn(), snapshotForChangeCycle: jest.fn(), clearSnapshot: jest.fn(), restore: jest.fn(), hasSnapshot: jest.fn().mockReturnValue(false), writePendingRevert: jest.fn(), readPendingRevert: jest.fn().mockReturnValue(null), clearPendingRevert: jest.fn(), isApplied: jest.fn().mockReturnValue(false), markApplied: jest.fn() },
 });
@@ -27,10 +29,21 @@ jest.mock('../../bootstrap/instance-config', () => ({
   writeInstanceConfig: jest.fn(),
 }));
 
+jest.mock('../ssl-staging', () => ({
+  stagingPopulated: jest.fn().mockReturnValue(false),
+  promoteStagedCertificates: jest.fn().mockReturnValue([]),
+  discardStagedCertificates: jest.fn(),
+}));
+
 const build = () => { const d = makeDeps(); return { d, svc: new PrimarySslService(d.bootstrap as any, d.ssl as any, d.preflight as any, d.info as any, d.snap as any) }; };
 
 beforeEach(() => {
   mockCur = { version: 2, state: 'applied', primaryDomain: 'a.com', proxyMode: 'none', sslMode: 'paste', port80: 'redirect', realIp: null };
+  // Module mocks persist across tests (no global resetMocks), so re-baseline
+  // the staging module's defaults here — same reason mockCur is reset above.
+  (staging.stagingPopulated as jest.Mock).mockReset().mockReturnValue(false);
+  (staging.promoteStagedCertificates as jest.Mock).mockReset().mockReturnValue([]);
+  (staging.discardStagedCertificates as jest.Mock).mockReset();
 });
 
 describe('PrimarySslService', () => {
@@ -48,6 +61,13 @@ describe('PrimarySslService', () => {
     expect(s.domain).toBe(domain);
     expect(s.sslMode).toBe('paste');
     expect(s.cert).not.toBeNull();
+  });
+
+  it('getStatus reports stagedCert from getStagedPrimaryCertInfo', async () => {
+    const { d, svc } = build();
+    d.info.getStagedPrimaryCertInfo.mockResolvedValue({ commonName: 'staged.example.com' });
+    const status = await svc.getStatus();
+    expect(status.stagedCert).toEqual({ commonName: 'staged.example.com' });
   });
 
   it('getStatus.cert comes from getServedPrimaryCertInfo (the SERVED cert), not getWildcardCertInfo', async () => {
@@ -75,17 +95,15 @@ describe('PrimarySslService', () => {
     expect(s.cert).toBeNull();
   });
 
-  it('stagePaste validates then saves for the fixed domain, snapshotting the OLD cert first', () => {
+  it('stagePaste validates then saves WITHOUT touching the snapshot (staging is provisional)', () => {
     const { d, svc } = build();
     const res = svc.stagePaste({ certificatePem: 'C', privateKeyPem: 'K', servingMode: 'none' } as any);
     expect(d.bootstrap.validateCertificatePair).toHaveBeenCalledWith('C', 'K', domain, 'none');
     expect(d.bootstrap.saveCertificates).toHaveBeenCalledWith('C', 'K', domain);
     expect(res.wildcardCovered).toBe(true);
-    // The snapshot must be taken BEFORE the cert is overwritten.
-    expect(d.snap.snapshotForChangeCycle).toHaveBeenCalled();
-    const snapOrder = d.snap.snapshotForChangeCycle.mock.invocationCallOrder[0];
-    const saveOrder = d.bootstrap.saveCertificates.mock.invocationCallOrder[0];
-    expect(snapOrder).toBeLessThan(saveOrder);
+    // saveCertificates now writes into staging/, not the live dir — nothing
+    // live changes yet, so there's nothing to snapshot until apply() promotes.
+    expect(d.snap.snapshotForChangeCycle).not.toHaveBeenCalled();
   });
 
   it('stagePaste throws when a serving revert is pending', () => {
@@ -118,7 +136,7 @@ describe('PrimarySslService.apply classification', () => {
   it('cert-only change behind a proxy writes config with no pending revert, and marks the snapshot applied', async () => {
     const { d, svc } = build();
     mockCur.proxyMode = 'cloudflare';
-    d.snap.hasSnapshot.mockReturnValue(true); // a cert was staged this cycle
+    (staging.stagingPopulated as jest.Mock).mockReturnValue(true); // a cert was staged this cycle
     const r = await svc.apply({ proxyMode: 'cloudflare', sslMode: 'paste', port80: 'redirect', realIp: undefined } as any);
     expect(r.kind).toBe('cert-only');
     expect(r.deadlineMs).toBeUndefined();
@@ -129,14 +147,12 @@ describe('PrimarySslService.apply classification', () => {
 
   it('cert change on direct serving gets the confirm window (pending revert + deadline, kind stays cert-only)', async () => {
     const { d, svc } = build();
-    d.snap.hasSnapshot.mockReturnValue(true); // staged-but-unapplied cert in flight
+    (staging.stagingPopulated as jest.Mock).mockReturnValue(true); // staged-but-unpromoted cert in flight
     const r = await svc.apply({ proxyMode: 'none', sslMode: 'paste', port80: 'redirect', realIp: undefined } as any);
     expect(r.kind).toBe('cert-only');
     expect(typeof r.deadlineMs).toBe('number');
     expect(d.snap.writePendingRevert).toHaveBeenCalled();
     expect(d.snap.markApplied).not.toHaveBeenCalled();
-    // classification must read the marker state BEFORE re-baselining can clear it
-    expect(d.snap.isApplied.mock.invocationCallOrder[0]).toBeLessThan(d.snap.snapshotForChangeCycle.mock.invocationCallOrder[0]);
   });
 
   it('sslMode-only swap on direct serving gets the confirm window even with no staged files', async () => {
@@ -148,14 +164,47 @@ describe('PrimarySslService.apply classification', () => {
     expect(d.snap.writePendingRevert).toHaveBeenCalled();
   });
 
-  it('a stale applied snapshot does not trigger the confirm window on a no-op direct-mode apply', async () => {
+  it('a no-op direct-mode apply with nothing staged and no sslMode change does not trigger the confirm window', async () => {
     const { d, svc } = build();
-    d.snap.hasSnapshot.mockReturnValue(true);
-    d.snap.isApplied.mockReturnValue(true); // left over from a committed change
+    // stagingPopulated() defaults to false (beforeEach) and sslMode is
+    // unchanged, so certAffecting is simply false — there's no "stale applied
+    // snapshot" leftover state to guard against under the new staging model.
     const r = await svc.apply({ proxyMode: 'none', sslMode: 'paste', port80: 'redirect', realIp: undefined } as any);
     expect(r.deadlineMs).toBeUndefined();
     expect(d.snap.writePendingRevert).not.toHaveBeenCalled();
     expect(d.snap.markApplied).toHaveBeenCalled();
+  });
+
+  it('apply promotes staging after snapshotting, in that order', async () => {
+    const { d, svc } = build();
+    (staging.stagingPopulated as jest.Mock).mockReturnValue(true);
+    await svc.apply({ proxyMode: 'proxy', sslMode: 'paste', port80: 'closed' } as any);
+    expect(staging.promoteStagedCertificates).toHaveBeenCalled();
+    const snapOrder = d.snap.snapshotForChangeCycle.mock.invocationCallOrder[0];
+    const promoteOrder = (staging.promoteStagedCertificates as jest.Mock).mock.invocationCallOrder[0];
+    expect(snapOrder).toBeLessThan(promoteOrder);
+  });
+
+  it('apply with sslMode selfsigned DISCARDS staging instead of promoting', async () => {
+    const { svc } = build();
+    (staging.stagingPopulated as jest.Mock).mockReturnValue(true);
+    await svc.apply({ proxyMode: 'proxy', sslMode: 'selfsigned' } as any);
+    expect(staging.discardStagedCertificates).toHaveBeenCalled();
+    expect(staging.promoteStagedCertificates).not.toHaveBeenCalled();
+  });
+
+  it('a populated stage on direct serving triggers the confirm window (certAffecting)', async () => {
+    const { d, svc } = build(); // current config: proxyMode 'none', sslMode 'paste' — same next values
+    (staging.stagingPopulated as jest.Mock).mockReturnValue(true);
+    const res = await svc.apply({ proxyMode: 'none', sslMode: 'paste', port80: 'redirect' } as any);
+    expect(res.deadlineMs).toBeDefined();
+    expect(d.snap.writePendingRevert).toHaveBeenCalled();
+  });
+
+  it('discardStaged clears the staging dir', () => {
+    const { svc } = build();
+    expect(svc.discardStaged()).toEqual({ discarded: true });
+    expect(staging.discardStagedCertificates).toHaveBeenCalled();
   });
 
   it('serving change writes a pending revert with a deadline and does not mark applied', async () => {
@@ -186,13 +235,12 @@ describe('PrimarySslService.apply classification', () => {
 });
 
 describe('PrimarySslService.issueLetsEncrypt', () => {
-  it('snapshots, preflights, then requests the cert', async () => {
+  it('preflights, then requests the cert into staging', async () => {
     const { d, svc } = build();
     d.ssl.requestPrimaryDomainCertificate.mockResolvedValue({ success: true, sans: ['a.com'] });
     const r = await svc.issueLetsEncrypt();
-    expect(d.snap.snapshotForChangeCycle).toHaveBeenCalled();
     expect(d.preflight.run).toHaveBeenCalledWith('a.com');
-    expect(d.ssl.requestPrimaryDomainCertificate).toHaveBeenCalledWith('a.com');
+    expect(d.ssl.requestPrimaryDomainCertificate).toHaveBeenCalledWith('a.com', { target: 'staging' });
     expect(r.issued).toBe(true);
   });
   it('surfaces reused: true when the underlying call reports the cert was reused (no-op re-issue)', async () => {
@@ -207,13 +255,12 @@ describe('PrimarySslService.issueLetsEncrypt', () => {
     const r = await svc.issueLetsEncrypt();
     expect(r.reused).toBe(false);
   });
-  it('snapshots BEFORE issuing so the OLD cert is the rollback baseline', async () => {
+  it('issueLetsEncrypt never snapshots — nothing live is written until apply', async () => {
     const { d, svc } = build();
     d.ssl.requestPrimaryDomainCertificate.mockResolvedValue({ success: true, sans: ['a.com'] });
     await svc.issueLetsEncrypt();
-    const snapOrder = d.snap.snapshotForChangeCycle.mock.invocationCallOrder[0];
-    const issueOrder = d.ssl.requestPrimaryDomainCertificate.mock.invocationCallOrder[0];
-    expect(snapOrder).toBeLessThan(issueOrder);
+    expect(d.snap.snapshotForChangeCycle).not.toHaveBeenCalled();
+    expect(d.snap.snapshot).not.toHaveBeenCalled();
   });
   it('throws when preflight fails, without requesting a cert', async () => {
     const { d, svc } = build();

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
@@ -6,7 +6,12 @@ import { SslInfoService, SslCertificateInfo } from '../../domains/ssl-info.servi
 import { PrimarySslSnapshotService } from './primary-ssl-snapshot.service';
 import { loadInstanceConfig, writeInstanceConfig, InstanceConfig, ProxyMode } from '../../bootstrap/instance-config';
 import { PrimarySslPasteDto, PrimarySslApplyDto } from './primary-ssl.dto';
-import { discardStagedCertificates, promoteStagedCertificates, stagingPopulated } from '../ssl-staging';
+import {
+  discardStagedCertificates,
+  promoteStagedCertificates,
+  stagingPopulated,
+  stagingPartiallyPopulated,
+} from '../ssl-staging';
 
 export interface PrimarySslStatus {
   domain: string | null;
@@ -124,6 +129,13 @@ export class PrimarySslService {
     this.assertEnabled();
     if (this.snap.readPendingRevert()) {
       throw new BadRequestException('A serving change is pending confirmation; confirm or roll it back first');
+    }
+    // A torn stage (only one of fullchain.pem/privkey.pem present — an
+    // interrupted write or manual tampering) must fail loudly rather than
+    // silently no-op: stagingPopulated() alone would just treat it as
+    // "nothing staged" and quietly skip promotion.
+    if (stagingPartiallyPopulated()) {
+      throw new BadRequestException('Staged certificate is incomplete — discard it and stage again');
     }
     const cur = loadInstanceConfig();
     if (!cur?.primaryDomain) throw new BadRequestException('No primary domain is configured yet');

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
@@ -6,6 +6,7 @@ import { SslInfoService, SslCertificateInfo } from '../../domains/ssl-info.servi
 import { PrimarySslSnapshotService } from './primary-ssl-snapshot.service';
 import { loadInstanceConfig, writeInstanceConfig, InstanceConfig, ProxyMode } from '../../bootstrap/instance-config';
 import { PrimarySslPasteDto, PrimarySslApplyDto } from './primary-ssl.dto';
+import { discardStagedCertificates, promoteStagedCertificates, stagingPopulated } from '../ssl-staging';
 
 export interface PrimarySslStatus {
   domain: string | null;
@@ -14,6 +15,7 @@ export interface PrimarySslStatus {
   port80: string | null;
   realIp: unknown;
   cert: SslCertificateInfo | null;
+  stagedCert: SslCertificateInfo | null;
   wildcardCovered: boolean;
   pendingRevert: { deadlineMs: number } | null;
 }
@@ -50,6 +52,7 @@ export class PrimarySslService {
     // leftover from an earlier SSL mode). Wildcard coverage is reported
     // separately and independently below.
     const cert = await this.info.getServedPrimaryCertInfo().catch(() => null);
+    const stagedCert = await this.info.getStagedPrimaryCertInfo().catch(() => null);
     const wildcardCert = await this.info.getWildcardCertInfo().catch(() => null);
     const pending = this.snap.readPendingRevert();
     return {
@@ -59,6 +62,7 @@ export class PrimarySslService {
       port80: cfg?.port80 ?? null,
       realIp: cfg?.realIp ?? null,
       cert,
+      stagedCert,
       wildcardCovered: !!wildcardCert,
       pendingRevert: pending ? { deadlineMs: pending.deadlineMs } : null,
     };
@@ -78,9 +82,8 @@ export class PrimarySslService {
     const result = this.bootstrap.validateCertificatePair(
       dto.certificatePem, dto.privateKeyPem, domain, dto.servingMode as ProxyMode,
     );
-    // Capture the OLD live cert BEFORE saveCertificates overwrites it, so a later
-    // rollback restores the pre-change cert (not the one we're about to write).
-    this.snap.snapshotForChangeCycle();
+    // #514: saveCertificates writes into staging/ — nothing live changes, so
+    // no snapshot is needed here. apply() snapshots before promoting.
     this.bootstrap.saveCertificates(dto.certificatePem, dto.privateKeyPem, domain);
     return result;
   }
@@ -106,15 +109,11 @@ export class PrimarySslService {
     if (this.snap.readPendingRevert()) {
       throw new BadRequestException('A serving change is pending confirmation; confirm or roll it back first');
     }
-    // Capture the current live cert BEFORE issuance overwrites it — unless a
-    // snapshot from earlier in this change cycle already holds it (a committed
-    // prior change re-baselines instead).
-    this.snap.snapshotForChangeCycle();
     const pre = await this.preflightSvc.run(domain);
     if (!pre.ok) {
       throw new BadRequestException('DNS/port-80 preflight failed; not requesting a certificate');
     }
-    const res = await this.ssl.requestPrimaryDomainCertificate(domain);
+    const res = await this.ssl.requestPrimaryDomainCertificate(domain, { target: 'staging' });
     if (!res.success) {
       throw new BadRequestException(res.error || 'Certificate issuance failed');
     }
@@ -150,11 +149,9 @@ export class PrimarySslService {
       realIp: applied.realIp,
     };
     const serving = this.isReachabilityChange(cur, next);
-    // A cert is "in flight" when a stage/issue snapshotted this cycle and no
-    // apply has committed it yet. An sslMode switch also changes the served
-    // cert (e.g. paste -> selfsigned) even with no newly staged files.
-    const certAffecting =
-      (this.snap.hasSnapshot() && !this.snap.isApplied()) || cur.sslMode !== next.sslMode;
+    // A cert change is in flight iff files are staged. An sslMode switch also
+    // changes the served cert (e.g. paste -> selfsigned) with nothing staged.
+    const certAffecting = stagingPopulated() || cur.sslMode !== next.sslMode;
     // On direct serving (nginx terminates TLS) a bad cert breaks the browser
     // on admin.<domain> — the page hosting the rollback button — so cert
     // changes there get the same provisional confirm window as reachability
@@ -162,10 +159,17 @@ export class PrimarySslService {
     // those stay manual-rollback-only (ce#511).
     const needsConfirm = serving || (certAffecting && next.proxyMode === 'none');
 
-    // Reuse the snapshot taken by a prior stage/issue (which holds the OLD
-    // cert); re-baseline over a stale applied one; otherwise snapshot the
-    // current known-good state.
+    // Snapshot the live pre-change state, THEN promote staging over it — the
+    // ordering is now structurally correct instead of call-order discipline.
     this.snap.snapshotForChangeCycle();
+    if (applied.sslMode === 'selfsigned') {
+      // Committing to self-signed abandons any staged cert: self-signed
+      // serves the bootstrap pair regardless, and a lingering "staged"
+      // indicator after this apply would mislead.
+      discardStagedCertificates();
+    } else {
+      promoteStagedCertificates();
+    }
     writeInstanceConfig(next); // watcher re-renders main.conf + reloads (~3s); no restart
 
     if (needsConfirm) {
@@ -193,5 +197,13 @@ export class PrimarySslService {
     this.assertEnabled();
     this.snap.clearPendingRevert();
     this.snap.restore();
+  }
+
+  discardStaged(): { discarded: true } {
+    this.assertEnabled();
+    // Touches nothing live, so no pending-revert gate: discarding while a
+    // revert is pending is harmless (staging was already cleared by apply).
+    discardStagedCertificates();
+    return { discarded: true };
   }
 }

--- a/apps/backend/src/setup/ssl-staging.spec.ts
+++ b/apps/backend/src/setup/ssl-staging.spec.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  sslLiveDir,
+  sslStagingDir,
+  stagingPopulated,
+  promoteStagedCertificates,
+  discardStagedCertificates,
+} from './ssl-staging';
+
+describe('ssl-staging', () => {
+  let liveDir: string;
+
+  beforeEach(() => {
+    liveDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bffless-ssl-'));
+    process.env.SSL_CERT_PATH = liveDir;
+  });
+
+  afterEach(() => {
+    fs.rmSync(liveDir, { recursive: true, force: true });
+    delete process.env.SSL_CERT_PATH;
+  });
+
+  const stage = (name: string, content = name) => {
+    fs.mkdirSync(sslStagingDir(), { recursive: true });
+    fs.writeFileSync(path.join(sslStagingDir(), name), content);
+  };
+
+  it('resolves the staging dir inside the live dir', () => {
+    expect(sslStagingDir()).toBe(path.join(liveDir, 'staging'));
+    expect(sslLiveDir()).toBe(liveDir);
+  });
+
+  it('stagingPopulated requires BOTH fullchain.pem and privkey.pem', () => {
+    expect(stagingPopulated()).toBe(false);
+    stage('fullchain.pem');
+    expect(stagingPopulated()).toBe(false);
+    stage('privkey.pem');
+    expect(stagingPopulated()).toBe(true);
+  });
+
+  it('promote moves every staged file into the live dir and clears staging', () => {
+    stage('fullchain.pem', 'CERT');
+    stage('privkey.pem', 'KEY');
+    stage('wildcard.example.com.crt', 'WCERT');
+    stage('wildcard.example.com.key', 'WKEY');
+    const promoted = promoteStagedCertificates();
+    expect(promoted.sort()).toEqual([
+      'fullchain.pem', 'privkey.pem', 'wildcard.example.com.crt', 'wildcard.example.com.key',
+    ]);
+    expect(fs.readFileSync(path.join(liveDir, 'fullchain.pem'), 'utf8')).toBe('CERT');
+    expect(fs.readFileSync(path.join(liveDir, 'wildcard.example.com.key'), 'utf8')).toBe('WKEY');
+    expect(fs.existsSync(sslStagingDir())).toBe(false);
+  });
+
+  it('promote overwrites existing live files', () => {
+    fs.writeFileSync(path.join(liveDir, 'fullchain.pem'), 'OLD');
+    stage('fullchain.pem', 'NEW');
+    stage('privkey.pem', 'KEY');
+    promoteStagedCertificates();
+    expect(fs.readFileSync(path.join(liveDir, 'fullchain.pem'), 'utf8')).toBe('NEW');
+  });
+
+  it('promote is a no-op returning [] when staging is absent or not populated', () => {
+    expect(promoteStagedCertificates()).toEqual([]);
+    stage('fullchain.pem'); // no privkey — not populated
+    expect(promoteStagedCertificates()).toEqual([]);
+    expect(fs.existsSync(path.join(liveDir, 'fullchain.pem'))).toBe(false);
+  });
+
+  it('promote skips leftover dotfile tmp artifacts', () => {
+    stage('fullchain.pem', 'CERT');
+    stage('privkey.pem', 'KEY');
+    stage('.fullchain.pem.123-abcd.tmp', 'JUNK');
+    const promoted = promoteStagedCertificates();
+    expect(promoted).not.toContain('.fullchain.pem.123-abcd.tmp');
+    expect(fs.existsSync(path.join(liveDir, '.fullchain.pem.123-abcd.tmp'))).toBe(false);
+  });
+
+  it('discard removes staging and is idempotent', () => {
+    stage('fullchain.pem');
+    discardStagedCertificates();
+    expect(fs.existsSync(sslStagingDir())).toBe(false);
+    expect(() => discardStagedCertificates()).not.toThrow();
+  });
+});

--- a/apps/backend/src/setup/ssl-staging.spec.ts
+++ b/apps/backend/src/setup/ssl-staging.spec.ts
@@ -5,6 +5,7 @@ import {
   sslLiveDir,
   sslStagingDir,
   stagingPopulated,
+  stagingPartiallyPopulated,
   promoteStagedCertificates,
   discardStagedCertificates,
 } from './ssl-staging';
@@ -38,6 +39,19 @@ describe('ssl-staging', () => {
     expect(stagingPopulated()).toBe(false);
     stage('privkey.pem');
     expect(stagingPopulated()).toBe(true);
+  });
+
+  it('stagingPartiallyPopulated is true iff exactly one of the pair is staged (XOR)', () => {
+    expect(stagingPartiallyPopulated()).toBe(false); // neither
+    stage('fullchain.pem');
+    expect(stagingPartiallyPopulated()).toBe(true); // fullchain only
+    stage('privkey.pem');
+    expect(stagingPartiallyPopulated()).toBe(false); // both — fully populated
+  });
+
+  it('stagingPartiallyPopulated is true when only privkey.pem is staged (the other order)', () => {
+    stage('privkey.pem');
+    expect(stagingPartiallyPopulated()).toBe(true);
   });
 
   it('promote moves every staged file into the live dir and clears staging', () => {

--- a/apps/backend/src/setup/ssl-staging.ts
+++ b/apps/backend/src/setup/ssl-staging.ts
@@ -1,0 +1,56 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Staging area for primary-domain certificates (#514). User-driven writers
+ * (day-2 paste, day-2 LE issuance, bootstrap wizard upload/issuance) write
+ * here; only apply() promotes into the live dir. Plain functions in the
+ * style of instance-config.ts so callers don't need DI plumbing.
+ *
+ * The staging dir deliberately lives INSIDE the live SSL dir: same
+ * filesystem, so promotion is an atomic per-file rename() (never a copy,
+ * never EXDEV). The nginx reload-watcher's inotifywait is non-recursive, so
+ * writes inside staging/ are invisible to it; creating/removing the dir
+ * itself wakes the watcher once, which is a benign guarded re-render.
+ */
+export function sslLiveDir(): string {
+  return process.env.SSL_CERT_PATH || '/etc/nginx/ssl';
+}
+
+export function sslStagingDir(): string {
+  return path.join(sslLiveDir(), 'staging');
+}
+
+/** A stage is only usable once the generic serving pair is fully present. */
+export function stagingPopulated(): boolean {
+  return (
+    fs.existsSync(path.join(sslStagingDir(), 'fullchain.pem')) &&
+    fs.existsSync(path.join(sslStagingDir(), 'privkey.pem'))
+  );
+}
+
+/**
+ * Promote staging → live: rename every staged regular file over its live
+ * counterpart, then drop the staging dir. Dotfiles are skipped — a crashed
+ * atomic write can leave a `.<name>.<pid>-<rand>.tmp` behind, and promoting
+ * junk into the watched dir would trigger a pointless reload.
+ */
+export function promoteStagedCertificates(): string[] {
+  if (!stagingPopulated()) return [];
+  const staging = sslStagingDir();
+  const promoted: string[] = [];
+  for (const name of fs.readdirSync(staging)) {
+    if (name.startsWith('.')) continue;
+    const src = path.join(staging, name);
+    if (!fs.statSync(src).isFile()) continue;
+    fs.renameSync(src, path.join(sslLiveDir(), name));
+    promoted.push(name);
+  }
+  fs.rmSync(staging, { recursive: true, force: true });
+  return promoted;
+}
+
+/** Abandoning a staged cert is just discarding the staging dir. Idempotent. */
+export function discardStagedCertificates(): void {
+  fs.rmSync(sslStagingDir(), { recursive: true, force: true });
+}

--- a/apps/backend/src/setup/ssl-staging.ts
+++ b/apps/backend/src/setup/ssl-staging.ts
@@ -30,6 +30,20 @@ export function stagingPopulated(): boolean {
 }
 
 /**
+ * True when exactly ONE of fullchain.pem / privkey.pem is staged — a torn
+ * stage (interrupted write, manual tampering) that is neither "nothing
+ * staged" nor a usable pair. Callers must reject this loudly rather than
+ * silently treating it as unpopulated: apply()'s stagingPopulated() check
+ * alone would just no-op promote/skip, quietly discarding the caller's
+ * belief that a cert was staged.
+ */
+export function stagingPartiallyPopulated(): boolean {
+  const hasFullchain = fs.existsSync(path.join(sslStagingDir(), 'fullchain.pem'));
+  const hasPrivkey = fs.existsSync(path.join(sslStagingDir(), 'privkey.pem'));
+  return hasFullchain !== hasPrivkey;
+}
+
+/**
  * Promote staging → live: rename every staged regular file over its live
  * counterpart, then drop the staging dir. Dotfiles are skipped — a crashed
  * atomic write can leave a `.<name>.<pid>-<rand>.tmp` behind, and promoting

--- a/apps/frontend/src/components/settings/primary-ssl/PrimarySslManager.tsx
+++ b/apps/frontend/src/components/settings/primary-ssl/PrimarySslManager.tsx
@@ -11,6 +11,8 @@ import {
   type PrimarySslStatus,
 } from '@/services/primarySslApi';
 import { useFeatureFlags } from '@/services/featureFlagsApi';
+import { useToast } from '@/hooks/use-toast';
+import { errorMessage } from './toastError';
 
 const DEFAULT_EDITOR_STATE: EditorState = {
   servingMode: 'none',
@@ -70,8 +72,25 @@ export function canApply(editor: EditorState, status: PrimarySslStatus | undefin
 export function PrimarySslManager() {
   const { data } = useGetPrimarySslStatusQuery();
   const { isEnabled } = useFeatureFlags();
+  const { toast } = useToast();
   const [editorState, setEditorState] = useState<EditorState>(DEFAULT_EDITOR_STATE);
   const [discardStaged, { isLoading: isDiscarding }] = useDiscardStagedCertificateMutation();
+
+  const handleDiscard = async () => {
+    try {
+      await discardStaged().unwrap();
+      toast({
+        title: 'Staged certificate discarded',
+        description: 'The staged certificate was removed. Nothing live changed.',
+      });
+    } catch (error: unknown) {
+      toast({
+        title: 'Error',
+        description: errorMessage(error, 'Failed to discard the staged certificate'),
+        variant: 'destructive',
+      });
+    }
+  };
 
   const realIpHeader = data?.realIp && 'header' in data.realIp ? data.realIp.header : null;
   const realIpRanges = data?.realIp && 'header' in data.realIp ? data.realIp.ranges.join('\n') : null;
@@ -112,7 +131,7 @@ export function PrimarySslManager() {
         <div className="flex items-center gap-2">
           <ApplyPanel config={config} disabled={!applyEnabled} />
           {data?.stagedCert && (
-            <Button variant="outline" onClick={() => discardStaged()} disabled={isDiscarding}>
+            <Button variant="outline" onClick={() => void handleDiscard()} disabled={isDiscarding}>
               {isDiscarding ? 'Discarding…' : 'Discard staged certificate'}
             </Button>
           )}

--- a/apps/frontend/src/components/settings/primary-ssl/PrimarySslManager.tsx
+++ b/apps/frontend/src/components/settings/primary-ssl/PrimarySslManager.tsx
@@ -66,7 +66,17 @@ export function canApply(editor: EditorState, status: PrimarySslStatus | undefin
   // Knob-only edits (port 80 / real-IP) on the mode that's already serving a
   // cert stay enabled; switching modes requires staging first. The backend
   // remains authoritative — this only prevents the guaranteed-422 click.
-  return editor.sslMode === status?.sslMode && status?.cert != null;
+  if (editor.sslMode === status?.sslMode && status?.cert != null) return true;
+  // Switching TO letsencrypt with a live cert present stays enabled even
+  // with nothing staged: issuance (requestPrimaryDomainCertificate) may
+  // legitimately reuse the still-valid live cert without ever populating
+  // stagedCert (the reuse check short-circuits before any staging write).
+  // Without this, switching mode -> letsencrypt with a reusable live cert
+  // dead-ends the Apply button with no way to stage anything (issuing again
+  // just reuses the same live cert, forever reporting stagedCert: null).
+  // The backend stays authoritative for anything this heuristic gets wrong.
+  if (editor.sslMode === 'letsencrypt' && status?.cert != null) return true;
+  return false;
 }
 
 export function PrimarySslManager() {

--- a/apps/frontend/src/components/settings/primary-ssl/PrimarySslManager.tsx
+++ b/apps/frontend/src/components/settings/primary-ssl/PrimarySslManager.tsx
@@ -3,7 +3,13 @@ import { CurrentSslStatus } from './CurrentSslStatus';
 import { ServingModelEditor, type EditorState } from './ServingModelEditor';
 import { ApplyPanel } from './ApplyPanel';
 import { RollbackPanel } from './RollbackPanel';
-import { useGetPrimarySslStatusQuery, type PrimarySslApplyBody } from '@/services/primarySslApi';
+import { Button } from '@/components/ui/button';
+import {
+  useGetPrimarySslStatusQuery,
+  useDiscardStagedCertificateMutation,
+  type PrimarySslApplyBody,
+  type PrimarySslStatus,
+} from '@/services/primarySslApi';
 import { useFeatureFlags } from '@/services/featureFlagsApi';
 
 const DEFAULT_EDITOR_STATE: EditorState = {
@@ -51,10 +57,21 @@ export function toApplyBody(editor: EditorState): PrimarySslApplyBody {
   return body;
 }
 
+// eslint-disable-next-line react-refresh/only-export-components -- exported for unit testing (see PrimarySslManager.test.tsx)
+export function canApply(editor: EditorState, status: PrimarySslStatus | undefined): boolean {
+  if (editor.sslMode === 'selfsigned') return true; // needs no cert
+  if (status?.stagedCert) return true; // a staged cert is ready to promote
+  // Knob-only edits (port 80 / real-IP) on the mode that's already serving a
+  // cert stay enabled; switching modes requires staging first. The backend
+  // remains authoritative — this only prevents the guaranteed-422 click.
+  return editor.sslMode === status?.sslMode && status?.cert != null;
+}
+
 export function PrimarySslManager() {
   const { data } = useGetPrimarySslStatusQuery();
   const { isEnabled } = useFeatureFlags();
   const [editorState, setEditorState] = useState<EditorState>(DEFAULT_EDITOR_STATE);
+  const [discardStaged, { isLoading: isDiscarding }] = useDiscardStagedCertificateMutation();
 
   const realIpHeader = data?.realIp && 'header' in data.realIp ? data.realIp.header : null;
   const realIpRanges = data?.realIp && 'header' in data.realIp ? data.realIp.ranges.join('\n') : null;
@@ -80,6 +97,7 @@ export function PrimarySslManager() {
   if (!isEnabled('ENABLE_PRIMARY_SSL_MANAGEMENT')) return null;
 
   const config = toApplyBody(editorState);
+  const applyEnabled = canApply(editorState, data);
 
   return (
     <div className="space-y-6">
@@ -87,13 +105,24 @@ export function PrimarySslManager() {
       <ServingModelEditor
         value={editorState}
         onChange={setEditorState}
-        onCertStaged={() => {
-          /* no-op: ApplyPanel reads the latest editorState on Apply click */
-        }}
         isCurrentlyLetsEncrypt={data?.sslMode === 'letsencrypt'}
         currentCertDaysLeft={data?.cert?.daysUntilExpiry ?? null}
       />
-      <ApplyPanel config={config} disabled={false} />
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <ApplyPanel config={config} disabled={!applyEnabled} />
+          {data?.stagedCert && (
+            <Button variant="outline" onClick={() => discardStaged()} disabled={isDiscarding}>
+              {isDiscarding ? 'Discarding…' : 'Discard staged certificate'}
+            </Button>
+          )}
+        </div>
+        {!applyEnabled && (
+          <p className="text-sm text-muted-foreground">
+            Validate &amp; stage a certificate to enable Apply.
+          </p>
+        )}
+      </div>
       <RollbackPanel pendingRevert={data?.pendingRevert ?? null} />
     </div>
   );

--- a/apps/frontend/src/components/settings/primary-ssl/ServingModelEditor.tsx
+++ b/apps/frontend/src/components/settings/primary-ssl/ServingModelEditor.tsx
@@ -40,13 +40,11 @@ function errorMessage(error: unknown, fallback: string): string {
 export function ServingModelEditor({
   value,
   onChange,
-  onCertStaged,
   currentCertDaysLeft = null,
   isCurrentlyLetsEncrypt = false,
 }: {
   value: EditorState;
   onChange: (v: EditorState) => void;
-  onCertStaged: () => void;
   /** Days left on the currently-served cert, when known (used to gate "Renew now"). */
   currentCertDaysLeft?: number | null;
   /** True when the LIVE status already reports sslMode === 'letsencrypt' (as opposed to the editor merely staging a switch to it). */
@@ -77,7 +75,6 @@ export function ServingModelEditor({
         servingMode: value.servingMode,
       }).unwrap();
       toast({ title: 'Certificate staged', description: 'Ready to apply.' });
-      onCertStaged();
     } catch (error: unknown) {
       toast({ title: 'Error', description: errorMessage(error, 'Failed to validate certificate'), variant: 'destructive' });
     }

--- a/apps/frontend/src/components/settings/primary-ssl/__tests__/PrimarySslManager.test.tsx
+++ b/apps/frontend/src/components/settings/primary-ssl/__tests__/PrimarySslManager.test.tsx
@@ -1,18 +1,20 @@
 import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
-import { PrimarySslManager, splitRanges, toApplyBody } from '../PrimarySslManager';
+import { PrimarySslManager, splitRanges, toApplyBody, canApply } from '../PrimarySslManager';
 import type { EditorState } from '../ServingModelEditor';
+import type { PrimarySslStatus } from '@/services/primarySslApi';
 
 let enabled = true;
 vi.mock('@/services/featureFlagsApi', () => ({ useFeatureFlags: () => ({ isEnabled: () => enabled }) }));
 vi.mock('@/services/primarySslApi', () => ({
-  useGetPrimarySslStatusQuery: () => ({ data: { domain: 'a.com', sslMode: 'paste', proxyMode: 'none', port80: 'redirect', realIp: null, cert: null, wildcardCovered: false, pendingRevert: null }, isLoading: false }),
+  useGetPrimarySslStatusQuery: () => ({ data: { domain: 'a.com', sslMode: 'paste', proxyMode: 'none', port80: 'redirect', realIp: null, cert: null, stagedCert: null, wildcardCovered: false, pendingRevert: null }, isLoading: false }),
   useApplyPrimarySslMutation: () => [vi.fn(), {}],
   useConfirmPrimarySslMutation: () => [vi.fn(), {}],
   useRollbackPrimarySslMutation: () => [vi.fn(), {}],
   useStagePrimaryCertificateMutation: () => [vi.fn(), {}],
   useIssuePrimaryLetsEncryptMutation: () => [vi.fn(), {}],
   usePrimarySslPreflightMutation: () => [vi.fn(), {}],
+  useDiscardStagedCertificateMutation: () => [vi.fn(), {}],
 }));
 
 describe('PrimarySslManager', () => {
@@ -111,5 +113,34 @@ describe('toApplyBody', () => {
     const editor: EditorState = { ...base, servingMode: 'none', sslMode: 'selfsigned', port80: 'closed' };
     const body = toApplyBody(editor);
     expect(body).toEqual({ proxyMode: 'none', sslMode: 'selfsigned', port80: 'closed' });
+  });
+});
+
+describe('canApply (#512)', () => {
+  const status = (over: Partial<PrimarySslStatus> = {}): PrimarySslStatus => ({
+    domain: 'example.com', proxyMode: 'proxy', sslMode: 'paste', port80: 'closed',
+    realIp: null, cert: { commonName: 'example.com' } as any, stagedCert: null,
+    wildcardCovered: false, pendingRevert: null, ...over,
+  });
+  const editor = (over: Partial<EditorState> = {}): EditorState => ({
+    servingMode: 'proxy', sslMode: 'paste', port80: 'closed',
+    realIp: null, certificatePem: '', privateKeyPem: '', ...over,
+  });
+
+  it('selfsigned needs no cert', () => {
+    expect(canApply(editor({ sslMode: 'selfsigned' }), undefined)).toBe(true);
+  });
+  it('a staged cert enables Apply for paste/letsencrypt', () => {
+    expect(canApply(editor(), status({ stagedCert: { commonName: 'x' } as any }))).toBe(true);
+    expect(canApply(editor({ sslMode: 'letsencrypt' }), status({ stagedCert: { commonName: 'x' } as any }))).toBe(true);
+  });
+  it('knob-only changes on the already-active mode stay enabled (live cert present)', () => {
+    expect(canApply(editor(), status())).toBe(true); // editor paste === status paste, cert present
+  });
+  it('switching mode with nothing staged disables Apply', () => {
+    expect(canApply(editor({ sslMode: 'paste' }), status({ sslMode: 'selfsigned' }))).toBe(false);
+  });
+  it('no status yet (loading) disables non-selfsigned Apply', () => {
+    expect(canApply(editor(), undefined)).toBe(false);
   });
 });

--- a/apps/frontend/src/components/settings/primary-ssl/__tests__/PrimarySslManager.test.tsx
+++ b/apps/frontend/src/components/settings/primary-ssl/__tests__/PrimarySslManager.test.tsx
@@ -193,4 +193,14 @@ describe('canApply (#512)', () => {
   it('no status yet (loading) disables non-selfsigned Apply', () => {
     expect(canApply(editor(), undefined)).toBe(false);
   });
+  it('switching mode to letsencrypt with a live cert present stays enabled even with nothing staged (#512)', () => {
+    // Issuance may legitimately reuse the still-valid live cert without ever
+    // populating stagedCert, which would otherwise dead-end the Apply button.
+    expect(
+      canApply(
+        editor({ sslMode: 'letsencrypt' }),
+        status({ sslMode: 'selfsigned', stagedCert: null }),
+      ),
+    ).toBe(true);
+  });
 });

--- a/apps/frontend/src/components/settings/primary-ssl/__tests__/PrimarySslManager.test.tsx
+++ b/apps/frontend/src/components/settings/primary-ssl/__tests__/PrimarySslManager.test.tsx
@@ -1,23 +1,34 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { PrimarySslManager, splitRanges, toApplyBody, canApply } from '../PrimarySslManager';
 import type { EditorState } from '../ServingModelEditor';
 import type { PrimarySslStatus } from '@/services/primarySslApi';
 
 let enabled = true;
+let stagedCert: PrimarySslStatus['stagedCert'] = null;
+const discardStaged = vi.fn();
+const mockToast = vi.fn();
 vi.mock('@/services/featureFlagsApi', () => ({ useFeatureFlags: () => ({ isEnabled: () => enabled }) }));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: mockToast }) }));
 vi.mock('@/services/primarySslApi', () => ({
-  useGetPrimarySslStatusQuery: () => ({ data: { domain: 'a.com', sslMode: 'paste', proxyMode: 'none', port80: 'redirect', realIp: null, cert: null, stagedCert: null, wildcardCovered: false, pendingRevert: null }, isLoading: false }),
+  useGetPrimarySslStatusQuery: () => ({ data: { domain: 'a.com', sslMode: 'paste', proxyMode: 'none', port80: 'redirect', realIp: null, cert: null, stagedCert, wildcardCovered: false, pendingRevert: null }, isLoading: false }),
   useApplyPrimarySslMutation: () => [vi.fn(), {}],
   useConfirmPrimarySslMutation: () => [vi.fn(), {}],
   useRollbackPrimarySslMutation: () => [vi.fn(), {}],
   useStagePrimaryCertificateMutation: () => [vi.fn(), {}],
   useIssuePrimaryLetsEncryptMutation: () => [vi.fn(), {}],
   usePrimarySslPreflightMutation: () => [vi.fn(), {}],
-  useDiscardStagedCertificateMutation: () => [vi.fn(), {}],
+  useDiscardStagedCertificateMutation: () => [discardStaged, { isLoading: false }],
 }));
 
 describe('PrimarySslManager', () => {
+  beforeEach(() => {
+    enabled = true;
+    stagedCert = null;
+    discardStaged.mockClear();
+    mockToast.mockClear();
+  });
+
   it('renders when the flag is enabled', () => {
     enabled = true;
     render(<PrimarySslManager />);
@@ -27,6 +38,45 @@ describe('PrimarySslManager', () => {
     enabled = false;
     const { container } = render(<PrimarySslManager />);
     expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('PrimarySslManager discard staged certificate (#512)', () => {
+  beforeEach(() => {
+    enabled = true;
+    stagedCert = { commonName: 'staged.example.com' } as unknown as PrimarySslStatus['stagedCert'];
+    discardStaged.mockClear();
+    mockToast.mockClear();
+  });
+
+  it('shows a success toast when discarding succeeds', async () => {
+    discardStaged.mockReturnValue({ unwrap: () => Promise.resolve({ discarded: true }) });
+    render(<PrimarySslManager />);
+
+    fireEvent.click(screen.getByRole('button', { name: /discard staged certificate/i }));
+
+    await waitFor(() => expect(discardStaged).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Staged certificate discarded',
+          description: 'The staged certificate was removed. Nothing live changed.',
+        }),
+      ),
+    );
+  });
+
+  it('shows an error toast when discarding fails', async () => {
+    discardStaged.mockReturnValue({ unwrap: () => Promise.reject({ data: { message: 'boom' } }) });
+    render(<PrimarySslManager />);
+
+    fireEvent.click(screen.getByRole('button', { name: /discard staged certificate/i }));
+
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Error', description: 'boom', variant: 'destructive' }),
+      ),
+    );
   });
 });
 

--- a/apps/frontend/src/components/settings/primary-ssl/__tests__/ServingModelEditor.test.tsx
+++ b/apps/frontend/src/components/settings/primary-ssl/__tests__/ServingModelEditor.test.tsx
@@ -25,7 +25,7 @@ describe('ServingModelEditor', () => {
 
   it('changing serving mode calls onChange', () => {
     const onChange = vi.fn();
-    render(<ServingModelEditor value={base} onChange={onChange} onCertStaged={vi.fn()} />);
+    render(<ServingModelEditor value={base} onChange={onChange} />);
     // ServingChoiceCards' Cloudflare card has "Cloudflare" in both its title
     // and body text, so getByText alone is ambiguous — click within the
     // wrapping <label> (native label→input forwarding still selects the
@@ -40,7 +40,6 @@ describe('ServingModelEditor', () => {
       <ServingModelEditor
         value={{ ...base, servingMode: 'none', sslMode: 'letsencrypt', port80: 'redirect' }}
         onChange={onChange}
-        onCertStaged={vi.fn()}
       />,
     );
     expect(screen.queryByRole('radio', { name: /close port 80/i })).not.toBeInTheDocument();
@@ -53,7 +52,6 @@ describe('ServingModelEditor', () => {
       <ServingModelEditor
         value={{ ...base, servingMode: 'none', sslMode: 'paste', port80: 'redirect' }}
         onChange={onChange}
-        onCertStaged={vi.fn()}
       />,
     );
     expect(screen.getByRole('radio', { name: /close port 80/i })).toBeInTheDocument();
@@ -65,7 +63,6 @@ describe('ServingModelEditor', () => {
       <ServingModelEditor
         value={{ ...base, servingMode: 'none', sslMode: 'letsencrypt', port80: 'closed' }}
         onChange={onChange}
-        onCertStaged={vi.fn()}
       />,
     );
     expect(onChange).toHaveBeenCalledWith(
@@ -79,7 +76,6 @@ describe('ServingModelEditor', () => {
       <ServingModelEditor
         value={{ ...base, servingMode: 'proxy', sslMode: 'selfsigned', port80: 'closed' }}
         onChange={onChange}
-        onCertStaged={vi.fn()}
       />,
     );
     // "none" and "proxy" both preset sslMode to 'letsencrypt' per presetSslFor;
@@ -97,7 +93,6 @@ describe('ServingModelEditor', () => {
         <ServingModelEditor
           value={{ ...base, servingMode: 'none', sslMode: 'letsencrypt' }}
           onChange={vi.fn()}
-          onCertStaged={vi.fn()}
         />,
       );
       fireEvent.click(screen.getByText("Issue Let's Encrypt"));
@@ -114,7 +109,6 @@ describe('ServingModelEditor', () => {
         <ServingModelEditor
           value={{ ...base, servingMode: 'none', sslMode: 'letsencrypt' }}
           onChange={vi.fn()}
-          onCertStaged={vi.fn()}
         />,
       );
       fireEvent.click(screen.getByText("Issue Let's Encrypt"));
@@ -132,7 +126,6 @@ describe('ServingModelEditor', () => {
         <ServingModelEditor
           value={{ ...base, servingMode: 'none', sslMode: 'letsencrypt' }}
           onChange={vi.fn()}
-          onCertStaged={vi.fn()}
           isCurrentlyLetsEncrypt={false}
         />,
       );
@@ -146,7 +139,6 @@ describe('ServingModelEditor', () => {
         <ServingModelEditor
           value={{ ...base, servingMode: 'none', sslMode: 'letsencrypt' }}
           onChange={vi.fn()}
-          onCertStaged={vi.fn()}
           isCurrentlyLetsEncrypt={true}
           currentCertDaysLeft={89}
         />,
@@ -164,7 +156,6 @@ describe('ServingModelEditor', () => {
         <ServingModelEditor
           value={{ ...base, servingMode: 'none', sslMode: 'letsencrypt' }}
           onChange={vi.fn()}
-          onCertStaged={vi.fn()}
           isCurrentlyLetsEncrypt={true}
           currentCertDaysLeft={10}
         />,

--- a/apps/frontend/src/services/primarySslApi.ts
+++ b/apps/frontend/src/services/primarySslApi.ts
@@ -7,6 +7,7 @@ export interface PrimarySslStatus {
   port80: 'closed' | 'redirect' | null;
   realIp: { header: string; ranges: string[] } | { preset: 'cloudflare' } | null;
   cert: { commonName: string; issuer: string; expiresAt: string; daysUntilExpiry: number; isValid: boolean } | null;
+  stagedCert: { commonName: string; issuer: string; expiresAt: string; daysUntilExpiry: number; isValid: boolean } | null;
   wildcardCovered: boolean;
   pendingRevert: { deadlineMs: number } | null;
 }
@@ -39,9 +40,11 @@ export const primarySslApi = api.injectEndpoints({
     }),
     stagePrimaryCertificate: builder.mutation<{ sans: string[]; wildcardCovered: boolean }, PrimarySslPasteBody>({
       query: (body) => ({ url: '/api/admin/ssl/certificate', method: 'POST', body }),
+      invalidatesTags: ['PrimarySsl'],
     }),
     issuePrimaryLetsEncrypt: builder.mutation<{ issued: boolean; sans: string[]; reused: boolean }, void>({
       query: () => ({ url: '/api/admin/ssl/letsencrypt', method: 'POST' }),
+      invalidatesTags: ['PrimarySsl'],
     }),
     applyPrimarySsl: builder.mutation<{ applied: true; kind: 'cert-only' | 'serving'; deadlineMs?: number }, PrimarySslApplyBody>({
       query: (body) => ({ url: '/api/admin/ssl/apply', method: 'POST', body }),
@@ -55,11 +58,15 @@ export const primarySslApi = api.injectEndpoints({
       query: () => ({ url: '/api/admin/ssl/rollback', method: 'POST' }),
       invalidatesTags: ['PrimarySsl'],
     }),
+    discardStagedCertificate: builder.mutation<{ discarded: true }, void>({
+      query: () => ({ url: '/api/admin/ssl/staged', method: 'DELETE' }),
+      invalidatesTags: ['PrimarySsl'],
+    }),
   }),
 });
 
 export const {
   useGetPrimarySslStatusQuery, usePrimarySslPreflightMutation, useStagePrimaryCertificateMutation,
   useIssuePrimaryLetsEncryptMutation, useApplyPrimarySslMutation, useConfirmPrimarySslMutation,
-  useRollbackPrimarySslMutation,
+  useRollbackPrimarySslMutation, useDiscardStagedCertificateMutation,
 } = primarySslApi;

--- a/docs/superpowers/plans/2026-07-24-ssl-cert-staging.md
+++ b/docs/superpowers/plans/2026-07-24-ssl-cert-staging.md
@@ -1,0 +1,1148 @@
+# SSL Cert Staging + Day-2 Follow-ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Certificates stage to `<SSL_CERT_PATH>/staging/` and are promoted to the live watched dir only by `apply()` (closes #514); the day-2 Apply button disables until a cert is actually available, with a Discard action (closes #512); the bootstrap wizard adopts the shared `Port80Choice` radio (closes #513).
+
+**Architecture:** A plain-function staging module (`ssl-staging.ts`, mirroring `instance-config.ts`'s style) owns the staging dir; the three user-driven cert writers write there; both apply endpoints promote via atomic per-file `rename()`. The LE renewal cron keeps writing live. Status gains `stagedCert`; the UI derives `canApply` from it.
+
+**Tech Stack:** NestJS + Jest (backend), React + RTK Query + Vitest (frontend). Repo: `/home/rico/bffless/repos/ce` (pnpm monorepo).
+
+**Spec:** `docs/superpowers/specs/2026-07-24-ssl-cert-staging-and-followups-design.md`
+
+## Global Constraints
+
+- Two PRs: **PR A** = Tasks 1–9 on branch `ssl-cert-staging` (#514 + #512); **PR B** = Task 10 on branch `wizard-port80-unify` (#513). Both branch from `main`.
+- Workspace rule: **every commit needs user approval** unless the user has granted blanket approval for these branches. Commit messages use conventional commits and end with the `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` + `Claude-Session:` trailer block from the session prompt.
+- The LE renewal cron path (`ssl-renewal.service.ts`) must keep writing certs **live** — never staged. Do not modify that file.
+- The nginx render script's only-if-missing guard (`render-main-conf.sh` lines ~154–157) stays as-is. No watcher (`nginx-reload-watcher.sh`) changes.
+- Backend commands run from `apps/backend/`, frontend from `apps/frontend/`. Type checks: `pnpm --filter backend exec tsc --noEmit`, `pnpm --filter frontend exec tsc --noEmit` from the repo root.
+- All new backend fs tests use the existing pattern: `fs.mkdtempSync(path.join(os.tmpdir(), ...))` + `process.env.SSL_CERT_PATH`, cleaned up in `afterEach`.
+
+---
+
+## PR A — cert staging (#514) + Apply gating (#512)
+
+### Task 1: Branch + commit the spec
+
+**Files:**
+- Commit: `docs/superpowers/specs/2026-07-24-ssl-cert-staging-and-followups-design.md`
+- Commit: `docs/superpowers/plans/2026-07-24-ssl-cert-staging.md`
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+cd /home/rico/bffless/repos/ce
+git checkout main && git pull
+git checkout -b ssl-cert-staging
+```
+
+- [ ] **Step 2: Commit spec + plan (with user approval)**
+
+```bash
+git add docs/superpowers/specs/2026-07-24-ssl-cert-staging-and-followups-design.md docs/superpowers/plans/2026-07-24-ssl-cert-staging.md
+git commit -m "docs: spec + plan for SSL cert staging (#514, #512, #513)"
+```
+
+### Task 2: `ssl-staging.ts` module
+
+**Files:**
+- Create: `apps/backend/src/setup/ssl-staging.ts`
+- Test: `apps/backend/src/setup/ssl-staging.spec.ts`
+
+**Interfaces:**
+- Produces (consumed by Tasks 3–7):
+  - `sslLiveDir(): string` — `SSL_CERT_PATH` env or `/etc/nginx/ssl`
+  - `sslStagingDir(): string` — `<sslLiveDir()>/staging`
+  - `stagingPopulated(): boolean` — staged `fullchain.pem` AND `privkey.pem` both exist
+  - `promoteStagedCertificates(): string[]` — atomically renames every staged regular file (dotfiles skipped) into the live dir, removes the staging dir, returns promoted filenames; `[]` no-op when not populated
+  - `discardStagedCertificates(): void` — removes the staging dir, idempotent
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/backend/src/setup/ssl-staging.spec.ts`:
+
+```ts
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  sslLiveDir,
+  sslStagingDir,
+  stagingPopulated,
+  promoteStagedCertificates,
+  discardStagedCertificates,
+} from './ssl-staging';
+
+describe('ssl-staging', () => {
+  let liveDir: string;
+
+  beforeEach(() => {
+    liveDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bffless-ssl-'));
+    process.env.SSL_CERT_PATH = liveDir;
+  });
+
+  afterEach(() => {
+    fs.rmSync(liveDir, { recursive: true, force: true });
+    delete process.env.SSL_CERT_PATH;
+  });
+
+  const stage = (name: string, content = name) => {
+    fs.mkdirSync(sslStagingDir(), { recursive: true });
+    fs.writeFileSync(path.join(sslStagingDir(), name), content);
+  };
+
+  it('resolves the staging dir inside the live dir', () => {
+    expect(sslStagingDir()).toBe(path.join(liveDir, 'staging'));
+    expect(sslLiveDir()).toBe(liveDir);
+  });
+
+  it('stagingPopulated requires BOTH fullchain.pem and privkey.pem', () => {
+    expect(stagingPopulated()).toBe(false);
+    stage('fullchain.pem');
+    expect(stagingPopulated()).toBe(false);
+    stage('privkey.pem');
+    expect(stagingPopulated()).toBe(true);
+  });
+
+  it('promote moves every staged file into the live dir and clears staging', () => {
+    stage('fullchain.pem', 'CERT');
+    stage('privkey.pem', 'KEY');
+    stage('wildcard.example.com.crt', 'WCERT');
+    stage('wildcard.example.com.key', 'WKEY');
+    const promoted = promoteStagedCertificates();
+    expect(promoted.sort()).toEqual([
+      'fullchain.pem', 'privkey.pem', 'wildcard.example.com.crt', 'wildcard.example.com.key',
+    ]);
+    expect(fs.readFileSync(path.join(liveDir, 'fullchain.pem'), 'utf8')).toBe('CERT');
+    expect(fs.readFileSync(path.join(liveDir, 'wildcard.example.com.key'), 'utf8')).toBe('WKEY');
+    expect(fs.existsSync(sslStagingDir())).toBe(false);
+  });
+
+  it('promote overwrites existing live files', () => {
+    fs.writeFileSync(path.join(liveDir, 'fullchain.pem'), 'OLD');
+    stage('fullchain.pem', 'NEW');
+    stage('privkey.pem', 'KEY');
+    promoteStagedCertificates();
+    expect(fs.readFileSync(path.join(liveDir, 'fullchain.pem'), 'utf8')).toBe('NEW');
+  });
+
+  it('promote is a no-op returning [] when staging is absent or not populated', () => {
+    expect(promoteStagedCertificates()).toEqual([]);
+    stage('fullchain.pem'); // no privkey — not populated
+    expect(promoteStagedCertificates()).toEqual([]);
+    expect(fs.existsSync(path.join(liveDir, 'fullchain.pem'))).toBe(false);
+  });
+
+  it('promote skips leftover dotfile tmp artifacts', () => {
+    stage('fullchain.pem', 'CERT');
+    stage('privkey.pem', 'KEY');
+    stage('.fullchain.pem.123-abcd.tmp', 'JUNK');
+    const promoted = promoteStagedCertificates();
+    expect(promoted).not.toContain('.fullchain.pem.123-abcd.tmp');
+    expect(fs.existsSync(path.join(liveDir, '.fullchain.pem.123-abcd.tmp'))).toBe(false);
+  });
+
+  it('discard removes staging and is idempotent', () => {
+    stage('fullchain.pem');
+    discardStagedCertificates();
+    expect(fs.existsSync(sslStagingDir())).toBe(false);
+    expect(() => discardStagedCertificates()).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/backend && pnpm test -- ssl-staging.spec`
+Expected: FAIL — `Cannot find module './ssl-staging'`
+
+- [ ] **Step 3: Write the implementation**
+
+`apps/backend/src/setup/ssl-staging.ts`:
+
+```ts
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Staging area for primary-domain certificates (#514). User-driven writers
+ * (day-2 paste, day-2 LE issuance, bootstrap wizard upload/issuance) write
+ * here; only apply() promotes into the live dir. Plain functions in the
+ * style of instance-config.ts so callers don't need DI plumbing.
+ *
+ * The staging dir deliberately lives INSIDE the live SSL dir: same
+ * filesystem, so promotion is an atomic per-file rename() (never a copy,
+ * never EXDEV). The nginx reload-watcher's inotifywait is non-recursive, so
+ * writes inside staging/ are invisible to it; creating/removing the dir
+ * itself wakes the watcher once, which is a benign guarded re-render.
+ */
+export function sslLiveDir(): string {
+  return process.env.SSL_CERT_PATH || '/etc/nginx/ssl';
+}
+
+export function sslStagingDir(): string {
+  return path.join(sslLiveDir(), 'staging');
+}
+
+/** A stage is only usable once the generic serving pair is fully present. */
+export function stagingPopulated(): boolean {
+  return (
+    fs.existsSync(path.join(sslStagingDir(), 'fullchain.pem')) &&
+    fs.existsSync(path.join(sslStagingDir(), 'privkey.pem'))
+  );
+}
+
+/**
+ * Promote staging → live: rename every staged regular file over its live
+ * counterpart, then drop the staging dir. Dotfiles are skipped — a crashed
+ * atomic write can leave a `.<name>.<pid>-<rand>.tmp` behind, and promoting
+ * junk into the watched dir would trigger a pointless reload.
+ */
+export function promoteStagedCertificates(): string[] {
+  if (!stagingPopulated()) return [];
+  const staging = sslStagingDir();
+  const promoted: string[] = [];
+  for (const name of fs.readdirSync(staging)) {
+    if (name.startsWith('.')) continue;
+    const src = path.join(staging, name);
+    if (!fs.statSync(src).isFile()) continue;
+    fs.renameSync(src, path.join(sslLiveDir(), name));
+    promoted.push(name);
+  }
+  fs.rmSync(staging, { recursive: true, force: true });
+  return promoted;
+}
+
+/** Abandoning a staged cert is just discarding the staging dir. Idempotent. */
+export function discardStagedCertificates(): void {
+  fs.rmSync(sslStagingDir(), { recursive: true, force: true });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/backend && pnpm test -- ssl-staging.spec`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit (with user approval)**
+
+```bash
+git add apps/backend/src/setup/ssl-staging.ts apps/backend/src/setup/ssl-staging.spec.ts
+git commit -m "feat(ssl): add cert staging module (staging dir, promote, discard) (#514)"
+```
+
+### Task 3: `BootstrapSetupService` writes to staging; presence/coverage read staging-first
+
+**Files:**
+- Modify: `apps/backend/src/setup/bootstrap-setup.service.ts` (`saveCertificates` ~line 270, `certificatesPresent` ~line 304, `assertStagedCertificateCovers` ~line 246)
+- Test: `apps/backend/src/setup/bootstrap-setup.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `sslStagingDir()`, `sslLiveDir()` from Task 2.
+- Produces (behavioral contract for Tasks 5 & 7):
+  - `saveCertificates(certPem, keyPem, domain): void` — now writes its four files into **staging/** (same names, same atomic write, same modes)
+  - `certificatesPresent(domain): boolean` — true when each of the four filenames exists in staging **or** live (per-file union)
+  - `assertStagedCertificateCovers(domain, servingMode): void` — reads `staging/fullchain.pem` when it exists, else live `fullchain.pem`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `bootstrap-setup.service.spec.ts` (it already has `sslDir` tmp + `makeCert` helpers; `stagingDir` below means `path.join(sslDir, 'staging')`):
+
+```ts
+describe('staging semantics (#514)', () => {
+  const stagingDir = () => path.join(sslDir, 'staging');
+
+  it('saveCertificates writes the four files into staging/, not the live dir', () => {
+    const { certPem, keyPem } = makeCert('example.com', keyA);
+    service.saveCertificates(certPem, keyPem, 'example.com');
+    for (const f of ['fullchain.pem', 'privkey.pem', 'wildcard.example.com.crt', 'wildcard.example.com.key']) {
+      expect(fs.existsSync(path.join(stagingDir(), f))).toBe(true);
+      expect(fs.existsSync(path.join(sslDir, f))).toBe(false);
+    }
+  });
+
+  it('certificatesPresent is a per-file union of staging and live', () => {
+    const { certPem, keyPem } = makeCert('example.com', keyA);
+    expect(service.certificatesPresent('example.com')).toBe(false);
+    // generic pair staged, wildcard pair live (the LE + real-DNS-01-wildcard case)
+    fs.mkdirSync(stagingDir(), { recursive: true });
+    fs.writeFileSync(path.join(stagingDir(), 'fullchain.pem'), certPem);
+    fs.writeFileSync(path.join(stagingDir(), 'privkey.pem'), keyPem);
+    fs.writeFileSync(path.join(sslDir, 'wildcard.example.com.crt'), certPem);
+    fs.writeFileSync(path.join(sslDir, 'wildcard.example.com.key'), keyPem);
+    expect(service.certificatesPresent('example.com')).toBe(true);
+  });
+
+  it('assertStagedCertificateCovers prefers the STAGED fullchain over the live one', () => {
+    const a = makeCert('aaa.com', keyA); // live: covers only aaa.com
+    const b = makeCert('bbb.com', keyB); // staged: covers only bbb.com
+    fs.writeFileSync(path.join(sslDir, 'fullchain.pem'), a.certPem);
+    fs.mkdirSync(stagingDir(), { recursive: true });
+    fs.writeFileSync(path.join(stagingDir(), 'fullchain.pem'), b.certPem);
+    // staged cert covers bbb.com → passes even though live covers only aaa.com
+    expect(() => service.assertStagedCertificateCovers('bbb.com', 'proxy')).not.toThrow();
+    // and correctly fails for aaa.com (staged takes precedence)
+    expect(() => service.assertStagedCertificateCovers('aaa.com', 'proxy')).toThrow(/does not cover/);
+  });
+
+  it('assertStagedCertificateCovers falls back to the live fullchain when nothing is staged', () => {
+    const a = makeCert('aaa.com', keyA);
+    fs.writeFileSync(path.join(sslDir, 'fullchain.pem'), a.certPem);
+    expect(() => service.assertStagedCertificateCovers('aaa.com', 'proxy')).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify the new tests fail**
+
+Run: `cd apps/backend && pnpm test -- bootstrap-setup.service.spec`
+Expected: the 4 new tests FAIL (files land in live dir; no staging fallback). Note which OLD tests also fail — any that assert `saveCertificates` wrote into `sslDir` directly now encode the pre-#514 behavior.
+
+- [ ] **Step 3: Implement**
+
+In `bootstrap-setup.service.ts`, add the import:
+
+```ts
+import { sslLiveDir, sslStagingDir } from './ssl-staging';
+```
+
+Replace the body of `sslDir()` (keep the method — other members use it) and note the delegation:
+
+```ts
+  /** Live cert dir — delegates to ssl-staging.ts so there is one resolution. */
+  private sslDir(): string {
+    return sslLiveDir();
+  }
+```
+
+In `saveCertificates`, change only the dir resolution (first lines of the method) — the atomic `write` helper and the four `write(...)` calls are unchanged:
+
+```ts
+  saveCertificates(certPem: string, keyPem: string, domain: string): void {
+    const validatedDomain = this.assertValidDomain(domain);
+    // #514: user-driven writes are provisional — they land in staging/ and
+    // only apply() promotes them into the watched live dir.
+    const dir = sslStagingDir();
+    fs.mkdirSync(dir, { recursive: true });
+    // ... (write helper + four write() calls exactly as before)
+```
+
+Replace `certificatesPresent`:
+
+```ts
+  certificatesPresent(domain: string): boolean {
+    const validatedDomain = this.assertValidDomain(domain);
+    // Per-file union of staging and live: after #514 a stage may hold only
+    // the generic pair (LE issuance with a real DNS-01 wildcard installed
+    // live), and after a promote everything is live — both must count.
+    const present = (name: string) =>
+      fs.existsSync(path.join(sslStagingDir(), name)) ||
+      fs.existsSync(path.join(this.sslDir(), name));
+    return (
+      present('fullchain.pem') &&
+      present('privkey.pem') &&
+      present(`wildcard.${validatedDomain}.crt`) &&
+      present(`wildcard.${validatedDomain}.key`)
+    );
+  }
+```
+
+In `assertStagedCertificateCovers`, replace the read with staging-first:
+
+```ts
+  assertStagedCertificateCovers(domain: string, servingMode: ProxyMode): void {
+    const validatedDomain = this.assertValidDomain(domain);
+    const stagedPath = path.join(sslStagingDir(), 'fullchain.pem');
+    const certPath = fs.existsSync(stagedPath)
+      ? stagedPath
+      : path.join(this.sslDir(), 'fullchain.pem');
+    let cert: X509Certificate;
+    try {
+      cert = new X509Certificate(fs.readFileSync(certPath));
+    } catch {
+      throw new BadRequestException(
+        'Installed certificate could not be read — re-install the certificate for this domain',
+      );
+    }
+    this.checkSansCover(this.dnsSans(cert), validatedDomain, servingMode);
+  }
+```
+
+- [ ] **Step 4: Run the whole spec; fix old assertions that encoded live-writes**
+
+Run: `cd apps/backend && pnpm test -- bootstrap-setup.service.spec`
+Expected: new tests PASS. Update any pre-existing test that asserted the four files appear directly in `sslDir` after `saveCertificates` (or that seeded `fullchain.pem` in `sslDir` to satisfy `assertStagedCertificateCovers` after a `saveCertificates` call) to use the staging path — the new expected behavior, not the test, is authoritative. Then: full spec PASS.
+
+- [ ] **Step 5: Commit (with user approval)**
+
+```bash
+git add apps/backend/src/setup/bootstrap-setup.service.ts apps/backend/src/setup/bootstrap-setup.service.spec.ts
+git commit -m "feat(ssl): bootstrap cert writes stage; presence/coverage read staging-first (#514)"
+```
+
+### Task 4: `SslCertificateService` — issuance target + staging-aware reuse check
+
+**Files:**
+- Modify: `apps/backend/src/domains/ssl-certificate.service.ts` (`requestPrimaryDomainCertificate` ~line 503, `stagedPrimaryCertificate` ~line 588, `savePrimaryCertificate` ~line 606, `issueMockPrimaryCertificate` ~line 648)
+- Test: `apps/backend/src/domains/ssl-certificate.service.spec.ts` (add cases; MOCK_SSL path makes this testable without ACME)
+
+**Interfaces:**
+- Consumes: `sslStagingDir()` from Task 2 (import path: `'../setup/ssl-staging'`).
+- Produces (consumed by Tasks 5 & 7):
+  - `requestPrimaryDomainCertificate(domain: string, opts?: { target?: 'live' | 'staging' })` — default `'live'` so the **renewal cron call site is untouched**; `'staging'` writes the issued cert into staging.
+  - Reuse semantics: for `target: 'live'` the check reads the **live** fullchain only (cron must never be satisfied by a stale staged cert); for `target: 'staging'` it reads staging first, then live.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing spec (it runs the service with `MOCK_SSL`; reuse its tmp-dir + env setup — if the file has no primary-issuance describe with tmp `SSL_CERT_PATH`, create one following the Task 2 spec's beforeEach/afterEach pattern, plus `process.env.MOCK_SSL = 'true'` and `await service.initialize()`):
+
+```ts
+describe('requestPrimaryDomainCertificate target (#514)', () => {
+  it("target 'staging' writes the issued cert under staging/, not live", async () => {
+    const res = await service.requestPrimaryDomainCertificate('example.com', { target: 'staging' });
+    expect(res.success).toBe(true);
+    expect(fs.existsSync(path.join(sslDir, 'staging', 'fullchain.pem'))).toBe(true);
+    expect(fs.existsSync(path.join(sslDir, 'staging', 'privkey.pem'))).toBe(true);
+    expect(fs.existsSync(path.join(sslDir, 'fullchain.pem'))).toBe(false);
+  });
+
+  it('default target writes live (renewal-cron contract)', async () => {
+    const res = await service.requestPrimaryDomainCertificate('example.com');
+    expect(res.success).toBe(true);
+    expect(fs.existsSync(path.join(sslDir, 'fullchain.pem'))).toBe(true);
+    expect(fs.existsSync(path.join(sslDir, 'staging'))).toBe(false);
+  });
+
+  it("a valid STAGED cert does NOT satisfy the reuse check for target 'live'", async () => {
+    // Stage a valid covering cert...
+    await service.requestPrimaryDomainCertificate('example.com', { target: 'staging' });
+    // ...then a live-target request must still issue (not report reused).
+    const res = await service.requestPrimaryDomainCertificate('example.com');
+    expect(res.reused).toBeFalsy();
+    expect(fs.existsSync(path.join(sslDir, 'fullchain.pem'))).toBe(true);
+  });
+
+  it("a valid staged cert IS reused for target 'staging'", async () => {
+    await service.requestPrimaryDomainCertificate('example.com', { target: 'staging' });
+    const res = await service.requestPrimaryDomainCertificate('example.com', { target: 'staging' });
+    expect(res.reused).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `cd apps/backend && pnpm test -- ssl-certificate.service.spec`
+Expected: new tests FAIL (`opts` unknown / files land live).
+
+- [ ] **Step 3: Implement**
+
+Import at top of `ssl-certificate.service.ts`:
+
+```ts
+import { sslStagingDir } from '../setup/ssl-staging';
+```
+
+Signature + reuse check in `requestPrimaryDomainCertificate`:
+
+```ts
+  async requestPrimaryDomainCertificate(
+    domain: string,
+    opts: { target?: 'live' | 'staging' } = {},
+  ): Promise<{ success: boolean; error?: string; expiresAt?: Date; sans?: string[]; reused?: boolean }> {
+    const target = opts.target ?? 'live';
+    const sans = [domain, `www.${domain}`, `admin.${domain}`];
+
+    // Idempotency (rate-limit protection). Target-scoped on purpose: the
+    // renewal cron (target 'live') must never be satisfied by a stale staged
+    // cert while the LIVE one approaches expiry; a user-driven staging
+    // request may reuse either a fresh stage or a still-valid live cert.
+    const staged = this.stagedPrimaryCertificate(sans, target);
+    if (staged) {
+      this.logger.log(`Primary cert already covers [${sans.join(', ')}] — reusing`);
+      return { success: true, expiresAt: staged.expiresAt, sans, reused: true };
+    }
+
+    if (this.mockMode) {
+      return this.issueMockPrimaryCertificate(domain, sans, target);
+    }
+    // ... unchanged ACME flow, except the save call at the end:
+      await this.savePrimaryCertificate(domain, certificate, key, target);
+    // ... rest unchanged
+```
+
+`stagedPrimaryCertificate` becomes target-aware:
+
+```ts
+  private stagedPrimaryCertificate(
+    sans: string[],
+    target: 'live' | 'staging',
+  ): { expiresAt: Date } | null {
+    const candidates =
+      target === 'staging'
+        ? [join(sslStagingDir(), 'fullchain.pem'), join(this.getSslPath(), 'fullchain.pem')]
+        : [join(this.getSslPath(), 'fullchain.pem')];
+    for (const certPath of candidates) {
+      try {
+        const cert = new X509Certificate(fs.readFileSync(certPath));
+        const certSans = (cert.subjectAltName ?? '')
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s.startsWith('DNS:'))
+          .map((s) => s.slice(4));
+        const covers = sans.every((s) => certSans.includes(s));
+        const expiresAt = new Date(cert.validTo);
+        const daysLeft = (expiresAt.getTime() - Date.now()) / 86_400_000;
+        if (covers && daysLeft > 30) return { expiresAt };
+      } catch {
+        // try next candidate
+      }
+    }
+    return null;
+  }
+```
+
+`savePrimaryCertificate` gains the target dir (the `installedWildcardIsReal` guard **stays pointed at the live dir** — it decides whether wildcard copies may exist at all, and a real live wildcard must never be clobbered at promote time):
+
+```ts
+  private async savePrimaryCertificate(
+    domain: string,
+    certificate: string,
+    key: Buffer,
+    target: 'live' | 'staging' = 'live',
+  ): Promise<void> {
+    const dir = target === 'staging' ? sslStagingDir() : this.getSslPath();
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'fullchain.pem'), certificate, { mode: 0o644 });
+    await writeFile(join(dir, 'privkey.pem'), key, { mode: 0o600 });
+    // (comment block unchanged) — guard still checks the LIVE wildcard:
+    if (!this.installedWildcardIsReal(domain)) {
+      await writeFile(join(dir, `wildcard.${domain}.crt`), certificate, { mode: 0o644 });
+      await writeFile(join(dir, `wildcard.${domain}.key`), key, { mode: 0o600 });
+    }
+  }
+```
+
+`issueMockPrimaryCertificate` threads the target:
+
+```ts
+  private async issueMockPrimaryCertificate(
+    domain: string,
+    sans: string[],
+    target: 'live' | 'staging' = 'live',
+  ): Promise<{ success: boolean; expiresAt?: Date; sans?: string[] }> {
+    const certPem = this.selfSignWithForge(domain, [...sans, `*.${domain}`]);
+    await this.savePrimaryCertificate(domain, certPem, Buffer.from(this.mockPrimaryKeyPem!), target);
+    // ... rest unchanged
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd apps/backend && pnpm test -- ssl-certificate.service.spec`
+Expected: PASS (new + existing; existing callers compile because `opts` is optional).
+
+- [ ] **Step 5: Commit (with user approval)**
+
+```bash
+git add apps/backend/src/domains/ssl-certificate.service.ts apps/backend/src/domains/ssl-certificate.service.spec.ts
+git commit -m "feat(ssl): primary-cert issuance can target staging; target-scoped reuse check (#514)"
+```
+
+### Task 5: `PrimarySslService` — stage without snapshot, apply promotes, discard endpoint logic, staged status
+
+**Files:**
+- Modify: `apps/backend/src/setup/primary-ssl/primary-ssl.service.ts`
+- Modify: `apps/backend/src/domains/ssl-info.service.ts` (add `getStagedPrimaryCertInfo`)
+- Test: `apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `stagingPopulated()`, `promoteStagedCertificates()`, `discardStagedCertificates()` from Task 2 (import path `'../ssl-staging'`); `requestPrimaryDomainCertificate(domain, { target: 'staging' })` from Task 4.
+- Produces (consumed by Tasks 6 & 9):
+  - `PrimarySslStatus` gains `stagedCert: SslCertificateInfo | null`
+  - `discardStaged(): { discarded: true }`
+  - `SslInfoService.getStagedPrimaryCertInfo(): Promise<SslCertificateInfo | null>` — parses `staging/fullchain.pem`, silent `null` when absent (absence is the normal state — no warn log)
+
+- [ ] **Step 1: Add `getStagedPrimaryCertInfo` to `ssl-info.service.ts`** (below `getServedPrimaryCertInfo`):
+
+```ts
+  /**
+   * Cert staged for the primary domain but not yet promoted by apply()
+   * (<SSL_CERT_PATH>/staging/fullchain.pem). Absence is the normal state,
+   * so unlike getServedPrimaryCertInfo this logs nothing on a miss.
+   */
+  async getStagedPrimaryCertInfo(): Promise<SslCertificateInfo | null> {
+    try {
+      const certContent = await readFile(
+        join(this.getSslPath(), 'staging', 'fullchain.pem'),
+        'utf-8',
+      );
+      return this.parseCertificate(certContent, 'individual');
+    } catch {
+      return null;
+    }
+  }
+```
+
+- [ ] **Step 2: Update the failing/changed service-spec expectations**
+
+The spec mocks collaborators (see its `d.bootstrap` / `d.snap` fixtures) and will need `jest.mock('../ssl-staging')` plus these behavioral flips — the module mock at the top of the spec:
+
+```ts
+import * as staging from '../ssl-staging';
+jest.mock('../ssl-staging', () => ({
+  stagingPopulated: jest.fn().mockReturnValue(false),
+  promoteStagedCertificates: jest.fn().mockReturnValue([]),
+  discardStagedCertificates: jest.fn(),
+}));
+```
+
+(and add `getStagedPrimaryCertInfo: jest.fn().mockResolvedValue(null)` to the `info` mock fixture). Then:
+
+1. `'stagePaste validates then saves for the fixed domain, snapshotting the OLD cert first'` (~line 78) → becomes `'stagePaste validates then saves WITHOUT touching the snapshot (staging is provisional)'`: keep the `saveCertificates` assertion, replace the snapshot-order assertions with `expect(d.snap.snapshotForChangeCycle).not.toHaveBeenCalled();`
+2. `'issueLetsEncrypt snapshots, preflights, then requests the cert'` (~line 189) → drop the snapshot assertion; add `expect(d.ssl.requestPrimaryDomainCertificate).toHaveBeenCalledWith(domain, { target: 'staging' });`
+3. Delete `'snapshots BEFORE issuing so the OLD cert is the rollback baseline'` (~line 210) — the ordering hazard no longer exists; replace with:
+
+```ts
+  it('issueLetsEncrypt never snapshots — nothing live is written until apply', async () => {
+    const d = deps();
+    await service(d).issueLetsEncrypt();
+    expect(d.snap.snapshotForChangeCycle).not.toHaveBeenCalled();
+    expect(d.snap.snapshot).not.toHaveBeenCalled();
+  });
+```
+
+4. New apply tests:
+
+```ts
+  it('apply promotes staging after snapshotting, in that order', async () => {
+    const d = deps();
+    (staging.stagingPopulated as jest.Mock).mockReturnValue(true);
+    await service(d).apply({ proxyMode: 'proxy', sslMode: 'paste', port80: 'closed' } as any);
+    expect(staging.promoteStagedCertificates).toHaveBeenCalled();
+    const snapOrder = d.snap.snapshotForChangeCycle.mock.invocationCallOrder[0];
+    const promoteOrder = (staging.promoteStagedCertificates as jest.Mock).mock.invocationCallOrder[0];
+    expect(snapOrder).toBeLessThan(promoteOrder);
+  });
+
+  it('apply with sslMode selfsigned DISCARDS staging instead of promoting', async () => {
+    const d = deps();
+    (staging.stagingPopulated as jest.Mock).mockReturnValue(true);
+    await service(d).apply({ proxyMode: 'proxy', sslMode: 'selfsigned' } as any);
+    expect(staging.discardStagedCertificates).toHaveBeenCalled();
+    expect(staging.promoteStagedCertificates).not.toHaveBeenCalled();
+  });
+
+  it('a populated stage on direct serving triggers the confirm window (certAffecting)', async () => {
+    const d = deps(); // current config: proxyMode 'none', sslMode 'paste' — same next values
+    (staging.stagingPopulated as jest.Mock).mockReturnValue(true);
+    const res = await service(d).apply({ proxyMode: 'none', sslMode: 'paste', port80: 'redirect' } as any);
+    expect(res.deadlineMs).toBeDefined();
+    expect(d.snap.writePendingRevert).toHaveBeenCalled();
+  });
+
+  it('getStatus reports stagedCert from getStagedPrimaryCertInfo', async () => {
+    const d = deps();
+    d.info.getStagedPrimaryCertInfo.mockResolvedValue({ commonName: 'staged.example.com' });
+    const status = await service(d).getStatus();
+    expect(status.stagedCert).toEqual({ commonName: 'staged.example.com' });
+  });
+
+  it('discardStaged clears the staging dir', () => {
+    const d = deps();
+    expect(service(d).discardStaged()).toEqual({ discarded: true });
+    expect(staging.discardStagedCertificates).toHaveBeenCalled();
+  });
+```
+
+Also update the existing `certAffecting` tests (~lines 130–160): the old heuristic asserted `isApplied`/`hasSnapshot` mock interplay — those become `stagingPopulated` mock returns. The `'sslMode-only swap ... even with no staged files'` test (~line 142) stays valid as-is (sslMode change still triggers).
+
+- [ ] **Step 3: Run to verify failures**
+
+Run: `cd apps/backend && pnpm test -- primary-ssl.service.spec`
+Expected: new/updated tests FAIL against the current implementation.
+
+- [ ] **Step 4: Implement in `primary-ssl.service.ts`**
+
+Imports:
+
+```ts
+import { discardStagedCertificates, promoteStagedCertificates, stagingPopulated } from '../ssl-staging';
+```
+
+`PrimarySslStatus` interface — add:
+
+```ts
+  stagedCert: SslCertificateInfo | null;
+```
+
+`getStatus()` — add alongside the `cert` lookup and to the return object:
+
+```ts
+    const stagedCert = await this.info.getStagedPrimaryCertInfo().catch(() => null);
+    // ...
+    return { /* existing fields */, stagedCert, /* rest */ };
+```
+
+`stagePaste` — delete the `snapshotForChangeCycle()` call and its comment; replace with:
+
+```ts
+    // #514: saveCertificates writes into staging/ — nothing live changes, so
+    // no snapshot is needed here. apply() snapshots before promoting.
+    this.bootstrap.saveCertificates(dto.certificatePem, dto.privateKeyPem, domain);
+```
+
+`issueLetsEncrypt` — delete its `snapshotForChangeCycle()` call + comment; change the request:
+
+```ts
+    const res = await this.ssl.requestPrimaryDomainCertificate(domain, { target: 'staging' });
+```
+
+`apply()` — replace the section from `const serving = ...` through `writeInstanceConfig(next);` with:
+
+```ts
+    const serving = this.isReachabilityChange(cur, next);
+    // A cert change is in flight iff files are staged. An sslMode switch also
+    // changes the served cert (e.g. paste -> selfsigned) with nothing staged.
+    const certAffecting = stagingPopulated() || cur.sslMode !== next.sslMode;
+    // (needsConfirm comment unchanged)
+    const needsConfirm = serving || (certAffecting && next.proxyMode === 'none');
+
+    // Snapshot the live pre-change state, THEN promote staging over it — the
+    // ordering is now structurally correct instead of call-order discipline.
+    this.snap.snapshotForChangeCycle();
+    if (applied.sslMode === 'selfsigned') {
+      // Committing to self-signed abandons any staged cert: self-signed
+      // serves the bootstrap pair regardless, and a lingering "staged"
+      // indicator after this apply would mislead.
+      discardStagedCertificates();
+    } else {
+      promoteStagedCertificates();
+    }
+    writeInstanceConfig(next); // watcher re-renders main.conf + reloads (~3s); no restart
+```
+
+Add the discard method (after `rollback()`):
+
+```ts
+  discardStaged(): { discarded: true } {
+    this.assertEnabled();
+    // Touches nothing live, so no pending-revert gate: discarding while a
+    // revert is pending is harmless (staging was already cleared by apply).
+    discardStagedCertificates();
+    return { discarded: true };
+  }
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd apps/backend && pnpm test -- primary-ssl.service.spec`
+Expected: PASS.
+
+- [ ] **Step 6: Commit (with user approval)**
+
+```bash
+git add apps/backend/src/setup/primary-ssl/primary-ssl.service.ts apps/backend/src/domains/ssl-info.service.ts apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
+git commit -m "feat(ssl): day-2 stage/issue write staging; apply promotes; add discard + stagedCert status (#514)"
+```
+
+### Task 6: `DELETE /api/admin/ssl/staged` endpoint
+
+**Files:**
+- Modify: `apps/backend/src/setup/primary-ssl/primary-ssl.controller.ts`
+- Test: `apps/backend/src/setup/primary-ssl/primary-ssl.controller.spec.ts`
+
+**Interfaces:**
+- Consumes: `svc.discardStaged()` from Task 5.
+- Produces: `DELETE /api/admin/ssl/staged` → `{ discarded: true }` (admin session + `ENABLE_PRIMARY_SSL_MANAGEMENT` flag, same guards as siblings — they're class-level).
+
+- [ ] **Step 1: Write the failing test** (follow the existing controller-spec pattern of calling controller methods with a mocked service):
+
+```ts
+  it('DELETE staged delegates to discardStaged', () => {
+    expect(controller.discardStaged()).toEqual({ discarded: true });
+    expect(svc.discardStaged).toHaveBeenCalled();
+  });
+```
+
+(add `discardStaged: jest.fn().mockReturnValue({ discarded: true })` to the service mock.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/backend && pnpm test -- primary-ssl.controller.spec`
+Expected: FAIL — `controller.discardStaged is not a function`
+
+- [ ] **Step 3: Implement** — add `Delete` to the `@nestjs/common` import and:
+
+```ts
+  @Delete('staged')
+  discardStaged() { return this.svc.discardStaged(); }
+```
+
+- [ ] **Step 4: Run tests** — `pnpm test -- primary-ssl.controller.spec` → PASS
+
+- [ ] **Step 5: Commit (with user approval)**
+
+```bash
+git add apps/backend/src/setup/primary-ssl/primary-ssl.controller.ts apps/backend/src/setup/primary-ssl/primary-ssl.controller.spec.ts
+git commit -m "feat(ssl): DELETE /api/admin/ssl/staged discards the staged certificate (#514)"
+```
+
+### Task 7: Bootstrap wizard apply promotes
+
+**Files:**
+- Modify: `apps/backend/src/setup/bootstrap-setup.controller.ts` (`apply` ~line 57)
+- Test: `apps/backend/src/setup/bootstrap-setup.controller.spec.ts`
+
+**Interfaces:**
+- Consumes: `promoteStagedCertificates()`, `discardStagedCertificates()` from Task 2; `requestPrimaryDomainCertificate(domain, { target: 'staging' })` from Task 4.
+
+- [ ] **Step 1: Write the failing tests** (the controller spec mocks `writeInstanceConfig` via `jest.mock('../bootstrap/instance-config')`; mock `./ssl-staging` the same way):
+
+```ts
+import * as staging from './ssl-staging';
+jest.mock('./ssl-staging', () => ({
+  promoteStagedCertificates: jest.fn().mockReturnValue([]),
+  discardStagedCertificates: jest.fn(),
+}));
+```
+
+```ts
+  it('apply promotes staged certs BEFORE writing instance config (non-selfsigned)', async () => {
+    await controller.apply(applyDto({ sslMode: 'paste' }));
+    expect(staging.promoteStagedCertificates).toHaveBeenCalled();
+    const promoteOrder = (staging.promoteStagedCertificates as jest.Mock).mock.invocationCallOrder[0];
+    const writeOrder = (writeInstanceConfig as jest.Mock).mock.invocationCallOrder[0];
+    expect(promoteOrder).toBeLessThan(writeOrder);
+  });
+
+  it('apply with selfsigned discards staging and does not promote', async () => {
+    await controller.apply(applyDto({ sslMode: 'selfsigned', proxyMode: 'proxy' }));
+    expect(staging.discardStagedCertificates).toHaveBeenCalled();
+    expect(staging.promoteStagedCertificates).not.toHaveBeenCalled();
+  });
+```
+
+(`applyDto` = whatever valid-DTO helper the spec already uses; reuse it.)
+
+- [ ] **Step 2: Run to verify failures** — `pnpm test -- bootstrap-setup.controller.spec` → new tests FAIL.
+
+- [ ] **Step 3: Implement.** In `apply()`, after `const applied = this.bootstrap.validateApplyConfig(dto);` and **before** `await this.bootstrap.finalizeSetup();`:
+
+```ts
+    // #514: certs staged by uploadCertificates / issue-certificate go live
+    // here — after every validation gate, before the instance write whose
+    // watcher-triggered render flips SSL_MODE and starts serving them.
+    if (applied.sslMode === 'selfsigned') {
+      discardStagedCertificates();
+    } else {
+      promoteStagedCertificates();
+    }
+```
+
+with the import `import { discardStagedCertificates, promoteStagedCertificates } from './ssl-staging';`. Also switch the wizard's LE issuance to staging in `issueCertificate` (~line 137):
+
+```ts
+    const result = await this.sslCert.requestPrimaryDomainCertificate(domain, { target: 'staging' });
+```
+
+- [ ] **Step 4: Run tests** — `pnpm test -- bootstrap-setup.controller.spec` → PASS (update any existing test seeding live certs to satisfy presence checks — seed staging instead).
+
+- [ ] **Step 5: Commit (with user approval)**
+
+```bash
+git add apps/backend/src/setup/bootstrap-setup.controller.ts apps/backend/src/setup/bootstrap-setup.controller.spec.ts
+git commit -m "feat(ssl): bootstrap apply promotes staged certs; wizard LE issuance stages (#514)"
+```
+
+### Task 8: Integration spec — stage → apply → rollback under staging semantics
+
+**Files:**
+- Modify: `apps/backend/src/setup/primary-ssl/primary-ssl.integration.service.spec.ts` (real services + tmp dirs; it already wires real `BootstrapSetupService`, snapshot service, and tmp `SSL_CERT_PATH`/`BOOTSTRAP_DIR`)
+
+- [ ] **Step 1: Add the end-to-end staging tests**
+
+```ts
+  it('stagePaste leaves the live cert untouched until apply promotes it', () => {
+    // seed a live cert as the "currently served" one
+    fs.writeFileSync(path.join(sslDir, 'fullchain.pem'), oldCertPem);
+    fs.writeFileSync(path.join(sslDir, 'privkey.pem'), oldKeyPem);
+    svc.stagePaste({ certificatePem: newCertPem, privateKeyPem: newKeyPem, servingMode: 'proxy' });
+    // live file unchanged; staged file holds the new cert
+    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe(oldCertPem);
+    expect(fs.readFileSync(path.join(sslDir, 'staging', 'fullchain.pem'), 'utf8')).toBe(newCertPem);
+  });
+
+  it('apply promotes the staged cert and rollback restores the OLD live cert', async () => {
+    fs.writeFileSync(path.join(sslDir, 'fullchain.pem'), oldCertPem);
+    fs.writeFileSync(path.join(sslDir, 'privkey.pem'), oldKeyPem);
+    svc.stagePaste({ certificatePem: newCertPem, privateKeyPem: newKeyPem, servingMode: 'none' });
+    await svc.apply({ proxyMode: 'none', sslMode: 'paste', port80: 'redirect' } as any);
+    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe(newCertPem);
+    expect(fs.existsSync(path.join(sslDir, 'staging'))).toBe(false);
+    svc.rollback();
+    expect(fs.readFileSync(path.join(sslDir, 'fullchain.pem'), 'utf8')).toBe(oldCertPem);
+  });
+
+  it('discardStaged aborts a stage cleanly', () => {
+    svc.stagePaste({ certificatePem: newCertPem, privateKeyPem: newKeyPem, servingMode: 'proxy' });
+    svc.discardStaged();
+    expect(fs.existsSync(path.join(sslDir, 'staging'))).toBe(false);
+  });
+```
+
+Use the spec's existing cert fixtures for `oldCertPem`/`newCertPem` — it already mints real cert pairs (two distinct pairs covering the test domain; reuse its makeCert-style helper and instance-config seeding, and match its existing `apply` call shape). The exact rollback assertion — restoring the pre-stage cert — is bug 1's regression test under the new architecture.
+
+- [ ] **Step 2: Run** — `pnpm test -- primary-ssl.integration.service.spec` → new tests PASS after fixing any pre-existing cases that asserted stage-writes-live (e.g. "stagePaste snapshots before overwriting" — that ordering concern is gone; the equivalent guarantee is now the apply-promotes test above).
+
+- [ ] **Step 3: Full backend suite + typecheck**
+
+```bash
+cd apps/backend && pnpm test
+cd ../.. && pnpm --filter backend exec tsc --noEmit
+```
+Expected: all green.
+
+- [ ] **Step 4: Commit (with user approval)**
+
+```bash
+git add apps/backend/src/setup/primary-ssl/primary-ssl.integration.service.spec.ts
+git commit -m "test(ssl): integration coverage for stage->promote->rollback staging semantics (#514)"
+```
+
+### Task 9: Frontend — Apply gating + Discard button (#512)
+
+**Files:**
+- Modify: `apps/frontend/src/services/primarySslApi.ts`
+- Modify: `apps/frontend/src/components/settings/primary-ssl/PrimarySslManager.tsx`
+- Modify: `apps/frontend/src/components/settings/primary-ssl/ServingModelEditor.tsx` (drop the now-dead `onCertStaged` prop)
+- Test: `apps/frontend/src/components/settings/primary-ssl/__tests__/PrimarySslManager.test.tsx`, `.../ServingModelEditor.test.tsx`
+
+**Interfaces:**
+- Consumes: `stagedCert` on `GET /api/admin/ssl/status`, `DELETE /api/admin/ssl/staged` (Tasks 5–6).
+- Produces: exported `canApply(editor: EditorState, status: PrimarySslStatus | undefined): boolean` from `PrimarySslManager.tsx` (exported for unit tests like `toApplyBody`).
+
+- [ ] **Step 1: API layer.** In `primarySslApi.ts`:
+
+Add to `PrimarySslStatus`:
+
+```ts
+  stagedCert: { commonName: string; issuer: string; expiresAt: string; daysUntilExpiry: number; isValid: boolean } | null;
+```
+
+Make staging visible + discardable (stage/issue must now invalidate the status so `stagedCert` refreshes):
+
+```ts
+    stagePrimaryCertificate: builder.mutation<{ sans: string[]; wildcardCovered: boolean }, PrimarySslPasteBody>({
+      query: (body) => ({ url: '/api/admin/ssl/certificate', method: 'POST', body }),
+      invalidatesTags: ['PrimarySsl'],
+    }),
+    issuePrimaryLetsEncrypt: builder.mutation<{ issued: boolean; sans: string[]; reused: boolean }, void>({
+      query: () => ({ url: '/api/admin/ssl/letsencrypt', method: 'POST' }),
+      invalidatesTags: ['PrimarySsl'],
+    }),
+    discardStagedCertificate: builder.mutation<{ discarded: true }, void>({
+      query: () => ({ url: '/api/admin/ssl/staged', method: 'DELETE' }),
+      invalidatesTags: ['PrimarySsl'],
+    }),
+```
+
+Export `useDiscardStagedCertificateMutation` from the hooks list.
+
+- [ ] **Step 2: Write the failing manager tests.** Add to `PrimarySslManager.test.tsx` (it already unit-tests exported helpers; extend the same style):
+
+```ts
+import { canApply } from '../PrimarySslManager';
+
+const status = (over: Partial<PrimarySslStatus> = {}): PrimarySslStatus => ({
+  domain: 'example.com', proxyMode: 'proxy', sslMode: 'paste', port80: 'closed',
+  realIp: null, cert: { commonName: 'example.com' } as any, stagedCert: null,
+  wildcardCovered: false, pendingRevert: null, ...over,
+});
+const editor = (over: Partial<EditorState> = {}): EditorState => ({
+  servingMode: 'proxy', sslMode: 'paste', port80: 'closed',
+  realIp: null, certificatePem: '', privateKeyPem: '', ...over,
+});
+
+describe('canApply (#512)', () => {
+  it('selfsigned needs no cert', () => {
+    expect(canApply(editor({ sslMode: 'selfsigned' }), undefined)).toBe(true);
+  });
+  it('a staged cert enables Apply for paste/letsencrypt', () => {
+    expect(canApply(editor(), status({ stagedCert: { commonName: 'x' } as any }))).toBe(true);
+    expect(canApply(editor({ sslMode: 'letsencrypt' }), status({ stagedCert: { commonName: 'x' } as any }))).toBe(true);
+  });
+  it('knob-only changes on the already-active mode stay enabled (live cert present)', () => {
+    expect(canApply(editor(), status())).toBe(true); // editor paste === status paste, cert present
+  });
+  it('switching mode with nothing staged disables Apply', () => {
+    expect(canApply(editor({ sslMode: 'paste' }), status({ sslMode: 'selfsigned' }))).toBe(false);
+  });
+  it('no status yet (loading) disables non-selfsigned Apply', () => {
+    expect(canApply(editor(), undefined)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify failure** — `cd apps/frontend && pnpm test -- PrimarySslManager` → FAIL (`canApply` not exported).
+
+- [ ] **Step 4: Implement `PrimarySslManager.tsx`.**
+
+```ts
+// eslint-disable-next-line react-refresh/only-export-components -- exported for unit testing (see PrimarySslManager.test.tsx)
+export function canApply(editor: EditorState, status: PrimarySslStatus | undefined): boolean {
+  if (editor.sslMode === 'selfsigned') return true; // needs no cert
+  if (status?.stagedCert) return true; // a staged cert is ready to promote
+  // Knob-only edits (port 80 / real-IP) on the mode that's already serving a
+  // cert stay enabled; switching modes requires staging first. The backend
+  // remains authoritative — this only prevents the guaranteed-422 click.
+  return editor.sslMode === status?.sslMode && status?.cert != null;
+}
+```
+
+In the component body:
+
+```tsx
+  const [discardStaged, { isLoading: isDiscarding }] = useDiscardStagedCertificateMutation();
+  const applyEnabled = canApply(editorState, data);
+```
+
+and replace the `<ApplyPanel ... />` line with:
+
+```tsx
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <ApplyPanel config={config} disabled={!applyEnabled} />
+          {data?.stagedCert && (
+            <Button variant="outline" onClick={() => discardStaged()} disabled={isDiscarding}>
+              {isDiscarding ? 'Discarding…' : 'Discard staged certificate'}
+            </Button>
+          )}
+        </div>
+        {!applyEnabled && (
+          <p className="text-sm text-muted-foreground">
+            Validate &amp; stage a certificate to enable Apply.
+          </p>
+        )}
+      </div>
+```
+
+(import `Button` from `@/components/ui/button`; import `type PrimarySslStatus` from the api service.)
+
+- [ ] **Step 5: Remove the dead `onCertStaged` prop.** Delete it from `ServingModelEditor`'s props + the `onCertStaged()` call in `handleStage` (RTK tag invalidation now refreshes `stagedCert`), and delete the no-op prop at the call site in `PrimarySslManager`. Update any `ServingModelEditor.test.tsx` renders passing `onCertStaged` (remove the prop; if a test asserted the callback fired on stage, replace it with nothing — the invalidation is covered by the api-layer `invalidatesTags` config).
+
+- [ ] **Step 6: Run frontend tests + typecheck**
+
+```bash
+cd apps/frontend && pnpm test -- primary-ssl
+cd ../.. && pnpm --filter frontend exec tsc --noEmit
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit (with user approval), then open PR A**
+
+```bash
+git add apps/frontend/src/services/primarySslApi.ts apps/frontend/src/components/settings/primary-ssl/
+git commit -m "fix(frontend): disable SSL Apply until a cert is staged; add discard action (#512)"
+git push -u origin ssl-cert-staging
+gh pr create --repo bffless/ce --title "feat(ssl): stage certs to a staging path; gate + discard staged certs in day-2 UI" --body "Closes #514. Closes #512. <summary + test plan>"
+```
+
+(PR body per repo conventions; include the standard generated-with footer.)
+
+---
+
+## PR B — wizard port-80 unification (#513)
+
+### Task 10: `ProxyOptions` adopts `Port80Choice`
+
+**Files:**
+- Modify: `apps/frontend/src/components/setup/domain-ssl/ProxyOptions.tsx`
+- Test: `apps/frontend/src/components/setup/__tests__/CertificatePhase.test.tsx` (lines ~151, ~193, ~390–408 reference the checkbox)
+
+**Interfaces:**
+- Consumes: `Port80Choice` (`value: 'closed' | 'redirect'`, `onChange`), `setBootstrapPort80(PayloadAction<'closed' | 'redirect' | null>)` — both existing, unchanged.
+- Behavior contract: store resolution is identical — backend maps `null → 'redirect'` in proxy mode, so dispatching explicit `'redirect'` instead of `null` is observationally equivalent.
+
+- [ ] **Step 1: Branch**
+
+```bash
+cd /home/rico/bffless/repos/ce
+git checkout main && git pull && git checkout -b wizard-port80-unify
+```
+
+- [ ] **Step 2: Update the tests first.** In `CertificatePhase.test.tsx`:
+  - ~line 151 `getByText(/close port 80/i)` still matches (the radio option keeps that copy) — verify, don't change blindly.
+  - ~line 193 `user.click(getByLabelText(/close port 80/i))` → the radio's label: `user.click(screen.getByLabelText(/close port 80/i))` still works (radio labels wrap inputs the same way in `Port80Choice`); the dispatch assertion changes from `setBootstrapPort80('closed')` on check / `null` on uncheck to `'closed'` on selecting the closed radio and `'redirect'` on selecting the redirect radio. Update the assertion accordingly.
+  - ~line 390/408 (hidden in LE mode): now assert the replacement copy is shown instead:
+
+```ts
+    expect(screen.queryByText(/close port 80/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/port 80 stays open so let's encrypt can validate/i)).toBeInTheDocument();
+```
+
+  - Add one new test: switching sub-mode to letsencrypt still dispatches `setBootstrapPort80(null)` (the LE-clear effect is unchanged).
+
+- [ ] **Step 3: Run to verify failures** — `cd apps/frontend && pnpm test -- CertificatePhase` → updated tests FAIL.
+
+- [ ] **Step 4: Implement.** In `ProxyOptions.tsx`, replace the checkbox state + JSX:
+
+```tsx
+import { Port80Choice } from '@/components/ssl-leaves/Port80Choice';
+```
+
+State: replace `const [closePort80, setClosePort80] = useState(false);` with:
+
+```tsx
+  // Explicit 'redirect' mirrors the backend's null→redirect resolution for
+  // proxy mode (validateApplyConfig), so swapping the old checkbox's
+  // unchecked/null state for this default is behavior-preserving (#513).
+  const [port80, setPort80] = useState<'closed' | 'redirect'>('redirect');
+```
+
+LE-clear effect: replace `setClosePort80(false);` with `setPort80('redirect');` (the `dispatch(setBootstrapPort80(null))` line stays exactly as-is).
+
+JSX: replace the checkbox `<label>…</label>` block with:
+
+```tsx
+      {bootstrapSslMode !== 'letsencrypt' ? (
+        <Port80Choice
+          value={port80}
+          onChange={(v) => {
+            setPort80(v);
+            dispatch(setBootstrapPort80(v));
+          }}
+        />
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Port 80 stays open so Let&apos;s Encrypt can validate over HTTP-01.
+        </p>
+      )}
+```
+
+- [ ] **Step 5: Run tests + typecheck**
+
+```bash
+cd apps/frontend && pnpm test -- CertificatePhase && pnpm test -- ProxyOptions
+cd ../.. && pnpm --filter frontend exec tsc --noEmit
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit (with user approval), open PR B**
+
+```bash
+git add apps/frontend/src/components/setup/domain-ssl/ProxyOptions.tsx apps/frontend/src/components/setup/__tests__/CertificatePhase.test.tsx
+git commit -m "refactor(frontend): wizard adopts shared Port80Choice control (#513)"
+git push -u origin wizard-port80-unify
+gh pr create --repo bffless/ce --title "refactor(frontend): unify the wizard's port-80 control with the day-2 leaf" --body "Closes #513. <summary + test plan>"
+```
+
+---
+
+## Final verification (both PRs)
+
+- [ ] `cd apps/backend && pnpm test` — full backend suite green
+- [ ] `cd apps/frontend && pnpm test` — full frontend suite green
+- [ ] `pnpm --filter backend exec tsc --noEmit && pnpm --filter frontend exec tsc --noEmit`
+- [ ] `grep -rn "staging" docs/ --include="*.md" -l` — check whether any day-2 SSL docs describe the old write-live "stage" semantics and update wording if so (the UI's "Validate & stage" copy is now accurate, not misleading)
+- [ ] Superpowers verification-before-completion + requesting-code-review before merge

--- a/docs/superpowers/specs/2026-07-24-ssl-cert-staging-and-followups-design.md
+++ b/docs/superpowers/specs/2026-07-24-ssl-cert-staging-and-followups-design.md
@@ -1,0 +1,159 @@
+# SSL Cert Staging + Day-2 Follow-ups — Design
+
+**Date:** 2026-07-24
+**Issues:** [#514](https://github.com/bffless/ce/issues/514) (cert staging path), [#512](https://github.com/bffless/ce/issues/512) (Apply gating), [#513](https://github.com/bffless/ce/issues/513) (port-80 control unification)
+**Context:** Follow-ups from PR #508 (day-2 SSL management), merged 2026-07-23.
+
+## Problem
+
+Certificates are written *live* into `/etc/nginx/ssl/` — the directory the
+nginx reload-watcher inotify-watches — rather than to a staging area that
+`apply()` promotes. Three separate bugs traced to this root cause (silent
+rollback no-op `b83566c`, self-signed re-render clobbering a staged cert
+`f80bd16`, and "stage" not actually being provisional). Each was fixed
+pointwise; the pattern keeps recurring.
+
+Two smaller follow-ups ride on the fix:
+- **#512:** the day-2 `ApplyPanel`'s `disabled` prop is hardcoded `false`, so
+  Apply is clickable with nothing staged and the user gets a 422 toast instead
+  of a disabled button.
+- **#513:** the bootstrap wizard's `ProxyOptions` still uses its original
+  port-80 checkbox (`closed`/`null`) while the day-2 page uses the shared
+  `Port80Choice` radio (`closed`/`redirect`) — a consistency gap that was
+  deliberately deferred while #508 was in flight (it merged; unblocked).
+
+## Decisions (agreed 2026-07-24)
+
+1. **PR structure:** two PRs — PR A: #514 + #512 (coupled: the Apply gating
+   needs the staging status field); PR B: #513 alone.
+2. **#514 scope:** staging covers **both** the day-2 flow and the bootstrap
+   wizard's cert upload. Eliminates the bug-2 class at the root instead of
+   relying on the render script's only-if-missing guard.
+3. **Discard UX:** yes — a `DELETE` endpoint plus a "Discard staged
+   certificate" button, making clean abort reachable from the UI.
+4. **Staging location:** `<SSL_CERT_PATH>/staging/` (approach A below).
+
+## Approaches considered for the staging location
+
+- **A. `staging/` subdir of `SSL_CERT_PATH` — chosen.** Same filesystem as
+  the live files, so promotion is an atomic `rename()` per file. The watcher's
+  `inotifywait` is non-recursive: writes *inside* `staging/` are invisible;
+  creating/removing the dir itself wakes the watcher once, a benign no-op
+  re-render (same class as the existing `pending-serving-revert.json` writes
+  into the watched bootstrap dir).
+- **B. Under `bootstrapDir()` next to `ssl-snapshot/`.** Rejected:
+  `/etc/nginx/bootstrap` and `/etc/nginx/ssl` can be different bind mounts, so
+  cross-mount `rename()` fails `EXDEV` and promotion degrades to copy — losing
+  the atomicity that motivated the issue.
+- **C. Keep pointwise fixes.** Rejected; that's the recurring pattern the
+  issue exists to end.
+
+## Design
+
+### 1. Backend staging architecture (#514)
+
+`saveCertificates()` (BootstrapSetupService) gains a target — staging vs live
+— keeping its per-file atomic write (tmp + rename) and the four-file layout
+(`fullchain.pem`, `privkey.pem`, `wildcard.<domain>.crt/.key`).
+
+**Writers that move to staging (user-driven):**
+- Day-2 `PrimarySslService.stagePaste` — validates, writes to `staging/`.
+  **Drops its `snapshotForChangeCycle()` call**: nothing live is touched, so
+  the snapshot-ordering discipline that caused bug 1 disappears.
+- Day-2 `PrimarySslService.issueLetsEncrypt` — issued cert written to
+  `staging/`; the "already valid, reuse" check (`stagedPrimaryCertificate`)
+  consults staging first, then live. Also drops its snapshot call.
+- Bootstrap wizard `POST /api/setup/certificates` — stages too.
+
+**Writer that stays live:** the LE renewal cron
+(`ssl-renewal.service` → `savePrimaryCertificate`) keeps writing directly to
+the live dir — auto-renewal must not wait for an Apply click.
+
+**`apply()` (both bootstrap and day-2) promotes:**
+- Staging populated → validate coverage against the *staged* fullchain →
+  `snapshotForChangeCycle()` (live pre-change state; ordering now trivially
+  correct) → `rename()` each staged file over its live counterpart → clear
+  `staging/` → `writeInstanceConfig` (watcher re-renders + reloads).
+- Staging empty → require live certs present (the unchanged knob-only path,
+  e.g. port-80/real-IP edits on an already-working mode).
+- Applying with `sslMode: 'selfsigned'` **discards** staging rather than
+  promoting: self-signed serves the bootstrap pair regardless, and a lingering
+  "staged" indicator after committing to self-signed would mislead.
+- The `certAffecting` heuristic (`hasSnapshot && !isApplied`) is replaced by
+  the direct fact: `stagingPopulated || cur.sslMode !== next.sslMode`.
+
+**Read paths:** `certificatesPresent` and `assertStagedCertificateCovers`
+check staging first, fall back to live — apply gates and wizard-resume status
+keep working across the transition.
+
+**Render script:** the f80bd16 only-if-missing guard in
+`render-main-conf.sh` stays (still materializes the self-signed pair), but a
+re-render can no longer clobber a staged cert — staged files never sit at
+`fullchain.pem`. No watcher changes.
+
+### 2. Status + discard API (#514 → enables #512)
+
+- `GET /api/setup/primary-ssl/status` gains
+  `stagedCert: SslCertificateInfo | null`, parsed from `staging/fullchain.pem`.
+- New `DELETE /api/setup/primary-ssl/staged` clears the staging dir. Same
+  guards as sibling endpoints (`assertEnabled`, admin session); it does not
+  need the pending-revert block since it touches nothing live.
+
+### 3. Apply gating in the UI (#512)
+
+`PrimarySslManager` derives:
+
+```ts
+canApply = editor.sslMode === 'selfsigned'
+        || stagedCert != null
+        || (editor.sslMode === data.sslMode && data.cert != null)
+```
+
+- Self-signed needs no cert; a staged cert enables Apply; the third clause
+  keeps knob-only changes enabled on an already-working mode.
+- When disabled, a hint line explains: "Validate & stage a certificate to
+  enable Apply."
+- A "Discard staged certificate" button renders next to Apply when
+  `stagedCert` is present; it calls the DELETE endpoint and invalidates the
+  status query.
+- Backend remains authoritative — this is UX, not enforcement.
+
+### 4. Wizard port-80 unification (#513, separate PR)
+
+`ProxyOptions` swaps its checkbox for the shared `Port80Choice` radio.
+Behavior-preserving because `validateApplyConfig` resolves
+`port80: null → 'redirect'` in proxy mode (`'closed'` only defaults for
+cloudflare, where `ProxyOptions` doesn't render): the radio initializes to
+`'redirect'` and dispatches explicit values; `null` survives only as the
+store's untouched-initial state. The LE-clear effect stays (same resolved
+outcome). For parity, the wizard also gets day-2's copy line — "Port 80 stays
+open so Let's Encrypt can validate over HTTP-01" — where the control hides in
+LE mode.
+
+## Error handling
+
+- Promotion failures follow the existing posture: validation happens before
+  any live write; `nginx -t` in the watcher fails closed on a half-applied
+  pair; per-file `rename()` keeps the mismatched-pair window as narrow as the
+  current live-write path.
+- A stage overwrites any prior stage (no accumulation); discard is idempotent
+  (`rm -rf` semantics, 200 even when empty).
+- Rollback (`snap.restore()`) is unchanged; staging is already cleared by the
+  promote that preceded any pending-revert window.
+
+## Testing
+
+- **Backend:** staging service unit tests (stage/promote/discard, staging-first
+  read fallbacks); `primary-ssl.service.spec` (promotion ordering, new
+  `certAffecting`, selfsigned-discard, apply-with-empty-staging);
+  `bootstrap-setup.service.spec` (target parameter, `certificatesPresent`
+  fallback); controller spec for the DELETE; integration spec re-verifies
+  stage → apply → rollback under staging semantics.
+- **Frontend:** `canApply` truth table in `PrimarySslManager.test.tsx`;
+  discard-button render/click; `ProxyOptions` radio dispatch test (PR B).
+
+## Out of scope
+
+- The DNS-01 wildcard flow (Domains → SSL) and its live writes.
+- Any change to the renewal cron's write-live behavior.
+- Wizard behavior changes beyond the port-80 control swap and the LE copy line.


### PR DESCRIPTION
Closes #514. Closes #512.

## What

Certificates are no longer written live into the inotify-watched `/etc/nginx/ssl/` by user-driven flows. They stage to `<SSL_CERT_PATH>/staging/` and only `apply()` promotes them — making "Validate & stage" genuinely provisional and the snapshot→promote ordering structurally correct instead of call-order discipline.

**Backend (#514)**
- New `ssl-staging.ts` module (plain functions): staging dir inside the live dir (same filesystem → atomic per-file `rename()` promote; the non-recursive watcher never sees writes inside it), `stagingPopulated`/`stagingPartiallyPopulated`, `promoteStagedCertificates`, `discardStagedCertificates`.
- Writers staged: day-2 paste (`stagePaste`), day-2 LE issuance, bootstrap wizard upload **and** wizard LE issuance. A stage always clears the previous stage first (no accumulation — protects a real DNS-01 wildcard from stale staged copies). The **LE renewal cron keeps writing live** (`target` defaults to `'live'`; its reuse check never consults staging).
- Both applies (day-2 + bootstrap): snapshot live state → promote staging→live → write instance config; applying `selfsigned` discards staging. A torn stage (fullchain XOR privkey) fails loudly with 422 instead of silently no-op-ing. `stagePaste`/`issueLetsEncrypt` no longer snapshot at all — the bug-1 (`b83566c`) ordering hazard is gone by construction, re-verified by a real-fs integration test (stage → apply → rollback restores the OLD cert bytes; chained applies re-baseline per ce#511).
- `GET /api/admin/ssl/status` gains `stagedCert`; new `DELETE /api/admin/ssl/staged`.

**Frontend (#512)**
- `ApplyPanel`'s `disabled` is now derived (`canApply`): self-signed always; staged cert present; knob-only edits on the already-active mode with a live cert; or switching to Let's Encrypt with a live cert present (issuance may legitimately reuse it without staging). Hint text when disabled; "Discard staged certificate" button (with toasts) when a cert is staged; stage/issue/discard mutations invalidate the status cache.

## Spec deviation (flagging for review)

The final review found the spec's original `canApply` formula dead-ended paste→LE switches when issuance reuses a still-valid live cert (`reused: true`, nothing staged). Fixed by the extra LE clause above rather than forcing re-issuance (kinder to LE rate limits). Spec: `docs/superpowers/specs/2026-07-24-ssl-cert-staging-and-followups-design.md`.

## Test plan

- Backend: 131/131 suites, 2085 passed / 0 failed (37 env-gated skips), `tsc --noEmit` clean. Includes new unit tests for the staging module (real tmp filesystems), no-accumulation and torn-stage guards, target-scoped issuance/reuse, promote-before-config ordering (invocationCallOrder), and real-service integration tests asserting cert **bytes** across stage/apply/rollback and chained-apply re-baselining.
- Frontend: 62 files, 657 passed, `tsc --noEmit` clean. `canApply` truth table, discard success/error toasts.
- Every task went through implement → independent spec+quality review → fix → re-review; final whole-branch review's three Important findings are fixed in the last two commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzeMNE2AKW3DvdNRRjtXFU
