### PR TITLE
refactor(frontend): unify the wizard's port-80 control with the day-2 leaf

### DIFF
--- a/apps/frontend/src/components/setup/__tests__/CertificatePhase.test.tsx
+++ b/apps/frontend/src/components/setup/__tests__/CertificatePhase.test.tsx
@@ -151,6 +151,20 @@ describe('CertificatePhase', () => {
     expect(screen.getByText(/close port 80/i)).toBeInTheDocument();
   });
 
+  it('port80 radio dispatches explicit closed/redirect values in both directions', async () => {
+    const user = userEvent.setup();
+    const store = renderWithStore(<CertificatePhase domain="example.com" onBack={noop} />, {
+      servingMode: 'proxy',
+      bootstrapSslMode: 'selfsigned',
+    });
+
+    await user.click(screen.getByLabelText(/close port 80/i));
+    expect(store.getState().setup.wizard.bootstrapPort80).toBe('closed');
+
+    await user.click(screen.getByLabelText(/redirect to https/i));
+    expect(store.getState().setup.wizard.bootstrapPort80).toBe('redirect');
+  });
+
   it('proxy options dispatch a valid realIp to the store', async () => {
     const user = userEvent.setup();
     const store = renderWithStore(<CertificatePhase domain="example.com" onBack={noop} />, {
@@ -382,12 +396,15 @@ describe('CertificatePhase', () => {
   // LE is HTTP-01 and needs port 80 open — validateApplyConfig rejects
   // port80:'closed' with sslMode:'letsencrypt' — and Apply has no Back
   // button, so building that combo in the wizard was a dead-end at Apply.
-  it('proxy + letsencrypt hides the close-port-80 checkbox', () => {
+  it('proxy + letsencrypt hides the close-port-80 radio and shows the LE-mode copy', () => {
     renderWithStore(<CertificatePhase domain="example.com" onBack={noop} />, {
       servingMode: 'proxy',
       bootstrapSslMode: 'letsencrypt',
     });
     expect(screen.queryByText(/close port 80/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/port 80 stays open so let's encrypt can validate/i)
+    ).toBeInTheDocument();
     // The rest of ProxyOptions (visitor-IP restore) still renders.
     expect(screen.getByText(/restore visitor ips/i)).toBeInTheDocument();
   });
@@ -406,6 +423,17 @@ describe('CertificatePhase', () => {
 
     await waitFor(() => expect(store.getState().setup.wizard.bootstrapPort80).toBeNull());
     expect(screen.queryByText(/close port 80/i)).not.toBeInTheDocument();
+  });
+
+  it('switching the proxy sub-choice to letsencrypt still dispatches null even without a prior close-port-80 selection', async () => {
+    const store = renderWithStore(<CertificatePhase domain="example.com" onBack={noop} />, {
+      servingMode: 'proxy',
+      bootstrapSslMode: 'selfsigned',
+    });
+
+    store.dispatch(setBootstrapSslMode('letsencrypt'));
+
+    await waitFor(() => expect(store.getState().setup.wizard.bootstrapPort80).toBeNull());
   });
 
   it('LE wildcard skip advances with wildcardIssued=false', async () => {

--- a/apps/frontend/src/components/setup/domain-ssl/ProxyOptions.tsx
+++ b/apps/frontend/src/components/setup/domain-ssl/ProxyOptions.tsx
@@ -4,6 +4,7 @@ import { RootState } from '@/store';
 import { setBootstrapRealIp, setBootstrapPort80 } from '@/store/slices/setupSlice';
 import { validateRealIp } from '@/lib/validateRealIp';
 import { RealIpFields } from '@/components/ssl-leaves/RealIpFields';
+import { Port80Choice } from '@/components/ssl-leaves/Port80Choice';
 
 // Proxy-only origin knobs, shared by all three proxy cert modes (self-signed,
 // Let's Encrypt, paste). Dispatches to the store on change so the Apply step
@@ -15,7 +16,10 @@ export function ProxyOptions() {
   const bootstrapSslMode = useSelector((s: RootState) => s.setup.wizard.bootstrapSslMode);
   const [rangesText, setRangesText] = useState('');
   const [header, setHeader] = useState('');
-  const [closePort80, setClosePort80] = useState(false);
+  // Explicit 'redirect' mirrors the backend's null→redirect resolution for
+  // proxy mode (validateApplyConfig), so swapping the old checkbox's
+  // unchecked/null state for this default is behavior-preserving (#513).
+  const [port80, setPort80] = useState<'closed' | 'redirect'>('redirect');
   const [rangesError, setRangesError] = useState<string | null>(null);
   const [headerError, setHeaderError] = useState<string | null>(null);
 
@@ -23,11 +27,11 @@ export function ProxyOptions() {
   // rejects port80:'closed' with sslMode:'letsencrypt'), and Apply has no
   // Back button — so a stale 'closed' picked under selfsigned/paste before
   // switching the sub-choice to letsencrypt would otherwise be a dead-end at
-  // Apply. Clear it (store + local checkbox) whenever the mode becomes
-  // letsencrypt; the checkbox itself is also hidden below in that mode.
+  // Apply. Clear it (store + local state) whenever the mode becomes
+  // letsencrypt; the control itself is also hidden below in that mode.
   useEffect(() => {
     if (bootstrapSslMode === 'letsencrypt') {
-      setClosePort80(false);
+      setPort80('redirect');
       dispatch(setBootstrapPort80(null));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -63,16 +67,18 @@ export function ProxyOptions() {
         headerError={headerError}
         rangesError={rangesError}
       />
-      {bootstrapSslMode !== 'letsencrypt' && (
-        <label className="flex items-start text-sm cursor-pointer">
-          <input
-            type="checkbox"
-            checked={closePort80}
-            onChange={(e) => { setClosePort80(e.target.checked); dispatch(setBootstrapPort80(e.target.checked ? 'closed' : null)); }}
-            className="mt-0.5 mr-2"
-          />
-          <span>Close port 80 — my CDN connects to this origin over HTTPS only</span>
-        </label>
+      {bootstrapSslMode !== 'letsencrypt' ? (
+        <Port80Choice
+          value={port80}
+          onChange={(v) => {
+            setPort80(v);
+            dispatch(setBootstrapPort80(v));
+          }}
+        />
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Port 80 stays open so Let&apos;s Encrypt can validate over HTTP-01.
+        </p>
       )}
     </div>
   );


### PR DESCRIPTION
Closes #513.

## What

The bootstrap wizard's `ProxyOptions` swaps its port-80 checkbox (`closed`/`null`) for the shared `Port80Choice` radio (`closed`/`redirect`) that the day-2 SSL page already uses — the consistency gap deliberately deferred while #508 was in flight.

Behavior-preserving: `validateApplyConfig` resolves `port80: null → 'redirect'` in proxy mode (the only path where `ProxyOptions` renders), so the radio's explicit `'redirect'` default dispatches values that resolve identically. The LE-clear effect still dispatches `null` exactly as before; `setupSlice` is untouched. In LE mode the control hides behind the same copy line the day-2 page shows ("Port 80 stays open so Let's Encrypt can validate over HTTP-01.").

## Test plan

- `CertificatePhase` tests updated: radio dispatch asserted in both directions against store state; LE-mode test asserts control hidden + copy line shown; new test that switching sub-mode to letsencrypt still dispatches `null`. 67/67 setup-folder tests green, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzeMNE2AKW3DvdNRRjtXFU
