### PR TITLE
feat(env-adoption): adopt legacy env-only installs into instance.json (.env stays authoritative)

### DIFF
--- a/apps/backend/src/bootstrap/hydrate.ts
+++ b/apps/backend/src/bootstrap/hydrate.ts
@@ -28,10 +28,16 @@
 // either way, so the regression would only surface on bootstrapped
 // instances). This repo has no import-order eslint rule as of this writing;
 // if one is added later, pin this import's position explicitly.
-import { hydrateProcessEnv } from './instance-config';
+import { adoptOrResyncEnvInstall, hydrateProcessEnv } from './instance-config';
 
+// Legacy env-install adoption/re-sync must run before hydration so the file
+// hydrate reads is never stale relative to .env (spec §3).
+adoptOrResyncEnvInstall();
 const instanceCfg = hydrateProcessEnv();
 if (instanceCfg?.state === 'applied') {
   // eslint-disable-next-line no-console
-  console.log(`[bootstrap] identity hydrated from instance.json: ${instanceCfg.primaryDomain}`);
+  console.log(
+    `[bootstrap] identity hydrated from instance.json: ${instanceCfg.primaryDomain}` +
+      (instanceCfg.origin === 'env' ? ' (env-adopted; .env remains authoritative)' : ''),
+  );
 }

--- a/apps/backend/src/bootstrap/instance-config.spec.ts
+++ b/apps/backend/src/bootstrap/instance-config.spec.ts
@@ -14,6 +14,10 @@ import {
   SHELL_SAFE_HEADER_RE,
   SHELL_SAFE_RANGE_RE,
   sniffSslMode,
+  sslDir,
+  envIdentity,
+  deriveAdoptedConfig,
+  adoptOrResyncEnvInstall,
 } from './instance-config';
 
 describe('instance-config', () => {
@@ -370,6 +374,101 @@ describe('instance-config', () => {
       expect(sniffSslMode(sslTmp, 'none')).toBe('paste');
       fs.writeFileSync(path.join(sslTmp, 'fullchain.pem'), 'not a pem');
       expect(sniffSslMode(sslTmp, 'none')).toBe('paste');
+    });
+  });
+
+  describe('env adoption & re-sync', () => {
+    let sslTmp: string;
+    let envBackup: NodeJS.ProcessEnv;
+
+    const legacyEnv = (over: Record<string, string | undefined> = {}): NodeJS.ProcessEnv =>
+      ({ PRIMARY_DOMAIN: 'legacy.com', PROXY_MODE: 'cloudflare', ...over } as NodeJS.ProcessEnv);
+
+    beforeEach(() => {
+      envBackup = { ...process.env };
+      sslTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bffless-ssl-'));
+    });
+    afterEach(() => {
+      process.env = envBackup;
+      fs.rmSync(sslTmp, { recursive: true, force: true });
+    });
+
+    it('adopts a legacy env install: applied, origin env, no knobs, sniffed sslMode', () => {
+      const cfg = adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp);
+      expect(cfg).toMatchObject({
+        version: 2, state: 'applied', origin: 'env',
+        primaryDomain: 'legacy.com', proxyMode: 'cloudflare', sslMode: 'paste',
+      });
+      expect(cfg!.port80).toBeUndefined();
+      expect(cfg!.realIp).toBeUndefined();
+      const onDisk = loadInstanceConfig(dir);
+      expect(onDisk).toEqual(cfg);
+      expect(fs.readFileSync(path.join(dir, 'instance.env'), 'utf8')).toContain('PRIMARY_DOMAIN=legacy.com');
+    });
+
+    it('omits proxyMode when PROXY_MODE is unset or unknown', () => {
+      const cfg = adoptOrResyncEnvInstall(dir, legacyEnv({ PROXY_MODE: undefined }), sslTmp);
+      expect(cfg!.proxyMode).toBeUndefined();
+      fs.rmSync(path.join(dir, 'instance.json'));
+      const cfg2 = adoptOrResyncEnvInstall(dir, legacyEnv({ PROXY_MODE: 'bogus' }), sslTmp);
+      expect(cfg2!.proxyMode).toBeUndefined();
+    });
+
+    it('skips adoption for localhost, missing domain, and platform mode', () => {
+      expect(adoptOrResyncEnvInstall(dir, legacyEnv({ PRIMARY_DOMAIN: 'localhost' }), sslTmp)).toBeNull();
+      expect(adoptOrResyncEnvInstall(dir, legacyEnv({ PRIMARY_DOMAIN: undefined }), sslTmp)).toBeNull();
+      expect(adoptOrResyncEnvInstall(dir, legacyEnv({ PLATFORM_MODE: 'true' }), sslTmp)).toBeNull();
+      expect(adoptOrResyncEnvInstall(dir, legacyEnv({ SSL_MANAGED_EXTERNALLY: 'true' }), sslTmp)).toBeNull();
+      expect(fs.existsSync(path.join(dir, 'instance.json'))).toBe(false);
+    });
+
+    it('never touches a wizard-origin file (explicit or absent origin)', () => {
+      writeInstanceConfig({ version: 2, state: 'applied', primaryDomain: 'wizard.com', proxyMode: 'none', sslMode: 'paste' }, dir);
+      const before = fs.readFileSync(path.join(dir, 'instance.json'), 'utf8');
+      expect(adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp)).toBeNull();
+      expect(fs.readFileSync(path.join(dir, 'instance.json'), 'utf8')).toBe(before);
+    });
+
+    it('leaves a corrupt instance.json untouched', () => {
+      fs.writeFileSync(path.join(dir, 'instance.json'), '{not json');
+      expect(adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp)).toBeNull();
+      expect(fs.readFileSync(path.join(dir, 'instance.json'), 'utf8')).toBe('{not json');
+    });
+
+    it('re-syncs an env-origin file when .env changes, and skips the write when unchanged', () => {
+      adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp);
+      // Spy on the real `fs` module (via require), not the `import * as fs`
+      // binding above: under this repo's CJS interop, `import * as fs` compiles
+      // to a live-binding getter proxy whose property descriptor is
+      // non-configurable, so jest.spyOn(fs, ...) throws "Cannot redefine
+      // property". The proxy forwards live reads to the real module object, so
+      // spying on that real object (require('fs')) is observed by
+      // instance-config.ts's own `import * as fs` calls too.
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const writeSpy = jest.spyOn(require('fs'), 'writeFileSync');
+      adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp); // unchanged
+      expect(writeSpy).not.toHaveBeenCalled();
+      const cfg = adoptOrResyncEnvInstall(dir, legacyEnv({ PRIMARY_DOMAIN: 'renamed.com' }), sslTmp);
+      expect(cfg!.primaryDomain).toBe('renamed.com');
+      expect(loadInstanceConfig(dir)!.primaryDomain).toBe('renamed.com');
+      writeSpy.mockRestore();
+    });
+
+    it('hydrateProcessEnv does not override process.env for origin:env files', () => {
+      adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp);
+      delete process.env.FRONTEND_URL;
+      process.env.PRIMARY_DOMAIN = 'fresh-from-env.com';
+      const cfg = hydrateProcessEnv(dir);
+      expect(cfg!.origin).toBe('env');
+      expect(process.env.PRIMARY_DOMAIN).toBe('fresh-from-env.com'); // NOT clobbered by the file
+      expect(process.env.FRONTEND_URL).toBeUndefined();
+    });
+
+    it('hydrateProcessEnv still overrides process.env for wizard files', () => {
+      writeInstanceConfig({ version: 2, state: 'applied', origin: 'wizard', primaryDomain: 'wizard.com', proxyMode: 'none', sslMode: 'paste' }, dir);
+      hydrateProcessEnv(dir);
+      expect(process.env.PRIMARY_DOMAIN).toBe('wizard.com');
+      expect(process.env.FRONTEND_URL).toBe('https://www.wizard.com');
     });
   });
 });

--- a/apps/backend/src/bootstrap/instance-config.spec.ts
+++ b/apps/backend/src/bootstrap/instance-config.spec.ts
@@ -317,11 +317,19 @@ describe('instance-config', () => {
 
   describe('sniffSslMode', () => {
     let sslTmp: string;
+    let savedProxyMode: string | undefined;
+
     beforeEach(() => {
       sslTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bffless-ssl-'));
+      savedProxyMode = process.env.PROXY_MODE;
     });
     afterEach(() => {
       fs.rmSync(sslTmp, { recursive: true, force: true });
+      if (savedProxyMode === undefined) {
+        delete process.env.PROXY_MODE;
+      } else {
+        process.env.PROXY_MODE = savedProxyMode;
+      }
     });
 
     function mintCert(subj: string): void {
@@ -336,7 +344,16 @@ describe('instance-config', () => {
     it('returns letsencrypt for an LE-issued cert when PROXY_MODE is not cloudflare', () => {
       mintCert("/O=Let's Encrypt/CN=R11");
       expect(sniffSslMode(sslTmp, 'none')).toBe('letsencrypt');
-      expect(sniffSslMode(sslTmp, undefined)).toBe('letsencrypt'); // unset counts as not-cloudflare
+      // Test with PROXY_MODE unset hermetically (omit arg to not trigger default at call time)
+      const saved = process.env.PROXY_MODE;
+      try {
+        delete process.env.PROXY_MODE;
+        expect(sniffSslMode(sslTmp)).toBe('letsencrypt'); // unset counts as not-cloudflare
+      } finally {
+        if (saved !== undefined) {
+          process.env.PROXY_MODE = saved;
+        }
+      }
     });
 
     it('returns paste for an LE cert behind cloudflare', () => {

--- a/apps/backend/src/bootstrap/instance-config.spec.ts
+++ b/apps/backend/src/bootstrap/instance-config.spec.ts
@@ -13,6 +13,7 @@ import {
   assertShellSafeRealIp,
   SHELL_SAFE_HEADER_RE,
   SHELL_SAFE_RANGE_RE,
+  sniffSslMode,
 } from './instance-config';
 
 describe('instance-config', () => {
@@ -311,6 +312,47 @@ describe('instance-config', () => {
       expect(() => assertShellSafeRealIp('X-Forwarded-For', ['0.0.0.0/0;'])).toThrow(
         /unsafe characters/,
       );
+    });
+  });
+
+  describe('sniffSslMode', () => {
+    let sslTmp: string;
+    beforeEach(() => {
+      sslTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bffless-ssl-'));
+    });
+    afterEach(() => {
+      fs.rmSync(sslTmp, { recursive: true, force: true });
+    });
+
+    function mintCert(subj: string): void {
+      execFileSync('openssl', [
+        'req', '-x509', '-nodes', '-days', '2', '-newkey', 'rsa:2048',
+        '-keyout', path.join(sslTmp, 'privkey.pem'),
+        '-out', path.join(sslTmp, 'fullchain.pem'),
+        '-subj', subj,
+      ], { stdio: 'ignore' });
+    }
+
+    it('returns letsencrypt for an LE-issued cert when PROXY_MODE is not cloudflare', () => {
+      mintCert("/O=Let's Encrypt/CN=R11");
+      expect(sniffSslMode(sslTmp, 'none')).toBe('letsencrypt');
+      expect(sniffSslMode(sslTmp, undefined)).toBe('letsencrypt'); // unset counts as not-cloudflare
+    });
+
+    it('returns paste for an LE cert behind cloudflare', () => {
+      mintCert("/O=Let's Encrypt/CN=R11");
+      expect(sniffSslMode(sslTmp, 'cloudflare')).toBe('paste');
+    });
+
+    it('returns paste for a non-LE issuer (Cloudflare Origin style)', () => {
+      mintCert('/O=CloudFlare, Inc./CN=CloudFlare Origin Certificate');
+      expect(sniffSslMode(sslTmp, 'none')).toBe('paste');
+    });
+
+    it('returns paste when fullchain.pem is missing or unparseable', () => {
+      expect(sniffSslMode(sslTmp, 'none')).toBe('paste');
+      fs.writeFileSync(path.join(sslTmp, 'fullchain.pem'), 'not a pem');
+      expect(sniffSslMode(sslTmp, 'none')).toBe('paste');
     });
   });
 });

--- a/apps/backend/src/bootstrap/instance-config.spec.ts
+++ b/apps/backend/src/bootstrap/instance-config.spec.ts
@@ -14,9 +14,6 @@ import {
   SHELL_SAFE_HEADER_RE,
   SHELL_SAFE_RANGE_RE,
   sniffSslMode,
-  sslDir,
-  envIdentity,
-  deriveAdoptedConfig,
   adoptOrResyncEnvInstall,
 } from './instance-config';
 
@@ -384,6 +381,18 @@ describe('instance-config', () => {
     const legacyEnv = (over: Record<string, string | undefined> = {}): NodeJS.ProcessEnv =>
       ({ PRIMARY_DOMAIN: 'legacy.com', PROXY_MODE: 'cloudflare', ...over } as NodeJS.ProcessEnv);
 
+    // A genuine legacy setup.sh install has real certs in ssl/ and no bootstrap
+    // marker — the C1 first-adoption gate. Mint a throwaway self-signed pair
+    // (non-LE subject so sniffSslMode stays 'paste').
+    const mintCerts = (dir: string): void => {
+      execFileSync('openssl', [
+        'req', '-x509', '-nodes', '-days', '2', '-newkey', 'rsa:2048',
+        '-keyout', path.join(dir, 'privkey.pem'),
+        '-out', path.join(dir, 'fullchain.pem'),
+        '-subj', '/CN=legacy.com',
+      ], { stdio: 'ignore' });
+    };
+
     beforeEach(() => {
       envBackup = { ...process.env };
       sslTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bffless-ssl-'));
@@ -394,6 +403,7 @@ describe('instance-config', () => {
     });
 
     it('adopts a legacy env install: applied, origin env, no knobs, sniffed sslMode', () => {
+      mintCerts(sslTmp);
       const cfg = adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp);
       expect(cfg).toMatchObject({
         version: 2, state: 'applied', origin: 'env',
@@ -407,6 +417,7 @@ describe('instance-config', () => {
     });
 
     it('omits proxyMode when PROXY_MODE is unset or unknown', () => {
+      mintCerts(sslTmp);
       const cfg = adoptOrResyncEnvInstall(dir, legacyEnv({ PROXY_MODE: undefined }), sslTmp);
       expect(cfg!.proxyMode).toBeUndefined();
       fs.rmSync(path.join(dir, 'instance.json'));
@@ -436,6 +447,7 @@ describe('instance-config', () => {
     });
 
     it('re-syncs an env-origin file when .env changes, and skips the write when unchanged', () => {
+      mintCerts(sslTmp);
       adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp);
       // Spy on the real `fs` module (via require), not the `import * as fs`
       // binding above: under this repo's CJS interop, `import * as fs` compiles
@@ -455,6 +467,7 @@ describe('instance-config', () => {
     });
 
     it('hydrateProcessEnv does not override process.env for origin:env files', () => {
+      mintCerts(sslTmp);
       adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp);
       delete process.env.FRONTEND_URL;
       process.env.PRIMARY_DOMAIN = 'fresh-from-env.com';
@@ -469,6 +482,83 @@ describe('instance-config', () => {
       hydrateProcessEnv(dir);
       expect(process.env.PRIMARY_DOMAIN).toBe('wizard.com');
       expect(process.env.FRONTEND_URL).toBe('https://www.wizard.com');
+    });
+
+    describe('C1: fresh web-bootstrap install is never adopted on first boot', () => {
+      it('refuses the docker-compose placeholder domain even with certs present', () => {
+        mintCerts(sslTmp);
+        expect(
+          adoptOrResyncEnvInstall(dir, legacyEnv({ PRIMARY_DOMAIN: 'yourdomain.com' }), sslTmp),
+        ).toBeNull();
+        expect(fs.existsSync(path.join(dir, 'instance.json'))).toBe(false);
+        expect(fs.existsSync(path.join(dir, 'instance.env'))).toBe(false);
+      });
+
+      it('refuses a cert-less install (fresh bootstrap boot has no real certs)', () => {
+        // sslTmp intentionally has no fullchain.pem/privkey.pem.
+        expect(adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp)).toBeNull();
+        expect(fs.existsSync(path.join(dir, 'instance.json'))).toBe(false);
+        expect(fs.existsSync(path.join(dir, 'instance.env'))).toBe(false);
+      });
+
+      it('refuses when certs AND a bootstrap marker are present (mid-wizard restart)', () => {
+        mintCerts(sslTmp);
+        fs.writeFileSync(path.join(sslTmp, 'bootstrap-selfsigned.crt'), 'marker');
+        expect(adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp)).toBeNull();
+        expect(fs.existsSync(path.join(dir, 'instance.json'))).toBe(false);
+        expect(fs.existsSync(path.join(dir, 'instance.env'))).toBe(false);
+      });
+
+      it('adopts a genuine legacy install: real certs, no marker, real domain', () => {
+        mintCerts(sslTmp);
+        const cfg = adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp);
+        expect(cfg).toMatchObject({ state: 'applied', origin: 'env', primaryDomain: 'legacy.com' });
+        expect(fs.existsSync(path.join(dir, 'instance.json'))).toBe(true);
+      });
+
+      it('re-sync of an existing env-origin file is NOT gated on cert presence', () => {
+        // First adopt with certs present…
+        mintCerts(sslTmp);
+        adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp);
+        // …then the certs vanish (e.g. swapped out) and the domain changes:
+        // the re-sync still runs because the file already proved adoptable.
+        fs.rmSync(path.join(sslTmp, 'fullchain.pem'));
+        fs.rmSync(path.join(sslTmp, 'privkey.pem'));
+        const cfg = adoptOrResyncEnvInstall(dir, legacyEnv({ PRIMARY_DOMAIN: 'renamed.com' }), sslTmp);
+        expect(cfg!.primaryDomain).toBe('renamed.com');
+        expect(loadInstanceConfig(dir)!.primaryDomain).toBe('renamed.com');
+      });
+    });
+
+    describe('I3: env-origin files deleted when env becomes non-adoptable', () => {
+      it('deletes both files and warns when an adopted env flips to platform mode', () => {
+        mintCerts(sslTmp);
+        adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp);
+        expect(fs.existsSync(path.join(dir, 'instance.json'))).toBe(true);
+        expect(fs.existsSync(path.join(dir, 'instance.env'))).toBe(true);
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const r = adoptOrResyncEnvInstall(dir, legacyEnv({ PLATFORM_MODE: 'true' }), sslTmp);
+        expect(r).toBeNull();
+        expect(fs.existsSync(path.join(dir, 'instance.json'))).toBe(false);
+        expect(fs.existsSync(path.join(dir, 'instance.env'))).toBe(false);
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+      });
+
+      it('leaves a wizard-origin file untouched under the same env flip', () => {
+        writeInstanceConfig(
+          { version: 2, state: 'applied', origin: 'wizard', primaryDomain: 'wizard.com', proxyMode: 'none', sslMode: 'paste' },
+          dir,
+        );
+        const before = fs.readFileSync(path.join(dir, 'instance.json'), 'utf8');
+        const r = adoptOrResyncEnvInstall(
+          dir,
+          legacyEnv({ PRIMARY_DOMAIN: 'wizard.com', PLATFORM_MODE: 'true' }),
+          sslTmp,
+        );
+        expect(r).toBeNull();
+        expect(fs.readFileSync(path.join(dir, 'instance.json'), 'utf8')).toBe(before);
+      });
     });
   });
 });

--- a/apps/backend/src/bootstrap/instance-config.ts
+++ b/apps/backend/src/bootstrap/instance-config.ts
@@ -113,6 +113,85 @@ export function sniffSslMode(
   return 'paste';
 }
 
+// Identity as expressed by a legacy .env install (docker-compose passes .env
+// into the backend's environment). Null = not an adoptable install: no/localhost
+// domain, or a platform workspace (identity is platform-managed there — same
+// check as SetupService.isPlatformManaged).
+export function envIdentity(
+  env: NodeJS.ProcessEnv = process.env,
+): { primaryDomain: string; proxyMode?: ProxyMode } | null {
+  if (env.PLATFORM_MODE === 'true' || env.SSL_MANAGED_EXTERNALLY === 'true') return null;
+  const d = env.PRIMARY_DOMAIN;
+  if (!d || d === 'localhost') return null;
+  const pm = env.PROXY_MODE;
+  const proxyMode = pm === 'cloudflare' || pm === 'proxy' || pm === 'none' ? pm : undefined;
+  return { primaryDomain: d, proxyMode };
+}
+
+// The instance.json a legacy env install maps to. Knobs (port80/realIp) are
+// deliberately omitted (v1-style): deriveKnobs and render-main-conf.sh's env
+// fallback derive identical values, so adoption changes nothing nginx renders.
+export function deriveAdoptedConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  ssl: string = sslDir(),
+): InstanceConfig | null {
+  const id = envIdentity(env);
+  if (!id) return null;
+  const cfg: InstanceConfig = {
+    version: 2,
+    state: 'applied',
+    origin: 'env',
+    primaryDomain: id.primaryDomain,
+    sslMode: sniffSslMode(ssl, env.PROXY_MODE),
+  };
+  if (id.proxyMode) cfg.proxyMode = id.proxyMode;
+  return cfg;
+}
+
+// Boot-time adoption/re-sync for legacy env installs (spec §§2–3). Rules:
+//   - no instance.json + env identity present → write an adopted file
+//   - origin:'env' file → re-derive from env, rewrite only if changed
+//   - wizard file (origin absent/'wizard') or corrupt file → never touched
+// For origin:'env', .env is truth and the files are derived caches — which is
+// also why hydrateProcessEnv skips its process.env override for them.
+// Must never throw: any failure degrades to today's env-only behavior.
+export function adoptOrResyncEnvInstall(
+  dir: string = bootstrapDir(),
+  env: NodeJS.ProcessEnv = process.env,
+  ssl: string = sslDir(),
+): InstanceConfig | null {
+  try {
+    const jsonPath = path.join(dir, 'instance.json');
+    const exists = fs.existsSync(jsonPath);
+    const existing = loadInstanceConfig(dir);
+    if (exists && !existing) {
+      console.warn('[bootstrap] instance.json present but unreadable — leaving it untouched');
+      return null;
+    }
+    if (existing && existing.origin !== 'env') {
+      const d = env.PRIMARY_DOMAIN;
+      if (d && d !== 'localhost' && d !== existing.primaryDomain) {
+        console.warn(
+          `[bootstrap] .env PRIMARY_DOMAIN=${d} differs from wizard-managed instance.json ` +
+            `(${existing.primaryDomain}); instance.json wins — change identity via the admin UI`,
+        );
+      }
+      return null;
+    }
+    const derived = deriveAdoptedConfig(env, ssl);
+    if (!derived) return null;
+    if (existing && JSON.stringify(existing) === JSON.stringify(derived)) return existing;
+    writeInstanceConfig(derived, dir);
+    console.log(
+      `[bootstrap] ${existing ? 're-synced' : 'adopted'} env identity into instance.json: ${derived.primaryDomain}`,
+    );
+    return derived;
+  } catch (err) {
+    console.warn(`[bootstrap] env adoption skipped: ${(err as Error).message}`);
+    return null;
+  }
+}
+
 export function loadInstanceConfig(dir: string = bootstrapDir()): InstanceConfig | null {
   try {
     const raw = fs.readFileSync(path.join(dir, 'instance.json'), 'utf8');
@@ -144,7 +223,12 @@ export function deriveIdentityEnv(cfg: InstanceConfig): Record<string, string> {
 export function hydrateProcessEnv(dir: string = bootstrapDir()): InstanceConfig | null {
   const cfg = loadInstanceConfig(dir);
   if (!cfg) return null;
-  Object.assign(process.env, deriveIdentityEnv(cfg));
+  // origin:'env' — .env is truth and already lives in process.env; assigning
+  // the file's values would resurrect stale identity on the first boot after
+  // an .env edit (SuperTokens captures env before re-sync could correct it).
+  if (cfg.origin !== 'env') {
+    Object.assign(process.env, deriveIdentityEnv(cfg));
+  }
   return cfg;
 }
 

--- a/apps/backend/src/bootstrap/instance-config.ts
+++ b/apps/backend/src/bootstrap/instance-config.ts
@@ -1,5 +1,6 @@
 // Pure Node module — NO NestJS imports. It runs at the very top of main.ts,
 // before Nest (and therefore before SuperTokens/CORS) reads process.env.
+import { X509Certificate } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -14,6 +15,12 @@ export type RealIpConfig = null | { preset: 'cloudflare' } | { header: string; r
 export interface InstanceConfig {
   version: 1 | 2;
   state: 'unclaimed' | 'applied';
+  // Who owns this file. 'wizard': the web wizard / admin UI wrote it — file is
+  // truth, hydration overrides process.env (absent = 'wizard': all files
+  // written before this field existed are wizard files). 'env': adopted from a
+  // legacy .env install — .env is truth and this file is a derived cache,
+  // re-synced on every boot by adoptOrResyncEnvInstall().
+  origin?: 'wizard' | 'env';
   primaryDomain?: string;
   proxyMode?: ProxyMode;
   sslMode?: SslMode;
@@ -77,6 +84,33 @@ export function assertShellSafeRealIp(header: string, ranges: string[]): void {
 
 export function bootstrapDir(): string {
   return process.env.BOOTSTRAP_DIR || path.resolve(process.cwd(), '../../bootstrap');
+}
+
+export function sslDir(): string {
+  return process.env.SSL_CERT_PATH || '/etc/nginx/ssl';
+}
+
+// Adoption-time sslMode inference for legacy env-only installs (spec §2): an
+// LE-issued primary cert on a non-cloudflare install means the operator used
+// the setup.sh certbot path, whose renewal is broken by default (one-time
+// copy into ssl/, standalone renew can't bind port 80) — adopt as
+// 'letsencrypt' so the in-app renewer takes over. Everything else (CF origin
+// certs, unknown issuers, missing/unreadable cert) adopts as 'paste'.
+// Unset PROXY_MODE counts as not-cloudflare, matching render-main-conf.sh's
+// derivation. Never throws: sniff failure must not prevent boot.
+export function sniffSslMode(
+  dir: string = sslDir(),
+  envProxyMode: string | undefined = process.env.PROXY_MODE,
+): SslMode {
+  if (envProxyMode === 'cloudflare') return 'paste';
+  try {
+    const pem = fs.readFileSync(path.join(dir, 'fullchain.pem'));
+    const cert = new X509Certificate(pem);
+    if (/O=Let's Encrypt/.test(cert.issuer)) return 'letsencrypt';
+  } catch {
+    // missing/unreadable → paste
+  }
+  return 'paste';
 }
 
 export function loadInstanceConfig(dir: string = bootstrapDir()): InstanceConfig | null {

--- a/apps/backend/src/bootstrap/instance-config.ts
+++ b/apps/backend/src/bootstrap/instance-config.ts
@@ -106,7 +106,11 @@ export function sniffSslMode(
   try {
     const pem = fs.readFileSync(path.join(dir, 'fullchain.pem'));
     const cert = new X509Certificate(pem);
-    if (/O=Let's Encrypt/.test(cert.issuer)) return 'letsencrypt';
+    // Anchor to a whole RDN line: node renders X509Certificate.issuer as one
+    // RDN per line ("O=Let's Encrypt\nCN=R11"), so match the O= line exactly
+    // (multiline ^…$) rather than a loose substring that a crafted issuer
+    // string containing "O=Let's Encrypt" as a fragment could satisfy.
+    if (/^O=Let's Encrypt$/m.test(cert.issuer)) return 'letsencrypt';
   } catch {
     // missing/unreadable → paste
   }
@@ -148,9 +152,42 @@ export function deriveAdoptedConfig(
   return cfg;
 }
 
+// First-adoption legacy gate (spec §2, C1). A fresh web-bootstrap install
+// (`setup.sh --bootstrap`) also boots with PRIMARY_DOMAIN set — docker-compose's
+// `PRIMARY_DOMAIN: ${PRIMARY_DOMAIN:-yourdomain.com}` substitutes for an empty
+// value too, so the backend sees `yourdomain.com` even though `.env` left it
+// blank — but it is cert-less and has already rendered bootstrap mode. Adopting
+// it would write state:'applied', kill the wizard (isBootstrapModeActive → false)
+// and cut nginx over to NORMAL mode for a domain with no certs. Only a genuine
+// legacy `setup.sh` install (real certs on disk, never bootstrap-rendered) is
+// adoptable on first boot. This mirrors render-main-conf.sh's should_bootstrap()
+// legacy carve-out — see its comment. Applies to first adoption ONLY: an
+// existing origin:'env' file keeps re-syncing regardless (re-sync is not gated).
+function isLegacyEnvInstall(ssl: string, primaryDomain: string): boolean {
+  // (3) Belt-and-braces: docker-compose.yml's `${PRIMARY_DOMAIN:-yourdomain.com}`
+  //     default means an unset/blank PRIMARY_DOMAIN surfaces as this placeholder;
+  //     it is never a real legacy identity, so refuse it outright.
+  if (primaryDomain === 'yourdomain.com') return false;
+  // (1) Real certs present: every non-localhost legacy setup.sh install has run
+  //     certbot / pasted CF origin certs into ssl/; a fresh bootstrap boot has not.
+  if (
+    !fs.existsSync(path.join(ssl, 'fullchain.pem')) ||
+    !fs.existsSync(path.join(ssl, 'privkey.pem'))
+  ) {
+    return false;
+  }
+  // (2) No bootstrap marker: its presence means this install has rendered
+  //     bootstrap mode at least once (render-main-conf.sh writes it and never
+  //     deletes it) — i.e. NOT legacy. This protects the mid-wizard-restart
+  //     window where the certificate step has staged real certs before Apply ran.
+  if (fs.existsSync(path.join(ssl, 'bootstrap-selfsigned.crt'))) return false;
+  return true;
+}
+
 // Boot-time adoption/re-sync for legacy env installs (spec §§2–3). Rules:
-//   - no instance.json + env identity present → write an adopted file
-//   - origin:'env' file → re-derive from env, rewrite only if changed
+//   - no instance.json + env identity present + legacy gate passes → adopt
+//   - origin:'env' file → re-derive from env, rewrite only if changed; if env
+//     is no longer adoptable, delete the now-stale derived files
 //   - wizard file (origin absent/'wizard') or corrupt file → never touched
 // For origin:'env', .env is truth and the files are derived caches — which is
 // also why hydrateProcessEnv skips its process.env override for them.
@@ -179,7 +216,33 @@ export function adoptOrResyncEnvInstall(
       return null;
     }
     const derived = deriveAdoptedConfig(env, ssl);
-    if (!derived) return null;
+    if (!derived) {
+      // I3: an already-adopted install whose .env has become non-adoptable
+      // (domain removed/localhost, or PLATFORM_MODE/SSL_MANAGED_EXTERNALLY now
+      // true). The derived files are a stale cache still steering nginx +
+      // renewal, so delete them rather than silently leaving state:'applied'
+      // behind. Only ever touches origin:'env' files (wizard files returned
+      // above).
+      if (existing?.origin === 'env') {
+        console.warn(
+          `[bootstrap] .env is no longer adoptable (domain removed/localhost or platform mode) — ` +
+            `deleting the stale env-origin instance.json/instance.env so nginx + renewal fall back to env`,
+        );
+        for (const f of ['instance.json', 'instance.env']) {
+          try {
+            fs.unlinkSync(path.join(dir, f));
+          } catch (e) {
+            if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
+          }
+        }
+      }
+      return null;
+    }
+    // First-adoption gate: only genuine legacy installs get adopted. An existing
+    // origin:'env' file re-syncs unconditionally (it already proved adoptable).
+    if (!existing && !isLegacyEnvInstall(ssl, derived.primaryDomain!)) {
+      return null;
+    }
     if (existing && JSON.stringify(existing) === JSON.stringify(derived)) return existing;
     writeInstanceConfig(derived, dir);
     console.log(

--- a/apps/backend/src/domains/ssl-certificate.service.spec.ts
+++ b/apps/backend/src/domains/ssl-certificate.service.spec.ts
@@ -162,6 +162,57 @@ describe('SslCertificateService.requestPrimaryDomainCertificate', () => {
       expect(fs.existsSync(path.join(sslDir, 'staging', 'privkey.pem'))).toBe(true);
     });
   });
+
+  it('unions extraSans with the default SAN set, deduped, defaults first', async () => {
+    const service = new SslCertificateService();
+    const result = await service.requestPrimaryDomainCertificate('example.com', {
+      extraSans: ['example.com', 'minio.example.com', 'www.example.com'],
+    });
+    expect(result.success).toBe(true);
+    expect(result.sans).toEqual([
+      'example.com',
+      'www.example.com',
+      'admin.example.com',
+      'minio.example.com',
+    ]);
+  });
+});
+
+describe('SslCertificateService.getPrimaryCertificateSans', () => {
+  let sslDir: string;
+
+  beforeEach(() => {
+    sslDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bffless-ssl-'));
+    process.env.SSL_CERT_PATH = sslDir;
+  });
+  afterEach(() => {
+    delete process.env.SSL_CERT_PATH;
+    fs.rmSync(sslDir, { recursive: true, force: true });
+  });
+
+  it('reads DNS SANs from fullchain.pem', () => {
+    // Mint a real cert carrying legacy certbot-style SANs (apex, www, minio —
+    // no admin) into the temp SSL_CERT_PATH dir, via the same forge helper
+    // pattern used elsewhere in this file.
+    const { certPem } = makeCert('example.com', [
+      'example.com',
+      'www.example.com',
+      'minio.example.com',
+    ]);
+    fs.writeFileSync(path.join(sslDir, 'fullchain.pem'), certPem);
+
+    const service = new SslCertificateService();
+    expect(service.getPrimaryCertificateSans()).toEqual([
+      'example.com',
+      'www.example.com',
+      'minio.example.com',
+    ]);
+  });
+
+  it('returns null when the cert is missing', () => {
+    const service = new SslCertificateService();
+    expect(service.getPrimaryCertificateSans()).toBeNull();
+  });
 });
 
 describe('SslCertificateService.checkWildcardCertificate', () => {

--- a/apps/backend/src/domains/ssl-certificate.service.ts
+++ b/apps/backend/src/domains/ssl-certificate.service.ts
@@ -500,6 +500,11 @@ export class SslCertificateService {
    * wildcard.<domain>.crt/.key filenames so the nginx render contract
    * (Task 4) holds — preview subdomains serve it with a hostname mismatch
    * until the optional DNS-01 wildcard flow replaces the copies.
+   *
+   * `extraSans` widens the SAN set beyond the fixed [apex, www, admin] union:
+   * the renewal cron passes the current cert's SANs for an env-adopted legacy
+   * certbot install (spec §4) so a renewal never drops names it already carried
+   * (e.g. minio.<domain>). The union is de-duplicated below.
    */
   async requestPrimaryDomainCertificate(
     domain: string,
@@ -515,7 +520,10 @@ export class SslCertificateService {
     // Renewal of an env-adopted install passes the current cert's SANs so we
     // never drop names the legacy certbot cert carried (e.g. minio.<domain>).
     // The union (defaults first, deduped) feeds the target-scoped
-    // stagedPrimaryCertificate reuse check unchanged.
+    // stagedPrimaryCertificate reuse check unchanged. The ACME order
+    // authorizes every name together, so if any single default SAN can't
+    // HTTP-01 validate the whole order fails — deliberate (a partial cert that
+    // silently dropped apex/www/admin would be worse than a loud failure).
     const sans = Array.from(
       new Set([domain, `www.${domain}`, `admin.${domain}`, ...(opts.extraSans ?? [])]),
     );

--- a/apps/backend/src/domains/ssl-certificate.service.ts
+++ b/apps/backend/src/domains/ssl-certificate.service.ts
@@ -503,7 +503,7 @@ export class SslCertificateService {
    */
   async requestPrimaryDomainCertificate(
     domain: string,
-    opts: { target?: 'live' | 'staging' } = {},
+    opts: { target?: 'live' | 'staging'; extraSans?: string[] } = {},
   ): Promise<{
     success: boolean;
     error?: string;
@@ -512,7 +512,13 @@ export class SslCertificateService {
     reused?: boolean;
   }> {
     const target = opts.target ?? 'live';
-    const sans = [domain, `www.${domain}`, `admin.${domain}`];
+    // Renewal of an env-adopted install passes the current cert's SANs so we
+    // never drop names the legacy certbot cert carried (e.g. minio.<domain>).
+    // The union (defaults first, deduped) feeds the target-scoped
+    // stagedPrimaryCertificate reuse check unchanged.
+    const sans = Array.from(
+      new Set([domain, `www.${domain}`, `admin.${domain}`, ...(opts.extraSans ?? [])]),
+    );
 
     // Idempotency (rate-limit protection). Target-scoped on purpose: the
     // renewal cron (target 'live') must never be satisfied by a stale staged
@@ -551,7 +557,7 @@ export class SslCertificateService {
 
       const [key, csr] = await acme.crypto.createCsr({
         commonName: domain,
-        altNames: [`www.${domain}`, `admin.${domain}`],
+        altNames: sans.filter((d) => d !== domain),
       });
       const finalizedOrder = await this.acmeClient.finalizeOrder(order, csr);
       let validOrder = finalizedOrder;
@@ -582,6 +588,23 @@ export class SslCertificateService {
       const pem = fs.readFileSync(join(this.getSslPath(), 'fullchain.pem'));
       const cert = new X509Certificate(pem);
       return Math.floor((new Date(cert.validTo).getTime() - Date.now()) / 86_400_000);
+    } catch {
+      return null;
+    }
+  }
+
+  /** DNS SANs of the current primary cert; null when absent/unparseable/empty. */
+  getPrimaryCertificateSans(): string[] | null {
+    try {
+      const pem = fs.readFileSync(join(this.getSslPath(), 'fullchain.pem'));
+      const cert = new X509Certificate(pem);
+      if (!cert.subjectAltName) return null;
+      const sans = cert.subjectAltName
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.startsWith('DNS:'))
+        .map((s) => s.slice(4));
+      return sans.length ? sans : null;
     } catch {
       return null;
     }

--- a/apps/backend/src/domains/ssl-renewal.service.spec.ts
+++ b/apps/backend/src/domains/ssl-renewal.service.spec.ts
@@ -107,7 +107,7 @@ const certInfo = (overrides: Partial<SslCertificateInfo> = {}): SslCertificateIn
 describe('SslRenewalService', () => {
   let service: SslRenewalService;
   let sslCert: jest.Mocked<Pick<SslCertificateService,
-    'getPrimaryCertificateExpiryDays' | 'requestPrimaryDomainCertificate' | 'renewWildcardCertificate' | 'requestCustomDomainCertificate'
+    'getPrimaryCertificateExpiryDays' | 'requestPrimaryDomainCertificate' | 'renewWildcardCertificate' | 'requestCustomDomainCertificate' | 'getPrimaryCertificateSans'
   >>;
   let sslInfo: jest.Mocked<Pick<SslInfoService, 'getWildcardCertInfo' | 'getDomainSslInfo'>>;
   let email: jest.Mocked<Pick<EmailService, 'sendEmail'>>;
@@ -124,6 +124,7 @@ describe('SslRenewalService', () => {
       requestPrimaryDomainCertificate: jest.fn(),
       renewWildcardCertificate: jest.fn(),
       requestCustomDomainCertificate: jest.fn(),
+      getPrimaryCertificateSans: jest.fn().mockReturnValue(null),
     };
     sslInfo = {
       getWildcardCertInfo: jest.fn().mockResolvedValue(null),
@@ -165,7 +166,50 @@ describe('SslRenewalService', () => {
 
       await service.checkAndRenewCertificates();
 
-      expect(sslCert.requestPrimaryDomainCertificate).toHaveBeenCalledWith('example.com');
+      expect(sslCert.requestPrimaryDomainCertificate).toHaveBeenCalledWith('example.com', {});
+    });
+
+    it('renews an env-adopted install with the current cert SAN list preserved', async () => {
+      (loadInstanceConfig as jest.Mock).mockReturnValue({
+        version: 2,
+        state: 'applied',
+        origin: 'env',
+        primaryDomain: 'example.com',
+        proxyMode: 'none',
+        sslMode: 'letsencrypt',
+      });
+      sslCert.getPrimaryCertificateExpiryDays.mockReturnValue(5);
+      sslCert.getPrimaryCertificateSans.mockReturnValue([
+        'example.com',
+        'www.example.com',
+        'admin.example.com',
+        'minio.example.com',
+      ]);
+      sslCert.requestPrimaryDomainCertificate.mockResolvedValue({ success: true });
+
+      await service.checkAndRenewCertificates();
+
+      expect(sslCert.requestPrimaryDomainCertificate).toHaveBeenCalledWith(
+        'example.com',
+        { extraSans: ['example.com', 'www.example.com', 'admin.example.com', 'minio.example.com'] },
+      );
+    });
+
+    it('renews a wizard install without a SAN override', async () => {
+      (loadInstanceConfig as jest.Mock).mockReturnValue({
+        version: 2,
+        state: 'applied',
+        primaryDomain: 'example.com',
+        proxyMode: 'none',
+        sslMode: 'letsencrypt',
+      });
+      sslCert.getPrimaryCertificateExpiryDays.mockReturnValue(5);
+      sslCert.requestPrimaryDomainCertificate.mockResolvedValue({ success: true });
+
+      await service.checkAndRenewCertificates();
+
+      expect(sslCert.requestPrimaryDomainCertificate).toHaveBeenCalledWith('example.com', {});
+      expect(sslCert.getPrimaryCertificateSans).not.toHaveBeenCalled();
     });
 
     it('skips primary renewal when sslMode is paste', async () => {

--- a/apps/backend/src/domains/ssl-renewal.service.ts
+++ b/apps/backend/src/domains/ssl-renewal.service.ts
@@ -120,8 +120,12 @@ export class SslRenewalService {
     // without this gate a Cloudflare/paste install could get BOTH reminders —
     // the second with DNS-01 TXT-record instructions that make no sense for
     // a pasted origin cert. Only skip when instance.json is present AND
-    // explicitly non-LE; a legacy env-only install (no instance.json) still
-    // goes through this path unchanged.
+    // explicitly non-LE. Legacy env-only installs are now adopted on first boot
+    // (adoptOrResyncEnvInstall writes instance.json with a sniffed sslMode), so
+    // a paste-adopted install has instance.json here and takes the reminder
+    // path instead (via checkAndRemindPrimaryPaste) — intended. Only a
+    // pre-adoption install with no bootstrap dir mounted still falls through
+    // this path unchanged.
     const instanceCfg = loadInstanceConfig();
     if (instanceCfg?.state === 'applied' && instanceCfg.sslMode !== 'letsencrypt') {
       return null;

--- a/apps/backend/src/domains/ssl-renewal.service.ts
+++ b/apps/backend/src/domains/ssl-renewal.service.ts
@@ -209,8 +209,16 @@ export class SslRenewalService {
       return { domain: cfg.primaryDomain, status: 'skipped' };
     }
     this.logger.log(`Primary LE cert expires in ${daysLeft} days, renewing…`);
+    // Env-adopted installs (legacy certbot certs) may carry SANs the wizard
+    // set doesn't (minio.<domain>) — renew with them preserved (spec §4).
+    const currentSans =
+      cfg.origin === 'env'
+        ? (this.sslCertificateService.getPrimaryCertificateSans() ?? undefined)
+        : undefined;
+    // target stays defaulted to 'live' — the renewal cron writes the live cert.
     const result = await this.sslCertificateService.requestPrimaryDomainCertificate(
       cfg.primaryDomain,
+      currentSans ? { extraSans: currentSans } : {},
     );
     await this.logRenewal({
       certificateType: 'individual',

--- a/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
@@ -149,6 +149,18 @@ describe('BootstrapSetupController', () => {
       writeSpy.mockRestore();
     });
 
+    it('apply stamps origin wizard so the install graduates from env adoption', async () => {
+      // Identity change (apply) is the graduation event: an install adopted
+      // from a legacy .env (origin:'env') must become wizard-owned once the
+      // wizard writes a new identity, per the graduation rule in the plan.
+      const writeSpy = jest
+        .spyOn(require('../bootstrap/instance-config'), 'writeInstanceConfig')
+        .mockImplementation(() => undefined);
+      await controller.apply({ domain: 'example.com', proxyMode: 'cloudflare', sslMode: 'paste' });
+      expect(writeSpy).toHaveBeenCalledWith(expect.objectContaining({ origin: 'wizard' }));
+      writeSpy.mockRestore();
+    });
+
     it('writes the v2 instance config shape (proxyMode/sslMode/port80/realIp) for a custom realIp proxy install', async () => {
       // v2 apply: validateApplyConfig resolves the knobs, and the controller
       // must pass all four through to writeInstanceConfig rather than the
@@ -168,6 +180,7 @@ describe('BootstrapSetupController', () => {
       expect(writeSpy).toHaveBeenCalledWith({
         version: 2,
         state: 'applied',
+        origin: 'wizard',
         primaryDomain: 'example.com',
         proxyMode: 'proxy',
         sslMode: 'paste',

--- a/apps/backend/src/setup/bootstrap-setup.controller.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.ts
@@ -112,6 +112,7 @@ export class BootstrapSetupController {
     writeInstanceConfig({
       version: 2,
       state: 'applied',
+      origin: 'wizard',
       primaryDomain: domain,
       proxyMode: applied.proxyMode,
       sslMode: applied.sslMode,

--- a/apps/backend/src/setup/primary-ssl/primary-ssl-snapshot.service.spec.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl-snapshot.service.spec.ts
@@ -88,6 +88,19 @@ describe('PrimarySslSnapshotService', () => {
     expect(svc.isApplied()).toBe(false);
   });
 
+  it('re-baselining preserves an env origin instead of graduating it', () => {
+    // Mechanical rewrites (snapshot/restore) must not perform the graduation
+    // that only the wizard apply endpoint is allowed to do — an env-adopted
+    // install's origin must ride along through the snapshot round trip.
+    writeInstanceConfig(
+      { version: 2, state: 'applied', origin: 'env', primaryDomain: 'a.com', proxyMode: 'none', sslMode: 'paste' },
+      dir,
+    );
+    svc.snapshot();
+    svc.restore();
+    expect(loadInstanceConfig(dir)!.origin).toBe('env');
+  });
+
   it('snapshotForChangeCycle re-baselines over an applied snapshot (rollback restores the LATEST pre-change bytes)', () => {
     // cycle 1: stage + cert-only apply of cert A over the original
     svc.snapshotForChangeCycle();               // baseline = ORIG

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
@@ -232,25 +232,27 @@ describe('PrimarySslService.apply classification', () => {
     expect(staging.discardStagedCertificates).toHaveBeenCalled();
   });
 
-  it('apply preserves origin: env from the loaded config in the written instance config (env-adopted installs)', async () => {
+  it('apply stamps origin: wizard, graduating an env-adopted install to UI-managed identity', async () => {
     const { svc } = build();
     const dto = { proxyMode: 'cloudflare', sslMode: 'paste', port80: 'redirect', realIp: undefined } as any;
     mockCur.proxyMode = 'cloudflare'; // no reachability change; mirrors the "cert-only change behind a proxy" case above
 
-    // No origin on the loaded config -> the written config carries origin: undefined
+    // A wizard (origin-absent) install stays wizard-owned; the write makes it explicit.
     await svc.apply(dto);
     const calls = (writeInstanceConfig as jest.Mock).mock.calls;
-    const noOriginWrite = calls[calls.length - 1][0];
-    expect(noOriginWrite.origin).toBeUndefined();
+    const wizardWrite = calls[calls.length - 1][0];
+    expect(wizardWrite.origin).toBe('wizard');
 
-    // Loaded config has origin: 'env' (day-2 apply on an env-adopted install) -> preserved in the write
+    // Day-2 apply on an env-adopted install (origin:'env') GRADUATES it: the
+    // written config becomes origin:'wizard' so the boot re-sync no longer
+    // treats .env as authoritative for identity (spec §3).
     mockCur.origin = 'env';
     await svc.apply(dto);
-    const envOriginWrite = calls[calls.length - 1][0];
-    expect(envOriginWrite).toEqual(expect.objectContaining({ origin: 'env' }));
+    const graduatedWrite = calls[calls.length - 1][0];
+    expect(graduatedWrite).toEqual(expect.objectContaining({ origin: 'wizard' }));
   });
 
-  it('warns that non-representable knobs revert on an env-origin install, and not on wizard-origin (I1)', async () => {
+  it('logs a graduation notice on an env-origin install, and not on a wizard-origin install', async () => {
     const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
     try {
       const { svc } = build();
@@ -258,10 +260,12 @@ describe('PrimarySslService.apply classification', () => {
       mockCur.proxyMode = 'cloudflare';
       const dto = { proxyMode: 'cloudflare', sslMode: 'paste', port80: 'redirect', realIp: undefined } as any;
 
+      // env-origin apply graduates the install -> a graduation notice is logged.
       mockCur.origin = 'env';
       await svc.apply(dto);
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining("origin:'env'"));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('graduated'));
 
+      // wizard-origin apply is unchanged -> nothing to graduate, no notice.
       warn.mockClear();
       mockCur.origin = 'wizard';
       await svc.apply(dto);

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
@@ -1,6 +1,7 @@
 import { ForbiddenException } from '@nestjs/common';
 import { PrimarySslService } from './primary-ssl.service';
 import * as staging from '../ssl-staging';
+import { writeInstanceConfig } from '../../bootstrap/instance-config';
 
 const domain = 'a.com';
 
@@ -229,6 +230,24 @@ describe('PrimarySslService.apply classification', () => {
     const { svc } = build();
     expect(svc.discardStaged()).toEqual({ discarded: true });
     expect(staging.discardStagedCertificates).toHaveBeenCalled();
+  });
+
+  it('apply preserves origin: env from the loaded config in the written instance config (env-adopted installs)', async () => {
+    const { svc } = build();
+    const dto = { proxyMode: 'cloudflare', sslMode: 'paste', port80: 'redirect', realIp: undefined } as any;
+    mockCur.proxyMode = 'cloudflare'; // no reachability change; mirrors the "cert-only change behind a proxy" case above
+
+    // No origin on the loaded config -> the written config carries origin: undefined
+    await svc.apply(dto);
+    const calls = (writeInstanceConfig as jest.Mock).mock.calls;
+    const noOriginWrite = calls[calls.length - 1][0];
+    expect(noOriginWrite.origin).toBeUndefined();
+
+    // Loaded config has origin: 'env' (day-2 apply on an env-adopted install) -> preserved in the write
+    mockCur.origin = 'env';
+    await svc.apply(dto);
+    const envOriginWrite = calls[calls.length - 1][0];
+    expect(envOriginWrite).toEqual(expect.objectContaining({ origin: 'env' }));
   });
 
   it('serving change writes a pending revert with a deadline and does not mark applied', async () => {

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException } from '@nestjs/common';
+import { ForbiddenException, Logger } from '@nestjs/common';
 import { PrimarySslService } from './primary-ssl.service';
 import * as staging from '../ssl-staging';
 import { writeInstanceConfig } from '../../bootstrap/instance-config';
@@ -248,6 +248,27 @@ describe('PrimarySslService.apply classification', () => {
     await svc.apply(dto);
     const envOriginWrite = calls[calls.length - 1][0];
     expect(envOriginWrite).toEqual(expect.objectContaining({ origin: 'env' }));
+  });
+
+  it('warns that non-representable knobs revert on an env-origin install, and not on wizard-origin (I1)', async () => {
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    try {
+      const { svc } = build();
+      // No reachability change (proxyMode matches cur) so apply commits cleanly.
+      mockCur.proxyMode = 'cloudflare';
+      const dto = { proxyMode: 'cloudflare', sslMode: 'paste', port80: 'redirect', realIp: undefined } as any;
+
+      mockCur.origin = 'env';
+      await svc.apply(dto);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("origin:'env'"));
+
+      warn.mockClear();
+      mockCur.origin = 'wizard';
+      await svc.apply(dto);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('serving change writes a pending revert with a deadline and does not mark applied', async () => {

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
@@ -154,6 +154,7 @@ export class PrimarySslService {
     const next: InstanceConfig = {
       version: 2,
       state: 'applied',
+      origin: cur.origin,
       primaryDomain: cur.primaryDomain,
       proxyMode: applied.proxyMode,
       sslMode: applied.sslMode,

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
@@ -156,7 +156,11 @@ export class PrimarySslService {
     const next: InstanceConfig = {
       version: 2,
       state: 'applied',
-      origin: cur.origin,
+      // Day-2 identity/SSL apply is a graduation event: the install becomes
+      // UI-managed regardless of how it was set up. A prior origin:'env'
+      // adoption is promoted to 'wizard' here so the boot re-sync stops
+      // treating .env as authoritative for identity (spec §3).
+      origin: 'wizard',
       primaryDomain: cur.primaryDomain,
       proxyMode: applied.proxyMode,
       sslMode: applied.sslMode,
@@ -174,21 +178,17 @@ export class PrimarySslService {
     // those stay manual-rollback-only (ce#511).
     const needsConfirm = serving || (certAffecting && next.proxyMode === 'none');
 
-    // I1: on an env-adopted install (.env is authoritative, this file is a
-    // derived cache re-synced every boot from adoptOrResyncEnvInstall), the
-    // boot re-sync re-derives the config from .env and drops any knob .env
-    // cannot express — proxyMode is re-read from PROXY_MODE, but port80/realIp
-    // are omitted entirely (v1-style). So a UI-applied change to those reverts
-    // silently on the next restart. Warn loudly rather than pretend it stuck;
-    // apply()'s response has no warnings field to surface it in, so this is
-    // log-only (graduation to a persisted wizard write stays wizard-only for now).
+    // Graduation notice (spec §3): an env-adopted install (origin:'env') that
+    // reaches a day-2 primary-SSL apply is promoted to UI-managed identity in
+    // `next` above. Say so loudly — .env identity edits no longer apply, and
+    // the boot-time divergence warning is the safety net if the operator keeps
+    // editing .env after this point.
     if (cur.origin === 'env') {
       this.logger.warn(
-        `Applying primary-SSL changes to an env-adopted install (origin:'env'): .env stays ` +
-          `authoritative, so the next boot re-sync will overwrite these from .env — ` +
-          `proxyMode=${next.proxyMode}, port80=${next.port80}, realIp=${JSON.stringify(next.realIp)} ` +
-          `(port80/realIp are not representable in .env and will revert). Manage identity/SSL via ` +
-          `the wizard to persist them.`,
+        `Primary-SSL apply on an env-adopted install (origin:'env') graduated it to ` +
+          `UI-managed identity: bootstrap/instance.json is now authoritative and .env ` +
+          `identity edits (PRIMARY_DOMAIN/PROXY_MODE/…) no longer apply. Manage identity and ` +
+          `SSL via the admin UI from now on.`,
       );
     }
 

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, Logger } from '@nestjs/common';
 import { BootstrapSetupService } from '../bootstrap-setup.service';
 import { SslCertificateService } from '../../domains/ssl-certificate.service';
 import { BootstrapDnsPreflightService, PreflightResult } from '../bootstrap-dns-preflight.service';
@@ -27,6 +27,8 @@ export interface PrimarySslStatus {
 
 @Injectable()
 export class PrimarySslService {
+  private readonly logger = new Logger(PrimarySslService.name);
+
   constructor(
     private readonly bootstrap: BootstrapSetupService,
     private readonly ssl: SslCertificateService,
@@ -171,6 +173,24 @@ export class PrimarySslService {
     // changes. Behind Cloudflare/proxy the origin cert isn't user-facing, so
     // those stay manual-rollback-only (ce#511).
     const needsConfirm = serving || (certAffecting && next.proxyMode === 'none');
+
+    // I1: on an env-adopted install (.env is authoritative, this file is a
+    // derived cache re-synced every boot from adoptOrResyncEnvInstall), the
+    // boot re-sync re-derives the config from .env and drops any knob .env
+    // cannot express — proxyMode is re-read from PROXY_MODE, but port80/realIp
+    // are omitted entirely (v1-style). So a UI-applied change to those reverts
+    // silently on the next restart. Warn loudly rather than pretend it stuck;
+    // apply()'s response has no warnings field to surface it in, so this is
+    // log-only (graduation to a persisted wizard write stays wizard-only for now).
+    if (cur.origin === 'env') {
+      this.logger.warn(
+        `Applying primary-SSL changes to an env-adopted install (origin:'env'): .env stays ` +
+          `authoritative, so the next boot re-sync will overwrite these from .env — ` +
+          `proxyMode=${next.proxyMode}, port80=${next.port80}, realIp=${JSON.stringify(next.realIp)} ` +
+          `(port80/realIp are not representable in .env and will revert). Manage identity/SSL via ` +
+          `the wizard to persist them.`,
+      );
+    }
 
     // Snapshot the live pre-change state, THEN promote staging over it — the
     // ordering is now structurally correct instead of call-order discipline.

--- a/docker/nginx/render-main-conf.test.sh
+++ b/docker/nginx/render-main-conf.test.sh
@@ -129,4 +129,37 @@ assert_contains "$ETC/ssl/privkey.pem"   'STAGED-REAL-KEY'  'selfsigned: staged 
 # fullchain.pem itself is guarded, PRIMARY_CERT/WILDCARD_CERT are unaffected.
 assert_contains "$ETC/sites-available/main.conf" "ssl_certificate $ETC/ssl/bootstrap-selfsigned.crt;" 'selfsigned: admin vhost still serves self-signed cert with a staged fullchain present'
 
+# --- adoption parity: an env-adopted instance.env must render main.conf
+# byte-identically to the pure-env legacy render it replaces (spec §2:
+# adoption changes nothing nginx serves). Paths embed $ETC, so normalize. ---
+setup_etc 'STATE=applied
+PRIMARY_DOMAIN=example.com
+PROXY_MODE=none
+SSL_MODE=letsencrypt'
+run_render
+ADOPTED_CONF="$(mktemp)"
+sed "s|$ETC|@ETC@|g" "$ETC/sites-available/main.conf" > "$ADOPTED_CONF"
+
+# pure-env legacy install: certs present, NO instance.env, NO bootstrap
+# marker (a genuine pre-wizard install never rendered bootstrap mode).
+ETC="$(mktemp -d)"
+mkdir -p "$ETC/ssl" "$ETC/bootstrap" "$ETC/sites-available"
+cp "$HERE/sites-available/"*.template "$ETC/sites-available/"
+openssl req -x509 -nodes -days 2 -newkey rsa:2048 -keyout "$ETC/ssl/privkey.pem" \
+    -out "$ETC/ssl/fullchain.pem" -subj "/CN=test" 2>/dev/null
+cp "$ETC/ssl/fullchain.pem" "$ETC/ssl/wildcard.example.com.crt"
+cp "$ETC/ssl/privkey.pem" "$ETC/ssl/wildcard.example.com.key"
+( NGINX_ETC="$ETC" CERTBOT_ROOT="$ETC/certbot" PRIMARY_DOMAIN=example.com PROXY_MODE=none \
+    sh "$HERE/render-main-conf.sh" >/dev/null )
+LEGACY_CONF="$(mktemp)"
+sed "s|$ETC|@ETC@|g" "$ETC/sites-available/main.conf" > "$LEGACY_CONF"
+
+if diff -u "$LEGACY_CONF" "$ADOPTED_CONF" >/dev/null; then
+    echo "ok: adoption parity: adopted instance.env renders identically to pure env"
+else
+    echo "FAIL: adoption parity: adopted vs pure-env main.conf differ:"
+    diff -u "$LEGACY_CONF" "$ADOPTED_CONF" || true
+    FAILURES=$((FAILURES+1))
+fi
+
 [ "$FAILURES" -eq 0 ] && echo 'ALL RENDER TESTS PASSED' || { echo "$FAILURES FAILURES"; exit 1; }

--- a/docs/superpowers/plans/2026-07-24-legacy-env-adoption.md
+++ b/docs/superpowers/plans/2026-07-24-legacy-env-adoption.md
@@ -1,0 +1,863 @@
+# Legacy Env-Install Adoption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Legacy env-only CE installs are adopted into `bootstrap/instance.json` on first boot after upgrade (`origin: 'env'`), with `.env` remaining the live source of truth via boot-time re-sync — so day-2 features (LE renewal, paste-expiry reminders) activate uniformly without breaking the "edit `.env` and restart" workflow.
+
+**Architecture:** All adoption/re-sync logic lives in the pure-Node pre-Nest module `apps/backend/src/bootstrap/instance-config.ts` (executed via the `hydrate.ts` side-effect import that is `main.ts`'s first import). `origin: 'env'` files are derived caches of `.env` (rewritten only on change, never overriding `process.env`); `origin: 'wizard'` (or absent) keeps today's semantics exactly. The renewal cron preserves existing-cert SANs for adopted installs.
+
+**Tech Stack:** NestJS 10 + Jest (backend), `node:crypto` `X509Certificate` (issuer sniff / SAN read), POSIX sh (nginx render tests), bash (smoke test).
+
+**Spec:** `docs/superpowers/specs/2026-07-24-legacy-env-adoption-design.md` — read it first.
+
+## Global Constraints
+
+- Adoption **never writes `.env`** — rollback to a pre-adoption image must be a no-op.
+- Never clobber a present-but-unparseable `instance.json` (could be a wizard file with transient corruption): log and skip.
+- Skip adoption when `PRIMARY_DOMAIN` is unset or `localhost`, or when `process.env.PLATFORM_MODE === 'true' || process.env.SSL_MANAGED_EXTERNALLY === 'true'` (exact check copied from `setup.service.ts:240`).
+- Adopted configs omit `port80`/`realIp` (v1-style, derived by `deriveKnobs`) — byte-parity with `render-main-conf.sh`'s env fallback.
+- `origin` absent ⇒ `'wizard'` semantics; `version` stays `2`; `instance.env` format unchanged.
+- No failure in adoption/re-sync may crash the backend — worst case is today's env-only behavior plus a log line.
+- Renewal must never drop SANs present in the current cert (legacy certbot certs carry `minio.<domain>`; the wizard set is only apex+www+admin).
+- Backend: 2-space indent, Jest specs colocated `*.spec.ts`, run `cd apps/backend && pnpm test -- <pattern>`. Shell: POSIX sh for `docker/nginx/`, bash for `test-bootstrap.sh`.
+- Commit prefix: `feat(env-adoption): …` (or `fix`/`test`/`docs`).
+- Branch: `spec/legacy-env-adoption` (already created off `origin/main`, spec committed as `79fe308`).
+
+## File Structure
+
+```
+apps/backend/src/bootstrap/instance-config.ts        # MODIFY: origin field, sslDir, sniffSslMode, envIdentity, deriveAdoptedConfig, adoptOrResyncEnvInstall, hydrate skip
+apps/backend/src/bootstrap/instance-config.spec.ts   # MODIFY: new describe blocks
+apps/backend/src/bootstrap/hydrate.ts                # MODIFY: call adoptOrResyncEnvInstall() before hydrateProcessEnv()
+apps/backend/src/setup/bootstrap-setup.controller.ts # MODIFY: stamp origin:'wizard' in apply
+apps/backend/src/setup/bootstrap-setup.controller.spec.ts # MODIFY: assert the stamp
+apps/backend/src/setup/primary-ssl/primary-ssl.service.ts # VERIFY/MODIFY: preserve loaded origin on write
+apps/backend/src/setup/primary-ssl/primary-ssl-snapshot.service.spec.ts # MODIFY: origin-preservation test
+apps/backend/src/domains/ssl-certificate.service.ts  # MODIFY: extraSans param, getPrimaryCertificateSans
+apps/backend/src/domains/ssl-certificate.service.spec.ts # MODIFY: SAN union + parse tests
+apps/backend/src/domains/ssl-renewal.service.ts      # MODIFY: pass current SANs for origin:'env'
+apps/backend/src/domains/ssl-renewal.service.spec.ts # MODIFY: adopted-install renewal tests
+docker/nginx/render-main-conf.test.sh                # MODIFY: adopted-vs-pure-env parity case
+test-bootstrap.sh                                    # MODIFY: opt-in legacy-upgrade leg (RUN_LEGACY_LEG=1)
+```
+
+Dependency order: Task 1 → 2 → 3 are sequential; Task 4 depends on 1; Tasks 5–6 independent of 3–4; Task 7 (docs note) last and lives in the separate `repos/docs-public` repo.
+
+---
+
+### Task 1: `origin` field + `sniffSslMode()`
+
+**Files:**
+- Modify: `apps/backend/src/bootstrap/instance-config.ts`
+- Test: `apps/backend/src/bootstrap/instance-config.spec.ts`
+
+**Interfaces:**
+- Consumes: existing `SslMode` type, `fs`/`path` imports already in the module.
+- Produces (later tasks rely on these exact names):
+  - `InstanceConfig.origin?: 'wizard' | 'env'` (absent ⇒ wizard semantics)
+  - `sslDir(): string` — `process.env.SSL_CERT_PATH || '/etc/nginx/ssl'`
+  - `sniffSslMode(dir?: string, envProxyMode?: string): SslMode` — never throws; returns `'letsencrypt'` or `'paste'` only.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `instance-config.spec.ts` (inside the top-level `describe`; `execFileSync`, `fs`, `os`, `path` are already imported):
+
+```ts
+describe('sniffSslMode', () => {
+  let sslTmp: string;
+  beforeEach(() => {
+    sslTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bffless-ssl-'));
+  });
+  afterEach(() => {
+    fs.rmSync(sslTmp, { recursive: true, force: true });
+  });
+
+  function mintCert(subj: string): void {
+    execFileSync('openssl', [
+      'req', '-x509', '-nodes', '-days', '2', '-newkey', 'rsa:2048',
+      '-keyout', path.join(sslTmp, 'privkey.pem'),
+      '-out', path.join(sslTmp, 'fullchain.pem'),
+      '-subj', subj,
+    ], { stdio: 'ignore' });
+  }
+
+  it('returns letsencrypt for an LE-issued cert when PROXY_MODE is not cloudflare', () => {
+    mintCert("/O=Let's Encrypt/CN=R11");
+    expect(sniffSslMode(sslTmp, 'none')).toBe('letsencrypt');
+    expect(sniffSslMode(sslTmp, undefined)).toBe('letsencrypt'); // unset counts as not-cloudflare
+  });
+
+  it('returns paste for an LE cert behind cloudflare', () => {
+    mintCert("/O=Let's Encrypt/CN=R11");
+    expect(sniffSslMode(sslTmp, 'cloudflare')).toBe('paste');
+  });
+
+  it('returns paste for a non-LE issuer (Cloudflare Origin style)', () => {
+    mintCert('/O=CloudFlare, Inc./CN=CloudFlare Origin Certificate');
+    expect(sniffSslMode(sslTmp, 'none')).toBe('paste');
+  });
+
+  it('returns paste when fullchain.pem is missing or unparseable', () => {
+    expect(sniffSslMode(sslTmp, 'none')).toBe('paste');
+    fs.writeFileSync(path.join(sslTmp, 'fullchain.pem'), 'not a pem');
+    expect(sniffSslMode(sslTmp, 'none')).toBe('paste');
+  });
+});
+```
+
+Add `sniffSslMode` to the import list at the top of the spec.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && pnpm test -- instance-config`
+Expected: FAIL — `sniffSslMode` is not exported.
+
+- [ ] **Step 3: Implement**
+
+In `instance-config.ts`, add to the imports:
+
+```ts
+import { X509Certificate } from 'crypto';
+```
+
+Add `origin` to `InstanceConfig` (after `state`):
+
+```ts
+  // Who owns this file. 'wizard': the web wizard / admin UI wrote it — file is
+  // truth, hydration overrides process.env (absent = 'wizard': all files
+  // written before this field existed are wizard files). 'env': adopted from a
+  // legacy .env install — .env is truth and this file is a derived cache,
+  // re-synced on every boot by adoptOrResyncEnvInstall().
+  origin?: 'wizard' | 'env';
+```
+
+Add below `bootstrapDir()`:
+
+```ts
+export function sslDir(): string {
+  return process.env.SSL_CERT_PATH || '/etc/nginx/ssl';
+}
+
+// Adoption-time sslMode inference for legacy env-only installs (spec §2): an
+// LE-issued primary cert on a non-cloudflare install means the operator used
+// the setup.sh certbot path, whose renewal is broken by default (one-time
+// copy into ssl/, standalone renew can't bind port 80) — adopt as
+// 'letsencrypt' so the in-app renewer takes over. Everything else (CF origin
+// certs, unknown issuers, missing/unreadable cert) adopts as 'paste'.
+// Unset PROXY_MODE counts as not-cloudflare, matching render-main-conf.sh's
+// derivation. Never throws: sniff failure must not prevent boot.
+export function sniffSslMode(
+  dir: string = sslDir(),
+  envProxyMode: string | undefined = process.env.PROXY_MODE,
+): SslMode {
+  if (envProxyMode === 'cloudflare') return 'paste';
+  try {
+    const pem = fs.readFileSync(path.join(dir, 'fullchain.pem'));
+    const cert = new X509Certificate(pem);
+    if (/O=Let's Encrypt/.test(cert.issuer)) return 'letsencrypt';
+  } catch {
+    // missing/unreadable → paste
+  }
+  return 'paste';
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/backend && pnpm test -- instance-config`
+Expected: PASS (all pre-existing cases too).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/bootstrap/instance-config.ts apps/backend/src/bootstrap/instance-config.spec.ts
+git commit -m "feat(env-adoption): origin field + sslMode issuer sniff"
+```
+
+---
+
+### Task 2: adoption + re-sync + hydrate skip
+
+**Files:**
+- Modify: `apps/backend/src/bootstrap/instance-config.ts`
+- Modify: `apps/backend/src/bootstrap/hydrate.ts`
+- Test: `apps/backend/src/bootstrap/instance-config.spec.ts`
+
+**Interfaces:**
+- Consumes: `sniffSslMode`, `sslDir` (Task 1); existing `loadInstanceConfig`, `writeInstanceConfig`, `deriveIdentityEnv`, `bootstrapDir`.
+- Produces:
+  - `envIdentity(env?: NodeJS.ProcessEnv): { primaryDomain: string; proxyMode?: ProxyMode } | null`
+  - `deriveAdoptedConfig(env?: NodeJS.ProcessEnv, ssl?: string): InstanceConfig | null`
+  - `adoptOrResyncEnvInstall(dir?: string, env?: NodeJS.ProcessEnv, ssl?: string): InstanceConfig | null`
+  - Changed behavior: `hydrateProcessEnv()` no longer assigns to `process.env` when `cfg.origin === 'env'` (still returns the config).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `instance-config.spec.ts`. These tests mutate `process.env`, so snapshot/restore it:
+
+```ts
+describe('env adoption & re-sync', () => {
+  let sslTmp: string;
+  let envBackup: NodeJS.ProcessEnv;
+
+  const legacyEnv = (over: Record<string, string | undefined> = {}): NodeJS.ProcessEnv =>
+    ({ PRIMARY_DOMAIN: 'legacy.com', PROXY_MODE: 'cloudflare', ...over } as NodeJS.ProcessEnv);
+
+  beforeEach(() => {
+    envBackup = { ...process.env };
+    sslTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bffless-ssl-'));
+  });
+  afterEach(() => {
+    process.env = envBackup;
+    fs.rmSync(sslTmp, { recursive: true, force: true });
+  });
+
+  it('adopts a legacy env install: applied, origin env, no knobs, sniffed sslMode', () => {
+    const cfg = adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp);
+    expect(cfg).toMatchObject({
+      version: 2, state: 'applied', origin: 'env',
+      primaryDomain: 'legacy.com', proxyMode: 'cloudflare', sslMode: 'paste',
+    });
+    expect(cfg!.port80).toBeUndefined();
+    expect(cfg!.realIp).toBeUndefined();
+    const onDisk = loadInstanceConfig(dir);
+    expect(onDisk).toEqual(cfg);
+    expect(fs.readFileSync(path.join(dir, 'instance.env'), 'utf8')).toContain('PRIMARY_DOMAIN=legacy.com');
+  });
+
+  it('omits proxyMode when PROXY_MODE is unset or unknown', () => {
+    const cfg = adoptOrResyncEnvInstall(dir, legacyEnv({ PROXY_MODE: undefined }), sslTmp);
+    expect(cfg!.proxyMode).toBeUndefined();
+    fs.rmSync(path.join(dir, 'instance.json'));
+    const cfg2 = adoptOrResyncEnvInstall(dir, legacyEnv({ PROXY_MODE: 'bogus' }), sslTmp);
+    expect(cfg2!.proxyMode).toBeUndefined();
+  });
+
+  it('skips adoption for localhost, missing domain, and platform mode', () => {
+    expect(adoptOrResyncEnvInstall(dir, legacyEnv({ PRIMARY_DOMAIN: 'localhost' }), sslTmp)).toBeNull();
+    expect(adoptOrResyncEnvInstall(dir, legacyEnv({ PRIMARY_DOMAIN: undefined }), sslTmp)).toBeNull();
+    expect(adoptOrResyncEnvInstall(dir, legacyEnv({ PLATFORM_MODE: 'true' }), sslTmp)).toBeNull();
+    expect(adoptOrResyncEnvInstall(dir, legacyEnv({ SSL_MANAGED_EXTERNALLY: 'true' }), sslTmp)).toBeNull();
+    expect(fs.existsSync(path.join(dir, 'instance.json'))).toBe(false);
+  });
+
+  it('never touches a wizard-origin file (explicit or absent origin)', () => {
+    writeInstanceConfig({ version: 2, state: 'applied', primaryDomain: 'wizard.com', proxyMode: 'none', sslMode: 'paste' }, dir);
+    const before = fs.readFileSync(path.join(dir, 'instance.json'), 'utf8');
+    expect(adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp)).toBeNull();
+    expect(fs.readFileSync(path.join(dir, 'instance.json'), 'utf8')).toBe(before);
+  });
+
+  it('leaves a corrupt instance.json untouched', () => {
+    fs.writeFileSync(path.join(dir, 'instance.json'), '{not json');
+    expect(adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp)).toBeNull();
+    expect(fs.readFileSync(path.join(dir, 'instance.json'), 'utf8')).toBe('{not json');
+  });
+
+  it('re-syncs an env-origin file when .env changes, and skips the write when unchanged', () => {
+    adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp);
+    const writeSpy = jest.spyOn(fs, 'writeFileSync');
+    adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp); // unchanged
+    expect(writeSpy).not.toHaveBeenCalled();
+    const cfg = adoptOrResyncEnvInstall(dir, legacyEnv({ PRIMARY_DOMAIN: 'renamed.com' }), sslTmp);
+    expect(cfg!.primaryDomain).toBe('renamed.com');
+    expect(loadInstanceConfig(dir)!.primaryDomain).toBe('renamed.com');
+    writeSpy.mockRestore();
+  });
+
+  it('hydrateProcessEnv does not override process.env for origin:env files', () => {
+    adoptOrResyncEnvInstall(dir, legacyEnv(), sslTmp);
+    delete process.env.FRONTEND_URL;
+    process.env.PRIMARY_DOMAIN = 'fresh-from-env.com';
+    const cfg = hydrateProcessEnv(dir);
+    expect(cfg!.origin).toBe('env');
+    expect(process.env.PRIMARY_DOMAIN).toBe('fresh-from-env.com'); // NOT clobbered by the file
+    expect(process.env.FRONTEND_URL).toBeUndefined();
+  });
+
+  it('hydrateProcessEnv still overrides process.env for wizard files', () => {
+    writeInstanceConfig({ version: 2, state: 'applied', origin: 'wizard', primaryDomain: 'wizard.com', proxyMode: 'none', sslMode: 'paste' }, dir);
+    hydrateProcessEnv(dir);
+    expect(process.env.PRIMARY_DOMAIN).toBe('wizard.com');
+    expect(process.env.FRONTEND_URL).toBe('https://www.wizard.com');
+  });
+});
+```
+
+Add `envIdentity`, `deriveAdoptedConfig`, `adoptOrResyncEnvInstall`, `sniffSslMode`, `sslDir` to the spec's import list.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && pnpm test -- instance-config`
+Expected: FAIL — `adoptOrResyncEnvInstall` not exported; the two `hydrateProcessEnv` origin tests fail.
+
+- [ ] **Step 3: Implement**
+
+In `instance-config.ts`, add after `sniffSslMode`:
+
+```ts
+// Identity as expressed by a legacy .env install (docker-compose passes .env
+// into the backend's environment). Null = not an adoptable install: no/localhost
+// domain, or a platform workspace (identity is platform-managed there — same
+// check as SetupService.isPlatformManaged).
+export function envIdentity(
+  env: NodeJS.ProcessEnv = process.env,
+): { primaryDomain: string; proxyMode?: ProxyMode } | null {
+  if (env.PLATFORM_MODE === 'true' || env.SSL_MANAGED_EXTERNALLY === 'true') return null;
+  const d = env.PRIMARY_DOMAIN;
+  if (!d || d === 'localhost') return null;
+  const pm = env.PROXY_MODE;
+  const proxyMode = pm === 'cloudflare' || pm === 'proxy' || pm === 'none' ? pm : undefined;
+  return { primaryDomain: d, proxyMode };
+}
+
+// The instance.json a legacy env install maps to. Knobs (port80/realIp) are
+// deliberately omitted (v1-style): deriveKnobs and render-main-conf.sh's env
+// fallback derive identical values, so adoption changes nothing nginx renders.
+export function deriveAdoptedConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  ssl: string = sslDir(),
+): InstanceConfig | null {
+  const id = envIdentity(env);
+  if (!id) return null;
+  const cfg: InstanceConfig = {
+    version: 2,
+    state: 'applied',
+    origin: 'env',
+    primaryDomain: id.primaryDomain,
+    sslMode: sniffSslMode(ssl, env.PROXY_MODE),
+  };
+  if (id.proxyMode) cfg.proxyMode = id.proxyMode;
+  return cfg;
+}
+
+// Boot-time adoption/re-sync for legacy env installs (spec §§2–3). Rules:
+//   - no instance.json + env identity present → write an adopted file
+//   - origin:'env' file → re-derive from env, rewrite only if changed
+//   - wizard file (origin absent/'wizard') or corrupt file → never touched
+// For origin:'env', .env is truth and the files are derived caches — which is
+// also why hydrateProcessEnv skips its process.env override for them.
+// Must never throw: any failure degrades to today's env-only behavior.
+export function adoptOrResyncEnvInstall(
+  dir: string = bootstrapDir(),
+  env: NodeJS.ProcessEnv = process.env,
+  ssl: string = sslDir(),
+): InstanceConfig | null {
+  try {
+    const jsonPath = path.join(dir, 'instance.json');
+    const exists = fs.existsSync(jsonPath);
+    const existing = loadInstanceConfig(dir);
+    if (exists && !existing) {
+      console.warn('[bootstrap] instance.json present but unreadable — leaving it untouched');
+      return null;
+    }
+    if (existing && existing.origin !== 'env') {
+      const d = env.PRIMARY_DOMAIN;
+      if (d && d !== 'localhost' && d !== existing.primaryDomain) {
+        console.warn(
+          `[bootstrap] .env PRIMARY_DOMAIN=${d} differs from wizard-managed instance.json ` +
+            `(${existing.primaryDomain}); instance.json wins — change identity via the admin UI`,
+        );
+      }
+      return null;
+    }
+    const derived = deriveAdoptedConfig(env, ssl);
+    if (!derived) return null;
+    if (existing && JSON.stringify(existing) === JSON.stringify(derived)) return existing;
+    writeInstanceConfig(derived, dir);
+    console.log(
+      `[bootstrap] ${existing ? 're-synced' : 'adopted'} env identity into instance.json: ${derived.primaryDomain}`,
+    );
+    return derived;
+  } catch (err) {
+    console.warn(`[bootstrap] env adoption skipped: ${(err as Error).message}`);
+    return null;
+  }
+}
+```
+
+Change `hydrateProcessEnv`:
+
+```ts
+export function hydrateProcessEnv(dir: string = bootstrapDir()): InstanceConfig | null {
+  const cfg = loadInstanceConfig(dir);
+  if (!cfg) return null;
+  // origin:'env' — .env is truth and already lives in process.env; assigning
+  // the file's values would resurrect stale identity on the first boot after
+  // an .env edit (SuperTokens captures env before re-sync could correct it).
+  if (cfg.origin !== 'env') {
+    Object.assign(process.env, deriveIdentityEnv(cfg));
+  }
+  return cfg;
+}
+```
+
+In `hydrate.ts`, replace the import + call block at the bottom:
+
+```ts
+import { adoptOrResyncEnvInstall, hydrateProcessEnv } from './instance-config';
+
+// Legacy env-install adoption/re-sync must run before hydration so the file
+// hydrate reads is never stale relative to .env (spec §3).
+adoptOrResyncEnvInstall();
+const instanceCfg = hydrateProcessEnv();
+if (instanceCfg?.state === 'applied') {
+  // eslint-disable-next-line no-console
+  console.log(
+    `[bootstrap] identity hydrated from instance.json: ${instanceCfg.primaryDomain}` +
+      (instanceCfg.origin === 'env' ? ' (env-adopted; .env remains authoritative)' : ''),
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/backend && pnpm test -- instance-config`
+Expected: PASS. Also run `cd apps/backend && pnpm test -- hydrate` — the existing hydrate spec must still pass (its fixtures have no `origin`, i.e. wizard semantics).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/bootstrap/instance-config.ts apps/backend/src/bootstrap/instance-config.spec.ts apps/backend/src/bootstrap/hydrate.ts
+git commit -m "feat(env-adoption): adopt & re-sync legacy env installs at boot"
+```
+
+---
+
+### Task 3: origin stamping & preservation at the writers
+
+**Files:**
+- Modify: `apps/backend/src/setup/bootstrap-setup.controller.ts` (the `writeInstanceConfig({...})` call near line 97)
+- Verify/Modify: `apps/backend/src/setup/primary-ssl/primary-ssl.service.ts` (the `writeInstanceConfig(next)` call near line 169)
+- Verify: `apps/backend/src/setup/primary-ssl/primary-ssl-snapshot.service.ts` (line ~87 rewrites a loaded cfg)
+- Test: `apps/backend/src/setup/bootstrap-setup.controller.spec.ts`, `apps/backend/src/setup/primary-ssl/primary-ssl-snapshot.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `InstanceConfig.origin` (Task 1).
+- Produces: the graduation rule — the wizard **apply** endpoint stamps `origin: 'wizard'`; mechanical rewrites (snapshot re-baselining) and day-2 cert-source changes **preserve** the loaded origin (cert actions must not silently stop `.env` edits from working; sslMode re-sync tracks cert reality anyway, per spec §3).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `bootstrap-setup.controller.spec.ts`, inside an existing apply test that spies on `writeInstanceConfig`, add (or extend the closest existing assertion on the spy's argument):
+
+```ts
+it('apply stamps origin wizard so the install graduates from env adoption', async () => {
+  const write = jest
+    .spyOn(require('../bootstrap/instance-config'), 'writeInstanceConfig')
+    .mockImplementation(() => undefined);
+  await controller.apply(validApplyDto()); // reuse the spec's existing valid-DTO helper/fixture
+  expect(write).toHaveBeenCalledWith(expect.objectContaining({ origin: 'wizard' }));
+});
+```
+
+(Adapt the `controller.apply(...)` invocation to match how the surrounding tests in that file call apply — same DTO fixture, same spies for its other collaborators.)
+
+In `primary-ssl-snapshot.service.spec.ts`, add:
+
+```ts
+it('re-baselining preserves an env origin instead of graduating it', () => {
+  writeInstanceConfig({ version: 2, state: 'applied', origin: 'env', primaryDomain: 'a.com', proxyMode: 'none', sslMode: 'paste' }, dir);
+  // invoke the same snapshot write path the surrounding tests use
+  expect(loadInstanceConfig(dir)!.origin).toBe('env');
+});
+```
+
+(Fill the middle line with the exact service call the file's neighboring tests use to trigger the `writeInstanceConfig(cfg)` write at `primary-ssl-snapshot.service.ts:87`.)
+
+- [ ] **Step 2: Run tests to verify the controller one fails**
+
+Run: `cd apps/backend && pnpm test -- bootstrap-setup.controller`
+Expected: FAIL — apply's written config has no `origin`.
+Run: `cd apps/backend && pnpm test -- primary-ssl-snapshot`
+Expected: likely PASS already (the service rewrites the loaded object, so the field rides along). If it fails, the service strips fields — fix it to spread the loaded config.
+
+- [ ] **Step 3: Implement**
+
+In `bootstrap-setup.controller.ts`, add `origin: 'wizard'` to the object literal passed to `writeInstanceConfig` (~line 97):
+
+```ts
+    writeInstanceConfig({
+      version: 2,
+      state: 'applied',
+      origin: 'wizard',
+      // ...existing fields unchanged
+```
+
+In `primary-ssl.service.ts`, inspect how `next` is built for the `writeInstanceConfig(next)` call (~line 169). If it spreads the loaded config (`{ ...cfg, ... }`), no change. If it constructs a fresh object, carry the field: `origin: cfg.origin`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/backend && pnpm test -- "bootstrap-setup|primary-ssl"`
+Expected: PASS, including all pre-existing cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/setup
+git commit -m "feat(env-adoption): apply stamps origin wizard; cert writers preserve origin"
+```
+
+---
+
+### Task 4: renewal SAN preservation for adopted installs
+
+**Files:**
+- Modify: `apps/backend/src/domains/ssl-certificate.service.ts` (`requestPrimaryDomainCertificate`, ~line 503; new `getPrimaryCertificateSans`)
+- Modify: `apps/backend/src/domains/ssl-renewal.service.ts` (`checkAndRenewPrimary`, ~line 204)
+- Test: `apps/backend/src/domains/ssl-certificate.service.spec.ts`, `apps/backend/src/domains/ssl-renewal.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `InstanceConfig.origin` (Task 1).
+- Produces:
+  - `requestPrimaryDomainCertificate(domain: string, extraSans?: string[])` — final SAN set is the deduped union `[domain, www.<domain>, admin.<domain>, ...extraSans]`; return shape unchanged.
+  - `getPrimaryCertificateSans(): string[] | null` — DNS SANs of the current `<SSL_CERT_PATH>/fullchain.pem`, null when absent/unparseable/empty.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `ssl-certificate.service.spec.ts` (mock/`MOCK_SSL` mode, following the file's existing service construction):
+
+```ts
+it('requestPrimaryDomainCertificate unions extraSans without duplicates', async () => {
+  const result = await service.requestPrimaryDomainCertificate('example.com', [
+    'example.com', 'minio.example.com', 'www.example.com',
+  ]);
+  expect(result.success).toBe(true);
+  expect(result.sans).toEqual([
+    'example.com', 'www.example.com', 'admin.example.com', 'minio.example.com',
+  ]);
+});
+
+it('getPrimaryCertificateSans reads DNS SANs from fullchain.pem', () => {
+  // Mint a cert with SANs into the spec's temp SSL_CERT_PATH dir:
+  execFileSync('openssl', [
+    'req', '-x509', '-nodes', '-days', '2', '-newkey', 'rsa:2048',
+    '-keyout', path.join(sslTmp, 'privkey.pem'),
+    '-out', path.join(sslTmp, 'fullchain.pem'),
+    '-subj', '/CN=example.com',
+    '-addext', 'subjectAltName=DNS:example.com,DNS:www.example.com,DNS:minio.example.com',
+  ], { stdio: 'ignore' });
+  expect(service.getPrimaryCertificateSans()).toEqual([
+    'example.com', 'www.example.com', 'minio.example.com',
+  ]);
+});
+
+it('getPrimaryCertificateSans returns null when the cert is missing', () => {
+  expect(service.getPrimaryCertificateSans()).toBeNull();
+});
+```
+
+(Use the spec's existing pattern for pointing `SSL_CERT_PATH` at a temp dir; create one if the file doesn't have one yet.)
+
+In `ssl-renewal.service.spec.ts` (it already `jest.mock('../bootstrap/instance-config')`s and drives `loadInstanceConfig` via `mockReturnValue`):
+
+```ts
+it('renews an env-adopted install with the current cert SAN list preserved', async () => {
+  (loadInstanceConfig as jest.Mock).mockReturnValue({
+    version: 2, state: 'applied', origin: 'env',
+    primaryDomain: 'example.com', proxyMode: 'none', sslMode: 'letsencrypt',
+  });
+  sslCertificateService.getPrimaryCertificateExpiryDays.mockReturnValue(5);
+  sslCertificateService.getPrimaryCertificateSans.mockReturnValue([
+    'example.com', 'www.example.com', 'admin.example.com', 'minio.example.com',
+  ]);
+  sslCertificateService.requestPrimaryDomainCertificate.mockResolvedValue({ success: true });
+  await service.handleCron(); // the spec's existing cron entry-point invocation
+  expect(sslCertificateService.requestPrimaryDomainCertificate).toHaveBeenCalledWith(
+    'example.com',
+    ['example.com', 'www.example.com', 'admin.example.com', 'minio.example.com'],
+  );
+});
+
+it('renews a wizard install without a SAN override', async () => {
+  (loadInstanceConfig as jest.Mock).mockReturnValue({
+    version: 2, state: 'applied',
+    primaryDomain: 'example.com', proxyMode: 'none', sslMode: 'letsencrypt',
+  });
+  sslCertificateService.getPrimaryCertificateExpiryDays.mockReturnValue(5);
+  sslCertificateService.requestPrimaryDomainCertificate.mockResolvedValue({ success: true });
+  await service.handleCron();
+  expect(sslCertificateService.requestPrimaryDomainCertificate).toHaveBeenCalledWith(
+    'example.com', undefined,
+  );
+});
+```
+
+(Match the mock-service object and cron invocation names to the file's existing tests around line 148 — the renewal spec already has a mocked `sslCertificateService` and drives the daily cron; extend that mock with `getPrimaryCertificateSans`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && pnpm test -- "ssl-certificate|ssl-renewal"`
+Expected: FAIL — no `extraSans` param, no `getPrimaryCertificateSans`, renewal called with one argument.
+
+- [ ] **Step 3: Implement**
+
+In `ssl-certificate.service.ts` (ensure `X509Certificate` is imported from `'crypto'`; the file already uses it for paste validation — if not, add it):
+
+```ts
+  async requestPrimaryDomainCertificate(domain: string, extraSans?: string[]): Promise<{
+    success: boolean;
+    error?: string;
+    expiresAt?: Date;
+    sans?: string[];
+    reused?: boolean;
+  }> {
+    // Renewal of an env-adopted install passes the current cert's SANs so we
+    // never drop names the legacy certbot cert carried (e.g. minio.<domain>).
+    const sans = Array.from(
+      new Set([domain, `www.${domain}`, `admin.${domain}`, ...(extraSans ?? [])]),
+    );
+```
+
+…and change the CSR to derive from `sans` instead of the hardcoded pair:
+
+```ts
+      const [key, csr] = await acme.crypto.createCsr({
+        commonName: domain,
+        altNames: sans.filter((d) => d !== domain),
+      });
+```
+
+(The `createOrder` identifiers and `stagedPrimaryCertificate(sans)` already consume the `sans` variable — no further changes.)
+
+Add the reader:
+
+```ts
+  /** DNS SANs of the current primary cert; null when absent/unparseable. */
+  getPrimaryCertificateSans(): string[] | null {
+    try {
+      const pem = fs.readFileSync(join(this.getSslPath(), 'fullchain.pem'));
+      const cert = new X509Certificate(pem);
+      if (!cert.subjectAltName) return null;
+      const sans = cert.subjectAltName
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.startsWith('DNS:'))
+        .map((s) => s.slice(4));
+      return sans.length ? sans : null;
+    } catch {
+      return null;
+    }
+  }
+```
+
+In `ssl-renewal.service.ts`, `checkAndRenewPrimary`, replace the request call:
+
+```ts
+    // Env-adopted installs (legacy certbot certs) may carry SANs the wizard
+    // set doesn't (minio.<domain>) — renew with them preserved (spec §4).
+    const extraSans =
+      cfg.origin === 'env'
+        ? (this.sslCertificateService.getPrimaryCertificateSans() ?? undefined)
+        : undefined;
+    const result = await this.sslCertificateService.requestPrimaryDomainCertificate(
+      cfg.primaryDomain,
+      extraSans,
+    );
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/backend && pnpm test -- "ssl-certificate|ssl-renewal"`
+Expected: PASS, including all pre-existing cases (the no-arg call sites — bootstrap wizard issue endpoint — are unaffected by the optional param).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/domains
+git commit -m "feat(env-adoption): renewal preserves current-cert SANs on adopted installs"
+```
+
+---
+
+### Task 5: render parity — adopted file vs pure env
+
+**Files:**
+- Modify: `docker/nginx/render-main-conf.test.sh` (append before the final `FAILURES` exit check)
+
+**Interfaces:**
+- Consumes: the harness's `assert_contains`, `setup_etc`, `run_render`, `$HERE`, `$FAILURES`.
+- Produces: proof that an adopted `instance.env` renders `main.conf` byte-identically to the pure-env legacy render it replaces.
+
+- [ ] **Step 1: Add the parity case**
+
+Append (before the final failure-count exit):
+
+```sh
+# --- adoption parity: an env-adopted instance.env must render main.conf
+# byte-identically to the pure-env legacy render it replaces (spec §2:
+# adoption changes nothing nginx serves). Paths embed $ETC, so normalize. ---
+setup_etc 'STATE=applied
+PRIMARY_DOMAIN=example.com
+PROXY_MODE=none
+SSL_MODE=letsencrypt'
+run_render
+ADOPTED_CONF="$(mktemp)"
+sed "s|$ETC|@ETC@|g" "$ETC/sites-available/main.conf" > "$ADOPTED_CONF"
+
+# pure-env legacy install: certs present, NO instance.env, NO bootstrap
+# marker (a genuine pre-wizard install never rendered bootstrap mode).
+ETC="$(mktemp -d)"
+mkdir -p "$ETC/ssl" "$ETC/bootstrap" "$ETC/sites-available"
+cp "$HERE/sites-available/"*.template "$ETC/sites-available/"
+openssl req -x509 -nodes -days 2 -newkey rsa:2048 -keyout "$ETC/ssl/privkey.pem" \
+    -out "$ETC/ssl/fullchain.pem" -subj "/CN=test" 2>/dev/null
+cp "$ETC/ssl/fullchain.pem" "$ETC/ssl/wildcard.example.com.crt"
+cp "$ETC/ssl/privkey.pem" "$ETC/ssl/wildcard.example.com.key"
+( NGINX_ETC="$ETC" CERTBOT_ROOT="$ETC/certbot" PRIMARY_DOMAIN=example.com PROXY_MODE=none \
+    sh "$HERE/render-main-conf.sh" >/dev/null )
+LEGACY_CONF="$(mktemp)"
+sed "s|$ETC|@ETC@|g" "$ETC/sites-available/main.conf" > "$LEGACY_CONF"
+
+if diff -u "$LEGACY_CONF" "$ADOPTED_CONF" >/dev/null; then
+    echo "ok: adoption parity: adopted instance.env renders identically to pure env"
+else
+    echo "FAIL: adoption parity: adopted vs pure-env main.conf differ:"
+    diff -u "$LEGACY_CONF" "$ADOPTED_CONF" || true
+    FAILURES=$((FAILURES+1))
+fi
+```
+
+- [ ] **Step 2: Run the harness**
+
+Run: `sh docker/nginx/render-main-conf.test.sh`
+Expected: all pre-existing cases plus `ok: adoption parity: ...`; exit 0. If the parity diff fails, the divergence is a real adoption bug — fix the adopted values (not the assertion) until the renders match.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/nginx/render-main-conf.test.sh
+git commit -m "test(env-adoption): render parity between adopted instance.env and pure env"
+```
+
+---
+
+### Task 6: legacy-upgrade smoke leg in test-bootstrap.sh
+
+**Files:**
+- Modify: `test-bootstrap.sh` (append after the LE-path leg block, before any final summary)
+
+**Interfaces:**
+- Consumes: the script's `fail`/`ok`/`info`/`wait_until` helpers, sandbox relocation (already active), compose project.
+- Produces: an opt-in `RUN_LEGACY_LEG=1` leg proving the full loop on a real stack: legacy `.env` install boots → adoption writes `origin:'env'` files → `.env` edit + container recreate re-syncs them.
+
+- [ ] **Step 1: Add the leg**
+
+Append after the LE leg's `fi`:
+
+```bash
+# ===========================================================================
+# Legacy-upgrade leg (opt-in: RUN_LEGACY_LEG=1). Simulates a pre-wizard
+# env-only install (identity in .env, certs in ssl/, empty bootstrap/) being
+# upgraded to this image: first boot must ADOPT it into bootstrap/
+# instance.json with origin:'env', and a later .env edit + container
+# recreate must RE-SYNC the file (spec §§2–3). Opt-in because it needs its
+# own fresh stack boot, like the LE leg.
+#   RUN_LEGACY_LEG=1 ./test-bootstrap.sh
+# ===========================================================================
+if [ "${RUN_LEGACY_LEG:-0}" = "1" ]; then
+    info "legacy leg: tearing down, building a hand-made legacy env install"
+    docker compose --profile postgres --profile minio --profile redis --profile supertokens down -v >/dev/null 2>&1
+    rm -rf bootstrap ssl
+    mkdir -p bootstrap ssl
+
+    LEGACY_DOMAIN="legacy-test.local"
+    # Legacy identity in .env, exactly as interactive setup.sh writes it.
+    sed -i "s/^PRIMARY_DOMAIN=.*/PRIMARY_DOMAIN=${LEGACY_DOMAIN}/" .env
+    sed -i "s|^FRONTEND_URL=.*|FRONTEND_URL=https://www.${LEGACY_DOMAIN}|" .env
+    grep -q '^PROXY_MODE=' .env && sed -i 's/^PROXY_MODE=.*/PROXY_MODE=cloudflare/' .env || echo 'PROXY_MODE=cloudflare' >> .env
+    # Legacy certs: self-signed stand-ins (non-LE issuer → must adopt as paste).
+    openssl req -x509 -nodes -days 2 -newkey rsa:2048 -keyout ssl/privkey.pem \
+        -out ssl/fullchain.pem -subj "/CN=${LEGACY_DOMAIN}" 2>/dev/null
+    cp ssl/fullchain.pem "ssl/wildcard.${LEGACY_DOMAIN}.crt"
+    cp ssl/privkey.pem "ssl/wildcard.${LEGACY_DOMAIN}.key"
+
+    ./start.sh
+    wait_until 90 "legacy leg: backend to adopt the env identity" -- \
+        bash -c 'docker compose logs backend 2>/dev/null | grep -q "adopted env identity into instance.json"'
+    grep -q '"origin": "env"' bootstrap/instance.json \
+        || fail "legacy leg: adopted instance.json missing origin:env: $(cat bootstrap/instance.json)"
+    grep -q "\"primaryDomain\": \"${LEGACY_DOMAIN}\"" bootstrap/instance.json \
+        || fail "legacy leg: adopted instance.json has wrong domain: $(cat bootstrap/instance.json)"
+    grep -q '"sslMode": "paste"' bootstrap/instance.json \
+        || fail "legacy leg: self-signed legacy cert must adopt as paste: $(cat bootstrap/instance.json)"
+    grep -q "PRIMARY_DOMAIN=${LEGACY_DOMAIN}" bootstrap/instance.env \
+        || fail "legacy leg: instance.env not written for nginx"
+    ok "legacy leg: env install adopted (origin:env, sslMode:paste)"
+
+    # .env edit must still work: recreate the backend (compose re-reads .env)
+    # and the file must follow.
+    RENAMED_DOMAIN="renamed-test.local"
+    sed -i "s/^PRIMARY_DOMAIN=.*/PRIMARY_DOMAIN=${RENAMED_DOMAIN}/" .env
+    docker compose up -d backend >/dev/null 2>&1
+    wait_until 90 "legacy leg: re-sync after .env edit" -- \
+        bash -c "grep -q '\"primaryDomain\": \"${RENAMED_DOMAIN}\"' bootstrap/instance.json"
+    ok "legacy leg passed: .env edit re-synced instance.json (env stays authoritative)"
+else
+    info "skipping legacy-upgrade leg (set RUN_LEGACY_LEG=1 to run it — needs its own fresh stack boot)"
+fi
+```
+
+- [ ] **Step 2: Syntax-check and run the default legs**
+
+Run: `bash -n test-bootstrap.sh`
+Expected: no output (parses clean).
+Run (on a docker host, several minutes): `RUN_LEGACY_LEG=1 ./test-bootstrap.sh`
+Expected: the standard wizard legs pass, then `legacy leg passed: ...`. If no docker host is available in this session, note that in the task report — the leg runs in CI/droplet like `RUN_LE_LEG`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test-bootstrap.sh
+git commit -m "test(env-adoption): legacy-upgrade smoke leg (RUN_LEGACY_LEG=1)"
+```
+
+---
+
+### Task 7: upgrade note (separate repo: docs-public)
+
+**Files:**
+- Modify: `/home/rico/bffless/repos/docs-public/docs/troubleshooting.md` (separate git repo — its own branch/commit/PR, do NOT mix into the CE branch)
+
+**Interfaces:** none (documentation only).
+
+- [ ] **Step 1: Add the note**
+
+Append a section:
+
+```markdown
+## Upgrading a pre-wizard install (identity in `.env`)
+
+Since the web-bootstrap release, instance identity lives in
+`bootstrap/instance.json`. Installs set up earlier (interactive `setup.sh`,
+identity in `.env`) are **adopted automatically** on the first boot after
+upgrading: the backend writes `bootstrap/instance.json` marked as
+env-managed. Nothing changes for you:
+
+- Editing `PRIMARY_DOMAIN` (etc.) in `.env` and restarting keeps working —
+  the file is re-synced from `.env` on every boot.
+- Rolling back to an older image is safe; `.env` is never modified.
+
+What you gain:
+
+- **Let's Encrypt installs**: certificate renewal now happens in-app (the
+  old `certbot --standalone` renewal could not re-bind port 80 while nginx
+  held it). You can remove any host-side certbot cron for this domain.
+- **Pasted certificates** (Cloudflare Origin or bring-your-own): you now get
+  expiry-reminder emails.
+
+If you later change your domain through the admin UI, the install graduates
+to UI-managed identity and `.env` identity edits stop applying (the startup
+log warns if the two ever diverge).
+```
+
+- [ ] **Step 2: Ask before committing**
+
+This is a separate repo (`repos/docs-public/`). Create a branch, show the diff, and ask the user before committing (workspace git rules).
+
+---
+
+## Self-Review (completed)
+
+- **Spec coverage:** §1 origin field → Task 1; §2 adoption + sniff → Tasks 1–2; §3 precedence/re-sync/graduation → Tasks 2–3; §4 renewal takeover + SAN rule → Task 4 (paste reminders need no code: they gate on `state: 'applied'`, which adoption provides — covered by the renewal spec's existing reminder tests plus Task 4's origin fixtures); §5 upgrade matrix → Tasks 2 (rollback/no-.env-writes, corrupt-file), 5 (render parity), 6 (real-stack adopt/re-sync); §6 error handling → Task 2 (try/catch + skip tests); §7 testing → Tasks 1–6; docs note → Task 7.
+- **Adaptation points, not placeholders:** Tasks 3 and 4 reference existing spec-file fixtures/helpers by location and instruct matching the surrounding test idiom — the code shown is complete; only fixture/helper names may need renaming to the file's local conventions.
+- **Type consistency:** `origin?: 'wizard' | 'env'`, `adoptOrResyncEnvInstall(dir?, env?, ssl?)`, `requestPrimaryDomainCertificate(domain, extraSans?)`, `getPrimaryCertificateSans(): string[] | null` used consistently across tasks.

--- a/docs/superpowers/specs/2026-07-24-legacy-env-adoption-design.md
+++ b/docs/superpowers/specs/2026-07-24-legacy-env-adoption-design.md
@@ -81,6 +81,30 @@ Preconditions (all must hold, otherwise do nothing):
 - `process.env.PRIMARY_DOMAIN` is set and ≠ `localhost`.
 - Not platform mode (`PLATFORM_MODE` / `SSL_MANAGED_EXTERNALLY` unset).
 
+**First-adoption legacy gate (C1).** The three preconditions above are not
+enough on their own: a *fresh web-bootstrap* install (`setup.sh --bootstrap`)
+leaves `PRIMARY_DOMAIN=""` in `.env`, but `docker-compose.yml` passes the
+backend `PRIMARY_DOMAIN: ${PRIMARY_DOMAIN:-yourdomain.com}` — and `:-`
+substitutes the placeholder for an *empty* value too. So a cert-less,
+wizard-bound install boots with `PRIMARY_DOMAIN=yourdomain.com` and no
+`instance.json`, which the naive rule would adopt as `state:'applied'` — killing
+the wizard (`isBootstrapModeActive()` → false) and cutting nginx over to NORMAL
+mode for a domain with no certs. So **first adoption additionally requires the
+install to actually be legacy** (an existing `origin:'env'` file re-syncs
+regardless — the gate is first-adoption only):
+
+1. **Real certs present:** both `ssl/fullchain.pem` and `ssl/privkey.pem` exist.
+   Every non-localhost legacy `setup.sh` install has run certbot / pasted CF
+   origin certs; a fresh bootstrap boot is cert-less.
+2. **No bootstrap marker:** `ssl/bootstrap-selfsigned.crt` is absent. Its
+   presence means this install has rendered bootstrap mode at least once (so it
+   is NOT legacy), and protects the mid-wizard-restart window where the
+   certificate step has staged real certs before Apply ran. Mirrors
+   `render-main-conf.sh`'s `should_bootstrap()` legacy carve-out.
+3. **Refuse the compose placeholder:** `primaryDomain === 'yourdomain.com'` is
+   never adopted — it is `docker-compose.yml`'s `${PRIMARY_DOMAIN:-yourdomain.com}`
+   default, not a real identity.
+
 Adopted config:
 
 | Field | Value |
@@ -121,6 +145,17 @@ shell-safety validation included).
   on `.env` identity is ignored; if a later boot finds `.env` identity that
   diverges from a wizard-origin file, log a loud warning naming both values and
   which one wins.
+- **Day-2 primary-SSL on an `origin:'env'` install (I1).** The day-2 primary-SSL
+  apply path (`primary-ssl.service.ts`) *does* run on env-origin installs and
+  preserves `origin:'env'` on its write — but the next boot re-sync re-derives
+  the config from `.env` and drops any knob `.env` can't express (`proxyMode` is
+  re-read from `PROXY_MODE`, while `port80`/`realIp` are omitted v1-style). So a
+  UI-applied `proxyMode`/`port80`/`realIp` change silently reverts on restart.
+  Decision (this spec): **warn loudly** — apply logs which knobs will revert;
+  it invents no new response field. **Graduation stays wizard-apply-only for
+  now**: to persist those knobs the operator must manage identity/SSL via the
+  wizard (which stamps `origin:'wizard'`). A full graduation-on-apply redesign
+  is deferred.
 
 ### 4. Renewal takeover
 
@@ -148,7 +183,9 @@ shell-safety validation included).
 | Existing wizard install | No `origin` field ⇒ `'wizard'` default ⇒ zero behavior change. |
 | **Rollback** to a pre-adoption image | Adoption never touches `.env`; old images ignore `bootstrap/` files entirely. Fully reversible. |
 | Corrupt `instance.json` | Logged, untouched, install runs env-only for the boot (as today). |
-| `localhost` / Umbrel / platform mode | Never adopted; unchanged. |
+| `localhost` / Umbrel / platform mode | Never adopted; unchanged. Umbrel is *additionally* covered by the cert-presence gate — its own entrypoint/config model doesn't stage certs into `ssl/` the way `setup.sh` does, so first-adoption can't fire there either. |
+| **Fresh web-bootstrap install** (cert-less, `PRIMARY_DOMAIN=yourdomain.com` from the compose default) | **Never adopted** (fails the C1 legacy gate — placeholder domain, no certs, and post-Domain-step a bootstrap marker). Wizard is unaffected: `state` stays unclaimed, `isBootstrapModeActive()` stays true. |
+| **Adopted install whose `.env` later becomes non-adoptable** (domain removed/localhost, or `PLATFORM_MODE`/`SSL_MANAGED_EXTERNALLY` flipped true) | The derived `origin:'env'` `instance.json` + `instance.env` are **deleted** with a warning (I3), so nginx + renewal fall back to env instead of following a stale `state:'applied'` cache. Wizard-origin files are never touched. |
 
 ### 6. Error handling
 

--- a/docs/superpowers/specs/2026-07-24-legacy-env-adoption-design.md
+++ b/docs/superpowers/specs/2026-07-24-legacy-env-adoption-design.md
@@ -145,17 +145,18 @@ shell-safety validation included).
   on `.env` identity is ignored; if a later boot finds `.env` identity that
   diverges from a wizard-origin file, log a loud warning naming both values and
   which one wins.
-- **Day-2 primary-SSL on an `origin:'env'` install (I1).** The day-2 primary-SSL
-  apply path (`primary-ssl.service.ts`) *does* run on env-origin installs and
-  preserves `origin:'env'` on its write — but the next boot re-sync re-derives
-  the config from `.env` and drops any knob `.env` can't express (`proxyMode` is
-  re-read from `PROXY_MODE`, while `port80`/`realIp` are omitted v1-style). So a
-  UI-applied `proxyMode`/`port80`/`realIp` change silently reverts on restart.
-  Decision (this spec): **warn loudly** — apply logs which knobs will revert;
-  it invents no new response field. **Graduation stays wizard-apply-only for
-  now**: to persist those knobs the operator must manage identity/SSL via the
-  wizard (which stamps `origin:'wizard'`). A full graduation-on-apply redesign
-  is deferred.
+- **Day-2 primary-SSL on an `origin:'env'` install (I1) — apply GRADUATES it.**
+  The day-2 primary-SSL apply path (`primary-ssl.service.ts`) *does* run on
+  env-origin installs. It is an admin-UI identity/SSL change, so by the
+  Graduation rule above it stamps `origin:'wizard'` on its write — the install
+  becomes UI-managed and the next boot re-sync no longer treats `.env` as
+  authoritative for identity. This is **option (a)** of the seam flagged in PR
+  review, chosen once #520 made the day-2 panel genuinely usable: silently
+  reverting a UI-applied `proxyMode`/`port80`/`realIp` change on the next reboot
+  (the earlier warn-only stance) is no longer acceptable. apply() logs a clear
+  graduation notice; the boot-time divergence warning (above) is the safety net
+  if the operator keeps editing `.env` afterwards. Mechanical rewrites
+  (snapshot/restore) still preserve `origin` — only an actual apply graduates.
 
 ### 4. Renewal takeover
 
@@ -178,7 +179,7 @@ shell-safety validation included).
 
 | Scenario | Behavior |
 | --- | --- |
-| Legacy env-only install, upgraded image + current compose file | Adopted on first boot; renewal/reminders activate; `.env` edits keep working via re-sync. |
+| Legacy env-only install, upgraded image + current compose file | Adopted on first boot; renewal/reminders activate; `.env` edits keep working via re-sync — until a day-2 primary-SSL apply graduates the install to `origin:'wizard'` (I1), after which identity is UI-managed and `.env` identity edits no longer apply. |
 | Legacy install, upgraded image but **old `docker-compose.yml`** (no `./bootstrap` mount / `BOOTSTRAP_DIR`) | Backend writes inside the container FS: ephemeral, invisible to nginx. Nginx keeps rendering from env with identical values. Degraded but correct; log an info line. |
 | Existing wizard install | No `origin` field ⇒ `'wizard'` default ⇒ zero behavior change. |
 | **Rollback** to a pre-adoption image | Adoption never touches `.env`; old images ignore `bootstrap/` files entirely. Fully reversible. |

--- a/docs/superpowers/specs/2026-07-24-legacy-env-adoption-design.md
+++ b/docs/superpowers/specs/2026-07-24-legacy-env-adoption-design.md
@@ -1,0 +1,186 @@
+# Legacy Install Adoption & `.env` Re-Sync — Design
+
+**Date:** 2026-07-24
+**Status:** Approved design, awaiting implementation plan
+**Depends on:** the web-bootstrap feature (PR #508) and the domain/SSL model rework (`2026-07-21-bootstrap-domain-ssl-model-design.md`)
+**Follow-up of:** the deferred "`setup.sh` parity" item in the 2026-07-21 spec (§Out of scope)
+
+## Problem
+
+The web-bootstrap wizard and the legacy interactive `./setup.sh` produce different
+state:
+
+| Resource | Legacy `./setup.sh` | `--bootstrap` + web wizard |
+| --- | --- | --- |
+| Identity (`PRIMARY_DOMAIN`, `FRONTEND_URL`, `COOKIE_*`, `PROXY_MODE`) | written into `.env` | `.env` left blank; lives in `bootstrap/instance.json` |
+| `bootstrap/instance.json` / `instance.env` | never created | created (v2, with knobs) |
+| SSL certs | host `certbot --standalone` (LE) or hand-pasted CF origin certs in `ssl/` | issued/pasted in-app via cert staging |
+| LE renewal | **broken by default**: one-time copy into `ssl/`, no deploy-hook; certbot's timer can't re-bind port 80 | in-app `ssl-renewal.service` cron |
+| Paste-cert expiry reminders | none (`loadInstanceConfig()` returns null) | reminder emails |
+
+Consequences of the divergence:
+
+1. **Day-2 features silently skip legacy installs.** `ssl-renewal.service.ts`
+   gates both primary-cert auto-renewal and paste-expiry reminders on
+   `instance.json` having `state: 'applied'`. Legacy installs have no file, so
+   they get neither — and their host-side certbot renewal is broken anyway
+   (standalone authenticator can't bind port 80 while nginx holds it).
+2. **Duplicate code paths.** `render-main-conf.sh` re-implements `deriveKnobs()`
+   in sh solely because legacy installs lack `instance.env`;
+   `should_bootstrap()` carries a bootstrap-marker special case solely to detect
+   "genuine legacy install".
+3. **Future identity features must be written twice** (`.env` for legacy,
+   `instance.json` for wizard installs).
+
+## Goal
+
+Every non-localhost, self-hosted CE install converges on
+`bootstrap/instance.json` + `bootstrap/instance.env` as the uniform state that
+day-2 features read — regardless of how it was set up — **without breaking the
+legacy operator workflow**: editing `PRIMARY_DOMAIN` (etc.) in `.env` and
+restarting must keep working on adopted installs.
+
+## Out of scope
+
+- The `setup.sh` rework (interactive setup becoming a client of the wizard's
+  `/api/setup/*` endpoints). That is **spec 2**, a separate follow-up; this spec
+  is its prerequisite and also protects installs that upgraded before spec 2
+  ships.
+- Umbrel installs (own entrypoint + config-file model, untouched).
+- `localhost` / dev installs (stay env-only; `deriveIdentityEnv` would produce
+  `https://www.localhost`).
+- Platform-mode workspaces: `PLATFORM_MODE` or `SSL_MANAGED_EXTERNALLY` set →
+  never adopt. Their identity and nginx config are platform-managed.
+- MOTD / docs copy beyond a short upgrade note.
+
+## Design
+
+### 1. Schema: `origin` field
+
+`InstanceConfig` gains an optional field:
+
+```ts
+origin?: 'wizard' | 'env';
+```
+
+- **Absent ⇒ `'wizard'`.** All existing wizard-written files keep today's
+  semantics with zero migration.
+- `version` stays `2` — the field is purely additive; v1 forward-read rules are
+  unchanged.
+- `instance.env` format is unchanged (nginx has no use for origin).
+
+### 2. Adoption (first boot on an upgraded image)
+
+Runs in the existing pre-Nest hydrate path (`instance-config.ts`, executed as
+`main.ts`'s first import — see `hydrate.ts` for why ordering matters).
+
+Preconditions (all must hold, otherwise do nothing):
+
+- No `instance.json` exists. A **present-but-unparseable** file is logged and
+  left alone — never clobber a possibly-wizard file.
+- `process.env.PRIMARY_DOMAIN` is set and ≠ `localhost`.
+- Not platform mode (`PLATFORM_MODE` / `SSL_MANAGED_EXTERNALLY` unset).
+
+Adopted config:
+
+| Field | Value |
+| --- | --- |
+| `version` | `2` |
+| `state` | `'applied'` |
+| `origin` | `'env'` |
+| `primaryDomain` | `process.env.PRIMARY_DOMAIN` |
+| `proxyMode` | `process.env.PROXY_MODE` **only if** it is a known `ProxyMode` value; otherwise omitted. This mirrors the render script's env-fallback defaults (unset ⇒ non-cloudflare knobs), so adoption is byte-parity with what sh derives today. |
+| `port80` / `realIp` | **omitted** (v1-style; derived by `deriveKnobs`) |
+| `sslMode` | issuer sniff, below |
+
+**sslMode inference:** parse `ssl/fullchain.pem` with `node:crypto`
+`X509Certificate`. Issuer organization is Let's Encrypt **and** env
+`PROXY_MODE` is not `'cloudflare'` (unset counts as not-cloudflare, matching
+the render script's derivation; legacy setup.sh only ever writes `cloudflare`
+or `none`) → `'letsencrypt'` (in-app renewal takes over, fixing the day-90
+breakage). Anything else — Cloudflare origin certs, unknown issuers,
+missing/unreadable cert — → `'paste'`.
+
+Files are written via the existing `writeInstanceConfig()` (single writer;
+shell-safety validation included).
+
+### 3. Precedence & re-sync
+
+- **`origin: 'env'` → `.env` is truth; the bootstrap files are derived caches.**
+  - On **every** boot, re-derive the adopted config from env (including
+    re-running the sslMode sniff — if the operator swaps certs, the mode
+    follows) and rewrite `instance.json`/`instance.env` **only if the content
+    changed** (avoids rewrite churn and nginx-watcher re-render storms).
+  - `hydrateProcessEnv()` does **not** `Object.assign` over `process.env` for
+    these files — env already carries the identity, and overriding would
+    resurrect stale values on the first boot after an `.env` edit.
+- **`origin: 'wizard'` (or absent) → exactly today's behavior**: files are
+  truth, hydration overrides `process.env`.
+- **Graduation:** any identity/SSL write through the wizard or a future admin
+  UI goes via `writeInstanceConfig()` and stamps `origin: 'wizard'`. From then
+  on `.env` identity is ignored; if a later boot finds `.env` identity that
+  diverges from a wizard-origin file, log a loud warning naming both values and
+  which one wins.
+
+### 4. Renewal takeover
+
+- Adopted `sslMode: 'letsencrypt'` installs enter the existing
+  `checkAndRenewPrimary` cron.
+  - **Hard requirement:** renewal must never *drop* SANs present in the
+    current cert. Legacy certbot certs carry `apex, www, admin, minio`; the
+    wizard's fixed SAN set may differ. Verify during planning; if it differs,
+    renew adopted certs with the existing cert's SAN list.
+  - **Verify during planning:** the ACME HTTP-01 challenge location must be
+    reachable on a legacy env-rendered nginx config (legacy installs derive
+    `PORT80=redirect`; confirm the rendered port-80 block serves the webroot).
+- Adopted `sslMode: 'paste'` installs get the existing expiry-reminder emails
+  (they gain `state: 'applied'`, which is the gate today).
+- Double-renewal risk with a host certbot timer is acceptable: the standalone
+  renewal fails while nginx holds port 80, and even a success never reaches
+  `ssl/`. The upgrade note tells operators they can remove host certbot.
+
+### 5. Backwards-compatibility guarantees (upgrade matrix)
+
+| Scenario | Behavior |
+| --- | --- |
+| Legacy env-only install, upgraded image + current compose file | Adopted on first boot; renewal/reminders activate; `.env` edits keep working via re-sync. |
+| Legacy install, upgraded image but **old `docker-compose.yml`** (no `./bootstrap` mount / `BOOTSTRAP_DIR`) | Backend writes inside the container FS: ephemeral, invisible to nginx. Nginx keeps rendering from env with identical values. Degraded but correct; log an info line. |
+| Existing wizard install | No `origin` field ⇒ `'wizard'` default ⇒ zero behavior change. |
+| **Rollback** to a pre-adoption image | Adoption never touches `.env`; old images ignore `bootstrap/` files entirely. Fully reversible. |
+| Corrupt `instance.json` | Logged, untouched, install runs env-only for the boot (as today). |
+| `localhost` / Umbrel / platform mode | Never adopted; unchanged. |
+
+### 6. Error handling
+
+- Unwritable/missing bootstrap dir: log and continue env-only — every consumer
+  already tolerates `loadInstanceConfig()` returning null.
+- Cert sniff failures (missing file, parse error): fall back to `'paste'`,
+  never throw — adoption must not be able to prevent boot.
+- All adoption/re-sync work is wrapped so that **no failure in it can crash the
+  backend**; worst case is today's env-only behavior plus a log line.
+
+### 7. Testing
+
+- `instance-config.spec.ts`: adoption happy path; skip rules (localhost,
+  platform mode, existing file, corrupt file); re-sync rewrites on env change;
+  no rewrite when unchanged; `origin:'env'` hydration does not override
+  `process.env`; `origin` absent defaults to wizard semantics; issuer sniff
+  against LE / Cloudflare-origin / self-signed fixture certs.
+- `ssl-renewal.service.spec.ts`: adopted-letsencrypt install renews; adopted
+  paste install gets reminders; SAN-preservation rule.
+- `test-bootstrap.sh`: a **legacy-upgrade smoke leg** — simulate an env-only
+  install (`.env` with identity, certs in `ssl/`, no `bootstrap/` files), boot,
+  assert files appear with `origin:'env'`; edit `.env` domain, reboot, assert
+  state follows; perform a wizard-style write, assert `.env` stops mattering.
+- `render-main-conf.test.sh`: render case with an adopted (`origin:'env'`)
+  `instance.env` matches the pure-env render byte-for-byte.
+
+## Sequencing
+
+1. This spec (adoption + re-sync) ships first — it protects every upgrading
+   user regardless of later work.
+2. Spec 2 (setup.sh as a wizard-API client) follows; with adoption in place it
+   only has to handle *new* installs.
+3. Later cleanup (not this spec): once adoption has been out for a while,
+   `render-main-conf.sh` can drop its sh-side knob derivation and
+   `should_bootstrap()`'s bootstrap-marker special case.

--- a/test-bootstrap.sh
+++ b/test-bootstrap.sh
@@ -478,3 +478,54 @@ if [ "${RUN_LE_LEG:-0}" = "1" ]; then
 else
     info "skipping LE-path leg (set RUN_LE_LEG=1 to run it — needs a second full stack boot + container-network DNS pinning; intended for CI/droplet where the extra minutes are cheap)"
 fi
+
+# ===========================================================================
+# Legacy-upgrade leg (opt-in: RUN_LEGACY_LEG=1). Simulates a pre-wizard
+# env-only install (identity in .env, certs in ssl/, empty bootstrap/) being
+# upgraded to this image: first boot must ADOPT it into bootstrap/
+# instance.json with origin:'env', and a later .env edit + container
+# recreate must RE-SYNC the file (spec §§2–3). Opt-in because it needs its
+# own fresh stack boot, like the LE leg.
+#   RUN_LEGACY_LEG=1 ./test-bootstrap.sh
+# ===========================================================================
+if [ "${RUN_LEGACY_LEG:-0}" = "1" ]; then
+    info "legacy leg: tearing down, building a hand-made legacy env install"
+    docker compose --profile postgres --profile minio --profile redis --profile supertokens down -v >/dev/null 2>&1
+    rm -rf bootstrap ssl
+    mkdir -p bootstrap ssl
+
+    LEGACY_DOMAIN="legacy-test.local"
+    # Legacy identity in .env, exactly as interactive setup.sh writes it.
+    sed -i "s/^PRIMARY_DOMAIN=.*/PRIMARY_DOMAIN=${LEGACY_DOMAIN}/" .env
+    sed -i "s|^FRONTEND_URL=.*|FRONTEND_URL=https://www.${LEGACY_DOMAIN}|" .env
+    grep -q '^PROXY_MODE=' .env && sed -i 's/^PROXY_MODE=.*/PROXY_MODE=cloudflare/' .env || echo 'PROXY_MODE=cloudflare' >> .env
+    # Legacy certs: self-signed stand-ins (non-LE issuer → must adopt as paste).
+    openssl req -x509 -nodes -days 2 -newkey rsa:2048 -keyout ssl/privkey.pem \
+        -out ssl/fullchain.pem -subj "/CN=${LEGACY_DOMAIN}" 2>/dev/null
+    cp ssl/fullchain.pem "ssl/wildcard.${LEGACY_DOMAIN}.crt"
+    cp ssl/privkey.pem "ssl/wildcard.${LEGACY_DOMAIN}.key"
+
+    ./start.sh
+    wait_until 90 "legacy leg: backend to adopt the env identity" -- \
+        bash -c 'docker compose logs backend 2>/dev/null | grep -q "adopted env identity into instance.json"'
+    grep -q '"origin": "env"' bootstrap/instance.json \
+        || fail "legacy leg: adopted instance.json missing origin:env: $(cat bootstrap/instance.json)"
+    grep -q "\"primaryDomain\": \"${LEGACY_DOMAIN}\"" bootstrap/instance.json \
+        || fail "legacy leg: adopted instance.json has wrong domain: $(cat bootstrap/instance.json)"
+    grep -q '"sslMode": "paste"' bootstrap/instance.json \
+        || fail "legacy leg: self-signed legacy cert must adopt as paste: $(cat bootstrap/instance.json)"
+    grep -q "PRIMARY_DOMAIN=${LEGACY_DOMAIN}" bootstrap/instance.env \
+        || fail "legacy leg: instance.env not written for nginx"
+    ok "legacy leg: env install adopted (origin:env, sslMode:paste)"
+
+    # .env edit must still work: recreate the backend (compose re-reads .env)
+    # and the file must follow.
+    RENAMED_DOMAIN="renamed-test.local"
+    sed -i "s/^PRIMARY_DOMAIN=.*/PRIMARY_DOMAIN=${RENAMED_DOMAIN}/" .env
+    docker compose up -d backend >/dev/null 2>&1
+    wait_until 90 "legacy leg: re-sync after .env edit" -- \
+        bash -c "grep -q '\"primaryDomain\": \"${RENAMED_DOMAIN}\"' bootstrap/instance.json"
+    ok "legacy leg passed: .env edit re-synced instance.json (env stays authoritative)"
+else
+    info "skipping legacy-upgrade leg (set RUN_LEGACY_LEG=1 to run it — needs its own fresh stack boot)"
+fi


### PR DESCRIPTION
## What

Legacy `.env`-only installs (interactive `setup.sh`, pre-web-bootstrap) are **adopted automatically** on first boot after upgrade: the backend writes `bootstrap/instance.json` + `instance.env` with `origin: 'env'`, so day-2 features (in-app LE renewal, paste-cert expiry reminders, future identity/SSL panels) activate uniformly across wizard and legacy installs — **without breaking the legacy operator workflow**: `.env` remains authoritative for adopted installs and is re-synced into the files on every boot.

Spec: `docs/superpowers/specs/2026-07-24-legacy-env-adoption-design.md` · Plan: `docs/superpowers/plans/2026-07-24-legacy-env-adoption.md`

## Design highlights

- **`origin` field** on `InstanceConfig`: absent/`'wizard'` = today's semantics (file is truth, hydration overrides env); `'env'` = file is a derived cache of `.env` (re-derived each boot, rewritten only on change, hydration does NOT override `process.env`).
- **Adoption runs pre-Nest** (in the `hydrate.ts` side-effect path) so hydration never reads a file stale relative to `.env`.
- **First-adoption gate** (the important one): only genuine legacy installs adopt — real certs in `ssl/`, no `bootstrap-selfsigned.crt` marker, and a non-placeholder domain. Without this, a fresh `setup.sh --bootstrap` install would boot with compose's `${PRIMARY_DOMAIN:-yourdomain.com}` placeholder (`:-` substitutes for the blank value bootstrap writes), get adopted as `applied`, and permanently disable the web wizard. Caught in final review; covered by unit tests for the fresh-bootstrap and mid-wizard-restart windows.
- **`sslMode` inference**: cert issuer sniff — LE-issued + non-cloudflare → `letsencrypt` (in-app renewal takes over, fixing the de-facto broken legacy `certbot --standalone` renewal); anything else → `paste` (expiry reminders).
- **Renewal preserves SANs**: adopted installs renew with the union of the wizard defaults and the current cert's SANs (legacy certbot certs carry `minio.<domain>`); wizard installs are verifiably unchanged.
- **Graduation**: wizard apply stamps `origin: 'wizard'`; cert-only day-2 writes preserve origin (and warn on env-origin installs that non-`.env`-representable knobs revert on reboot). Note: graduation is currently unreachable for adopted installs (bootstrap apply is gated off `applied` state) — it lands with the future identity-change admin UI; documented in the spec.
- **Safety rails**: adoption never writes `.env` (rollback to an older image is a no-op); corrupt files are never clobbered; a stale adopted file is deleted with a warning if the env later becomes non-adoptable; no failure in the path can crash boot.

## Tests

- `instance-config` unit suite: adoption/re-sync/gates/deletion/sniff (openssl-minted fixture certs), hydration-skip semantics.
- Renewal + cert-service suites: SAN union, `getPrimaryCertificateSans`, env-vs-wizard gating.
- `docker/nginx/render-main-conf.test.sh`: adopted `instance.env` renders `main.conf` **byte-identically** to the pure-env legacy render.
- `test-bootstrap.sh`: new opt-in `RUN_LEGACY_LEG=1` leg — boots a hand-made legacy install, asserts adoption (`origin:'env'`, `sslMode:'paste'`), edits `.env`, recreates the backend, asserts re-sync.

## ⚠️ Merge gate

The full-stack smoke must run with **branch-built images** (a local run pulls pre-built registry images without this code and proves nothing):

```
./test-bootstrap.sh              # standard wizard legs — would have caught the placeholder-adoption bug
RUN_LEGACY_LEG=1 ./test-bootstrap.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH3NWL2XTNabxM3hCczWdE
