### PR TITLE
fix: v0.2.18 review fixes — selfsigned crash-loop (C1), apply stranding, port-80/CF defaults, day-2 cert-source selector, hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ rm -rf bootstrap/instance.json bootstrap/instance.env
 docker compose restart backend nginx
 ```
 
+### Updating
+
+`git pull` first, always — image-only updates run, but new features that live
+in the repo (compose mounts, the nginx image) silently stay dormant:
+
+```bash
+cd /opt/bffless
+git pull
+./stop.sh
+docker compose pull
+./start.sh        # rebuilds the local nginx image from the pulled tree
+```
+
 ## Technology Stack
 
 **Backend:** NestJS, TypeScript, PostgreSQL, Drizzle ORM, SuperTokens

--- a/apps/backend/src/bootstrap/instance-config.spec.ts
+++ b/apps/backend/src/bootstrap/instance-config.spec.ts
@@ -561,4 +561,53 @@ describe('instance-config', () => {
       });
     });
   });
+
+  describe('v0218 review hardening', () => {
+    let ssl: string;
+
+    beforeEach(() => {
+      ssl = fs.mkdtempSync(path.join(os.tmpdir(), 'bffless-ssl-'));
+    });
+    afterEach(() => {
+      fs.rmSync(ssl, { recursive: true, force: true });
+    });
+
+    it('m2: does not warn about divergence when .env holds the compose placeholder', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      writeInstanceConfig({ version: 2, state: 'applied', origin: 'wizard', primaryDomain: 'example.com', sslMode: 'paste' }, dir);
+      adoptOrResyncEnvInstall(dir, { PRIMARY_DOMAIN: 'yourdomain.com' } as NodeJS.ProcessEnv, ssl);
+      expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('differs from wizard-managed'));
+      warn.mockRestore();
+    });
+
+    it('m2: still warns when .env holds a genuinely different real domain', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      writeInstanceConfig({ version: 2, state: 'applied', origin: 'wizard', primaryDomain: 'example.com', sslMode: 'paste' }, dir);
+      adoptOrResyncEnvInstall(dir, { PRIMARY_DOMAIN: 'other.com' } as NodeJS.ProcessEnv, ssl);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('differs from wizard-managed'));
+      warn.mockRestore();
+    });
+
+    it('hostname hardening: refuses adoption of a shell-metacharacter PRIMARY_DOMAIN', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      // real certs on disk so only the hostname gate can refuse
+      fs.writeFileSync(path.join(ssl, 'fullchain.pem'), 'x');
+      fs.writeFileSync(path.join(ssl, 'privkey.pem'), 'x');
+      const out = adoptOrResyncEnvInstall(dir, { PRIMARY_DOMAIN: 'evil.com; rm -rf /' } as NodeJS.ProcessEnv, ssl);
+      expect(out).toBeNull();
+      expect(fs.existsSync(path.join(dir, 'instance.json'))).toBe(false);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('not a valid hostname'));
+      warn.mockRestore();
+    });
+
+    it('M2: warns loudly when the bootstrap trap state is detected', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      fs.writeFileSync(path.join(ssl, 'fullchain.pem'), 'x');
+      fs.writeFileSync(path.join(ssl, 'privkey.pem'), 'x');
+      fs.writeFileSync(path.join(ssl, 'bootstrap-selfsigned.crt'), 'x'); // the trap marker
+      adoptOrResyncEnvInstall(dir, { PRIMARY_DOMAIN: 'example.com' } as NodeJS.ProcessEnv, ssl);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('stuck in bootstrap mode'));
+      warn.mockRestore();
+    });
+  });
 });

--- a/apps/backend/src/bootstrap/instance-config.ts
+++ b/apps/backend/src/bootstrap/instance-config.ts
@@ -71,6 +71,13 @@ export interface AppliedConfig {
 export const SHELL_SAFE_HEADER_RE = /^[A-Za-z0-9!#*+.^_~-]+$/;
 export const SHELL_SAFE_RANGE_RE = /^[0-9A-Fa-f:./]+$/;
 
+// Same shape the DTO layer enforces (bootstrap-setup.service HOSTNAME_RE):
+// dot-separated LDH labels. Applied at adoption because .env's PRIMARY_DOMAIN
+// is the one identity input that bypasses DTO validation yet still lands in
+// the shell-sourced instance.env.
+export const ADOPTABLE_HOSTNAME_RE =
+  /^(?=.{1,253}$)[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$/;
+
 export function assertShellSafeRealIp(header: string, ranges: string[]): void {
   if (!SHELL_SAFE_HEADER_RE.test(header)) {
     throw new Error(`Real-IP header contains unsafe characters: ${JSON.stringify(header)}`);
@@ -127,9 +134,13 @@ export function envIdentity(
   if (env.PLATFORM_MODE === 'true' || env.SSL_MANAGED_EXTERNALLY === 'true') return null;
   const d = env.PRIMARY_DOMAIN;
   if (!d || d === 'localhost') return null;
+  if (!ADOPTABLE_HOSTNAME_RE.test(d.toLowerCase())) {
+    console.warn(`[bootstrap] PRIMARY_DOMAIN=${JSON.stringify(d)} is not a valid hostname — not adoptable`);
+    return null;
+  }
   const pm = env.PROXY_MODE;
   const proxyMode = pm === 'cloudflare' || pm === 'proxy' || pm === 'none' ? pm : undefined;
-  return { primaryDomain: d, proxyMode };
+  return { primaryDomain: d.toLowerCase(), proxyMode };
 }
 
 // The instance.json a legacy env install maps to. Knobs (port80/realIp) are
@@ -180,7 +191,21 @@ function isLegacyEnvInstall(ssl: string, primaryDomain: string): boolean {
   //     bootstrap mode at least once (render-main-conf.sh writes it and never
   //     deletes it) — i.e. NOT legacy. This protects the mid-wizard-restart
   //     window where the certificate step has staged real certs before Apply ran.
-  if (fs.existsSync(path.join(ssl, 'bootstrap-selfsigned.crt'))) return false;
+  if (fs.existsSync(path.join(ssl, 'bootstrap-selfsigned.crt'))) {
+    // Real certs + a real env identity + the marker + (checked by our caller)
+    // no instance.json: this is the "stuck in bootstrap mode" trap — the
+    // marker was durably written during a transient cert outage and now
+    // defeats both the render legacy carve-out and this adoption gate
+    // (v0.2.18 review, M2). We refuse adoption regardless (the marker may
+    // be legitimate mid-wizard state), but say exactly how to escape.
+    console.warn(
+      '[bootstrap] this install looks like a legacy env install stuck in bootstrap mode ' +
+        '(real certs + real PRIMARY_DOMAIN + ssl/bootstrap-selfsigned.crt, no instance.json). ' +
+        'If nginx is serving the setup wizard on your domain, recover with: ' +
+        'rm ssl/bootstrap-selfsigned.crt ssl/bootstrap-selfsigned.key && docker compose restart nginx',
+    );
+    return false;
+  }
   return true;
 }
 
@@ -207,7 +232,10 @@ export function adoptOrResyncEnvInstall(
     }
     if (existing && existing.origin !== 'env') {
       const d = env.PRIMARY_DOMAIN;
-      if (d && d !== 'localhost' && d !== existing.primaryDomain) {
+      // 'yourdomain.com' is compose's ${PRIMARY_DOMAIN:-yourdomain.com} placeholder
+      // for a blank .env — every wizard install boots with it (see
+      // isLegacyEnvInstall), so it is never a real divergence.
+      if (d && d !== 'localhost' && d !== 'yourdomain.com' && d !== existing.primaryDomain) {
         console.warn(
           `[bootstrap] .env PRIMARY_DOMAIN=${d} differs from wizard-managed instance.json ` +
             `(${existing.primaryDomain}); instance.json wins — change identity via the admin UI`,

--- a/apps/backend/src/bootstrap/instance-config.ts
+++ b/apps/backend/src/bootstrap/instance-config.ts
@@ -97,6 +97,17 @@ export function sslDir(): string {
   return process.env.SSL_CERT_PATH || '/etc/nginx/ssl';
 }
 
+// One-file seam for the renewal cron (v0.2.18 review, m7): the durable
+// pending-revert marker PrimarySslSnapshotService writes lives at this
+// path; a pure existence check avoids a domains→setup Nest dependency.
+export function pendingServingRevertExists(dir: string = bootstrapDir()): boolean {
+  try {
+    return fs.existsSync(path.join(dir, 'pending-serving-revert.json'));
+  } catch {
+    return false;
+  }
+}
+
 // Adoption-time sslMode inference for legacy env-only installs (spec §2): an
 // LE-issued primary cert on a non-cloudflare install means the operator used
 // the setup.sh certbot path, whose renewal is broken by default (one-time

--- a/apps/backend/src/domains/ssl-certificate.service.spec.ts
+++ b/apps/backend/src/domains/ssl-certificate.service.spec.ts
@@ -178,6 +178,54 @@ describe('SslCertificateService.requestPrimaryDomainCertificate', () => {
   });
 });
 
+describe('SslCertificateService.requestPrimaryDomainCertificate — HTTP-01 challenge cleanup (m9)', () => {
+  let sslDir: string;
+  let webrootDir: string;
+
+  beforeEach(() => {
+    sslDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bffless-ssl-'));
+    webrootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bffless-webroot-'));
+    process.env.SSL_CERT_PATH = sslDir;
+    process.env.CERTBOT_WEBROOT = webrootDir; // real (non-mock) ACME path below
+  });
+  afterEach(() => {
+    delete process.env.SSL_CERT_PATH;
+    delete process.env.CERTBOT_WEBROOT;
+    fs.rmSync(sslDir, { recursive: true, force: true });
+    fs.rmSync(webrootDir, { recursive: true, force: true });
+  });
+
+  it('m9: removes the challenge token file when validation fails', async () => {
+    const service = new SslCertificateService();
+    // No jest.mock('acme-client') exists in this file (all other tests here
+    // exercise MOCK_SSL's forge-based stub path) — so the ACME client is
+    // hand-stubbed and injected directly into the private field to drive the
+    // real (non-mock) HTTP-01 challenge loop under test.
+    const mockAcmeClient = {
+      createOrder: jest.fn().mockResolvedValue({}),
+      getAuthorizations: jest.fn().mockResolvedValue([
+        {
+          identifier: { value: 'example.com' },
+          challenges: [{ type: 'http-01', token: 'm9-token' }],
+        },
+      ]),
+      getChallengeKeyAuthorization: jest.fn().mockResolvedValue('key-auth'),
+      completeChallenge: jest.fn().mockResolvedValue(undefined),
+      waitForValidStatus: jest.fn().mockRejectedValue(new Error('authorization invalid')),
+    };
+    (service as any).acmeClient = mockAcmeClient;
+
+    const removeSpy = jest
+      .spyOn(service as any, 'removeHttpChallenge')
+      .mockResolvedValue(undefined);
+
+    await expect(
+      service.requestPrimaryDomainCertificate('example.com', { target: 'staging' }),
+    ).resolves.toMatchObject({ success: false });
+    expect(removeSpy).toHaveBeenCalled();
+  });
+});
+
 describe('SslCertificateService.getPrimaryCertificateSans', () => {
   let sslDir: string;
 

--- a/apps/backend/src/domains/ssl-certificate.service.ts
+++ b/apps/backend/src/domains/ssl-certificate.service.ts
@@ -434,12 +434,15 @@ export class SslCertificateService {
 
         this.logger.log(`Completing HTTP-01 challenge for ${authz.identifier.value}`);
 
-        // Complete challenge
-        await this.acmeClient.completeChallenge(challenge);
-        await this.acmeClient.waitForValidStatus(challenge);
-
-        // Cleanup challenge file
-        await this.removeHttpChallenge(challenge.token);
+        try {
+          // Complete challenge
+          await this.acmeClient.completeChallenge(challenge);
+          await this.acmeClient.waitForValidStatus(challenge);
+        } finally {
+          // Failed authorizations must not leave token litter in the shared
+          // ACME webroot (v0.2.18 review, m9).
+          await this.removeHttpChallenge(challenge.token);
+        }
       }
 
       // Generate CSR with all domains
@@ -558,9 +561,14 @@ export class SslCertificateService {
         const keyAuth = await this.acmeClient.getChallengeKeyAuthorization(challenge);
         await this.writeHttpChallenge(challenge.token, keyAuth);
         this.logger.log(`Completing HTTP-01 challenge for ${authz.identifier.value}`);
-        await this.acmeClient.completeChallenge(challenge);
-        await this.acmeClient.waitForValidStatus(challenge);
-        await this.removeHttpChallenge(challenge.token);
+        try {
+          await this.acmeClient.completeChallenge(challenge);
+          await this.acmeClient.waitForValidStatus(challenge);
+        } finally {
+          // Failed authorizations must not leave token litter in the shared
+          // ACME webroot (v0.2.18 review, m9).
+          await this.removeHttpChallenge(challenge.token);
+        }
       }
 
       const [key, csr] = await acme.crypto.createCsr({

--- a/apps/backend/src/domains/ssl-renewal.service.spec.ts
+++ b/apps/backend/src/domains/ssl-renewal.service.spec.ts
@@ -86,7 +86,7 @@ import { NginxConfigService } from './nginx-config.service';
 import { NginxReloadService } from './nginx-reload.service';
 import { ProjectsService } from '../projects/projects.service';
 import { EmailService } from '../email/email.service';
-import { loadInstanceConfig } from '../bootstrap/instance-config';
+import { loadInstanceConfig, pendingServingRevertExists } from '../bootstrap/instance-config';
 import type { SslCertificateInfo } from './ssl-info.service';
 
 /** Minimal SslCertificateInfo fixture (SslInfoService's real return shape). */
@@ -147,6 +147,10 @@ describe('SslRenewalService', () => {
     );
 
     (loadInstanceConfig as jest.Mock).mockReturnValue(null);
+    // mockReturnValue persists across clearAllMocks (only mockReset would drop
+    // it), so re-pin the default here or a prior test's
+    // pendingServingRevertExists(true) leaks into later tests.
+    (pendingServingRevertExists as jest.Mock).mockReturnValue(false);
   });
 
   describe('primary-domain LE renewal', () => {
@@ -238,6 +242,23 @@ describe('SslRenewalService', () => {
 
       await service.checkAndRenewCertificates();
 
+      expect(sslCert.requestPrimaryDomainCertificate).not.toHaveBeenCalled();
+    });
+
+    it('m7: skips primary renewal while a serving-confirm window is pending', async () => {
+      (loadInstanceConfig as jest.Mock).mockReturnValue({
+        version: 2,
+        state: 'applied',
+        primaryDomain: 'example.com',
+        proxyMode: 'none',
+        sslMode: 'letsencrypt',
+      });
+      sslCert.getPrimaryCertificateExpiryDays.mockReturnValue(5); // inside threshold
+      (pendingServingRevertExists as jest.Mock).mockReturnValue(true);
+
+      const result = await (service as any).checkAndRenewPrimary(30);
+
+      expect(result).toBeNull();
       expect(sslCert.requestPrimaryDomainCertificate).not.toHaveBeenCalled();
     });
   });
@@ -533,6 +554,34 @@ describe('SslRenewalService', () => {
           text: expect.stringContaining('fails.example.com: ACME failure'),
         }),
       );
+    });
+
+    it('m8: failure digest is throttled to once per 7 days', async () => {
+      settingsStore['notification_email'] = 'admin@example.com';
+      settingsStore['renewal_failure_last_sent'] = new Date(
+        Date.now() - 3 * 86_400_000,
+      ).toISOString();
+
+      await (service as any).sendFailureNotifications([
+        { domain: 'x.com', status: 'failed', error: 'boom' },
+      ]);
+
+      expect(email.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('m8: failure digest sends again after the window and stamps the marker', async () => {
+      settingsStore['notification_email'] = 'admin@example.com';
+      settingsStore['renewal_failure_last_sent'] = new Date(
+        Date.now() - 8 * 86_400_000,
+      ).toISOString();
+      const updateSettingSpy = jest.spyOn(service as any, 'updateSetting');
+
+      await (service as any).sendFailureNotifications([
+        { domain: 'x.com', status: 'failed', error: 'boom' },
+      ]);
+
+      expect(email.sendEmail).toHaveBeenCalled();
+      expect(updateSettingSpy).toHaveBeenCalledWith('renewal_failure_last_sent', expect.any(String));
     });
   });
 });

--- a/apps/backend/src/domains/ssl-renewal.service.ts
+++ b/apps/backend/src/domains/ssl-renewal.service.ts
@@ -15,7 +15,7 @@ import { NginxConfigService } from './nginx-config.service';
 import { NginxReloadService } from './nginx-reload.service';
 import { ProjectsService } from '../projects/projects.service';
 import { EmailService } from '../email/email.service';
-import { loadInstanceConfig } from '../bootstrap/instance-config';
+import { loadInstanceConfig, pendingServingRevertExists } from '../bootstrap/instance-config';
 
 interface RenewalResult {
   domain: string;
@@ -208,6 +208,13 @@ export class SslRenewalService {
   private async checkAndRenewPrimary(thresholdDays: number): Promise<RenewalResult | null> {
     const cfg = loadInstanceConfig();
     if (cfg?.state !== 'applied' || cfg.sslMode !== 'letsencrypt' || !cfg.primaryDomain) return null;
+    if (pendingServingRevertExists()) {
+      // A day-2 serving change is inside its confirm window; a renewal now
+      // would be silently undone by auto-revert/rollback (v0.2.18 review,
+      // m7). Next night's run proceeds normally.
+      this.logger.log('Primary renewal skipped: a serving-change confirm window is pending');
+      return null;
+    }
     const daysLeft = this.sslCertificateService.getPrimaryCertificateExpiryDays();
     if (daysLeft === null || daysLeft > thresholdDays) {
       return { domain: cfg.primaryDomain, status: 'skipped' };
@@ -511,6 +518,17 @@ export class SslRenewalService {
    * Send failure notifications
    */
   private async sendFailureNotifications(failures: RenewalResult[]): Promise<void> {
+    // Recurring failures (e.g. adopted certs with SANs HTTP-01 can't satisfy)
+    // otherwise email every single night (v0.2.18 review, m8). Same 7-day
+    // pattern as wildcard_reminder_last_sent; failures still log every run.
+    const last = await this.getSetting('renewal_failure_last_sent');
+    if (last && Date.now() - new Date(last).getTime() < 7 * 86_400_000) {
+      this.logger.warn(
+        `SSL renewal failures (digest throttled): ${failures.map((f) => `${f.domain}: ${f.error}`).join(', ')}`,
+      );
+      return;
+    }
+
     const to = await this.getReminderRecipient();
     if (!to) {
       this.logger.warn('No notification recipient configured for renewal failures');
@@ -530,7 +548,9 @@ export class SslRenewalService {
       text: failures.map((f) => `${f.domain}: ${f.error || 'Unknown error'}`).join('\n'),
     });
 
-    if (!result.success) {
+    if (result.success) {
+      await this.updateSetting('renewal_failure_last_sent', new Date().toISOString());
+    } else {
       this.logger.error(`Failed to send SSL renewal failure notification email: ${result.error}`);
     }
   }

--- a/apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
+++ b/apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
@@ -46,4 +46,31 @@ describe('BootstrapDnsPreflightService', () => {
     await service.run('example.com');
     expect(fs.readdirSync(path.join(webroot, '.well-known', 'acme-challenge'))).toEqual([]);
   });
+
+  describe('m6: SSRF hardening — private/reserved resolutions are refused', () => {
+    it.each([
+      ['loopback', '127.0.0.1'],
+      ['rfc1918', '10.1.2.3'],
+      ['rfc1918-172', '172.16.5.5'],
+      ['rfc1918-192', '192.168.1.1'],
+      ['link-local/metadata', '169.254.169.254'],
+      ['cgnat', '100.64.0.1'],
+    ])('m6: refuses to probe a host resolving to %s', async (_label, ip) => {
+      jest.spyOn(service as never, 'resolveA' as never).mockResolvedValue([ip] as never);
+      const fetchSpy = jest.spyOn(service as never, 'fetchProbe' as never);
+      const result = await service.run('internal.example.com');
+      expect(result.ok).toBe(false);
+      expect(result.checks[0].error).toContain('private or reserved');
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('m6: public addresses still probe', async () => {
+      jest.spyOn(service as never, 'resolveA' as never).mockResolvedValue(['93.184.216.34'] as never);
+      jest
+        .spyOn(service as never, 'fetchProbe' as never)
+        .mockResolvedValue('tokenbody' as never);
+      const result = await service.run('example.com');
+      expect(result.checks[0].error === 'resolves to a private or reserved address').toBe(false);
+    });
+  });
 });

--- a/apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
+++ b/apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
@@ -21,7 +21,7 @@ describe('BootstrapDnsPreflightService', () => {
     jest.spyOn(service as never, 'resolveA' as never).mockResolvedValue(['203.0.113.7'] as never);
     jest
       .spyOn(service as never, 'fetchProbe' as never)
-      .mockImplementation((async (_host: string, _token: string, content: string) => content) as never);
+      .mockImplementation((async (_host: string, _ip: string, _token: string, content: string) => content) as never);
     const res = await service.run('example.com');
     expect(res.ok).toBe(true);
     expect(res.checks.map((c) => c.host)).toEqual(['example.com', 'www.example.com', 'admin.example.com']);
@@ -32,7 +32,7 @@ describe('BootstrapDnsPreflightService', () => {
     jest.spyOn(service as never, 'resolveA' as never).mockResolvedValue([] as never);
     jest
       .spyOn(service as never, 'fetchProbe' as never)
-      .mockImplementation((async (host: string, _t: string, content: string) =>
+      .mockImplementation((async (host: string, _ip: string, _t: string, content: string) =>
         host === 'www.example.com' ? 'someone else answered' : content) as never);
     const res = await service.run('example.com');
     expect(res.ok).toBe(false);
@@ -71,6 +71,33 @@ describe('BootstrapDnsPreflightService', () => {
         .mockResolvedValue('tokenbody' as never);
       const result = await service.run('example.com');
       expect(result.checks[0].error === 'resolves to a private or reserved address').toBe(false);
+    });
+  });
+
+  describe('m6 TOCTOU fix: probe connects to the vetted IP, not the hostname', () => {
+    it('pins the connection to the resolved IP and sends the real hostname via the Host header', async () => {
+      jest.spyOn(service as never, 'resolveA' as never).mockResolvedValue(['93.184.216.34'] as never);
+      const transportSpy = jest
+        .spyOn(service as never, 'sendProbeRequest' as never)
+        .mockResolvedValue({ statusCode: 200, body: '' } as never);
+
+      await service.run('example.com');
+
+      expect(transportSpy).toHaveBeenCalled();
+      const options = transportSpy.mock.calls[0][0] as {
+        host: string;
+        headers: Record<string, string>;
+        path: string;
+      };
+      // Connection target must be the already-vetted IP — never the raw
+      // hostname, which would let the HTTP client re-resolve DNS itself and
+      // reopen the resolve/connect TOCTOU window.
+      expect(options.host).toBe('93.184.216.34');
+      expect(options.host).not.toBe('example.com');
+      // The hostname still travels via the Host header so ACME webroot
+      // vhost routing on the target server keeps working.
+      expect(options.headers.Host).toBe('example.com');
+      expect(options.path).toMatch(/^\/\.well-known\/acme-challenge\//);
     });
   });
 });

--- a/apps/backend/src/setup/bootstrap-dns-preflight.service.ts
+++ b/apps/backend/src/setup/bootstrap-dns-preflight.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { promises as dns } from 'dns';
 import * as crypto from 'crypto';
 import * as fs from 'fs/promises';
+import * as http from 'http';
 import * as path from 'path';
 
 export interface PreflightCheck {
@@ -70,7 +71,7 @@ export class BootstrapDnsPreflightService {
         let probeOk = false;
         let error: string | undefined;
         try {
-          const body = await this.fetchProbe(host, token, content);
+          const body = await this.fetchProbe(host, resolvedIps[0], token, content);
           probeOk = body === content;
           if (!probeOk) error = 'Another server answered on port 80 for this hostname';
         } catch (e) {
@@ -100,12 +101,47 @@ export class BootstrapDnsPreflightService {
     }
   }
 
-  private async fetchProbe(host: string, token: string, _content: string): Promise<string> {
-    const res = await fetch(`http://${host}/.well-known/acme-challenge/${token}`, {
-      redirect: 'manual', // a 301 means the ACME location is missing — that's a failure
-      signal: AbortSignal.timeout(5000),
+  // SSRF/TOCTOU guard (v0.2.18 review, m6 follow-up): `host` was already
+  // resolved and vetted by resolveA()/isDisallowedProbeIp() in run(). If we
+  // handed the raw hostname to fetch()/http here, the HTTP client would
+  // re-resolve DNS itself — a short-TTL record could rebind to a private or
+  // metadata IP (or answer with an AAAA record, bypassing the IPv4-only
+  // check entirely) between the vetting resolve and this connection. So we
+  // pin the TCP connection to the already-vetted IPv4 address (`ip`) and
+  // send the real hostname via the Host header, which keeps ACME webroot
+  // vhost routing on the target server working exactly as before.
+  //
+  // Redirects are NOT followed — same as the previous `redirect: 'manual'`
+  // fetch() behavior: any non-2xx (including a 3xx) is treated as a probe
+  // failure below. A redirect target could point at a different hostname,
+  // which would reopen the same rebinding hole one hop later.
+  private async fetchProbe(host: string, ip: string | undefined, token: string, _content: string): Promise<string> {
+    if (!ip) throw new Error('No resolved address to probe');
+    const { statusCode, body } = await this.sendProbeRequest({
+      host: ip,
+      port: 80,
+      path: `/.well-known/acme-challenge/${token}`,
+      method: 'GET',
+      headers: { Host: host },
+      timeout: 5000,
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status} from ${host}`);
-    return await res.text();
+    if (statusCode < 200 || statusCode >= 300) throw new Error(`HTTP ${statusCode} from ${host}`);
+    return body;
+  }
+
+  private sendProbeRequest(options: http.RequestOptions): Promise<{ statusCode: number; body: string }> {
+    return new Promise((resolve, reject) => {
+      const req = http.request(options, (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () =>
+          resolve({ statusCode: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8') }),
+        );
+        res.on('error', reject);
+      });
+      req.on('timeout', () => req.destroy(new Error(`Timed out probing ${String(options.host)}`)));
+      req.on('error', reject);
+      req.end();
+    });
   }
 }

--- a/apps/backend/src/setup/bootstrap-dns-preflight.service.ts
+++ b/apps/backend/src/setup/bootstrap-dns-preflight.service.ts
@@ -16,6 +16,24 @@ export interface PreflightResult {
   checks: PreflightCheck[];
 }
 
+// SSRF guard (v0.2.18 review, m6): the probe is a blind GET to a
+// caller-supplied hostname; refuse anything resolving into private,
+// loopback, link-local (incl. cloud metadata), CGNAT or reserved space.
+// IPv4-only because resolveA only asks for A records.
+export function isDisallowedProbeIp(ip: string): boolean {
+  const parts = ip.split('.').map(Number);
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) return true;
+  const [a, b] = parts;
+  return (
+    a === 0 || a === 127 || a === 10 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254) ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    a >= 224 // multicast + reserved
+  );
+}
+
 /**
  * Preflight for the direct + Let's Encrypt path. The probe writes a token
  * into the ACME webroot and fetches it back over the PUBLIC internet
@@ -45,6 +63,10 @@ export class BootstrapDnsPreflightService {
       const checks: PreflightCheck[] = [];
       for (const host of hosts) {
         const resolvedIps = await this.resolveA(host);
+        if (resolvedIps.some((ip) => isDisallowedProbeIp(ip))) {
+          checks.push({ host, resolvedIps, probeOk: false, error: 'resolves to a private or reserved address' });
+          continue;
+        }
         let probeOk = false;
         let error: string | undefined;
         try {

--- a/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
@@ -87,7 +87,9 @@ describe('BootstrapSetupController', () => {
         servingMode: 'cloudflare',
         token: 'claim-123',
       });
-      expect(svc.validateClaimToken).toHaveBeenCalledWith('claim-123');
+      // m5: validateClaimToken now also forwards the client IP (req?.ip);
+      // the test doesn't pass a mock request, so it's undefined here.
+      expect(svc.validateClaimToken).toHaveBeenCalledWith('claim-123', undefined);
     });
 
     it('rejects a bad claim token before touching the cert (session-less auth gate)', async () => {
@@ -143,7 +145,9 @@ describe('BootstrapSetupController', () => {
         expect.objectContaining({ state: 'applied', primaryDomain: 'example.com', proxyMode: 'cloudflare' }),
       );
       expect(res).toEqual({ applying: true, adminUrl: 'https://admin.example.com' });
-      expect(svc.validateClaimToken).toHaveBeenCalledWith(undefined);
+      // m5: second arg is the client IP (req?.ip) — undefined since no mock
+      // request was passed to this call.
+      expect(svc.validateClaimToken).toHaveBeenCalledWith(undefined, undefined);
       // Setup is marked complete as part of apply, so the restarted backend
       // lands the user at login instead of back in the wizard.
       expect(svc.finalizeSetup).toHaveBeenCalled();
@@ -409,7 +413,9 @@ describe('BootstrapSetupController', () => {
       preflight.run.mockResolvedValue({ ok: true, checks: [] });
       const res = await controller.dnsPreflight({ domain: 'Example.com', token: 't' });
       expect(svc.assertBootstrapAllowed).toHaveBeenCalled();
-      expect(svc.validateClaimToken).toHaveBeenCalledWith('t');
+      // m5: second arg is the client IP (req?.ip) — undefined since no mock
+      // request was passed to this call.
+      expect(svc.validateClaimToken).toHaveBeenCalledWith('t', undefined);
       expect(svc.validateDomain).toHaveBeenCalledWith('Example.com');
       expect(preflight.run).toHaveBeenCalledWith('example.com');
       expect(res.ok).toBe(true);

--- a/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
@@ -87,9 +87,37 @@ describe('BootstrapSetupController', () => {
         servingMode: 'cloudflare',
         token: 'claim-123',
       });
-      // m5: validateClaimToken now also forwards the client IP (req?.ip);
-      // the test doesn't pass a mock request, so it's undefined here.
+      // m5: validateClaimToken now also forwards the client IP via
+      // extractClientIp(); the test doesn't pass a mock request, so it's
+      // undefined here.
       expect(svc.validateClaimToken).toHaveBeenCalledWith('claim-123', undefined);
+    });
+
+    it('forwards the X-Forwarded-For-derived IP, not the raw socket peer (req.ip)', async () => {
+      // Only nginx ever connects directly to the backend (no exposed ports),
+      // so req.ip/req.socket.remoteAddress is always nginx's own address —
+      // using it for per-IP rate limiting would collapse every client into
+      // one bucket, reproducing the lockout DoS this rate limiter exists to
+      // prevent. extractClientIp() must be used instead, which reads the
+      // client IP nginx forwards in X-Forwarded-For.
+      const mockReq = {
+        headers: { 'x-forwarded-for': '203.0.113.7, 10.0.0.5' },
+        ip: '10.0.0.5',
+        socket: { remoteAddress: '10.0.0.5' },
+      };
+
+      await controller.uploadCertificates(
+        {
+          domain: 'example.com',
+          certificatePem: 'CERT',
+          privateKeyPem: 'KEY',
+          servingMode: 'cloudflare',
+          token: 'claim-123',
+        },
+        mockReq as any,
+      );
+
+      expect(svc.validateClaimToken).toHaveBeenCalledWith('claim-123', '203.0.113.7');
     });
 
     it('rejects a bad claim token before touching the cert (session-less auth gate)', async () => {
@@ -145,8 +173,8 @@ describe('BootstrapSetupController', () => {
         expect.objectContaining({ state: 'applied', primaryDomain: 'example.com', proxyMode: 'cloudflare' }),
       );
       expect(res).toEqual({ applying: true, adminUrl: 'https://admin.example.com' });
-      // m5: second arg is the client IP (req?.ip) — undefined since no mock
-      // request was passed to this call.
+      // m5: second arg is the client IP via extractClientIp() — undefined
+      // since no mock request was passed to this call.
       expect(svc.validateClaimToken).toHaveBeenCalledWith(undefined, undefined);
       // Setup is marked complete as part of apply, so the restarted backend
       // lands the user at login instead of back in the wizard.
@@ -413,8 +441,8 @@ describe('BootstrapSetupController', () => {
       preflight.run.mockResolvedValue({ ok: true, checks: [] });
       const res = await controller.dnsPreflight({ domain: 'Example.com', token: 't' });
       expect(svc.assertBootstrapAllowed).toHaveBeenCalled();
-      // m5: second arg is the client IP (req?.ip) — undefined since no mock
-      // request was passed to this call.
+      // m5: second arg is the client IP via extractClientIp() — undefined
+      // since no mock request was passed to this call.
       expect(svc.validateClaimToken).toHaveBeenCalledWith('t', undefined);
       expect(svc.validateDomain).toHaveBeenCalledWith('Example.com');
       expect(preflight.run).toHaveBeenCalledWith('example.com');

--- a/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
@@ -24,7 +24,9 @@ describe('BootstrapSetupController', () => {
     validateApplyConfig: jest.fn((dto: any) => ({
       proxyMode: dto.proxyMode,
       sslMode: dto.sslMode,
-      port80: dto.port80 ?? (dto.proxyMode === 'cloudflare' ? 'closed' : 'redirect'),
+      // Mirrors the real validateApplyConfig default (m13): 'redirect' for
+      // every path when port80 is not chosen explicitly, Cloudflare included.
+      port80: dto.port80 ?? 'redirect',
       realIp:
         dto.proxyMode === 'cloudflare'
           ? { preset: 'cloudflare' }

--- a/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, InternalServerErrorException } from '@nestjs/common';
 import { BootstrapSetupController } from './bootstrap-setup.controller';
 import { ApplyBootstrapDto } from './setup.dto';
 import * as staging from './ssl-staging';
@@ -33,6 +33,7 @@ describe('BootstrapSetupController', () => {
             : null,
     })),
     finalizeSetup: jest.fn(),
+    unfinalizeSetup: jest.fn(),
   };
   const preflight = {
     run: jest.fn(),
@@ -57,6 +58,7 @@ describe('BootstrapSetupController', () => {
     svc.assertStagedCertificateCovers.mockReturnValue(undefined);
     svc.validateDomain.mockImplementation((d: string) => d.toLowerCase());
     svc.finalizeSetup.mockResolvedValue(undefined);
+    svc.unfinalizeSetup.mockResolvedValue(undefined);
     preflight.run.mockResolvedValue({ ok: true, checks: [] });
     sslCert.initialize.mockResolvedValue(undefined);
     controller = new BootstrapSetupController(svc as any, preflight as any, sslCert as any);
@@ -351,6 +353,24 @@ describe('BootstrapSetupController', () => {
       } as ApplyBootstrapDto);
       expect(staging.discardStagedCertificates).toHaveBeenCalled();
       expect(staging.promoteStagedCertificates).not.toHaveBeenCalled();
+      writeSpy.mockRestore();
+    });
+
+    it('M3: un-finalizes setup and returns 500 when writeInstanceConfig throws (box stays browser-recoverable)', async () => {
+      const writeSpy = jest
+        .spyOn(require('../bootstrap/instance-config'), 'writeInstanceConfig')
+        .mockImplementation(() => {
+          throw new Error('ENOSPC: no space left on device');
+        });
+      await expect(
+        controller.apply({ domain: 'example.com', proxyMode: 'cloudflare', sslMode: 'paste' }),
+      ).rejects.toThrow(InternalServerErrorException);
+      expect(svc.finalizeSetup).toHaveBeenCalled();
+      expect(svc.unfinalizeSetup).toHaveBeenCalled();
+      // scheduleExit is overridden with exitFn (a plain jest.fn) in
+      // beforeEach — asserting on it is equivalent to spying on the
+      // prototype method, which the override already shadows.
+      expect(exitFn).not.toHaveBeenCalled();
       writeSpy.mockRestore();
     });
   });

--- a/apps/backend/src/setup/bootstrap-setup.controller.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.ts
@@ -1,4 +1,11 @@
-import { BadRequestException, Body, Controller, Logger, Post } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  InternalServerErrorException,
+  Logger,
+  Post,
+} from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { BootstrapSetupService } from './bootstrap-setup.service';
 import { BootstrapDnsPreflightService, PreflightResult } from './bootstrap-dns-preflight.service';
@@ -109,16 +116,28 @@ export class BootstrapSetupController {
     // user at login, not back in the normal-mode wizard. Must persist before
     // the process exit below (awaited here, exit is a deferred timer).
     await this.bootstrap.finalizeSetup();
-    writeInstanceConfig({
-      version: 2,
-      state: 'applied',
-      origin: 'wizard',
-      primaryDomain: domain,
-      proxyMode: applied.proxyMode,
-      sslMode: applied.sslMode,
-      port80: applied.port80,
-      realIp: applied.realIp,
-    });
+    try {
+      writeInstanceConfig({
+        version: 2,
+        state: 'applied',
+        origin: 'wizard',
+        primaryDomain: domain,
+        proxyMode: applied.proxyMode,
+        sslMode: applied.sslMode,
+        port80: applied.port80,
+        realIp: applied.realIp,
+      });
+    } catch (err) {
+      // Failed fs write with setup already finalized = permanently dead
+      // wizard AND no identity (M3). Put the wizard back so Apply can be
+      // retried from the browser once the underlying problem (disk space,
+      // mount perms) is fixed.
+      await this.bootstrap.unfinalizeSetup();
+      this.logger.error(`[bootstrap] apply failed writing instance config: ${(err as Error).message}`);
+      throw new InternalServerErrorException(
+        'Could not write the instance configuration to disk (check free disk space). Setup was NOT completed — fix the disk issue and retry Apply.',
+      );
+    }
     this.scheduleExit();
     return { applying: true, adminUrl: `https://admin.${domain}` };
   }

--- a/apps/backend/src/setup/bootstrap-setup.controller.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
+import { extractClientIp } from '../common/utils/request-ip.util';
 import { BootstrapSetupService } from './bootstrap-setup.service';
 import { BootstrapDnsPreflightService, PreflightResult } from './bootstrap-dns-preflight.service';
 import { SslCertificateService } from '../domains/ssl-certificate.service';
@@ -54,7 +55,7 @@ export class BootstrapSetupController {
     // are claim-token-gated (the same rate-limited token that gates admin
     // creation), not admin-session-guarded. Runs after the mode gate, before
     // any cert parsing or disk writes.
-    this.bootstrap.validateClaimToken(dto.token, req?.ip);
+    this.bootstrap.validateClaimToken(dto.token, req ? extractClientIp(req) : undefined);
     const { sans, wildcardCovered } = this.bootstrap.validateCertificatePair(
       dto.certificatePem,
       dto.privateKeyPem,
@@ -75,7 +76,7 @@ export class BootstrapSetupController {
     // claim-token auth gate, before the certificate presence check or any
     // filesystem/response work.
     await this.bootstrap.assertBootstrapAllowed();
-    this.bootstrap.validateClaimToken(dto.token, req?.ip);
+    this.bootstrap.validateClaimToken(dto.token, req ? extractClientIp(req) : undefined);
     // Self-signed keeps serving the built-in bootstrap cert (behind a
     // TLS-terminating proxy) — there is deliberately no staged fullchain to
     // check. Every other mode stages a real cert (paste) or has one issued
@@ -155,7 +156,7 @@ export class BootstrapSetupController {
     @Req() req?: Request,
   ): Promise<PreflightResult> {
     await this.bootstrap.assertBootstrapAllowed();
-    this.bootstrap.validateClaimToken(dto.token, req?.ip);
+    this.bootstrap.validateClaimToken(dto.token, req ? extractClientIp(req) : undefined);
     const domain = this.bootstrap.validateDomain(dto.domain);
     return this.preflight.run(domain);
   }
@@ -167,7 +168,7 @@ export class BootstrapSetupController {
     @Req() req?: Request,
   ): Promise<{ issued: true; sans: string[] }> {
     await this.bootstrap.assertBootstrapAllowed();
-    this.bootstrap.validateClaimToken(dto.token, req?.ip);
+    this.bootstrap.validateClaimToken(dto.token, req ? extractClientIp(req) : undefined);
     const domain = this.bootstrap.validateDomain(dto.domain);
     // Server-side re-check — the client's claim that preflight passed is
     // advisory only. Cheap (one token write + three HTTP GETs) relative to
@@ -193,7 +194,7 @@ export class BootstrapSetupController {
     @Req() req?: Request,
   ): Promise<{ recordName: string; recordValues: string[]; expiresAt: string }> {
     await this.bootstrap.assertBootstrapAllowed();
-    this.bootstrap.validateClaimToken(dto.token, req?.ip);
+    this.bootstrap.validateClaimToken(dto.token, req ? extractClientIp(req) : undefined);
     const domain = this.bootstrap.validateDomain(dto.domain);
     await this.sslCert.initialize();
     const challenge = await this.sslCert.startWildcardCertificateRequest(domain);
@@ -211,7 +212,7 @@ export class BootstrapSetupController {
     @Req() req?: Request,
   ): Promise<{ success: boolean; error?: string }> {
     await this.bootstrap.assertBootstrapAllowed();
-    this.bootstrap.validateClaimToken(dto.token, req?.ip);
+    this.bootstrap.validateClaimToken(dto.token, req ? extractClientIp(req) : undefined);
     const domain = this.bootstrap.validateDomain(dto.domain);
     await this.sslCert.initialize();
     const result = await this.sslCert.completeWildcardCertificateRequest(domain);

--- a/apps/backend/src/setup/bootstrap-setup.controller.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.ts
@@ -5,8 +5,10 @@ import {
   InternalServerErrorException,
   Logger,
   Post,
+  Req,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
 import { BootstrapSetupService } from './bootstrap-setup.service';
 import { BootstrapDnsPreflightService, PreflightResult } from './bootstrap-dns-preflight.service';
 import { SslCertificateService } from '../domains/ssl-certificate.service';
@@ -41,6 +43,7 @@ export class BootstrapSetupController {
   @ApiOperation({ summary: 'Validate and install SSL certificate pair (bootstrap mode)' })
   async uploadCertificates(
     @Body() dto: UploadCertificatesDto,
+    @Req() req?: Request,
   ): Promise<{ saved: true; sans: string[]; wildcardCovered: boolean }> {
     // Must be awaited: assertBootstrapAllowed is async (it calls the async
     // FeatureFlagsService.isEnabled). Awaiting first, before any validation
@@ -51,7 +54,7 @@ export class BootstrapSetupController {
     // are claim-token-gated (the same rate-limited token that gates admin
     // creation), not admin-session-guarded. Runs after the mode gate, before
     // any cert parsing or disk writes.
-    this.bootstrap.validateClaimToken(dto.token);
+    this.bootstrap.validateClaimToken(dto.token, req?.ip);
     const { sans, wildcardCovered } = this.bootstrap.validateCertificatePair(
       dto.certificatePem,
       dto.privateKeyPem,
@@ -64,12 +67,15 @@ export class BootstrapSetupController {
 
   @Post('apply')
   @ApiOperation({ summary: 'Apply domain identity and restart into HTTPS mode (bootstrap mode)' })
-  async apply(@Body() dto: ApplyBootstrapDto): Promise<{ applying: true; adminUrl: string }> {
+  async apply(
+    @Body() dto: ApplyBootstrapDto,
+    @Req() req?: Request,
+  ): Promise<{ applying: true; adminUrl: string }> {
     // Same ordering as uploadCertificates: mode gate first, then the
     // claim-token auth gate, before the certificate presence check or any
     // filesystem/response work.
     await this.bootstrap.assertBootstrapAllowed();
-    this.bootstrap.validateClaimToken(dto.token);
+    this.bootstrap.validateClaimToken(dto.token, req?.ip);
     // Self-signed keeps serving the built-in bootstrap cert (behind a
     // TLS-terminating proxy) — there is deliberately no staged fullchain to
     // check. Every other mode stages a real cert (paste) or has one issued
@@ -144,9 +150,12 @@ export class BootstrapSetupController {
 
   @Post('dns-preflight')
   @ApiOperation({ summary: 'Check DNS + port-80 reachability for the LE path (bootstrap mode)' })
-  async dnsPreflight(@Body() dto: BootstrapDomainActionDto): Promise<PreflightResult> {
+  async dnsPreflight(
+    @Body() dto: BootstrapDomainActionDto,
+    @Req() req?: Request,
+  ): Promise<PreflightResult> {
     await this.bootstrap.assertBootstrapAllowed();
-    this.bootstrap.validateClaimToken(dto.token);
+    this.bootstrap.validateClaimToken(dto.token, req?.ip);
     const domain = this.bootstrap.validateDomain(dto.domain);
     return this.preflight.run(domain);
   }
@@ -155,9 +164,10 @@ export class BootstrapSetupController {
   @ApiOperation({ summary: "Issue the primary-domain Let's Encrypt certificate (bootstrap mode)" })
   async issueCertificate(
     @Body() dto: BootstrapDomainActionDto,
+    @Req() req?: Request,
   ): Promise<{ issued: true; sans: string[] }> {
     await this.bootstrap.assertBootstrapAllowed();
-    this.bootstrap.validateClaimToken(dto.token);
+    this.bootstrap.validateClaimToken(dto.token, req?.ip);
     const domain = this.bootstrap.validateDomain(dto.domain);
     // Server-side re-check — the client's claim that preflight passed is
     // advisory only. Cheap (one token write + three HTTP GETs) relative to
@@ -180,9 +190,10 @@ export class BootstrapSetupController {
   @ApiOperation({ summary: 'Start the optional DNS-01 wildcard (bootstrap mode)' })
   async wildcardStart(
     @Body() dto: BootstrapDomainActionDto,
+    @Req() req?: Request,
   ): Promise<{ recordName: string; recordValues: string[]; expiresAt: string }> {
     await this.bootstrap.assertBootstrapAllowed();
-    this.bootstrap.validateClaimToken(dto.token);
+    this.bootstrap.validateClaimToken(dto.token, req?.ip);
     const domain = this.bootstrap.validateDomain(dto.domain);
     await this.sslCert.initialize();
     const challenge = await this.sslCert.startWildcardCertificateRequest(domain);
@@ -197,9 +208,10 @@ export class BootstrapSetupController {
   @ApiOperation({ summary: 'Verify TXT records and issue the wildcard (bootstrap mode)' })
   async wildcardComplete(
     @Body() dto: BootstrapDomainActionDto,
+    @Req() req?: Request,
   ): Promise<{ success: boolean; error?: string }> {
     await this.bootstrap.assertBootstrapAllowed();
-    this.bootstrap.validateClaimToken(dto.token);
+    this.bootstrap.validateClaimToken(dto.token, req?.ip);
     const domain = this.bootstrap.validateDomain(dto.domain);
     await this.sslCert.initialize();
     const result = await this.sslCert.completeWildcardCertificateRequest(domain);

--- a/apps/backend/src/setup/bootstrap-setup.service.spec.ts
+++ b/apps/backend/src/setup/bootstrap-setup.service.spec.ts
@@ -659,7 +659,7 @@ describe('BootstrapSetupService', () => {
     it('resolves cloudflare preset defaults', () => {
       const cfg = service.validateApplyConfig({ ...base, proxyMode: 'cloudflare', sslMode: 'paste' } as ApplyBootstrapDto);
       expect(cfg).toEqual({
-        proxyMode: 'cloudflare', sslMode: 'paste', port80: 'closed', realIp: { preset: 'cloudflare' },
+        proxyMode: 'cloudflare', sslMode: 'paste', port80: 'redirect', realIp: { preset: 'cloudflare' },
       });
     });
 
@@ -749,6 +749,20 @@ describe('BootstrapSetupService', () => {
       expect(() => service.validateApplyConfig({
         domain: 'example.com', proxyMode: 'proxy', sslMode: 'letsencrypt', port80: 'closed',
       } as ApplyBootstrapDto)).toThrow(/Port 80 must stay open/);
+    });
+
+    it('m13: cloudflare apply with no explicit port80 defaults to redirect (fresh CF zones have Always-Use-HTTPS off; closed → edge 520s)', () => {
+      const out = service.validateApplyConfig({
+        domain: 'example.com', proxyMode: 'cloudflare', sslMode: 'paste',
+      } as ApplyBootstrapDto);
+      expect(out.port80).toBe('redirect');
+    });
+
+    it('m13: explicit closed on cloudflare is still honored', () => {
+      const out = service.validateApplyConfig({
+        domain: 'example.com', proxyMode: 'cloudflare', sslMode: 'paste', port80: 'closed',
+      } as ApplyBootstrapDto);
+      expect(out.port80).toBe('closed');
     });
   });
 });

--- a/apps/backend/src/setup/bootstrap-setup.service.spec.ts
+++ b/apps/backend/src/setup/bootstrap-setup.service.spec.ts
@@ -126,14 +126,14 @@ describe('BootstrapSetupService', () => {
   });
 
   describe('validateClaimToken', () => {
-    it('delegates to SetupService.validateOnboardingToken with the supplied token', () => {
+    it('delegates to SetupService.validateOnboardingToken with the supplied token and client IP (m5)', () => {
       const validateOnboardingToken = jest.fn();
       const svc = new BootstrapSetupService(
         { validateOnboardingToken } as any,
         { isEnabled: () => true } as any,
       );
-      svc.validateClaimToken('claim-abc');
-      expect(validateOnboardingToken).toHaveBeenCalledWith('claim-abc');
+      svc.validateClaimToken('claim-abc', '203.0.113.5');
+      expect(validateOnboardingToken).toHaveBeenCalledWith('claim-abc', '203.0.113.5');
     });
 
     it('propagates the validator throwing on a bad token', () => {

--- a/apps/backend/src/setup/bootstrap-setup.service.ts
+++ b/apps/backend/src/setup/bootstrap-setup.service.ts
@@ -45,8 +45,8 @@ export class BootstrapSetupService {
    * ONBOARDING_TOKEN is configured (LAN/Umbrel profile) — identical semantics
    * to admin creation, so the two can never disagree.
    */
-  validateClaimToken(token?: string): void {
-    this.setupService.validateOnboardingToken(token);
+  validateClaimToken(token?: string, clientIp?: string): void {
+    this.setupService.validateOnboardingToken(token, clientIp);
   }
 
   /**

--- a/apps/backend/src/setup/bootstrap-setup.service.ts
+++ b/apps/backend/src/setup/bootstrap-setup.service.ts
@@ -58,6 +58,10 @@ export class BootstrapSetupService {
     await this.setupService.finalizeBootstrapSetup();
   }
 
+  async unfinalizeSetup(): Promise<void> {
+    await this.setupService.unfinalizeBootstrapSetup();
+  }
+
   /** Live cert dir — delegates to ssl-staging.ts so there is one resolution. */
   private sslDir(): string {
     return sslLiveDir();

--- a/apps/backend/src/setup/bootstrap-setup.service.ts
+++ b/apps/backend/src/setup/bootstrap-setup.service.ts
@@ -407,8 +407,11 @@ export class BootstrapSetupService {
       }
     }
 
-    const port80: Port80Mode =
-      dto.port80 ?? (dto.proxyMode === 'cloudflare' ? 'closed' : 'redirect');
+    // 'redirect' for every path, Cloudflare included: fresh CF zones ship
+    // with Always Use HTTPS off, so a closed origin port 80 turns every
+    // plain-http visitor into a CF 520 error page (v0.2.18 review, m13 —
+    // observed through the live CF edge). Closing stays an explicit choice.
+    const port80: Port80Mode = dto.port80 ?? 'redirect';
     const realIp: RealIpConfig =
       dto.proxyMode === 'cloudflare'
         ? { preset: 'cloudflare' }

--- a/apps/backend/src/setup/setup.controller.spec.ts
+++ b/apps/backend/src/setup/setup.controller.spec.ts
@@ -65,9 +65,34 @@ describe('SetupController', () => {
       const result = await controller.initialize(mockDto);
 
       expect(result).toEqual(mockResult);
-      // m5: initialize() now also forwards the client IP (req?.ip); the test
-      // doesn't pass a mock request, so it's undefined here.
+      // m5: initialize() now also forwards the client IP via extractClientIp();
+      // the test doesn't pass a mock request, so it's undefined here.
       expect(service.initialize).toHaveBeenCalledWith(mockDto, undefined);
+    });
+
+    it('forwards the X-Forwarded-For-derived IP, not the raw socket peer (req.ip)', async () => {
+      // Only nginx ever connects directly to the backend (no exposed ports),
+      // so req.ip/req.socket.remoteAddress is always nginx's own address —
+      // using it for rate limiting would collapse every client into one
+      // bucket. extractClientIp() must be used instead, which reads the
+      // client IP nginx forwards in X-Forwarded-For.
+      const mockDto = {
+        email: 'admin@example.com',
+        password: 'SecurePass123!',
+        username: 'admin',
+      };
+      const mockResult = { success: true, message: 'System initialized' };
+      jest.spyOn(service, 'initialize').mockResolvedValue(mockResult as any);
+
+      const mockReq = {
+        headers: { 'x-forwarded-for': '203.0.113.7, 10.0.0.5' },
+        ip: '10.0.0.5',
+        socket: { remoteAddress: '10.0.0.5' },
+      };
+
+      await controller.initialize(mockDto, mockReq as any);
+
+      expect(service.initialize).toHaveBeenCalledWith(mockDto, '203.0.113.7');
     });
   });
 

--- a/apps/backend/src/setup/setup.controller.spec.ts
+++ b/apps/backend/src/setup/setup.controller.spec.ts
@@ -65,7 +65,9 @@ describe('SetupController', () => {
       const result = await controller.initialize(mockDto);
 
       expect(result).toEqual(mockResult);
-      expect(service.initialize).toHaveBeenCalledWith(mockDto);
+      // m5: initialize() now also forwards the client IP (req?.ip); the test
+      // doesn't pass a mock request, so it's undefined here.
+      expect(service.initialize).toHaveBeenCalledWith(mockDto, undefined);
     });
   });
 

--- a/apps/backend/src/setup/setup.controller.ts
+++ b/apps/backend/src/setup/setup.controller.ts
@@ -16,6 +16,7 @@ import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { SessionContainer } from 'supertokens-node/recipe/session';
 import { SetupService } from './setup.service';
+import { extractClientIp } from '../common/utils/request-ip.util';
 import { SessionAuthGuard } from '../auth/session-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
@@ -161,7 +162,7 @@ export class SetupController {
     @Body() dto: InitializeSystemDto,
     @Req() req?: Request,
   ): Promise<InitializeResponseDto> {
-    return this.setupService.initialize(dto, req?.ip);
+    return this.setupService.initialize(dto, req ? extractClientIp(req) : undefined);
   }
 
   @Post('check-email')
@@ -206,7 +207,7 @@ export class SetupController {
     @Body() dto: AdoptExistingUserDto,
     @Req() req?: Request,
   ): Promise<AdoptExistingUserResponseDto> {
-    return this.setupService.adoptExistingUser(dto.email, dto.password, dto.token, req?.ip);
+    return this.setupService.adoptExistingUser(dto.email, dto.password, dto.token, req ? extractClientIp(req) : undefined);
   }
 
   @Post('adopt-session-user')
@@ -247,7 +248,7 @@ export class SetupController {
       throw new UnauthorizedException('User not found');
     }
 
-    return this.setupService.adoptSessionUser(userId, user.email, dto.token, req?.ip);
+    return this.setupService.adoptSessionUser(userId, user.email, dto.token, req ? extractClientIp(req) : undefined);
   }
 
   @Post('storage')

--- a/apps/backend/src/setup/setup.controller.ts
+++ b/apps/backend/src/setup/setup.controller.ts
@@ -157,8 +157,11 @@ export class SetupController {
     status: 400,
     description: 'Invalid input data',
   })
-  async initialize(@Body() dto: InitializeSystemDto): Promise<InitializeResponseDto> {
-    return this.setupService.initialize(dto);
+  async initialize(
+    @Body() dto: InitializeSystemDto,
+    @Req() req?: Request,
+  ): Promise<InitializeResponseDto> {
+    return this.setupService.initialize(dto, req?.ip);
   }
 
   @Post('check-email')
@@ -199,8 +202,11 @@ export class SetupController {
     status: 400,
     description: 'Invalid credentials or user cannot be adopted',
   })
-  async adoptExistingUser(@Body() dto: AdoptExistingUserDto): Promise<AdoptExistingUserResponseDto> {
-    return this.setupService.adoptExistingUser(dto.email, dto.password, dto.token);
+  async adoptExistingUser(
+    @Body() dto: AdoptExistingUserDto,
+    @Req() req?: Request,
+  ): Promise<AdoptExistingUserResponseDto> {
+    return this.setupService.adoptExistingUser(dto.email, dto.password, dto.token, req?.ip);
   }
 
   @Post('adopt-session-user')
@@ -241,7 +247,7 @@ export class SetupController {
       throw new UnauthorizedException('User not found');
     }
 
-    return this.setupService.adoptSessionUser(userId, user.email, dto.token);
+    return this.setupService.adoptSessionUser(userId, user.email, dto.token, req?.ip);
   }
 
   @Post('storage')

--- a/apps/backend/src/setup/setup.service.spec.ts
+++ b/apps/backend/src/setup/setup.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ModuleRef } from '@nestjs/core';
 import * as fs from 'fs';
@@ -349,7 +350,9 @@ describe('SetupService', () => {
   describe('validateOnboardingToken — rate limiting', () => {
     beforeEach(() => {
       process.env.ONBOARDING_TOKEN = 'right-token';
-      (service as any).claimAttempts = { count: 0, windowStart: 0 }; // reset internal state
+      // Reset internal state (m5: per-IP Map + global backstop counter).
+      (service as any).claimAttempts = new Map();
+      (service as any).claimGlobal = { count: 0, windowStart: 0 };
     });
     afterEach(() => delete process.env.ONBOARDING_TOKEN);
 
@@ -364,7 +367,9 @@ describe('SetupService', () => {
     it('a successful validation resets the counter', () => {
       expect(() => (service as any).validateOnboardingToken('wrong')).toThrow();
       expect(() => (service as any).validateOnboardingToken('right-token')).not.toThrow();
-      expect((service as any).claimAttempts.count).toBe(0);
+      // m5: success clears the calling bucket entirely (no `unknown` entry left),
+      // rather than resetting a single global `.count` field to 0.
+      expect((service as any).claimAttempts.has('unknown')).toBe(false);
     });
 
     // Exercises the real public entry point (`initialize`) instead of poking
@@ -398,10 +403,35 @@ describe('SetupService', () => {
         // Window has elapsed — a fresh attempt (even a wrong one) is allowed,
         // proving the counter reset rather than merely tolerating one more try.
         expect(() => (service as any).validateOnboardingToken('wrong')).toThrow(/invalid/i);
-        expect((service as any).claimAttempts.count).toBe(1);
+        // m5: the per-IP bucket ('unknown', since no clientIp was passed) now
+        // lives in a Map rather than a flat `.count` field.
+        expect((service as any).claimAttempts.get('unknown')?.count).toBe(1);
       } finally {
         jest.useRealTimers();
       }
+    });
+
+    // m5 (v0.2.18 review): the old single global counter let 5 bad guesses
+    // from ANYONE lock the legitimate operator out for 15 minutes — an
+    // onboarding DoS on a public IP. Per-IP buckets fix that: a flood from one
+    // IP must not consume another IP's attempts.
+    it('m5: lockout is per client IP — a second IP still gets attempts', () => {
+      process.env.ONBOARDING_TOKEN = 'right';
+      for (let i = 0; i < 5; i++) {
+        expect(() => service.validateOnboardingToken('wrong', '1.1.1.1')).toThrow();
+      }
+      expect(() => service.validateOnboardingToken('right', '1.1.1.1')).toThrow(UnauthorizedException); // locked
+      expect(() => service.validateOnboardingToken('right', '2.2.2.2')).not.toThrow(); // different IP fine
+    });
+
+    it('m5: global backstop trips after 50 failures across IPs', () => {
+      process.env.ONBOARDING_TOKEN = 'right';
+      for (let ip = 0; ip < 10; ip++) {
+        for (let i = 0; i < 5; i++) {
+          try { service.validateOnboardingToken('wrong', `10.0.0.${ip}`); } catch { /* per-IP throws expected */ }
+        }
+      }
+      expect(() => service.validateOnboardingToken('right', '99.99.99.99')).toThrow(UnauthorizedException);
     });
   });
 });

--- a/apps/backend/src/setup/setup.service.ts
+++ b/apps/backend/src/setup/setup.service.ts
@@ -1078,6 +1078,23 @@ export class SetupService {
   }
 
   /**
+   * Inverse of finalizeBootstrapSetup, for the one caller that needs it:
+   * bootstrap apply marks setup complete BEFORE writing instance.json, and a
+   * failed write must put the wizard back (isBootstrapModeActive requires
+   * !isSetupComplete) or the box is stranded with no identity and no wizard
+   * (v0.2.18 review, M3).
+   */
+  async unfinalizeBootstrapSetup(): Promise<void> {
+    const config = await this.getSystemConfig();
+    if (!config || !config.isSetupComplete) return;
+    await db
+      .update(systemConfig)
+      .set({ isSetupComplete: false, updatedAt: new Date() })
+      .where(eq(systemConfig.id, config.id));
+    this.logger.warn('[bootstrap] setup un-finalized after a failed apply write — wizard restored');
+  }
+
+  /**
    * Get decrypted storage configuration mapped to adapter format
    */
   async getStorageConfig(): Promise<any> {

--- a/apps/backend/src/setup/setup.service.ts
+++ b/apps/backend/src/setup/setup.service.ts
@@ -86,18 +86,15 @@ export class SetupService {
   // Onboarding token from environment (for secure workspace setup)
   private readonly onboardingToken: string | null;
 
-  // Claim-token rate limiting: 5 failed attempts within a 15-minute fixed
-  // window locks out further attempts (even a correct token) until the
-  // window elapses. In-memory only — a k8s deployment with multiple backend
-  // replicas does NOT share this counter across pods, so an attacker who
-  // gets routed to different replicas could effectively get more than 5
-  // guesses. This is acceptable for CE: the token is short-lived and
-  // delivered out-of-band (Platform relays the correct token via the setup
-  // URL), so rate limiting here only ever throttles genuinely failed
-  // (brute-force) attempts — it is defense-in-depth on top of the token
-  // itself being unguessable, not the sole line of defense.
-  private claimAttempts = { count: 0, windowStart: 0 };
+  // Per-IP fixed-window claim limiting (v0.2.18 review, m5): the old single
+  // global counter let 5 bad guesses from ANYONE lock the legitimate
+  // operator out for 15 minutes — an onboarding DoS on a public IP. Per-IP
+  // buckets keep brute-force defense; the global backstop bounds distributed
+  // guessing. In-memory only (same multi-replica caveat as before).
+  private claimAttempts = new Map<string, { count: number; windowStart: number }>();
+  private claimGlobal = { count: 0, windowStart: 0 };
   private static readonly CLAIM_MAX_ATTEMPTS = 5;
+  private static readonly CLAIM_GLOBAL_MAX_ATTEMPTS = 50;
   private static readonly CLAIM_WINDOW_MS = 15 * 60 * 1000;
 
   constructor(
@@ -155,10 +152,12 @@ export class SetupService {
    * - If ONBOARDING_TOKEN is set in env, the provided token must match
    * - If ONBOARDING_TOKEN is not set, validation is skipped (CE mode backwards compatibility)
    * - This prevents unauthorized users from claiming admin access to new workspaces
-   * - Rate-limited: 5 failed attempts within a 15-minute window locks out further
-   *   attempts (including a correct token) until the window elapses. A successful
-   *   validation resets the counter. See `claimAttempts` field comment for the
-   *   in-memory/multi-replica caveat.
+   * - Rate-limited per client IP: 5 failed attempts within a 15-minute window from
+   *   the SAME IP locks out further attempts from that IP (including a correct
+   *   token) until the window elapses; a global backstop additionally locks out
+   *   ALL IPs after 50 failures across any IPs in the same window. A successful
+   *   validation resets only the calling IP's bucket. See `claimAttempts`/
+   *   `claimGlobal` field comment for the in-memory/multi-replica caveat.
    *
    * Reads `process.env.ONBOARDING_TOKEN` directly (rather than the `onboardingToken`
    * field cached at construction time) so it stays consistent with how
@@ -171,65 +170,57 @@ export class SetupService {
   // run inside the anonymous, session-less setup wizard (every setup step is
   // public), so they are token-gated rather than session-gated — see
   // BootstrapSetupService.validateClaimToken and the bootstrap controller.
-  validateOnboardingToken(providedToken?: string): void {
+  validateOnboardingToken(providedToken?: string, clientIp?: string): void {
     const expectedToken = process.env.ONBOARDING_TOKEN;
-
-    // If no token configured in environment, skip validation (CE mode)
     if (!expectedToken) {
       return;
     }
 
     const now = Date.now();
+    const key = clientIp || 'unknown';
 
-    // Fixed 15-minute window: only reset once it has fully elapsed since the
-    // first failure that opened it. Gated on `count > 0` (rather than
-    // comparing `windowStart` to a 0 sentinel) so the reset logic doesn't
-    // depend on `Date.now()` being far from the epoch — a sentinel-based
-    // check would work in production (real timestamps are always far past
-    // epoch) but silently do the wrong thing under mocked/fake clocks that
-    // start near 0, which is exactly the kind of bug that only shows up in
-    // tests.
-    if (
-      this.claimAttempts.count > 0 &&
-      now - this.claimAttempts.windowStart > SetupService.CLAIM_WINDOW_MS
-    ) {
-      this.claimAttempts = { count: 0, windowStart: 0 };
+    // Fixed windows, per bucket. Gated on count > 0 (not a 0-sentinel
+    // comparison) for the same mocked-clock reason as before.
+    const bucket = this.claimAttempts.get(key);
+    if (bucket && bucket.count > 0 && now - bucket.windowStart > SetupService.CLAIM_WINDOW_MS) {
+      this.claimAttempts.delete(key);
+    }
+    if (this.claimGlobal.count > 0 && now - this.claimGlobal.windowStart > SetupService.CLAIM_WINDOW_MS) {
+      this.claimGlobal = { count: 0, windowStart: 0 };
     }
 
-    if (this.claimAttempts.count >= SetupService.CLAIM_MAX_ATTEMPTS) {
+    if ((this.claimAttempts.get(key)?.count ?? 0) >= SetupService.CLAIM_MAX_ATTEMPTS) {
+      throw new UnauthorizedException('Too many attempts, try again later');
+    }
+    if (this.claimGlobal.count >= SetupService.CLAIM_GLOBAL_MAX_ATTEMPTS) {
       throw new UnauthorizedException('Too many attempts, try again later');
     }
 
-    // Token is configured, so it must be provided and match
     if (!providedToken) {
-      this.recordFailedClaimAttempt(now);
+      this.recordFailedClaimAttempt(key, now);
       throw new BadRequestException(
         'Onboarding token is required. Please use the setup link provided during workspace provisioning.',
       );
     }
-
     if (providedToken !== expectedToken) {
-      this.recordFailedClaimAttempt(now);
+      this.recordFailedClaimAttempt(key, now);
       throw new BadRequestException(
         'Invalid onboarding token. Please use the correct setup link.',
       );
     }
 
-    // Successful validation resets the counter.
-    this.claimAttempts = { count: 0, windowStart: 0 };
+    // Success clears this IP's bucket only — the global backstop keeps its
+    // window (success from one IP must not reset distributed-guessing math).
+    this.claimAttempts.delete(key);
   }
 
-  /**
-   * Record a failed claim-token attempt for rate limiting. Only stamps
-   * `windowStart` on the first failure of a window, so subsequent failures
-   * within the same window don't push the window forward (fixed window, not
-   * sliding).
-   */
-  private recordFailedClaimAttempt(now: number): void {
-    if (this.claimAttempts.count === 0) {
-      this.claimAttempts.windowStart = now;
-    }
-    this.claimAttempts.count += 1;
+  private recordFailedClaimAttempt(key: string, now: number): void {
+    const bucket = this.claimAttempts.get(key) ?? { count: 0, windowStart: 0 };
+    if (bucket.count === 0) bucket.windowStart = now;
+    bucket.count += 1;
+    this.claimAttempts.set(key, bucket);
+    if (this.claimGlobal.count === 0) this.claimGlobal.windowStart = now;
+    this.claimGlobal.count += 1;
   }
 
   /**
@@ -487,9 +478,9 @@ export class SetupService {
   /**
    * Initialize system with first admin user
    */
-  async initialize(dto: InitializeSystemDto): Promise<InitializeResponseDto> {
+  async initialize(dto: InitializeSystemDto, clientIp?: string): Promise<InitializeResponseDto> {
     // Validate onboarding token (prevents unauthorized admin creation)
-    this.validateOnboardingToken(dto.token);
+    this.validateOnboardingToken(dto.token, clientIp);
 
     // Check if setup is already complete
     const status = await this.getSetupStatus();
@@ -2440,9 +2431,10 @@ export class SetupService {
     sessionUserId: string,
     sessionEmail: string,
     token?: string,
+    clientIp?: string,
   ): Promise<{ message: string; userId: string; email: string }> {
     // Validate onboarding token (prevents unauthorized admin creation)
-    this.validateOnboardingToken(token);
+    this.validateOnboardingToken(token, clientIp);
 
     // Check if setup is already complete
     const status = await this.getSetupStatus();
@@ -2519,9 +2511,10 @@ export class SetupService {
     email: string,
     password: string,
     token?: string,
+    clientIp?: string,
   ): Promise<{ message: string; userId: string; email: string }> {
     // Validate onboarding token (prevents unauthorized admin creation)
-    this.validateOnboardingToken(token);
+    this.validateOnboardingToken(token, clientIp);
 
     // Check if setup is already complete
     const status = await this.getSetupStatus();

--- a/apps/frontend/src/components/settings/primary-ssl/ServingModelEditor.tsx
+++ b/apps/frontend/src/components/settings/primary-ssl/ServingModelEditor.tsx
@@ -120,23 +120,24 @@ export function ServingModelEditor({
         }}
       />
 
-      {value.servingMode !== 'cloudflare' && (
+      {value.servingMode !== 'cloudflare' ? (
         <div className="space-y-4 pl-1">
           {value.sslMode === 'letsencrypt' ? (
             <p className="text-sm text-muted-foreground">
               Port 80 stays open so Let&apos;s Encrypt can validate over HTTP-01.
             </p>
           ) : (
-            <Port80Choice
-              value={value.port80}
-              onChange={(port80) => onChange({ ...value, port80 })}
-            />
+            <Port80Choice value={value.port80} onChange={(port80) => onChange({ ...value, port80 })} />
           )}
           <RealIpFields
             header={value.realIp?.header ?? ''}
             ranges={value.realIp?.ranges ?? ''}
             onChange={(realIp) => onChange({ ...value, realIp })}
           />
+        </div>
+      ) : (
+        <div className="space-y-4 pl-1">
+          <Port80Choice value={value.port80} onChange={(port80) => onChange({ ...value, port80 })} />
         </div>
       )}
 

--- a/apps/frontend/src/components/settings/primary-ssl/ServingModelEditor.tsx
+++ b/apps/frontend/src/components/settings/primary-ssl/ServingModelEditor.tsx
@@ -32,6 +32,31 @@ function presetSslFor(mode: ServingMode): SslMode {
   return 'letsencrypt';
 }
 
+// Wizard-parity cert-source sets (mirrors the wizard's per-path choices:
+// CertificatePhase + the proxy path's three modes). The wizard promises
+// "change this later in Settings → SSL" — this selector is that promise
+// (v0.2.18 review, m11).
+export function allowedSslModesFor(mode: ServingMode): SslMode[] {
+  if (mode === 'proxy') return ['selfsigned', 'letsencrypt', 'paste'];
+  if (mode === 'cloudflare') return ['paste'];
+  return ['letsencrypt', 'paste'];
+}
+
+const SSL_MODE_LABELS: Record<SslMode, { label: string; hint: string }> = {
+  selfsigned: {
+    label: 'Keep the built-in certificate',
+    hint: 'Zero maintenance. Works with CDNs that don’t validate the origin certificate.',
+  },
+  letsencrypt: {
+    label: "Auto-issue with Let's Encrypt",
+    hint: 'A real auto-renewing certificate on this server. Needs ACME challenges to reach the origin.',
+  },
+  paste: {
+    label: 'Paste my own certificate',
+    hint: 'Your CDN’s origin certificate or any browser-trusted cert. Re-paste when it expires.',
+  },
+};
+
 function errorMessage(error: unknown, fallback: string): string {
   const err = error as { data?: { message?: string } };
   return err?.data?.message || fallback;
@@ -107,6 +132,10 @@ export function ServingModelEditor({
       <ServingChoiceCards
         value={value.servingMode}
         onChange={(mode) => {
+          // The preset still applies on every mode change (unchanged
+          // behavior) — it's the best default for that serving path. The
+          // cert-source selector below then lets the user adjust within the
+          // newly-allowed set afterward (m11 wizard parity).
           const sslMode = presetSslFor(mode);
           onChange({
             ...value,
@@ -119,6 +148,36 @@ export function ServingModelEditor({
           });
         }}
       />
+
+      {allowedSslModesFor(value.servingMode).length > 1 && (
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-foreground">Certificate for the origin</p>
+          {allowedSslModesFor(value.servingMode).map((mode) => (
+            <label key={mode} className="flex items-start text-sm cursor-pointer">
+              <input
+                type="radio"
+                name="day2-ssl-mode"
+                checked={value.sslMode === mode}
+                onChange={() =>
+                  onChange({
+                    ...value,
+                    sslMode: mode,
+                    // LE is HTTP-01: mirrors the wizard's ProxyOptions clearing
+                    // of a stale 'closed' pick.
+                    port80: mode === 'letsencrypt' ? 'redirect' : value.port80,
+                  })
+                }
+                className="mt-0.5 mr-2"
+                aria-label={SSL_MODE_LABELS[mode].label}
+              />
+              <span>
+                <span className="font-medium">{SSL_MODE_LABELS[mode].label}</span>{' '}
+                <span className="text-muted-foreground">{SSL_MODE_LABELS[mode].hint}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+      )}
 
       {value.servingMode !== 'cloudflare' ? (
         <div className="space-y-4 pl-1">

--- a/apps/frontend/src/components/settings/primary-ssl/__tests__/ServingModelEditor.test.tsx
+++ b/apps/frontend/src/components/settings/primary-ssl/__tests__/ServingModelEditor.test.tsx
@@ -57,6 +57,12 @@ describe('ServingModelEditor', () => {
     expect(screen.getByRole('radio', { name: /close port 80/i })).toBeInTheDocument();
   });
 
+  it('m12: shows the port-80 control on the cloudflare path (and no realIp fields)', () => {
+    render(<ServingModelEditor value={{ ...base, servingMode: 'cloudflare', sslMode: 'paste' }} onChange={vi.fn()} />);
+    expect(screen.getByText('Port 80 (HTTP)')).toBeInTheDocument();
+    expect(screen.queryByText(/Restore visitor IPs/i)).not.toBeInTheDocument();
+  });
+
   it('reactively forces port80 to redirect when seeded with letsencrypt + closed', () => {
     const onChange = vi.fn();
     render(

--- a/apps/frontend/src/components/settings/primary-ssl/__tests__/ServingModelEditor.test.tsx
+++ b/apps/frontend/src/components/settings/primary-ssl/__tests__/ServingModelEditor.test.tsx
@@ -170,4 +170,32 @@ describe('ServingModelEditor', () => {
       expect(button).not.toBeDisabled();
     });
   });
+
+  describe('m11 cert-source selector', () => {
+    it('proxy path offers selfsigned/letsencrypt/paste', () => {
+      render(<ServingModelEditor value={{ ...base, servingMode: 'proxy', sslMode: 'selfsigned' }} onChange={vi.fn()} />);
+      expect(screen.getByLabelText(/Keep the built-in certificate/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Auto-issue with Let's Encrypt/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Paste my own certificate/i)).toBeInTheDocument();
+    });
+
+    it('cloudflare path offers no selector (paste only)', () => {
+      render(<ServingModelEditor value={{ ...base, servingMode: 'cloudflare', sslMode: 'paste' }} onChange={vi.fn()} />);
+      expect(screen.queryByLabelText(/Keep the built-in certificate/i)).not.toBeInTheDocument();
+    });
+
+    it('direct path offers letsencrypt/paste, not selfsigned', () => {
+      render(<ServingModelEditor value={{ ...base, servingMode: 'none', sslMode: 'letsencrypt' }} onChange={vi.fn()} />);
+      expect(screen.getByLabelText(/Auto-issue with Let's Encrypt/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Paste my own certificate/i)).toBeInTheDocument();
+      expect(screen.queryByLabelText(/Keep the built-in certificate/i)).not.toBeInTheDocument();
+    });
+
+    it('selecting paste on the proxy path swaps in the paste fields', () => {
+      const onChange = vi.fn();
+      render(<ServingModelEditor value={{ ...base, servingMode: 'proxy', sslMode: 'selfsigned' }} onChange={onChange} />);
+      fireEvent.click(screen.getByLabelText(/Paste my own certificate/i));
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ sslMode: 'paste' }));
+    });
+  });
 });

--- a/apps/frontend/src/components/setup/ApplyStep.tsx
+++ b/apps/frontend/src/components/setup/ApplyStep.tsx
@@ -48,8 +48,8 @@ export function ApplyStep() {
   const isLetsEncrypt = sslMode === 'letsencrypt';
   // Port 80 handling, resolved the same way bootstrap-setup.service's
   // validateApplyConfig defaults it server-side: 'redirect' whenever the user
-  // hasn't chosen explicitly (commit 23689df) — including cloudflare, which
-  // used to default to 'closed' before that change.
+  // hasn't chosen explicitly (v0.2.18 review, m13) — including cloudflare,
+  // which used to default to 'closed' before that change.
   const resolvedPort80 = bootstrapPort80 ?? 'redirect';
   // Visitor-IP restore: cloudflare always trusts Cloudflare's ranges (preset,
   // no user input needed), proxy mode only restores it when a custom

--- a/apps/frontend/src/components/setup/ApplyStep.tsx
+++ b/apps/frontend/src/components/setup/ApplyStep.tsx
@@ -47,11 +47,10 @@ export function ApplyStep() {
   const sslMode: BootstrapSslMode = bootstrapSslMode ?? 'paste';
   const isLetsEncrypt = sslMode === 'letsencrypt';
   // Port 80 handling, resolved the same way bootstrap-setup.service's
-  // validateApplyConfig defaults it server-side: closed for cloudflare
-  // (nothing needs it — the ACME challenge, if any, is served through the
-  // proxy), open/redirect otherwise (proxy/none both need it reachable, the
-  // latter for Let's Encrypt HTTP-01 renewal).
-  const resolvedPort80 = bootstrapPort80 ?? (servingMode === 'cloudflare' ? 'closed' : 'redirect');
+  // validateApplyConfig defaults it server-side: 'redirect' whenever the user
+  // hasn't chosen explicitly (commit 23689df) — including cloudflare, which
+  // used to default to 'closed' before that change.
+  const resolvedPort80 = bootstrapPort80 ?? 'redirect';
   // Visitor-IP restore: cloudflare always trusts Cloudflare's ranges (preset,
   // no user input needed), proxy mode only restores it when a custom
   // header/ranges were configured, and direct serving has nothing in front

--- a/apps/frontend/src/components/setup/__tests__/ApplyStep.test.tsx
+++ b/apps/frontend/src/components/setup/__tests__/ApplyStep.test.tsx
@@ -141,6 +141,20 @@ describe('ApplyStep', () => {
     expect(screen.queryByRole('radio')).not.toBeInTheDocument();
   });
 
+  it('shows the port-80 summary as open/redirect for cloudflare when unset, matching the backend default', () => {
+    // The backend (bootstrap-setup.service's validateApplyConfig) now defaults
+    // an unset port80 to 'redirect' even for cloudflare (commit 23689df) — it
+    // used to default to 'closed'. The summary must reflect what the backend
+    // will actually apply, not the old default.
+    renderWithStore(<ApplyStep />, {
+      bootstrapDomain: 'example.com',
+      servingMode: 'cloudflare',
+      bootstrapSslMode: 'paste',
+    });
+    expect(screen.getByText(/open \(redirects to https\)/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^closed$/i)).not.toBeInTheDocument();
+  });
+
   it('LE path pre-satisfies the DNS confirmation', () => {
     renderWithStore(<ApplyStep />, {
       bootstrapDomain: 'example.com',

--- a/apps/frontend/src/components/setup/__tests__/ApplyStep.test.tsx
+++ b/apps/frontend/src/components/setup/__tests__/ApplyStep.test.tsx
@@ -143,9 +143,9 @@ describe('ApplyStep', () => {
 
   it('shows the port-80 summary as open/redirect for cloudflare when unset, matching the backend default', () => {
     // The backend (bootstrap-setup.service's validateApplyConfig) now defaults
-    // an unset port80 to 'redirect' even for cloudflare (commit 23689df) — it
-    // used to default to 'closed'. The summary must reflect what the backend
-    // will actually apply, not the old default.
+    // an unset port80 to 'redirect' even for cloudflare (v0.2.18 review, m13)
+    // — it used to default to 'closed'. The summary must reflect what the
+    // backend will actually apply, not the old default.
     renderWithStore(<ApplyStep />, {
       bootstrapDomain: 'example.com',
       servingMode: 'cloudflare',

--- a/apps/frontend/src/components/setup/__tests__/CertificatePhase.test.tsx
+++ b/apps/frontend/src/components/setup/__tests__/CertificatePhase.test.tsx
@@ -117,6 +117,14 @@ describe('CertificatePhase', () => {
     expect(screen.queryByText(/restore visitor ips/i)).not.toBeInTheDocument();
   });
 
+  it('m13: cloudflare path renders the port-80 choice above the paste form', () => {
+    renderWithStore(<CertificatePhase domain="example.com" onBack={noop} />, {
+      servingMode: 'cloudflare',
+      bootstrapSslMode: 'paste',
+    });
+    expect(screen.getByText('Port 80 (HTTP)')).toBeInTheDocument();
+  });
+
   it('proxy path renders neutral copy and the visitor-IP option', () => {
     // servingMode 'proxy' now defaults bootstrapSslMode to 'selfsigned'
     // (Task 5); explicitly select 'paste' here to exercise the

--- a/apps/frontend/src/components/setup/domain-ssl/CertificatePhase.tsx
+++ b/apps/frontend/src/components/setup/domain-ssl/CertificatePhase.tsx
@@ -28,5 +28,15 @@ export function CertificatePhase({ domain, onBack }: CertificatePhaseProps) {
       </div>
     );
   }
+  // Cloudflare: port 80 is a real choice (redirect default per m13); realIp
+  // is preset server-side so only the port control shows.
+  if (servingMode === 'cloudflare') {
+    return (
+      <div className="space-y-6">
+        <ProxyOptions showRealIp={false} />
+        {certView}
+      </div>
+    );
+  }
   return certView;
 }

--- a/apps/frontend/src/components/setup/domain-ssl/ProxyOptions.tsx
+++ b/apps/frontend/src/components/setup/domain-ssl/ProxyOptions.tsx
@@ -11,7 +11,7 @@ import { Port80Choice } from '@/components/ssl-leaves/Port80Choice';
 // reads them back. The realIp fields are OPTIONAL — invalid input shows an
 // inline error and simply isn't applied (dispatched as null), rather than
 // hard-blocking; the backend combo-validation is the authoritative gate.
-export function ProxyOptions() {
+export function ProxyOptions({ showRealIp = true }: { showRealIp?: boolean } = {}) {
   const dispatch = useDispatch();
   const bootstrapSslMode = useSelector((s: RootState) => s.setup.wizard.bootstrapSslMode);
   const [rangesText, setRangesText] = useState('');
@@ -56,17 +56,19 @@ export function ProxyOptions() {
 
   return (
     <div className="space-y-4">
-      <RealIpFields
-        header={header}
-        ranges={rangesText}
-        onChange={({ header: nextHeader, ranges: nextRanges }) => {
-          setRangesText(nextRanges);
-          setHeader(nextHeader);
-          applyRealIp(nextRanges, nextHeader);
-        }}
-        headerError={headerError}
-        rangesError={rangesError}
-      />
+      {showRealIp && (
+        <RealIpFields
+          header={header}
+          ranges={rangesText}
+          onChange={({ header: nextHeader, ranges: nextRanges }) => {
+            setRangesText(nextRanges);
+            setHeader(nextHeader);
+            applyRealIp(nextRanges, nextHeader);
+          }}
+          headerError={headerError}
+          rangesError={rangesError}
+        />
+      )}
       {bootstrapSslMode !== 'letsencrypt' ? (
         <Port80Choice
           value={port80}

--- a/apps/frontend/src/components/ssl-leaves/ServingChoiceCards.tsx
+++ b/apps/frontend/src/components/ssl-leaves/ServingChoiceCards.tsx
@@ -4,7 +4,7 @@ const CHOICES: { mode: ServingMode; title: string; body: string }[] = [
   {
     mode: 'cloudflare',
     title: 'Through Cloudflare (recommended)',
-    body: 'Cloudflare proxies your traffic and terminates TLS at its edge. You paste a free Origin Certificate; port 80 stays closed.',
+    body: 'Cloudflare proxies your traffic and terminates TLS at its edge. You paste a free Origin Certificate; plain HTTP redirects to HTTPS (you can close port 80 instead if you enable Always Use HTTPS in Cloudflare).',
   },
   {
     mode: 'proxy',

--- a/docker/nginx/render-main-conf.sh
+++ b/docker/nginx/render-main-conf.sh
@@ -130,8 +130,21 @@ if [ "${SSL_MODE}" = "selfsigned" ]; then
     # built-in self-signed cert — no real cert is ever pasted or issued. Serve
     # it for both the admin and wildcard vhosts.
     if [ ! -f "${SSL_DIR}/bootstrap-selfsigned.crt" ] || [ ! -f "${SSL_DIR}/bootstrap-selfsigned.key" ]; then
-        echo "❌ SSL_MODE=selfsigned but bootstrap-selfsigned.crt/.key is missing"
-        exit 1
+        # Env-ADOPTED installs never have the pair (adoption gates on its
+        # absence; only the bootstrap-mode branch above generates it), so a
+        # day-2 switch to selfsigned would otherwise dead-end: exit-1 here is
+        # a silent no-op under the watcher and a crash-loop via the
+        # entrypoint on the next restart (v0.2.18 review, C1). Generate on
+        # demand — same shape as the bootstrap-mode generation. Writing the
+        # marker on a NORMAL-mode install is fine: should_bootstrap() /
+        # isLegacyEnvInstall() only consult it before an applied
+        # instance.env exists, and reaching this branch requires one.
+        echo "🔐 SSL_MODE=selfsigned with no pair on disk — generating it"
+        openssl req -x509 -nodes -days 825 -newkey rsa:2048 \
+            -keyout "${SSL_DIR}/bootstrap-selfsigned.key" \
+            -out "${SSL_DIR}/bootstrap-selfsigned.crt" \
+            -subj "/CN=bffless-bootstrap" 2>/dev/null
+        chmod 600 "${SSL_DIR}/bootstrap-selfsigned.key"
     fi
     echo "✅ Serving the built-in self-signed certificate (a proxy terminates browser TLS)"
     # Backend-generated vhost configs (primary-content, custom/subdomain blocks)

--- a/docker/nginx/render-main-conf.test.sh
+++ b/docker/nginx/render-main-conf.test.sh
@@ -162,4 +162,27 @@ else
     FAILURES=$((FAILURES+1))
 fi
 
+# --- C1: selfsigned WITHOUT a pre-existing pair (env-adopted install) ---
+# Adoption gates on the marker being ABSENT, so an adopted install that
+# switches to selfsigned day-2 has no bootstrap-selfsigned.* at all. The
+# render must generate the pair on demand instead of exit-1 (which silently
+# no-ops under the watcher and crash-loops nginx on the next restart).
+setup_etc 'STATE=applied
+PRIMARY_DOMAIN=example.com
+PROXY_MODE=proxy
+SSL_MODE=selfsigned
+PORT80=redirect
+REALIP_MODE=off'
+rm -f "$ETC/ssl/bootstrap-selfsigned.crt" "$ETC/ssl/bootstrap-selfsigned.key"
+rm -f "$ETC/ssl/fullchain.pem" "$ETC/ssl/privkey.pem"
+run_render
+[ -f "$ETC/ssl/bootstrap-selfsigned.crt" ] && echo "ok: C1 pair generated on demand" \
+    || { echo "FAIL: C1 selfsigned pair not generated"; FAILURES=$((FAILURES+1)); }
+[ -f "$ETC/ssl/fullchain.pem" ] && echo "ok: C1 fullchain materialized" \
+    || { echo "FAIL: C1 fullchain.pem not materialized"; FAILURES=$((FAILURES+1)); }
+key_mode=$(stat -c '%a' "$ETC/ssl/bootstrap-selfsigned.key" 2>/dev/null || stat -f '%Lp' "$ETC/ssl/bootstrap-selfsigned.key")
+[ "$key_mode" = "600" ] && echo "ok: C1 key is 0600" \
+    || { echo "FAIL: C1 key mode is $key_mode"; FAILURES=$((FAILURES+1)); }
+assert_contains "$ETC/sites-available/main.conf" 'bootstrap-selfsigned.crt' 'C1: vhosts serve the generated pair'
+
 [ "$FAILURES" -eq 0 ] && echo 'ALL RENDER TESTS PASSED' || { echo "$FAILURES FAILURES"; exit 1; }

--- a/docs/releases/v0.2.18-upgrade-notes.md
+++ b/docs/releases/v0.2.18-upgrade-notes.md
@@ -1,0 +1,23 @@
+# Upgrading to v0.2.18
+
+**`git pull` is a required upgrade step for this release.** v0.2.18 adds
+compose mounts (`bootstrap/`), an `ONBOARDING_TOKEN` passthrough, and a
+rebuilt nginx image. Pulling only the Docker images leaves the new day-2 SSL
+management silently inert (settings apply but never reach nginx) and breaks
+automatic renewal takeover for migrated Let's Encrypt installs.
+
+```bash
+cd /opt/bffless && git pull && ./stop.sh && docker compose pull && ./start.sh
+```
+
+Notes for upgraders:
+
+- **Migrated (pre-wizard) installs** are adopted automatically on first boot:
+  `bootstrap/instance.json` appears with `origin: "env"` and your `.env`
+  stays authoritative. No action needed.
+- **One-time rollback quirk:** if you had used cert staging before this
+  upgrade, the first SSL change cycle after upgrading may roll back one step
+  further than expected, then self-heals (see #516).
+- **If nginx ever serves the setup wizard on your production domain** after
+  cert files went briefly missing, recover with:
+  `rm ssl/bootstrap-selfsigned.crt ssl/bootstrap-selfsigned.key && docker compose restart nginx`

--- a/docs/superpowers/plans/2026-07-25-v0218-review-fixes.md
+++ b/docs/superpowers/plans/2026-07-25-v0218-review-fixes.md
@@ -1,0 +1,1291 @@
+# v0.2.18 Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix every finding from the v0.2.18 release review (spec: `docs/superpowers/specs/2026-07-25-v0218-review-fixes-design.md`) — one critical crash-loop, three major gaps, and the minor hardening/UX set — so the release ships without a known foot-gun.
+
+**Architecture:** Small, surgical changes across four surfaces: the nginx render script (shell), the bootstrap/setup + SSL backend (NestJS), the wizard/day-2 SSL frontend (React), and the repo-root install scripts. No schema changes, no new endpoints, no new deps.
+
+**Tech Stack:** POSIX sh (render script), bash (root scripts), NestJS + Jest (backend), React + Redux Toolkit + Vitest (frontend).
+
+## Global Constraints
+
+- Branch: `spec/v0218-review-fixes` (this worktree). One PR into `main`, merged **before** release PR #515 is cut.
+- Existing installs' applied knobs are never rewritten; only defaults for *new* choices change (spec: m12/m13). `deriveKnobs`' v1 derivation (`cloudflare → closed`) must stay unchanged.
+- Never delete `ssl/bootstrap-selfsigned.*` automatically (spec non-goal).
+- Backend tests: `cd apps/backend && pnpm test -- <pattern>`. Frontend: `cd apps/frontend && pnpm test -- <pattern>`. Render harness: `sh docker/nginx/render-main-conf.test.sh`.
+- Commit after every task (conventional commits, present tense). Run `pnpm --filter backend exec tsc --noEmit` / `pnpm --filter frontend exec tsc --noEmit` before each commit that touches TS.
+
+---
+
+### Task 1: C1 — render script generates the selfsigned pair on demand
+
+**Files:**
+- Modify: `docker/nginx/render-main-conf.sh:132-135` (the selfsigned missing-pair guard)
+- Test: `docker/nginx/render-main-conf.test.sh` (new case at end, before the exit-code footer)
+
+**Interfaces:**
+- Produces: `SSL_MODE=selfsigned` render succeeds with no pre-existing pair; generates `bootstrap-selfsigned.crt/.key` (0600 key) in `${SSL_DIR}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `docker/nginx/render-main-conf.test.sh` (before the final `if [ "$FAILURES" ...` block; follow the existing `setup_etc`/`run_render` pattern). Note `setup_etc` pre-creates marker files with `touch` — this case must delete them to simulate an adopted install:
+
+```sh
+# --- C1: selfsigned WITHOUT a pre-existing pair (env-adopted install) ---
+# Adoption gates on the marker being ABSENT, so an adopted install that
+# switches to selfsigned day-2 has no bootstrap-selfsigned.* at all. The
+# render must generate the pair on demand instead of exit-1 (which silently
+# no-ops under the watcher and crash-loops nginx on the next restart).
+setup_etc 'STATE=applied
+PRIMARY_DOMAIN=example.com
+PROXY_MODE=proxy
+SSL_MODE=selfsigned
+PORT80=redirect
+REALIP_MODE=off'
+rm -f "$ETC/ssl/bootstrap-selfsigned.crt" "$ETC/ssl/bootstrap-selfsigned.key"
+rm -f "$ETC/ssl/fullchain.pem" "$ETC/ssl/privkey.pem"
+run_render
+[ -f "$ETC/ssl/bootstrap-selfsigned.crt" ] && echo "ok: C1 pair generated on demand" \
+    || { echo "FAIL: C1 selfsigned pair not generated"; FAILURES=$((FAILURES+1)); }
+[ -f "$ETC/ssl/fullchain.pem" ] && echo "ok: C1 fullchain materialized" \
+    || { echo "FAIL: C1 fullchain.pem not materialized"; FAILURES=$((FAILURES+1)); }
+key_mode=$(stat -c '%a' "$ETC/ssl/bootstrap-selfsigned.key" 2>/dev/null || stat -f '%Lp' "$ETC/ssl/bootstrap-selfsigned.key")
+[ "$key_mode" = "600" ] && echo "ok: C1 key is 0600" \
+    || { echo "FAIL: C1 key mode is $key_mode"; FAILURES=$((FAILURES+1)); }
+assert_contains "$ETC/sites-available/main.conf" 'bootstrap-selfsigned.crt' 'C1: vhosts serve the generated pair'
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `sh docker/nginx/render-main-conf.test.sh`
+Expected: the new case FAILs — `run_render` exits 1 (`set -e` aborts the harness) or the pair-generated assertion fails. If `set -e` aborts the whole harness, that IS the failure signal.
+
+- [ ] **Step 3: Implement**
+
+In `docker/nginx/render-main-conf.sh`, replace the guard (currently lines 132-135):
+
+```sh
+    if [ ! -f "${SSL_DIR}/bootstrap-selfsigned.crt" ] || [ ! -f "${SSL_DIR}/bootstrap-selfsigned.key" ]; then
+        echo "❌ SSL_MODE=selfsigned but bootstrap-selfsigned.crt/.key is missing"
+        exit 1
+    fi
+```
+
+with:
+
+```sh
+    if [ ! -f "${SSL_DIR}/bootstrap-selfsigned.crt" ] || [ ! -f "${SSL_DIR}/bootstrap-selfsigned.key" ]; then
+        # Env-ADOPTED installs never have the pair (adoption gates on its
+        # absence; only the bootstrap-mode branch above generates it), so a
+        # day-2 switch to selfsigned would otherwise dead-end: exit-1 here is
+        # a silent no-op under the watcher and a crash-loop via the
+        # entrypoint on the next restart (v0.2.18 review, C1). Generate on
+        # demand — same shape as the bootstrap-mode generation. Writing the
+        # marker on a NORMAL-mode install is fine: should_bootstrap() /
+        # isLegacyEnvInstall() only consult it before an applied
+        # instance.env exists, and reaching this branch requires one.
+        echo "🔐 SSL_MODE=selfsigned with no pair on disk — generating it"
+        openssl req -x509 -nodes -days 825 -newkey rsa:2048 \
+            -keyout "${SSL_DIR}/bootstrap-selfsigned.key" \
+            -out "${SSL_DIR}/bootstrap-selfsigned.crt" \
+            -subj "/CN=bffless-bootstrap" 2>/dev/null
+        chmod 600 "${SSL_DIR}/bootstrap-selfsigned.key"
+    fi
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `sh docker/nginx/render-main-conf.test.sh`
+Expected: all cases `ok`, exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/nginx/render-main-conf.sh docker/nginx/render-main-conf.test.sh
+git commit -m "fix(ssl): render generates the selfsigned pair on demand — day-2 selfsigned on adopted installs no longer arms a crash-loop (C1)"
+```
+
+---
+
+### Task 2: C1 end-to-end — adopted-install selfsigned leg in test-bootstrap.sh
+
+**Files:**
+- Modify: `test-bootstrap.sh` (new opt-in leg after the `RUN_LEGACY_LEG` block, same else-skip pattern)
+- Modify: `.github/workflows/pr-tests.yml` only if the legacy leg is wired there (check with `grep -n RUN_LEGACY_LEG .github/workflows/*.yml`; mirror whatever gating it uses — if it is not wired in CI, skip the workflow change and note it in the commit body).
+
+**Interfaces:**
+- Consumes: the running stack + helpers already defined in `test-bootstrap.sh` (`info`, `ok`, `fail`, `wait_until`), and Task 1's render behavior.
+
+- [ ] **Step 1: Write the leg** (this is shell — the "failing test" is running it before Task 1's fix would have been the failure; with Task 1 landed it must pass)
+
+Append after the `RUN_LEGACY_LEG` block, following its structure exactly:
+
+```sh
+# ===========================================================================
+# Adopted-install day-2 selfsigned leg (opt-in: RUN_ADOPTED_SELFSIGNED_LEG=1).
+# C1 regression (v0.2.18 review): an env-adopted install has NO
+# bootstrap-selfsigned pair; switching its instance.env to SSL_MODE=selfsigned
+# must still render (the script generates the pair) and must survive an nginx
+# restart. Builds on the legacy leg's hand-made env install.
+#   RUN_ADOPTED_SELFSIGNED_LEG=1 ./test-bootstrap.sh
+# ===========================================================================
+if [ "${RUN_ADOPTED_SELFSIGNED_LEG:-0}" = "1" ]; then
+    info "adopted-selfsigned leg: tearing down, building a legacy env install"
+    docker compose --profile postgres --profile minio --profile redis --profile supertokens down -v >/dev/null 2>&1
+    rm -rf bootstrap ssl
+    mkdir -p bootstrap ssl
+
+    ADOPT_DOMAIN="adopted-ss.local"
+    sed -i "s/^PRIMARY_DOMAIN=.*/PRIMARY_DOMAIN=${ADOPT_DOMAIN}/" .env
+    grep -q '^PROXY_MODE=' .env && sed -i 's/^PROXY_MODE=.*/PROXY_MODE=proxy/' .env || echo 'PROXY_MODE=proxy' >> .env
+    openssl req -x509 -nodes -days 2 -newkey rsa:2048 -keyout ssl/privkey.pem \
+        -out ssl/fullchain.pem -subj "/CN=${ADOPT_DOMAIN}" 2>/dev/null
+    cp ssl/fullchain.pem "ssl/wildcard.${ADOPT_DOMAIN}.crt"
+    cp ssl/privkey.pem "ssl/wildcard.${ADOPT_DOMAIN}.key"
+
+    ./start.sh
+    wait_until 90 "adopted-selfsigned leg: backend to adopt the env identity" -- \
+        bash -c 'docker compose logs backend 2>/dev/null | grep -q "adopted env identity into instance.json"'
+    [ ! -f ssl/bootstrap-selfsigned.crt ] \
+        || fail "adopted-selfsigned leg: precondition broken — pair already exists"
+
+    # Day-2 switch to proxy+selfsigned, exactly as PrimarySslService.apply()
+    # writes it (we edit the files directly: the leg tests the RENDER path,
+    # not the session-guarded admin API).
+    python3 - <<'PYEOF'
+import json
+cfg = json.load(open('bootstrap/instance.json'))
+cfg['sslMode'] = 'selfsigned'
+cfg['proxyMode'] = 'proxy'
+open('bootstrap/instance.json', 'w').write(json.dumps(cfg, indent=2) + '\n')
+PYEOF
+    sed -i 's/^SSL_MODE=.*/SSL_MODE=selfsigned/; s/^PROXY_MODE=.*/PROXY_MODE=proxy/' bootstrap/instance.env
+
+    wait_until 60 "adopted-selfsigned leg: watcher render generates the pair" -- \
+        test -f ssl/bootstrap-selfsigned.crt
+    ok "adopted-selfsigned leg: pair generated on demand"
+
+    docker compose restart nginx >/dev/null 2>&1
+    wait_until 60 "adopted-selfsigned leg: nginx healthy after restart" -- \
+        bash -c 'docker compose ps nginx | grep -q "Up"'
+    sleep 5
+    docker compose ps nginx | grep -q "Restarting" \
+        && fail "adopted-selfsigned leg: nginx is crash-looping after restart"
+    ok "adopted-selfsigned leg passed: selfsigned renders and survives restart"
+else
+    info "skipping adopted-selfsigned leg (set RUN_ADOPTED_SELFSIGNED_LEG=1 — needs its own fresh stack boot)"
+fi
+```
+
+- [ ] **Step 2: Syntax-check and dry-run the skip path**
+
+Run: `bash -n test-bootstrap.sh && sh docker/nginx/render-main-conf.test.sh`
+Expected: no syntax errors; render harness still green. (The full leg needs a compose stack — CI/droplet runs it; do not run it in this workspace.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test-bootstrap.sh
+git commit -m "test(bootstrap): adopted-install day-2 selfsigned leg (RUN_ADOPTED_SELFSIGNED_LEG=1) — C1 regression"
+```
+
+---
+
+### Task 3: instance-config hardening — placeholder warning (m2), trap warning (M2), hostname validation
+
+**Files:**
+- Modify: `apps/backend/src/bootstrap/instance-config.ts`
+- Test: `apps/backend/src/bootstrap/instance-config.spec.ts`
+
+**Interfaces:**
+- Produces: `envIdentity()` returns `null` for non-hostname `PRIMARY_DOMAIN` values; `adoptOrResyncEnvInstall()` logs `[bootstrap] legacy install is stuck in bootstrap mode` when marker+certs+identity coexist; wizard-file divergence warning silent for the compose placeholder.
+
+- [ ] **Step 1: Write the failing tests** (three cases in `instance-config.spec.ts`, following the existing spec's tmp-dir fixture style)
+
+```ts
+describe('v0218 review hardening', () => {
+  it('m2: does not warn about divergence when .env holds the compose placeholder', () => {
+    // fixture: wizard-origin instance.json (primaryDomain example.com), env PRIMARY_DOMAIN=yourdomain.com
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    writeInstanceConfig({ version: 2, state: 'applied', origin: 'wizard', primaryDomain: 'example.com', sslMode: 'paste' }, dir);
+    adoptOrResyncEnvInstall(dir, { PRIMARY_DOMAIN: 'yourdomain.com' } as NodeJS.ProcessEnv, ssl);
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('differs from wizard-managed'));
+    warn.mockRestore();
+  });
+
+  it('m2: still warns when .env holds a genuinely different real domain', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    writeInstanceConfig({ version: 2, state: 'applied', origin: 'wizard', primaryDomain: 'example.com', sslMode: 'paste' }, dir);
+    adoptOrResyncEnvInstall(dir, { PRIMARY_DOMAIN: 'other.com' } as NodeJS.ProcessEnv, ssl);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('differs from wizard-managed'));
+    warn.mockRestore();
+  });
+
+  it('hostname hardening: refuses adoption of a shell-metacharacter PRIMARY_DOMAIN', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // real certs on disk so only the hostname gate can refuse
+    fs.writeFileSync(path.join(ssl, 'fullchain.pem'), 'x');
+    fs.writeFileSync(path.join(ssl, 'privkey.pem'), 'x');
+    const out = adoptOrResyncEnvInstall(dir, { PRIMARY_DOMAIN: 'evil.com; rm -rf /' } as NodeJS.ProcessEnv, ssl);
+    expect(out).toBeNull();
+    expect(fs.existsSync(path.join(dir, 'instance.json'))).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('not a valid hostname'));
+    warn.mockRestore();
+  });
+
+  it('M2: warns loudly when the bootstrap trap state is detected', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    fs.writeFileSync(path.join(ssl, 'fullchain.pem'), 'x');
+    fs.writeFileSync(path.join(ssl, 'privkey.pem'), 'x');
+    fs.writeFileSync(path.join(ssl, 'bootstrap-selfsigned.crt'), 'x'); // the trap marker
+    adoptOrResyncEnvInstall(dir, { PRIMARY_DOMAIN: 'example.com' } as NodeJS.ProcessEnv, ssl);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('stuck in bootstrap mode'));
+    warn.mockRestore();
+  });
+});
+```
+
+Adapt fixture variable names (`dir`, `ssl`) to the spec file's existing `beforeEach` tmp-dir setup — reuse it, don't duplicate.
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `cd apps/backend && pnpm test -- instance-config.spec -t "v0218 review hardening"`
+Expected: 4 FAIL (placeholder still warns; metachar domain adopted; no trap warning; second m2 case may pass — that is fine, it is the guard-rail).
+
+- [ ] **Step 3: Implement in `instance-config.ts`**
+
+(a) Add a hostname gate. Near `SHELL_SAFE_HEADER_RE`:
+
+```ts
+// Same shape the DTO layer enforces (bootstrap-setup.service HOSTNAME_RE):
+// dot-separated LDH labels. Applied at adoption because .env's PRIMARY_DOMAIN
+// is the one identity input that bypasses DTO validation yet still lands in
+// the shell-sourced instance.env.
+export const ADOPTABLE_HOSTNAME_RE =
+  /^(?=.{1,253}$)[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$/;
+```
+
+In `envIdentity()`, after the `!d || d === 'localhost'` check:
+
+```ts
+  if (!ADOPTABLE_HOSTNAME_RE.test(d.toLowerCase())) {
+    console.warn(`[bootstrap] PRIMARY_DOMAIN=${JSON.stringify(d)} is not a valid hostname — not adoptable`);
+    return null;
+  }
+```
+
+(and use `d.toLowerCase()` as the returned `primaryDomain` so adoption normalizes case the same way the wizard does).
+
+(b) m2 — in `adoptOrResyncEnvInstall`, the wizard-file divergence warning guard becomes:
+
+```ts
+      if (d && d !== 'localhost' && d !== 'yourdomain.com' && d !== existing.primaryDomain) {
+```
+
+with a comment: `// 'yourdomain.com' is compose's ${PRIMARY_DOMAIN:-yourdomain.com} placeholder for a blank .env — every wizard install boots with it (see isLegacyEnvInstall), so it is never a real divergence.`
+
+(c) M2 — in `isLegacyEnvInstall`, replace the bare marker check with:
+
+```ts
+  if (fs.existsSync(path.join(ssl, 'bootstrap-selfsigned.crt'))) {
+    // Real certs + a real env identity + the marker + (checked by our caller)
+    // no instance.json: this is the "stuck in bootstrap mode" trap — the
+    // marker was durably written during a transient cert outage and now
+    // defeats both the render legacy carve-out and this adoption gate
+    // (v0.2.18 review, M2). We refuse adoption regardless (the marker may
+    // be legitimate mid-wizard state), but say exactly how to escape.
+    console.warn(
+      '[bootstrap] this install looks like a legacy env install stuck in bootstrap mode ' +
+        '(real certs + real PRIMARY_DOMAIN + ssl/bootstrap-selfsigned.crt, no instance.json). ' +
+        'If nginx is serving the setup wizard on your domain, recover with: ' +
+        'rm ssl/bootstrap-selfsigned.crt ssl/bootstrap-selfsigned.key && docker compose restart nginx',
+    );
+    return false;
+  }
+```
+
+(Note: this point in the function is only reached when the cert-pair check above it passed and the caller already established env identity + no existing instance.json — so the log fires exactly in the trap state.)
+
+- [ ] **Step 4: Run to verify passes + no regressions**
+
+Run: `cd apps/backend && pnpm test -- instance-config.spec`
+Expected: all PASS (including all pre-existing cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/bootstrap/instance-config.ts apps/backend/src/bootstrap/instance-config.spec.ts
+git commit -m "fix(bootstrap): placeholder-aware divergence warning, trap-state recovery hint, hostname-gated adoption (m2/M2 review items)"
+```
+
+---
+
+### Task 4: M3 — bootstrap apply un-finalizes when the instance write fails
+
+**Files:**
+- Modify: `apps/backend/src/setup/bootstrap-setup.controller.ts:107-123` (apply tail)
+- Modify: `apps/backend/src/setup/bootstrap-setup.service.ts` (new `unfinalizeSetup()` next to `finalizeSetup()`, ~line 57)
+- Modify: `apps/backend/src/setup/setup.service.ts` (new `unfinalizeBootstrapSetup()` next to `finalizeBootstrapSetup()`, ~line 1070)
+- Test: `apps/backend/src/setup/bootstrap-setup.controller.spec.ts`
+
+**Interfaces:**
+- Produces: `SetupService.unfinalizeBootstrapSetup(): Promise<void>` (sets `isSetupComplete: false`); `BootstrapSetupService.unfinalizeSetup(): Promise<void>` (delegates). Controller apply throws `InternalServerErrorException` with message containing `retry` on write failure, and does NOT schedule exit.
+
+- [ ] **Step 1: Write the failing test** (in the controller spec, alongside the existing apply cases; reuse its mock wiring)
+
+```ts
+it('M3: un-finalizes setup and returns 500 when writeInstanceConfig throws (box stays browser-recoverable)', async () => {
+  mockBootstrapService.finalizeSetup.mockResolvedValue(undefined);
+  mockBootstrapService.unfinalizeSetup.mockResolvedValue(undefined);
+  (writeInstanceConfig as jest.Mock).mockImplementation(() => {
+    throw new Error('ENOSPC: no space left on device');
+  });
+  await expect(controller.apply(validApplyDto)).rejects.toThrow(InternalServerErrorException);
+  expect(mockBootstrapService.unfinalizeSetup).toHaveBeenCalled();
+  expect(scheduleExitSpy).not.toHaveBeenCalled();
+});
+```
+
+(`writeInstanceConfig` is already module-mocked in this spec for the happy-path apply cases — extend that mock; `scheduleExitSpy` = `jest.spyOn(controller as any, 'scheduleExit')`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/backend && pnpm test -- bootstrap-setup.controller.spec -t "M3"`
+Expected: FAIL — `unfinalizeSetup` is not a function / not called.
+
+- [ ] **Step 3: Implement**
+
+`setup.service.ts` (next to `finalizeBootstrapSetup`):
+
+```ts
+  /**
+   * Inverse of finalizeBootstrapSetup, for the one caller that needs it:
+   * bootstrap apply marks setup complete BEFORE writing instance.json, and a
+   * failed write must put the wizard back (isBootstrapModeActive requires
+   * !isSetupComplete) or the box is stranded with no identity and no wizard
+   * (v0.2.18 review, M3).
+   */
+  async unfinalizeBootstrapSetup(): Promise<void> {
+    const config = await this.getSystemConfig();
+    if (!config || !config.isSetupComplete) return;
+    await db
+      .update(systemConfig)
+      .set({ isSetupComplete: false, updatedAt: new Date() })
+      .where(eq(systemConfig.id, config.id));
+    this.logger.warn('[bootstrap] setup un-finalized after a failed apply write — wizard restored');
+  }
+```
+
+`bootstrap-setup.service.ts` (next to `finalizeSetup`):
+
+```ts
+  async unfinalizeSetup(): Promise<void> {
+    await this.setupService.unfinalizeBootstrapSetup();
+  }
+```
+
+`bootstrap-setup.controller.ts` — wrap the write (keep finalize-first ordering; swapping just moves the stranding to the DB-failure side):
+
+```ts
+    await this.bootstrap.finalizeSetup();
+    try {
+      writeInstanceConfig({
+        version: 2,
+        state: 'applied',
+        origin: 'wizard',
+        primaryDomain: domain,
+        proxyMode: applied.proxyMode,
+        sslMode: applied.sslMode,
+        port80: applied.port80,
+        realIp: applied.realIp,
+      });
+    } catch (err) {
+      // Failed fs write with setup already finalized = permanently dead
+      // wizard AND no identity (M3). Put the wizard back so Apply can be
+      // retried from the browser once the underlying problem (disk space,
+      // mount perms) is fixed.
+      await this.bootstrap.unfinalizeSetup();
+      this.logger.error(`[bootstrap] apply failed writing instance config: ${(err as Error).message}`);
+      throw new InternalServerErrorException(
+        'Could not write the instance configuration to disk (check free disk space). Setup was NOT completed — fix the disk issue and retry Apply.',
+      );
+    }
+    this.scheduleExit();
+```
+
+Add `InternalServerErrorException` to the `@nestjs/common` import.
+
+- [ ] **Step 4: Run to verify passes**
+
+Run: `cd apps/backend && pnpm test -- bootstrap-setup.controller.spec`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/setup/bootstrap-setup.controller.ts apps/backend/src/setup/bootstrap-setup.service.ts apps/backend/src/setup/setup.service.ts apps/backend/src/setup/bootstrap-setup.controller.spec.ts
+git commit -m "fix(bootstrap): un-finalize setup when the apply instance write fails — keeps the wizard recoverable (M3)"
+```
+
+---
+
+### Task 5: m13 backend — Cloudflare apply defaults port 80 to redirect
+
+**Files:**
+- Modify: `apps/backend/src/setup/bootstrap-setup.service.ts:406-407` (`validateApplyConfig` port80 default)
+- Test: `apps/backend/src/setup/bootstrap-setup.service.spec.ts`
+
+**Interfaces:**
+- Produces: `validateApplyConfig({ proxyMode:'cloudflare', port80: undefined })` resolves `port80:'redirect'`. Explicit `'closed'` still honored. `deriveKnobs` (instance-config.ts) untouched.
+
+- [ ] **Step 1: Failing test** (service spec, next to existing validateApplyConfig cases)
+
+```ts
+it('m13: cloudflare apply with no explicit port80 defaults to redirect (fresh CF zones have Always-Use-HTTPS off; closed → edge 520s)', () => {
+  const out = service.validateApplyConfig({
+    domain: 'example.com', proxyMode: 'cloudflare', sslMode: 'paste',
+  } as ApplyBootstrapDto);
+  expect(out.port80).toBe('redirect');
+});
+
+it('m13: explicit closed on cloudflare is still honored', () => {
+  const out = service.validateApplyConfig({
+    domain: 'example.com', proxyMode: 'cloudflare', sslMode: 'paste', port80: 'closed',
+  } as ApplyBootstrapDto);
+  expect(out.port80).toBe('closed');
+});
+```
+
+- [ ] **Step 2: Run to verify the first fails** — `cd apps/backend && pnpm test -- bootstrap-setup.service.spec -t "m13"` → 1 FAIL (`closed`), 1 PASS.
+
+- [ ] **Step 3: Implement** — in `validateApplyConfig` replace:
+
+```ts
+    const port80: Port80Mode =
+      dto.port80 ?? (dto.proxyMode === 'cloudflare' ? 'closed' : 'redirect');
+```
+
+with:
+
+```ts
+    // 'redirect' for every path, Cloudflare included: fresh CF zones ship
+    // with Always Use HTTPS off, so a closed origin port 80 turns every
+    // plain-http visitor into a CF 520 error page (v0.2.18 review, m13 —
+    // observed through the live CF edge). Closing stays an explicit choice.
+    const port80: Port80Mode = dto.port80 ?? 'redirect';
+```
+
+- [ ] **Step 4: Verify** — `cd apps/backend && pnpm test -- bootstrap-setup.service.spec` → all PASS. Also `pnpm test -- instance-config.spec` (deriveKnobs cases must be untouched).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/setup/bootstrap-setup.service.ts apps/backend/src/setup/bootstrap-setup.service.spec.ts
+git commit -m "fix(bootstrap): cloudflare apply defaults port 80 to redirect — plain-http visitors no longer 520 at the CF edge (m13)"
+```
+
+---
+
+### Task 6: m12/m13 frontend — port-80 control visible on the Cloudflare path, honest copy
+
+**Files:**
+- Modify: `apps/frontend/src/components/ssl-leaves/ServingChoiceCards.tsx:7` (CF card copy)
+- Modify: `apps/frontend/src/components/setup/domain-ssl/ProxyOptions.tsx` (add `showRealIp` prop)
+- Modify: `apps/frontend/src/components/setup/domain-ssl/CertificatePhase.tsx` (render options on the CF path)
+- Modify: `apps/frontend/src/components/settings/primary-ssl/ServingModelEditor.tsx:123-141` (show Port80Choice for CF)
+- Test: `apps/frontend/src/components/settings/primary-ssl/__tests__/ServingModelEditor.test.tsx`, `apps/frontend/src/components/setup/__tests__/CertificatePhase.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 5's backend default (frontend still sends `port80: bootstrapPort80 ?? undefined` from ApplyStep — unchanged; undefined now resolves to redirect server-side).
+
+- [ ] **Step 1: Failing tests**
+
+`ServingModelEditor.test.tsx`:
+
+```ts
+it('m12: shows the port-80 control on the cloudflare path (and no realIp fields)', () => {
+  render(<ServingModelEditor value={{ ...baseState, servingMode: 'cloudflare', sslMode: 'paste' }} onChange={vi.fn()} />);
+  expect(screen.getByText('Port 80 (HTTP)')).toBeInTheDocument();
+  expect(screen.queryByText(/Restore visitor IPs/i)).not.toBeInTheDocument();
+});
+```
+
+`CertificatePhase.test.tsx` (follow its existing store-wrapped render helper):
+
+```ts
+it('m13: cloudflare path renders the port-80 choice above the paste form', () => {
+  renderWithState({ servingMode: 'cloudflare', bootstrapSslMode: 'paste' });
+  expect(screen.getByText('Port 80 (HTTP)')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run to verify failures** — `cd apps/frontend && pnpm test -- ServingModelEditor CertificatePhase` → the two new cases FAIL.
+
+- [ ] **Step 3: Implement**
+
+(a) `ServingChoiceCards.tsx` CF card body:
+
+```ts
+    body: 'Cloudflare proxies your traffic and terminates TLS at its edge. You paste a free Origin Certificate; plain HTTP redirects to HTTPS (you can close port 80 instead if you enable Always Use HTTPS in Cloudflare).',
+```
+
+(b) `ProxyOptions.tsx` — accept a prop, default preserving today's behavior:
+
+```ts
+export function ProxyOptions({ showRealIp = true }: { showRealIp?: boolean } = {}) {
+```
+
+and wrap the `<RealIpFields …/>` block in `{showRealIp && ( … )}`. (Cloudflare's realIp is a backend preset; only the proxy path collects custom values.)
+
+(c) `CertificatePhase.tsx` — add the CF branch:
+
+```ts
+  if (servingMode === 'proxy') {
+    return (
+      <div className="space-y-6">
+        <ProxyOptions />
+        {certView}
+      </div>
+    );
+  }
+  // Cloudflare: port 80 is a real choice (redirect default per m13); realIp
+  // is preset server-side so only the port control shows.
+  if (servingMode === 'cloudflare') {
+    return (
+      <div className="space-y-6">
+        <ProxyOptions showRealIp={false} />
+        {certView}
+      </div>
+    );
+  }
+  return certView;
+```
+
+(d) `ServingModelEditor.tsx` — replace the `value.servingMode !== 'cloudflare'` block condition so port80 shows on CF too but realIp does not:
+
+```tsx
+      {value.servingMode !== 'cloudflare' ? (
+        <div className="space-y-4 pl-1">
+          {value.sslMode === 'letsencrypt' ? (
+            <p className="text-sm text-muted-foreground">
+              Port 80 stays open so Let&apos;s Encrypt can validate over HTTP-01.
+            </p>
+          ) : (
+            <Port80Choice value={value.port80} onChange={(port80) => onChange({ ...value, port80 })} />
+          )}
+          <RealIpFields
+            header={value.realIp?.header ?? ''}
+            ranges={value.realIp?.ranges ?? ''}
+            onChange={(realIp) => onChange({ ...value, realIp })}
+          />
+        </div>
+      ) : (
+        <div className="space-y-4 pl-1">
+          <Port80Choice value={value.port80} onChange={(port80) => onChange({ ...value, port80 })} />
+        </div>
+      )}
+```
+
+- [ ] **Step 4: Verify** — `cd apps/frontend && pnpm test -- ServingModelEditor CertificatePhase ProxyOptions leaves` → all PASS; `pnpm --filter frontend exec tsc --noEmit` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/frontend/src/components/ssl-leaves/ServingChoiceCards.tsx apps/frontend/src/components/setup/domain-ssl/ProxyOptions.tsx apps/frontend/src/components/setup/domain-ssl/CertificatePhase.tsx apps/frontend/src/components/settings/primary-ssl/ServingModelEditor.tsx apps/frontend/src/components/settings/primary-ssl/__tests__/ServingModelEditor.test.tsx apps/frontend/src/components/setup/__tests__/CertificatePhase.test.tsx
+git commit -m "fix(frontend): port-80 choice visible on the Cloudflare path with honest copy (m12/m13)"
+```
+
+---
+
+### Task 7: m11 — day-2 cert-source selector (wizard parity)
+
+**Files:**
+- Modify: `apps/frontend/src/components/settings/primary-ssl/ServingModelEditor.tsx`
+- Test: `apps/frontend/src/components/settings/primary-ssl/__tests__/ServingModelEditor.test.tsx`
+
+**Interfaces:**
+- Consumes: existing `EditorState`, `presetSslFor`, and the render branches for paste/LE/selfsigned already in the file.
+- Produces: exported `allowedSslModesFor(mode: ServingMode): SslMode[]` used by the component and tests.
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+describe('m11 cert-source selector', () => {
+  it('proxy path offers selfsigned/letsencrypt/paste', () => {
+    render(<ServingModelEditor value={{ ...baseState, servingMode: 'proxy', sslMode: 'selfsigned' }} onChange={vi.fn()} />);
+    expect(screen.getByLabelText(/Keep the built-in certificate/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Auto-issue with Let's Encrypt/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Paste my own certificate/i)).toBeInTheDocument();
+  });
+
+  it('cloudflare path offers no selector (paste only)', () => {
+    render(<ServingModelEditor value={{ ...baseState, servingMode: 'cloudflare', sslMode: 'paste' }} onChange={vi.fn()} />);
+    expect(screen.queryByLabelText(/Keep the built-in certificate/i)).not.toBeInTheDocument();
+  });
+
+  it('direct path offers letsencrypt/paste, not selfsigned', () => {
+    render(<ServingModelEditor value={{ ...baseState, servingMode: 'none', sslMode: 'letsencrypt' }} onChange={vi.fn()} />);
+    expect(screen.getByLabelText(/Auto-issue with Let's Encrypt/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Paste my own certificate/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Keep the built-in certificate/i)).not.toBeInTheDocument();
+  });
+
+  it('selecting paste on the proxy path swaps in the paste fields', () => {
+    const onChange = vi.fn();
+    render(<ServingModelEditor value={{ ...baseState, servingMode: 'proxy', sslMode: 'selfsigned' }} onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText(/Paste my own certificate/i));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ sslMode: 'paste' }));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failures** — `cd apps/frontend && pnpm test -- ServingModelEditor -t m11` → FAIL (labels absent).
+
+- [ ] **Step 3: Implement** in `ServingModelEditor.tsx`
+
+Add next to `presetSslFor`:
+
+```ts
+// Wizard-parity cert-source sets (mirrors the wizard's per-path choices:
+// CertificatePhase + the proxy path's three modes). The wizard promises
+// "change this later in Settings → SSL" — this selector is that promise
+// (v0.2.18 review, m11).
+export function allowedSslModesFor(mode: ServingMode): SslMode[] {
+  if (mode === 'proxy') return ['selfsigned', 'letsencrypt', 'paste'];
+  if (mode === 'cloudflare') return ['paste'];
+  return ['letsencrypt', 'paste'];
+}
+
+const SSL_MODE_LABELS: Record<SslMode, { label: string; hint: string }> = {
+  selfsigned: {
+    label: 'Keep the built-in certificate',
+    hint: 'Zero maintenance. Works with CDNs that don’t validate the origin certificate.',
+  },
+  letsencrypt: {
+    label: "Auto-issue with Let's Encrypt",
+    hint: 'A real auto-renewing certificate on this server. Needs ACME challenges to reach the origin.',
+  },
+  paste: {
+    label: 'Paste my own certificate',
+    hint: 'Your CDN’s origin certificate or any browser-trusted cert. Re-paste when it expires.',
+  },
+};
+```
+
+Render the group between `<ServingChoiceCards …/>` and the port-80 block, only when there is a real choice:
+
+```tsx
+      {allowedSslModesFor(value.servingMode).length > 1 && (
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-foreground">Certificate for the origin</p>
+          {allowedSslModesFor(value.servingMode).map((mode) => (
+            <label key={mode} className="flex items-start text-sm cursor-pointer">
+              <input
+                type="radio"
+                name="day2-ssl-mode"
+                checked={value.sslMode === mode}
+                onChange={() =>
+                  onChange({
+                    ...value,
+                    sslMode: mode,
+                    // LE is HTTP-01: mirrors the wizard's ProxyOptions clearing
+                    // of a stale 'closed' pick.
+                    port80: mode === 'letsencrypt' ? 'redirect' : value.port80,
+                  })
+                }
+                className="mt-0.5 mr-2"
+                aria-label={SSL_MODE_LABELS[mode].label}
+              />
+              <span>
+                <span className="font-medium">{SSL_MODE_LABELS[mode].label}</span>{' '}
+                <span className="text-muted-foreground">{SSL_MODE_LABELS[mode].hint}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+      )}
+```
+
+Also update the `ServingChoiceCards` onChange handler comment: preset still applies on mode change (unchanged behavior); the selector adjusts within the allowed set afterward.
+
+- [ ] **Step 4: Verify** — `cd apps/frontend && pnpm test -- ServingModelEditor PrimarySslManager ApplyPanel` → all PASS; tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/frontend/src/components/settings/primary-ssl/ServingModelEditor.tsx apps/frontend/src/components/settings/primary-ssl/__tests__/ServingModelEditor.test.tsx
+git commit -m "feat(frontend): day-2 cert-source selector with wizard parity (m11)"
+```
+
+---
+
+### Task 8: m5 — per-IP claim-token rate limiting
+
+**Files:**
+- Modify: `apps/backend/src/setup/setup.service.ts:89-232` (limiter internals + `validateOnboardingToken` signature)
+- Modify: `apps/backend/src/setup/bootstrap-setup.service.ts:48-50` (`validateClaimToken` passes IP through)
+- Modify: `apps/backend/src/setup/bootstrap-setup.controller.ts` (6 call sites pass `req.ip`; add `@Req() req: Request` where missing)
+- Modify: `apps/backend/src/setup/setup.controller.ts` and the two other `validateOnboardingToken` call sites in `setup.service.ts` (lines ~492/2428/2507 — pass the request IP where a request is in scope; internal callers may pass `undefined`)
+- Test: `apps/backend/src/setup/setup.service.spec.ts`
+
+**Interfaces:**
+- Produces: `validateOnboardingToken(providedToken?: string, clientIp?: string): void` and `validateClaimToken(token?: string, clientIp?: string): void`. `undefined` clientIp buckets under the key `'unknown'`.
+
+- [ ] **Step 1: Failing tests** (setup.service.spec, next to the existing rate-limit cases — extend, don't replace; existing global-lockout tests will need updating to per-IP semantics in the same change)
+
+```ts
+it('m5: lockout is per client IP — a second IP still gets attempts', () => {
+  process.env.ONBOARDING_TOKEN = 'right';
+  for (let i = 0; i < 5; i++) {
+    expect(() => service.validateOnboardingToken('wrong', '1.1.1.1')).toThrow();
+  }
+  expect(() => service.validateOnboardingToken('right', '1.1.1.1')).toThrow(UnauthorizedException); // locked
+  expect(() => service.validateOnboardingToken('right', '2.2.2.2')).not.toThrow(); // different IP fine
+});
+
+it('m5: global backstop trips after 50 failures across IPs', () => {
+  process.env.ONBOARDING_TOKEN = 'right';
+  for (let ip = 0; ip < 10; ip++) {
+    for (let i = 0; i < 5; i++) {
+      try { service.validateOnboardingToken('wrong', `10.0.0.${ip}`); } catch { /* per-IP throws expected */ }
+    }
+  }
+  expect(() => service.validateOnboardingToken('right', '99.99.99.99')).toThrow(UnauthorizedException);
+});
+```
+
+- [ ] **Step 2: Run to verify failures** — `cd apps/backend && pnpm test -- setup.service.spec -t "m5"` → FAIL.
+
+- [ ] **Step 3: Implement**
+
+Replace the limiter state in `setup.service.ts`:
+
+```ts
+  // Per-IP fixed-window claim limiting (v0.2.18 review, m5): the old single
+  // global counter let 5 bad guesses from ANYONE lock the legitimate
+  // operator out for 15 minutes — an onboarding DoS on a public IP. Per-IP
+  // buckets keep brute-force defense; the global backstop bounds distributed
+  // guessing. In-memory only (same multi-replica caveat as before).
+  private claimAttempts = new Map<string, { count: number; windowStart: number }>();
+  private claimGlobal = { count: 0, windowStart: 0 };
+  private static readonly CLAIM_MAX_ATTEMPTS = 5;
+  private static readonly CLAIM_GLOBAL_MAX_ATTEMPTS = 50;
+  private static readonly CLAIM_WINDOW_MS = 15 * 60 * 1000;
+```
+
+Replace the limiter portion of `validateOnboardingToken` (keep the doc comment, updating its rate-limit sentence to per-IP semantics) and `recordFailedClaimAttempt`:
+
+```ts
+  validateOnboardingToken(providedToken?: string, clientIp?: string): void {
+    const expectedToken = process.env.ONBOARDING_TOKEN;
+    if (!expectedToken) {
+      return;
+    }
+
+    const now = Date.now();
+    const key = clientIp || 'unknown';
+
+    // Fixed windows, per bucket. Gated on count > 0 (not a 0-sentinel
+    // comparison) for the same mocked-clock reason as before.
+    const bucket = this.claimAttempts.get(key);
+    if (bucket && bucket.count > 0 && now - bucket.windowStart > SetupService.CLAIM_WINDOW_MS) {
+      this.claimAttempts.delete(key);
+    }
+    if (this.claimGlobal.count > 0 && now - this.claimGlobal.windowStart > SetupService.CLAIM_WINDOW_MS) {
+      this.claimGlobal = { count: 0, windowStart: 0 };
+    }
+
+    if ((this.claimAttempts.get(key)?.count ?? 0) >= SetupService.CLAIM_MAX_ATTEMPTS) {
+      throw new UnauthorizedException('Too many attempts, try again later');
+    }
+    if (this.claimGlobal.count >= SetupService.CLAIM_GLOBAL_MAX_ATTEMPTS) {
+      throw new UnauthorizedException('Too many attempts, try again later');
+    }
+
+    if (!providedToken) {
+      this.recordFailedClaimAttempt(key, now);
+      throw new BadRequestException(
+        'Onboarding token is required. Please use the setup link provided during workspace provisioning.',
+      );
+    }
+    if (providedToken !== expectedToken) {
+      this.recordFailedClaimAttempt(key, now);
+      throw new BadRequestException(
+        'Invalid onboarding token. Please use the correct setup link.',
+      );
+    }
+
+    // Success clears this IP's bucket only — the global backstop keeps its
+    // window (success from one IP must not reset distributed-guessing math).
+    this.claimAttempts.delete(key);
+  }
+
+  private recordFailedClaimAttempt(key: string, now: number): void {
+    const bucket = this.claimAttempts.get(key) ?? { count: 0, windowStart: 0 };
+    if (bucket.count === 0) bucket.windowStart = now;
+    bucket.count += 1;
+    this.claimAttempts.set(key, bucket);
+    if (this.claimGlobal.count === 0) this.claimGlobal.windowStart = now;
+    this.claimGlobal.count += 1;
+  }
+```
+
+`bootstrap-setup.service.ts`:
+
+```ts
+  validateClaimToken(token?: string, clientIp?: string): void {
+    this.setupService.validateOnboardingToken(token, clientIp);
+  }
+```
+
+Controller call sites become `this.bootstrap.validateClaimToken(dto.token, req.ip)` — add `@Req() req: Request` params where the handler lacks one. For `setup.service.ts`'s internal call sites (~492/2428/2507): pass the request IP where the calling controller has a request; otherwise pass `undefined`.
+
+- [ ] **Step 4: Verify** — `cd apps/backend && pnpm test -- setup.service.spec bootstrap-setup.controller.spec` → all PASS (update any pre-existing global-lockout expectations to the per-IP model deliberately, preserving their intent).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/setup/setup.service.ts apps/backend/src/setup/bootstrap-setup.service.ts apps/backend/src/setup/bootstrap-setup.controller.ts apps/backend/src/setup/setup.controller.ts apps/backend/src/setup/setup.service.spec.ts
+git commit -m "fix(setup): per-IP claim-token rate limiting with a global backstop (m5)"
+```
+
+---
+
+### Task 9: m6 — private-range denylist in the DNS preflight
+
+**Files:**
+- Modify: `apps/backend/src/setup/bootstrap-dns-preflight.service.ts`
+- Test: `apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts`
+
+**Interfaces:**
+- Produces: exported `isDisallowedProbeIp(ip: string): boolean`; `run()` marks a host failed (`error: 'resolves to a private or reserved address'`, no fetch) when **any** resolved address is disallowed. `issue-certificate` inherits the gate via its existing `preflight.run()` re-check.
+
+- [ ] **Step 1: Failing tests** (mock `resolveA` per the spec's existing seam)
+
+```ts
+it.each([
+  ['loopback', '127.0.0.1'],
+  ['rfc1918', '10.1.2.3'],
+  ['rfc1918-172', '172.16.5.5'],
+  ['rfc1918-192', '192.168.1.1'],
+  ['link-local/metadata', '169.254.169.254'],
+  ['cgnat', '100.64.0.1'],
+])('m6: refuses to probe a host resolving to %s', async (_label, ip) => {
+  jest.spyOn(service as any, 'resolveA').mockResolvedValue([ip]);
+  const fetchSpy = jest.spyOn(service as any, 'fetchProbe');
+  const result = await service.run('internal.example.com');
+  expect(result.ok).toBe(false);
+  expect(result.checks[0].error).toContain('private or reserved');
+  expect(fetchSpy).not.toHaveBeenCalled();
+});
+
+it('m6: public addresses still probe', async () => {
+  jest.spyOn(service as any, 'resolveA').mockResolvedValue(['93.184.216.34']);
+  jest.spyOn(service as any, 'fetchProbe').mockResolvedValue('tokenbody');
+  const result = await service.run('example.com');
+  expect(result.checks[0].error === 'resolves to a private or reserved address').toBe(false);
+});
+```
+
+- [ ] **Step 2: Run to verify failures** — `cd apps/backend && pnpm test -- bootstrap-dns-preflight -t m6` → FAIL (fetch attempted / no error).
+
+- [ ] **Step 3: Implement**
+
+```ts
+// SSRF guard (v0.2.18 review, m6): the probe is a blind GET to a
+// caller-supplied hostname; refuse anything resolving into private,
+// loopback, link-local (incl. cloud metadata), CGNAT or reserved space.
+// IPv4-only because resolveA only asks for A records.
+export function isDisallowedProbeIp(ip: string): boolean {
+  const parts = ip.split('.').map(Number);
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) return true;
+  const [a, b] = parts;
+  return (
+    a === 0 || a === 127 || a === 10 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254) ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    a >= 224 // multicast + reserved
+  );
+}
+```
+
+In `run()`'s per-host loop, after `resolveA`:
+
+```ts
+        if (resolvedIps.some((ip) => isDisallowedProbeIp(ip))) {
+          checks.push({ host, resolvedIps, probeOk: false, error: 'resolves to a private or reserved address' });
+          continue;
+        }
+```
+
+(IP-literal "domains" never reach here — `validateDomain`'s HOSTNAME_RE runs first in the controller — but the resolver-level check catches a hostname whose A record points internally, which is the actual SSRF vector.)
+
+- [ ] **Step 4: Verify** — `cd apps/backend && pnpm test -- bootstrap-dns-preflight` → all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/setup/bootstrap-dns-preflight.service.ts apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
+git commit -m "fix(setup): DNS preflight refuses private/reserved resolutions (m6 SSRF hardening)"
+```
+
+---
+
+### Task 10: m7 + m8 — renewal cron respects the confirm window; failure emails throttled
+
+**Files:**
+- Modify: `apps/backend/src/bootstrap/instance-config.ts` (tiny pure helper)
+- Modify: `apps/backend/src/domains/ssl-renewal.service.ts` (gate in `checkAndRenewPrimary` ~line 208; throttle in `sendFailureNotifications` ~line 513)
+- Test: `apps/backend/src/domains/ssl-renewal.service.spec.ts`
+
+**Interfaces:**
+- Produces: `pendingServingRevertExists(dir?: string): boolean` exported from `instance-config.ts` (pure fs check on `<bootstrapDir>/pending-serving-revert.json` — same path `PrimarySslSnapshotService` uses; a pure helper avoids a cross-module Nest injection for one file-exists check).
+- Produces: failure digest writes/reads the `renewal_failure_last_sent` key via the existing `getSetting`/`updateSetting`, 7-day window (same pattern as `wildcard_reminder_last_sent`).
+
+- [ ] **Step 1: Failing tests** (renewal spec, following its existing fixture/mocks)
+
+```ts
+it('m7: skips primary renewal while a serving-confirm window is pending', async () => {
+  (pendingServingRevertExists as jest.Mock).mockReturnValue(true);
+  // fixture: applied letsencrypt instance.json + cert inside threshold (reuse existing helpers)
+  const result = await (service as any).checkAndRenewPrimary(30);
+  expect(result).toBeNull();
+  expect(mockSslCertService.requestPrimaryDomainCertificate).not.toHaveBeenCalled();
+});
+
+it('m8: failure digest is throttled to once per 7 days', async () => {
+  mockGetSetting.mockImplementation(async (k: string) =>
+    k === 'renewal_failure_last_sent' ? new Date(Date.now() - 3 * 86_400_000).toISOString() : null);
+  await (service as any).sendFailureNotifications([{ domain: 'x.com', status: 'failed', error: 'boom' }]);
+  expect(mockEmailService.sendEmail).not.toHaveBeenCalled();
+});
+
+it('m8: failure digest sends again after the window and stamps the marker', async () => {
+  mockGetSetting.mockImplementation(async (k: string) =>
+    k === 'renewal_failure_last_sent' ? new Date(Date.now() - 8 * 86_400_000).toISOString() : null);
+  mockEmailService.sendEmail.mockResolvedValue({ success: true });
+  await (service as any).sendFailureNotifications([{ domain: 'x.com', status: 'failed', error: 'boom' }]);
+  expect(mockEmailService.sendEmail).toHaveBeenCalled();
+  expect(mockUpdateSetting).toHaveBeenCalledWith('renewal_failure_last_sent', expect.any(String));
+});
+```
+
+- [ ] **Step 2: Run to verify failures** — `cd apps/backend && pnpm test -- ssl-renewal.service.spec -t "m7|m8"` → FAIL.
+
+- [ ] **Step 3: Implement**
+
+`instance-config.ts`:
+
+```ts
+// One-file seam for the renewal cron (v0.2.18 review, m7): the durable
+// pending-revert marker PrimarySslSnapshotService writes lives at this
+// path; a pure existence check avoids a domains→setup Nest dependency.
+export function pendingServingRevertExists(dir: string = bootstrapDir()): boolean {
+  try {
+    return fs.existsSync(path.join(dir, 'pending-serving-revert.json'));
+  } catch {
+    return false;
+  }
+}
+```
+
+`ssl-renewal.service.ts` — top of `checkAndRenewPrimary`, after loading the instance config check:
+
+```ts
+    if (pendingServingRevertExists()) {
+      // A day-2 serving change is inside its confirm window; a renewal now
+      // would be silently undone by auto-revert/rollback (v0.2.18 review,
+      // m7). Next night's run proceeds normally.
+      this.logger.log('Primary renewal skipped: a serving-change confirm window is pending');
+      return null;
+    }
+```
+
+`sendFailureNotifications` — before recipient resolution:
+
+```ts
+    // Recurring failures (e.g. adopted certs with SANs HTTP-01 can't satisfy)
+    // otherwise email every single night (v0.2.18 review, m8). Same 7-day
+    // pattern as wildcard_reminder_last_sent; failures still log every run.
+    const last = await this.getSetting('renewal_failure_last_sent');
+    if (last && Date.now() - new Date(last).getTime() < 7 * 86_400_000) {
+      this.logger.warn(
+        `SSL renewal failures (digest throttled): ${failures.map((f) => `${f.domain}: ${f.error}`).join(', ')}`,
+      );
+      return;
+    }
+```
+
+and stamp after a successful send: `await this.updateSetting('renewal_failure_last_sent', new Date().toISOString());`
+
+- [ ] **Step 4: Verify** — `cd apps/backend && pnpm test -- ssl-renewal.service.spec instance-config.spec` → all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/bootstrap/instance-config.ts apps/backend/src/domains/ssl-renewal.service.ts apps/backend/src/domains/ssl-renewal.service.spec.ts
+git commit -m "fix(ssl): renewal cron yields to pending confirm windows; failure digest throttled to 7 days (m7/m8)"
+```
+
+---
+
+### Task 11: m9 — ACME challenge files removed on failure too
+
+**Files:**
+- Modify: `apps/backend/src/domains/ssl-certificate.service.ts:434-443` and `:555-564` (the two per-authorization challenge loops)
+- Test: `apps/backend/src/domains/ssl-certificate.service.spec.ts`
+
+- [ ] **Step 1: Failing test**
+
+```ts
+it('m9: removes the challenge token file when validation fails', async () => {
+  const removeSpy = jest.spyOn(service as any, 'removeHttpChallenge').mockResolvedValue(undefined);
+  mockAcmeClient.waitForValidStatus.mockRejectedValue(new Error('authorization invalid'));
+  await expect(
+    service.requestPrimaryDomainCertificate('example.com', { target: 'staging' }),
+  ).resolves.toMatchObject({ success: false });
+  expect(removeSpy).toHaveBeenCalled();
+});
+```
+
+(Adapt the mock wiring to the spec's existing acme-client mock; the pre-fix behavior throws past the cleanup line.)
+
+- [ ] **Step 2: Run to verify failure** — `cd apps/backend && pnpm test -- ssl-certificate.service.spec -t m9` → FAIL (`removeHttpChallenge` not called).
+
+- [ ] **Step 3: Implement** — in BOTH loops, wrap complete/wait so cleanup always runs:
+
+```ts
+        try {
+          await this.acmeClient.completeChallenge(challenge);
+          await this.acmeClient.waitForValidStatus(challenge);
+        } finally {
+          // Failed authorizations must not leave token litter in the shared
+          // ACME webroot (v0.2.18 review, m9).
+          await this.removeHttpChallenge(challenge.token);
+        }
+```
+
+(delete the old post-wait `removeHttpChallenge` lines the `finally` replaces).
+
+- [ ] **Step 4: Verify** — `cd apps/backend && pnpm test -- ssl-certificate.service.spec` → all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/domains/ssl-certificate.service.ts apps/backend/src/domains/ssl-certificate.service.spec.ts
+git commit -m "fix(ssl): ACME challenge tokens cleaned up on failed validations too (m9)"
+```
+
+---
+
+### Task 12: m3 — reset-bootstrap.sh mints a claim token when .env lacks one
+
+**Files:**
+- Modify: `reset-bootstrap.sh` (new step between the current steps 3 and 4; renumber the step labels 4→5)
+
+- [ ] **Step 1: Implement** (shell task — verification is Step 2)
+
+Insert after the "Clearing bootstrap state on disk" block:
+
+```bash
+# 4. A claim token must exist before the wizard comes back up: a formerly
+#    classic (non-bootstrap) install's .env has none, and without it the
+#    relaunched wizard is claim-ungated on a public IP (v0.2.18 review, m3).
+echo -e "${YELLOW}[4/5] Ensuring a claim token exists...${NC}"
+if ! grep -q '^ONBOARDING_TOKEN=..*' .env 2>/dev/null; then
+  CLAIM_TOKEN=$(openssl rand -hex 16)
+  {
+    echo ""
+    echo "# Web-bootstrap claim token (shown in the server's login banner)"
+    echo "ONBOARDING_TOKEN=${CLAIM_TOKEN}"
+  } >> .env
+  echo "  minted a new claim token (none was set)"
+else
+  CLAIM_TOKEN="$(grep '^ONBOARDING_TOKEN=' .env | head -1 | cut -d= -f2-)"
+  echo "  keeping the existing claim token"
+fi
+```
+
+Renumber the start step to `[5/5]`, and extend the completion message:
+
+```bash
+echo "Claim token for the wizard: ${CLAIM_TOKEN}"
+```
+
+Also update the header comment's ".env (and its claim token) is left untouched" sentence to: "`.env` is left untouched, except that a claim token is minted if none exists."
+
+- [ ] **Step 2: Verify**
+
+Run: `bash -n reset-bootstrap.sh && cd "$(mktemp -d)" && printf 'FOO=1\n' > .env && bash -c 'set -euo pipefail; if ! grep -q "^ONBOARDING_TOKEN=..*" .env; then echo "ONBOARDING_TOKEN=$(openssl rand -hex 16)" >> .env; fi; grep -c ONBOARDING_TOKEN .env'`
+Expected: syntax OK; the snippet prints `1`. (Full-script execution needs a compose stack — covered when the droplet re-test runs.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add reset-bootstrap.sh
+git commit -m "fix(scripts): reset-bootstrap mints a claim token when .env has none (m3)"
+```
+
+---
+
+### Task 13: m4 — setup.sh warns when an existing postgres volume will desync the new password
+
+**Files:**
+- Modify: `setup.sh` (new helper + calls at the two fresh-password sites: the interactive `create_env_file` path ~line 658 and the bootstrap path ~line 1685)
+
+- [ ] **Step 1: Implement**
+
+Add helper near the other `command_exists`-style helpers:
+
+```sh
+# A surviving postgres-data volume keeps the OLD password; writing a fresh
+# POSTGRES_PASSWORD then yields an install that boots but fails every DB
+# query with only a soft migration warning (v0.2.18 review, m4). Warn, and
+# interactively offer the wipe. Never deletes silently.
+check_stale_postgres_volume() {
+    command_exists docker || return 0
+    project="$(basename "$(pwd)")"
+    vol="$(docker volume ls --format '{{.Name}}' 2>/dev/null | grep -E "^(${project}|${COMPOSE_PROJECT_NAME:-$project})_postgres-data$" | head -1)"
+    [ -n "$vol" ] || return 0
+    echo ""
+    print_warning "Existing database volume found: $vol"
+    echo "  A new POSTGRES_PASSWORD is about to be generated, but this volume keeps"
+    echo "  the OLD password — the stack would start and then fail every database"
+    echo "  query with 'password authentication failed'."
+    if [ "$INTERACTIVE" = true ]; then
+        printf "Delete this volume and start with a fresh database? ALL DATA IS LOST. (y/N): "
+        read -r wipe_reply
+        case "$wipe_reply" in
+            [yY][eE][sS]|[yY])
+                docker volume rm "$vol" >/dev/null && print_success "Removed $vol" ;;
+            *)
+                echo "  Keeping the volume. Either reuse the old password in .env, or remove it later:"
+                echo "    docker compose down && docker volume rm $vol" ;;
+        esac
+    else
+        echo "  Non-interactive mode: NOT deleting. Fix before ./start.sh with either:"
+        echo "    docker volume rm $vol            # fresh database"
+        echo "    (or set the previous POSTGRES_PASSWORD back in .env)"
+    fi
+    echo ""
+}
+```
+
+Call it immediately before each `POSTGRES_PASSWORD=$(generate_password 32)` site (lines ~658 and ~1685): `check_stale_postgres_volume`.
+
+- [ ] **Step 2: Verify**
+
+Run: `sh -n setup.sh` (POSIX syntax check) and `docker volume create bffless_postgres-data >/dev/null 2>&1 || true` is NOT needed — instead verify with a dry grep: `grep -n 'check_stale_postgres_volume' setup.sh` shows the helper + exactly 2 call sites.
+Expected: syntax OK, 3 matches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add setup.sh
+git commit -m "fix(scripts): setup.sh warns (and can wipe) a stale postgres volume before regenerating the password (m4)"
+```
+
+---
+
+### Task 14: M1 — README updating section + release-note block
+
+**Files:**
+- Modify: `README.md` (extend the Setup section)
+- Create: `docs/releases/v0.2.18-upgrade-notes.md`
+
+- [ ] **Step 1: Write**
+
+README — add after the existing "Web bootstrap setup" subsection:
+
+```markdown
+### Updating
+
+`git pull` first, always — image-only updates run, but new features that live
+in the repo (compose mounts, the nginx image) silently stay dormant:
+
+​```bash
+cd /opt/bffless
+git pull
+./stop.sh
+docker compose pull
+./start.sh        # rebuilds the local nginx image from the pulled tree
+​```
+```
+
+`docs/releases/v0.2.18-upgrade-notes.md` (verbatim source for the GitHub release body):
+
+```markdown
+# Upgrading to v0.2.18
+
+**`git pull` is a required upgrade step for this release.** v0.2.18 adds
+compose mounts (`bootstrap/`), an `ONBOARDING_TOKEN` passthrough, and a
+rebuilt nginx image. Pulling only the Docker images leaves the new day-2 SSL
+management silently inert (settings apply but never reach nginx) and breaks
+automatic renewal takeover for migrated Let's Encrypt installs.
+
+​```bash
+cd /opt/bffless && git pull && ./stop.sh && docker compose pull && ./start.sh
+​```
+
+Notes for upgraders:
+
+- **Migrated (pre-wizard) installs** are adopted automatically on first boot:
+  `bootstrap/instance.json` appears with `origin: "env"` and your `.env`
+  stays authoritative. No action needed.
+- **One-time rollback quirk:** if you had used cert staging before this
+  upgrade, the first SSL change cycle after upgrading may roll back one step
+  further than expected, then self-heals (see #516).
+- **If nginx ever serves the setup wizard on your production domain** after
+  cert files went briefly missing, recover with:
+  `rm ssl/bootstrap-selfsigned.crt ssl/bootstrap-selfsigned.key && docker compose restart nginx`
+```
+
+(Strip the zero-width escapes around the inner code fences when writing the real files — they are only here to nest fences in this plan.)
+
+- [ ] **Step 2: Verify** — `grep -n "git pull" README.md docs/releases/v0.2.18-upgrade-notes.md` shows both; markdown renders (no broken fences): `head -40 docs/releases/v0.2.18-upgrade-notes.md`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md docs/releases/v0.2.18-upgrade-notes.md
+git commit -m "docs: updating instructions + v0.2.18 upgrade notes (M1)"
+```
+
+---
+
+### Task 15: Full-suite gate, PR, and the docs-repo companion
+
+**Files:**
+- No new source files. PR creation + a separate `bffless/docs` clone.
+
+- [ ] **Step 1: Full verification**
+
+```bash
+cd apps/backend && pnpm test && pnpm exec tsc --noEmit
+cd ../frontend && pnpm test && pnpm exec tsc --noEmit
+cd ../.. && sh docker/nginx/render-main-conf.test.sh && bash -n test-bootstrap.sh reset-bootstrap.sh && sh -n setup.sh
+```
+Expected: everything green.
+
+- [ ] **Step 2: Push and open the PR** (ASK THE USER before pushing if session policy requires; base `main`)
+
+```bash
+git push -u origin spec/v0218-review-fixes
+gh pr create --title "fix: v0.2.18 review fixes — selfsigned crash-loop (C1), apply stranding, port-80/CF defaults, day-2 cert-source selector, hardening" --body "$(cat docs/releases/v0.2.18-upgrade-notes.md)
+
+Implements docs/superpowers/specs/2026-07-25-v0218-review-fixes-design.md (all findings from the v0.2.18 release review). Merge BEFORE cutting release PR #515.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 3: Docs companion (separate repo)**
+
+Clone `bffless/docs` to a temp dir (`gh repo clone bffless/docs /tmp/bffless-docs`), branch `docs/v0218-upgrade-and-bootstrap`, and:
+1. Update every "Updating" section that shows `./stop.sh && docker compose pull && ./start.sh --fresh` (the manual-setup and DigitalOcean pages) to lead with `git pull` (same block as Task 14's README).
+2. Add a new getting-started page `web-bootstrap-setup.md`: claim token (where to find it: `.env` `ONBOARDING_TOKEN` / DO console banner), the 7 wizard steps by name, the three serving paths and when to pick each, and the recovery section (`rm -rf bootstrap/instance.json bootstrap/instance.env && docker compose restart backend nginx`, plus the M2 marker recovery line).
+3. `pnpm install && pnpm build` in that repo to prove the site builds; open a PR titled "docs: git-pull-first updating flow + zero-SSH web bootstrap setup page".
+
+- [ ] **Step 4: Report** — summarize PR URLs and any deviations for the user.

--- a/docs/superpowers/specs/2026-07-25-v0218-review-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-25-v0218-review-fixes-design.md
@@ -1,0 +1,145 @@
+# v0.2.18 Review Fixes — Design
+
+**Date:** 2026-07-25
+**Status:** Approved
+**Source:** Release review of PR #515 (v0.2.18) — code review by three parallel reviewers plus eight live test legs on a DigitalOcean droplet (sahp.app: legacy install, both upgrade styles, fresh zero-SSH wizard via Bunny, bare-IP wizard, day-2 SSL staging/rollback, real Cloudflare NS cutover on Full strict). Full findings report: session artifact `CE v0.2.18 Release Review`.
+**Sequencing decision:** this branch merges **before** release PR #515 is cut, so v0.2.18 ships with the critical fixed. Release-please folds these commits into the same release.
+
+## Problem
+
+The v0.2.18 release (web bootstrap #508, SSL staging #520, env adoption #522, plus fixes) passed live migration testing overall, but the review surfaced one critical defect, three major gaps, and a set of minor hardening/UX issues. All are to be fixed in one cohesive change set.
+
+Finding IDs below match the review report (C1, M1–M3, m2–m13).
+
+## Non-goals
+
+- No behavior change for existing installs' port-80 knob (adoption/upgrade never rewrites an applied knob; only *defaults for new choices* change).
+- No auto-deletion of `ssl/bootstrap-selfsigned.crt` to escape the M2 trap — those files are the live serving cert in selfsigned mode; deletion heuristics are riskier than the trap.
+- The cert-less-legacy-install-serves-the-wizard behavior (review info item) gets no dedicated change; M2's warning covers operator visibility.
+- Umbrel/tunnel profile, LE-behind-CF, and DNS-provider auto-renew remain out of scope as before.
+
+## Design by workstream
+
+### C1 (Critical): generate the selfsigned pair on demand in the render script
+
+`render-main-conf.sh`'s `SSL_MODE=selfsigned` branch currently `exit 1`s when `${SSL_DIR}/bootstrap-selfsigned.crt/.key` are missing. Env-adopted installs never have the pair (the adoption gate requires its absence; only bootstrap-mode render generates it), so a day-2 switch to selfsigned commits an unrenderable config: silent no-op under the watcher, nginx crash-loop on the next container restart.
+
+**Change:** in the selfsigned branch, when the pair is missing, generate it exactly as the bootstrap-mode branch does (`openssl req -x509 -nodes -days 825 -newkey rsa:2048 … -subj "/CN=bffless-bootstrap"`, key `chmod 600`) and continue. Keep the existing `exit 1` only if generation itself fails. The fix lives render-side only: the nginx image installs openssl; the backend image cannot be assumed to have it, and every consumer (entrypoint, watcher re-render, restart) already goes through this script.
+
+**Note on M2 interaction:** generating the pair here writes the bootstrap marker file on a NORMAL-mode install. That is acceptable: the marker's role in `should_bootstrap()` and `isLegacyEnvInstall()` only matters *before* an `instance.env` with `STATE=applied` exists, and reaching the selfsigned branch requires exactly such a file. Document this in a comment at the generation site.
+
+**Tests:** new `render-main-conf.test.sh` case — fixture with `instance.env` (`STATE=applied`, `SSL_MODE=selfsigned`) and **no** selfsigned pair → render succeeds, pair exists afterward, `fullchain.pem`/`privkey.pem` materialized from it. Plus a `test-bootstrap.sh` leg (`RUN_ADOPTED_SELFSIGNED_LEG=1`): simulate an adopted install (real certs, no marker, instance.json origin env), apply a day-2 switch to proxy+selfsigned via the API, assert nginx reloads and serves the generated selfsigned cert, then restart nginx and assert it comes back up.
+
+### M3: bootstrap apply must not strand the box on an fs failure
+
+`BootstrapSetupController.apply()` runs `finalizeSetup()` (DB: `isSetupComplete=true`) before `writeInstanceConfig()` (fs). If the fs write throws (ENOSPC, EACCES), setup is complete ⇒ bootstrap mode permanently off ⇒ every wizard endpoint 403s, yet no identity exists — browser recovery impossible.
+
+**Change:** keep the current order (swapping creates the mirror stranding on DB failure) but wrap `writeInstanceConfig()`; on failure, un-finalize (`setSetupComplete(false)` or equivalent revert of exactly what `finalizeSetup` set), log the underlying error, and return 500 with a message telling the operator the disk write failed and Apply can be retried. The wizard's ApplyStep already surfaces API errors.
+
+**Tests:** controller spec — `writeInstanceConfig` throws → setup is un-finalized, 500 returned, bootstrap mode still active; retry path succeeds.
+
+### M2: make the legacy bootstrap-mode trap visible
+
+When render runs on a new-nginx install with no visible `instance.env` while real certs are transiently missing, it durably writes the selfsigned marker; the marker then defeats both the render legacy carve-out and backend adoption, leaving a production box serving the wizard until the marker is deleted by hand.
+
+**Change (visibility only):** backend boot-time check — when `ssl/bootstrap-selfsigned.crt` exists AND real `fullchain.pem`/`privkey.pem` exist AND `envIdentity()` returns a real domain AND no `instance.json` exists, log a prominent warning naming the recovery (`rm ssl/bootstrap-selfsigned.crt ssl/bootstrap-selfsigned.key && docker compose restart nginx`). Same recovery snippet goes into README's bootstrap section and the release notes.
+
+**Tests:** unit spec for the new check (all four conditions, and each condition absent → no warning).
+
+### M1: upgrade documentation
+
+The documented update flow (`./stop.sh && docker compose pull && ./start.sh --fresh`) lacks `git pull`, but 0.2.18 makes repo files load-bearing (compose `bootstrap/` mounts, `ONBOARDING_TOKEN` passthrough, rebuilt nginx image with the renderer). Verified live: images-only upgrade works but silently loses day-2 serving changes and adopted-LE renewal.
+
+**Changes (this repo):**
+- README "Updating" section: `git pull` as step 1, followed by `./stop.sh`, `docker compose pull`, `./start.sh` (start.sh rebuilds nginx), with a call-out box for the 0.2.18 upgrade specifically.
+- Release-note block (pasted into the release PR body / GitHub release): the git-pull requirement, the M2 recovery one-liner, and the disclosed one-time snapshot-rollback overshoot (#516's transitional quirk).
+
+**Companion deliverable (separate repo, same execution session):** `bffless/docs` PR updating the manual-setup and DigitalOcean "Updating" sections identically, plus a new zero-SSH web-bootstrap setup page (claim token → wizard walkthrough → recovery section). The execution plan carries this as its final task; it does not block the ce PR.
+
+### m2: placeholder divergence warning
+
+`adoptOrResyncEnvInstall`'s wizard-file divergence warning fires on every boot of every web-bootstrap install because compose substitutes `yourdomain.com` for a blank `PRIMARY_DOMAIN`.
+
+**Change:** in the warning guard, skip when `d === 'yourdomain.com'` (mirroring `isLegacyEnvInstall`'s exclusion, with a comment referencing it). **Test:** spec case — placeholder domain + wizard file → no warning; a genuinely different real domain still warns.
+
+### m3: reset-bootstrap.sh mints a claim token when absent
+
+On a formerly-classic install, the kept `.env` has no `ONBOARDING_TOKEN`, so the relaunched wizard is claim-ungated on a public IP.
+
+**Change:** after the wipe, if `.env` lacks a non-empty `ONBOARDING_TOKEN`, generate one (`openssl rand -hex 16`), append it with the same comment header `setup.sh --bootstrap` uses, and print it in the completion message (the script already prints next-step guidance).
+
+**Tests:** shell-level check in `test-bootstrap.sh`'s reset coverage (token present after reset from a token-less `.env`; existing token preserved).
+
+### m4: setup.sh guards against a surviving postgres volume
+
+`setup.sh --force` regenerates `POSTGRES_PASSWORD` while an existing `bffless_postgres-data` volume keeps the old one; the install comes up broken with only a soft migration warning. Hit twice during live testing.
+
+**Change:** when setup.sh is about to write a **new** `POSTGRES_PASSWORD` (fresh `.env` or `--force`) and `docker volume ls` shows an existing `*_postgres-data` volume for this project: interactive mode → explain and offer to remove the volume (default no); non-interactive/bootstrap mode → print a prominent warning with the exact fix (`docker compose down && docker volume rm <name>` or reuse of the old password). No silent deletion ever.
+
+**Tests:** covered by a `test-bootstrap.sh` assertion (warning text emitted when the volume pre-exists in the non-interactive path).
+
+### m11: day-2 cert-source selector (wizard parity)
+
+`ServingModelEditor` hard-presets `sslMode` per serving mode and renders no control to change it, so a proxy-path install cannot paste a cert or switch to LE day-2 — while the wizard offers those choices and reminder emails promise them.
+
+**Change:** add a cert-source radio group to `ServingModelEditor`, mirroring the wizard's per-mode options exactly:
+- `proxy`: keep self-signed (default) / Let's Encrypt / paste
+- `cloudflare`: paste (only — parity with the wizard's CF path)
+- `none` (direct): Let's Encrypt (default) / paste
+
+Selecting a mode still applies today's preset; the group then allows switching within the allowed set. Reuse the existing `ssl-leaves` components (`PasteCertificateFields`, the LE issue/renew panel, `SelfSignedConfirm` copy) — the render branches for paste/LE/selfsigned already exist in the editor; the change is exposing the choice rather than adding new apply semantics. Backend `ApplyDto` already accepts all three modes; no API change. The LE-forces-`port80:redirect` effect and `canApply` staging gates keep working unchanged.
+
+**Tests:** frontend Vitest — per serving mode: allowed options rendered, disallowed absent; switching source swaps the sub-panel; existing ApplyPanel gating tests extended for a proxy+paste stage/apply flow.
+
+### m12 + m13: port-80 defaults and visibility on the Cloudflare path
+
+Live-verified through the real CF edge: the wizard's CF default (`port80: closed`) plus Cloudflare's default-off "Always Use HTTPS" means every plain-`http://` visitor gets a Cloudflare 520. Meanwhile the day-2 CF card's copy claims "port 80 stays closed" but preserves whatever knob exists, and hides the control.
+
+**Change (decided with the user):** default `port80: 'redirect'` for the Cloudflare path in both the wizard and the day-2 editor; render the shared `Port80Choice` control on the CF path in both places so "closed" remains an explicit choice; update the CF card copy ("port 80 redirects to HTTPS; you can close it below if you enable Always Use HTTPS in Cloudflare"). `deriveKnobs`' v1-file derivation (`cloudflare → closed`) is **unchanged** — it describes existing installs, which keep their knob.
+
+**Tests:** wizard + editor Vitest for the new default and visible control; `instance-config` spec asserting `deriveKnobs` legacy derivation unchanged.
+
+### m5: per-IP claim-token rate limiting
+
+The global 5-attempt/15-min lockout lets anyone deny claiming for everyone (including the holder of the correct token).
+
+**Change:** key `claimAttempts` by client IP (`X-Real-IP` → `X-Forwarded-For` first hop → socket address, matching how the app resolves client IPs elsewhere), same 5/15-min budget per key, plus a global backstop of 50 attempts/15 min across all IPs against distributed guessing. A correct token from a non-locked IP always succeeds.
+
+**Tests:** service spec — lockout is per-IP; other IPs unaffected; global cap trips; window expiry resets.
+
+### m6: private-range denylist in DNS preflight and LE issuance
+
+`bootstrap-dns-preflight` (and by extension `issue-certificate`) GET `http://<domain>/...` where `<domain>` is caller-supplied and may resolve to internal ranges.
+
+**Change:** before fetching, resolve the domain (all A/AAAA answers) and refuse — with the existing `{ ok:false, reason }` shape — when any answer is loopback, RFC1918, link-local (169.254.0.0/16 incl. metadata), CGNAT (100.64/10), ULA/fc00::/7, or ::1. Also refuse IP-literal "domains" with an explicit check (do not rely on HOSTNAME_RE happening to reject all-numeric labels). Applies to both the preflight service and any direct fetch in the issuance path.
+
+**Tests:** service spec with mocked DNS answers per range; public IP still passes.
+
+### m7: renewal cron respects a pending confirm window
+
+**Change:** `checkAndRenewPrimary` returns early (log line, no email) when `PrimarySslSnapshotService.readPendingRevert()` is non-null; next night's run proceeds normally.
+**Tests:** renewal spec case.
+
+### m8 + m9: renewal failure-email throttle and challenge cleanup
+
+**Change:** (a) `sendFailureNotifications` for the primary-renewal path gets the same 7-day per-domain throttle mechanism the reminder emails use (failures still log every run); (b) ACME HTTP-01 challenge token files are removed in a `finally` so failed authorizations don't accumulate webroot litter.
+**Tests:** renewal spec — second failure within the window sends no email; token file removed on a failed `waitForValidStatus`.
+
+### Hostname hardening at adoption
+
+`deriveAdoptedConfig` copies `.env`'s `PRIMARY_DOMAIN` verbatim into shell-sourced `instance.env`. Operator-controlled, but a malformed value (space, metacharacter) crash-loops the render — and it's the one identity path that bypasses DTO validation.
+
+**Change:** `envIdentity()` validates the domain against the same hostname rule the DTOs use (`HOSTNAME_RE`, lowercased); invalid → return null (not adoptable) with a one-line warning. This also hardens the divergence-warning path for free.
+**Tests:** instance-config spec — metacharacter/space/overlong domains refused with warning; valid domains unaffected.
+
+## Testing strategy
+
+- Every code change lands with unit/spec coverage in the suite that owns the file (backend Jest, frontend Vitest, `render-main-conf.test.sh`).
+- One new integration leg: `RUN_ADOPTED_SELFSIGNED_LEG=1` in `test-bootstrap.sh` (C1 end-to-end incl. restart survival). CI runs it with branch-built images alongside the existing legs, same gating as the legacy leg (#522's convention).
+- Full `pnpm test` (backend + frontend) and `tsc --noEmit` green before PR.
+
+## Execution
+
+- Branch: `spec/v0218-review-fixes` (this worktree), one PR into `main`, merged before release PR #515 is cut.
+- Implementation plan: `docs/superpowers/plans/2026-07-25-v0218-review-fixes.md` (written next via the writing-plans skill), executed in a fresh session with superpowers:subagent-driven-development.
+- The `bffless/docs` companion PR is the plan's final task (separate repo checkout at `repos/docs-public` is **stale** — the live docs repo is `bffless/docs` per its own conventions; the task clones/uses the correct repo).

--- a/reset-bootstrap.sh
+++ b/reset-bootstrap.sh
@@ -22,8 +22,7 @@
 #      (inside the container), and the frontend re-syncs its bundle — so no host
 #      tooling and no 404.
 #
-# .env (and its claim token) is left untouched. For a brand-new token, run
-# `./setup.sh --bootstrap --force` before this script.
+# .env is left untouched, except that a claim token is minted if none exists.
 
 set -euo pipefail
 
@@ -71,12 +70,12 @@ if [ "$FORCE" != true ]; then
 fi
 
 # 1. Stop the stack (keep volumes for now; we remove specific ones next).
-echo -e "${YELLOW}[1/4] Stopping the stack...${NC}"
+echo -e "${YELLOW}[1/5] Stopping the stack...${NC}"
 # shellcheck disable=SC2086 # word-splitting of $PROFILES is intentional
 docker compose $PROFILES down --remove-orphans
 
 # 2. Remove the data volumes (by their compose-project-prefixed names).
-echo -e "${YELLOW}[2/4] Wiping data volumes...${NC}"
+echo -e "${YELLOW}[2/5] Wiping data volumes...${NC}"
 project="${COMPOSE_PROJECT_NAME:-$(basename "$(pwd)")}"
 removed_any=false
 for v in $DATA_VOLUMES; do
@@ -94,7 +93,7 @@ done
 [ "$removed_any" = true ] || echo "  (no data volumes found — already clean)"
 
 # 3. Clear bind-mounted host state (survives `docker compose down -v`).
-echo -e "${YELLOW}[3/4] Clearing bootstrap state on disk...${NC}"
+echo -e "${YELLOW}[3/5] Clearing bootstrap state on disk...${NC}"
 # Applied identity — removing these drops the instance back to bootstrap mode.
 rm -f bootstrap/instance.json bootstrap/instance.env 2>/dev/null || true
 # Wizard-staged certs. Keep bootstrap-selfsigned.* and acme-account.key.
@@ -105,12 +104,30 @@ rm -f docker/nginx/sites-enabled/*.conf 2>/dev/null || true
 mkdir -p bootstrap ssl
 echo "  cleared instance.*, staged certs, and per-domain nginx configs"
 
-# 4. Bring it back up. Backend migrates on boot; frontend re-syncs its bundle.
-echo -e "${YELLOW}[4/4] Starting the stack...${NC}"
+# 4. A claim token must exist before the wizard comes back up: a formerly
+#    classic (non-bootstrap) install's .env has none, and without it the
+#    relaunched wizard is claim-ungated on a public IP (v0.2.18 review, m3).
+echo -e "${YELLOW}[4/5] Ensuring a claim token exists...${NC}"
+if ! grep -q '^ONBOARDING_TOKEN=..*' .env 2>/dev/null; then
+  CLAIM_TOKEN=$(openssl rand -hex 16)
+  {
+    echo ""
+    echo "# Web-bootstrap claim token (shown in the server's login banner)"
+    echo "ONBOARDING_TOKEN=${CLAIM_TOKEN}"
+  } >> .env
+  echo "  minted a new claim token (none was set)"
+else
+  CLAIM_TOKEN="$(grep '^ONBOARDING_TOKEN=' .env | head -1 | cut -d= -f2-)"
+  echo "  keeping the existing claim token"
+fi
+
+# 5. Bring it back up. Backend migrates on boot; frontend re-syncs its bundle.
+echo -e "${YELLOW}[5/5] Starting the stack...${NC}"
 ./start.sh
 
 echo ""
 echo -e "${GREEN}Done — reset to a fresh setup wizard.${NC}"
+echo "Claim token for the wizard: ${CLAIM_TOKEN}"
 echo ""
 echo "Give it ~45s, then check it's healthy and back in bootstrap mode:"
 echo "  curl -sk https://localhost/api/setup/status    # want bootstrapMode:true, claimRequired:true"

--- a/setup.sh
+++ b/setup.sh
@@ -194,8 +194,20 @@ uncomment_and_set() {
 # interactively offer the wipe. Never deletes silently.
 check_stale_postgres_volume() {
     command_exists docker || return 0
-    project="$(basename "$(pwd)")"
-    vol="$(docker volume ls --format '{{.Name}}' 2>/dev/null | grep -E "^(${project}|${COMPOSE_PROJECT_NAME:-$project})_postgres-data$" | head -1)"
+    # Docker Compose lowercases/normalizes the directory name when deriving the
+    # default project name, so an install dir like /opt/BFFless becomes
+    # "bffless" - lowercase our guess the same way or the exact-prefix match
+    # below silently never fires.
+    project="$(basename "$(pwd)" | tr '[:upper:]' '[:lower:]')"
+    compose_project="${COMPOSE_PROJECT_NAME:-$project}"
+    vol="$(docker volume ls --format '{{.Name}}' 2>/dev/null | grep -E "^(${project}|${compose_project})_postgres-data$" | head -1)"
+    if [ -z "$vol" ]; then
+        # Fall back to any postgres-data volume in this daemon - covers project
+        # names we still failed to guess (custom COMPOSE_PROJECT_NAME casing,
+        # unusual directory naming, etc). The warning below names the volume
+        # so the operator can judge whether it's actually theirs.
+        vol="$(docker volume ls --format '{{.Name}}' 2>/dev/null | grep -E '_postgres-data$' | head -1)"
+    fi
     [ -n "$vol" ] || return 0
     echo ""
     print_warning "Existing database volume found: $vol"

--- a/setup.sh
+++ b/setup.sh
@@ -188,6 +188,38 @@ uncomment_and_set() {
     fi
 }
 
+# A surviving postgres-data volume keeps the OLD password; writing a fresh
+# POSTGRES_PASSWORD then yields an install that boots but fails every DB
+# query with only a soft migration warning (v0.2.18 review, m4). Warn, and
+# interactively offer the wipe. Never deletes silently.
+check_stale_postgres_volume() {
+    command_exists docker || return 0
+    project="$(basename "$(pwd)")"
+    vol="$(docker volume ls --format '{{.Name}}' 2>/dev/null | grep -E "^(${project}|${COMPOSE_PROJECT_NAME:-$project})_postgres-data$" | head -1)"
+    [ -n "$vol" ] || return 0
+    echo ""
+    print_warning "Existing database volume found: $vol"
+    echo "  A new POSTGRES_PASSWORD is about to be generated, but this volume keeps"
+    echo "  the OLD password — the stack would start and then fail every database"
+    echo "  query with 'password authentication failed'."
+    if [ "$INTERACTIVE" = true ]; then
+        printf "Delete this volume and start with a fresh database? ALL DATA IS LOST. (y/N): "
+        read -r wipe_reply
+        case "$wipe_reply" in
+            [yY][eE][sS]|[yY])
+                docker volume rm "$vol" >/dev/null && print_success "Removed $vol" ;;
+            *)
+                echo "  Keeping the volume. Either reuse the old password in .env, or remove it later:"
+                echo "    docker compose down && docker volume rm $vol" ;;
+        esac
+    else
+        echo "  Non-interactive mode: NOT deleting. Fix before ./start.sh with either:"
+        echo "    docker volume rm $vol            # fresh database"
+        echo "    (or set the previous POSTGRES_PASSWORD back in .env)"
+    fi
+    echo ""
+}
+
 # =============================================================================
 # Prerequisite Installation (Debian/Ubuntu)
 # =============================================================================
@@ -655,6 +687,7 @@ prompt_configuration() {
         echo "(auto-generated)"
     fi
     if [ -z "$POSTGRES_PASSWORD" ]; then
+        check_stale_postgres_volume
         POSTGRES_PASSWORD=$(generate_password 32)
         print_info "Generated PostgreSQL password"
     fi
@@ -1682,6 +1715,7 @@ run_bootstrap_mode() {
     check_existing_env          # respects --force semantics; aborts if .env exists without it
 
     PRIMARY_DOMAIN=""           # identity comes later from the web wizard via instance.json
+    check_stale_postgres_volume
     POSTGRES_PASSWORD=$(generate_password 32)
     MINIO_ROOT_USER="$DEFAULT_MINIO_USER"
     MINIO_ROOT_PASSWORD=$(generate_password 32)

--- a/test-bootstrap.sh
+++ b/test-bootstrap.sh
@@ -529,3 +529,58 @@ if [ "${RUN_LEGACY_LEG:-0}" = "1" ]; then
 else
     info "skipping legacy-upgrade leg (set RUN_LEGACY_LEG=1 to run it — needs its own fresh stack boot)"
 fi
+
+# ===========================================================================
+# Adopted-install day-2 selfsigned leg (opt-in: RUN_ADOPTED_SELFSIGNED_LEG=1).
+# C1 regression (v0.2.18 review): an env-adopted install has NO
+# bootstrap-selfsigned pair; switching its instance.env to SSL_MODE=selfsigned
+# must still render (the script generates the pair) and must survive an nginx
+# restart. Builds on the legacy leg's hand-made env install.
+#   RUN_ADOPTED_SELFSIGNED_LEG=1 ./test-bootstrap.sh
+# ===========================================================================
+if [ "${RUN_ADOPTED_SELFSIGNED_LEG:-0}" = "1" ]; then
+    info "adopted-selfsigned leg: tearing down, building a legacy env install"
+    docker compose --profile postgres --profile minio --profile redis --profile supertokens down -v >/dev/null 2>&1
+    rm -rf bootstrap ssl
+    mkdir -p bootstrap ssl
+
+    ADOPT_DOMAIN="adopted-ss.local"
+    sed -i "s/^PRIMARY_DOMAIN=.*/PRIMARY_DOMAIN=${ADOPT_DOMAIN}/" .env
+    grep -q '^PROXY_MODE=' .env && sed -i 's/^PROXY_MODE=.*/PROXY_MODE=proxy/' .env || echo 'PROXY_MODE=proxy' >> .env
+    openssl req -x509 -nodes -days 2 -newkey rsa:2048 -keyout ssl/privkey.pem \
+        -out ssl/fullchain.pem -subj "/CN=${ADOPT_DOMAIN}" 2>/dev/null
+    cp ssl/fullchain.pem "ssl/wildcard.${ADOPT_DOMAIN}.crt"
+    cp ssl/privkey.pem "ssl/wildcard.${ADOPT_DOMAIN}.key"
+
+    ./start.sh
+    wait_until 90 "adopted-selfsigned leg: backend to adopt the env identity" -- \
+        bash -c 'docker compose logs backend 2>/dev/null | grep -q "adopted env identity into instance.json"'
+    [ ! -f ssl/bootstrap-selfsigned.crt ] \
+        || fail "adopted-selfsigned leg: precondition broken — pair already exists"
+
+    # Day-2 switch to proxy+selfsigned, exactly as PrimarySslService.apply()
+    # writes it (we edit the files directly: the leg tests the RENDER path,
+    # not the session-guarded admin API).
+    python3 - <<'PYEOF'
+import json
+cfg = json.load(open('bootstrap/instance.json'))
+cfg['sslMode'] = 'selfsigned'
+cfg['proxyMode'] = 'proxy'
+open('bootstrap/instance.json', 'w').write(json.dumps(cfg, indent=2) + '\n')
+PYEOF
+    sed -i 's/^SSL_MODE=.*/SSL_MODE=selfsigned/; s/^PROXY_MODE=.*/PROXY_MODE=proxy/' bootstrap/instance.env
+
+    wait_until 60 "adopted-selfsigned leg: watcher render generates the pair" -- \
+        test -f ssl/bootstrap-selfsigned.crt
+    ok "adopted-selfsigned leg: pair generated on demand"
+
+    docker compose restart nginx >/dev/null 2>&1
+    wait_until 60 "adopted-selfsigned leg: nginx healthy after restart" -- \
+        bash -c 'docker compose ps nginx | grep -q "Up"'
+    sleep 5
+    docker compose ps nginx | grep -q "Restarting" \
+        && fail "adopted-selfsigned leg: nginx is crash-looping after restart"
+    ok "adopted-selfsigned leg passed: selfsigned renders and survives restart"
+else
+    info "skipping adopted-selfsigned leg (set RUN_ADOPTED_SELFSIGNED_LEG=1 — needs its own fresh stack boot)"
+fi


### PR DESCRIPTION
# Upgrading to v0.2.18

**`git pull` is a required upgrade step for this release.** v0.2.18 adds
compose mounts (`bootstrap/`), an `ONBOARDING_TOKEN` passthrough, and a
rebuilt nginx image. Pulling only the Docker images leaves the new day-2 SSL
management silently inert (settings apply but never reach nginx) and breaks
automatic renewal takeover for migrated Let's Encrypt installs.

```bash
cd /opt/bffless && git pull && ./stop.sh && docker compose pull && ./start.sh
```

Notes for upgraders:

- **Migrated (pre-wizard) installs** are adopted automatically on first boot:
  `bootstrap/instance.json` appears with `origin: "env"` and your `.env`
  stays authoritative. No action needed.
- **One-time rollback quirk:** if you had used cert staging before this
  upgrade, the first SSL change cycle after upgrading may roll back one step
  further than expected, then self-heals (see #516).
- **If nginx ever serves the setup wizard on your production domain** after
  cert files went briefly missing, recover with:
  `rm ssl/bootstrap-selfsigned.crt ssl/bootstrap-selfsigned.key && docker compose restart nginx`

Implements docs/superpowers/specs/2026-07-25-v0218-review-fixes-design.md (all findings from the v0.2.18 release review). Merge BEFORE cutting release PR #515.

Review-loop fixes beyond the plan: claim-token rate limiting keys on the real client IP (extractClientIp — req.ip is the nginx socket peer); DNS-preflight probe pins to the vetted IP (closes a resolve/fetch TOCTOU rebinding gap); ApplyStep summary reflects the new CF port-80 redirect default; setup.sh volume detection matches compose's lowercased project names.

Known caveats: env-adopted domains are lowercased on resync (one-time benign); per-IP rate limiting is XFF-spoofable — the 50-failure global backstop is the enforced bound (request-ip hardening filed as follow-up, applies to Platform too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnSB54xLE81yJqj6L6EzPa