### PR TITLE
fix: unmask bootstrap apply write errors + seed day-2 SSL editor from derived effective knobs

### DIFF
--- a/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, InternalServerErrorException } from '@nestjs/common';
+import { BadRequestException, InternalServerErrorException, Logger } from '@nestjs/common';
 import { BootstrapSetupController } from './bootstrap-setup.controller';
 import { ApplyBootstrapDto } from './setup.dto';
 import * as staging from './ssl-staging';
@@ -406,6 +406,32 @@ describe('BootstrapSetupController', () => {
       // prototype method, which the override already shadows.
       expect(exitFn).not.toHaveBeenCalled();
       writeSpy.mockRestore();
+    });
+
+    it('M3 follow-up (#525): a rejecting unfinalizeSetup() does not mask the write failure — both errors logged, friendly 500 still thrown', async () => {
+      const writeSpy = jest
+        .spyOn(require('../bootstrap/instance-config'), 'writeInstanceConfig')
+        .mockImplementation(() => {
+          throw new Error('ENOSPC: no space left on device');
+        });
+      svc.unfinalizeSetup.mockRejectedValue(new Error('connection to database lost'));
+      const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+      try {
+        // The DB rejection must not propagate raw: the browser still gets the
+        // actionable disk-space 500, not an opaque database error.
+        await expect(
+          controller.apply({ domain: 'example.com', proxyMode: 'cloudflare', sslMode: 'paste' }),
+        ).rejects.toThrow(InternalServerErrorException);
+        // Both the original (more actionable) disk error AND the recovery
+        // failure must reach the log.
+        const logged = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
+        expect(logged).toContain('ENOSPC');
+        expect(logged).toContain('connection to database lost');
+        expect(exitFn).not.toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+        writeSpy.mockRestore();
+      }
     });
   });
 

--- a/apps/backend/src/setup/bootstrap-setup.controller.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.ts
@@ -136,11 +136,22 @@ export class BootstrapSetupController {
       });
     } catch (err) {
       // Failed fs write with setup already finalized = permanently dead
-      // wizard AND no identity (M3). Put the wizard back so Apply can be
-      // retried from the browser once the underlying problem (disk space,
-      // mount perms) is fixed.
-      await this.bootstrap.unfinalizeSetup();
+      // wizard AND no identity (M3). Log the original (more actionable) disk
+      // error before anything else — the recovery below can itself fail.
       this.logger.error(`[bootstrap] apply failed writing instance config: ${(err as Error).message}`);
+      try {
+        // Put the wizard back so Apply can be retried from the browser once
+        // the underlying problem (disk space, mount perms) is fixed.
+        await this.bootstrap.unfinalizeSetup();
+      } catch (recoveryErr) {
+        // An fs failure followed by a DB failure (#525). The raw rejection
+        // must not escape this catch: it would mask the disk error with an
+        // opaque database error. Setup stays finalized, so the wizard may not
+        // come back until the backend restarts with both problems fixed.
+        this.logger.error(
+          `[bootstrap] un-finalizing setup after the failed apply also failed (wizard may not reopen until restart): ${(recoveryErr as Error).message}`,
+        );
+      }
       throw new InternalServerErrorException(
         'Could not write the instance configuration to disk (check free disk space). Setup was NOT completed — fix the disk issue and retry Apply.',
       );

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
@@ -28,6 +28,9 @@ const makeDeps = () => ({
 jest.mock('../../bootstrap/instance-config', () => ({
   loadInstanceConfig: () => mockCur,
   writeInstanceConfig: jest.fn(),
+  // getStatus derives the effective knobs from the raw config — use the real
+  // derivation so these tests cover the v1/env-adopted defaulting (#527).
+  deriveKnobs: jest.requireActual('../../bootstrap/instance-config').deriveKnobs,
 }));
 
 jest.mock('../ssl-staging', () => ({
@@ -75,6 +78,36 @@ describe('PrimarySslService', () => {
     expect(s.domain).toBe(domain);
     expect(s.sslMode).toBe('paste');
     expect(s.cert).not.toBeNull();
+  });
+
+  it('getStatus reports the derived effective port80 (closed) for an env-adopted cloudflare config with no explicit knob (#527)', async () => {
+    // A v1 / env-adopted instance.json carries no port80; deriveKnobs says the
+    // effective knob for cloudflare is 'closed'. The status must report that
+    // derived value — reporting the raw null made the day-2 editor seed its
+    // hardcoded 'redirect' default, silently flipping the install on apply.
+    mockCur = { version: 1, state: 'applied', origin: 'env', primaryDomain: 'a.com', proxyMode: 'cloudflare', sslMode: 'paste' };
+    const { svc } = build();
+    const s = await svc.getStatus();
+    expect(s.port80).toBe('closed');
+    // realIp gets the same effective-knob treatment (cloudflare preset).
+    expect(s.realIp).toEqual({ preset: 'cloudflare' });
+  });
+
+  it('getStatus derives port80 redirect for a knob-less non-cloudflare config', async () => {
+    mockCur = { version: 1, state: 'applied', origin: 'env', primaryDomain: 'a.com', proxyMode: 'none', sslMode: 'paste' };
+    const { svc } = build();
+    const s = await svc.getStatus();
+    expect(s.port80).toBe('redirect');
+    expect(s.realIp).toBeNull();
+  });
+
+  it('getStatus keeps an explicit port80 over the proxyMode-derived default', async () => {
+    mockCur = { version: 2, state: 'applied', primaryDomain: 'a.com', proxyMode: 'cloudflare', sslMode: 'paste', port80: 'redirect', realIp: null };
+    const { svc } = build();
+    const s = await svc.getStatus();
+    expect(s.port80).toBe('redirect');
+    // explicit null is a meaningful "no realip" choice — not re-derived.
+    expect(s.realIp).toBeNull();
   });
 
   it('getStatus reports stagedCert from getStagedPrimaryCertInfo', async () => {

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
@@ -4,7 +4,7 @@ import { SslCertificateService } from '../../domains/ssl-certificate.service';
 import { BootstrapDnsPreflightService, PreflightResult } from '../bootstrap-dns-preflight.service';
 import { SslInfoService, SslCertificateInfo } from '../../domains/ssl-info.service';
 import { PrimarySslSnapshotService } from './primary-ssl-snapshot.service';
-import { loadInstanceConfig, writeInstanceConfig, InstanceConfig, ProxyMode } from '../../bootstrap/instance-config';
+import { deriveKnobs, loadInstanceConfig, writeInstanceConfig, InstanceConfig, ProxyMode } from '../../bootstrap/instance-config';
 import { PrimarySslPasteDto, PrimarySslApplyDto } from './primary-ssl.dto';
 import {
   discardStagedCertificates,
@@ -62,12 +62,19 @@ export class PrimarySslService {
     const stagedCert = await this.info.getStagedPrimaryCertInfo().catch(() => null);
     const wildcardCert = await this.info.getWildcardCertInfo().catch(() => null);
     const pending = this.snap.readPendingRevert();
+    // Report the *effective* knobs, not the raw file values: a v1 /
+    // env-adopted config carries no explicit port80/realIp, and the effective
+    // default is proxyMode-dependent (cloudflare → port80 'closed'). The
+    // day-2 editor seeds from this status — reporting the raw null here made
+    // it fall back to its hardcoded 'redirect', silently flipping an
+    // env-adopted Cloudflare install closed→redirect on the next apply (#527).
+    const knobs = cfg ? deriveKnobs(cfg) : null;
     return {
       domain: cfg?.primaryDomain ?? null,
       proxyMode: cfg?.proxyMode ?? null,
       sslMode: cfg?.sslMode ?? null,
-      port80: cfg?.port80 ?? null,
-      realIp: cfg?.realIp ?? null,
+      port80: knobs?.port80 ?? null,
+      realIp: knobs?.realIp ?? null,
       cert,
       stagedCert,
       wildcardCovered: !!wildcardCert,


### PR DESCRIPTION
Fixes #525
Fixes #527

Two follow-ups from the v0.2.18 review fixes (#523).

## #525 — `unfinalizeSetup()` rejection masked the original apply write error (M3 follow-up)

In `bootstrap-setup.controller.ts` apply, if `writeInstanceConfig` threw and the recovery `unfinalizeSetup()` then also rejected (fs failure followed by DB failure), the DB rejection propagated raw out of the catch — the friendly `InternalServerErrorException` was never thrown and the original, more actionable disk error was never logged.

**Fix:** log the original write error *before* attempting recovery, wrap `unfinalizeSetup()` in a nested try/catch that logs the recovery failure separately (noting the wizard may not reopen until restart, since setup stays finalized in that case), and always throw the intended 500.

## #527 — day-2 SSL editor seeded `port80: 'redirect'` instead of the derived effective knob

An env-adopted Cloudflare install has no `port80` in `instance.json`; its *effective* knob is `closed` via `deriveKnobs` v1 (cloudflare→closed). But `getStatus()` reported the raw file value (`null`), so `PrimarySslManager` fell back to its hardcoded `'redirect'` default — and any day-2 apply silently flipped the install closed→redirect.

**Fix:** `getStatus()` now reports the `deriveKnobs`-derived effective `port80`/`realIp` (backend stays the single source of truth for the derivation; explicit file values still win). The editor therefore seeds from the derived effective knob with no frontend change. `realIp` gets the same treatment for consistency — editor behavior is unchanged there, since the cloudflare preset shape carries no `header` key and `toApplyBody` omits realIp for cloudflare anyway.

Note: the first day-2 apply on such an install now writes the explicit `port80: 'closed'` it was already effectively running with; `isReachabilityChange` compares raw values so that one apply is classified as a serving change and gets the confirm window — safe direction, one-time (the write makes the knob explicit).

## Tests

Test-first (red→green): 3 new backend tests —
- controller spec: rejecting `unfinalizeSetup()` → both errors logged, friendly 500 still thrown
- service spec: knob-less cloudflare config → status reports `closed` + cloudflare realIp preset; knob-less non-cloudflare → `redirect`; explicit values still win

Verified: full backend suite 131 suites / 2141 passed (37 skipped, 0 failures), backend + frontend `tsc --noEmit` clean, frontend primary-ssl vitest 52/52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzeMNE2AKW3DvdNRRjtXFU
