### PR TITLE
docs: rename upgrade notes to v0.3.0 (release renumbered)

### DIFF
--- a/docs/releases/v0.3.0-upgrade-notes.md
+++ b/docs/releases/v0.3.0-upgrade-notes.md
@@ -1,6 +1,6 @@
-# Upgrading to v0.2.18
+# Upgrading to v0.3.0
 
-**`git pull` is a required upgrade step for this release.** v0.2.18 adds
+**`git pull` is a required upgrade step for this release.** v0.3.0 adds
 compose mounts (`bootstrap/`), an `ONBOARDING_TOKEN` passthrough, and a
 rebuilt nginx image. Pulling only the Docker images leaves the new day-2 SSL
 management silently inert (settings apply but never reach nginx) and breaks


### PR DESCRIPTION
The release was renumbered 0.2.18 → 0.3.0 (Release-As on main). Renames docs/releases/v0.2.18-upgrade-notes.md → v0.3.0-upgrade-notes.md and updates its version references. Land before release PR #515 merges so the file matches the release it describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnSB54xLE81yJqj6L6EzPa