### PR TITLE
fix(traffic): failed first blocklist refresh strands stale Baseline-only edge rules

### DIFF
--- a/apps/backend/src/traffic/blocklist.service.spec.ts
+++ b/apps/backend/src/traffic/blocklist.service.spec.ts
@@ -162,6 +162,27 @@ describe('BlocklistService', () => {
       expect(listener).not.toHaveBeenCalled();
     });
 
+    it('notifies on the first successful refresh after the boot refresh failed outright (#531)', async () => {
+      // Live incident: the outer catch (e.g. featureFlags.isEnabled() throwing
+      // because postgres isn't ready yet) used to leave lastFingerprint null,
+      // so the next successful refresh's null-guard suppressed notification
+      // and NginxStartupService's Baseline-only render was never corrected.
+      const listener = jest.fn();
+      service.onEffectiveChange(listener);
+
+      featureFlags.isEnabled.mockRejectedValueOnce(new Error('connection refused'));
+      await service.refresh(); // boot refresh: outer catch, Baseline-only stands
+      expect(listener).not.toHaveBeenCalled();
+
+      mockDb.__queue([listRow()]);
+      mockDb.__queue([entryRow()]);
+      mockDb.__queue([]); // attachments
+      mockDb.__queue([]); // domain mappings
+      await service.refresh(); // first successful refresh after the failure
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(service.shouldBlock('/custom-probe')).toBe(true);
+    });
+
     it('fires listeners when the effective set changes (mutation or toggle flip)', async () => {
       const listener = jest.fn();
       service.onEffectiveChange(listener);

--- a/apps/backend/src/traffic/blocklist.service.ts
+++ b/apps/backend/src/traffic/blocklist.service.ts
@@ -118,6 +118,17 @@ export class BlocklistService implements OnModuleInit {
 
   /** Fingerprint of the last compiled state; null until the first refresh. */
   private lastFingerprint: string | null = null;
+  /**
+   * Set when a refresh dies in the outer catch below (e.g. postgres not
+   * ready yet at boot) — `lastFingerprint` stays null in that case, but the
+   * Baseline-only matcher from the constructor is already live and rendered
+   * into every nginx config by NginxStartupService. Without this flag, the
+   * next successful refresh's null-guard on `changed` would treat that as
+   * "no change" and never call notifyEffectiveChange(), stranding the
+   * Baseline-only edge rules until a manual edit forces a refresh (v0.3.0
+   * live incident, #531). Cleared once the first post-failure refresh notifies.
+   */
+  private refreshEverFailed = false;
   private readonly changeListeners: Array<() => void> = [];
 
   constructor(private readonly featureFlags: FeatureFlagsService) {}
@@ -294,13 +305,23 @@ export class BlocklistService implements OnModuleInit {
         .sort()
         .join(';');
       const fingerprint = `${enabled}|${defaultMatcher.blockSource ?? ''}|${defaultMatcher.allowSource ?? ''}|${domainPart}`;
-      const changed = this.lastFingerprint !== null && this.lastFingerprint !== fingerprint;
+      // Normally the null-guard means "first refresh ever, nothing to diff
+      // against, don't notify" — startup config regen already reads this
+      // state directly. But if an EARLIER refresh died in the outer catch
+      // below, the Baseline-only matcher it left behind is already live in
+      // rendered nginx configs, so this first *successful* refresh must
+      // notify even though lastFingerprint is still null (#531).
+      const changed =
+        this.refreshEverFailed ||
+        (this.lastFingerprint !== null && this.lastFingerprint !== fingerprint);
       this.lastFingerprint = fingerprint;
+      this.refreshEverFailed = false;
       if (changed) {
         this.notifyEffectiveChange();
       }
     } catch (error) {
       // Keep the last good matchers; never let a refresh failure break serving.
+      this.refreshEverFailed = true;
       this.logger.error(`Blocklist refresh failed: ${String(error)}`);
     }
   }


### PR DESCRIPTION
## Summary

Live incident on bffless.dev after the v0.3.0 upgrade restart: every domain served edge rules with only the code-shipped Baseline block (no allowlist), so the `exact:/install.sh` exception was ignored (nginx 444 → Cloudflare 520). A no-op admin edit fixed it instantly, which was the tell.

**Mechanism** (`apps/backend/src/traffic/blocklist.service.ts`):

1. Boot `refresh()` races postgres (lazy connect); `featureFlags.isEnabled()` throws → the **outer** catch fires, leaving the constructor's Baseline-only matcher in place and `lastFingerprint` still `null`.
2. `NginxStartupService` then regenerates every config from that Baseline-only state.
3. 30s later the interval `refresh()` succeeds and loads the real lists — but `changed = lastFingerprint !== null && lastFingerprint !== fingerprint` evaluates `false` on this first successful refresh (the null-guard), so `notifyEffectiveChange()` never fires. Every later refresh computes the same fingerprint, so the stale Baseline-only edge rules persist until a manual blocklist edit or another (lucky) restart.

The **inner** catch ("Could not load Blocklists; enforcing Baseline only") already self-heals correctly, since it still sets `lastFingerprint` on that pass — only the outer-catch path poisons the null.

## Fix

Added a `refreshEverFailed` flag, set in the outer catch and consumed (then cleared) on the next refresh: if a prior refresh died outright, the next successful refresh is unconditionally treated as "changed" and notifies, even though `lastFingerprint` is still `null`. Normal boot (first refresh succeeds) is untouched — the null-guard still suppresses notification there, preserving the original intent that startup config regeneration (not the change-listener path) covers the initial load.

Chose this over seeding `lastFingerprint` with the in-effect state during the failure path because that state (the constructor's `defaultMatcher`) isn't attached to the real toggle/domain fingerprint format computed later, and re-deriving it there would duplicate the fingerprinting logic for no real benefit — over-notification is already cheap: `EdgeBlocklistService.sync()` fingerprints independently and `regenerateAllForBlocklistChange()` early-returns when nothing actually changed.

## Test plan

- [x] Added a failing-first test: mock `featureFlags.isEnabled` to reject once (outer-catch path), then let the next `refresh()` succeed — asserts the change listener fires on that first successful refresh.
- [x] Confirmed existing tests for normal boot (first refresh succeeds → no notify; unchanged refresh → no notify; a subsequent state change → notifies) still pass unmodified.
- [x] `pnpm test -- blocklist.service.spec` — 43/43 passing.
- [x] `pnpm test -- traffic domains/edge-blocklist domains/nginx-startup` — 135/135 passing.
- [x] `pnpm --filter backend exec tsc --noEmit` — clean.

Fixes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnSB54xLE81yJqj6L6EzPa