### PR TITLE
feat(onboarding): welcome step with walkthrough video and docs link

### DIFF
--- a/apps/frontend/src/components/setup/onboarding/OnboardingModal.test.tsx
+++ b/apps/frontend/src/components/setup/onboarding/OnboardingModal.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { OnboardingModal } from './OnboardingModal';
+import { api } from '@/services/api';
+import setupReducer from '@/store/slices/setupSlice';
+
+// This codebase has no MSW harness — RTK Query hooks are mocked directly, the
+// same pattern the setup wizard tests use.
+vi.mock('@/hooks/useBranding', () => ({
+  useBranding: () => ({ siteName: 'BFFLESS' }),
+}));
+
+vi.mock('@/services/projectsApi', () => ({
+  useCreateProjectMutation: () => [vi.fn(), { isLoading: false }],
+}));
+
+function renderModal() {
+  const store = configureStore({
+    reducer: { setup: setupReducer, [api.reducerPath]: api.reducer },
+    middleware: (getDefault) => getDefault().concat(api.middleware),
+  });
+
+  return render(
+    <Provider store={store}>
+      <OnboardingModal isOpen onClose={vi.fn()} />
+    </Provider>
+  );
+}
+
+describe('OnboardingModal', () => {
+  afterEach(cleanup);
+
+  it('opens on the welcome step, not the repository form', () => {
+    renderModal();
+
+    expect(screen.getByText('Welcome to BFFLESS')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /first-deployment guide/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Repository Name')).toBeNull();
+  });
+
+  it('advances from welcome to the repository form', async () => {
+    renderModal();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Get Started' }));
+
+    expect(screen.getByText('Create Your First Repository')).toBeInTheDocument();
+    expect(screen.getByLabelText('Repository Name')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/setup/onboarding/OnboardingModal.tsx
+++ b/apps/frontend/src/components/setup/onboarding/OnboardingModal.tsx
@@ -7,9 +7,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { useBranding } from '@/hooks/useBranding';
+import { WelcomeStep } from './WelcomeStep';
 import { CreateRepoStep } from './CreateRepoStep';
 import { ApiKeyStep } from './ApiKeyStep';
 import { GitHubActionsStep } from './GitHubActionsStep';
+
+const LAST_STEP = 4;
 
 interface OnboardingModalProps {
   isOpen: boolean;
@@ -18,6 +22,7 @@ interface OnboardingModalProps {
 
 export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
   const dispatch = useDispatch();
+  const { siteName } = useBranding();
   const { onboardingStep, createdProjectId, createdApiKey } = useSelector(
     (state: RootState) => state.setup.onboarding
   );
@@ -28,7 +33,7 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
   };
 
   const handleNext = () => {
-    if (onboardingStep < 3) {
+    if (onboardingStep < LAST_STEP) {
       dispatch(setOnboardingStep(onboardingStep + 1));
     } else {
       dispatch(completeOnboarding());
@@ -39,8 +44,10 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
   const renderStep = () => {
     switch (onboardingStep) {
       case 1:
-        return <CreateRepoStep onNext={handleNext} onSkip={handleSkip} />;
+        return <WelcomeStep onNext={handleNext} onSkip={handleSkip} />;
       case 2:
+        return <CreateRepoStep onNext={handleNext} onSkip={handleSkip} />;
+      case 3:
         return (
           <ApiKeyStep
             projectId={createdProjectId}
@@ -48,7 +55,7 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
             onSkip={handleSkip}
           />
         );
-      case 3:
+      case 4:
         return (
           <GitHubActionsStep
             apiKey={createdApiKey}
@@ -63,10 +70,12 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
   const getTitle = () => {
     switch (onboardingStep) {
       case 1:
-        return 'Create Your First Repository';
+        return `Welcome to ${siteName}`;
       case 2:
-        return 'Generate API Key';
+        return 'Create Your First Repository';
       case 3:
+        return 'Generate API Key';
+      case 4:
         return 'Set Up GitHub Actions';
       default:
         return 'Getting Started';
@@ -75,7 +84,10 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-lg">
+      {/* DialogContent is vertically centred with no height cap of its own, so
+          the welcome step's video would push the buttons off-screen on short
+          viewports (~700px laptops). Cap and scroll instead. */}
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{getTitle()}</DialogTitle>
         </DialogHeader>

--- a/apps/frontend/src/components/setup/onboarding/WelcomeStep.test.tsx
+++ b/apps/frontend/src/components/setup/onboarding/WelcomeStep.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WelcomeStep } from './WelcomeStep';
+
+const DOCS_URL = 'https://docs.bffless.dev/getting-started/first-deployment/';
+
+describe('WelcomeStep', () => {
+  afterEach(cleanup);
+
+  it('links to the first-deployment guide in a new tab', () => {
+    render(<WelcomeStep onNext={vi.fn()} onSkip={vi.fn()} />);
+
+    const link = screen.getByRole('link', { name: /first-deployment guide/i });
+    expect(link).toHaveAttribute('href', DOCS_URL);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  it('does not embed the YouTube iframe until play is pressed', async () => {
+    render(<WelcomeStep onNext={vi.fn()} onSkip={vi.fn()} />);
+
+    // Facade only — no third-party frame on first render.
+    expect(document.querySelector('iframe')).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: /play video/i }));
+
+    const iframe = document.querySelector('iframe');
+    expect(iframe).not.toBeNull();
+    // youtube-nocookie keeps a self-hosted install off Google's cookie domain.
+    expect(iframe?.getAttribute('src')).toContain(
+      'https://www.youtube-nocookie.com/embed/cNqh02HyD0s'
+    );
+  });
+
+  it('advances on Get Started and dismisses on Skip for now', async () => {
+    const onNext = vi.fn();
+    const onSkip = vi.fn();
+    render(<WelcomeStep onNext={onNext} onSkip={onSkip} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Get Started' }));
+    expect(onNext).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Skip for now' }));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the thumbnail image when it fails to load, keeping the play control', () => {
+    render(<WelcomeStep onNext={vi.fn()} onSkip={vi.fn()} />);
+
+    const img = document.querySelector('img');
+    expect(img).not.toBeNull();
+    // A locked-down network (or blocked i.ytimg.com) must not leave a broken image.
+    fireEvent.error(img!);
+
+    expect(document.querySelector('img')).toBeNull();
+    expect(screen.getByRole('button', { name: /play video/i })).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/setup/onboarding/WelcomeStep.tsx
+++ b/apps/frontend/src/components/setup/onboarding/WelcomeStep.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { BookOpen, ExternalLink, Play } from 'lucide-react';
+
+const VIDEO_ID = 'cNqh02HyD0s';
+const VIDEO_TITLE = 'BFFless: your first deployment';
+const DOCS_URL = 'https://docs.bffless.dev/getting-started/first-deployment/';
+
+// hqdefault always exists for a public video (unlike maxresdefault), and is 4:3
+// with letterbox bars — object-cover inside the 16:9 frame crops them off.
+const thumbnailUrl = `https://i.ytimg.com/vi/${VIDEO_ID}/hqdefault.jpg`;
+
+interface WelcomeStepProps {
+  onNext: () => void;
+  onSkip: () => void;
+}
+
+/**
+ * First screen of post-setup onboarding: welcomes the operator, offers the
+ * walkthrough video and the first-deployment guide, then hands off to
+ * CreateRepoStep.
+ *
+ * The video is a click-to-load facade: on render it fetches only the static
+ * thumbnail from i.ytimg.com, and the tracking-capable player iframe
+ * (youtube-nocookie.com) is mounted only once the operator presses play. If
+ * i.ytimg.com is blocked or unreachable — a self-hosted instance behind a
+ * strict egress policy — onError drops the image and the gradient placeholder
+ * plus play button remain, rather than a broken-image icon.
+ */
+export function WelcomeStep({ onNext, onSkip }: WelcomeStepProps) {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [thumbnailFailed, setThumbnailFailed] = useState(false);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Your instance is up and running. Watch the walkthrough, or jump straight
+        in — the next few steps create your first repository, generate an API
+        key, and hand you a GitHub Actions workflow to copy.
+      </p>
+
+      <div className="relative aspect-video overflow-hidden rounded-lg bg-gradient-to-br from-zinc-800 to-zinc-900">
+        {isPlaying ? (
+          <iframe
+            className="absolute inset-0 h-full w-full"
+            src={`https://www.youtube-nocookie.com/embed/${VIDEO_ID}?autoplay=1&rel=0`}
+            title={VIDEO_TITLE}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            referrerPolicy="strict-origin-when-cross-origin"
+            allowFullScreen
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setIsPlaying(true)}
+            aria-label={`Play video: ${VIDEO_TITLE}`}
+            className="group absolute inset-0 h-full w-full"
+          >
+            {!thumbnailFailed && (
+              <img
+                src={thumbnailUrl}
+                alt=""
+                loading="lazy"
+                onError={() => setThumbnailFailed(true)}
+                className="absolute inset-0 h-full w-full object-cover"
+              />
+            )}
+            {/* No caption overlay: YouTube thumbnails usually carry their own
+                title art, and text on top of it collides. */}
+            <span className="absolute inset-0 bg-black/20 transition-colors group-hover:bg-black/35" />
+            <span className="absolute inset-0 flex items-center justify-center">
+              <span className="flex h-14 w-14 items-center justify-center rounded-full bg-[#d96459] shadow-lg transition-transform group-hover:scale-110">
+                <Play className="h-6 w-6 translate-x-[1px] fill-white text-white" />
+              </span>
+            </span>
+          </button>
+        )}
+      </div>
+
+      <a
+        href={DOCS_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-2 rounded-lg border p-3 text-sm transition-colors hover:border-[#d96459]/50 hover:bg-muted/50"
+      >
+        <BookOpen className="h-4 w-4 flex-shrink-0 text-[#d96459]" />
+        <span className="font-medium">Read the first-deployment guide</span>
+        <ExternalLink className="ml-auto h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+      </a>
+
+      <div className="flex justify-between pt-4">
+        <Button type="button" variant="ghost" onClick={onSkip}>
+          Skip for now
+        </Button>
+        <Button type="button" onClick={onNext}>
+          Get Started
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem

On first login the onboarding modal opens directly on **Create Your First Repository** — a bare form with no orientation, no pointer to the docs, and nothing explaining what the next few steps are for.

## Change

Adds a **Welcome** step ahead of the form, so onboarding is now Welcome → Create Repo → API Key → GitHub Actions.

The step carries:
- a short intro that sets expectations for the remaining steps
- the walkthrough video (`cNqh02HyD0s`)
- a link to the [first-deployment guide](https://docs.bffless.dev/getting-started/first-deployment/)

### Notable decisions

**Click-to-load video facade.** On render only the static thumbnail (`i.ytimg.com`) is fetched; the tracking-capable `youtube-nocookie.com` player mounts only once the operator presses play. CE is self-hosted — a fresh install shouldn't load a Google player uninvited on first login. If `i.ytimg.com` is blocked (strict egress policy), `onError` drops the image and the gradient placeholder plus play button remain, rather than a broken-image icon.

**Branded title.** The modal title reads `Welcome to ${siteName}` via `useBranding`, so white-labeled installs aren't hardcoded to "BFFLESS".

**Modal height cap (bug this change would otherwise introduce).** `DialogContent` is vertically centred with no height cap of its own, so the taller welcome content pushed the action buttons off-screen on ~700px-tall viewports with no way to scroll to them. Now `max-h-[90vh] overflow-y-auto`.

## Verification

- `tsc --noEmit` clean, `eslint` clean
- **687/687** frontend tests pass; 6 new tests cover the docs link, click-to-play, navigation, thumbnail failure, and that the modal opens on Welcome rather than the repo form
- Driven in real headless Chromium: click mounts the iframe at the nocookie URL and the YouTube player element renders

**Caveat:** in the headless run the embed showed *"Sign in to confirm you're not a bot"* — YouTube's datacenter-IP check against the VPS, not a code defect. Actual playback could not be observed from that environment.

## Follow-ups (not in this PR)

- The docs page for first-deployment embeds a **different** video (`fGYmvUqhGYk`, "First Deployment Walkthrough") than the one used here (`cNqh02HyD0s`, "Deploy with GitHub Actions"). Worth confirming which belongs on this screen.
- Pre-existing a11y gap, surfaced in test output: `DialogContent` has no `DialogDescription`/`aria-describedby`, so screen readers get no description on any of the four steps. Left alone to keep this diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
