### PR TITLE
fix: preserve ?token= across the /setup redirect

### DIFF
--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -125,7 +125,7 @@ export function HomePage() {
 
   // Check setup status first - redirect to setup if not complete
   if (!isSetupLoading && setupStatus && !setupStatus.isSetupComplete) {
-    return <Navigate to="/setup" replace />;
+    return <Navigate to={{ pathname: '/setup', search: window.location.search }} replace />;
   }
 
   // Show loading while checking setup status (auth loading handled by ProtectedRoute)

--- a/apps/frontend/src/pages/LoginPage.tsx
+++ b/apps/frontend/src/pages/LoginPage.tsx
@@ -167,7 +167,7 @@ export function LoginPage() {
 
   // Redirect to setup if not complete
   if (!isLoadingSetup && setupStatus && !setupStatus.isSetupComplete) {
-    return <Navigate to="/setup" replace />;
+    return <Navigate to={{ pathname: '/setup', search: window.location.search }} replace />;
   }
 
   const onSubmit = async (data: LoginFormValues) => {


### PR DESCRIPTION
## Summary

`https://<ip>/?token=<claim>` was landing on `/setup` **without** the token. The cert-warning interstitial was suspected first, but the real culprit is ours: both setup redirects (`HomePage.tsx:128`, `LoginPage.tsx:170`) used `<Navigate to="/setup" replace />`, which discards `location.search`. The wizard reads `?token=` on the `/setup` route (`SetupWizard.tsx`, `ClaimStep.tsx`), so the prefill never saw it.

Fix: `<Navigate to={{ pathname: '/setup', search: window.location.search }} replace />` in both places (same `window.location` idiom ClaimStep already uses). Both URL forms now work: `/?token=…` and `/setup?token=…`.

Found during DO 1-Click droplet testing (follow-up to #538/#541). The banner/MOTD copy-paste-token flow from #538 remains the documented fallback either way.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run SetupWizard.bootstrap.test.tsx` — 23/23 pass
- [x] Manual: `/?token=x` now arrives at `/setup?token=x` (ClaimStep strips it from the URL after reading, as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163A8vKpvtvTP4XqJdyLNHG
