### PR TITLE
feat: update.sh prunes superseded images

### DIFF
--- a/scripts/lifecycle.test.sh
+++ b/scripts/lifecycle.test.sh
@@ -112,6 +112,7 @@ echo "— update.sh: clean tree pulls with detected profiles and restarts —"
         "docker compose --profile postgres --profile minio --profile supertokens pull" \
         "profile-aware image pull (minio on, redis off)"
     assert_contains "calls.log" "restart" "restart.sh invoked"
+    assert_contains "$DOCKER_LOG" "docker image prune -f" "superseded images pruned after restart"
     cd / && rm -rf "$SB"
     exit "$FAILURES"
 ); FAILURES=$((FAILURES+$?))

--- a/update.sh
+++ b/update.sh
@@ -16,6 +16,7 @@ Updates this BFFless install:
   2. git pull --ff-only
   3. docker compose pull (only the profiles this install has enabled)
   4. ./restart.sh — start.sh rebuilds the local nginx image from the pulled tree
+  5. docker image prune -f — reclaims disk from superseded (dangling) images
 EOF
     exit 0
 fi
@@ -54,5 +55,11 @@ echo "Pulling latest images..."
 docker compose $PROFILES pull
 
 ./restart.sh
+
+# Reclaim disk from superseded images: after the restart nothing references
+# the previous pulls/builds, and prune -f only touches dangling (untagged)
+# images — pinned tags are never removed.
+echo "Pruning superseded images..."
+docker image prune -f || true
 
 echo -e "Updated to: ${GREEN}$(current_version)${NC}"


### PR DESCRIPTION
## Summary

`update.sh` pulled new images but never reclaimed the old ones: each update strands the previous `latest` (untagged after the pull) plus the prior local nginx build. On a 24 GB 1-Click droplet that's a slow-motion disk-full after months of updates.

Fix: `docker image prune -f` after `./restart.sh`. Safe by construction — prune only removes dangling (untagged) images, and after the restart nothing references the superseded ones; pinned tags are never touched. `|| true` keeps a prune hiccup from failing an otherwise-successful update. Help text updated, covered by a new lifecycle-test assertion.

## Test plan
- [x] shellcheck clean
- [x] `bash scripts/lifecycle.test.sh` — all pass incl. new prune assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163A8vKpvtvTP4XqJdyLNHG
