### PR TITLE
feat(cli): bffless login credential store + auth commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -56,7 +56,7 @@ CI should keep using `BFFLESS_API_KEY` — env always beats the store.
 ## Auth & config precedence
 
 - API URL: `--api-url` > `BFFLESS_API_URL` env > `.bffless/config.json`'s `apiUrl`.
-- API key: `--api-key` > `BFFLESS_API_KEY` env only (never read from config, so it's safe to commit).
+- API key: `--api-key` > `BFFLESS_API_KEY` env > login credential store (see Authentication above; never read from config, so it's safe to commit).
 - Project: `--project` > `.bffless/config.json`'s `project` (UUID, `owner/name`, or bare name).
   Prefer a UUID or `owner/name`: both resolve for any user with a role on the project. A bare
   name has to be matched against `GET /api/projects`, which lists only the projects the API

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -27,6 +27,32 @@ pnpm add -D bffless              # or pin it as a devDependency
 Rule-set directories default to the nearest `.bffless/config.json`'s `ruleSets` glob array
 when `[dirs...]` is omitted.
 
+## Authentication
+
+Every server command needs an API key, resolved as: `--api-key` flag >
+`BFFLESS_API_KEY` env > the login credential store. Keys are never read from
+`.bffless/config.json` (it is committed to the repo).
+
+One-time per machine + instance, store a key interactively:
+
+    bffless login                       # instance from .bffless/config.json
+    bffless login --api-url https://admin.example.com
+
+`login` tells you where to create the key (admin UI → Settings → API Keys),
+validates the pasted key against the instance, and saves it to
+`~/.config/bffless/credentials.json` (mode 0600, keyed by instance URL — one
+entry per instance).
+
+    bffless auth status                 # list stored instances + validity
+    bffless auth token                  # print the key (for scripts/agents)
+    bffless logout                      # remove an instance's entry
+
+Scripts and other tools can reuse the stored key without parsing anything:
+
+    curl -H "X-API-Key: $(bffless auth token)" https://admin.example.com/api/projects
+
+CI should keep using `BFFLESS_API_KEY` — env always beats the store.
+
 ## Auth & config precedence
 
 - API URL: `--api-url` > `BFFLESS_API_URL` env > `.bffless/config.json`'s `apiUrl`.

--- a/packages/cli/src/api/client.ts
+++ b/packages/cli/src/api/client.ts
@@ -4,10 +4,12 @@
  * Base-URL resolution: `--api-url` flag > `BFFLESS_API_URL` env > `apiUrl` in the nearest
  * `.bffless/config.json`.
  *
- * API-key resolution: `--api-key` flag > `BFFLESS_API_KEY` env — and NOTHING else.
- * The key is deliberately never read from `.bffless/config.json`: that file is meant to be
- * committed to the repo (it carries `apiUrl`/`project`/`ruleSets` for the whole team), so
- * supporting a key there would invite committing credentials. Keys stay in flags/env only.
+ * API-key resolution: `--api-key` flag > `BFFLESS_API_KEY` env > the `bffless login`
+ * credential store (~/.config/bffless/credentials.json, keyed by normalized apiUrl) —
+ * and NOTHING else. The key is deliberately never read from `.bffless/config.json`:
+ * that file is meant to be committed to the repo (it carries `apiUrl`/`project`/
+ * `ruleSets` for the whole team), so supporting a key there would invite committing
+ * credentials. Keys stay in flags/env/the out-of-repo store only.
  *
  * Auth is the backend's `ApiKeyGuard`, which reads the `X-API-Key` request header.
  *
@@ -19,6 +21,7 @@
  * fast and loudly rather than mask a flaky endpoint.
  */
 import { findConfig, type BfflessConfig } from '../config.js';
+import { getStoredKey } from './credentials.js';
 import { resolveRemediation, type Remediation } from './remediation.js';
 
 /** Error thrown for any failed request; `status` is 0 for network-level failures. */
@@ -46,6 +49,8 @@ export interface ClientDeps {
   /** Pre-loaded config (tests / callers that already ran `findConfig`); when absent the
    *  nearest `.bffless/config.json` above `cwd` is used. */
   config?: BfflessConfig | null;
+  /** Override the credential-store file path (tests). Default: `credentialsPath()`. */
+  credentialsFile?: string;
   /** Override the "how to fix it" wording of config/auth errors. Unset fields keep the
    *  CLI's default phrasing — an embedder with no flags should override the ones its user
    *  can actually act on. */
@@ -178,8 +183,10 @@ export function createClient(flags: ClientFlags, cwd: string, deps?: ClientDeps)
     throw new Error(`no API URL configured — ${remediation.apiUrl}`);
   }
 
-  // Key precedence is flag > env ONLY — never config.json (a committed file; see module doc).
-  const apiKey = flags.apiKey ?? env.BFFLESS_API_KEY;
+  // Key precedence is flag > env > credential store — never config.json (a committed
+  // file; see module doc). The store (written by `bffless login`) lives in ~/.config,
+  // outside any repo, and is keyed by normalized apiUrl.
+  const apiKey = flags.apiKey ?? env.BFFLESS_API_KEY ?? getStoredKey(apiUrl, deps?.credentialsFile);
   if (!apiKey) {
     throw new Error(`no API key configured — ${remediation.apiKey}`);
   }

--- a/packages/cli/src/api/credentials.ts
+++ b/packages/cli/src/api/credentials.ts
@@ -1,0 +1,100 @@
+/**
+ * Credential store for `bffless login` — `$XDG_CONFIG_HOME/bffless/credentials.json`
+ * (default `~/.config/bffless/credentials.json`), mode 0600, written atomically.
+ *
+ * Keys are stored OUTSIDE any repo, keyed by normalized API URL, so the client.ts
+ * invariant holds: API keys are never read from a repo-committed file. Resolution
+ * precedence stays flag > env > (this store) — see createClient.
+ *
+ * A present-but-broken file is a hard error naming the path (same stance as
+ * config.ts): silently treating it as "no credentials" would send the user down a
+ * confusing "why am I logged out" path instead of "your file is corrupt".
+ */
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { z } from 'zod';
+
+export const CredentialsFileSchema = z
+  .object({
+    version: z.literal(1),
+    credentials: z.record(
+      z.object({ apiKey: z.string().min(1), createdAt: z.string() }).strict(),
+    ),
+  })
+  .strict();
+export type CredentialsFile = z.infer<typeof CredentialsFileSchema>;
+
+/** Default store location, honouring `$XDG_CONFIG_HOME`. */
+export function credentialsPath(env: Record<string, string | undefined> = process.env): string {
+  const base =
+    env.XDG_CONFIG_HOME && env.XDG_CONFIG_HOME.length > 0
+      ? env.XDG_CONFIG_HOME
+      : path.join(os.homedir(), '.config');
+  return path.join(base, 'bffless', 'credentials.json');
+}
+
+/** Canonical store key for an instance URL: URL-parsed (lowercased host), trailing slashes stripped. */
+export function normalizeApiUrl(raw: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`invalid API URL: "${raw}" — expected e.g. https://admin.example.com`);
+  }
+  const pathname = url.pathname.replace(/\/+$/, '');
+  return `${url.protocol}//${url.host}${pathname}`;
+}
+
+/** Parse the store. `null` when the file does not exist; throws (naming the path) when broken. */
+export function readCredentialsFile(file: string): CredentialsFile | null {
+  if (!existsSync(file)) return null;
+  const raw = readFileSync(file, 'utf8');
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`${file}: invalid JSON — ${(err as Error).message}`);
+  }
+  const result = CredentialsFileSchema.safeParse(data);
+  if (!result.success) {
+    throw new Error(
+      `${file}: does not match the credentials schema — fix or delete the file and run \`bffless login\` again`,
+    );
+  }
+  return result.data;
+}
+
+export function getStoredKey(apiUrl: string, file: string = credentialsPath()): string | undefined {
+  return readCredentialsFile(file)?.credentials[normalizeApiUrl(apiUrl)]?.apiKey;
+}
+
+export function storeKey(
+  apiUrl: string,
+  apiKey: string,
+  file: string = credentialsPath(),
+  now: Date = new Date(),
+): void {
+  const store = readCredentialsFile(file) ?? { version: 1 as const, credentials: {} };
+  store.credentials[normalizeApiUrl(apiUrl)] = { apiKey, createdAt: now.toISOString() };
+  writeCredentialsFile(file, store);
+}
+
+/** Remove an instance's entry. Returns whether anything was removed. */
+export function removeKey(apiUrl: string, file: string = credentialsPath()): boolean {
+  const store = readCredentialsFile(file);
+  const key = normalizeApiUrl(apiUrl);
+  if (!store || !(key in store.credentials)) return false;
+  delete store.credentials[key];
+  writeCredentialsFile(file, store);
+  return true;
+}
+
+/** Atomic write (temp + rename), file 0600, parent dir 0700. */
+function writeCredentialsFile(file: string, data: CredentialsFile): void {
+  mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const tmp = `${file}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
+  renameSync(tmp, file);
+  chmodSync(file, 0o600);
+}

--- a/packages/cli/src/api/remediation.ts
+++ b/packages/cli/src/api/remediation.ts
@@ -25,12 +25,12 @@ export interface Remediation {
 export const CLI_REMEDIATION: Remediation = {
   apiUrl: 'pass --api-url, set BFFLESS_API_URL, or add "apiUrl" to .bffless/config.json',
   apiKey:
-    'pass --api-key or set BFFLESS_API_KEY (API keys are never read from .bffless/config.json, ' +
-    'which is committed to the repo)',
+    'pass --api-key, set BFFLESS_API_KEY, or run `bffless login` (API keys are never read ' +
+    'from .bffless/config.json, which is committed to the repo)',
   project: 'pass --project <uuid|owner/name|name> or add "project" to .bffless/config.json',
   auth:
-    'The API key is sent as the X-API-Key header — pass --api-key or set BFFLESS_API_KEY to a ' +
-    'key with access to this project.',
+    'The API key is sent as the X-API-Key header — pass --api-key, set BFFLESS_API_KEY, or ' +
+    'run `bffless login` with a key that has access to this project.',
 };
 
 /** Fill any unspecified field from {@link CLI_REMEDIATION}. */

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -80,13 +80,13 @@ export function promptSecret(question: string): Promise<string> {
           resolve(value.trim());
           return;
         }
-        if (ch === '') {
+        if (ch === '\u0003') {
           // Ctrl-C
           stdin.setRawMode(false);
           process.stdout.write('\n');
           process.exit(130);
         }
-        if (ch === '' || ch === '\b') {
+        if (ch === '\u007f' || ch === '\b') {
           value = value.slice(0, -1);
           continue;
         }

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,0 +1,183 @@
+/**
+ * `bffless login` / `logout` / `auth status` / `auth token` — the paste-a-key
+ * credential flow over api/credentials.ts.
+ *
+ * The API URL identifies WHICH instance to act on and resolves exactly like the
+ * client's base URL: `--api-url` flag > `BFFLESS_API_URL` env > nearest
+ * `.bffless/config.json`. So inside an app repo clone, `bffless login` /
+ * `auth token` need no arguments at all.
+ *
+ * `login` validates the pasted key with a real call (`GET /api/projects` — cheap,
+ * key-only) BEFORE storing: a typo'd key should fail at login time, not on the
+ * first `rules push` a week later.
+ */
+import { findConfig } from '../config.js';
+import { ApiClient, type FetchLike } from '../api/client.js';
+import {
+  credentialsPath,
+  getStoredKey,
+  normalizeApiUrl,
+  readCredentialsFile,
+  removeKey,
+  storeKey,
+} from '../api/credentials.js';
+
+export interface AuthDeps {
+  env?: Record<string, string | undefined>;
+  fetchImpl?: FetchLike;
+  /** Override the credential-store file path (tests). */
+  credentialsFile?: string;
+  /** Override the interactive secret prompt (tests). */
+  promptSecret?: (question: string) => Promise<string>;
+  /** Override instruction output (tests). Default: console.log. */
+  log?: (message: string) => void;
+}
+
+export interface AuthStatusRow {
+  apiUrl: string;
+  keyPrefix: string;
+  valid: boolean;
+}
+
+const API_URL_REMEDIATION =
+  'pass --api-url, set BFFLESS_API_URL, or run from a repo with "apiUrl" in .bffless/config.json';
+
+/** Same base-URL precedence as createClient: flag > env > config walk-up. */
+function resolveApiUrl(
+  opts: { apiUrl?: string },
+  cwd: string,
+  env: Record<string, string | undefined>,
+): string | undefined {
+  return opts.apiUrl ?? env.BFFLESS_API_URL ?? findConfig(cwd)?.config.apiUrl ?? undefined;
+}
+
+/** Read a secret from the terminal (masked) or from piped stdin (first line). */
+export function promptSecret(question: string): Promise<string> {
+  if (!process.stdin.isTTY) {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      process.stdin.on('data', (c: Buffer) => chunks.push(c));
+      process.stdin.on('end', () =>
+        resolve(Buffer.concat(chunks).toString('utf8').split('\n')[0].trim()),
+      );
+      process.stdin.on('error', reject);
+    });
+  }
+  process.stdout.write(question);
+  return new Promise((resolve) => {
+    const stdin = process.stdin;
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding('utf8');
+    let value = '';
+    const onData = (chunk: string) => {
+      for (const ch of chunk) {
+        if (ch === '\r' || ch === '\n') {
+          stdin.setRawMode(false);
+          stdin.pause();
+          stdin.off('data', onData);
+          process.stdout.write('\n');
+          resolve(value.trim());
+          return;
+        }
+        if (ch === '') {
+          // Ctrl-C
+          stdin.setRawMode(false);
+          process.stdout.write('\n');
+          process.exit(130);
+        }
+        if (ch === '' || ch === '\b') {
+          value = value.slice(0, -1);
+          continue;
+        }
+        value += ch;
+      }
+    };
+    stdin.on('data', onData);
+  });
+}
+
+export async function runLogin(
+  opts: { apiUrl?: string },
+  cwd: string,
+  deps?: AuthDeps,
+): Promise<{ ok: true; apiUrl: string } | { ok: false; error: string }> {
+  const env = deps?.env ?? process.env;
+  const log = deps?.log ?? console.log;
+  const rawUrl = resolveApiUrl(opts, cwd, env);
+  if (!rawUrl) return { ok: false, error: `no API URL configured — ${API_URL_REMEDIATION}` };
+
+  let apiUrl: string;
+  try {
+    apiUrl = normalizeApiUrl(rawUrl);
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  log(`Logging in to ${apiUrl}`);
+  log(`Create an API key in the BFFless admin UI (${apiUrl} → Settings → API Keys), then paste it below.`);
+  const key = (await (deps?.promptSecret ?? promptSecret)('API key: ')).trim();
+  if (key.length === 0) return { ok: false, error: 'empty API key — nothing stored' };
+
+  const client = new ApiClient({ apiUrl, apiKey: key, fetchImpl: deps?.fetchImpl });
+  try {
+    await client.get('/api/projects', 'project list');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `key validation failed — nothing stored.\n${msg}` };
+  }
+
+  storeKey(apiUrl, key, deps?.credentialsFile);
+  return { ok: true, apiUrl };
+}
+
+export function runLogout(
+  opts: { apiUrl?: string },
+  cwd: string,
+  deps?: AuthDeps,
+): { ok: true; apiUrl: string; removed: boolean } | { ok: false; error: string } {
+  const env = deps?.env ?? process.env;
+  const rawUrl = resolveApiUrl(opts, cwd, env);
+  if (!rawUrl) return { ok: false, error: `no API URL configured — ${API_URL_REMEDIATION}` };
+  const apiUrl = normalizeApiUrl(rawUrl);
+  return { ok: true, apiUrl, removed: removeKey(apiUrl, deps?.credentialsFile) };
+}
+
+export async function runAuthStatus(deps?: AuthDeps): Promise<AuthStatusRow[]> {
+  const file = deps?.credentialsFile ?? credentialsPath(deps?.env ?? process.env);
+  const store = readCredentialsFile(file);
+  if (!store) return [];
+  const rows: AuthStatusRow[] = [];
+  for (const [apiUrl, entry] of Object.entries(store.credentials).sort(([a], [b]) => a.localeCompare(b))) {
+    const client = new ApiClient({ apiUrl, apiKey: entry.apiKey, fetchImpl: deps?.fetchImpl });
+    let valid = true;
+    try {
+      await client.get('/api/projects', 'project list');
+    } catch {
+      valid = false;
+    }
+    rows.push({ apiUrl, keyPrefix: `${entry.apiKey.slice(0, 8)}…`, valid });
+  }
+  return rows;
+}
+
+export function runAuthToken(
+  opts: { apiUrl?: string },
+  cwd: string,
+  deps?: AuthDeps,
+): { ok: true; token: string } | { ok: false; error: string } {
+  const env = deps?.env ?? process.env;
+  const rawUrl = resolveApiUrl(opts, cwd, env);
+  if (!rawUrl) return { ok: false, error: `no API URL configured — ${API_URL_REMEDIATION}` };
+  const apiUrl = normalizeApiUrl(rawUrl);
+  const token = getStoredKey(apiUrl, deps?.credentialsFile);
+  if (!token) {
+    return {
+      ok: false,
+      error:
+        `no stored credentials for ${apiUrl} — run \`bffless login\` once on this machine, ` +
+        'or set BFFLESS_API_KEY',
+    };
+  }
+  return { ok: true, token };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import { runRevisionsList, formatRevisionsTable } from './commands/revisions.js'
 import { runRollback } from './commands/rollback.js';
 import { runDev, type DevOptions } from './commands/dev.js';
 import { runInit } from './commands/init.js';
+import { runLogin, runLogout, runAuthStatus, runAuthToken } from './commands/auth.js';
 
 /** `<file>:<line> <message>` when `line` is present, `<file> <message>` otherwise. */
 function formatIssue(issue: Issue): string {
@@ -361,6 +362,78 @@ rules
         handle.close().then(resolve, resolve);
       });
     });
+  });
+
+program
+  .command('login')
+  .description(
+    'Store an API key for a BFFless instance in ~/.config/bffless/credentials.json ' +
+      '(paste-a-key; validated against the instance before saving). All commands then ' +
+      'use it automatically when --api-key/BFFLESS_API_KEY are absent.',
+  )
+  .option('--api-url <url>', 'API base URL (overrides BFFLESS_API_URL and config apiUrl)')
+  .action(async (opts: { apiUrl?: string }) => {
+    const result = await runLogin(opts, process.cwd());
+    if (!result.ok) {
+      console.error(result.error);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`stored credentials for ${result.apiUrl}`);
+  });
+
+program
+  .command('logout')
+  .description('Remove the stored API key for a BFFless instance')
+  .option('--api-url <url>', 'API base URL (overrides BFFLESS_API_URL and config apiUrl)')
+  .action((opts: { apiUrl?: string }) => {
+    const result = runLogout(opts, process.cwd());
+    if (!result.ok) {
+      console.error(result.error);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(
+      result.removed
+        ? `removed credentials for ${result.apiUrl}`
+        : `no stored credentials for ${result.apiUrl} — nothing to remove`,
+    );
+  });
+
+const auth = program
+  .command('auth')
+  .description('Inspect the credential store written by `bffless login` (status, token)');
+
+auth
+  .command('status')
+  .description('List stored instances (key prefix only) and whether each key still validates')
+  .action(async () => {
+    const rows = await runAuthStatus();
+    if (rows.length === 0) {
+      console.log('no stored credentials — run `bffless login`');
+      return;
+    }
+    for (const row of rows) {
+      console.log(`${row.apiUrl}  ${row.keyPrefix}  ${row.valid ? 'valid' : 'INVALID'}`);
+    }
+    if (rows.some((r) => !r.valid)) process.exitCode = 1;
+  });
+
+auth
+  .command('token')
+  .description(
+    'Print the stored API key for the resolved instance to stdout (pipe-safe), e.g. ' +
+      'curl -H "X-API-Key: $(bffless auth token)" …',
+  )
+  .option('--api-url <url>', 'API base URL (overrides BFFLESS_API_URL and config apiUrl)')
+  .action((opts: { apiUrl?: string }) => {
+    const result = runAuthToken(opts, process.cwd());
+    if (!result.ok) {
+      console.error(result.error);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(result.token);
   });
 
 program.parseAsync().catch((err) => {

--- a/packages/cli/test/auth.test.ts
+++ b/packages/cli/test/auth.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runLogin, runLogout, runAuthStatus, runAuthToken } from '../src/commands/auth.js';
+import { getStoredKey, storeKey } from '../src/api/credentials.js';
+import type { FetchLike } from '../src/api/client.js';
+
+function tmpFile(): string {
+  return path.join(mkdtempSync(path.join(os.tmpdir(), 'bffless-auth-')), 'credentials.json');
+}
+
+/** fetch stub keyed by `METHOD url`, answering by the request's X-API-Key. */
+function fetchByKey(url: string, keyStatus: Record<string, number>): FetchLike {
+  return async (reqUrl, init) => {
+    if (reqUrl !== `${url}/api/projects`) throw new Error(`unexpected url ${reqUrl}`);
+    const key = (init?.headers as Record<string, string>)['X-API-Key'];
+    const status = keyStatus[key] ?? 401;
+    return new Response(status === 200 ? '[]' : '{"message":"Invalid API key"}', {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+}
+
+describe('runLogin', () => {
+  it('validates the pasted key then stores it under the normalized URL', async () => {
+    const file = tmpFile();
+    const logs: string[] = [];
+    const result = await runLogin({ apiUrl: 'https://Api.Test/' }, '/tmp', {
+      env: {},
+      credentialsFile: file,
+      fetchImpl: fetchByKey('https://api.test', { 'k-good': 200 }),
+      promptSecret: async () => 'k-good',
+      log: (m) => logs.push(m),
+    });
+    expect(result).toEqual({ ok: true, apiUrl: 'https://api.test' });
+    expect(getStoredKey('https://api.test', file)).toBe('k-good');
+    expect(logs.join('\n')).toMatch(/API key/i);
+  });
+
+  it('stores NOTHING when validation fails', async () => {
+    const file = tmpFile();
+    const result = await runLogin({ apiUrl: 'https://api.test' }, '/tmp', {
+      env: {},
+      credentialsFile: file,
+      fetchImpl: fetchByKey('https://api.test', {}),
+      promptSecret: async () => 'k-bad',
+      log: () => {},
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/nothing (was )?stored/i);
+    expect(existsSync(file)).toBe(false);
+  });
+
+  it('rejects an empty key without a network call', async () => {
+    const result = await runLogin({ apiUrl: 'https://api.test' }, '/tmp', {
+      env: {},
+      credentialsFile: tmpFile(),
+      fetchImpl: async () => { throw new Error('must not be called'); },
+      promptSecret: async () => '  ',
+      log: () => {},
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/empty/i);
+  });
+
+  it('errors when no apiUrl is resolvable', async () => {
+    const result = await runLogin({}, os.tmpdir(), {
+      env: {},
+      credentialsFile: tmpFile(),
+      promptSecret: async () => 'k',
+      log: () => {},
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/--api-url/);
+  });
+
+  it('falls back to BFFLESS_API_URL from env', async () => {
+    const file = tmpFile();
+    const result = await runLogin({}, os.tmpdir(), {
+      env: { BFFLESS_API_URL: 'https://env.test' },
+      credentialsFile: file,
+      fetchImpl: fetchByKey('https://env.test', { 'k-good': 200 }),
+      promptSecret: async () => 'k-good',
+      log: () => {},
+    });
+    expect(result).toEqual({ ok: true, apiUrl: 'https://env.test' });
+  });
+});
+
+describe('runLogout', () => {
+  it('removes the entry and reports removed: true, then false on repeat', () => {
+    const file = tmpFile();
+    storeKey('https://api.test', 'k', file);
+    const deps = { env: {}, credentialsFile: file };
+    expect(runLogout({ apiUrl: 'https://api.test' }, '/tmp', deps)).toEqual({
+      ok: true,
+      apiUrl: 'https://api.test',
+      removed: true,
+    });
+    expect(runLogout({ apiUrl: 'https://api.test' }, '/tmp', deps)).toEqual({
+      ok: true,
+      apiUrl: 'https://api.test',
+      removed: false,
+    });
+  });
+});
+
+describe('runAuthStatus', () => {
+  it('lists each stored instance with a key prefix and live validity', async () => {
+    const file = tmpFile();
+    storeKey('https://a.test', 'k-valid-12345', file);
+    storeKey('https://b.test', 'k-revoked-999', file);
+    const fetchImpl: FetchLike = async (reqUrl) =>
+      new Response(reqUrl.startsWith('https://a.test') ? '[]' : '{"message":"Invalid API key"}', {
+        status: reqUrl.startsWith('https://a.test') ? 200 : 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    const rows = await runAuthStatus({ credentialsFile: file, fetchImpl });
+    expect(rows).toEqual([
+      { apiUrl: 'https://a.test', keyPrefix: 'k-valid-…', valid: true },
+      { apiUrl: 'https://b.test', keyPrefix: 'k-revoke…', valid: false },
+    ]);
+  });
+
+  it('returns [] when nothing is stored', async () => {
+    expect(await runAuthStatus({ credentialsFile: tmpFile() })).toEqual([]);
+  });
+});
+
+describe('runAuthToken', () => {
+  it('returns the stored key for the resolved instance', () => {
+    const file = tmpFile();
+    storeKey('https://api.test', 'k-tok', file);
+    expect(runAuthToken({ apiUrl: 'https://api.test' }, '/tmp', { env: {}, credentialsFile: file })).toEqual({
+      ok: true,
+      token: 'k-tok',
+    });
+  });
+
+  it('errors with login remediation when nothing is stored for the instance', () => {
+    const result = runAuthToken({ apiUrl: 'https://api.test' }, '/tmp', { env: {}, credentialsFile: tmpFile() });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/bffless login/);
+      expect(result.error).toMatch(/BFFLESS_API_KEY/);
+    }
+  });
+});

--- a/packages/cli/test/client.test.ts
+++ b/packages/cli/test/client.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { ApiClient, ApiError, createClient, type FetchLike } from '../src/api/client.js';
 import { CLI_REMEDIATION, resolveRemediation } from '../src/api/remediation.js';
 import { requireProject } from '../src/api/resolve.js';
+import { storeKey } from '../src/api/credentials.js';
 
 interface RecordedCall {
   url: string;
@@ -160,7 +164,7 @@ describe('createClient — precedence and sourcing rules', () => {
     // supply a key. The error explains where keys may come from and why config is excluded.
     const config = { apiUrl: 'https://config.test', project: 'p' };
     expect(() => createClient({}, '/nowhere', { env: {}, config, fetchImpl: okFetch })).toThrow(
-      /--api-key or set BFFLESS_API_KEY.*never read from \.bffless\/config\.json/s,
+      /--api-key.*set BFFLESS_API_KEY.*bffless login.*never read from \.bffless\/config\.json/s,
     );
   });
 });
@@ -204,5 +208,58 @@ describe('remediation overrides', () => {
     expect(merged.project).toBe('X');
     expect(merged.apiKey).toBe(CLI_REMEDIATION.apiKey);
     expect(resolveRemediation()).toEqual(CLI_REMEDIATION);
+  });
+});
+
+describe('createClient credential-store fallback', () => {
+  function seededStore(apiUrl: string, key: string): string {
+    const file = path.join(mkdtempSync(path.join(os.tmpdir(), 'bffless-cred-')), 'credentials.json');
+    storeKey(apiUrl, key, file);
+    return file;
+  }
+
+  it('uses the stored key when flag and env are absent', async () => {
+    const file = seededStore('https://api.test', 'k-stored');
+    const { fetchImpl, calls } = stubFetch({ 'GET https://api.test/api/projects': { body: [] } });
+    const client = createClient({}, '/tmp', {
+      env: {},
+      config: { apiUrl: 'https://api.test' },
+      credentialsFile: file,
+      fetchImpl,
+    });
+    await client.get('/api/projects');
+    expect((calls[0].init?.headers as Record<string, string>)['X-API-Key']).toBe('k-stored');
+  });
+
+  it('flag and env both beat the store', async () => {
+    const file = seededStore('https://api.test', 'k-stored');
+    const base = { config: { apiUrl: 'https://api.test' }, credentialsFile: file } as const;
+    const a = stubFetch({ 'GET https://api.test/api/projects': { body: [] } });
+    await createClient({ apiKey: 'k-flag' }, '/tmp', { ...base, env: {}, fetchImpl: a.fetchImpl }).get('/api/projects');
+    expect((a.calls[0].init?.headers as Record<string, string>)['X-API-Key']).toBe('k-flag');
+
+    const b = stubFetch({ 'GET https://api.test/api/projects': { body: [] } });
+    await createClient({}, '/tmp', { ...base, env: { BFFLESS_API_KEY: 'k-env' }, fetchImpl: b.fetchImpl }).get('/api/projects');
+    expect((b.calls[0].init?.headers as Record<string, string>)['X-API-Key']).toBe('k-env');
+  });
+
+  it('store lookup matches by normalized URL (config URL with trailing slash)', async () => {
+    const file = seededStore('https://api.test', 'k-stored');
+    const { fetchImpl, calls } = stubFetch({ 'GET https://api.test/api/projects': { body: [] } });
+    const client = createClient({}, '/tmp', {
+      env: {},
+      config: { apiUrl: 'https://api.test/' },
+      credentialsFile: file,
+      fetchImpl,
+    });
+    await client.get('/api/projects');
+    expect((calls[0].init?.headers as Record<string, string>)['X-API-Key']).toBe('k-stored');
+  });
+
+  it('no flag, env, or store entry → error mentions bffless login', () => {
+    const file = path.join(mkdtempSync(path.join(os.tmpdir(), 'bffless-cred-')), 'credentials.json');
+    expect(() =>
+      createClient({}, '/tmp', { env: {}, config: { apiUrl: 'https://api.test' }, credentialsFile: file }),
+    ).toThrow(/bffless login/);
   });
 });

--- a/packages/cli/test/credentials.test.ts
+++ b/packages/cli/test/credentials.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, readFileSync, statSync, existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  credentialsPath,
+  normalizeApiUrl,
+  readCredentialsFile,
+  getStoredKey,
+  storeKey,
+  removeKey,
+} from '../src/api/credentials.js';
+
+function tmpFile(): string {
+  return path.join(mkdtempSync(path.join(os.tmpdir(), 'bffless-cred-')), 'credentials.json');
+}
+
+describe('credentialsPath', () => {
+  it('defaults to ~/.config/bffless/credentials.json', () => {
+    expect(credentialsPath({})).toBe(path.join(os.homedir(), '.config', 'bffless', 'credentials.json'));
+  });
+
+  it('respects XDG_CONFIG_HOME', () => {
+    expect(credentialsPath({ XDG_CONFIG_HOME: '/xdg' })).toBe(path.join('/xdg', 'bffless', 'credentials.json'));
+  });
+});
+
+describe('normalizeApiUrl', () => {
+  it('lowercases the host and strips trailing slashes, keeping any base path', () => {
+    expect(normalizeApiUrl('https://Admin.Example.com/')).toBe('https://admin.example.com');
+    expect(normalizeApiUrl('https://admin.example.com/base/')).toBe('https://admin.example.com/base');
+    expect(normalizeApiUrl('https://admin.example.com')).toBe('https://admin.example.com');
+  });
+
+  it('throws on an unparseable URL', () => {
+    expect(() => normalizeApiUrl('not a url')).toThrow(/invalid API URL/);
+  });
+});
+
+describe('store round-trip', () => {
+  it('storeKey then getStoredKey returns the key, keyed by normalized URL', () => {
+    const file = tmpFile();
+    storeKey('https://Admin.Example.com/', 'k-123', file);
+    expect(getStoredKey('https://admin.example.com', file)).toBe('k-123');
+  });
+
+  it('writes valid JSON with version 1 and an ISO createdAt', () => {
+    const file = tmpFile();
+    storeKey('https://a.test', 'k', file, new Date('2026-07-27T00:00:00Z'));
+    const parsed = JSON.parse(readFileSync(file, 'utf8'));
+    expect(parsed).toEqual({
+      version: 1,
+      credentials: { 'https://a.test': { apiKey: 'k', createdAt: '2026-07-27T00:00:00.000Z' } },
+    });
+  });
+
+  it('re-storing the same instance overwrites; other instances are kept', () => {
+    const file = tmpFile();
+    storeKey('https://a.test', 'k-old', file);
+    storeKey('https://b.test', 'k-b', file);
+    storeKey('https://a.test', 'k-new', file);
+    expect(getStoredKey('https://a.test', file)).toBe('k-new');
+    expect(getStoredKey('https://b.test', file)).toBe('k-b');
+  });
+
+  it('creates the file with mode 0600', () => {
+    if (process.platform === 'win32') return;
+    const file = tmpFile();
+    storeKey('https://a.test', 'k', file);
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe('missing / corrupt files', () => {
+  it('getStoredKey returns undefined for a missing file and an unknown instance', () => {
+    const file = tmpFile();
+    expect(getStoredKey('https://a.test', file)).toBeUndefined();
+    storeKey('https://a.test', 'k', file);
+    expect(getStoredKey('https://other.test', file)).toBeUndefined();
+  });
+
+  it('readCredentialsFile returns null for a missing file', () => {
+    expect(readCredentialsFile(tmpFile())).toBeNull();
+  });
+
+  it('throws (naming the path) on invalid JSON — never silently treats it as absent', () => {
+    const file = tmpFile();
+    storeKey('https://a.test', 'k', file);
+    const fs = require('node:fs') as typeof import('node:fs');
+    fs.writeFileSync(file, '{ nope');
+    expect(() => getStoredKey('https://a.test', file)).toThrow(new RegExp(file.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  });
+
+  it('throws (naming the path) on schema-invalid content', () => {
+    const file = tmpFile();
+    storeKey('https://a.test', 'k', file);
+    const fs = require('node:fs') as typeof import('node:fs');
+    fs.writeFileSync(file, JSON.stringify({ version: 2, credentials: {} }));
+    expect(() => getStoredKey('https://a.test', file)).toThrow(/credentials/);
+  });
+});
+
+describe('removeKey', () => {
+  it('removes an entry and reports true; false when nothing was stored', () => {
+    const file = tmpFile();
+    storeKey('https://a.test', 'k', file);
+    expect(removeKey('https://a.test/', file)).toBe(true);
+    expect(getStoredKey('https://a.test', file)).toBeUndefined();
+    expect(removeKey('https://a.test', file)).toBe(false);
+    expect(removeKey('https://a.test', tmpFile())).toBe(false);
+  });
+});

--- a/packages/cli/test/pull-live.test.ts
+++ b/packages/cli/test/pull-live.test.ts
@@ -88,7 +88,7 @@ describe('rules pull — live path', () => {
       config,
     });
     expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/--api-key or set BFFLESS_API_KEY/);
+    expect(result.error).toMatch(/--api-key.*set BFFLESS_API_KEY.*bffless login/s);
   });
 
   it('refuses a non-empty output dir without --force, honors --force', async () => {


### PR DESCRIPTION
Adds a paste-a-key credential store to the CLI so agents and scripts no longer
scrape API keys out of runtime configs.

- `bffless login` / `logout` — store/remove a validated key per instance in
  `~/.config/bffless/credentials.json` (0600, atomic writes)
- `bffless auth status` / `auth token` — inspect / retrieve stored keys
- Key resolution is now flag > env > store (env still wins for CI); keys remain
  never-read from committed files
- Spec: bffless/apps `docs/superpowers/specs/2026-07-27-app-skills-and-cli-auth-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
