### PR TITLE
fix: resolve served content types from storage, with charset

### DIFF
--- a/apps/backend/src/common/utils/content-type.util.spec.ts
+++ b/apps/backend/src/common/utils/content-type.util.spec.ts
@@ -1,0 +1,62 @@
+import { resolveContentType } from './content-type.util';
+
+describe('resolveContentType', () => {
+  describe('from the key extension', () => {
+    it('appends charset=utf-8 to text types so browsers do not fall back to windows-1252', () => {
+      expect(resolveContentType('reports/index.html')).toBe('text/html; charset=utf-8');
+      expect(resolveContentType('assets/app.css')).toBe('text/css; charset=utf-8');
+    });
+
+    it('resolves extensions the hand-rolled tables omitted', () => {
+      expect(resolveContentType('notes.md')).toBe('text/markdown; charset=utf-8');
+      expect(resolveContentType('page.htm')).toBe('text/html; charset=utf-8');
+      expect(resolveContentType('mod.mjs')).toBe('application/javascript; charset=utf-8');
+      expect(resolveContentType('lib.wasm')).toBe('application/wasm');
+      expect(resolveContentType('photo.avif')).toBe('image/avif');
+      expect(resolveContentType('site.webmanifest')).toBe('application/manifest+json; charset=utf-8');
+    });
+
+    it('leaves binary types without a charset', () => {
+      expect(resolveContentType('doc.pdf')).toBe('application/pdf');
+      expect(resolveContentType('img.png')).toBe('image/png');
+    });
+
+    it('falls back to application/octet-stream for an unknown extension', () => {
+      expect(resolveContentType('archive.xyzzy')).toBe('application/octet-stream');
+      expect(resolveContentType('no-extension')).toBe('application/octet-stream');
+    });
+  });
+
+  describe('from the stored content type', () => {
+    it('prefers the stored type when the extension is unknown', () => {
+      expect(resolveContentType('blob.xyzzy', 'application/pdf')).toBe('application/pdf');
+    });
+
+    it('appends charset=utf-8 to a stored text type that lacks one', () => {
+      expect(resolveContentType('blob.xyzzy', 'text/html')).toBe('text/html; charset=utf-8');
+    });
+
+    it('preserves a stored charset verbatim rather than forcing utf-8', () => {
+      expect(resolveContentType('legacy.html', 'text/html; charset=iso-8859-1')).toBe(
+        'text/html; charset=iso-8859-1',
+      );
+    });
+
+    it('ignores a stored application/octet-stream when the extension is known', () => {
+      expect(resolveContentType('notes.md', 'application/octet-stream')).toBe(
+        'text/markdown; charset=utf-8',
+      );
+    });
+
+    it('ignores an empty or whitespace-only stored type', () => {
+      expect(resolveContentType('notes.md', '')).toBe('text/markdown; charset=utf-8');
+      expect(resolveContentType('notes.md', '   ')).toBe('text/markdown; charset=utf-8');
+    });
+
+    it('keeps application/octet-stream when neither source knows better', () => {
+      expect(resolveContentType('blob.xyzzy', 'application/octet-stream')).toBe(
+        'application/octet-stream',
+      );
+    });
+  });
+});

--- a/apps/backend/src/common/utils/content-type.util.ts
+++ b/apps/backend/src/common/utils/content-type.util.ts
@@ -1,0 +1,46 @@
+import path from 'path';
+
+import * as mime from 'mime-types';
+
+/** What both storage and HTTP mean by "I don't know what this is". */
+const UNKNOWN_TYPE = 'application/octet-stream';
+
+/**
+ * Append `charset=utf-8` when the type is text-ish and carries no charset of
+ * its own.
+ *
+ * Without it a browser falls back to windows-1252 for `text/*` and mangles
+ * every non-ASCII byte (`·` → `Â·`). A charset already on the value is
+ * preserved verbatim — the object may genuinely not be UTF-8.
+ */
+function withCharset(contentType: string): string {
+  if (/;\s*charset=/i.test(contentType)) {
+    return contentType;
+  }
+  const base = contentType.split(';')[0].trim();
+  return mime.charsets.lookup(base) ? `${contentType}; charset=utf-8` : contentType;
+}
+
+/**
+ * Resolve the `Content-Type` to serve an object with.
+ *
+ * Prefers the type storage recorded for the object, falling back to the key's
+ * extension. A stored `application/octet-stream` counts as "unknown" rather
+ * than as an answer, so a known extension still wins over it — that value is
+ * what an adapter reports when the uploader sent nothing useful.
+ *
+ * @param key         Storage key or filename the object is served under.
+ * @param storedType  Content type storage reports for the object, if any.
+ */
+export function resolveContentType(key: string, storedType?: string | null): string {
+  const stored = storedType?.trim();
+  if (stored && stored.split(';')[0].trim().toLowerCase() !== UNKNOWN_TYPE) {
+    return withCharset(stored);
+  }
+
+  // Look the extension up, never the whole key: `mime.contentType()` treats any
+  // string containing a `/` as a MIME type rather than a path, and storage keys
+  // always contain slashes.
+  const fromExtension = mime.contentType(path.extname(key));
+  return fromExtension ? withCharset(fromExtension) : UNKNOWN_TYPE;
+}

--- a/apps/backend/src/deployments/public.controller.spec.ts
+++ b/apps/backend/src/deployments/public.controller.spec.ts
@@ -340,7 +340,7 @@ describe('PublicController', () => {
       await controller.serveDefault(mockOwner, mockRepo, req, res);
 
       expect(res.status).toHaveBeenCalledWith(404);
-      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html');
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html; charset=utf-8');
       expect(res.send).toHaveBeenCalled();
     });
 
@@ -360,7 +360,7 @@ describe('PublicController', () => {
       await controller.serveDefault(mockOwner, mockRepo, req, res);
 
       expect(res.status).toHaveBeenCalledWith(404);
-      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html');
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html; charset=utf-8');
       expect(res.send).toHaveBeenCalled();
     });
 
@@ -401,7 +401,7 @@ describe('PublicController', () => {
       await controller.serveCommitAsset(mockOwner, mockRepo, mockCommitSha, 'index.html', req, res);
 
       expect(mockStorageAdapter.download).toHaveBeenCalledWith(mockAsset.storageKey);
-      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html');
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html; charset=utf-8');
       expect(res.setHeader).toHaveBeenCalledWith(
         'Cache-Control',
         'public, max-age=31536000, immutable',
@@ -496,7 +496,7 @@ describe('PublicController', () => {
       await controller.serveCommitAsset(mockOwner, mockRepo, mockCommitSha, 'missing.html', req, res);
 
       expect(res.status).toHaveBeenCalledWith(404);
-      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html');
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html; charset=utf-8');
       expect(res.send).toHaveBeenCalled();
     });
 
@@ -537,7 +537,7 @@ describe('PublicController', () => {
       await controller.serveCommitAsset(mockOwner, mockRepo, mockCommitSha, 'index.html', req, res);
 
       expect(res.status).toHaveBeenCalledWith(404);
-      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html');
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html; charset=utf-8');
       expect(res.send).toHaveBeenCalled();
     });
   });
@@ -580,7 +580,7 @@ describe('PublicController', () => {
       await controller.serveAliasAsset(mockOwner, mockRepo, 'non-existent', 'index.html', req, res);
 
       expect(res.status).toHaveBeenCalledWith(404);
-      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html');
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html; charset=utf-8');
       expect(res.send).toHaveBeenCalled();
     });
   });
@@ -614,7 +614,7 @@ describe('PublicController', () => {
         res,
       );
 
-      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/css');
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/css; charset=utf-8');
     });
 
     it('should detect JavaScript mime type', async () => {
@@ -636,14 +636,61 @@ describe('PublicController', () => {
         res,
       );
 
-      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/javascript');
+      expect(res.setHeader).toHaveBeenCalledWith(
+        'Content-Type',
+        'application/javascript; charset=utf-8',
+      );
+    });
+
+    it('should serve HTML with a charset so browsers do not fall back to windows-1252', async () => {
+      const htmlAsset = {
+        ...mockAsset,
+        fileName: 'index.html',
+        publicPath: 'index.html',
+        mimeType: null,
+      };
+      setupDbMock([[htmlAsset]]);
+      const res = createMockResponse();
+
+      await controller.serveCommitAsset(
+        mockOwner,
+        mockRepo,
+        mockCommitSha,
+        'index.html',
+        createMockRequest(),
+        res,
+      );
+
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html; charset=utf-8');
+    });
+
+    it('should add the missing charset to a stored text mime type', async () => {
+      const storedAsset = {
+        ...mockAsset,
+        fileName: 'index.html',
+        publicPath: 'index.html',
+        mimeType: 'text/html',
+      };
+      setupDbMock([[storedAsset]]);
+      const res = createMockResponse();
+
+      await controller.serveCommitAsset(
+        mockOwner,
+        mockRepo,
+        mockCommitSha,
+        'index.html',
+        createMockRequest(),
+        res,
+      );
+
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html; charset=utf-8');
     });
 
     it('should default to octet-stream for unknown types', async () => {
       const unknownAsset = {
         ...mockAsset,
-        fileName: 'data.xyz',
-        publicPath: 'data.xyz',
+        fileName: 'data.xyzzy',
+        publicPath: 'data.xyzzy',
         mimeType: null,
       };
       setupDbMock([[unknownAsset]]);
@@ -653,7 +700,7 @@ describe('PublicController', () => {
         mockOwner,
         mockRepo,
         mockCommitSha,
-        'data.xyz',
+        'data.xyzzy',
         createMockRequest(),
         res,
       );

--- a/apps/backend/src/deployments/public.controller.ts
+++ b/apps/backend/src/deployments/public.controller.ts
@@ -32,6 +32,7 @@ import { CacheConfigService } from '../cache-rules/cache-config.service';
 import { MetadataCacheService } from '../storage/cache/metadata-cache.service';
 import { ShareLinksService } from '../share-links/share-links.service';
 import { ResponseHeaderConfigService } from '../response-header-rules/response-header-config.service';
+import { resolveContentType } from '../common/utils/content-type.util';
 
 /**
  * Options for serving files with appropriate cache headers
@@ -49,38 +50,6 @@ interface ServeFileOptions {
   filePath: string;
 }
 
-// Common MIME type mapping
-const MIME_TYPES: Record<string, string> = {
-  '.html': 'text/html',
-  '.htm': 'text/html',
-  '.css': 'text/css',
-  '.js': 'application/javascript',
-  '.mjs': 'application/javascript',
-  '.json': 'application/json',
-  '.xml': 'application/xml',
-  '.txt': 'text/plain',
-  '.md': 'text/markdown',
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.gif': 'image/gif',
-  '.svg': 'image/svg+xml',
-  '.ico': 'image/x-icon',
-  '.webp': 'image/webp',
-  '.avif': 'image/avif',
-  '.woff': 'font/woff',
-  '.woff2': 'font/woff2',
-  '.ttf': 'font/ttf',
-  '.otf': 'font/otf',
-  '.eot': 'application/vnd.ms-fontobject',
-  '.mp4': 'video/mp4',
-  '.webm': 'video/webm',
-  '.mp3': 'audio/mpeg',
-  '.wav': 'audio/wav',
-  '.pdf': 'application/pdf',
-  '.zip': 'application/zip',
-  '.wasm': 'application/wasm',
-};
 
 @ApiTags('Public')
 @Controller('public')
@@ -629,7 +598,7 @@ export class PublicController {
     const { immutable, statusCode = 200, isPublic, projectId, filePath } = options;
 
     try {
-      const mimeType = asset.mimeType || this.getMimeType(asset.fileName);
+      const mimeType = resolveContentType(asset.fileName, asset.mimeType);
 
       // Get cache configuration from rules (or defaults) BEFORE download
       // so we can pass TTL hint to Redis caching
@@ -1209,14 +1178,6 @@ export class PublicController {
   }
 
   /**
-   * Get MIME type from file extension
-   */
-  private getMimeType(filename: string): string {
-    const ext = '.' + filename.split('.').pop()?.toLowerCase();
-    return MIME_TYPES[ext] || 'application/octet-stream';
-  }
-
-  /**
    * Check for path traversal attempts
    */
   private containsPathTraversal(path: string): boolean {
@@ -1298,7 +1259,7 @@ export class PublicController {
     // These responses vary based on authentication state, so must not be cached
     res
       .status(404)
-      .setHeader('Content-Type', 'text/html')
+      .setHeader('Content-Type', 'text/html; charset=utf-8')
       .setHeader('Cache-Control', 'private, no-store')
       .setHeader('Vary', 'Cookie')
       .send(html);
@@ -1444,7 +1405,7 @@ export class PublicController {
     // Prevent caching of auth-dependent 403 responses by upstream proxies/CDN
     res
       .status(403)
-      .setHeader('Content-Type', 'text/html')
+      .setHeader('Content-Type', 'text/html; charset=utf-8')
       .setHeader('Cache-Control', 'private, no-store')
       .setHeader('Vary', 'Cookie')
       .send(html);

--- a/apps/backend/src/pipelines/handlers/file-serve.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/file-serve.handler.spec.ts
@@ -329,7 +329,7 @@ describe('FileServeHandler — explicit key mode', () => {
     expect(storage.downloadStream).toHaveBeenCalledWith('o/r/uploads/content/abc-styles.css');
     expect(res.status).toHaveBeenCalledWith(200);
     // Content-Type comes from the key's extension, not the request path.
-    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/css');
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/css; charset=utf-8');
   });
 
   it('interpolates a `key` expression resolved from a prior step', async () => {
@@ -355,7 +355,10 @@ describe('FileServeHandler — explicit key mode', () => {
     );
 
     expect(storage.downloadStream).toHaveBeenCalledWith('o/r/uploads/content/def-app.js');
-    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/javascript');
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'application/javascript; charset=utf-8',
+    );
   });
 
   it('rejects a resolved key containing ".." (path traversal)', async () => {
@@ -376,5 +379,105 @@ describe('FileServeHandler — explicit key mode', () => {
 
     expect(result.success).toBe(false);
     expect(storage.downloadStream).not.toHaveBeenCalled();
+  });
+});
+
+describe('FileServeHandler — content type', () => {
+  const makeRes = () => {
+    const res: any = {
+      headersSent: false,
+      writableEnded: false,
+      setHeader: jest.fn(),
+      end: jest.fn(),
+      on: jest.fn(),
+      json: jest.fn(),
+    };
+    res.status = jest.fn(() => res);
+    res.flushHeaders = jest.fn(() => {
+      res.headersSent = true;
+    });
+    return res;
+  };
+
+  const makeStream = () => ({ pipe: jest.fn(), on: jest.fn(), destroy: jest.fn() });
+
+  const buildHandler = (storage: Partial<IStorageAdapter>) => {
+    const registry = { register: jest.fn() } as unknown as StepHandlerRegistry;
+    const cacheConfigService = {
+      getCacheConfig: jest.fn().mockResolvedValue({ source: 'default' }),
+      buildCacheControlHeader: jest.fn(),
+    } as unknown as CacheConfigService;
+    return new FileServeHandler(
+      registry,
+      storage as IStorageAdapter,
+      cacheConfigService,
+      new ExpressionEvaluator(),
+    );
+  };
+
+  const buildContext = (res: any, path: string): PipelineContext =>
+    ({
+      projectId: 'p1',
+      deployment: { owner: 'o', repo: 'r', commitSha: 'sha' },
+      metadata: { path, headers: {} },
+      stepOutputs: {},
+      request: { res },
+    }) as unknown as PipelineContext;
+
+  const serve = async (
+    key: string,
+    storageOverrides: Partial<{ streamMime: string; metaMime: string; stream: boolean }> = {},
+  ) => {
+    const { streamMime, metaMime, stream = true } = storageOverrides;
+    const res = makeRes();
+    const storage: any = {
+      getMetadata: jest.fn().mockResolvedValue({ size: 42, etag: 'e', mimeType: metaMime }),
+    };
+    if (stream) {
+      storage.downloadStream = jest
+        .fn()
+        .mockResolvedValue({ stream: makeStream(), size: 42, etag: 'e', mimeType: streamMime });
+    } else {
+      storage.download = jest.fn().mockResolvedValue(Buffer.from('x'));
+    }
+    const step = {
+      id: 'serve',
+      name: 'serve',
+      handlerType: 'file_serve_handler',
+      config: { key },
+    } as unknown as PipelineStep;
+
+    await buildHandler(storage).execute(buildContext(res, '/api/uploads/content/x'), step);
+    return res;
+  };
+
+  it('serves HTML with a charset so browsers do not fall back to windows-1252', async () => {
+    const res = await serve('content/reports/index.html');
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html; charset=utf-8');
+  });
+
+  it('serves extensions missing from the old table by their real type, not octet-stream', async () => {
+    const res = await serve('content/notes.md');
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/markdown; charset=utf-8');
+  });
+
+  it('prefers the type storage recorded for the object over the extension guess', async () => {
+    const res = await serve('content/download.bin', { streamMime: 'application/pdf' });
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/pdf');
+  });
+
+  it('falls back to the extension when storage reports octet-stream', async () => {
+    const res = await serve('content/styles.css', { streamMime: 'application/octet-stream' });
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/css; charset=utf-8');
+  });
+
+  it('applies the same resolution on the buffered path', async () => {
+    const res = await serve('content/notes.md', { stream: false, metaMime: 'text/markdown' });
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/markdown; charset=utf-8');
   });
 });

--- a/apps/backend/src/pipelines/handlers/file-serve.handler.ts
+++ b/apps/backend/src/pipelines/handlers/file-serve.handler.ts
@@ -7,39 +7,11 @@ import { PipelineStep } from '../types';
 import { ConfigurationError } from '../errors';
 import { IStorageAdapter, STORAGE_ADAPTER } from '../../storage/storage.interface';
 import { CacheConfigService } from '../../cache-rules/cache-config.service';
+import { resolveContentType } from '../../common/utils/content-type.util';
 import { db } from '../../db/client';
 import { projects } from '../../db/schema';
 import { eq } from 'drizzle-orm';
-import * as path from 'path';
 import crypto from 'crypto';
-
-// Common MIME type lookup
-const MIME_TYPES: Record<string, string> = {
-  '.html': 'text/html',
-  '.css': 'text/css',
-  '.js': 'application/javascript',
-  '.json': 'application/json',
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.gif': 'image/gif',
-  '.svg': 'image/svg+xml',
-  '.webp': 'image/webp',
-  '.ico': 'image/x-icon',
-  '.pdf': 'application/pdf',
-  '.zip': 'application/zip',
-  '.mp4': 'video/mp4',
-  '.webm': 'video/webm',
-  '.mp3': 'audio/mpeg',
-  '.ogg': 'audio/ogg',
-  '.wav': 'audio/wav',
-  '.woff': 'font/woff',
-  '.woff2': 'font/woff2',
-  '.ttf': 'font/ttf',
-  '.txt': 'text/plain',
-  '.csv': 'text/csv',
-  '.xml': 'application/xml',
-};
 
 /**
  * File Serve Handler
@@ -161,9 +133,9 @@ export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
 
     const storageKey = `${owner}/${repo}/uploads/${relativePath}`;
 
-    // Determine content type from file extension
-    const ext = path.extname(relativePath).toLowerCase();
-    const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+    // The content type is resolved per response, not here: storage reports the
+    // type it recorded for the object, which beats guessing from the extension.
+    // `relativePath` is what that resolution falls back to.
 
     // Resolve cache headers: check cache rules first, fall back to config/default.
     // Files served through a pipeline are typically behind app-defined access
@@ -209,7 +181,7 @@ export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
       if (this.storageAdapter.downloadStream) {
         return await this.serveWithStream(
           storageKey,
-          contentType,
+          relativePath,
           cacheControlHeader,
           context,
           res,
@@ -217,7 +189,7 @@ export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
       }
 
       // Fallback: buffer-based serving for adapters without stream support
-      return await this.serveWithBuffer(storageKey, contentType, cacheControlHeader, res);
+      return await this.serveWithBuffer(storageKey, relativePath, cacheControlHeader, res);
     } catch (error) {
       this.logger.debug(`File not found: ${storageKey}`);
       if (!res.headersSent) {
@@ -244,7 +216,7 @@ export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
    */
   private async serveWithStream(
     storageKey: string,
-    contentType: string,
+    relativePath: string,
     cacheControlHeader: string,
     context: PipelineContext,
     res: any,
@@ -316,7 +288,7 @@ export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
       // Fetch ONLY the requested range from storage.
       const { stream } = await this.storageAdapter.downloadStream!(storageKey, { start, end });
 
-      res.setHeader('Content-Type', contentType);
+      res.setHeader('Content-Type', resolveContentType(relativePath, meta.mimeType));
       res.setHeader('Content-Length', end - start + 1);
       res.setHeader('Content-Range', `bytes ${start}-${end}/${fileSize}`);
       setEtag(meta.etag);
@@ -327,7 +299,7 @@ export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
       // Full file response — stream directly.
       const result = await this.storageAdapter.downloadStream!(storageKey);
 
-      res.setHeader('Content-Type', contentType);
+      res.setHeader('Content-Type', resolveContentType(relativePath, result.mimeType));
       res.setHeader('Content-Length', result.size);
       setEtag(result.etag);
       res.status(200);
@@ -346,7 +318,7 @@ export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
    */
   private async serveWithBuffer(
     storageKey: string,
-    contentType: string,
+    relativePath: string,
     cacheControlHeader: string,
     res: any,
   ): Promise<StepResult> {
@@ -360,14 +332,16 @@ export class FileServeHandler implements StepHandler<FileServeHandlerConfig> {
     }
 
     let etag: string | undefined;
+    let storedType: string | undefined;
     try {
       const metadata = await this.storageAdapter.getMetadata(storageKey);
       etag = metadata.etag;
+      storedType = metadata.mimeType;
     } catch {
       // Non-fatal
     }
 
-    res.setHeader('Content-Type', contentType);
+    res.setHeader('Content-Type', resolveContentType(relativePath, storedType));
     res.setHeader('Content-Length', data.length);
     res.setHeader('Cache-Control', cacheControlHeader);
     res.setHeader('Accept-Ranges', 'bytes');


### PR DESCRIPTION
Closes #557.

## The bug

Both serve paths derived `Content-Type` from their own hard-coded extension table, ignoring the type storage recorded for the object. Two consequences:

1. **No charset on text responses.** A bare `text/html` makes browsers fall back to windows-1252, so a document without an in-page `<meta charset="utf-8">` renders mojibake for every non-ASCII byte (`·` → `Â·`).
2. **Unlisted extensions served as `application/octet-stream`** — `.md`, `.htm`, `.mjs`, `.wasm`, `.avif`, `.map`, `.webmanifest`, `.otf` — even when the object's stored type was correct.

The charset one is nasty to spot: it looks **fine** inside an app viewer, because an iframe with no declared charset inherits the parent page's UTF-8. It only breaks when the content URL is opened directly. Found while serving an HTML report through a Handoff deployment.

## The fix

New `resolveContentType(key, storedType)` in `common/utils/`:

- prefers the type storage recorded for the object
- falls back to the key's extension via **`mime-types`** — already a dependency (`package.json:78`), used by `assets.service` and `deployments.service` — whose `contentType()` appends the charset for text types
- treats a stored `application/octet-stream` as *unknown* rather than as an answer, so a known extension still wins over it (that value is what an adapter reports when the uploader sent nothing useful)
- preserves a stored charset verbatim rather than forcing UTF-8

Wired into both paths:

- **`file_serve_handler`** resolves per response instead of once up-front, so the `mimeType` it *already received* from `downloadStream()` / `getMetadata()` reaches the client instead of being discarded at the `setHeader` call. Covers the streaming, range and buffered paths.
- **`public.controller`** uses the same resolver; its `getMimeType()` and second table are gone, so pipeline-served and deployment-served bytes finally agree on the type. Its two 404 pages now send the charset their own `<meta>` already declared.

Both hand-rolled `MIME_TYPES` tables are deleted (−95 lines of table and helper).

No adapter changes: every adapter already populates `mimeType` — including S3, which inherits MinIO's implementation — and `DynamicStorageAdapter` passes it through.

## Tests

TDD; every test was watched fail first.

- `content-type.util.spec.ts` — 10 new tests (extension resolution, charset appending, stored-type preference, octet-stream handling, unknown extensions)
- `file-serve.handler.spec.ts` — 5 new tests → 18/18
- `public.controller.spec.ts` — 2 new tests → 22/22
- **Full backend suite: 2159 passed, 37 skipped, 0 failed**; `tsc --noEmit` clean; lint error count unchanged (8, all pre-existing on untouched lines)

## Behaviour changes to expect

- Text responses now carry `; charset=utf-8` — several existing assertions were updated to match; this is the point of the change.
- Extensions the old tables didn't know now resolve through the full mime-db, e.g. `.xyz` → `chemical/x-xyz` instead of `application/octet-stream`. One test's fixture moved to a genuinely unknown extension to preserve its intent.
- Pages that already compensate with an in-document `<meta charset>` are unaffected — meta and header agree.
- Clients special-casing `application/octet-stream` for `.md` (e.g. Handoff's viewer) keep working; their fallback branch simply stops being taken.

## Gotcha worth knowing

`mime.contentType()` treats any string containing a `/` as a MIME type rather than a path, so it must be called with the **extension** — passing a storage key makes it echo `reports/index.html` back as its own content type. A test caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
