### PR TITLE
fix: coerce data-write values to schema field types; add now_ms()

### DIFF
--- a/apps/backend/src/pipelines/execution/expression-evaluator.spec.ts
+++ b/apps/backend/src/pipelines/execution/expression-evaluator.spec.ts
@@ -1,0 +1,22 @@
+import { ExpressionEvaluator } from './expression-evaluator';
+import { PipelineContext } from './pipeline-context.interface';
+
+const context = {} as PipelineContext;
+
+describe('ExpressionEvaluator built-in time functions', () => {
+  const evaluator = new ExpressionEvaluator();
+
+  it('now() keeps returning an ISO-8601 string (backward compatible)', () => {
+    const value = evaluator.evaluateExpression('now()', context);
+    expect(typeof value).toBe('string');
+    expect(value).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+
+  it('now_ms() returns epoch milliseconds as a number', () => {
+    const before = Date.now();
+    const value = evaluator.evaluateExpression('now_ms()', context);
+    expect(typeof value).toBe('number');
+    expect(value as number).toBeGreaterThanOrEqual(before);
+    expect(value as number).toBeLessThanOrEqual(Date.now());
+  });
+});

--- a/apps/backend/src/pipelines/execution/expression-evaluator.ts
+++ b/apps/backend/src/pipelines/execution/expression-evaluator.ts
@@ -12,7 +12,8 @@ import { v4 as uuidv4 } from 'uuid';
  * - user.id, user.email - Current user
  * - steps.stepName.fieldName - Previous step output
  * - deployment.alias - Current deployment alias
- * - now() - Current timestamp
+ * - now() - Current timestamp as ISO-8601 string
+ * - now_ms() - Current timestamp as epoch milliseconds
  * - uuid() - Generate UUID
  *
  * Templates use {{expression}} syntax:
@@ -38,6 +39,9 @@ export class ExpressionEvaluator {
     // Handle built-in functions
     if (trimmed === 'now()') {
       return new Date().toISOString();
+    }
+    if (trimmed === 'now_ms()') {
+      return Date.now();
     }
     if (trimmed === 'uuid()') {
       return uuidv4();

--- a/apps/backend/src/pipelines/handlers/data-create.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/data-create.handler.spec.ts
@@ -1,0 +1,101 @@
+import { DataCreateHandler } from './data-create.handler';
+import { ExpressionEvaluator } from '../execution/expression-evaluator';
+import { PipelineDataService } from '../pipeline-data.service';
+import { PipelineSchemasService } from '../pipeline-schemas.service';
+import { PipelineContext } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+
+const SCHEMA = {
+  id: 'schema-1',
+  projectId: 'proj-1',
+  name: 'handoff_comments',
+  version: 1,
+  fields: [
+    { name: 'body', type: 'string', required: true },
+    { name: 'createdMs', type: 'number', required: false },
+  ],
+};
+
+function buildHandler() {
+  const registry = { register: jest.fn() };
+  const dataService = {
+    create: jest.fn(async (_schemaId: string, _projectId: string, data: Record<string, unknown>) => ({
+      id: 'rec-1',
+      data,
+      alias: null,
+      version: 1,
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    })),
+  } as unknown as jest.Mocked<Pick<PipelineDataService, 'create'>>;
+  const schemasService = {
+    getById: jest.fn(async () => SCHEMA),
+  } as unknown as PipelineSchemasService;
+  const handler = new DataCreateHandler(
+    registry as any,
+    new ExpressionEvaluator(),
+    dataService as unknown as PipelineDataService,
+    schemasService,
+  );
+  return { handler, dataService };
+}
+
+const step = (config: unknown): PipelineStep =>
+  ({ name: 'create', handlerType: 'data_create', config }) as unknown as PipelineStep;
+const context = (body: Record<string, unknown> = {}): PipelineContext =>
+  ({
+    projectId: 'proj-1',
+    stepOutputs: {},
+    metadata: { body },
+    user: { id: 'user-1' },
+  }) as unknown as PipelineContext;
+
+describe('DataCreateHandler schema type coercion (ce#562)', () => {
+  it('stores now() into a number-typed field as epoch milliseconds', async () => {
+    const { handler, dataService } = buildHandler();
+
+    const result = await handler.execute(
+      context({ body: 'hello' }),
+      step({ schemaId: 'schema-1', fields: { body: 'request.body.body', createdMs: 'now()' } }),
+    );
+
+    expect(result.success).toBe(true);
+    const stored = dataService.create.mock.calls[0][2];
+    expect(typeof stored.createdMs).toBe('number');
+    expect(stored.createdMs as number).toBeGreaterThan(Date.now() - 60_000);
+    expect(stored.createdMs as number).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('coerces numeric strings from the request into number fields', async () => {
+    const { handler, dataService } = buildHandler();
+
+    const result = await handler.execute(
+      context({ body: 'hello', createdMs: '1704067200000' }),
+      step({
+        schemaId: 'schema-1',
+        fields: { body: 'request.body.body', createdMs: 'request.body.createdMs' },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(dataService.create.mock.calls[0][2].createdMs).toBe(1704067200000);
+  });
+
+  it('fails loudly when a non-coercible value hits a number field', async () => {
+    const { handler, dataService } = buildHandler();
+
+    const result = await handler.execute(
+      context({ body: 'hello', createdMs: 'not-a-number' }),
+      step({
+        schemaId: 'schema-1',
+        fields: { body: 'request.body.body', createdMs: 'request.body.createdMs' },
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('VALIDATION_ERROR');
+    expect(
+      (result.error?.details as { errors: Record<string, string> }).errors.createdMs,
+    ).toBeDefined();
+    expect(dataService.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/pipelines/handlers/data-create.handler.ts
+++ b/apps/backend/src/pipelines/handlers/data-create.handler.ts
@@ -7,6 +7,7 @@ import { PipelineStep } from '../types';
 import { PipelineDataService } from '../pipeline-data.service';
 import { PipelineSchemasService } from '../pipeline-schemas.service';
 import { ConfigurationError, SchemaNotFoundError } from '../errors';
+import { coerceFieldsToSchema } from './field-coercion.util';
 
 /**
  * Data Create Handler
@@ -58,17 +59,18 @@ export class DataCreateHandler implements StepHandler<DataCreateHandlerConfig> {
     }
 
     // Evaluate field expressions to build data object
-    const data: Record<string, unknown> = {};
+    const rawData: Record<string, unknown> = {};
     for (const [fieldName, expression] of Object.entries(config.fields)) {
-      data[fieldName] = this.expressionEvaluator.evaluateExpression(
+      rawData[fieldName] = this.expressionEvaluator.evaluateExpression(
         expression,
         context,
         stepName,
       );
     }
 
-    // Validate required fields against schema
-    const errors: Record<string, string> = {};
+    // Coerce values to the schema's declared field types, then validate
+    // required fields against schema
+    const { data, errors } = coerceFieldsToSchema(rawData, schema.fields);
     for (const field of schema.fields) {
       if (field.required && (data[field.name] === undefined || data[field.name] === null)) {
         errors[field.name] = `${field.name} is required`;

--- a/apps/backend/src/pipelines/handlers/data-update.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/data-update.handler.spec.ts
@@ -94,6 +94,58 @@ describe('DataUpdateHandler in operator', () => {
   });
 });
 
+describe('DataUpdateHandler schema type coercion (ce#562)', () => {
+  beforeEach(() => mockDb.__reset());
+
+  function buildTypedHandler() {
+    const { handler } = buildHandler();
+    const typedSchema = {
+      ...SCHEMA,
+      fields: [
+        { name: 'updatedMs', type: 'number', required: false },
+        { name: 'read', type: 'boolean', required: false },
+      ],
+    };
+    (handler as unknown as { schemasService: { getById: jest.Mock } }).schemasService = {
+      getById: jest.fn(async () => typedSchema),
+    };
+    return handler;
+  }
+
+  it('coerces an ISO date string into a number-typed field as epoch ms', async () => {
+    const handler = buildTypedHandler();
+    mockDb.__queue([{ id: 'i1', data: { read: false } }]); // select matches
+    mockDb.__queue([{ id: 'i1', data: { updatedMs: 1704067200000 } }]); // update .returning()
+
+    const result = await handler.execute(
+      context({}),
+      step({
+        schemaId: 'schema-1',
+        recordId: 'i1',
+        fields: { updatedMs: '2024-01-01T00:00:00.000Z' },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    const setArg = mockDb.set.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(setArg.data.updatedMs).toBe(1704067200000);
+  });
+
+  it('returns VALIDATION_ERROR for a non-coercible value instead of writing it', async () => {
+    const handler = buildTypedHandler();
+    mockDb.__queue([{ id: 'i1', data: {} }]); // select matches
+
+    const result = await handler.execute(
+      context({}),
+      step({ schemaId: 'schema-1', recordId: 'i1', fields: { updatedMs: 'garbage' } }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('VALIDATION_ERROR');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+});
+
 describe('DataUpdateHandler ne operator is null-safe', () => {
   beforeEach(() => mockDb.__reset());
 

--- a/apps/backend/src/pipelines/handlers/data-update.handler.ts
+++ b/apps/backend/src/pipelines/handlers/data-update.handler.ts
@@ -10,6 +10,7 @@ import { PipelineSchemasService } from '../pipeline-schemas.service';
 import { db } from '../../db/client';
 import { ConfigurationError, SchemaNotFoundError } from '../errors';
 import { buildInPredicate } from './in-filter.util';
+import { coerceFieldsToSchema } from './field-coercion.util';
 
 /**
  * Data Update Handler
@@ -158,13 +159,26 @@ export class DataUpdateHandler implements StepHandler<DataUpdateHandlerConfig> {
     }
 
     // Evaluate field expressions for updates
-    const updates: Record<string, unknown> = {};
+    const rawUpdates: Record<string, unknown> = {};
     for (const [fieldName, expression] of Object.entries(config.fields)) {
-      updates[fieldName] = this.expressionEvaluator.evaluateExpression(
+      rawUpdates[fieldName] = this.expressionEvaluator.evaluateExpression(
         expression,
         context,
         stepName,
       );
+    }
+
+    // Coerce values to the schema's declared field types
+    const { data: updates, errors } = coerceFieldsToSchema(rawUpdates, schema.fields);
+    if (Object.keys(errors).length > 0) {
+      return {
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Data validation failed',
+          details: { errors },
+        },
+      };
     }
 
     // Update each matching record

--- a/apps/backend/src/pipelines/handlers/data-upsert-many.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/data-upsert-many.handler.spec.ts
@@ -467,3 +467,33 @@ describe('DataUpsertManyHandler', () => {
     );
   });
 });
+
+describe('DataUpsertManyHandler schema type coercion (ce#562)', () => {
+  it('coerces now() ISO strings into number-typed columns as epoch ms', async () => {
+    const { handler, dataService, schemasService } = buildHandler();
+    schemasService.getById.mockResolvedValue({
+      ...SCHEMA,
+      fields: [
+        { name: 'guid', type: 'string', required: false },
+        { name: 'title', type: 'string', required: true },
+        { name: 'fetchedMs', type: 'number', required: false },
+      ],
+    } as never);
+
+    const items = [{ guid: 'a', title: 'A' }];
+    const result = await handler.execute(
+      contextWith(items),
+      step({
+        schemaId: 'schema-1',
+        items: 'steps.feed.items',
+        dedupField: 'guid',
+        dedupKey: 'steps.item.guid',
+        map: { guid: 'steps.item.guid', title: 'steps.item.title', fetchedMs: 'now()' },
+      }),
+    );
+
+    expect((result.output as DataUpsertManyOutput).inserted).toBe(1);
+    const records = dataService.createMany.mock.calls[0][2] as Record<string, unknown>[];
+    expect(records[0].fetchedMs).toBe(1704067200000); // Date.parse('2024-01-01T00:00:00.000Z')
+  });
+});

--- a/apps/backend/src/pipelines/handlers/data-upsert-many.handler.ts
+++ b/apps/backend/src/pipelines/handlers/data-upsert-many.handler.ts
@@ -8,6 +8,7 @@ import { PipelineStep } from '../types';
 import { PipelineDataService } from '../pipeline-data.service';
 import { PipelineSchemasService } from '../pipeline-schemas.service';
 import { ConfigurationError, SchemaNotFoundError } from '../errors';
+import { coerceFieldsToSchema } from './field-coercion.util';
 
 /**
  * Configuration for the data_upsert_many handler.
@@ -218,12 +219,18 @@ export class DataUpsertManyHandler implements StepHandler<DataUpsertManyHandlerC
       const item = rawItems[i];
       const itemContext = this.withItem(context, item);
       try {
-        const data = this.mapItem(config.map, itemContext, stepName);
-        const key = this.resolveDedupKey(chain, itemContext, data, stepName);
+        const mapped = this.mapItem(config.map, itemContext, stepName);
+        const key = this.resolveDedupKey(chain, itemContext, mapped, stepName);
 
         // Force the stored dedup column to the resolved key so the existence
         // check round-trips even when the key came from a fallback/hash.
-        data[config.dedupField] = key;
+        mapped[config.dedupField] = key;
+
+        // Coerce values to the schema's declared field types
+        const { data, errors: coercionErrors } = coerceFieldsToSchema(mapped, schema.fields);
+        if (Object.keys(coercionErrors).length > 0) {
+          throw new Error(Object.values(coercionErrors).join('; '));
+        }
 
         this.validateRequired(schema.fields, data, config.dedupField);
 

--- a/apps/backend/src/pipelines/handlers/field-coercion.util.spec.ts
+++ b/apps/backend/src/pipelines/handlers/field-coercion.util.spec.ts
@@ -1,0 +1,88 @@
+import { coerceFieldsToSchema } from './field-coercion.util';
+import { SchemaField } from '../../db/schema/pipeline-schemas.schema';
+
+const fields: SchemaField[] = [
+  { name: 'createdMs', type: 'number', required: false },
+  { name: 'read', type: 'boolean', required: false },
+  { name: 'title', type: 'string', required: false },
+  { name: 'meta', type: 'json', required: false },
+];
+
+describe('coerceFieldsToSchema', () => {
+  describe('number fields', () => {
+    it('passes numbers through unchanged', () => {
+      const { data, errors } = coerceFieldsToSchema({ createdMs: 1704067200000 }, fields);
+      expect(errors).toEqual({});
+      expect(data.createdMs).toBe(1704067200000);
+    });
+
+    it('coerces numeric strings to numbers', () => {
+      const { data, errors } = coerceFieldsToSchema({ createdMs: '42.5' }, fields);
+      expect(errors).toEqual({});
+      expect(data.createdMs).toBe(42.5);
+    });
+
+    it('coerces ISO date strings to epoch milliseconds (the now() case)', () => {
+      const { data, errors } = coerceFieldsToSchema(
+        { createdMs: '2024-01-01T00:00:00.000Z' },
+        fields,
+      );
+      expect(errors).toEqual({});
+      expect(data.createdMs).toBe(1704067200000);
+    });
+
+    it('rejects non-numeric, non-date strings', () => {
+      const { errors } = coerceFieldsToSchema({ createdMs: 'not-a-number' }, fields);
+      expect(errors.createdMs).toContain('number');
+    });
+
+    it('rejects booleans', () => {
+      const { errors } = coerceFieldsToSchema({ createdMs: true }, fields);
+      expect(errors.createdMs).toContain('number');
+    });
+  });
+
+  describe('boolean fields', () => {
+    it('passes booleans through unchanged', () => {
+      const { data, errors } = coerceFieldsToSchema({ read: false }, fields);
+      expect(errors).toEqual({});
+      expect(data.read).toBe(false);
+    });
+
+    it('coerces "true"/"false" strings', () => {
+      expect(coerceFieldsToSchema({ read: 'true' }, fields).data.read).toBe(true);
+      expect(coerceFieldsToSchema({ read: 'false' }, fields).data.read).toBe(false);
+    });
+
+    it('rejects other values', () => {
+      const { errors } = coerceFieldsToSchema({ read: 'yes' }, fields);
+      expect(errors.read).toContain('boolean');
+    });
+  });
+
+  it('leaves null and undefined values alone (required checks live elsewhere)', () => {
+    const { data, errors } = coerceFieldsToSchema({ createdMs: null, read: undefined }, fields);
+    expect(errors).toEqual({});
+    expect(data.createdMs).toBeNull();
+    expect(data.read).toBeUndefined();
+  });
+
+  it('leaves string/json fields and undeclared fields untouched', () => {
+    const input = { title: '2024-01-01', meta: { a: 1 }, extra: '42' };
+    const { data, errors } = coerceFieldsToSchema(input, fields);
+    expect(errors).toEqual({});
+    expect(data).toEqual(input);
+  });
+
+  it('no-ops when the schema has no field list', () => {
+    const { data, errors } = coerceFieldsToSchema({ createdMs: 'junk' }, undefined);
+    expect(errors).toEqual({});
+    expect(data.createdMs).toBe('junk');
+  });
+
+  it('does not mutate the input object', () => {
+    const input = { createdMs: '2024-01-01T00:00:00.000Z' };
+    coerceFieldsToSchema(input, fields);
+    expect(input.createdMs).toBe('2024-01-01T00:00:00.000Z');
+  });
+});

--- a/apps/backend/src/pipelines/handlers/field-coercion.util.ts
+++ b/apps/backend/src/pipelines/handlers/field-coercion.util.ts
@@ -1,0 +1,67 @@
+import { SchemaField } from '../../db/schema/pipeline-schemas.schema';
+
+/**
+ * Coerce evaluated field values to their schema-declared types before writing.
+ *
+ * Data records live in JSONB, so nothing at the storage layer enforces the
+ * schema's field types — an expression like `now()` (an ISO string) written
+ * into a `number` column would otherwise be stored verbatim and break epoch-ms
+ * consumers. Only `number` and `boolean` fields are coerced; a value that
+ * cannot be coerced is reported as an error rather than written. Date-parsable
+ * strings destined for `number` fields become epoch milliseconds. Fields not
+ * declared in the schema, and null/undefined values, pass through untouched
+ * (required-ness is validated separately by each handler).
+ */
+export function coerceFieldsToSchema(
+  data: Record<string, unknown>,
+  fields: SchemaField[] | undefined | null,
+): { data: Record<string, unknown>; errors: Record<string, string> } {
+  const result: Record<string, unknown> = { ...data };
+  const errors: Record<string, string> = {};
+  if (!fields) {
+    return { data: result, errors };
+  }
+
+  for (const field of fields) {
+    if (!(field.name in result)) continue;
+    const value = result[field.name];
+    if (value === null || value === undefined) continue;
+
+    switch (field.type) {
+      case 'number': {
+        if (typeof value === 'number' && Number.isFinite(value)) break;
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          if (trimmed !== '' && Number.isFinite(Number(trimmed))) {
+            result[field.name] = Number(trimmed);
+            break;
+          }
+          const parsedMs = Date.parse(trimmed);
+          if (!Number.isNaN(parsedMs)) {
+            result[field.name] = parsedMs;
+            break;
+          }
+        }
+        errors[field.name] = `${field.name} must be a number, got ${JSON.stringify(value)}`;
+        break;
+      }
+      case 'boolean': {
+        if (typeof value === 'boolean') break;
+        if (value === 'true') {
+          result[field.name] = true;
+          break;
+        }
+        if (value === 'false') {
+          result[field.name] = false;
+          break;
+        }
+        errors[field.name] = `${field.name} must be a boolean, got ${JSON.stringify(value)}`;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return { data: result, errors };
+}


### PR DESCRIPTION
## Summary

Fixes #562 — `data_create` with `createdMs: now()` stored an ISO string into a `number`-typed schema field, so epoch-ms consumers did `Number("2026-07-28T…Z")` → `NaN` → "57y ago".

Two changes:

**1. Schema-aware type coercion at write time** (shared `field-coercion.util.ts`, wired into `data_create`, `data_update`, and `data_upsert_many`):
- `number` fields: numbers pass through; numeric strings coerce to numbers; date-parsable strings (the `now()` case) coerce to **epoch milliseconds**; anything else fails loudly with `VALIDATION_ERROR` instead of being written (per-item error entry in `data_upsert_many`).
- `boolean` fields: booleans pass through; `"true"`/`"false"` coerce; anything else fails loudly.
- All other field types, undeclared fields, and null/undefined values pass through unchanged (required-ness stays a separate check).

Existing broken rules like `createdMs: now()` now self-heal — new writes store epoch ms without any rule change. Records already stored with ISO strings are not migrated.

**2. `now_ms()` expression built-in** returning `Date.now()` (a number), for rules that want epoch ms explicitly. `now()` is unchanged (ISO string) to avoid breaking every rule using it in string/datetime/template contexts.

## Tests

- New `field-coercion.util.spec.ts` — full coercion matrix (numbers, ISO→epoch, booleans, pass-through, non-mutation, missing field list).
- New `data-create.handler.spec.ts` — live repro of the #562 case (`now()` → number field stores epoch ms), numeric-string coercion, loud failure path.
- New `expression-evaluator.spec.ts` — `now_ms()` returns a number; `now()` still returns ISO-8601.
- Wiring tests added to `data-update.handler.spec.ts` and `data-upsert-many.handler.spec.ts`.

All written TDD (watched fail first). Full `src/pipelines` suite: 28 suites / 314 tests pass; backend `tsc --noEmit` clean.

## Follow-up (not in this PR)

- Document `now_ms()` in the `bffless/skills` pipelines skill.
- Existing records on live instances (e.g. the share-links lazy root-record on j5s.dev) still hold ISO strings in `createdMs`; clients keep their defensive parsing or data gets backfilled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
