### PR TITLE
feat: pipeline user.groups + member-accessible group directory

### DIFF
--- a/apps/backend/src/pipelines/dto/test-pipeline.dto.ts
+++ b/apps/backend/src/pipelines/dto/test-pipeline.dto.ts
@@ -36,6 +36,16 @@ export class MockUserDto {
   @IsOptional()
   @IsString()
   role?: string;
+
+  @ApiPropertyOptional({
+    description: 'Group ids to simulate the user as a member of',
+    example: ['group-123'],
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  groups?: string[];
 }
 
 export class TestPipelineDto {

--- a/apps/backend/src/pipelines/execution/pipeline-context.interface.ts
+++ b/apps/backend/src/pipelines/execution/pipeline-context.interface.ts
@@ -7,6 +7,8 @@ export interface PipelineUser {
   id: string;
   email?: string;
   role?: string;
+  /** Group ids the user is a member of (strict membership). Absent only on pre-groups callers. */
+  groups?: string[];
 }
 
 /**

--- a/apps/backend/src/pipelines/execution/pipeline-execution.service.ts
+++ b/apps/backend/src/pipelines/execution/pipeline-execution.service.ts
@@ -420,7 +420,11 @@ export class PipelineExecutionService {
     // Check condition if present
     let conditionResult: boolean | undefined;
     if (config.condition) {
-      conditionResult = this.expressionEvaluator.evaluateCondition(config.condition, context, stepName);
+      conditionResult = this.expressionEvaluator.evaluateCondition(
+        config.condition,
+        context,
+        stepName,
+      );
       if (!conditionResult) {
         const endTime = Date.now();
         this.logger.debug(`Skipping step '${stepName}' - condition not met`);
@@ -456,7 +460,10 @@ export class PipelineExecutionService {
     });
 
     try {
-      const result = await Promise.race([handler.execute(context, step as PipelineStep), timeoutPromise]);
+      const result = await Promise.race([
+        handler.execute(context, step as PipelineStep),
+        timeoutPromise,
+      ]);
       const endTime = Date.now();
 
       return {
@@ -620,12 +627,13 @@ export class PipelineExecutionService {
         }
       } catch (error) {
         const endTime = Date.now();
-        const errorInfo = error instanceof PipelineError
-          ? error.toResponse()
-          : {
-              code: 'STEP_EXECUTION_ERROR',
-              message: error instanceof Error ? error.message : 'Unknown error',
-            };
+        const errorInfo =
+          error instanceof PipelineError
+            ? error.toResponse()
+            : {
+                code: 'STEP_EXECUTION_ERROR',
+                message: error instanceof Error ? error.message : 'Unknown error',
+              };
 
         debugInfo.push({
           stepId: step.id,
@@ -690,7 +698,9 @@ export class PipelineExecutionService {
 
     if (forwardedFor) {
       // X-Forwarded-For can be a comma-separated list; first IP is the original client
-      const forwardedIp = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor.split(',')[0];
+      const forwardedIp = Array.isArray(forwardedFor)
+        ? forwardedFor[0]
+        : forwardedFor.split(',')[0];
       ip = forwardedIp?.trim();
     }
 
@@ -706,5 +716,4 @@ export class PipelineExecutionService {
 
     return ip;
   }
-
 }

--- a/apps/backend/src/pipelines/execution/pipeline-execution.service.ts
+++ b/apps/backend/src/pipelines/execution/pipeline-execution.service.ts
@@ -3,6 +3,7 @@ import { Request } from 'express';
 import {
   PipelineContext,
   PipelineDebugResult,
+  PipelineUser,
   StepResult,
   StepDebugInfo,
   ValidatorDebugInfo,
@@ -44,7 +45,7 @@ export class PipelineExecutionService {
   async executePipelineWithDebug(
     pipeline: Pipeline & { steps: PipelineStep[] },
     req: Request,
-    user?: { id: string; email?: string; role?: string },
+    user?: PipelineUser,
     options?: {
       dryRun?: boolean;
       deployment?: { owner: string; repo: string; commitSha: string; alias?: string };
@@ -105,7 +106,7 @@ export class PipelineExecutionService {
   private async executePipelineWithDebugInner(
     pipeline: Pipeline & { steps: PipelineStep[] },
     req: Request,
-    user?: { id: string; email?: string; role?: string },
+    user?: PipelineUser,
     options?: {
       dryRun?: boolean;
       deployment?: { owner: string; repo: string; commitSha: string; alias?: string };

--- a/apps/backend/src/pipelines/handlers/function.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/function.handler.spec.ts
@@ -1,0 +1,84 @@
+import { FunctionHandler } from './function.handler';
+import { StepHandlerRegistry } from '../execution/step-handler.registry';
+import { FunctionRunnerService } from '../function-runner.service';
+import { PipelineContext } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+
+function createHandler() {
+  const registry = { register: jest.fn() };
+  const runnerMock = {
+    validateCode: jest.fn().mockReturnValue({ valid: true }),
+    run: jest.fn(),
+  };
+  const handler = new FunctionHandler(
+    registry as unknown as StepHandlerRegistry,
+    runnerMock as unknown as FunctionRunnerService,
+  );
+  return { handler, runnerMock };
+}
+
+function makeContext(overrides: Partial<PipelineContext> = {}): PipelineContext {
+  return {
+    request: { body: {} } as never,
+    stepOutputs: {},
+    projectId: 'proj-1',
+    pipelineId: 'pipe-1',
+    metadata: { path: '/x', method: 'POST', headers: {}, query: {}, body: {} },
+    ...overrides,
+  } as PipelineContext;
+}
+
+function makeStep(config: Record<string, unknown>): PipelineStep {
+  return {
+    id: 'fn',
+    name: 'fn',
+    handlerType: 'function_handler',
+    config,
+  } as PipelineStep;
+}
+
+describe('FunctionHandler.execute — user.groups', () => {
+  it('exposes user.groups to the sandboxed function', async () => {
+    const { handler, runnerMock } = createHandler();
+    runnerMock.run.mockResolvedValue({ success: true, output: {}, executionTime: 1, logs: [] });
+    const context = makeContext({
+      user: { id: 'u1', email: 'u@example.com', role: 'user', groups: ['g1', 'g2'] },
+    });
+
+    await handler.execute(context, makeStep({ code: 'export default () => ({})' }));
+
+    expect(runnerMock.run).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ user: expect.objectContaining({ groups: ['g1', 'g2'] }) }),
+      expect.anything(),
+    );
+  });
+
+  it('defaults user.groups to [] when the context user has none', async () => {
+    const { handler, runnerMock } = createHandler();
+    runnerMock.run.mockResolvedValue({ success: true, output: {}, executionTime: 1, logs: [] });
+    const context = makeContext({ user: { id: 'u1', role: 'user' } });
+
+    await handler.execute(context, makeStep({ code: 'export default () => ({})' }));
+
+    expect(runnerMock.run).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ user: expect.objectContaining({ groups: [] }) }),
+      expect.anything(),
+    );
+  });
+
+  it('leaves user undefined for anonymous requests', async () => {
+    const { handler, runnerMock } = createHandler();
+    runnerMock.run.mockResolvedValue({ success: true, output: {}, executionTime: 1, logs: [] });
+    const context = makeContext();
+
+    await handler.execute(context, makeStep({ code: 'export default () => ({})' }));
+
+    expect(runnerMock.run).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ user: undefined }),
+      expect.anything(),
+    );
+  });
+});

--- a/apps/backend/src/pipelines/handlers/function.handler.ts
+++ b/apps/backend/src/pipelines/handlers/function.handler.ts
@@ -72,6 +72,7 @@ export class FunctionHandler implements StepHandler<FunctionHandlerConfig> {
             id: context.user.id,
             email: context.user.email,
             role: context.user.role,
+            groups: context.user.groups ?? [],
           }
         : undefined,
       request: {

--- a/apps/backend/src/pipelines/handlers/function.handler.ts
+++ b/apps/backend/src/pipelines/handlers/function.handler.ts
@@ -45,7 +45,10 @@ export class FunctionHandler implements StepHandler<FunctionHandlerConfig> {
         throw new ConfigurationError('timeout must be a number', 'function_handler');
       }
       if (config.timeout < 1000 || config.timeout > 30000) {
-        throw new ConfigurationError('timeout must be between 1000 and 30000 milliseconds', 'function_handler');
+        throw new ConfigurationError(
+          'timeout must be between 1000 and 30000 milliseconds',
+          'function_handler',
+        );
       }
     }
 

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
@@ -6,6 +6,7 @@ import { PipelineExecutionService } from '../pipelines/execution';
 import { PipelineExecutionLogService } from '../pipelines/pipeline-execution-log.service';
 import { DeploymentsService } from '../deployments/deployments.service';
 import { ProjectsService } from '../projects/projects.service';
+import { UserGroupsService } from '../user-groups/user-groups.service';
 import { CurrentUserData } from '../auth/decorators/current-user.decorator';
 
 describe('ProxyRulesController', () => {
@@ -14,6 +15,7 @@ describe('ProxyRulesController', () => {
   let mockPipelineExecutionService: jest.Mocked<PipelineExecutionService>;
   let mockDeploymentsService: jest.Mocked<DeploymentsService>;
   let mockProjectsService: jest.Mocked<ProjectsService>;
+  let mockUserGroupsService: jest.Mocked<UserGroupsService>;
 
   const mockUser: CurrentUserData = {
     id: 'user-1',
@@ -70,6 +72,10 @@ describe('ProxyRulesController', () => {
       getProjectById: jest.fn(),
     } as unknown as jest.Mocked<ProjectsService>;
 
+    mockUserGroupsService = {
+      getGroupIdsForUser: jest.fn(),
+    } as unknown as jest.Mocked<UserGroupsService>;
+
     const mockExecutionLogService = {
       log: jest.fn().mockResolvedValue(undefined),
     };
@@ -82,6 +88,7 @@ describe('ProxyRulesController', () => {
         { provide: PipelineExecutionLogService, useValue: mockExecutionLogService },
         { provide: DeploymentsService, useValue: mockDeploymentsService },
         { provide: ProjectsService, useValue: mockProjectsService },
+        { provide: UserGroupsService, useValue: mockUserGroupsService },
       ],
     }).compile();
 
@@ -141,6 +148,109 @@ describe('ProxyRulesController', () => {
         'user-1',
         'admin',
         undefined,
+      );
+    });
+  });
+
+  describe('testPipelineRule', () => {
+    const createMockPipelineRule = (overrides: Record<string, unknown> = {}) =>
+      createMockRule({
+        proxyType: 'pipeline' as const,
+        pipelineConfig: {
+          name: 'Test Pipeline',
+          steps: [
+            {
+              id: 'step-1',
+              handlerType: 'response_handler',
+              config: {},
+              isEnabled: true,
+            },
+          ],
+        },
+        ...overrides,
+      });
+
+    const mockRuleSet = { id: 'rule-set-1', projectId: 'project-1' };
+
+    beforeEach(() => {
+      mockProxyRulesService.getRuleSetById = jest.fn().mockResolvedValue(mockRuleSet);
+      mockPipelineExecutionService.executePipelineWithDebug.mockResolvedValue({
+        success: true,
+        response: { status: 200, body: {} },
+        stepOutputs: {},
+        debug: undefined,
+      } as any);
+    });
+
+    it('passes mockUser.groups through to executePipelineWithDebug', async () => {
+      mockProxyRulesService.getRuleById.mockResolvedValue(createMockPipelineRule());
+
+      await controller.testPipelineRule(
+        'rule-1',
+        {
+          mockUser: { id: 'mock-user-1', email: 'mock@example.com', role: 'user', groups: ['group-a', 'group-b'] },
+        },
+        mockUser,
+        { file: undefined } as any,
+      );
+
+      expect(mockPipelineExecutionService.executePipelineWithDebug).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          id: 'mock-user-1',
+          groups: ['group-a', 'group-b'],
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('does not crash when mockUser.groups is absent', async () => {
+      mockProxyRulesService.getRuleById.mockResolvedValue(createMockPipelineRule());
+
+      await expect(
+        controller.testPipelineRule(
+          'rule-1',
+          { mockUser: { id: 'mock-user-1', email: 'mock@example.com', role: 'user' } },
+          mockUser,
+          { file: undefined } as any,
+        ),
+      ).resolves.toBeDefined();
+
+      expect(mockPipelineExecutionService.executePipelineWithDebug).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ id: 'mock-user-1', groups: undefined }),
+        expect.anything(),
+      );
+    });
+
+    it('enriches the real-user branch with group memberships', async () => {
+      mockProxyRulesService.getRuleById.mockResolvedValue(createMockPipelineRule());
+      mockUserGroupsService.getGroupIdsForUser.mockResolvedValue(['group-x']);
+
+      await controller.testPipelineRule('rule-1', {}, mockUser, { file: undefined } as any);
+
+      expect(mockUserGroupsService.getGroupIdsForUser).toHaveBeenCalledWith('user-1');
+      expect(mockPipelineExecutionService.executePipelineWithDebug).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ id: 'user-1', groups: ['group-x'] }),
+        expect.anything(),
+      );
+    });
+
+    it('degrades to empty groups when group lookup fails for the real user', async () => {
+      mockProxyRulesService.getRuleById.mockResolvedValue(createMockPipelineRule());
+      mockUserGroupsService.getGroupIdsForUser.mockRejectedValue(new Error('db down'));
+
+      await controller.testPipelineRule('rule-1', {}, mockUser, { file: undefined } as any);
+
+      expect(mockPipelineExecutionService.executePipelineWithDebug).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ id: 'user-1', groups: [] }),
+        expect.anything(),
       );
     });
   });

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.ts
@@ -15,6 +15,7 @@ import {
   BadRequestException,
   Inject,
   forwardRef,
+  Logger,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
@@ -32,8 +33,10 @@ import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.de
 import { PipelineExecutionService } from '../pipelines/execution';
 import { PipelineExecutionLogService } from '../pipelines/pipeline-execution-log.service';
 import { TestPipelineDto, PipelineTestResultDto } from '../pipelines/dto';
+import { PipelineUser } from '../pipelines/execution/pipeline-context.interface';
 import { DeploymentsService } from '../deployments/deployments.service';
 import { ProjectsService } from '../projects/projects.service';
+import { UserGroupsService } from '../user-groups/user-groups.service';
 
 /**
  * Controller for individual proxy rule operations.
@@ -45,6 +48,8 @@ import { ProjectsService } from '../projects/projects.service';
 @Controller('api/proxy-rules')
 @UseGuards(ApiKeyGuard)
 export class ProxyRulesController {
+  private readonly logger = new Logger(ProxyRulesController.name);
+
   constructor(
     private readonly proxyRulesService: ProxyRulesService,
     private readonly pipelineExecutionService: PipelineExecutionService,
@@ -53,6 +58,7 @@ export class ProxyRulesController {
     private readonly deploymentsService: DeploymentsService,
     @Inject(forwardRef(() => ProjectsService))
     private readonly projectsService: ProjectsService,
+    private readonly userGroupsService: UserGroupsService,
   ) {}
 
   @Get(':id')
@@ -256,7 +262,7 @@ export class ProxyRulesController {
     } as any;
 
     // Determine which user to use for the test
-    let testUser: { id: string; email?: string; role?: string } | undefined;
+    let testUser: PipelineUser | undefined;
 
     if (dto.simulateAuth !== false) {
       if (dto.mockUser) {
@@ -264,12 +270,24 @@ export class ProxyRulesController {
           id: dto.mockUser.id,
           email: dto.mockUser.email,
           role: dto.mockUser.role,
+          groups: dto.mockUser.groups,
         };
       } else {
+        // Enrich with the real user's group memberships so pipeline conditions
+        // gated on user.groups can be exercised from the test endpoint. Group
+        // lookup must never take the test down: on failure, degrade to "no groups".
+        let groups: string[] = [];
+        try {
+          groups = await this.userGroupsService.getGroupIdsForUser(user.id);
+        } catch (error) {
+          this.logger.warn(`Group membership lookup failed for ${user.id}: ${error}`);
+          groups = [];
+        }
         testUser = {
           id: user.id,
           email: user.email,
           role: user.role,
+          groups,
         };
       }
     }

--- a/apps/backend/src/proxy-rules/proxy-rules.module.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.module.ts
@@ -12,6 +12,7 @@ import { DomainsModule } from '../domains/domains.module';
 import { PipelinesModule } from '../pipelines/pipelines.module';
 import { DeploymentsModule } from '../deployments/deployments.module';
 import { ProjectsModule } from '../projects/projects.module';
+import { UserGroupsModule } from '../user-groups/user-groups.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { ProjectsModule } from '../projects/projects.module';
     forwardRef(() => PipelinesModule),
     forwardRef(() => DeploymentsModule),
     forwardRef(() => ProjectsModule),
+    UserGroupsModule,
   ],
   controllers: [ProxyRulesController, PipelineLogsController, ProxyRuleSetsController],
   providers: [

--- a/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
@@ -8,6 +8,7 @@ import { PipelineExecutionLogService } from '../pipelines/pipeline-execution-log
 import { VisibilityService } from '../domains/visibility.service';
 import { PermissionsService } from '../permissions/permissions.service';
 import { TrafficRoutingService } from '../domains/traffic-routing.service';
+import { UserGroupsService } from '../user-groups/user-groups.service';
 import { Request, Response, NextFunction } from 'express';
 
 // Mock the database client
@@ -32,6 +33,7 @@ describe('ProxyMiddleware', () => {
   let mockVisibilityService: jest.Mocked<VisibilityService>;
   let mockPermissionsService: jest.Mocked<PermissionsService>;
   let mockTrafficRoutingService: jest.Mocked<TrafficRoutingService>;
+  let mockUserGroupsService: jest.Mocked<UserGroupsService>;
   let mockNext: NextFunction;
 
   beforeEach(() => {
@@ -81,6 +83,10 @@ describe('ProxyMiddleware', () => {
       selectVariant: jest.fn().mockResolvedValue(null),
     } as any;
 
+    mockUserGroupsService = {
+      getGroupIdsForUser: jest.fn().mockResolvedValue([]),
+    } as any;
+
     middleware = new ProxyMiddleware(
       mockProxyRulesService,
       mockProxyService,
@@ -91,6 +97,7 @@ describe('ProxyMiddleware', () => {
       mockVisibilityService,
       mockPermissionsService,
       mockTrafficRoutingService,
+      mockUserGroupsService,
     );
     mockNext = jest.fn();
   });

--- a/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
@@ -199,11 +199,27 @@ describe('ProxyMiddleware', () => {
     });
 
     it('should match middle wildcard patterns', () => {
-      expect((middleware as any).matchesPattern('/api/uploads/feedback-*', '/api/uploads/feedback-screenshots')).toBe(true);
-      expect((middleware as any).matchesPattern('/api/uploads/feedback-*', '/api/uploads/feedback-audio/foo.mp3')).toBe(true);
-      expect((middleware as any).matchesPattern('/api/uploads/feedback-*', '/api/uploads/feedback-')).toBe(true);
-      expect((middleware as any).matchesPattern('/api/uploads/feedback-*', '/api/uploads/other')).toBe(false);
-      expect((middleware as any).matchesPattern('/api/uploads/feedback-*', '/api/uploads')).toBe(false);
+      expect(
+        (middleware as any).matchesPattern(
+          '/api/uploads/feedback-*',
+          '/api/uploads/feedback-screenshots',
+        ),
+      ).toBe(true);
+      expect(
+        (middleware as any).matchesPattern(
+          '/api/uploads/feedback-*',
+          '/api/uploads/feedback-audio/foo.mp3',
+        ),
+      ).toBe(true);
+      expect(
+        (middleware as any).matchesPattern('/api/uploads/feedback-*', '/api/uploads/feedback-'),
+      ).toBe(true);
+      expect(
+        (middleware as any).matchesPattern('/api/uploads/feedback-*', '/api/uploads/other'),
+      ).toBe(false);
+      expect((middleware as any).matchesPattern('/api/uploads/feedback-*', '/api/uploads')).toBe(
+        false,
+      );
     });
   });
 

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -6,7 +6,15 @@ import * as jwt from 'jsonwebtoken';
 import * as bcrypt from 'bcrypt';
 import { asc } from 'drizzle-orm';
 import { db } from '../db/client';
-import { projects, deploymentAliases, domainMappings, users, apiKeys, aliasProxyRuleSets, projectDefaultProxyRuleSets } from '../db/schema';
+import {
+  projects,
+  deploymentAliases,
+  domainMappings,
+  users,
+  apiKeys,
+  aliasProxyRuleSets,
+  projectDefaultProxyRuleSets,
+} from '../db/schema';
 import { ProxyRulesService } from './proxy-rules.service';
 import { ProxyService } from './proxy.service';
 import { EmailFormHandlerService } from './email-form-handler.service';
@@ -143,13 +151,19 @@ export class ProxyMiddleware implements NestMiddleware {
             resolvedCommitSha = alias.commitSha;
           }
           // Resolve rule set IDs: join table → legacy column → project default
-          effectiveRuleSetIds = await this.resolveRuleSetIdsForAlias(alias.id, alias.proxyRuleSetId);
+          effectiveRuleSetIds = await this.resolveRuleSetIdsForAlias(
+            alias.id,
+            alias.proxyRuleSetId,
+          );
         }
       }
 
       // Fall back to project defaults if no rule sets resolved
       if (effectiveRuleSetIds.length === 0) {
-        effectiveRuleSetIds = await this.resolveProjectDefaultRuleSetIds(project.id, project.defaultProxyRuleSetId);
+        effectiveRuleSetIds = await this.resolveProjectDefaultRuleSetIds(
+          project.id,
+          project.defaultProxyRuleSetId,
+        );
       }
 
       // Apply traffic splitting: check traffic rules and variant cookie
@@ -178,7 +192,10 @@ export class ProxyMiddleware implements NestMiddleware {
             );
             resolvedCommitSha = variantAlias.commitSha;
             // Update effectiveRuleSetIds if variant alias has its own rules
-            const variantRuleSetIds = await this.resolveRuleSetIdsForAlias(variantAlias.id, variantAlias.proxyRuleSetId);
+            const variantRuleSetIds = await this.resolveRuleSetIdsForAlias(
+              variantAlias.id,
+              variantAlias.proxyRuleSetId,
+            );
             if (variantRuleSetIds.length > 0) {
               effectiveRuleSetIds = variantRuleSetIds;
             }
@@ -424,7 +441,10 @@ export class ProxyMiddleware implements NestMiddleware {
     }
 
     if (effectiveRuleSetIds.length === 0) {
-      effectiveRuleSetIds = await this.resolveProjectDefaultRuleSetIds(project.id, project.defaultProxyRuleSetId);
+      effectiveRuleSetIds = await this.resolveProjectDefaultRuleSetIds(
+        project.id,
+        project.defaultProxyRuleSetId,
+      );
     }
 
     // Get effective rules from the resolved rule sets
@@ -1150,7 +1170,10 @@ export class ProxyMiddleware implements NestMiddleware {
       let pipelineUser: PipelineUser | undefined = user;
       if (user) {
         try {
-          pipelineUser = { ...user, groups: await this.userGroupsService.getGroupIdsForUser(user.id) };
+          pipelineUser = {
+            ...user,
+            groups: await this.userGroupsService.getGroupIdsForUser(user.id),
+          };
         } catch (error) {
           this.logger.warn(`Group membership lookup failed for ${user.id}: ${error}`);
           pipelineUser = { ...user, groups: [] };
@@ -1218,11 +1241,18 @@ export class ProxyMiddleware implements NestMiddleware {
               this.logger.error('Failed to capture post-steps debug info', err);
             }
           }
-          await this.executionLogService.log(rule.id, projectId, result, {
-            ip: req.ip,
-            userAgent: req.headers['user-agent'],
-            userId: user?.id,
-          }, req.method, req.path);
+          await this.executionLogService.log(
+            rule.id,
+            projectId,
+            result,
+            {
+              ip: req.ip,
+              userAgent: req.headers['user-agent'],
+              userId: user?.id,
+            },
+            req.method,
+            req.path,
+          );
         };
         persistLog().catch((err) =>
           this.logger.error('Failed to persist pipeline execution log', err),
@@ -1247,7 +1277,11 @@ export class ProxyMiddleware implements NestMiddleware {
    * Parse multipart form data using multer (for file upload pipelines).
    * Populates req.file with the uploaded file buffer.
    */
-  private parseMultipartUpload(req: Request, fieldName = 'file', maxFileSize = 50 * 1024 * 1024): Promise<void> {
+  private parseMultipartUpload(
+    req: Request,
+    fieldName = 'file',
+    maxFileSize = 50 * 1024 * 1024,
+  ): Promise<void> {
     return new Promise((resolve, reject) => {
       const upload = multer({
         storage: multer.memoryStorage(),
@@ -1497,9 +1531,7 @@ export class ProxyMiddleware implements NestMiddleware {
     // Glob → regex: escape regex metacharacters (but not '*'), then replace
     // '*' with '.*' and anchor. Handles trailing, leading, and middle wildcards.
     const regexSource =
-      '^' +
-      pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') +
-      '$';
+      '^' + pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$';
     return new RegExp(regexSource).test(path);
   }
 }

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -14,12 +14,14 @@ import { ProxyRule, ProxyType, PipelineConfig } from '../db/schema/proxy-rules.s
 import { ConfigService } from '@nestjs/config';
 import { PipelineExecutionService } from '../pipelines/execution';
 import { PipelineExecutionLogService } from '../pipelines/pipeline-execution-log.service';
+import { PipelineUser } from '../pipelines/execution/pipeline-context.interface';
 import { Pipeline, PipelineStep } from '../pipelines/types';
 import multer from 'multer';
 import { CustomDomainAuthService } from '../auth/custom-domain-auth.service';
 import { VisibilityService, AccessControlInfo } from '../domains/visibility.service';
 import { PermissionsService } from '../permissions/permissions.service';
 import { TrafficRoutingService } from '../domains/traffic-routing.service';
+import { UserGroupsService } from '../user-groups/user-groups.service';
 import { matchesMethod } from './method-match';
 
 interface ParsedPublicPath {
@@ -52,6 +54,7 @@ export class ProxyMiddleware implements NestMiddleware {
     private readonly visibilityService: VisibilityService,
     private readonly permissionsService: PermissionsService,
     private readonly trafficRoutingService: TrafficRoutingService,
+    private readonly userGroupsService: UserGroupsService,
   ) {}
 
   /**
@@ -1142,11 +1145,23 @@ export class ProxyMiddleware implements NestMiddleware {
       // Extract user from session if available (optional - don't fail if not authenticated)
       const user = await this.getOptionalUser(req, res);
 
+      // Enrich with group memberships for the sandboxed pipeline context. Group
+      // lookup must never take the request down: on failure, degrade to "no groups".
+      let pipelineUser: PipelineUser | undefined = user;
+      if (user) {
+        try {
+          pipelineUser = { ...user, groups: await this.userGroupsService.getGroupIdsForUser(user.id) };
+        } catch (error) {
+          this.logger.warn(`Group membership lookup failed for ${user.id}: ${error}`);
+          pipelineUser = { ...user, groups: [] };
+        }
+      }
+
       // Execute the pipeline with deployment context for skills access
       const result = await this.pipelineExecutionService.executePipelineWithDebug(
         pipeline,
         req,
-        user,
+        pipelineUser,
         // Only retain in-memory debug snapshots when this rule actually persists
         // them; otherwise they're built and thrown away, needlessly pressuring the heap.
         { deployment, captureDebug: rule.debugEnabled },

--- a/apps/backend/src/user-groups/user-groups-directory.controller.spec.ts
+++ b/apps/backend/src/user-groups/user-groups-directory.controller.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import 'reflect-metadata';
+import { UserGroupsDirectoryController } from './user-groups-directory.controller';
+import { UserGroupsService } from './user-groups.service';
+import { AuthService } from '../auth/auth.service';
+
+describe('UserGroupsDirectoryController', () => {
+  let controller: UserGroupsDirectoryController;
+
+  const mockUserGroupsService = {
+    searchGroupDirectory: jest.fn(),
+    getMyGroups: jest.fn(),
+  };
+
+  const mockAuthService = {
+    getUserById: jest.fn(),
+    getUserByEmail: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserGroupsDirectoryController],
+      providers: [
+        {
+          provide: UserGroupsService,
+          useValue: mockUserGroupsService,
+        },
+        {
+          provide: AuthService,
+          useValue: mockAuthService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<UserGroupsDirectoryController>(UserGroupsDirectoryController);
+
+    jest.clearAllMocks();
+  });
+
+  it('delegates directory search to the service', async () => {
+    mockUserGroupsService.searchGroupDirectory.mockResolvedValue({ groups: [] });
+    await expect(controller.searchDirectory({ search: 'des', limit: 5 })).resolves.toEqual({
+      groups: [],
+    });
+    expect(mockUserGroupsService.searchGroupDirectory).toHaveBeenCalledWith('des', 5);
+  });
+
+  it('returns the current user own memberships', async () => {
+    mockUserGroupsService.getMyGroups.mockResolvedValue({ groups: [{ id: 'g1', name: 'Design' }] });
+    await expect(controller.myGroups({ id: 'u1', email: 'e', role: 'user' })).resolves.toEqual({
+      groups: [{ id: 'g1', name: 'Design' }],
+    });
+    expect(mockUserGroupsService.getMyGroups).toHaveBeenCalledWith('u1');
+  });
+
+  it('is NOT admin-gated (no roles metadata on controller or handlers)', () => {
+    expect(Reflect.getMetadata('roles', UserGroupsDirectoryController)).toBeUndefined();
+    expect(
+      Reflect.getMetadata('roles', UserGroupsDirectoryController.prototype.searchDirectory),
+    ).toBeUndefined();
+    expect(
+      Reflect.getMetadata('roles', UserGroupsDirectoryController.prototype.myGroups),
+    ).toBeUndefined();
+  });
+});

--- a/apps/backend/src/user-groups/user-groups-directory.controller.ts
+++ b/apps/backend/src/user-groups/user-groups-directory.controller.ts
@@ -1,0 +1,61 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiKeyGuard } from '../auth/api-key.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { UserGroupsService } from './user-groups.service';
+import {
+  GroupDirectoryResponseDto,
+  MyGroupsResponseDto,
+  SearchGroupDirectoryQueryDto,
+} from './user-groups.dto';
+
+interface CurrentUserData {
+  id: string;
+  email: string;
+  role: string;
+}
+
+/**
+ * Member-accessible group endpoints: directory search (for share-dialog
+ * group pickers) and the current user's own memberships. Deliberately has
+ * NO @Roles decorator — any authenticated session or API key can call
+ * these, unlike UserGroupsController which is admin-only. Never returns
+ * member lists or emails.
+ */
+@Controller('api/user-groups')
+@UseGuards(ApiKeyGuard, RolesGuard)
+@ApiTags('User Groups')
+@ApiBearerAuth()
+export class UserGroupsDirectoryController {
+  constructor(private readonly userGroupsService: UserGroupsService) {}
+
+  @Get('directory')
+  @ApiOperation({
+    summary: 'Search the group directory',
+    description:
+      'Group picker for share dialogs. Available to any authenticated user (session or ' +
+      'API key) — NOT admin-only. Returns only id, name, and member count; never member ' +
+      'lists or emails. A blank search lists all groups (capped).',
+  })
+  @ApiResponse({ status: 200, type: GroupDirectoryResponseDto })
+  @ApiResponse({ status: 401, description: 'Not authenticated' })
+  async searchDirectory(
+    @Query() query: SearchGroupDirectoryQueryDto,
+  ): Promise<GroupDirectoryResponseDto> {
+    return this.userGroupsService.searchGroupDirectory(query.search, query.limit);
+  }
+
+  @Get('mine')
+  @ApiOperation({
+    summary: "List the current user's group memberships",
+    description:
+      'Strict memberships only (creating a group does not make you a member). Lets an app ' +
+      'mirror server-side group access checks client-side.',
+  })
+  @ApiResponse({ status: 200, type: MyGroupsResponseDto })
+  @ApiResponse({ status: 401, description: 'Not authenticated' })
+  async myGroups(@CurrentUser() user: CurrentUserData): Promise<MyGroupsResponseDto> {
+    return this.userGroupsService.getMyGroups(user.id);
+  }
+}

--- a/apps/backend/src/user-groups/user-groups.dto.ts
+++ b/apps/backend/src/user-groups/user-groups.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsOptional, IsUUID, MaxLength } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, IsUUID, MaxLength, IsInt } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class CreateGroupDto {
   @ApiProperty({
@@ -162,4 +163,36 @@ export class GroupListResponseDto {
     type: [GroupResponseDto],
   })
   groups: GroupResponseDto[];
+}
+
+export class MyGroupDto {
+  @ApiProperty() id: string;
+  @ApiProperty() name: string;
+}
+
+export class MyGroupsResponseDto {
+  @ApiProperty({ type: [MyGroupDto] }) groups: MyGroupDto[];
+}
+
+export class GroupDirectoryEntryDto {
+  @ApiProperty() id: string;
+  @ApiProperty() name: string;
+  @ApiProperty() memberCount: number;
+}
+
+export class GroupDirectoryResponseDto {
+  @ApiProperty({ type: [GroupDirectoryEntryDto] }) groups: GroupDirectoryEntryDto[];
+}
+
+export class SearchGroupDirectoryQueryDto {
+  @ApiPropertyOptional({ description: 'Case-insensitive group-name substring' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({ description: 'Max results (server-capped)' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  limit?: number;
 }

--- a/apps/backend/src/user-groups/user-groups.module.spec.ts
+++ b/apps/backend/src/user-groups/user-groups.module.spec.ts
@@ -1,0 +1,24 @@
+import 'reflect-metadata';
+import { UserGroupsModule } from './user-groups.module';
+import { UserGroupsController } from './user-groups.controller';
+import { UserGroupsDirectoryController } from './user-groups-directory.controller';
+
+describe('UserGroupsModule', () => {
+  it(
+    'registers the member-accessible directory controller BEFORE the admin ' +
+      "controller, so its static /directory and /mine routes aren't swallowed " +
+      "by UserGroupsController's @Get(':id')",
+    () => {
+      const controllers = Reflect.getMetadata('controllers', UserGroupsModule) as unknown[];
+
+      expect(controllers).toBeDefined();
+
+      const directoryIndex = controllers.indexOf(UserGroupsDirectoryController);
+      const adminIndex = controllers.indexOf(UserGroupsController);
+
+      expect(directoryIndex).toBeGreaterThanOrEqual(0);
+      expect(adminIndex).toBeGreaterThanOrEqual(0);
+      expect(directoryIndex).toBeLessThan(adminIndex);
+    },
+  );
+});

--- a/apps/backend/src/user-groups/user-groups.module.ts
+++ b/apps/backend/src/user-groups/user-groups.module.ts
@@ -1,9 +1,15 @@
 import { Module } from '@nestjs/common';
 import { UserGroupsService } from './user-groups.service';
 import { UserGroupsController } from './user-groups.controller';
+import { UserGroupsDirectoryController } from './user-groups-directory.controller';
 
 @Module({
-  controllers: [UserGroupsController],
+  // Order matters: Nest registers routes in this array's order, and
+  // UserGroupsController has @Get(':id'). UserGroupsDirectoryController's
+  // static /directory and /mine paths MUST be listed first, or ':id'
+  // swallows them (id === 'directory') and non-admins get a 403 from the
+  // admin-only controller instead of reaching the member-accessible one.
+  controllers: [UserGroupsDirectoryController, UserGroupsController],
   providers: [UserGroupsService],
   exports: [UserGroupsService],
 })

--- a/apps/backend/src/user-groups/user-groups.service.spec.ts
+++ b/apps/backend/src/user-groups/user-groups.service.spec.ts
@@ -574,7 +574,9 @@ describe('UserGroupsService', () => {
 
   describe('searchGroupDirectory', () => {
     it('returns groups with numeric memberCount and applies the default limit', async () => {
-      const limitMock = jest.fn().mockResolvedValue([{ id: 'g1', name: 'Design', memberCount: '3' }]);
+      const limitMock = jest
+        .fn()
+        .mockResolvedValue([{ id: 'g1', name: 'Design', memberCount: '3' }]);
       mockDb.select.mockReturnValueOnce({
         from: jest.fn().mockReturnValue({
           leftJoin: jest.fn().mockReturnValue({
@@ -593,7 +595,9 @@ describe('UserGroupsService', () => {
 
     it('caps an oversized limit at 50', async () => {
       /* same chain mock */
-      const limitMock = jest.fn().mockResolvedValue([{ id: 'g1', name: 'Design', memberCount: '3' }]);
+      const limitMock = jest
+        .fn()
+        .mockResolvedValue([{ id: 'g1', name: 'Design', memberCount: '3' }]);
       mockDb.select.mockReturnValueOnce({
         from: jest.fn().mockReturnValue({
           leftJoin: jest.fn().mockReturnValue({

--- a/apps/backend/src/user-groups/user-groups.service.spec.ts
+++ b/apps/backend/src/user-groups/user-groups.service.spec.ts
@@ -21,6 +21,9 @@ jest.mock('../db/schema', () => ({
 
 import { db } from '../db/client';
 
+// Type the mocked db
+export const mockDb = db as any;
+
 describe('UserGroupsService', () => {
   let service: UserGroupsService;
 
@@ -532,6 +535,78 @@ describe('UserGroupsService', () => {
       });
 
       await expect(service.getGroupMembers(mockGroupId)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getGroupIdsForUser', () => {
+    it('returns the groupId column of the membership rows', async () => {
+      const whereMock = jest.fn().mockResolvedValue([{ groupId: 'g1' }, { groupId: 'g2' }]);
+      mockDb.select.mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({ where: whereMock }),
+      });
+      await expect(service.getGroupIdsForUser('u1')).resolves.toEqual(['g1', 'g2']);
+    });
+
+    it('returns [] for a user with no memberships', async () => {
+      const whereMock = jest.fn().mockResolvedValue([]);
+      mockDb.select.mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({ where: whereMock }),
+      });
+      await expect(service.getGroupIdsForUser('u1')).resolves.toEqual([]);
+    });
+  });
+
+  describe('getMyGroups', () => {
+    it('returns id+name of groups the user is a member of', async () => {
+      const orderByMock = jest.fn().mockResolvedValue([{ id: 'g1', name: 'Design' }]);
+      mockDb.select.mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          innerJoin: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnValue({ orderBy: orderByMock }),
+          }),
+        }),
+      });
+      await expect(service.getMyGroups('u1')).resolves.toEqual({
+        groups: [{ id: 'g1', name: 'Design' }],
+      });
+    });
+  });
+
+  describe('searchGroupDirectory', () => {
+    it('returns groups with numeric memberCount and applies the default limit', async () => {
+      const limitMock = jest.fn().mockResolvedValue([{ id: 'g1', name: 'Design', memberCount: '3' }]);
+      mockDb.select.mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          leftJoin: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnValue({
+              groupBy: jest.fn().mockReturnValue({
+                orderBy: jest.fn().mockReturnValue({ limit: limitMock }),
+              }),
+            }),
+          }),
+        }),
+      });
+      const result = await service.searchGroupDirectory(undefined);
+      expect(result.groups).toEqual([{ id: 'g1', name: 'Design', memberCount: 3 }]);
+      expect(limitMock).toHaveBeenCalledWith(20);
+    });
+
+    it('caps an oversized limit at 50', async () => {
+      /* same chain mock */
+      const limitMock = jest.fn().mockResolvedValue([{ id: 'g1', name: 'Design', memberCount: '3' }]);
+      mockDb.select.mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          leftJoin: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnValue({
+              groupBy: jest.fn().mockReturnValue({
+                orderBy: jest.fn().mockReturnValue({ limit: limitMock }),
+              }),
+            }),
+          }),
+        }),
+      });
+      await service.searchGroupDirectory('a', 9999);
+      expect(limitMock).toHaveBeenCalledWith(50);
     });
   });
 });

--- a/apps/backend/src/user-groups/user-groups.service.ts
+++ b/apps/backend/src/user-groups/user-groups.service.ts
@@ -306,6 +306,8 @@ export class UserGroupsService {
       .orderBy(asc(userGroups.name))
       .limit(capped);
 
-    return { groups: rows.map((r) => ({ id: r.id, name: r.name, memberCount: Number(r.memberCount) })) };
+    return {
+      groups: rows.map((r) => ({ id: r.id, name: r.name, memberCount: Number(r.memberCount) })),
+    };
   }
 }

--- a/apps/backend/src/user-groups/user-groups.service.ts
+++ b/apps/backend/src/user-groups/user-groups.service.ts
@@ -4,9 +4,12 @@ import {
   ConflictException,
   ForbiddenException,
 } from '@nestjs/common';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, ilike, asc, sql } from 'drizzle-orm';
 import { db } from '../db/client';
 import { userGroups, userGroupMembers, users, UserGroup, UserGroupMember } from '../db/schema';
+import { MyGroupsResponseDto, GroupDirectoryResponseDto } from './user-groups.dto';
+
+const GROUP_DIRECTORY_MAX_LIMIT = 50;
 
 export interface UserGroupWithMembers extends UserGroup {
   members: (UserGroupMember & { user: typeof users.$inferSelect })[];
@@ -251,5 +254,58 @@ export class UserGroupsService {
       .where(eq(userGroupMembers.groupId, groupId));
 
     return members;
+  }
+
+  /**
+   * Group ids the user is a MEMBER of (strict: user_group_members only;
+   * creating a group does not make you a member). Consumed per-request by
+   * the pipeline context builder — keep it a single indexed query.
+   */
+  async getGroupIdsForUser(userId: string): Promise<string[]> {
+    const rows = await db
+      .select({ groupId: userGroupMembers.groupId })
+      .from(userGroupMembers)
+      .where(eq(userGroupMembers.userId, userId));
+    return rows.map((row) => row.groupId);
+  }
+
+  /**
+   * The session user's own memberships, id + name only. Member-accessible:
+   * apps need it client-side to mirror the gate's group evaluation.
+   */
+  async getMyGroups(userId: string): Promise<MyGroupsResponseDto> {
+    const rows = await db
+      .select({ id: userGroups.id, name: userGroups.name })
+      .from(userGroupMembers)
+      .innerJoin(userGroups, eq(userGroupMembers.groupId, userGroups.id))
+      .where(eq(userGroupMembers.userId, userId))
+      .orderBy(asc(userGroups.name));
+    return { groups: rows };
+  }
+
+  /**
+   * Group picker for share dialogs. Member-accessible and deliberately
+   * minimal: id, name, member count — never members or emails. A blank
+   * search returns all groups (they are few and browsable), unlike the
+   * user directory where a blank term must not dump the user table.
+   */
+  async searchGroupDirectory(search?: string, limit = 20): Promise<GroupDirectoryResponseDto> {
+    const term = (search ?? '').trim();
+    const capped = Math.min(Math.max(Math.trunc(limit) || 20, 1), GROUP_DIRECTORY_MAX_LIMIT);
+
+    const rows = await db
+      .select({
+        id: userGroups.id,
+        name: userGroups.name,
+        memberCount: sql<number>`count(${userGroupMembers.id})`,
+      })
+      .from(userGroups)
+      .leftJoin(userGroupMembers, eq(userGroupMembers.groupId, userGroups.id))
+      .where(term.length > 0 ? ilike(userGroups.name, `%${term}%`) : undefined)
+      .groupBy(userGroups.id)
+      .orderBy(asc(userGroups.name))
+      .limit(capped);
+
+    return { groups: rows.map((r) => ({ id: r.id, name: r.name, memberCount: Number(r.memberCount) })) };
   }
 }

--- a/docs/superpowers/plans/2026-07-29-pipeline-user-groups.md
+++ b/docs/superpowers/plans/2026-07-29-pipeline-user-groups.md
@@ -450,6 +450,6 @@ Expected: PASS, no regressions.
 Run: `pnpm lint`
 Expected: clean.
 
-- [ ] **Step 3: End-to-end smoke through a pipeline.** In the local dev stack, create a throwaway proxy rule with a one-step pipeline `function_handler` whose code is `export default function h({ user }) { return { groups: (user && user.groups) || null } }`, call it with a session/API key belonging to a user who is a member of one group, and confirm the response contains that group id. Delete the rule afterwards.
+- [ ] **Step 3: End-to-end smoke through a pipeline.** In the local dev stack, create a throwaway proxy rule with a one-step pipeline `function_handler` whose code is `function handler({ user }) { return { groups: (user && user.groups) || null } }`, call it with a session/API key belonging to a user who is a member of one group, and confirm the response contains that group id. Delete the rule afterwards. (Note: the sandbox has no module loader — no `export`/`import`; the handler is a plain top-level `function handler(data) { ... }`.)
 
 - [ ] **Step 4: Push and open PR** (rebase on `origin/main` first; PR title `feat: pipeline user.groups + member-accessible group directory`). Merging and the release/deploy to j5s.dev gate the Handoff plan — its rules 404 gracefully until then.

--- a/docs/superpowers/plans/2026-07-29-pipeline-user-groups.md
+++ b/docs/superpowers/plans/2026-07-29-pipeline-user-groups.md
@@ -1,0 +1,455 @@
+# Pipeline User Groups (CE) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose a user's group memberships to pipeline function handlers (`user.groups`) and add two member-accessible read endpoints so apps (Handoff first) can grant folder access to CE User Groups.
+
+**Architecture:** Three thin additions to existing seams — a strict-membership lookup in `UserGroupsService`, enrichment of the pipeline user object where `ProxyMiddleware` invokes pipeline execution, and a new non-admin controller in the user-groups module. No schema changes; `user_groups` / `user_group_members` and their indexes already exist.
+
+**Tech Stack:** NestJS, Drizzle ORM (PostgreSQL), Jest (colocated `.spec.ts`, mocked drizzle chains).
+
+**Spec:** `repos/apps` worktree `.claude/worktrees/group-sharing/apps/handoff/docs/superpowers/specs/2026-07-29-group-sharing-design.md` (Part 1 is the CE half).
+
+## Global Constraints
+
+- Repo: `/home/rico/bffless/repos/ce`, worktree `.claude/worktrees/group-sharing`, branch `group-sharing`. All paths below are relative to `apps/backend/`.
+- Membership is **strict**: only `user_group_members` rows count. `userGroups.createdBy` does NOT confer membership (creators are admins; admins already short-circuit everywhere).
+- The two new endpoints are member-accessible (any authenticated session or API key), never admin-only, and never return member lists or emails.
+- Group management stays admin-only — this plan adds **zero** write surface.
+- Tests: `pnpm --filter backend test -- <path>` from the repo root (or `pnpm test -- <path>` inside `apps/backend/`).
+- Commit after each task; conventional-commit messages (release-please reads them).
+
+---
+
+### Task 1: Membership lookups + directory search in UserGroupsService
+
+**Files:**
+- Modify: `src/user-groups/user-groups.service.ts`
+- Modify: `src/user-groups/user-groups.dto.ts`
+- Create: `src/user-groups/user-groups.service.spec.ts` (none exists today)
+
+**Interfaces:**
+- Consumes: existing drizzle tables `userGroups`, `userGroupMembers` from `../db/schema` (already imported by the service).
+- Produces (Tasks 2 and 3 call these exact signatures):
+  - `getGroupIdsForUser(userId: string): Promise<string[]>`
+  - `getMyGroups(userId: string): Promise<MyGroupsResponseDto>` — `{ groups: [{ id, name }] }`
+  - `searchGroupDirectory(search?: string, limit?: number): Promise<GroupDirectoryResponseDto>` — `{ groups: [{ id, name, memberCount }] }`
+
+- [ ] **Step 1: Add DTOs** to `src/user-groups/user-groups.dto.ts` (mirror decorator style of the file's existing DTOs; `SearchGroupDirectoryQueryDto` mirrors `SearchDirectoryQueryDto` in `src/users/users.dto.ts`):
+
+```ts
+export class MyGroupDto {
+  @ApiProperty() id: string;
+  @ApiProperty() name: string;
+}
+
+export class MyGroupsResponseDto {
+  @ApiProperty({ type: [MyGroupDto] }) groups: MyGroupDto[];
+}
+
+export class GroupDirectoryEntryDto {
+  @ApiProperty() id: string;
+  @ApiProperty() name: string;
+  @ApiProperty() memberCount: number;
+}
+
+export class GroupDirectoryResponseDto {
+  @ApiProperty({ type: [GroupDirectoryEntryDto] }) groups: GroupDirectoryEntryDto[];
+}
+
+export class SearchGroupDirectoryQueryDto {
+  @ApiPropertyOptional({ description: 'Case-insensitive group-name substring' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({ description: 'Max results (server-capped)' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  limit?: number;
+}
+```
+
+- [ ] **Step 2: Write failing tests** in `src/user-groups/user-groups.service.spec.ts`. Copy the `mockDb` jest setup from the top of `src/users/users.service.spec.ts` (module-level `jest.mock` of the db import plus chainable select mocks). Cases:
+
+```ts
+describe('getGroupIdsForUser', () => {
+  it('returns the groupId column of the membership rows', async () => {
+    const whereMock = jest.fn().mockResolvedValue([{ groupId: 'g1' }, { groupId: 'g2' }]);
+    mockDb.select.mockReturnValueOnce({
+      from: jest.fn().mockReturnValue({ where: whereMock }),
+    });
+    await expect(service.getGroupIdsForUser('u1')).resolves.toEqual(['g1', 'g2']);
+  });
+
+  it('returns [] for a user with no memberships', async () => {
+    const whereMock = jest.fn().mockResolvedValue([]);
+    mockDb.select.mockReturnValueOnce({
+      from: jest.fn().mockReturnValue({ where: whereMock }),
+    });
+    await expect(service.getGroupIdsForUser('u1')).resolves.toEqual([]);
+  });
+});
+
+describe('getMyGroups', () => {
+  it('returns id+name of groups the user is a member of', async () => {
+    const orderByMock = jest.fn().mockResolvedValue([{ id: 'g1', name: 'Design' }]);
+    mockDb.select.mockReturnValueOnce({
+      from: jest.fn().mockReturnValue({
+        innerJoin: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({ orderBy: orderByMock }),
+        }),
+      }),
+    });
+    await expect(service.getMyGroups('u1')).resolves.toEqual({
+      groups: [{ id: 'g1', name: 'Design' }],
+    });
+  });
+});
+
+describe('searchGroupDirectory', () => {
+  it('returns groups with numeric memberCount and applies the default limit', async () => {
+    const limitMock = jest.fn().mockResolvedValue([{ id: 'g1', name: 'Design', memberCount: '3' }]);
+    mockDb.select.mockReturnValueOnce({
+      from: jest.fn().mockReturnValue({
+        leftJoin: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            groupBy: jest.fn().mockReturnValue({
+              orderBy: jest.fn().mockReturnValue({ limit: limitMock }),
+            }),
+          }),
+        }),
+      }),
+    });
+    const result = await service.searchGroupDirectory(undefined);
+    expect(result.groups).toEqual([{ id: 'g1', name: 'Design', memberCount: 3 }]);
+    expect(limitMock).toHaveBeenCalledWith(20);
+  });
+
+  it('caps an oversized limit at 50', async () => {
+    /* same chain mock */
+    await service.searchGroupDirectory('a', 9999);
+    expect(limitMock).toHaveBeenCalledWith(50);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pnpm test -- src/user-groups/user-groups.service.spec.ts`
+Expected: FAIL — `getGroupIdsForUser is not a function` (and siblings).
+
+- [ ] **Step 4: Implement the three methods** in `src/user-groups/user-groups.service.ts` (add `ilike`, `asc`, `sql` to the existing drizzle-orm import):
+
+```ts
+const GROUP_DIRECTORY_MAX_LIMIT = 50;
+
+/**
+ * Group ids the user is a MEMBER of (strict: user_group_members only;
+ * creating a group does not make you a member). Consumed per-request by
+ * the pipeline context builder — keep it a single indexed query.
+ */
+async getGroupIdsForUser(userId: string): Promise<string[]> {
+  const rows = await db
+    .select({ groupId: userGroupMembers.groupId })
+    .from(userGroupMembers)
+    .where(eq(userGroupMembers.userId, userId));
+  return rows.map((row) => row.groupId);
+}
+
+/**
+ * The session user's own memberships, id + name only. Member-accessible:
+ * apps need it client-side to mirror the gate's group evaluation.
+ */
+async getMyGroups(userId: string): Promise<MyGroupsResponseDto> {
+  const rows = await db
+    .select({ id: userGroups.id, name: userGroups.name })
+    .from(userGroupMembers)
+    .innerJoin(userGroups, eq(userGroupMembers.groupId, userGroups.id))
+    .where(eq(userGroupMembers.userId, userId))
+    .orderBy(asc(userGroups.name));
+  return { groups: rows };
+}
+
+/**
+ * Group picker for share dialogs. Member-accessible and deliberately
+ * minimal: id, name, member count — never members or emails. A blank
+ * search returns all groups (they are few and browsable), unlike the
+ * user directory where a blank term must not dump the user table.
+ */
+async searchGroupDirectory(search?: string, limit = 20): Promise<GroupDirectoryResponseDto> {
+  const term = (search ?? '').trim();
+  const capped = Math.min(Math.max(Math.trunc(limit) || 20, 1), GROUP_DIRECTORY_MAX_LIMIT);
+
+  const rows = await db
+    .select({
+      id: userGroups.id,
+      name: userGroups.name,
+      memberCount: sql<number>`count(${userGroupMembers.id})`,
+    })
+    .from(userGroups)
+    .leftJoin(userGroupMembers, eq(userGroupMembers.groupId, userGroups.id))
+    .where(term.length > 0 ? ilike(userGroups.name, `%${term}%`) : undefined)
+    .groupBy(userGroups.id)
+    .orderBy(asc(userGroups.name))
+    .limit(capped);
+
+  return { groups: rows.map((r) => ({ id: r.id, name: r.name, memberCount: Number(r.memberCount) })) };
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm test -- src/user-groups/user-groups.service.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/user-groups/
+git commit -m "feat(user-groups): membership lookups and member-accessible directory search"
+```
+
+---
+
+### Task 2: `user.groups` through the pipeline context
+
+**Files:**
+- Modify: `src/pipelines/execution/pipeline-context.interface.ts` (PipelineUser, ~line 6)
+- Modify: `src/pipelines/execution/pipeline-execution.service.ts` (user params at ~lines 47 and 108)
+- Modify: `src/pipelines/handlers/function.handler.ts` (user mapping at ~lines 70–75)
+- Modify: `src/proxy-rules/proxy-rules.module.ts` (import UserGroupsModule)
+- Modify: `src/proxy-rules/proxy.middleware.ts` (inject service; enrich at the pipeline-exec call site, ~line 1142)
+- Test: `src/pipelines/handlers/function.handler.spec.ts` (extend if present, create alongside `ai.handler.spec.ts` otherwise)
+
+**Interfaces:**
+- Consumes: `getGroupIdsForUser(userId): Promise<string[]>` from Task 1.
+- Produces: sandboxed pipeline functions receive `user.groups: string[]` (empty array when authenticated with no memberships; `user` still `undefined` when anonymous). This is the contract the Handoff plan's gate functions read.
+
+- [ ] **Step 1: Write the failing handler test** — assert `FunctionRunnerService.run` receives `data.user.groups`. Mirror the mock style of `ai.handler.spec.ts` for constructing the handler with a mocked runner:
+
+```ts
+it('exposes user.groups to the sandboxed function', async () => {
+  runnerMock.run.mockResolvedValue({ ok: true });
+  const context = makeContext({
+    user: { id: 'u1', email: 'u@example.com', role: 'user', groups: ['g1', 'g2'] },
+  });
+  await handler.execute(context, makeStep({ code: 'export default () => ({})' }));
+  expect(runnerMock.run).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.objectContaining({ user: expect.objectContaining({ groups: ['g1', 'g2'] }) }),
+    expect.anything(),
+  );
+});
+
+it('defaults user.groups to [] when the context user has none', async () => {
+  runnerMock.run.mockResolvedValue({ ok: true });
+  const context = makeContext({ user: { id: 'u1', role: 'user' } });
+  await handler.execute(context, makeStep({ code: 'export default () => ({})' }));
+  expect(runnerMock.run).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.objectContaining({ user: expect.objectContaining({ groups: [] }) }),
+    expect.anything(),
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- src/pipelines/handlers/function.handler.spec.ts`
+Expected: FAIL — received user object has no `groups` key.
+
+- [ ] **Step 3: Type + mapping changes**
+
+`pipeline-context.interface.ts`:
+
+```ts
+export interface PipelineUser {
+  id: string;
+  email?: string;
+  role?: string;
+  /** Group ids the user is a member of (strict membership). Absent only on pre-groups callers. */
+  groups?: string[];
+}
+```
+
+`pipeline-execution.service.ts` — widen both `user?: { id: string; email?: string; role?: string }` params (lines ~47 and ~108) to `user?: PipelineUser` (import from `./pipeline-context.interface`).
+
+`function.handler.ts` user mapping:
+
+```ts
+user: context.user
+  ? {
+      id: context.user.id,
+      email: context.user.email,
+      role: context.user.role,
+      groups: context.user.groups ?? [],
+    }
+  : undefined,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test -- src/pipelines/handlers/function.handler.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Enrich at the middleware call site.** In `src/proxy-rules/proxy-rules.module.ts`, add `UserGroupsModule` to `imports` (it already exports `UserGroupsService`). In `proxy.middleware.ts`, add `private readonly userGroupsService: UserGroupsService` to the constructor, then at the pipeline-execution call site (~line 1142, where `getOptionalUser` feeds `executePipelineWithDebug`):
+
+```ts
+const user = await this.getOptionalUser(req, res);
+let pipelineUser: PipelineUser | undefined = user;
+if (user) {
+  try {
+    pipelineUser = { ...user, groups: await this.userGroupsService.getGroupIdsForUser(user.id) };
+  } catch (error) {
+    // Group lookup must never take the request down — degrade to "no groups".
+    this.logger.warn(`Group membership lookup failed for ${user.id}: ${error}`);
+    pipelineUser = { ...user, groups: [] };
+  }
+}
+```
+
+Pass `pipelineUser` (not `user`) into `executePipelineWithDebug`. Do NOT enrich inside `getOptionalUser` — its other caller (~line 583, proxy access control) doesn't need groups and shouldn't pay the query.
+
+- [ ] **Step 6: Run the pipelines + proxy-rules suites**
+
+Run: `pnpm test -- src/pipelines src/proxy-rules`
+Expected: PASS (existing proxy.middleware specs may need the new constructor dep mocked — provide `{ getGroupIdsForUser: jest.fn().mockResolvedValue([]) }`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pipelines/ src/proxy-rules/
+git commit -m "feat(pipelines): expose user group memberships as user.groups in handler context"
+```
+
+---
+
+### Task 3: Member-accessible directory controller
+
+**Files:**
+- Create: `src/user-groups/user-groups-directory.controller.ts`
+- Create: `src/user-groups/user-groups-directory.controller.spec.ts`
+- Modify: `src/user-groups/user-groups.module.ts`
+
+**Interfaces:**
+- Consumes: `searchGroupDirectory`, `getMyGroups` from Task 1; `ApiKeyGuard`, `RolesGuard`, `CurrentUser` from `../auth/` (same imports as `user-groups.controller.ts`).
+- Produces: `GET /api/user-groups/directory` → `GroupDirectoryResponseDto`; `GET /api/user-groups/mine` → `MyGroupsResponseDto`. These are the URLs the Handoff proxy rules target.
+
+- [ ] **Step 1: Write failing controller tests** (mocked service, like `users.controller.spec.ts`):
+
+```ts
+it('delegates directory search to the service', async () => {
+  serviceMock.searchGroupDirectory.mockResolvedValue({ groups: [] });
+  await expect(controller.searchDirectory({ search: 'des', limit: 5 })).resolves.toEqual({ groups: [] });
+  expect(serviceMock.searchGroupDirectory).toHaveBeenCalledWith('des', 5);
+});
+
+it('returns the current user own memberships', async () => {
+  serviceMock.getMyGroups.mockResolvedValue({ groups: [{ id: 'g1', name: 'Design' }] });
+  await expect(controller.myGroups({ id: 'u1', email: 'e', role: 'user' })).resolves.toEqual({
+    groups: [{ id: 'g1', name: 'Design' }],
+  });
+  expect(serviceMock.getMyGroups).toHaveBeenCalledWith('u1');
+});
+
+it('is NOT admin-gated (no roles metadata on controller or handlers)', () => {
+  expect(Reflect.getMetadata('roles', UserGroupsDirectoryController)).toBeUndefined();
+  expect(Reflect.getMetadata('roles', UserGroupsDirectoryController.prototype.searchDirectory)).toBeUndefined();
+  expect(Reflect.getMetadata('roles', UserGroupsDirectoryController.prototype.myGroups)).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test -- src/user-groups/user-groups-directory.controller.spec.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the controller** (guards but **no** `@Roles` — that is the whole point; management stays in the admin controller):
+
+```ts
+@Controller('api/user-groups')
+@UseGuards(ApiKeyGuard, RolesGuard)
+@ApiTags('User Groups')
+@ApiBearerAuth()
+export class UserGroupsDirectoryController {
+  constructor(private readonly userGroupsService: UserGroupsService) {}
+
+  @Get('directory')
+  @ApiOperation({
+    summary: 'Search the group directory',
+    description:
+      'Group picker for share dialogs. Available to any authenticated user (session or ' +
+      'API key) — NOT admin-only. Returns only id, name, and member count; never member ' +
+      'lists or emails. A blank search lists all groups (capped).',
+  })
+  @ApiResponse({ status: 200, type: GroupDirectoryResponseDto })
+  @ApiResponse({ status: 401, description: 'Not authenticated' })
+  async searchDirectory(@Query() query: SearchGroupDirectoryQueryDto): Promise<GroupDirectoryResponseDto> {
+    return this.userGroupsService.searchGroupDirectory(query.search, query.limit);
+  }
+
+  @Get('mine')
+  @ApiOperation({
+    summary: "List the current user's group memberships",
+    description:
+      'Strict memberships only (creating a group does not make you a member). Lets an app ' +
+      'mirror server-side group access checks client-side.',
+  })
+  @ApiResponse({ status: 200, type: MyGroupsResponseDto })
+  @ApiResponse({ status: 401, description: 'Not authenticated' })
+  async myGroups(@CurrentUser() user: CurrentUserData): Promise<MyGroupsResponseDto> {
+    return this.userGroupsService.getMyGroups(user.id);
+  }
+}
+```
+
+(Declare the same `interface CurrentUserData { id: string; email: string; role: string }` used by `user-groups.controller.ts`.)
+
+- [ ] **Step 4: Register it FIRST in the module.** `UserGroupsController` has `@Get(':id')`; Nest registers routes in `controllers` array order, so the static `directory`/`mine` paths must come first or `:id` swallows them (`id === 'directory'` → 403 for non-admins):
+
+```ts
+controllers: [UserGroupsDirectoryController, UserGroupsController],
+```
+
+Add a comment on that line stating the ordering constraint.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm test -- src/user-groups/`
+Expected: PASS.
+
+- [ ] **Step 6: Manual route-order check** (this is the failure the unit tests can't see). Start the backend (`pnpm dev` or the docker dev stack) and, with a **non-admin** session or API key:
+
+```bash
+curl -s -H "X-API-Key: $NON_ADMIN_KEY" http://localhost:3000/api/user-groups/directory
+curl -s -H "X-API-Key: $NON_ADMIN_KEY" http://localhost:3000/api/user-groups/mine
+```
+
+Expected: 200 JSON from both (NOT 403). Then confirm admin routes still work: `curl -s -H "X-API-Key: $ADMIN_KEY" http://localhost:3000/api/user-groups` → 200.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/user-groups/
+git commit -m "feat(user-groups): member-accessible group directory and my-memberships endpoints"
+```
+
+---
+
+### Task 4: Full verification
+
+- [ ] **Step 1: Full backend suite**
+
+Run: `pnpm test` (from `apps/backend/`)
+Expected: PASS, no regressions.
+
+- [ ] **Step 2: Lint**
+
+Run: `pnpm lint`
+Expected: clean.
+
+- [ ] **Step 3: End-to-end smoke through a pipeline.** In the local dev stack, create a throwaway proxy rule with a one-step pipeline `function_handler` whose code is `export default function h({ user }) { return { groups: (user && user.groups) || null } }`, call it with a session/API key belonging to a user who is a member of one group, and confirm the response contains that group id. Delete the rule afterwards.
+
+- [ ] **Step 4: Push and open PR** (rebase on `origin/main` first; PR title `feat: pipeline user.groups + member-accessible group directory`). Merging and the release/deploy to j5s.dev gate the Handoff plan — its rules 404 gracefully until then.


### PR DESCRIPTION
## Summary

Exposes user-group memberships to pipeline function handlers and adds two member-accessible read endpoints, so apps built on BFFless (Handoff first) can grant folder access to CE User Groups.

- **`user.groups` in the pipeline handler context** — strict memberships (`user_group_members` only; creating a group confers nothing), resolved by one indexed query at the pipeline-execution call site in `ProxyMiddleware`. Lookup failure degrades to `[]` and never fails the request. Anonymous requests are untouched (`user` stays `undefined`); the access-control path pays no extra query.
- **`GET /api/user-groups/directory`** — member-accessible group picker (id, name, memberCount; never member lists or emails; blank search lists all, capped at 50).
- **`GET /api/user-groups/mine`** — the session user's own memberships (id, name), so apps can mirror server-side group checks client-side.
- **Route-shadowing guard** — the new controller registers before the admin controller (whose `@Get(':id')` would swallow `directory`/`mine`), with a module test pinning the order.
- **Pipeline test endpoint** can now simulate groups (`mockUser.groups`) and enriches real users, so group-gated pipelines are testable.

Zero write surface added — group management stays admin-only. No schema changes.

## Verification

- Full backend suite green (134 suites / 2154 tests), `tsc --noEmit` clean.
- Live checks against a from-source backend: non-admin session → 200 on both new endpoints; admin CRUD unaffected; end-to-end pipeline call returned the caller's real `user.groups`.
- Spec: `apps` repo, `apps/handoff/docs/superpowers/specs/2026-07-29-group-sharing-design.md` (Part 1). Plan: `docs/superpowers/plans/2026-07-29-pipeline-user-groups.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1FwQsg44yeeF9Zcyu1oFx
