### PR TITLE
feat(apps): app catalog — 1-click app install

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -334,6 +334,12 @@ MINIO_USE_SSL=false
 # presign key independently of ENCRYPTION_KEY.
 # LOCAL_PRESIGN_SECRET=
 
+# App catalog registry. The Admin → Apps catalog fetches its index of installable
+# first-party apps from this URL (cached ~1h; the catalog degrades to
+# "unavailable" if unreachable). Override for air-gapped or self-published
+# catalogs. There is deliberately no arbitrary-URL install field in the UI.
+# APPS_REGISTRY_URL=https://apps.bffless.dev/registry.json
+
 
 # ============================================================================
 # 7. CACHE CONFIGURATION [OPTIONAL]

--- a/apps/backend/drizzle/0040_dashing_wither.sql
+++ b/apps/backend/drizzle/0040_dashing_wither.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "installed_apps" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"app_id" varchar(100) NOT NULL,
+	"name" varchar(200) NOT NULL,
+	"version" varchar(50) NOT NULL,
+	"project_id" uuid NOT NULL,
+	"alias" varchar(100) NOT NULL,
+	"domain_id" uuid,
+	"deployment_id" uuid,
+	"rule_set_ids" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"schema_ids" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"bundle_sha256" varchar(64) NOT NULL,
+	"manifest" jsonb NOT NULL,
+	"manual_steps_acked" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"status" varchar(20) DEFAULT 'installing' NOT NULL,
+	"created_resources" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"installed_by" uuid NOT NULL,
+	"installed_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "installed_apps_app_project_unique" UNIQUE("app_id","project_id")
+);
+--> statement-breakpoint
+ALTER TABLE "installed_apps" ADD CONSTRAINT "installed_apps_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "installed_apps" ADD CONSTRAINT "installed_apps_installed_by_users_id_fk" FOREIGN KEY ("installed_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "installed_apps_project_id_idx" ON "installed_apps" USING btree ("project_id");

--- a/apps/backend/drizzle/meta/0040_snapshot.json
+++ b/apps/backend/drizzle/meta/0040_snapshot.json
@@ -1,0 +1,7276 @@
+{
+  "id": "29b3cc75-780c-4fd8-bcca-fac752c6dfe4",
+  "prevId": "0df9fb37-0d1c-4546-8de7-754f2513e0c2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alias_proxy_rule_sets": {
+      "name": "alias_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alias_proxy_rule_sets_alias_ruleset_unique": {
+          "name": "alias_proxy_rule_sets_alias_ruleset_unique",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_alias_id_idx": {
+          "name": "alias_proxy_rule_sets_alias_id_idx",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_rule_set_id_idx": {
+          "name": "alias_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk": {
+          "name": "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "deployment_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_project_id_idx": {
+          "name": "api_keys_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_path": {
+          "name": "original_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_number": {
+          "name": "workflow_run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'commits'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_project_id_idx": {
+          "name": "assets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_type_idx": {
+          "name": "assets_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_path_idx": {
+          "name": "assets_project_commit_path_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_branch_idx": {
+          "name": "assets_project_branch_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_idx": {
+          "name": "assets_project_commit_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_created_at_idx": {
+          "name": "assets_project_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_committed_at_idx": {
+          "name": "assets_project_committed_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_path_idx": {
+          "name": "assets_deployment_path_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_id_idx": {
+          "name": "assets_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_size_idx": {
+          "name": "assets_deployment_size_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_uploaded_by_users_id_fk": {
+          "name": "assets_uploaded_by_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist_entries": {
+      "name": "blocklist_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prefix'"
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklist_entries_blocklist_id_idx": {
+          "name": "blocklist_entries_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocklist_entries_unique": {
+          "name": "blocklist_entries_unique",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocklist_entries_blocklist_id_blocklists_id_fk": {
+          "name": "blocklist_entries_blocklist_id_blocklists_id_fk",
+          "tableFrom": "blocklist_entries",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklists": {
+      "name": "blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklists_name_unique": {
+          "name": "blocklists_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cache_rules": {
+      "name": "cache_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_max_age": {
+          "name": "browser_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "cdn_max_age": {
+          "name": "cdn_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stale_while_revalidate": {
+          "name": "stale_while_revalidate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immutable": {
+          "name": "immutable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cacheability": {
+          "name": "cacheability",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cache_rules_project_pattern_unique": {
+          "name": "cache_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_id_idx": {
+          "name": "cache_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_priority_idx": {
+          "name": "cache_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cache_rules_project_id_projects_id_fk": {
+          "name": "cache_rules_project_id_projects_id_fk",
+          "tableFrom": "cache_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_aliases": {
+      "name": "deployment_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_preview": {
+          "name": "is_auto_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployment_aliases_project_alias_unique": {
+          "name": "deployment_aliases_project_alias_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_project_id_idx": {
+          "name": "deployment_aliases_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_alias_unique": {
+          "name": "deployment_aliases_repository_alias_unique",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_idx": {
+          "name": "deployment_aliases_repository_idx",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_commit_sha_idx": {
+          "name": "deployment_aliases_commit_sha_idx",
+          "columns": [
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_deployment_id_idx": {
+          "name": "deployment_aliases_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_aliases_project_id_projects_id_fk": {
+          "name": "deployment_aliases_project_id_projects_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_blocklists": {
+      "name": "domain_blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_blocklists_domain_blocklist_unique": {
+          "name": "domain_blocklists_domain_blocklist_unique",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_blocklists_domain_mapping_id_idx": {
+          "name": "domain_blocklists_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_blocklists_blocklist_id_idx": {
+          "name": "domain_blocklists_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_blocklists_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "domain_blocklists_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "domain_blocklists",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_blocklists_blocklist_id_blocklists_id_fk": {
+          "name": "domain_blocklists_blocklist_id_blocklists_id_fk",
+          "tableFrom": "domain_blocklists",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_mappings": {
+      "name": "domain_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_type": {
+          "name": "domain_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ssl_expires_at": {
+          "name": "ssl_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_verified": {
+          "name": "dns_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dns_verified_at": {
+          "name": "dns_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_renew_ssl": {
+          "name": "auto_renew_ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_renewed_at": {
+          "name": "ssl_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_status": {
+          "name": "ssl_renewal_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_error": {
+          "name": "ssl_renewal_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sticky_sessions_enabled": {
+          "name": "sticky_sessions_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sticky_session_duration": {
+          "name": "sticky_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 86400
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_mappings_project_id_idx": {
+          "name": "domain_mappings_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_domain_idx": {
+          "name": "domain_mappings_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_is_active_idx": {
+          "name": "domain_mappings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_mappings_project_id_projects_id_fk": {
+          "name": "domain_mappings_project_id_projects_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_mappings_created_by_users_id_fk": {
+          "name": "domain_mappings_created_by_users_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_mappings_domain_unique": {
+          "name": "domain_mappings_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_redirects": {
+      "name": "domain_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_domain": {
+          "name": "source_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_domain_id": {
+          "name": "target_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_redirects_target_domain_id_idx": {
+          "name": "domain_redirects_target_domain_id_idx",
+          "columns": [
+            {
+              "expression": "target_domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_redirects_source_domain_idx": {
+          "name": "domain_redirects_source_domain_idx",
+          "columns": [
+            {
+              "expression": "source_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_redirects_target_domain_id_domain_mappings_id_fk": {
+          "name": "domain_redirects_target_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "target_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_redirects_created_by_users_id_fk": {
+          "name": "domain_redirects_created_by_users_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_redirects_source_domain_unique": {
+          "name": "domain_redirects_source_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_rules": {
+      "name": "domain_traffic_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_key": {
+          "name": "condition_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_value": {
+          "name": "condition_value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_rules_domain_id_idx": {
+          "name": "domain_traffic_rules_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_traffic_rules_domain_id_priority_idx": {
+          "name": "domain_traffic_rules_domain_id_priority_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_rules_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_rules_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_rules",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_weights": {
+      "name": "domain_traffic_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_weights_domain_id_idx": {
+          "name": "domain_traffic_weights_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_weights_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_weights_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_weights",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_traffic_weights_domain_alias_unique": {
+          "name": "domain_traffic_weights_domain_alias_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain_id",
+            "alias"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flags_key_idx": {
+          "name": "feature_flags_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_integration_credentials": {
+      "name": "google_integration_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured": {
+          "name": "configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "google_integration_credentials_service_unique": {
+          "name": "google_integration_credentials_service_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installed_apps": {
+      "name": "installed_apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_set_ids": {
+          "name": "rule_set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "schema_ids": {
+          "name": "schema_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "bundle_sha256": {
+          "name": "bundle_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manual_steps_acked": {
+          "name": "manual_steps_acked",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'installing'"
+        },
+        "created_resources": {
+          "name": "created_resources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "installed_by": {
+          "name": "installed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "installed_apps_project_id_idx": {
+          "name": "installed_apps_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "installed_apps_project_id_projects_id_fk": {
+          "name": "installed_apps_project_id_projects_id_fk",
+          "tableFrom": "installed_apps",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "installed_apps_installed_by_users_id_fk": {
+          "name": "installed_apps_installed_by_users_id_fk",
+          "tableFrom": "installed_apps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "installed_apps_app_project_unique": {
+          "name": "installed_apps_app_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oidc_providers_provider_id_unique": {
+          "name": "oidc_providers_provider_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rule_executions": {
+      "name": "onboarding_rule_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rule_executions_user_idx": {
+          "name": "onboarding_rule_executions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_rule_idx": {
+          "name": "onboarding_rule_executions_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_executed_at_idx": {
+          "name": "onboarding_rule_executions_executed_at_idx",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_status_idx": {
+          "name": "onboarding_rule_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rule_executions_rule_id_onboarding_rules_id_fk": {
+          "name": "onboarding_rule_executions_rule_id_onboarding_rules_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "onboarding_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "onboarding_rule_executions_user_id_users_id_fk": {
+          "name": "onboarding_rule_executions_user_id_users_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rules": {
+      "name": "onboarding_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_signup'"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rules_enabled_trigger_idx": {
+          "name": "onboarding_rules_enabled_trigger_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rules_priority_idx": {
+          "name": "onboarding_rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rules_created_by_users_id_fk": {
+          "name": "onboarding_rules_created_by_users_id_fk",
+          "tableFrom": "onboarding_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_preferences": {
+      "name": "path_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spa_mode": {
+          "name": "spa_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_path_preferences_project_id": {
+          "name": "idx_path_preferences_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_preferences_project_id_projects_id_fk": {
+          "name": "path_preferences_project_id_projects_id_fk",
+          "tableFrom": "path_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "path_preferences_project_filepath_unique": {
+          "name": "path_preferences_project_filepath_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "filepath"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_redirects": {
+      "name": "path_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'100'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "path_redirects_domain_mapping_id_idx": {
+          "name": "path_redirects_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "path_redirects_source_path_idx": {
+          "name": "path_redirects_source_path_idx",
+          "columns": [
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_redirects_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "path_redirects_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "path_redirects_created_by_users_id_fk": {
+          "name": "path_redirects_created_by_users_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_token": {
+          "name": "upload_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_token_idx": {
+          "name": "pending_uploads_token_idx",
+          "columns": [
+            {
+              "expression": "upload_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_project_idx": {
+          "name": "pending_uploads_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_project_id_projects_id_fk": {
+          "name": "pending_uploads_project_id_projects_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_uploaded_by_users_id_fk": {
+          "name": "pending_uploads_uploaded_by_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_uploads_upload_token_unique": {
+          "name": "pending_uploads_upload_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data_embeddings": {
+      "name": "pipeline_data_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_data_id": {
+          "name": "pipeline_data_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_embeddings_data_id_idx": {
+          "name": "pipeline_data_embeddings_data_id_idx",
+          "columns": [
+            {
+              "expression": "pipeline_data_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_embeddings_schema_field_idx": {
+          "name": "pipeline_data_embeddings_schema_field_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk": {
+          "name": "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_data",
+          "columnsFrom": [
+            "pipeline_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data": {
+      "name": "pipeline_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_project_id_idx": {
+          "name": "pipeline_data_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_schema_id_idx": {
+          "name": "pipeline_data_schema_id_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_created_at_idx": {
+          "name": "pipeline_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_project_id_projects_id_fk": {
+          "name": "pipeline_data_project_id_projects_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_created_by_users_id_fk": {
+          "name": "pipeline_data_created_by_users_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_execution_logs": {
+      "name": "pipeline_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_id": {
+          "name": "proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps_count": {
+          "name": "steps_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_step": {
+          "name": "error_step",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_meta": {
+          "name": "request_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_exec_logs_rule_created_idx": {
+          "name": "pipeline_exec_logs_rule_created_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_project_idx": {
+          "name": "pipeline_exec_logs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_created_idx": {
+          "name": "pipeline_exec_logs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_execution_logs_project_id_projects_id_fk": {
+          "name": "pipeline_execution_logs_project_id_projects_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schedules": {
+      "name": "pipeline_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_proxy_rule_id": {
+          "name": "target_proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schedules_project_id_idx": {
+          "name": "pipeline_schedules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_schedules_target_proxy_rule_id_idx": {
+          "name": "pipeline_schedules_target_proxy_rule_id_idx",
+          "columns": [
+            {
+              "expression": "target_proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_schedules_enabled_next_run_idx": {
+          "name": "pipeline_schedules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schedules_project_id_projects_id_fk": {
+          "name": "pipeline_schedules_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schedules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_schedules_target_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_schedules_target_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_schedules",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "target_proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schemas": {
+      "name": "pipeline_schemas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schemas_project_id_idx": {
+          "name": "pipeline_schemas_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schemas_project_id_projects_id_fk": {
+          "name": "pipeline_schemas_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schemas",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pipeline_schemas_project_name_unique": {
+          "name": "pipeline_schemas_project_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.primary_content": {
+      "name": "primary_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "www_enabled": {
+          "name": "www_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'redirect-to-www'"
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "primary_content_project_id_projects_id_fk": {
+          "name": "primary_content_project_id_projects_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "primary_content_configured_by_users_id_fk": {
+          "name": "primary_content_configured_by_users_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_default_proxy_rule_sets": {
+      "name": "project_default_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_default_proxy_rule_sets_project_ruleset_unique": {
+          "name": "project_default_proxy_rule_sets_project_ruleset_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_project_id_idx": {
+          "name": "project_default_proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_rule_set_id_idx": {
+          "name": "project_default_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_default_proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "project_default_proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite_links": {
+      "name": "project_invite_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guest'"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invite_links_project_id_idx": {
+          "name": "project_invite_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_token_idx": {
+          "name": "project_invite_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_is_active_idx": {
+          "name": "project_invite_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_links_project_id_projects_id_fk": {
+          "name": "project_invite_links_project_id_projects_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_links_created_by_users_id_fk": {
+          "name": "project_invite_links_created_by_users_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_links_token_unique": {
+          "name": "project_invite_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_group_permissions": {
+      "name": "project_group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_group_permissions_project_idx": {
+          "name": "project_group_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_permissions_group_idx": {
+          "name": "project_group_permissions_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_permissions_project_id_projects_id_fk": {
+          "name": "project_group_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_group_id_user_groups_id_fk": {
+          "name": "project_group_permissions_group_id_user_groups_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_granted_by_users_id_fk": {
+          "name": "project_group_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_group_permissions_unique": {
+          "name": "project_group_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "group_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_permissions": {
+      "name": "project_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_permissions_project_idx": {
+          "name": "project_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_permissions_user_idx": {
+          "name": "project_permissions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_permissions_project_id_projects_id_fk": {
+          "name": "project_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_user_id_users_id_fk": {
+          "name": "project_permissions_user_id_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_granted_by_users_id_fk": {
+          "name": "project_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_permissions_unique": {
+          "name": "project_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_secrets": {
+      "name": "project_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_secrets_project_name_unique": {
+          "name": "project_secrets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_secrets_project_id_idx": {
+          "name": "project_secrets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_secrets_project_id_projects_id_fk": {
+          "name": "project_secrets_project_id_projects_id_fk",
+          "tableFrom": "project_secrets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_found'"
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authenticated'"
+        },
+        "allow_public_signup": {
+          "name": "allow_public_signup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_providers": {
+          "name": "ai_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_services": {
+          "name": "ai_services",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_proxy_rule_set_id": {
+          "name": "default_proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_created_by_idx": {
+          "name": "projects_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_owner_idx": {
+          "name": "projects_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_owner_name_unique": {
+          "name": "projects_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_set_revisions": {
+      "name": "proxy_rule_set_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_set_revisions_set_created_idx": {
+          "name": "proxy_rule_set_revisions_set_created_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_set_revisions_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rule_set_revisions_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rule_set_revisions",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_sets": {
+      "name": "proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_sets_project_name_unique": {
+          "name": "proxy_rule_sets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_project_id_idx": {
+          "name": "proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_environment_idx": {
+          "name": "proxy_rule_sets_environment_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rules": {
+      "name": "proxy_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "methods": {
+          "name": "methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strip_prefix": {
+          "name": "strip_prefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "preserve_host": {
+          "name": "preserve_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forward_cookies": {
+          "name": "forward_cookies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "header_config": {
+          "name": "header_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_transform": {
+          "name": "auth_transform",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_rewrite": {
+          "name": "internal_rewrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proxy_type": {
+          "name": "proxy_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external_proxy'"
+        },
+        "email_handler_config": {
+          "name": "email_handler_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "debug_enabled": {
+          "name": "debug_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rules_rule_set_path_method_unique": {
+          "name": "proxy_rules_rule_set_path_method_unique",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_id_idx": {
+          "name": "proxy_rules_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_order_idx": {
+          "name": "proxy_rules_rule_set_order_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_proxy_type_idx": {
+          "name": "proxy_rules_proxy_type_idx",
+          "columns": [
+            {
+              "expression": "proxy_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rules_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rules_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rules",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_header_rules": {
+      "name": "response_header_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_policy": {
+          "name": "frame_policy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sameorigin'"
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_header_rules_project_pattern_unique": {
+          "name": "response_header_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_id_idx": {
+          "name": "response_header_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_priority_idx": {
+          "name": "response_header_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "response_header_rules_project_id_projects_id_fk": {
+          "name": "response_header_rules_project_id_projects_id_fk",
+          "tableFrom": "response_header_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_logs": {
+      "name": "retention_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_count": {
+          "name": "asset_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "freed_bytes": {
+          "name": "freed_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_partial": {
+          "name": "is_partial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_logs_project_id_idx": {
+          "name": "retention_logs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_rule_id_idx": {
+          "name": "retention_logs_rule_id_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_deleted_at_idx": {
+          "name": "retention_logs_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_project_deleted_at_idx": {
+          "name": "retention_logs_project_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_logs_project_id_projects_id_fk": {
+          "name": "retention_logs_project_id_projects_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retention_logs_rule_id_retention_rules_id_fk": {
+          "name": "retention_logs_rule_id_retention_rules_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "retention_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_rules": {
+      "name": "retention_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_pattern": {
+          "name": "branch_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_branches": {
+          "name": "exclude_branches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keep_with_alias": {
+          "name": "keep_with_alias",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "keep_minimum": {
+          "name": "keep_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "path_patterns": {
+          "name": "path_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_mode": {
+          "name": "path_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_summary": {
+          "name": "last_run_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_rules_project_id_idx": {
+          "name": "retention_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_next_run_idx": {
+          "name": "retention_rules_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_enabled_next_run_idx": {
+          "name": "retention_rules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_rules_project_id_projects_id_fk": {
+          "name": "retention_rules_project_id_projects_id_fk",
+          "tableFrom": "retention_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "share_links_project_id_idx": {
+          "name": "share_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_domain_mapping_id_idx": {
+          "name": "share_links_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_token_idx": {
+          "name": "share_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_is_active_idx": {
+          "name": "share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_project_id_projects_id_fk": {
+          "name": "share_links_project_id_projects_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "share_links_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_created_by_users_id_fk": {
+          "name": "share_links_created_by_users_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "share_links_token_unique": {
+          "name": "share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_challenges": {
+      "name": "ssl_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "base_domain": {
+          "name": "base_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_type": {
+          "name": "challenge_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_name": {
+          "name": "record_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_value": {
+          "name": "record_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_data": {
+          "name": "order_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authz_data": {
+          "name": "authz_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_authorization": {
+          "name": "key_authorization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_challenges_base_domain_idx": {
+          "name": "ssl_challenges_base_domain_idx",
+          "columns": [
+            {
+              "expression": "base_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_challenges_status_idx": {
+          "name": "ssl_challenges_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ssl_challenges_base_domain_unique": {
+          "name": "ssl_challenges_base_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "base_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_renewal_history": {
+      "name": "ssl_renewal_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_type": {
+          "name": "certificate_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_expires_at": {
+          "name": "new_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_renewal_history_domain_id_idx": {
+          "name": "ssl_renewal_history_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_renewal_history_created_at_idx": {
+          "name": "ssl_renewal_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssl_renewal_history_domain_id_domain_mappings_id_fk": {
+          "name": "ssl_renewal_history_domain_id_domain_mappings_id_fk",
+          "tableFrom": "ssl_renewal_history",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_settings": {
+      "name": "ssl_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_config": {
+      "name": "system_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_setup_complete": {
+          "name": "is_setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_config": {
+          "name": "storage_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_provider": {
+          "name": "email_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_config": {
+          "name": "email_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_configured": {
+          "name": "email_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "smtp_config": {
+          "name": "smtp_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_configured": {
+          "name": "smtp_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_config": {
+          "name": "cache_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwt_secret": {
+          "name": "jwt_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_salt": {
+          "name": "api_key_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_public_signups": {
+          "name": "allow_public_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "telemetry_enabled": {
+          "name": "telemetry_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "telemetry_last_sent": {
+          "name": "telemetry_last_sent",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_config": {
+          "name": "branding_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_ip_rollups": {
+      "name": "traffic_ip_rollups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_paths": {
+          "name": "sample_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "sample_user_agents": {
+          "name": "sample_user_agents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_ip_rollups_ip_unique": {
+          "name": "traffic_ip_rollups_ip_unique",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_request_count_idx": {
+          "name": "traffic_ip_rollups_request_count_idx",
+          "columns": [
+            {
+              "expression": "request_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_last_seen_idx": {
+          "name": "traffic_ip_rollups_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_requests": {
+      "name": "traffic_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_version": {
+          "name": "http_version",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referer": {
+          "name": "referer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_requests_timestamp_idx": {
+          "name": "traffic_requests_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_ip_idx": {
+          "name": "traffic_requests_ip_idx",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_status_idx": {
+          "name": "traffic_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_classification_idx": {
+          "name": "traffic_requests_classification_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_group_members": {
+      "name": "user_group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_members_group_idx": {
+          "name": "user_group_members_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_group_members_user_idx": {
+          "name": "user_group_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_group_members_group_id_user_groups_id_fk": {
+          "name": "user_group_members_group_id_user_groups_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_user_id_users_id_fk": {
+          "name": "user_group_members_user_id_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_added_by_users_id_fk": {
+          "name": "user_group_members_added_by_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_group_members_unique": {
+          "name": "user_group_members_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_groups_created_by_idx": {
+          "name": "user_groups_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_created_by_users_id_fk": {
+          "name": "user_groups_created_by_users_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_verified_at": {
+          "name": "oidc_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_invitations_email": {
+          "name": "idx_workspace_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_invitations_token": {
+          "name": "idx_workspace_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invitations_invited_by_users_id_fk": {
+          "name": "workspace_invitations_invited_by_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_accepted_user_id_users_id_fk": {
+          "name": "workspace_invitations_accepted_user_id_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitations_token_unique": {
+          "name": "workspace_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1783896812504,
       "tag": "0039_thick_trish_tilby",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1785457155737,
+      "tag": "0040_dashing_wither",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/app-catalog/__fixtures__/make-fixture-bundle.ts
+++ b/apps/backend/src/app-catalog/__fixtures__/make-fixture-bundle.ts
@@ -1,0 +1,117 @@
+import { createHash } from 'crypto';
+import { zipSync } from 'fflate';
+import type { AppManifest } from '../app-manifest.types';
+
+/**
+ * `makeFixtureBundle` — builds a real, valid app bundle zip in memory (via
+ * `zipSync`, the same library the installer itself uses to build deploy
+ * zips). Committed as CODE, not a binary fixture, so it stays readable/diffable
+ * and the two versions stay obviously in sync with each other.
+ *
+ * This is the fixture behind `app-catalog.e2e-ish.spec.ts` (Task 11's
+ * orchestration spec): the bytes returned here are fed through the REAL
+ * `AppBundleService` (real unzip + real `validateAppManifest`) and the
+ * installer's REAL rule-set DTO validation — only the network fetch and the
+ * downstream side-effecting services (sync/deploy/domains/projects/schedules)
+ * are mocked by the spec.
+ *
+ * Two rule sets, two rules, two distinct schemas total:
+ *  - `fixture-a.json`: 1 rule, declares schema `fixture_items`.
+ *  - `fixture-b.json`: 1 rule (2 in v2 — "adds a rule"), declares the SAME
+ *    `fixture_items` schema again (same id — the shared-name reuse path) PLUS
+ *    a second, distinct schema `fixture_notes`.
+ *
+ * v2 vs v1: version bump, `fixture-b.json` gains a second rule, and `dist/`
+ * changes (different `index.html` content + a new `assets/app.js`) — the
+ * "same alias redeployed" case for the update orchestration test.
+ */
+
+// Valid v4-shaped UUIDs (version nibble '4', variant nibble '8') — class-validator's
+// @IsUUID() default ('all') still checks the version/variant nibbles, so an
+// all-same-digit string like '1111...-1111...' fails validation.
+const FIXTURE_ITEMS_SCHEMA_ID = '11111111-1111-4111-8111-111111111111';
+const FIXTURE_NOTES_SCHEMA_ID = '22222222-2222-4222-8222-222222222222';
+
+export interface FixtureBundle {
+  buf: Uint8Array;
+  sha256: string;
+  manifest: AppManifest;
+}
+
+function encode(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function manifestFor(version: '1.0.0' | '2.0.0'): AppManifest {
+  return {
+    schemaVersion: 1,
+    id: 'fixture-app',
+    name: 'Fixture App',
+    version,
+    summary: 'Orchestration-spec fixture app',
+    install: {
+      alias: 'fixture-app',
+      deployment: { path: 'dist', basePath: '/apps/fixture-app/dist' },
+      ruleSets: [{ file: 'rulesets/fixture-a.json' }, { file: 'rulesets/fixture-b.json' }],
+    },
+  };
+}
+
+function ruleSetA(): unknown {
+  return {
+    version: 2,
+    kind: 'proxy-rule-set',
+    ruleSet: { name: 'fixture-app-a', description: 'Fixture rule set A' },
+    rules: [{ pathPattern: '/api/items', method: 'GET', targetUrl: 'https://api.example.com/items' }],
+    schemas: [
+      {
+        id: FIXTURE_ITEMS_SCHEMA_ID,
+        name: 'fixture_items',
+        fields: [{ name: 'title', type: 'string', required: true }],
+      },
+    ],
+  };
+}
+
+function ruleSetB(version: '1.0.0' | '2.0.0'): unknown {
+  const rules = [{ pathPattern: '/api/notes', method: 'GET', targetUrl: 'https://api.example.com/notes' }];
+  if (version === '2.0.0') {
+    rules.push({ pathPattern: '/api/notes', method: 'POST', targetUrl: 'https://api.example.com/notes' });
+  }
+  return {
+    version: 2,
+    kind: 'proxy-rule-set',
+    ruleSet: { name: 'fixture-app-b', description: 'Fixture rule set B' },
+    rules,
+    schemas: [
+      {
+        id: FIXTURE_ITEMS_SCHEMA_ID,
+        name: 'fixture_items',
+        fields: [{ name: 'title', type: 'string', required: true }],
+      },
+      {
+        id: FIXTURE_NOTES_SCHEMA_ID,
+        name: 'fixture_notes',
+        fields: [{ name: 'body', type: 'text', required: false }],
+      },
+    ],
+  };
+}
+
+export function makeFixtureBundle(version: '1.0.0' | '2.0.0'): FixtureBundle {
+  const manifest = manifestFor(version);
+
+  const files: Record<string, Uint8Array> = {
+    'bffless-app.json': encode(JSON.stringify(manifest)),
+    'rulesets/fixture-a.json': encode(JSON.stringify(ruleSetA())),
+    'rulesets/fixture-b.json': encode(JSON.stringify(ruleSetB(version))),
+    'dist/index.html': encode(`<!doctype html><title>Fixture App</title>fixture app v${version}`),
+  };
+  if (version === '2.0.0') {
+    files['dist/assets/app.js'] = encode('console.log("fixture app v2")');
+  }
+
+  const buf = zipSync(files);
+  const sha256 = createHash('sha256').update(buf).digest('hex');
+  return { buf, sha256, manifest };
+}

--- a/apps/backend/src/app-catalog/app-bundle.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-bundle.service.spec.ts
@@ -1,0 +1,172 @@
+import { zipSync, strToU8 } from 'fflate';
+import { createHash } from 'crypto';
+import { BadRequestException } from '@nestjs/common';
+import { AppBundleService } from './app-bundle.service';
+import { TEST_MANIFEST } from './app-manifest.util.spec';
+
+function makeBundle(manifest: unknown = TEST_MANIFEST): { buf: Uint8Array; sha256: string } {
+  const buf = zipSync({
+    'bffless-app.json': strToU8(JSON.stringify(manifest)),
+    'rulesets/handoff.json': strToU8(JSON.stringify({ ruleSet: { name: 'handoff' }, rules: [], schemas: [] })),
+    'rulesets/handoff-rss-feed.json': strToU8(
+      JSON.stringify({ ruleSet: { name: 'handoff-rss-feed' }, rules: [], schemas: [] }),
+    ),
+    'dist/index.html': strToU8('<!doctype html>ok'),
+  });
+  return { buf, sha256: createHash('sha256').update(buf).digest('hex') };
+}
+
+function fetchResponse(bytes: Uint8Array, opts: { contentLength?: number } = {}): Response {
+  const contentLength = opts.contentLength ?? bytes.byteLength;
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get: (name: string) => (name.toLowerCase() === 'content-length' ? String(contentLength) : null),
+    },
+    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  } as unknown as Response;
+}
+
+describe('AppBundleService', () => {
+  let service: AppBundleService;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    service = new AppBundleService();
+    fetchSpy = jest.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  describe('loadFromBuffer', () => {
+    it('parses the manifest and exposes files on a matching sha', async () => {
+      const { buf, sha256 } = makeBundle();
+
+      const loaded = await service.loadFromBuffer(buf, sha256);
+
+      expect(loaded.manifest).toEqual(TEST_MANIFEST);
+      expect(loaded.sha256).toBe(sha256);
+      expect(loaded.files['dist/index.html']).toBeInstanceOf(Uint8Array);
+      expect(new TextDecoder().decode(loaded.files['dist/index.html'])).toBe('<!doctype html>ok');
+    });
+
+    it('throws BadRequestException mentioning sha256 on mismatch, before parsing', async () => {
+      const { buf } = makeBundle();
+
+      await expect(service.loadFromBuffer(buf, 'f'.repeat(64))).rejects.toThrow(BadRequestException);
+      await expect(service.loadFromBuffer(buf, 'f'.repeat(64))).rejects.toThrow(/sha256/i);
+    });
+
+    it('throws when bffless-app.json is missing', async () => {
+      const buf = zipSync({
+        'dist/index.html': strToU8('<!doctype html>ok'),
+      });
+      const sha256 = createHash('sha256').update(buf).digest('hex');
+
+      await expect(service.loadFromBuffer(buf, sha256)).rejects.toThrow();
+    });
+
+    it('throws with the validator errors when the manifest fails validateAppManifest', async () => {
+      const { buf, sha256 } = makeBundle({ ...TEST_MANIFEST, schemaVersion: 2 });
+
+      await expect(service.loadFromBuffer(buf, sha256)).rejects.toThrow(/schemaVersion/);
+    });
+
+    it('throws when a declared ruleSets file is missing from the zip', async () => {
+      const buf = zipSync({
+        'bffless-app.json': strToU8(JSON.stringify(TEST_MANIFEST)),
+        'rulesets/handoff.json': strToU8(JSON.stringify({ ruleSet: { name: 'handoff' }, rules: [], schemas: [] })),
+        // rulesets/handoff-rss-feed.json intentionally omitted
+        'dist/index.html': strToU8('<!doctype html>ok'),
+      });
+      const sha256 = createHash('sha256').update(buf).digest('hex');
+
+      await expect(service.loadFromBuffer(buf, sha256)).rejects.toThrow(/declared file missing/i);
+    });
+
+    it('works without an expectedSha256 (fixture/test path)', async () => {
+      const { buf } = makeBundle();
+
+      const loaded = await service.loadFromBuffer(buf);
+
+      expect(loaded.manifest).toEqual(TEST_MANIFEST);
+    });
+  });
+
+  describe('fetchBundle', () => {
+    it('downloads, verifies sha, and returns the loaded bundle', async () => {
+      const { buf, sha256 } = makeBundle();
+      fetchSpy.mockResolvedValue(fetchResponse(buf));
+
+      const loaded = await service.fetchBundle('https://example.com/handoff.zip', sha256);
+
+      expect(loaded.manifest).toEqual(TEST_MANIFEST);
+      expect(loaded.files['dist/index.html']).toBeInstanceOf(Uint8Array);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws on sha mismatch', async () => {
+      const { buf } = makeBundle();
+      fetchSpy.mockResolvedValue(fetchResponse(buf));
+
+      await expect(
+        service.fetchBundle('https://example.com/handoff.zip', 'f'.repeat(64)),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects an oversized body before hashing, via Content-Length', async () => {
+      const { buf } = makeBundle();
+      const arrayBufferSpy = jest.fn(async () => buf.buffer);
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: {
+          get: (name: string) =>
+            name.toLowerCase() === 'content-length' ? String(300 * 1024 * 1024) : null,
+        },
+        arrayBuffer: arrayBufferSpy,
+      } as unknown as Response);
+
+      await expect(
+        service.fetchBundle('https://example.com/huge.zip', 'a'.repeat(64)),
+      ).rejects.toThrow(/too large|size|exceeds/i);
+      expect(arrayBufferSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects an oversized body discovered after download (no Content-Length header)', async () => {
+      const bigBuf = new Uint8Array(0); // real 200MiB alloc is impractical in a unit test
+      const arrayBufferSpy = jest.fn(async () => {
+        const fake = new ArrayBuffer(0);
+        Object.defineProperty(fake, 'byteLength', { value: 300 * 1024 * 1024 });
+        return fake;
+      });
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        arrayBuffer: arrayBufferSpy,
+      } as unknown as Response);
+      void bigBuf;
+
+      await expect(
+        service.fetchBundle('https://example.com/huge.zip', 'a'.repeat(64)),
+      ).rejects.toThrow(/too large|size|exceeds/i);
+    });
+
+    it('throws when the response is not ok', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 404,
+        headers: { get: () => null },
+        arrayBuffer: async () => new ArrayBuffer(0),
+      } as unknown as Response);
+
+      await expect(
+        service.fetchBundle('https://example.com/missing.zip', 'a'.repeat(64)),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/apps/backend/src/app-catalog/app-bundle.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-bundle.service.spec.ts
@@ -108,6 +108,18 @@ describe('AppBundleService', () => {
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('does not re-download when the sha is already cached (preflight then install)', async () => {
+      const { buf, sha256 } = makeBundle();
+      fetchSpy.mockResolvedValue(fetchResponse(buf));
+
+      const first = await service.fetchBundle('https://example.com/handoff.zip', sha256);
+      const second = await service.fetchBundle('https://example.com/handoff.zip', sha256);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(second).toBe(first);
+      expect(second.manifest).toEqual(TEST_MANIFEST);
+    });
+
     it('throws on sha mismatch', async () => {
       const { buf } = makeBundle();
       fetchSpy.mockResolvedValue(fetchResponse(buf));

--- a/apps/backend/src/app-catalog/app-bundle.service.ts
+++ b/apps/backend/src/app-catalog/app-bundle.service.ts
@@ -24,6 +24,16 @@ export class AppBundleService {
   private readonly cache = new Map<string, LoadedBundle>();
 
   async fetchBundle(url: string, expectedSha256: string): Promise<LoadedBundle> {
+    if (expectedSha256) {
+      const cached = this.cache.get(expectedSha256.toLowerCase());
+      if (cached) {
+        // Bump recency (Map preserves insertion order).
+        this.cache.delete(cached.sha256);
+        this.cache.set(cached.sha256, cached);
+        return cached;
+      }
+    }
+
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.DOWNLOAD_TIMEOUT_MS);
     let res: Response;

--- a/apps/backend/src/app-catalog/app-bundle.service.ts
+++ b/apps/backend/src/app-catalog/app-bundle.service.ts
@@ -1,0 +1,141 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { unzip } from 'fflate';
+import { createHash } from 'crypto';
+import { validateAppManifest } from './app-manifest.util';
+import type { AppManifest } from './app-manifest.types';
+
+export interface LoadedBundle {
+  manifest: AppManifest;
+  /** entry path -> bytes; directory entries stripped */
+  files: Record<string, Uint8Array>;
+  sha256: string;
+}
+
+/**
+ * AppBundleService — downloads/parses an app bundle zip, verifying its
+ * sha256 before doing any (potentially expensive) parsing, and validating
+ * the manifest + declared ruleSet files are actually present in the zip.
+ */
+@Injectable()
+export class AppBundleService {
+  private readonly MAX_BUNDLE_BYTES = 200 * 1024 * 1024;
+  private readonly DOWNLOAD_TIMEOUT_MS = 30_000;
+  private readonly MAX_CACHE_ENTRIES = 3;
+  private readonly cache = new Map<string, LoadedBundle>();
+
+  async fetchBundle(url: string, expectedSha256: string): Promise<LoadedBundle> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.DOWNLOAD_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await fetch(url, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (!res.ok) {
+      throw new BadRequestException(`Bundle download failed with HTTP ${res.status}`);
+    }
+
+    const contentLengthHeader = res.headers.get('content-length');
+    if (contentLengthHeader) {
+      const contentLength = Number(contentLengthHeader);
+      if (Number.isFinite(contentLength) && contentLength > this.MAX_BUNDLE_BYTES) {
+        throw new BadRequestException(
+          `Bundle size (${contentLength} bytes) exceeds the maximum allowed size of ${this.MAX_BUNDLE_BYTES} bytes`,
+        );
+      }
+    }
+
+    const arrayBuffer = await res.arrayBuffer();
+    if (arrayBuffer.byteLength > this.MAX_BUNDLE_BYTES) {
+      throw new BadRequestException(
+        `Bundle size (${arrayBuffer.byteLength} bytes) exceeds the maximum allowed size of ${this.MAX_BUNDLE_BYTES} bytes`,
+      );
+    }
+
+    return this.loadFromBuffer(new Uint8Array(arrayBuffer), expectedSha256);
+  }
+
+  async loadFromBuffer(buf: Uint8Array, expectedSha256?: string): Promise<LoadedBundle> {
+    const actualSha256 = createHash('sha256').update(buf).digest('hex').toLowerCase();
+
+    if (expectedSha256 && expectedSha256.toLowerCase() !== actualSha256) {
+      throw new BadRequestException(
+        `Bundle sha256 mismatch: expected ${expectedSha256.toLowerCase()}, got ${actualSha256}`,
+      );
+    }
+
+    const cached = this.cache.get(actualSha256);
+    if (cached) {
+      // Bump recency (Map preserves insertion order).
+      this.cache.delete(actualSha256);
+      this.cache.set(actualSha256, cached);
+      return cached;
+    }
+
+    const files = await this.unzip(buf);
+
+    const manifestBytes = files['bffless-app.json'];
+    if (!manifestBytes) {
+      throw new BadRequestException('Bundle is missing required file: bffless-app.json');
+    }
+
+    let manifestJson: unknown;
+    try {
+      manifestJson = JSON.parse(new TextDecoder().decode(manifestBytes));
+    } catch (error) {
+      throw new BadRequestException(
+        `bffless-app.json is not valid JSON: ${error instanceof Error ? error.message : 'unknown error'}`,
+      );
+    }
+
+    const validated = validateAppManifest(manifestJson);
+    if (!validated.ok) {
+      throw new BadRequestException(`bffless-app.json failed validation: ${validated.errors.join('; ')}`);
+    }
+    const manifest = validated.manifest;
+
+    for (const ruleSet of manifest.install.ruleSets) {
+      if (!files[ruleSet.file]) {
+        throw new BadRequestException(`Bundle declared file missing: ${ruleSet.file}`);
+      }
+    }
+
+    const deploymentPrefix = `${manifest.install.deployment.path.replace(/\/+$/, '')}/`;
+    const hasDeploymentFiles = Object.keys(files).some((entryPath) =>
+      entryPath.startsWith(deploymentPrefix),
+    );
+    if (!hasDeploymentFiles) {
+      throw new BadRequestException(
+        `Bundle has no files under the declared deployment path: ${manifest.install.deployment.path}`,
+      );
+    }
+
+    const loaded: LoadedBundle = { manifest, files, sha256: actualSha256 };
+    this.cache.set(actualSha256, loaded);
+    if (this.cache.size > this.MAX_CACHE_ENTRIES) {
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey !== undefined) this.cache.delete(oldestKey);
+    }
+
+    return loaded;
+  }
+
+  private unzip(buf: Uint8Array): Promise<Record<string, Uint8Array>> {
+    return new Promise((resolve, reject) => {
+      unzip(buf, (err, result) => {
+        if (err) {
+          reject(new BadRequestException(`Failed to parse bundle zip: ${err.message}`));
+          return;
+        }
+        const files: Record<string, Uint8Array> = {};
+        for (const [entryPath, contentArray] of Object.entries(result)) {
+          if (entryPath.endsWith('/')) continue; // directory entry
+          files[entryPath] = contentArray;
+        }
+        resolve(files);
+      });
+    });
+  }
+}

--- a/apps/backend/src/app-catalog/app-catalog.controller.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.controller.spec.ts
@@ -1,6 +1,8 @@
 import { AppCatalogController } from './app-catalog.controller';
+import { AppCatalogService } from './app-catalog.service';
 import { REQUIRED_FLAGS_KEY } from '../feature-flags/feature-flag.guard';
 import { ROLES_KEY } from '../auth/roles.guard';
+import type { CurrentUserData } from '../auth/decorators/current-user.decorator';
 
 describe('AppCatalogController guards', () => {
   it('requires the ENABLE_APP_CATALOG feature flag', () => {
@@ -11,5 +13,93 @@ describe('AppCatalogController guards', () => {
   it('requires the admin role', () => {
     const roles = Reflect.getMetadata(ROLES_KEY, AppCatalogController);
     expect(roles).toEqual(['admin']);
+  });
+});
+
+describe('AppCatalogController routes', () => {
+  let controller: AppCatalogController;
+  let catalog: jest.Mocked<AppCatalogService>;
+  const user: CurrentUserData = { id: 'user-1', email: 'a@b.com', role: 'admin' };
+
+  beforeEach(() => {
+    catalog = {
+      listCatalog: jest.fn().mockResolvedValue({ data: [] }),
+      preflight: jest.fn().mockResolvedValue({ gates: [], syncPlans: [], appHost: null }),
+      install: jest.fn().mockResolvedValue({ jobId: 'job-1' }),
+      getJob: jest.fn().mockReturnValue({ id: 'job-1' }),
+      undoJob: jest.fn().mockResolvedValue({ removed: [] }),
+      updateInstalled: jest.fn().mockResolvedValue({ jobId: 'job-2' }),
+      uninstallPreview: jest.fn().mockResolvedValue({ dataTables: [] }),
+      uninstall: jest.fn().mockResolvedValue({ removed: {}, dataTables: {}, note: '' }),
+      ejectPayload: jest.fn().mockResolvedValue({ repo: 'bffless/apps' }),
+      ackManualStep: jest.fn().mockResolvedValue(['step-1']),
+    } as unknown as jest.Mocked<AppCatalogService>;
+    controller = new AppCatalogController(catalog);
+  });
+
+  it('list() delegates to catalog.listCatalog()', async () => {
+    const result = await controller.list();
+    expect(catalog.listCatalog).toHaveBeenCalledWith();
+    expect(result).toEqual({ data: [] });
+  });
+
+  it('preflight() delegates with appId, body, and the current user id', async () => {
+    const body = { projectId: 'proj-1' };
+    await controller.preflight('handoff', body as never, user);
+    expect(catalog.preflight).toHaveBeenCalledWith('handoff', body, 'user-1');
+  });
+
+  it('install() delegates with appId, body, and the current user id', async () => {
+    const body = { newProject: { owner: 'acme', name: 'site' } };
+    const result = await controller.install('handoff', body as never, user);
+    expect(catalog.install).toHaveBeenCalledWith('handoff', body, 'user-1');
+    expect(result).toEqual({ jobId: 'job-1' });
+  });
+
+  it('getJob() delegates to catalog.getJob(jobId)', async () => {
+    const result = await controller.getJob('job-1');
+    expect(catalog.getJob).toHaveBeenCalledWith('job-1');
+    expect(result).toEqual({ id: 'job-1' });
+  });
+
+  it('undoJob() delegates with jobId and the current user id', async () => {
+    await controller.undoJob('job-1', user);
+    expect(catalog.undoJob).toHaveBeenCalledWith('job-1', 'user-1');
+  });
+
+  it('update() delegates with id, prune (defaulted false), and the current user id', async () => {
+    await controller.update('ia-1', {}, user);
+    expect(catalog.updateInstalled).toHaveBeenCalledWith('ia-1', false, 'user-1');
+  });
+
+  it('update() passes through an explicit prune: true', async () => {
+    await controller.update('ia-1', { prune: true }, user);
+    expect(catalog.updateInstalled).toHaveBeenCalledWith('ia-1', true, 'user-1');
+  });
+
+  it('uninstallPreview() delegates to catalog.uninstallPreview(id)', async () => {
+    await controller.uninstallPreview('ia-1');
+    expect(catalog.uninstallPreview).toHaveBeenCalledWith('ia-1');
+  });
+
+  it('uninstall() delegates with id, deleteData (defaulted false), and the current user id', async () => {
+    await controller.uninstall('ia-1', {}, user);
+    expect(catalog.uninstall).toHaveBeenCalledWith('ia-1', false, 'user-1');
+  });
+
+  it('uninstall() passes through an explicit deleteData: true', async () => {
+    await controller.uninstall('ia-1', { deleteData: true }, user);
+    expect(catalog.uninstall).toHaveBeenCalledWith('ia-1', true, 'user-1');
+  });
+
+  it('eject() delegates to catalog.ejectPayload(id)', async () => {
+    await controller.eject('ia-1');
+    expect(catalog.ejectPayload).toHaveBeenCalledWith('ia-1');
+  });
+
+  it('ack() delegates to catalog.ackManualStep and wraps the result as { acked }', async () => {
+    const result = await controller.ack('ia-1', { stepId: 'bucket-cors' });
+    expect(catalog.ackManualStep).toHaveBeenCalledWith('ia-1', 'bucket-cors');
+    expect(result).toEqual({ acked: ['step-1'] });
   });
 });

--- a/apps/backend/src/app-catalog/app-catalog.controller.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.controller.spec.ts
@@ -1,0 +1,15 @@
+import { AppCatalogController } from './app-catalog.controller';
+import { REQUIRED_FLAGS_KEY } from '../feature-flags/feature-flag.guard';
+import { ROLES_KEY } from '../auth/roles.guard';
+
+describe('AppCatalogController guards', () => {
+  it('requires the ENABLE_APP_CATALOG feature flag', () => {
+    const flags = Reflect.getMetadata(REQUIRED_FLAGS_KEY, AppCatalogController);
+    expect(flags).toEqual(['ENABLE_APP_CATALOG']);
+  });
+
+  it('requires the admin role', () => {
+    const roles = Reflect.getMetadata(ROLES_KEY, AppCatalogController);
+    expect(roles).toEqual(['admin']);
+  });
+});

--- a/apps/backend/src/app-catalog/app-catalog.controller.ts
+++ b/apps/backend/src/app-catalog/app-catalog.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { FeatureFlagGuard, RequireFeatureFlags } from '../feature-flags/feature-flag.guard';
+import { AppCatalogService } from './app-catalog.service';
+
+@ApiTags('Admin - App Catalog')
+@Controller('api/admin/apps')
+@UseGuards(SessionAuthGuard, RolesGuard, FeatureFlagGuard)
+@Roles('admin')
+@RequireFeatureFlags('ENABLE_APP_CATALOG')
+export class AppCatalogController {
+  constructor(private readonly catalog: AppCatalogService) {}
+
+  @Get()
+  async list() {
+    return { data: await this.catalog.listCatalog() };
+  }
+}

--- a/apps/backend/src/app-catalog/app-catalog.controller.ts
+++ b/apps/backend/src/app-catalog/app-catalog.controller.ts
@@ -1,11 +1,23 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { SessionAuthGuard } from '../auth/session-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser, type CurrentUserData } from '../auth/decorators/current-user.decorator';
 import { FeatureFlagGuard, RequireFeatureFlags } from '../feature-flags/feature-flag.guard';
 import { AppCatalogService } from './app-catalog.service';
+import {
+  AckManualStepDto,
+  PreflightRequestDto,
+  UninstallQueryDto,
+  UpdateInstalledAppDto,
+} from './app-catalog.dtos';
 
+/**
+ * The full admin HTTP surface for the app catalog (Task 11 of the app-catalog
+ * spec). Every route is a thin delegation to `AppCatalogService` — no
+ * business logic lives here.
+ */
 @ApiTags('Admin - App Catalog')
 @Controller('api/admin/apps')
 @UseGuards(SessionAuthGuard, RolesGuard, FeatureFlagGuard)
@@ -16,6 +28,68 @@ export class AppCatalogController {
 
   @Get()
   async list() {
-    return { data: await this.catalog.listCatalog() };
+    return this.catalog.listCatalog();
+  }
+
+  @Post(':appId/preflight')
+  async preflight(
+    @Param('appId') appId: string,
+    @Body() body: PreflightRequestDto,
+    @CurrentUser() user: CurrentUserData,
+  ) {
+    return this.catalog.preflight(appId, body, user.id);
+  }
+
+  @Post(':appId/install')
+  async install(
+    @Param('appId') appId: string,
+    @Body() body: PreflightRequestDto,
+    @CurrentUser() user: CurrentUserData,
+  ) {
+    return this.catalog.install(appId, body, user.id);
+  }
+
+  @Get('jobs/:jobId')
+  async getJob(@Param('jobId') jobId: string) {
+    return this.catalog.getJob(jobId);
+  }
+
+  @Post('jobs/:jobId/undo')
+  async undoJob(@Param('jobId') jobId: string, @CurrentUser() user: CurrentUserData) {
+    return this.catalog.undoJob(jobId, user.id);
+  }
+
+  @Post('installed/:id/update')
+  async update(
+    @Param('id') id: string,
+    @Body() body: UpdateInstalledAppDto,
+    @CurrentUser() user: CurrentUserData,
+  ) {
+    return this.catalog.updateInstalled(id, body.prune ?? false, user.id);
+  }
+
+  @Get('installed/:id/uninstall-preview')
+  async uninstallPreview(@Param('id') id: string) {
+    return this.catalog.uninstallPreview(id);
+  }
+
+  @Delete('installed/:id')
+  async uninstall(
+    @Param('id') id: string,
+    @Query() query: UninstallQueryDto,
+    @CurrentUser() user: CurrentUserData,
+  ) {
+    return this.catalog.uninstall(id, query.deleteData ?? false, user.id);
+  }
+
+  @Get('installed/:id/eject')
+  async eject(@Param('id') id: string) {
+    return this.catalog.ejectPayload(id);
+  }
+
+  @Post('installed/:id/ack-manual-step')
+  async ack(@Param('id') id: string, @Body() body: AckManualStepDto) {
+    const acked = await this.catalog.ackManualStep(id, body.stepId);
+    return { acked };
   }
 }

--- a/apps/backend/src/app-catalog/app-catalog.dtos.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.dtos.spec.ts
@@ -1,0 +1,71 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { PreflightRequestDto } from './app-catalog.dtos';
+
+/**
+ * `subdomain` is the install-time override for the manifest's
+ * `install.domain.subdomain` default (live-tester feedback: the manifest
+ * default must not be forced on the operator). This DTO only enforces
+ * DNS-label shape — reserved-name enforcement happens in
+ * `AppPreflightService` (see `app-preflight.service.spec.ts`), since it needs
+ * the manifest to know what's reserved and whether a domain applies at all.
+ *
+ * validate() options mirror the global ValidationPipe in main.ts:
+ * { whitelist: true, transform: true, forbidNonWhitelisted: true }.
+ */
+const VALIDATE_OPTIONS = { whitelist: true, forbidNonWhitelisted: true };
+
+function build(extra: Record<string, unknown>): PreflightRequestDto {
+  return plainToInstance(PreflightRequestDto, {
+    projectId: '550e8400-e29b-41d4-a716-446655440000',
+    ...extra,
+  });
+}
+
+describe('PreflightRequestDto.subdomain', () => {
+  it('is optional — absent is valid', async () => {
+    const dto = build({});
+    const errors = await validate(dto, VALIDATE_OPTIONS);
+    expect(errors).toEqual([]);
+  });
+
+  it('accepts a valid DNS label', async () => {
+    const dto = build({ subdomain: 'my-app' });
+    const errors = await validate(dto, VALIDATE_OPTIONS);
+    expect(errors).toEqual([]);
+    expect(dto.subdomain).toBe('my-app');
+  });
+
+  it('accepts a single-character label', async () => {
+    const dto = build({ subdomain: 'a' });
+    const errors = await validate(dto, VALIDATE_OPTIONS);
+    expect(errors).toEqual([]);
+  });
+
+  it.each([
+    ['uppercase letters', 'MyApp'],
+    ['a leading hyphen', '-myapp'],
+    ['a trailing hyphen', 'myapp-'],
+    ['an underscore', 'my_app'],
+    ['a dot', 'my.app'],
+    ['a space', 'my app'],
+    ['empty string', ''],
+  ])('rejects a label with %s ("%s")', async (_label, value) => {
+    const dto = build({ subdomain: value });
+    const errors = await validate(dto, VALIDATE_OPTIONS);
+    expect(errors.some((e) => e.property === 'subdomain')).toBe(true);
+  });
+
+  it('rejects a label longer than 63 characters (the DNS label cap)', async () => {
+    const dto = build({ subdomain: 'a'.repeat(64) });
+    const errors = await validate(dto, VALIDATE_OPTIONS);
+    expect(errors.some((e) => e.property === 'subdomain')).toBe(true);
+  });
+
+  it('accepts a label exactly at the 63-character cap', async () => {
+    const dto = build({ subdomain: 'a'.repeat(63) });
+    const errors = await validate(dto, VALIDATE_OPTIONS);
+    expect(errors).toEqual([]);
+  });
+});

--- a/apps/backend/src/app-catalog/app-catalog.dtos.ts
+++ b/apps/backend/src/app-catalog/app-catalog.dtos.ts
@@ -1,6 +1,17 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
-import { IsBoolean, IsOptional, IsString, IsUUID, Matches, ValidateNested } from 'class-validator';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Matches,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+
+/** DNS label rule — matches `app-manifest.util.ts`'s `SUBDOMAIN_PATTERN` for `install.domain.subdomain`. */
+const SUBDOMAIN_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
 
 /**
  * DTOs for the app-catalog admin HTTP surface (Task 11 of the app-catalog
@@ -37,6 +48,25 @@ export class PreflightRequestDto {
   @ValidateNested()
   @Type(() => NewProjectDto)
   newProject?: NewProjectDto;
+
+  /**
+   * Overrides the manifest's `install.domain.subdomain` default. Reserved-name
+   * enforcement (and rejecting an override for a manifest that declares no
+   * domain at all) happens in `AppPreflightService.projectGates`, not here —
+   * this DTO only enforces DNS-label shape.
+   */
+  @ApiPropertyOptional({
+    description: "Override the app manifest's default install subdomain",
+    example: 'my-app',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(63)
+  @Matches(SUBDOMAIN_PATTERN, {
+    message:
+      'subdomain must be a valid DNS label: lowercase letters, digits and hyphens, not starting/ending with a hyphen',
+  })
+  subdomain?: string;
 }
 
 export class UpdateInstalledAppDto {

--- a/apps/backend/src/app-catalog/app-catalog.dtos.ts
+++ b/apps/backend/src/app-catalog/app-catalog.dtos.ts
@@ -1,0 +1,68 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import { IsBoolean, IsOptional, IsString, IsUUID, Matches, ValidateNested } from 'class-validator';
+
+/**
+ * DTOs for the app-catalog admin HTTP surface (Task 11 of the app-catalog
+ * spec). `PreflightRequestDto` is shared by both `preflight` and `install` —
+ * the wizard re-submits the same target it just previewed.
+ */
+
+export class NewProjectDto {
+  @ApiPropertyOptional({ description: 'Project owner (org/user segment)', example: 'acme' })
+  @IsString()
+  @Matches(/^[a-zA-Z0-9_-]+$/)
+  owner!: string;
+
+  @ApiPropertyOptional({ description: 'Project name', example: 'site' })
+  @IsString()
+  @Matches(/^[a-zA-Z0-9_-]+$/)
+  name!: string;
+}
+
+/**
+ * Install target: exactly one of `projectId` (install into an existing
+ * project) or `newProject` (create one first) — enforced in
+ * `AppCatalogService.toInstallTarget`, not here, since class-validator has no
+ * built-in XOR-across-properties constraint that also reports a clean error.
+ */
+export class PreflightRequestDto {
+  @ApiPropertyOptional({ description: 'Install into this existing project' })
+  @IsOptional()
+  @IsUUID()
+  projectId?: string;
+
+  @ApiPropertyOptional({ type: NewProjectDto, description: 'Create a new project first' })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => NewProjectDto)
+  newProject?: NewProjectDto;
+}
+
+export class UpdateInstalledAppDto {
+  @ApiPropertyOptional({
+    description: 'Delete live rules absent from the new bundle (default: keep them)',
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  prune?: boolean;
+}
+
+export class AckManualStepDto {
+  @ApiPropertyOptional({ description: 'The manual step id to mark acknowledged' })
+  @IsString()
+  stepId!: string;
+}
+
+/** `DELETE .../installed/:id?deleteData=true|false` — query strings arrive as text. */
+export class UninstallQueryDto {
+  @ApiPropertyOptional({
+    description: 'Also delete data tables this install created (default: keep all data)',
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => value === 'true' || value === true)
+  deleteData?: boolean;
+}

--- a/apps/backend/src/app-catalog/app-catalog.e2e-ish.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.e2e-ish.spec.ts
@@ -361,7 +361,13 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
     const job = jobs.get(jobId)!;
     expect(job.kind).toBe('update');
     expect(job.status).toBe('succeeded');
-    expect(job.steps.map((s) => s.id)).toEqual(['fetch', 'sync-rules', 'deploy', 'record']);
+    expect(job.steps.map((s) => s.id)).toEqual([
+      'preflight',
+      'fetch',
+      'sync-rules',
+      'deploy',
+      'record',
+    ]);
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy).toHaveBeenCalledWith(ENTRY_V2.bundleUrl, expect.anything());

--- a/apps/backend/src/app-catalog/app-catalog.e2e-ish.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.e2e-ish.spec.ts
@@ -1,0 +1,436 @@
+// Thenable chainable db mock: every builder method returns the chain, and
+// awaiting consumes the next queued result in await order. House pattern,
+// same as app-installer.service.spec.ts — deviation 4 of the app-catalog
+// spec: this is a house db mock, not a real Postgres. Declared above imports
+// because jest.mock is hoisted.
+jest.mock('../db/client', () => {
+  const queued: unknown[] = [];
+  const methods = [
+    'select',
+    'from',
+    'innerJoin',
+    'where',
+    'orderBy',
+    'limit',
+    'insert',
+    'values',
+    'update',
+    'set',
+    'delete',
+    'returning',
+  ];
+  const chainable: Record<string, unknown> = {};
+  for (const method of methods) {
+    chainable[method] = jest.fn(() => chainable);
+  }
+  chainable.then = (
+    resolve: (value: unknown) => unknown,
+    reject: (reason: unknown) => unknown,
+  ) => Promise.resolve(queued.length > 0 ? queued.shift() : []).then(resolve, reject);
+  chainable.__queue = (result: unknown) => queued.push(result);
+  chainable.__reset = () => {
+    queued.length = 0;
+    for (const method of methods) {
+      (chainable[method] as jest.Mock).mockClear();
+    }
+  };
+  return { db: chainable };
+});
+
+import { ConfigService } from '@nestjs/config';
+import { db } from '../db/client';
+import { AppBundleService } from './app-bundle.service';
+import { AppInstallJobsService } from './app-install-jobs.service';
+import { AppInstallerService } from './app-installer.service';
+import { makeFixtureBundle } from './__fixtures__/make-fixture-bundle';
+import type { AppRegistryEntry } from './app-manifest.types';
+import type { CreatedResources, InstalledApp } from '../db/schema';
+
+/**
+ * Orchestration spec (Task 11): the closest CE-side approximation of the
+ * spec's integration suite. Unlike `app-installer.service.spec.ts` (which
+ * hands the installer a hand-authored `LoadedBundle` directly), this spec
+ * drives `AppInstallerService` through a REAL `AppBundleService` fed REAL zip
+ * bytes built by `makeFixtureBundle` — so the manifest parse, `validateAppManifest`,
+ * the sha256 check, and the rule-set-file-presence check all run for real. Only
+ * the network fetch and the downstream side-effecting services
+ * (sync/deploy/domains/projects/schedules) are mocked, returning realistic
+ * response shapes. The real-DB pass happens on the live droplet (Task 16
+ * checklist) — this spec is the contract seam for that.
+ */
+
+const mockDb = db as unknown as Record<string, jest.Mock> & {
+  __queue: (result: unknown) => void;
+  __reset: () => void;
+};
+
+function fetchResponse(bytes: Uint8Array): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: (name: string) => (name.toLowerCase() === 'content-length' ? String(bytes.byteLength) : null) },
+    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  } as unknown as Response;
+}
+
+const v1 = makeFixtureBundle('1.0.0');
+const v2 = makeFixtureBundle('2.0.0');
+
+const ENTRY_V1: AppRegistryEntry = {
+  id: 'fixture-app',
+  name: 'Fixture App',
+  version: '1.0.0',
+  bundleUrl: 'https://apps.bffless.dev/fixture-app-1.0.0.zip',
+  sha256: v1.sha256,
+};
+
+const ENTRY_V2: AppRegistryEntry = {
+  id: 'fixture-app',
+  name: 'Fixture App',
+  version: '2.0.0',
+  bundleUrl: 'https://apps.bffless.dev/fixture-app-2.0.0.zip',
+  sha256: v2.sha256,
+};
+
+function deployResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    deploymentId: 'dep-fixture-1',
+    commitSha: v1.sha256.slice(0, 40),
+    fileCount: 1,
+    totalSize: 64,
+    urls: {
+      sha: 'https://admin.example.com/repo/acme/site/sha',
+      default: 'https://admin.example.com/public/acme/site/',
+    },
+    aliases: ['fixture-app'],
+    ...overrides,
+  };
+}
+
+/** Simulated state after a v1 install then a v2 update completed for real —
+ * used to seed the two independent uninstall scenarios below. `sch-items` is
+ * this app's own table; `sch-notes` was adopted from a table that already
+ * existed in the project (a `reuse` resolution), so it must survive even a
+ * `deleteData: true` uninstall. */
+const POST_UPDATE_ROW: InstalledApp = {
+  id: 'ia-fixture',
+  appId: 'fixture-app',
+  name: 'Fixture App',
+  version: '2.0.0',
+  projectId: 'proj-1',
+  alias: 'fixture-app',
+  domainId: null,
+  deploymentId: 'dep-fixture-2',
+  ruleSetIds: ['rs-a', 'rs-b'],
+  schemaIds: ['sch-items', 'sch-notes'],
+  bundleSha256: v2.sha256,
+  manifest: v2.manifest,
+  manualStepsAcked: [],
+  status: 'installed',
+  createdResources: {
+    projectCreated: false,
+    ruleSetIds: ['rs-a', 'rs-b'],
+    schemaIdsCreated: ['sch-items'],
+    aliasName: 'fixture-app',
+    deploymentId: 'dep-fixture-2',
+    scheduleIds: [],
+  },
+  installedBy: 'user-1',
+  installedAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-02T00:00:00Z'),
+} as unknown as InstalledApp;
+
+describe('App catalog orchestration (fixture bundle, real bytes + real manifest validation)', () => {
+  let jobs: AppInstallJobsService;
+  let bundleService: AppBundleService;
+  let service: AppInstallerService;
+  let fetchSpy: jest.SpyInstance;
+  let preflight: { instanceGates: jest.Mock; projectGates: jest.Mock };
+  let certStep: { plan: jest.Mock; execute: jest.Mock };
+  let ruleSets: { syncRuleSet: jest.Mock; delete: jest.Mock };
+  let deployments: {
+    createDeploymentFromZip: jest.Mock;
+    deleteDeployment: jest.Mock;
+    deleteAlias: jest.Mock;
+  };
+  let domains: { create: jest.Mock; remove: jest.Mock };
+  let projects: {
+    findOrCreateProject: jest.Mock;
+    projectExists: jest.Mock;
+    getProjectById: jest.Mock;
+    deleteProject: jest.Mock;
+  };
+  let schedules: {
+    listPipelineRules: jest.Mock;
+    listSchedules: jest.Mock;
+    createSchedule: jest.Mock;
+    deleteSchedule: jest.Mock;
+  };
+  let schemas: { delete: jest.Mock; getByIdWithCount: jest.Mock };
+  let config: { get: jest.Mock };
+
+  beforeEach(() => {
+    mockDb.__reset();
+    jobs = new AppInstallJobsService();
+    bundleService = new AppBundleService();
+    fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(((url: string) => {
+      if (url === ENTRY_V1.bundleUrl) return Promise.resolve(fetchResponse(v1.buf));
+      if (url === ENTRY_V2.bundleUrl) return Promise.resolve(fetchResponse(v2.buf));
+      return Promise.reject(new Error(`unexpected fetch url: ${url}`));
+    }) as typeof fetch);
+
+    preflight = {
+      instanceGates: jest.fn().mockResolvedValue([]),
+      projectGates: jest.fn().mockResolvedValue({ gates: [], syncPlans: [], appHost: null }),
+    };
+    certStep = { plan: jest.fn(), execute: jest.fn() }; // unused: the fixture manifest declares no domain
+    ruleSets = { syncRuleSet: jest.fn(), delete: jest.fn().mockResolvedValue(undefined) };
+    deployments = {
+      createDeploymentFromZip: jest.fn().mockResolvedValue(deployResponse()),
+      deleteDeployment: jest.fn().mockResolvedValue(undefined),
+      deleteAlias: jest.fn().mockResolvedValue(undefined),
+    };
+    domains = { create: jest.fn(), remove: jest.fn().mockResolvedValue(undefined) };
+    projects = {
+      findOrCreateProject: jest.fn().mockResolvedValue({ id: 'proj-1', owner: 'acme', name: 'site' }),
+      projectExists: jest.fn().mockResolvedValue(true),
+      getProjectById: jest.fn().mockResolvedValue({ id: 'proj-1', owner: 'acme', name: 'site' }),
+      deleteProject: jest.fn().mockResolvedValue(undefined),
+    };
+    schedules = {
+      listPipelineRules: jest.fn().mockResolvedValue([]),
+      listSchedules: jest.fn().mockResolvedValue([]),
+      createSchedule: jest.fn(),
+      deleteSchedule: jest.fn().mockResolvedValue(undefined),
+    };
+    schemas = { delete: jest.fn().mockResolvedValue(undefined), getByIdWithCount: jest.fn() };
+    config = { get: jest.fn((key: string) => (key === 'PRIMARY_DOMAIN' ? 'example.com' : undefined)) };
+
+    service = new AppInstallerService(
+      jobs,
+      bundleService,
+      preflight as never,
+      certStep as never,
+      ruleSets as never,
+      deployments as never,
+      domains as never,
+      projects as never,
+      schedules as never,
+      schemas as never,
+      config as unknown as ConfigService,
+      { supportsPresignedUrls: () => true } as never,
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function queueInstallDb() {
+    mockDb.__queue([]); // select existing installed_apps row (none)
+    mockDb.__queue([{ ...POST_UPDATE_ROW, id: 'ia-fixture', version: '1.0.0', status: 'installing' }]); // insert ... returning
+    mockDb.__queue([]); // extra buffer (unused, non-`.returning()` awaits don't destructure)
+  }
+
+  it('installs v1 from real bundle bytes: manifest + rule-set DTOs validated for real, bookkeeping recorded', async () => {
+    ruleSets.syncRuleSet
+      .mockReset()
+      .mockResolvedValueOnce({
+        ruleSetId: 'rs-a',
+        created: [{ pathPattern: '/api/items', method: 'GET' }],
+        updated: [],
+        deleted: [],
+        unchanged: [],
+        pruneCandidates: [],
+        schemaResolutions: [{ name: 'fixture_items', action: 'create', targetSchemaId: 'sch-items', fieldMismatch: false }],
+        missingSecrets: [],
+        warnings: [],
+        dryRun: false,
+        setCreated: true,
+      })
+      .mockResolvedValueOnce({
+        ruleSetId: 'rs-b',
+        created: [{ pathPattern: '/api/notes', method: 'GET' }],
+        updated: [],
+        deleted: [],
+        unchanged: [],
+        pruneCandidates: [],
+        schemaResolutions: [
+          { name: 'fixture_items', action: 'reuse', targetSchemaId: 'sch-items', fieldMismatch: false },
+          { name: 'fixture_notes', action: 'create', targetSchemaId: 'sch-notes', fieldMismatch: false },
+        ],
+        missingSecrets: [],
+        warnings: [],
+        dryRun: false,
+        setCreated: true,
+      });
+    queueInstallDb();
+
+    const { jobId } = service.startInstall(ENTRY_V1, { projectId: 'proj-1' }, 'user-1');
+    await service.whenIdle();
+
+    const job = jobs.get(jobId)!;
+    expect(job.status).toBe('succeeded');
+    expect(job.steps.filter((s) => s.status === 'failed')).toHaveLength(0);
+    expect(job.steps.find((s) => s.id === 'domain')!.status).toBe('skipped');
+    expect(job.steps.find((s) => s.id === 'certificate')!.status).toBe('skipped');
+    expect(job.steps.find((s) => s.id === 'schedules')!.status).toBe('skipped');
+
+    // Real network fetch happened once (preflight + fetch steps share the sha256 cache).
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(ENTRY_V1.bundleUrl, expect.anything());
+
+    expect(ruleSets.syncRuleSet).toHaveBeenCalledTimes(2);
+    expect(ruleSets.syncRuleSet.mock.calls[0][1].ruleSet.name).toBe('fixture-app-a');
+    expect(ruleSets.syncRuleSet.mock.calls[1][1].ruleSet.name).toBe('fixture-app-b');
+    expect(ruleSets.syncRuleSet.mock.calls[0][1].options).toEqual({ dryRun: false, prune: false });
+
+    const finalUpdate = mockDb.set.mock.calls.at(-1)![0] as {
+      status: string;
+      version: string;
+      bundleSha256: string;
+      ruleSetIds: string[];
+      schemaIds: string[];
+      createdResources: CreatedResources;
+    };
+    expect(finalUpdate.status).toBe('installed');
+    expect(finalUpdate.version).toBe('1.0.0');
+    expect(finalUpdate.bundleSha256).toBe(v1.sha256);
+    expect(finalUpdate.ruleSetIds).toEqual(['rs-a', 'rs-b']);
+    expect(finalUpdate.schemaIds).toEqual(['sch-items', 'sch-notes']);
+    expect(finalUpdate.createdResources.ruleSetIds).toEqual(['rs-a', 'rs-b']);
+    expect(finalUpdate.createdResources.schemaIdsCreated).toEqual(['sch-items', 'sch-notes']);
+
+    // Real zip built from real bundle bytes: only dist/, re-keyed under basePath.
+    const { unzipSync } = jest.requireActual('fflate') as typeof import('fflate');
+    const zippedFile = deployments.createDeploymentFromZip.mock.calls[0][0] as { buffer: Buffer };
+    const entries = Object.keys(unzipSync(new Uint8Array(zippedFile.buffer))).sort();
+    expect(entries).toEqual(['apps/fixture-app/dist/index.html']);
+  });
+
+  it('updates to v2 from real bundle bytes: same alias redeployed, prune false, version bumped', async () => {
+    const installedAfterV1: InstalledApp = {
+      ...POST_UPDATE_ROW,
+      version: '1.0.0',
+      bundleSha256: v1.sha256,
+      manifest: v1.manifest,
+      deploymentId: 'dep-fixture-1',
+      createdResources: {
+        ...POST_UPDATE_ROW.createdResources,
+        schemaIdsCreated: ['sch-items', 'sch-notes'],
+        deploymentId: 'dep-fixture-1',
+      },
+    };
+    ruleSets.syncRuleSet
+      .mockReset()
+      .mockResolvedValueOnce({
+        ruleSetId: 'rs-a',
+        created: [],
+        updated: [],
+        deleted: [],
+        unchanged: [{ pathPattern: '/api/items', method: 'GET' }],
+        pruneCandidates: [],
+        schemaResolutions: [{ name: 'fixture_items', action: 'reuse', targetSchemaId: 'sch-items', fieldMismatch: false }],
+        missingSecrets: [],
+        warnings: [],
+        dryRun: false,
+        setCreated: false,
+      })
+      .mockResolvedValueOnce({
+        ruleSetId: 'rs-b',
+        created: [{ pathPattern: '/api/notes', method: 'POST' }],
+        updated: [],
+        deleted: [],
+        unchanged: [{ pathPattern: '/api/notes', method: 'GET' }],
+        pruneCandidates: [],
+        schemaResolutions: [
+          { name: 'fixture_items', action: 'reuse', targetSchemaId: 'sch-items', fieldMismatch: false },
+          { name: 'fixture_notes', action: 'reuse', targetSchemaId: 'sch-notes', fieldMismatch: false },
+        ],
+        missingSecrets: [],
+        warnings: [],
+        dryRun: false,
+        setCreated: false,
+      });
+    deployments.createDeploymentFromZip.mockResolvedValue(deployResponse({ deploymentId: 'dep-fixture-2' }));
+    mockDb.__queue([]); // final record update — startUpdate takes the row directly, no db read
+
+    const { jobId } = service.startUpdate(installedAfterV1, ENTRY_V2, 'user-1', { prune: false });
+    await service.whenIdle();
+
+    const job = jobs.get(jobId)!;
+    expect(job.kind).toBe('update');
+    expect(job.status).toBe('succeeded');
+    expect(job.steps.map((s) => s.id)).toEqual(['fetch', 'sync-rules', 'deploy', 'record']);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(ENTRY_V2.bundleUrl, expect.anything());
+
+    // prune false, on both synced rule sets
+    expect(ruleSets.syncRuleSet.mock.calls[0][1].options).toEqual({ dryRun: false, prune: false });
+    expect(ruleSets.syncRuleSet.mock.calls[1][1].options).toEqual({ dryRun: false, prune: false });
+
+    // Same alias redeployed — not a new one.
+    const [zippedFile, deployDto] = deployments.createDeploymentFromZip.mock.calls[0] as [
+      { buffer: Buffer },
+      { alias: string },
+    ];
+    expect(deployDto.alias).toBe('fixture-app');
+    expect(domains.create).not.toHaveBeenCalled(); // update never touches the domain step
+
+    const finalUpdate = mockDb.set.mock.calls.at(-1)![0] as {
+      status: string;
+      version: string;
+      bundleSha256: string;
+      deploymentId: string;
+    };
+    expect(finalUpdate.status).toBe('installed');
+    expect(finalUpdate.version).toBe('2.0.0');
+    expect(finalUpdate.bundleSha256).toBe(v2.sha256);
+    expect(finalUpdate.deploymentId).toBe('dep-fixture-2');
+
+    // Real v2 zip: dist/ changed — index.html content differs and assets/app.js is new.
+    const { unzipSync } = jest.requireActual('fflate') as typeof import('fflate');
+    const entries = Object.keys(unzipSync(new Uint8Array(zippedFile.buffer))).sort();
+    expect(entries).toEqual(['apps/fixture-app/dist/assets/app.js', 'apps/fixture-app/dist/index.html']);
+  });
+
+  describe('uninstall (post v1-install, v2-update state)', () => {
+    beforeEach(() => {
+      schemas.getByIdWithCount = jest.fn((id: string) => {
+        if (id === 'sch-items') return Promise.resolve({ id, name: 'fixture_items', recordCount: 5 });
+        return Promise.resolve({ id, name: 'fixture_notes', recordCount: 12 });
+      });
+    });
+
+    it('keep-data: keeps every data table and never calls schema delete', async () => {
+      mockDb.__queue([POST_UPDATE_ROW]);
+      mockDb.__queue([]); // delete installed_apps row
+
+      const summary = await service.uninstall('ia-fixture', 'user-1', { deleteData: false });
+
+      expect(schemas.delete).not.toHaveBeenCalled();
+      expect(ruleSets.delete).toHaveBeenCalledTimes(2);
+      expect(deployments.deleteAlias).toHaveBeenCalledWith('acme/site', 'fixture-app', 'user-1', 'admin');
+      expect(deployments.deleteDeployment).toHaveBeenCalledWith('dep-fixture-2', 'user-1', 'admin');
+      expect(summary.dataTables.deleted).toEqual([]);
+      expect(summary.dataTables.kept.slice().sort()).toEqual(['fixture_items', 'fixture_notes']);
+      expect(mockDb.delete).toHaveBeenCalled();
+    });
+
+    it('delete-data: deletes only the table this install created, keeps the adopted one', async () => {
+      mockDb.__queue([POST_UPDATE_ROW]);
+      mockDb.__queue([]);
+
+      const summary = await service.uninstall('ia-fixture', 'user-1', { deleteData: true });
+
+      expect(schemas.delete).toHaveBeenCalledTimes(1);
+      expect(schemas.delete).toHaveBeenCalledWith('sch-items', 'user-1', 'admin', null);
+      expect(schemas.delete).not.toHaveBeenCalledWith('sch-notes', 'user-1', 'admin', null);
+      expect(summary.dataTables.deleted).toEqual(['fixture_items']);
+      expect(summary.dataTables.kept).toEqual(['fixture_notes']);
+      expect(summary.dataTables.deletedRecordCounts).toEqual({ fixture_items: 5 });
+      expect(mockDb.delete).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/app-catalog/app-catalog.module.ts
+++ b/apps/backend/src/app-catalog/app-catalog.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { AppCatalogController } from './app-catalog.controller';
 import { AppCatalogService } from './app-catalog.service';
+import { AppsRegistryService } from './apps-registry.service';
+import { AppBundleService } from './app-bundle.service';
 
 @Module({
   imports: [],
   controllers: [AppCatalogController],
-  providers: [AppCatalogService],
+  providers: [AppCatalogService, AppsRegistryService, AppBundleService],
 })
 export class AppCatalogModule {}

--- a/apps/backend/src/app-catalog/app-catalog.module.ts
+++ b/apps/backend/src/app-catalog/app-catalog.module.ts
@@ -1,12 +1,28 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { AppCatalogController } from './app-catalog.controller';
 import { AppCatalogService } from './app-catalog.service';
 import { AppsRegistryService } from './apps-registry.service';
 import { AppBundleService } from './app-bundle.service';
+import { AppPreflightService } from './app-preflight.service';
+import { BootstrapDnsPreflightService } from '../setup/bootstrap-dns-preflight.service';
+import { ProxyRulesModule } from '../proxy-rules/proxy-rules.module';
 
 @Module({
-  imports: [],
+  // Task 9 adds more imports here as install execution lands (e.g. deployments/domains).
+  imports: [forwardRef(() => ProxyRulesModule)],
   controllers: [AppCatalogController],
-  providers: [AppCatalogService, AppsRegistryService, AppBundleService],
+  providers: [
+    AppCatalogService,
+    AppsRegistryService,
+    AppBundleService,
+    AppPreflightService,
+    // BootstrapDnsPreflightService has a zero-dependency constructor and is
+    // NOT exported by SetupModule, so — the same pattern SetupModule itself
+    // uses for SslCertificateService — we provide a second instance directly
+    // here rather than importing SetupModule (heavy transitive deps this
+    // module doesn't otherwise need). Safe: probeHost is stateless (only
+    // reads/writes a per-call temp ACME challenge file).
+    BootstrapDnsPreflightService,
+  ],
 })
 export class AppCatalogModule {}

--- a/apps/backend/src/app-catalog/app-catalog.module.ts
+++ b/apps/backend/src/app-catalog/app-catalog.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AppCatalogController } from './app-catalog.controller';
+import { AppCatalogService } from './app-catalog.service';
+
+@Module({
+  imports: [],
+  controllers: [AppCatalogController],
+  providers: [AppCatalogService],
+})
+export class AppCatalogModule {}

--- a/apps/backend/src/app-catalog/app-catalog.module.ts
+++ b/apps/backend/src/app-catalog/app-catalog.module.ts
@@ -5,16 +5,40 @@ import { AppsRegistryService } from './apps-registry.service';
 import { AppBundleService } from './app-bundle.service';
 import { AppPreflightService } from './app-preflight.service';
 import { AppCertStepService } from './app-cert-step.service';
+import { AppInstallJobsService } from './app-install-jobs.service';
+import { AppInstallerService } from './app-installer.service';
 import { BootstrapDnsPreflightService } from '../setup/bootstrap-dns-preflight.service';
 import { ProxyRulesModule } from '../proxy-rules/proxy-rules.module';
+import { DeploymentsModule } from '../deployments/deployments.module';
 import { DomainsModule } from '../domains/domains.module';
+import { ProjectsModule } from '../projects/projects.module';
+import { PipelineSchedulesModule } from '../pipeline-schedules/pipeline-schedules.module';
+import { PipelinesModule } from '../pipelines/pipelines.module';
 import { SetupModule } from '../setup/setup.module';
 
 @Module({
-  // Task 9 adds more imports here as install execution lands (e.g. deployments).
-  // DomainsModule: AppCertStepService needs DomainsService.getWildcardCertificateStatus().
-  // SetupModule: AppCertStepService needs PrimarySslService.issueLetsEncrypt().
-  imports: [forwardRef(() => ProxyRulesModule), DomainsModule, SetupModule],
+  // The applier (Task 9) is where the cross-module edges land: it drives the
+  // real services rather than reimplementing their behaviour, so an app
+  // install is indistinguishable from a careful operator clicking through the
+  // admin UI.
+  //  - ProxyRulesModule:      ProxyRuleSetsService.syncRuleSet (forwardRef —
+  //                           the module forwardRefs internally)
+  //  - DeploymentsModule:     DeploymentsService (zip deploy, alias/deployment deletes)
+  //  - DomainsModule:         DomainsService (app subdomain) + AppCertStepService's
+  //                           getWildcardCertificateStatus()
+  //  - ProjectsModule:        ProjectsService (findOrCreate/exists/delete)
+  //  - PipelineSchedulesModule: PipelineSchedulesService (manifest schedules)
+  //  - PipelinesModule:       PipelineSchemasService (created-schema cleanup)
+  //  - SetupModule:           PrimarySslService for AppCertStepService
+  imports: [
+    forwardRef(() => ProxyRulesModule),
+    forwardRef(() => DeploymentsModule),
+    forwardRef(() => DomainsModule),
+    forwardRef(() => ProjectsModule),
+    PipelineSchedulesModule,
+    forwardRef(() => PipelinesModule),
+    SetupModule,
+  ],
   controllers: [AppCatalogController],
   providers: [
     AppCatalogService,
@@ -22,14 +46,17 @@ import { SetupModule } from '../setup/setup.module';
     AppBundleService,
     AppPreflightService,
     AppCertStepService,
+    AppInstallJobsService,
+    AppInstallerService,
     // BootstrapDnsPreflightService is NOT exported by SetupModule (only
-    // SetupService/PrimarySslService are), so even though SetupModule is now
-    // imported below (for PrimarySslService), we still provide a second
+    // SetupService/PrimarySslService are), so even though SetupModule is
+    // imported above (for PrimarySslService), we still provide a second
     // instance directly here — same pattern SetupModule itself uses for
     // SslCertificateService. Safe: probeHost is stateless (only reads/writes
     // a per-call temp ACME challenge file), so the two instances share all
     // durable state through the filesystem, not in-memory state.
     BootstrapDnsPreflightService,
   ],
+  exports: [AppInstallJobsService, AppInstallerService],
 })
 export class AppCatalogModule {}

--- a/apps/backend/src/app-catalog/app-catalog.module.ts
+++ b/apps/backend/src/app-catalog/app-catalog.module.ts
@@ -4,24 +4,31 @@ import { AppCatalogService } from './app-catalog.service';
 import { AppsRegistryService } from './apps-registry.service';
 import { AppBundleService } from './app-bundle.service';
 import { AppPreflightService } from './app-preflight.service';
+import { AppCertStepService } from './app-cert-step.service';
 import { BootstrapDnsPreflightService } from '../setup/bootstrap-dns-preflight.service';
 import { ProxyRulesModule } from '../proxy-rules/proxy-rules.module';
+import { DomainsModule } from '../domains/domains.module';
+import { SetupModule } from '../setup/setup.module';
 
 @Module({
-  // Task 9 adds more imports here as install execution lands (e.g. deployments/domains).
-  imports: [forwardRef(() => ProxyRulesModule)],
+  // Task 9 adds more imports here as install execution lands (e.g. deployments).
+  // DomainsModule: AppCertStepService needs DomainsService.getWildcardCertificateStatus().
+  // SetupModule: AppCertStepService needs PrimarySslService.issueLetsEncrypt().
+  imports: [forwardRef(() => ProxyRulesModule), DomainsModule, SetupModule],
   controllers: [AppCatalogController],
   providers: [
     AppCatalogService,
     AppsRegistryService,
     AppBundleService,
     AppPreflightService,
-    // BootstrapDnsPreflightService has a zero-dependency constructor and is
-    // NOT exported by SetupModule, so — the same pattern SetupModule itself
-    // uses for SslCertificateService — we provide a second instance directly
-    // here rather than importing SetupModule (heavy transitive deps this
-    // module doesn't otherwise need). Safe: probeHost is stateless (only
-    // reads/writes a per-call temp ACME challenge file).
+    AppCertStepService,
+    // BootstrapDnsPreflightService is NOT exported by SetupModule (only
+    // SetupService/PrimarySslService are), so even though SetupModule is now
+    // imported below (for PrimarySslService), we still provide a second
+    // instance directly here — same pattern SetupModule itself uses for
+    // SslCertificateService. Safe: probeHost is stateless (only reads/writes
+    // a per-call temp ACME challenge file), so the two instances share all
+    // durable state through the filesystem, not in-memory state.
     BootstrapDnsPreflightService,
   ],
 })

--- a/apps/backend/src/app-catalog/app-catalog.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.spec.ts
@@ -499,8 +499,29 @@ describe('AppCatalogService', () => {
   });
 
   describe('undoJob', () => {
+    it('refuses to undo an update — that would delete the original install and its data tables', async () => {
+      // createdResources is cumulative, so undo on an update job would tear
+      // down the ORIGINAL install: rule sets, alias, domain, deployment and
+      // (undo passes includeSchemas: true) its populated data tables.
+      jobs.get.mockReturnValue({
+        id: 'job-2',
+        kind: 'update',
+        installedAppId: 'ia-1',
+        status: 'failed',
+      });
+
+      await expect(service.undoJob('job-2', 'user-1')).rejects.toThrow(BadRequestException);
+      await expect(service.undoJob('job-2', 'user-1')).rejects.toThrow(/alias/i);
+      expect(installer.undo).not.toHaveBeenCalled();
+    });
+
     it('delegates to installer.undo using the job’s installedAppId', async () => {
-      jobs.get.mockReturnValue({ id: 'job-1', installedAppId: 'ia-1', status: 'failed' });
+      jobs.get.mockReturnValue({
+        id: 'job-1',
+        kind: 'install',
+        installedAppId: 'ia-1',
+        status: 'failed',
+      });
 
       const result = await service.undoJob('job-1', 'user-1');
 
@@ -509,7 +530,7 @@ describe('AppCatalogService', () => {
     });
 
     it('returns an empty removal with no installer call when the job never reached a row', async () => {
-      jobs.get.mockReturnValue({ id: 'job-1', status: 'failed' });
+      jobs.get.mockReturnValue({ id: 'job-1', kind: 'install', status: 'failed' });
 
       const result = await service.undoJob('job-1', 'user-1');
 

--- a/apps/backend/src/app-catalog/app-catalog.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.spec.ts
@@ -372,6 +372,83 @@ describe('AppCatalogService', () => {
       const ids = result.data.map((e) => e.id).sort();
       expect(ids).toEqual(['handoff', 'legacy-app']);
     });
+
+    describe('appUrl (regression: catalog card linked to the manifest default, not the actual install)', () => {
+      // Manifest default subdomain is "handoff" — the operator overrode it to
+      // "files" at install time, so the domain row is files.example.com. The
+      // card's "Open" link must follow the row, not the manifest.
+      const MANIFEST_WITH_DOMAIN: AppManifest = {
+        ...MANIFEST,
+        install: { ...MANIFEST.install, domain: { subdomain: 'handoff' } },
+      };
+
+      it('resolves appUrl from the stored domain row, not the manifest default subdomain', async () => {
+        registry.getRegistry.mockResolvedValue({
+          ok: true,
+          registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+        });
+        mockDb.__queue([{ ...ROW, manifest: MANIFEST_WITH_DOMAIN, domainId: 'dom-1' }]);
+        mockDb.__queue([{ id: 'dom-1', domain: 'files.example.com' }]);
+
+        const result = await service.listCatalog();
+
+        expect(result.data[0].installed!.appUrl).toBe('https://files.example.com');
+      });
+
+      it('yields undefined appUrl when domainId points at a since-deleted mapping', async () => {
+        registry.getRegistry.mockResolvedValue({
+          ok: true,
+          registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+        });
+        mockDb.__queue([{ ...ROW, manifest: MANIFEST_WITH_DOMAIN, domainId: 'dom-gone' }]);
+        mockDb.__queue([]); // domain mapping no longer exists
+
+        const result = await service.listCatalog();
+
+        expect(result.data[0].installed!.appUrl).toBeUndefined();
+      });
+
+      it('yields undefined appUrl with no domainId lookup at all when the row has none', async () => {
+        registry.getRegistry.mockResolvedValue({
+          ok: true,
+          registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+        });
+        mockDb.__queue([{ ...ROW, manifest: MANIFEST_WITH_DOMAIN, domainId: null }]);
+
+        const result = await service.listCatalog();
+
+        expect(result.data[0].installed!.appUrl).toBeUndefined();
+        // No domainId anywhere -> the batch query is skipped entirely (only
+        // the installedApps row select happened).
+        expect(mockDb.select).toHaveBeenCalledTimes(1);
+      });
+
+      it('batches the domain lookup into a single query for multiple installed rows (no N+1)', async () => {
+        registry.getRegistry.mockResolvedValue({
+          ok: true,
+          registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+        });
+        const rowA = { ...ROW, id: 'ia-1', appId: 'handoff', manifest: MANIFEST_WITH_DOMAIN, domainId: 'dom-1' };
+        const rowB = { ...LEGACY_ROW, id: 'ia-legacy', appId: 'legacy-app', domainId: 'dom-2' };
+        mockDb.__queue([rowA, rowB]);
+        mockDb.__queue([
+          { id: 'dom-1', domain: 'files.example.com' },
+          { id: 'dom-2', domain: 'legacy.example.com' },
+        ]);
+
+        const result = await service.listCatalog();
+
+        // One select() for the installedApps rows, one for the batched domain
+        // lookup — never one per row (N rows here, still 2 selects total).
+        expect(mockDb.select).toHaveBeenCalledTimes(2);
+        expect(mockDb.where).toHaveBeenCalledTimes(1);
+
+        const handoff = result.data.find((e) => e.id === 'handoff')!;
+        const legacy = result.data.find((e) => e.id === 'legacy-app')!;
+        expect(handoff.installed!.appUrl).toBe('https://files.example.com');
+        expect(legacy.installed!.appUrl).toBe('https://legacy.example.com');
+      });
+    });
   });
 
   describe('preflight', () => {

--- a/apps/backend/src/app-catalog/app-catalog.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.spec.ts
@@ -119,7 +119,11 @@ describe('AppCatalogService', () => {
     uninstallPreview: jest.Mock;
   };
   let jobs: { get: jest.Mock };
-  let storageAdapter: { supportsPresignedUrls: jest.Mock; getAdapterType?: jest.Mock };
+  let storageAdapter: {
+    supportsPresignedUrls: jest.Mock;
+    isLocalAdapter?: boolean;
+    getUnderlyingAdapter?: jest.Mock;
+  };
 
   beforeEach(() => {
     mockDb.__reset();
@@ -149,7 +153,9 @@ describe('AppCatalogService', () => {
     jobs = { get: jest.fn() };
     storageAdapter = {
       supportsPresignedUrls: jest.fn().mockReturnValue(true),
-      getAdapterType: jest.fn().mockReturnValue('LocalStorageAdapter'),
+      // Brands as local the way `resolveLocalAdapter` expects (see local.adapter.ts):
+      // the real LocalStorageAdapter carries `readonly isLocalAdapter = true`.
+      isLocalAdapter: true,
     };
 
     service = new AppCatalogService(
@@ -288,6 +294,26 @@ describe('AppCatalogService', () => {
         manualSteps: [{ id: 'always-step', title: 'Always', body: 'always applies' }],
         manualStepsAcked: [],
       });
+    });
+
+    it('does not treat a CachingStorageAdapter-wrapped local adapter as bucket storage (regression: live droplet Redis cache)', async () => {
+      // Shape observed live: STORAGE_ADAPTER is a CachingStorageAdapter wrapping the real
+      // LocalStorageAdapter. It has no getAdapterType(), so the old `getAdapterType?.() ??
+      // constructor.name` fallback resolved to 'CachingStorageAdapter' -> bucketStorage=true,
+      // wrongly surfacing the bucket-cors manual step on a local-FS install.
+      storageAdapter.isLocalAdapter = undefined;
+      storageAdapter.getUnderlyingAdapter = jest.fn().mockReturnValue({ isLocalAdapter: true });
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+      });
+      mockDb.__queue([ROW]);
+
+      const result = await service.listCatalog();
+
+      expect(result.data[0].installed!.manualSteps).toEqual([
+        { id: 'always-step', title: 'Always', body: 'always applies' },
+      ]);
     });
 
     it('updateAvailable is false when the installed version already matches the registry', async () => {

--- a/apps/backend/src/app-catalog/app-catalog.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.spec.ts
@@ -394,6 +394,7 @@ describe('AppCatalogService', () => {
         { manifest: MANIFEST, files: {}, sha256: 'a'.repeat(64) },
         { projectId: 'proj-1' },
         'user-1',
+        undefined,
       );
       expect(result.gates).toEqual([
         { id: 'storage', status: 'pass', message: 'ok' },
@@ -402,6 +403,38 @@ describe('AppCatalogService', () => {
       expect(result.syncPlans).toHaveLength(1);
       expect(result.appHost).toBe('handoff.example.com');
       expect(result.appUrl).toBe('https://handoff.example.com');
+    });
+
+    it('passes dto.subdomain through to projectGates as the override', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+      });
+      bundle.fetchBundle.mockResolvedValue({
+        manifest: MANIFEST,
+        files: {},
+        sha256: 'a'.repeat(64),
+      });
+      preflight.projectGates.mockResolvedValue({
+        gates: [],
+        syncPlans: [],
+        appHost: 'my-app.example.com',
+      });
+
+      const result = await service.preflight(
+        'handoff',
+        { projectId: 'proj-1', subdomain: 'my-app' } as never,
+        'user-1',
+      );
+
+      expect(preflight.projectGates).toHaveBeenCalledWith(
+        { manifest: MANIFEST, files: {}, sha256: 'a'.repeat(64) },
+        { projectId: 'proj-1' },
+        'user-1',
+        'my-app',
+      );
+      expect(result.appHost).toBe('my-app.example.com');
+      expect(result.appUrl).toBe('https://my-app.example.com');
     });
 
     it('throws NotFoundException for an app id not in the registry', async () => {
@@ -463,8 +496,29 @@ describe('AppCatalogService', () => {
         HANDOFF_ENTRY,
         { newProject: { owner: 'acme', name: 'site' } },
         'user-1',
+        undefined,
       );
       expect(result).toEqual({ jobId: 'job-1' });
+    });
+
+    it('passes dto.subdomain through to the installer as the override', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+      });
+
+      await service.install(
+        'handoff',
+        { projectId: 'proj-1', subdomain: 'my-app' } as never,
+        'user-1',
+      );
+
+      expect(installer.startInstall).toHaveBeenCalledWith(
+        HANDOFF_ENTRY,
+        { projectId: 'proj-1' },
+        'user-1',
+        'my-app',
+      );
     });
 
     it('throws NotFoundException for an unknown app id', async () => {

--- a/apps/backend/src/app-catalog/app-catalog.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.spec.ts
@@ -21,10 +21,10 @@ jest.mock('../db/client', () => {
 });
 
 import { ConfigService } from '@nestjs/config';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { db } from '../db/client';
 import { AppCatalogService } from './app-catalog.service';
-import type { AppManifest } from './app-manifest.types';
+import type { AppManifest, AppRegistryEntry } from './app-manifest.types';
 
 const mockDb = db as unknown as Record<string, jest.Mock> & {
   __queue: (result: unknown) => void;
@@ -40,6 +40,10 @@ const MANIFEST: AppManifest = {
     alias: 'handoff',
     deployment: { path: 'dist', basePath: '/apps/handoff/dist' },
     ruleSets: [{ file: 'rulesets/handoff.json' }],
+    manualSteps: [
+      { id: 'bucket-cors', title: 'CORS', body: 'set it up', appliesWhen: 'bucketStorage' },
+      { id: 'always-step', title: 'Always', body: 'always applies' },
+    ],
   },
   eject: {
     repo: 'bffless/apps',
@@ -47,6 +51,18 @@ const MANIFEST: AppManifest = {
     deployWorkflow: 'deploy-handoff.yml',
     variables: ['BFFLESS_URL', 'BFFLESS_PROJECT'],
     secrets: ['BFFLESS_API_KEY'],
+  },
+};
+
+const LEGACY_MANIFEST: AppManifest = {
+  schemaVersion: 1,
+  id: 'legacy-app',
+  name: 'Legacy App',
+  version: '1.0.0',
+  install: {
+    alias: 'legacy-app',
+    deployment: { path: 'dist', basePath: '/apps/legacy-app/dist' },
+    ruleSets: [{ file: 'rulesets/legacy-app.json' }],
   },
 };
 
@@ -64,17 +80,46 @@ const ROW = {
   bundleSha256: 'a'.repeat(64),
   manifest: MANIFEST,
   manualStepsAcked: [] as string[],
-  status: 'installed',
+  status: 'installed' as const,
   createdResources: {},
   installedBy: 'user-1',
-  installedAt: new Date(),
-  updatedAt: new Date(),
+  installedAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+const LEGACY_ROW = {
+  ...ROW,
+  id: 'ia-legacy',
+  appId: 'legacy-app',
+  name: 'Legacy App',
+  manifest: LEGACY_MANIFEST,
+};
+
+const HANDOFF_ENTRY: AppRegistryEntry = {
+  id: 'handoff',
+  name: 'Handoff',
+  version: '1.0.0',
+  bundleUrl: 'https://apps.bffless.dev/handoff.zip',
+  sha256: 'a'.repeat(64),
+  requires: { presignedStorage: true },
 };
 
 describe('AppCatalogService', () => {
   let service: AppCatalogService;
   let projects: { getProjectById: jest.Mock };
   let config: { get: jest.Mock };
+  let registry: { getRegistry: jest.Mock };
+  let bundle: { fetchBundle: jest.Mock };
+  let preflight: { instanceGates: jest.Mock; projectGates: jest.Mock };
+  let installer: {
+    startInstall: jest.Mock;
+    startUpdate: jest.Mock;
+    undo: jest.Mock;
+    uninstall: jest.Mock;
+    uninstallPreview: jest.Mock;
+  };
+  let jobs: { get: jest.Mock };
+  let storageAdapter: { supportsPresignedUrls: jest.Mock; getAdapterType?: jest.Mock };
 
   beforeEach(() => {
     mockDb.__reset();
@@ -82,7 +127,41 @@ describe('AppCatalogService', () => {
       getProjectById: jest.fn().mockResolvedValue({ id: 'proj-1', owner: 'acme', name: 'site' }),
     };
     config = { get: jest.fn().mockReturnValue(undefined) };
-    service = new AppCatalogService(projects as never, config as unknown as ConfigService);
+    registry = {
+      getRegistry: jest.fn().mockResolvedValue({ ok: true, registry: { schemaVersion: 1, apps: [] } }),
+    };
+    bundle = { fetchBundle: jest.fn() };
+    preflight = {
+      instanceGates: jest.fn().mockResolvedValue([{ id: 'storage', status: 'pass', message: 'ok' }]),
+      projectGates: jest.fn().mockResolvedValue({
+        gates: [{ id: 'dns', status: 'pass', message: 'ok' }],
+        syncPlans: [],
+        appHost: null,
+      }),
+    };
+    installer = {
+      startInstall: jest.fn().mockReturnValue({ jobId: 'job-1' }),
+      startUpdate: jest.fn().mockReturnValue({ jobId: 'job-2' }),
+      undo: jest.fn().mockResolvedValue({ removed: ['ruleSet:rs-1'] }),
+      uninstall: jest.fn().mockResolvedValue({ removed: {}, dataTables: {}, note: 'note' }),
+      uninstallPreview: jest.fn().mockResolvedValue({ dataTables: [] }),
+    };
+    jobs = { get: jest.fn() };
+    storageAdapter = {
+      supportsPresignedUrls: jest.fn().mockReturnValue(true),
+      getAdapterType: jest.fn().mockReturnValue('LocalStorageAdapter'),
+    };
+
+    service = new AppCatalogService(
+      projects as never,
+      config as unknown as ConfigService,
+      registry as never,
+      bundle as never,
+      preflight as never,
+      installer as never,
+      jobs as never,
+      storageAdapter as never,
+    );
   });
 
   describe('ejectPayload', () => {
@@ -143,6 +222,317 @@ describe('AppCatalogService', () => {
       const acked = await service.ackManualStep('ia-1', 'bucket-cors');
 
       expect(acked).toEqual(['bucket-cors']);
+    });
+  });
+
+  describe('listCatalog', () => {
+    it('lists a registry app with no installs: instance gates only, installable true, no installed block', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+      });
+      mockDb.__queue([]); // no installed rows
+
+      const result = await service.listCatalog();
+
+      expect(preflight.instanceGates).toHaveBeenCalledWith(HANDOFF_ENTRY.requires);
+      expect(result.registryError).toBeUndefined();
+      expect(result.data).toEqual([
+        {
+          id: 'handoff',
+          name: 'Handoff',
+          summary: undefined,
+          iconUrl: undefined,
+          docsUrl: undefined,
+          sourceUrl: undefined,
+          registryVersion: '1.0.0',
+          gates: [{ id: 'storage', status: 'pass', message: 'ok' }],
+          installable: true,
+        },
+      ]);
+    });
+
+    it('marks a registry app not-installable when an instance gate fails', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+      });
+      preflight.instanceGates.mockResolvedValue([{ id: 'storage', status: 'fail', message: 'nope' }]);
+      mockDb.__queue([]);
+
+      const result = await service.listCatalog();
+
+      expect(result.data[0].installable).toBe(false);
+    });
+
+    it('attaches the installed summary, computing updateAvailable via compareSemver', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [{ ...HANDOFF_ENTRY, version: '1.1.0' }] },
+      });
+      mockDb.__queue([ROW]); // one installed row, version 1.0.0
+      storageAdapter.supportsPresignedUrls.mockReturnValue(true);
+
+      const result = await service.listCatalog();
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].installed).toEqual({
+        installedAppId: 'ia-1',
+        version: '1.0.0',
+        projectId: 'proj-1',
+        projectName: 'acme/site',
+        alias: 'handoff',
+        appUrl: undefined,
+        status: 'installed',
+        updateAvailable: true, // 1.1.0 > 1.0.0
+        manualSteps: [{ id: 'always-step', title: 'Always', body: 'always applies' }],
+        manualStepsAcked: [],
+      });
+    });
+
+    it('updateAvailable is false when the installed version already matches the registry', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] }, // version 1.0.0, same as ROW
+      });
+      mockDb.__queue([ROW]);
+
+      const result = await service.listCatalog();
+
+      expect(result.data[0].installed!.updateAvailable).toBe(false);
+    });
+
+    it('degrades to registryError while still listing installed apps', async () => {
+      registry.getRegistry.mockResolvedValue({ ok: false, error: 'registry unreachable' });
+      mockDb.__queue([ROW]);
+
+      const result = await service.listCatalog();
+
+      expect(result.registryError).toBe('registry unreachable');
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].id).toBe('handoff');
+      expect(result.data[0].registryVersion).toBeUndefined();
+      expect(result.data[0].installable).toBe(false);
+      expect(result.data[0].installed!.installedAppId).toBe('ia-1');
+      // instanceGates computed from the stored manifest's requires, not a registry entry.
+      expect(preflight.instanceGates).toHaveBeenCalledWith(undefined);
+    });
+
+    it('renders an installed app that is no longer present in a healthy registry', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [] }, // handoff removed from the registry
+      });
+      mockDb.__queue([ROW]);
+
+      const result = await service.listCatalog();
+
+      expect(result.registryError).toBeUndefined();
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].registryVersion).toBeUndefined();
+      expect(result.data[0].installable).toBe(false);
+      expect(result.data[0].installed!.installedAppId).toBe('ia-1');
+    });
+
+    it('lists multiple unrelated installed-only apps alongside registry apps', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+      });
+      mockDb.__queue([ROW, LEGACY_ROW]);
+
+      const result = await service.listCatalog();
+
+      const ids = result.data.map((e) => e.id).sort();
+      expect(ids).toEqual(['handoff', 'legacy-app']);
+    });
+  });
+
+  describe('preflight', () => {
+    it('combines instance and project gates and derives appUrl from appHost', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+      });
+      bundle.fetchBundle.mockResolvedValue({ manifest: MANIFEST, files: {}, sha256: 'a'.repeat(64) });
+      preflight.projectGates.mockResolvedValue({
+        gates: [{ id: 'dns', status: 'pass', message: 'ok' }],
+        syncPlans: [{ ruleSet: 'handoff', created: 1, updated: 0, unchanged: 0, pruneCandidates: 0, schemaResolutions: [] }],
+        appHost: 'handoff.example.com',
+      });
+
+      const result = await service.preflight('handoff', { projectId: 'proj-1' } as never, 'user-1');
+
+      expect(bundle.fetchBundle).toHaveBeenCalledWith(HANDOFF_ENTRY.bundleUrl, HANDOFF_ENTRY.sha256);
+      expect(preflight.projectGates).toHaveBeenCalledWith(
+        { manifest: MANIFEST, files: {}, sha256: 'a'.repeat(64) },
+        { projectId: 'proj-1' },
+        'user-1',
+      );
+      expect(result.gates).toEqual([
+        { id: 'storage', status: 'pass', message: 'ok' },
+        { id: 'dns', status: 'pass', message: 'ok' },
+      ]);
+      expect(result.syncPlans).toHaveLength(1);
+      expect(result.appHost).toBe('handoff.example.com');
+      expect(result.appUrl).toBe('https://handoff.example.com');
+    });
+
+    it('throws NotFoundException for an app id not in the registry', async () => {
+      registry.getRegistry.mockResolvedValue({ ok: true, registry: { schemaVersion: 1, apps: [] } });
+
+      await expect(
+        service.preflight('unknown-app', { projectId: 'proj-1' } as never, 'user-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when the registry is unavailable', async () => {
+      registry.getRegistry.mockResolvedValue({ ok: false, error: 'boom' });
+
+      await expect(
+        service.preflight('handoff', { projectId: 'proj-1' } as never, 'user-1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when neither projectId nor newProject is given', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+      });
+
+      await expect(service.preflight('handoff', {} as never, 'user-1')).rejects.toThrow(BadRequestException);
+      expect(bundle.fetchBundle).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when both projectId and newProject are given', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+      });
+
+      await expect(
+        service.preflight(
+          'handoff',
+          { projectId: 'proj-1', newProject: { owner: 'acme', name: 'site' } } as never,
+          'user-1',
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('install', () => {
+    it('resolves the registry entry and target, then delegates to the installer', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+      });
+
+      const result = await service.install(
+        'handoff',
+        { newProject: { owner: 'acme', name: 'site' } } as never,
+        'user-1',
+      );
+
+      expect(installer.startInstall).toHaveBeenCalledWith(
+        HANDOFF_ENTRY,
+        { newProject: { owner: 'acme', name: 'site' } },
+        'user-1',
+      );
+      expect(result).toEqual({ jobId: 'job-1' });
+    });
+
+    it('throws NotFoundException for an unknown app id', async () => {
+      registry.getRegistry.mockResolvedValue({ ok: true, registry: { schemaVersion: 1, apps: [] } });
+
+      await expect(service.install('unknown', { projectId: 'proj-1' } as never, 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(installer.startInstall).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateInstalled', () => {
+    it('loads the row, resolves the matching registry entry, and delegates to the installer', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [{ ...HANDOFF_ENTRY, version: '1.1.0' }] },
+      });
+      mockDb.__queue([ROW]);
+
+      const result = await service.updateInstalled('ia-1', true, 'user-1');
+
+      expect(installer.startUpdate).toHaveBeenCalledWith(
+        ROW,
+        { ...HANDOFF_ENTRY, version: '1.1.0' },
+        'user-1',
+        { prune: true },
+      );
+      expect(result).toEqual({ jobId: 'job-2' });
+    });
+
+    it('throws NotFoundException when the installed app row does not exist', async () => {
+      mockDb.__queue([]);
+
+      await expect(service.updateInstalled('missing', false, 'user-1')).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when the app is no longer in the registry', async () => {
+      registry.getRegistry.mockResolvedValue({ ok: true, registry: { schemaVersion: 1, apps: [] } });
+      mockDb.__queue([ROW]);
+
+      await expect(service.updateInstalled('ia-1', false, 'user-1')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getJob', () => {
+    it('returns the job when found', () => {
+      jobs.get.mockReturnValue({ id: 'job-1', status: 'running' });
+
+      expect(service.getJob('job-1')).toEqual({ id: 'job-1', status: 'running' });
+    });
+
+    it('throws NotFoundException for an unknown job id', () => {
+      jobs.get.mockReturnValue(null);
+
+      expect(() => service.getJob('missing')).toThrow(NotFoundException);
+    });
+  });
+
+  describe('undoJob', () => {
+    it('delegates to installer.undo using the job’s installedAppId', async () => {
+      jobs.get.mockReturnValue({ id: 'job-1', installedAppId: 'ia-1', status: 'failed' });
+
+      const result = await service.undoJob('job-1', 'user-1');
+
+      expect(installer.undo).toHaveBeenCalledWith('ia-1', 'user-1');
+      expect(result).toEqual({ removed: ['ruleSet:rs-1'] });
+    });
+
+    it('returns an empty removal with no installer call when the job never reached a row', async () => {
+      jobs.get.mockReturnValue({ id: 'job-1', status: 'failed' });
+
+      const result = await service.undoJob('job-1', 'user-1');
+
+      expect(installer.undo).not.toHaveBeenCalled();
+      expect(result).toEqual({ removed: [] });
+    });
+
+    it('throws NotFoundException for an unknown job id', async () => {
+      jobs.get.mockReturnValue(null);
+
+      await expect(service.undoJob('missing', 'user-1')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('uninstallPreview / uninstall', () => {
+    it('uninstallPreview delegates straight to the installer', async () => {
+      await service.uninstallPreview('ia-1');
+      expect(installer.uninstallPreview).toHaveBeenCalledWith('ia-1');
+    });
+
+    it('uninstall delegates with the deleteData option', async () => {
+      await service.uninstall('ia-1', true, 'user-1');
+      expect(installer.uninstall).toHaveBeenCalledWith('ia-1', 'user-1', { deleteData: true });
     });
   });
 });

--- a/apps/backend/src/app-catalog/app-catalog.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.spec.ts
@@ -1,0 +1,148 @@
+// Thenable chainable db mock — same house pattern as app-installer.service.spec.ts.
+jest.mock('../db/client', () => {
+  const queued: unknown[] = [];
+  const methods = ['select', 'from', 'where', 'limit', 'update', 'set', 'returning'];
+  const chainable: Record<string, unknown> = {};
+  for (const method of methods) {
+    chainable[method] = jest.fn(() => chainable);
+  }
+  chainable.then = (
+    resolve: (value: unknown) => unknown,
+    reject: (reason: unknown) => unknown,
+  ) => Promise.resolve(queued.length > 0 ? queued.shift() : []).then(resolve, reject);
+  chainable.__queue = (result: unknown) => queued.push(result);
+  chainable.__reset = () => {
+    queued.length = 0;
+    for (const method of methods) {
+      (chainable[method] as jest.Mock).mockClear();
+    }
+  };
+  return { db: chainable };
+});
+
+import { ConfigService } from '@nestjs/config';
+import { NotFoundException } from '@nestjs/common';
+import { db } from '../db/client';
+import { AppCatalogService } from './app-catalog.service';
+import type { AppManifest } from './app-manifest.types';
+
+const mockDb = db as unknown as Record<string, jest.Mock> & {
+  __queue: (result: unknown) => void;
+  __reset: () => void;
+};
+
+const MANIFEST: AppManifest = {
+  schemaVersion: 1,
+  id: 'handoff',
+  name: 'Handoff',
+  version: '1.0.0',
+  install: {
+    alias: 'handoff',
+    deployment: { path: 'dist', basePath: '/apps/handoff/dist' },
+    ruleSets: [{ file: 'rulesets/handoff.json' }],
+  },
+  eject: {
+    repo: 'bffless/apps',
+    appPath: 'apps/handoff',
+    deployWorkflow: 'deploy-handoff.yml',
+    variables: ['BFFLESS_URL', 'BFFLESS_PROJECT'],
+    secrets: ['BFFLESS_API_KEY'],
+  },
+};
+
+const ROW = {
+  id: 'ia-1',
+  appId: 'handoff',
+  name: 'Handoff',
+  version: '1.0.0',
+  projectId: 'proj-1',
+  alias: 'handoff',
+  domainId: null,
+  deploymentId: 'dep-1',
+  ruleSetIds: ['rs-1'],
+  schemaIds: [] as string[],
+  bundleSha256: 'a'.repeat(64),
+  manifest: MANIFEST,
+  manualStepsAcked: [] as string[],
+  status: 'installed',
+  createdResources: {},
+  installedBy: 'user-1',
+  installedAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('AppCatalogService', () => {
+  let service: AppCatalogService;
+  let projects: { getProjectById: jest.Mock };
+  let config: { get: jest.Mock };
+
+  beforeEach(() => {
+    mockDb.__reset();
+    projects = {
+      getProjectById: jest.fn().mockResolvedValue({ id: 'proj-1', owner: 'acme', name: 'site' }),
+    };
+    config = { get: jest.fn().mockReturnValue(undefined) };
+    service = new AppCatalogService(projects as never, config as unknown as ConfigService);
+  });
+
+  describe('ejectPayload', () => {
+    it('derives BFFLESS_URL from https://admin.PRIMARY_DOMAIN when PUBLIC_ORIGIN is unset', async () => {
+      config.get.mockImplementation((key: string) => (key === 'PRIMARY_DOMAIN' ? 'example.com' : undefined));
+      mockDb.__queue([ROW]);
+
+      const payload = await service.ejectPayload('ia-1');
+
+      expect(payload.variables.BFFLESS_URL).toBe('https://admin.example.com');
+      expect(payload.variables.BFFLESS_PROJECT).toBe('acme/site');
+      expect(payload.repo).toBe('bffless/apps');
+      expect(payload.appPath).toBe('apps/handoff');
+      expect(payload.deployWorkflow).toBe('deploy-handoff.yml');
+      expect(payload.forkUrl).toBe('https://github.com/bffless/apps/fork');
+      expect(payload.secrets).toEqual(['BFFLESS_API_KEY']);
+      expect(payload.alias).toBe('handoff');
+      expect(payload.note).toMatch(/same alias/i);
+    });
+
+    it('prefers an explicit PUBLIC_ORIGIN over PRIMARY_DOMAIN', async () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'PUBLIC_ORIGIN') return 'https://my-bffless.example/';
+        if (key === 'PRIMARY_DOMAIN') return 'example.com';
+        return undefined;
+      });
+      mockDb.__queue([ROW]);
+
+      const payload = await service.ejectPayload('ia-1');
+
+      expect(payload.variables.BFFLESS_URL).toBe('https://my-bffless.example');
+    });
+
+    it('throws when the installed app is not found', async () => {
+      mockDb.__queue([]);
+
+      await expect(service.ejectPayload('missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('ackManualStep', () => {
+    it('appends a step id to the acked list', async () => {
+      mockDb.__queue([{ ...ROW, manualStepsAcked: ['bucket-cors'] }]);
+      mockDb.__queue([]); // update
+
+      const acked = await service.ackManualStep('ia-1', 'platform-only');
+
+      expect(acked).toEqual(expect.arrayContaining(['bucket-cors', 'platform-only']));
+      expect(mockDb.set).toHaveBeenCalledWith(
+        expect.objectContaining({ manualStepsAcked: expect.arrayContaining(['bucket-cors', 'platform-only']) }),
+      );
+    });
+
+    it('is idempotent — double-acking the same step does not duplicate it', async () => {
+      mockDb.__queue([{ ...ROW, manualStepsAcked: ['bucket-cors'] }]);
+      mockDb.__queue([]);
+
+      const acked = await service.ackManualStep('ia-1', 'bucket-cors');
+
+      expect(acked).toEqual(['bucket-cors']);
+    });
+  });
+});

--- a/apps/backend/src/app-catalog/app-catalog.service.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppCatalogService {
+  async listCatalog(): Promise<unknown[]> {
+    return [];
+  }
+}

--- a/apps/backend/src/app-catalog/app-catalog.service.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.ts
@@ -146,6 +146,7 @@ export class AppCatalogService {
       bundle,
       this.toPreflightTarget(target),
       userId,
+      dto.subdomain,
     );
 
     return {
@@ -159,7 +160,7 @@ export class AppCatalogService {
   async install(appId: string, dto: PreflightRequestDto, userId: string): Promise<{ jobId: string }> {
     const entry = await this.requireRegistryEntry(appId);
     const target = this.toInstallTarget(dto);
-    return this.installerService.startInstall(entry, target, userId);
+    return this.installerService.startInstall(entry, target, userId, dto.subdomain);
   }
 
   async updateInstalled(

--- a/apps/backend/src/app-catalog/app-catalog.service.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.ts
@@ -1,8 +1,100 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { eq } from 'drizzle-orm';
+import { db } from '../db/client';
+import { installedApps, type InstalledApp } from '../db/schema';
+import { ProjectsService } from '../projects/projects.service';
+import type { AppManifest } from './app-manifest.types';
+
+export interface EjectPayload {
+  repo: string;
+  appPath: string;
+  deployWorkflow: string;
+  /** https://github.com/<repo>/fork */
+  forkUrl: string;
+  variables: Record<string, string>;
+  secrets: string[];
+  alias: string;
+  note: string;
+}
 
 @Injectable()
 export class AppCatalogService {
+  constructor(
+    private readonly projectsService: ProjectsService,
+    private readonly configService: ConfigService,
+  ) {}
+
   async listCatalog(): Promise<unknown[]> {
     return [];
+  }
+
+  /**
+   * Renders the "eject to your own repo" panel straight from the stored
+   * manifest — no registry refetch, so eject still works offline / after the
+   * bundle has moved on. API-key minting stays a frontend concern (the
+   * existing api-keys endpoints already cover it); this only tells the
+   * caller which secret name the workflow expects.
+   */
+  async ejectPayload(installedAppId: string): Promise<EjectPayload> {
+    const row = await this.requireRow(installedAppId);
+    const manifest = row.manifest as AppManifest;
+    if (!manifest.eject) {
+      throw new NotFoundException(`App ${row.appId} does not declare an eject configuration`);
+    }
+
+    const project = await this.projectsService.getProjectById(row.projectId);
+
+    return {
+      repo: manifest.eject.repo,
+      appPath: manifest.eject.appPath,
+      deployWorkflow: manifest.eject.deployWorkflow,
+      forkUrl: `https://github.com/${manifest.eject.repo}/fork`,
+      variables: {
+        BFFLESS_URL: this.adminOrigin(),
+        BFFLESS_PROJECT: `${project.owner}/${project.name}`,
+      },
+      secrets: manifest.eject.secrets,
+      alias: row.alias,
+      note: "The workflow's first deploy lands on this same alias.",
+    };
+  }
+
+  /** Idempotent: acking an already-acked step id is a no-op, not a duplicate entry. */
+  async ackManualStep(installedAppId: string, stepId: string): Promise<string[]> {
+    const row = await this.requireRow(installedAppId);
+    const acked = new Set(row.manualStepsAcked ?? []);
+    acked.add(stepId);
+    const updated = [...acked];
+
+    await db
+      .update(installedApps)
+      .set({ manualStepsAcked: updated, updatedAt: new Date() })
+      .where(eq(installedApps.id, row.id));
+
+    return updated;
+  }
+
+  /**
+   * `PUBLIC_ORIGIN` wins when set (an explicit override); otherwise the app's
+   * eject target is always reachable at the admin host, so — unlike
+   * `presign.util.ts`'s `explicitPublicOrigin` — falling back to
+   * `PRIMARY_DOMAIN` here is correct rather than a guess.
+   */
+  private adminOrigin(): string {
+    const explicit = this.configService.get<string>('PUBLIC_ORIGIN')?.trim();
+    if (explicit) return explicit.replace(/\/+$/, '');
+    const primaryDomain = this.configService.get<string>('PRIMARY_DOMAIN')?.trim() ?? '';
+    return `https://admin.${primaryDomain}`;
+  }
+
+  private async requireRow(installedAppId: string): Promise<InstalledApp> {
+    const [row] = await db
+      .select()
+      .from(installedApps)
+      .where(eq(installedApps.id, installedAppId))
+      .limit(1);
+    if (!row) throw new NotFoundException(`Installed app ${installedAppId} not found`);
+    return row;
   }
 }

--- a/apps/backend/src/app-catalog/app-catalog.service.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.ts
@@ -5,6 +5,7 @@ import { db } from '../db/client';
 import { installedApps, type InstalledApp, type InstalledAppStatus } from '../db/schema';
 import { ProjectsService } from '../projects/projects.service';
 import { IStorageAdapter, STORAGE_ADAPTER } from '../storage/storage.interface';
+import { resolveLocalAdapter } from '../storage/local.adapter';
 import { AppsRegistryService } from './apps-registry.service';
 import { AppBundleService } from './app-bundle.service';
 import {
@@ -392,10 +393,8 @@ export class AppCatalogService {
   /** Mirrors `AppInstallerService`'s private helper of the same name — small enough that
    * extracting a shared util isn't worth the cross-module coupling yet. */
   private instanceContext(): { bucketStorage: boolean; platformMode: boolean } {
-    const adapter = this.storageAdapter as IStorageAdapter & { getAdapterType?: () => string };
-    const adapterName = adapter.getAdapterType?.() ?? this.storageAdapter.constructor.name;
     return {
-      bucketStorage: !adapterName.toLowerCase().includes('local'),
+      bucketStorage: resolveLocalAdapter(this.storageAdapter) === null,
       platformMode:
         this.configService.get<string>('PLATFORM_MODE') === 'true' ||
         process.env.PLATFORM_MODE === 'true',

--- a/apps/backend/src/app-catalog/app-catalog.service.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.ts
@@ -1,10 +1,29 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { eq } from 'drizzle-orm';
 import { db } from '../db/client';
-import { installedApps, type InstalledApp } from '../db/schema';
+import { installedApps, type InstalledApp, type InstalledAppStatus } from '../db/schema';
 import { ProjectsService } from '../projects/projects.service';
-import type { AppManifest } from './app-manifest.types';
+import { IStorageAdapter, STORAGE_ADAPTER } from '../storage/storage.interface';
+import { AppsRegistryService } from './apps-registry.service';
+import { AppBundleService } from './app-bundle.service';
+import {
+  AppPreflightService,
+  type GateResult,
+  type SyncPlanSummary,
+  type InstallTarget as PreflightInstallTarget,
+} from './app-preflight.service';
+import {
+  AppInstallerService,
+  type InstallTarget,
+  type UninstallPreview,
+  type UninstallSummary,
+} from './app-installer.service';
+import { AppInstallJobsService, type InstallJob } from './app-install-jobs.service';
+import { compareSemver } from './ce-version.util';
+import { manualStepApplies } from './app-manifest.util';
+import type { AppManifest, AppManualStep, AppRegistryEntry } from './app-manifest.types';
+import type { PreflightRequestDto } from './app-catalog.dtos';
 
 export interface EjectPayload {
   repo: string;
@@ -18,15 +37,165 @@ export interface EjectPayload {
   note: string;
 }
 
+export interface CatalogEntry {
+  id: string;
+  name: string;
+  summary?: string;
+  iconUrl?: string;
+  docsUrl?: string;
+  sourceUrl?: string;
+  /** Absent when the registry is unavailable, or this app isn't (or no longer) listed in it. */
+  registryVersion?: string;
+  /** Instance-level gates only (storage/CE-version/platform-config) — project gates are preflight-only. */
+  gates: GateResult[];
+  /** Every instance gate passed AND the app is present in the registry. */
+  installable: boolean;
+  installed?: {
+    installedAppId: string;
+    version: string;
+    projectId: string;
+    projectName: string;
+    alias: string;
+    appUrl?: string;
+    status: InstalledAppStatus;
+    updateAvailable: boolean;
+    manualSteps: AppManualStep[];
+    manualStepsAcked: string[];
+  };
+}
+
+export interface CatalogListResult {
+  data: CatalogEntry[];
+  registryError?: string;
+}
+
+export interface PreflightResult {
+  gates: GateResult[];
+  syncPlans: SyncPlanSummary[];
+  appHost: string | null;
+  appUrl?: string;
+}
+
+/**
+ * AppCatalogService — the admin HTTP surface's single entry point (Task 11 of
+ * the app-catalog spec). Assembles the browsable catalog and fronts every
+ * other app-catalog service (registry, bundle, preflight, installer, jobs)
+ * behind one API the controller can call without knowing which of them owns
+ * what. It does not reimplement any of their logic.
+ */
 @Injectable()
 export class AppCatalogService {
   constructor(
     private readonly projectsService: ProjectsService,
     private readonly configService: ConfigService,
+    private readonly registryService: AppsRegistryService,
+    private readonly bundleService: AppBundleService,
+    private readonly preflightService: AppPreflightService,
+    private readonly installerService: AppInstallerService,
+    private readonly jobsService: AppInstallJobsService,
+    @Inject(STORAGE_ADAPTER) private readonly storageAdapter: IStorageAdapter,
   ) {}
 
-  async listCatalog(): Promise<unknown[]> {
-    return [];
+  // ==================== catalog ====================
+
+  /**
+   * registry ∪ installed rows. A registry entry gets `instanceGates` for its
+   * `requires`; an installed row whose app isn't (or no longer is) in the
+   * registry still renders — from its own stored manifest, `registryVersion`
+   * absent — rather than disappearing. A registry fetch failure degrades to
+   * `registryError` at the top level; installed apps keep listing regardless.
+   */
+  async listCatalog(): Promise<CatalogListResult> {
+    const registryResult = await this.registryService.getRegistry();
+    const rows = await db.select().from(installedApps);
+
+    const rowsByAppId = new Map<string, InstalledApp[]>();
+    for (const row of rows) {
+      const existing = rowsByAppId.get(row.appId);
+      if (existing) existing.push(row);
+      else rowsByAppId.set(row.appId, [row]);
+    }
+
+    const data: CatalogEntry[] = [];
+    const seen = new Set<string>();
+
+    if (registryResult.ok) {
+      for (const entry of registryResult.registry.apps) {
+        seen.add(entry.id);
+        data.push(await this.buildRegistryEntry(entry, rowsByAppId.get(entry.id) ?? []));
+      }
+    }
+
+    for (const [appId, appRows] of rowsByAppId) {
+      if (seen.has(appId)) continue;
+      data.push(await this.buildManifestOnlyEntry(appRows));
+    }
+
+    return registryResult.ok ? { data } : { data, registryError: registryResult.error };
+  }
+
+  /** Combined instance + project gates, for the install wizard's preview screen. */
+  async preflight(appId: string, dto: PreflightRequestDto, userId: string): Promise<PreflightResult> {
+    const entry = await this.requireRegistryEntry(appId);
+    const target = this.toInstallTarget(dto);
+    const bundle = await this.bundleService.fetchBundle(entry.bundleUrl, entry.sha256);
+
+    const instanceGates = await this.preflightService.instanceGates(entry.requires);
+    const { gates: projectGates, syncPlans, appHost } = await this.preflightService.projectGates(
+      bundle,
+      this.toPreflightTarget(target),
+      userId,
+    );
+
+    return {
+      gates: [...instanceGates, ...projectGates],
+      syncPlans,
+      appHost,
+      appUrl: appHost ? `https://${appHost}` : undefined,
+    };
+  }
+
+  async install(appId: string, dto: PreflightRequestDto, userId: string): Promise<{ jobId: string }> {
+    const entry = await this.requireRegistryEntry(appId);
+    const target = this.toInstallTarget(dto);
+    return this.installerService.startInstall(entry, target, userId);
+  }
+
+  async updateInstalled(
+    installedAppId: string,
+    prune: boolean,
+    userId: string,
+  ): Promise<{ jobId: string }> {
+    const row = await this.requireRow(installedAppId);
+    const entry = await this.requireRegistryEntry(row.appId);
+    return this.installerService.startUpdate(row, entry, userId, { prune });
+  }
+
+  getJob(jobId: string): InstallJob {
+    const job = this.jobsService.get(jobId);
+    if (!job) throw new NotFoundException(`Install job ${jobId} not found`);
+    return job;
+  }
+
+  /**
+   * Undo is keyed by jobId (the wizard only has the job it just started), not
+   * by installedAppId — a job that failed before an `installed_apps` row ever
+   * got created has nothing to undo.
+   */
+  async undoJob(jobId: string, userId: string): Promise<{ removed: string[]; failures?: string[] }> {
+    const job = this.getJob(jobId);
+    if (!job.installedAppId) {
+      return { removed: [] };
+    }
+    return this.installerService.undo(job.installedAppId, userId);
+  }
+
+  uninstallPreview(installedAppId: string): Promise<UninstallPreview> {
+    return this.installerService.uninstallPreview(installedAppId);
+  }
+
+  uninstall(installedAppId: string, deleteData: boolean, userId: string): Promise<UninstallSummary> {
+    return this.installerService.uninstall(installedAppId, userId, { deleteData });
   }
 
   /**
@@ -75,6 +244,98 @@ export class AppCatalogService {
     return updated;
   }
 
+  // ==================== catalog assembly helpers ====================
+
+  private async buildRegistryEntry(entry: AppRegistryEntry, rows: InstalledApp[]): Promise<CatalogEntry> {
+    const gates = await this.preflightService.instanceGates(entry.requires);
+    const base: CatalogEntry = {
+      id: entry.id,
+      name: entry.name ?? entry.id,
+      summary: entry.summary,
+      iconUrl: entry.iconUrl,
+      docsUrl: entry.docsUrl,
+      sourceUrl: entry.sourceUrl,
+      registryVersion: entry.version,
+      gates,
+      installable: gates.every((gate) => gate.status !== 'fail'),
+    };
+    if (rows.length === 0) return base;
+
+    const row = pickPrimaryRow(rows);
+    return { ...base, installed: await this.buildInstalledSummary(row, entry.version) };
+  }
+
+  /** An installed app whose app id isn't (or no longer is) in the registry. */
+  private async buildManifestOnlyEntry(rows: InstalledApp[]): Promise<CatalogEntry> {
+    const row = pickPrimaryRow(rows);
+    const manifest = row.manifest as AppManifest;
+    const gates = await this.preflightService.instanceGates(manifest.requires);
+
+    return {
+      id: manifest.id,
+      name: manifest.name,
+      summary: manifest.summary,
+      iconUrl: manifest.iconUrl,
+      docsUrl: manifest.docsUrl,
+      sourceUrl: manifest.sourceUrl,
+      gates,
+      installable: false, // no registry entry to install/reinstall from
+      installed: await this.buildInstalledSummary(row, undefined),
+    };
+  }
+
+  private async buildInstalledSummary(
+    row: InstalledApp,
+    registryVersion: string | undefined,
+  ): Promise<NonNullable<CatalogEntry['installed']>> {
+    const manifest = row.manifest as AppManifest;
+    const project = await this.projectsService.getProjectById(row.projectId);
+    const updateAvailable =
+      registryVersion !== undefined && compareSemver(registryVersion, row.version) > 0;
+
+    return {
+      installedAppId: row.id,
+      version: row.version,
+      projectId: row.projectId,
+      projectName: `${project.owner}/${project.name}`,
+      alias: row.alias,
+      appUrl: this.computeAppUrl(manifest, row),
+      status: row.status,
+      updateAvailable,
+      manualSteps: this.applicableManualSteps(manifest),
+      manualStepsAcked: row.manualStepsAcked ?? [],
+    };
+  }
+
+  // ==================== helpers ====================
+
+  private async requireRegistryEntry(appId: string): Promise<AppRegistryEntry> {
+    const result = await this.registryService.getRegistry();
+    if (!result.ok) {
+      throw new BadRequestException(`App catalog registry is unavailable: ${result.error}`);
+    }
+    const entry = result.registry.apps.find((app) => app.id === appId);
+    if (!entry) {
+      throw new NotFoundException(`App "${appId}" was not found in the catalog registry`);
+    }
+    return entry;
+  }
+
+  private toInstallTarget(dto: PreflightRequestDto): InstallTarget {
+    const hasProjectId = Boolean(dto.projectId);
+    const hasNewProject = Boolean(dto.newProject);
+    if (hasProjectId === hasNewProject) {
+      throw new BadRequestException('Provide exactly one of projectId or newProject');
+    }
+    return hasProjectId ? { projectId: dto.projectId } : { newProject: dto.newProject };
+  }
+
+  private toPreflightTarget(target: InstallTarget): PreflightInstallTarget {
+    if (target.projectId) return { projectId: target.projectId };
+    if (target.newProject) return { newProject: target.newProject };
+    throw new BadRequestException('Provide exactly one of projectId or newProject');
+  }
+
   /**
    * `PUBLIC_ORIGIN` wins when set (an explicit override); otherwise the app's
    * eject target is always reachable at the admin host, so — unlike
@@ -88,6 +349,44 @@ export class AppCatalogService {
     return `https://admin.${primaryDomain}`;
   }
 
+  /**
+   * Only computable when this install owns a domain mapping — there is no
+   * persisted "default alias URL" on the row to fall back to (unlike the
+   * installer's in-flight `deployment.urls.default`), so a domain-less app
+   * simply has no catalog `appUrl` and the admin UI links to the deployment
+   * instead.
+   */
+  private computeAppUrl(manifest: AppManifest, row: InstalledApp): string | undefined {
+    if (!row.domainId) return undefined;
+    const appHost = this.computeAppHost(manifest);
+    return appHost ? `https://${appHost}` : undefined;
+  }
+
+  private computeAppHost(manifest: AppManifest): string | null {
+    const subdomain = manifest.install.domain?.subdomain;
+    if (!subdomain) return null;
+    const primaryDomain = this.configService.get<string>('PRIMARY_DOMAIN') || '';
+    return primaryDomain ? `${subdomain}.${primaryDomain}` : null;
+  }
+
+  private applicableManualSteps(manifest: AppManifest): AppManualStep[] {
+    const ctx = this.instanceContext();
+    return (manifest.install.manualSteps ?? []).filter((step) => manualStepApplies(step, ctx));
+  }
+
+  /** Mirrors `AppInstallerService`'s private helper of the same name — small enough that
+   * extracting a shared util isn't worth the cross-module coupling yet. */
+  private instanceContext(): { bucketStorage: boolean; platformMode: boolean } {
+    const adapter = this.storageAdapter as IStorageAdapter & { getAdapterType?: () => string };
+    const adapterName = adapter.getAdapterType?.() ?? this.storageAdapter.constructor.name;
+    return {
+      bucketStorage: !adapterName.toLowerCase().includes('local'),
+      platformMode:
+        this.configService.get<string>('PLATFORM_MODE') === 'true' ||
+        process.env.PLATFORM_MODE === 'true',
+    };
+  }
+
   private async requireRow(installedAppId: string): Promise<InstalledApp> {
     const [row] = await db
       .select()
@@ -97,4 +396,14 @@ export class AppCatalogService {
     if (!row) throw new NotFoundException(`Installed app ${installedAppId} not found`);
     return row;
   }
+}
+
+/**
+ * An app can (in principle) be installed into more than one project, but
+ * `CatalogEntry.installed` is singular — the catalog is a browse view, not a
+ * per-project inventory. Picks the most recently touched row so the entry
+ * reflects whatever the operator did last.
+ */
+function pickPrimaryRow(rows: InstalledApp[]): InstalledApp {
+  return rows.reduce((latest, row) => (row.updatedAt > latest.updatedAt ? row : latest));
 }

--- a/apps/backend/src/app-catalog/app-catalog.service.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.ts
@@ -181,9 +181,24 @@ export class AppCatalogService {
    * Undo is keyed by jobId (the wizard only has the job it just started), not
    * by installedAppId — a job that failed before an `installed_apps` row ever
    * got created has nothing to undo.
+   *
+   * Undo is an INSTALL-only operation. `createdResources` is cumulative across
+   * the row's whole lifetime, so undoing a failed *update* would tear down the
+   * ORIGINAL install — rule sets, alias, domain, deployment and, because undo
+   * passes `includeSchemas: true`, the data tables that install created, live
+   * records and all. A transient fetch blip during an update must never be one
+   * click away from that. An update has its own, non-destructive rollback: the
+   * alias's deployment history still points at the previous version.
    */
   async undoJob(jobId: string, userId: string): Promise<{ removed: string[]; failures?: string[] }> {
     const job = this.getJob(jobId);
+    if (job.kind === 'update') {
+      throw new BadRequestException(
+        'Undo is not available for an update — it would delete the original install, including its data ' +
+          "tables. Nothing was removed: roll back by re-pointing the app's alias to the previous deployment " +
+          'in its history, or run the update again once the cause is fixed.',
+      );
+    }
     if (!job.installedAppId) {
       return { removed: [] };
     }

--- a/apps/backend/src/app-catalog/app-catalog.service.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.ts
@@ -1,8 +1,13 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import { db } from '../db/client';
-import { installedApps, type InstalledApp, type InstalledAppStatus } from '../db/schema';
+import {
+  domainMappings,
+  installedApps,
+  type InstalledApp,
+  type InstalledAppStatus,
+} from '../db/schema';
 import { ProjectsService } from '../projects/projects.service';
 import { IStorageAdapter, STORAGE_ADAPTER } from '../storage/storage.interface';
 import { resolveLocalAdapter } from '../storage/local.adapter';
@@ -117,19 +122,23 @@ export class AppCatalogService {
       else rowsByAppId.set(row.appId, [row]);
     }
 
+    const domainsById = await this.fetchDomainsById(rows);
+
     const data: CatalogEntry[] = [];
     const seen = new Set<string>();
 
     if (registryResult.ok) {
       for (const entry of registryResult.registry.apps) {
         seen.add(entry.id);
-        data.push(await this.buildRegistryEntry(entry, rowsByAppId.get(entry.id) ?? []));
+        data.push(
+          await this.buildRegistryEntry(entry, rowsByAppId.get(entry.id) ?? [], domainsById),
+        );
       }
     }
 
     for (const [appId, appRows] of rowsByAppId) {
       if (seen.has(appId)) continue;
-      data.push(await this.buildManifestOnlyEntry(appRows));
+      data.push(await this.buildManifestOnlyEntry(appRows, domainsById));
     }
 
     return registryResult.ok ? { data } : { data, registryError: registryResult.error };
@@ -263,7 +272,11 @@ export class AppCatalogService {
 
   // ==================== catalog assembly helpers ====================
 
-  private async buildRegistryEntry(entry: AppRegistryEntry, rows: InstalledApp[]): Promise<CatalogEntry> {
+  private async buildRegistryEntry(
+    entry: AppRegistryEntry,
+    rows: InstalledApp[],
+    domainsById: Map<string, string>,
+  ): Promise<CatalogEntry> {
     const gates = await this.preflightService.instanceGates(entry.requires);
     const base: CatalogEntry = {
       id: entry.id,
@@ -279,11 +292,14 @@ export class AppCatalogService {
     if (rows.length === 0) return base;
 
     const row = pickPrimaryRow(rows);
-    return { ...base, installed: await this.buildInstalledSummary(row, entry.version) };
+    return { ...base, installed: await this.buildInstalledSummary(row, entry.version, domainsById) };
   }
 
   /** An installed app whose app id isn't (or no longer is) in the registry. */
-  private async buildManifestOnlyEntry(rows: InstalledApp[]): Promise<CatalogEntry> {
+  private async buildManifestOnlyEntry(
+    rows: InstalledApp[],
+    domainsById: Map<string, string>,
+  ): Promise<CatalogEntry> {
     const row = pickPrimaryRow(rows);
     const manifest = row.manifest as AppManifest;
     const gates = await this.preflightService.instanceGates(manifest.requires);
@@ -297,13 +313,14 @@ export class AppCatalogService {
       sourceUrl: manifest.sourceUrl,
       gates,
       installable: false, // no registry entry to install/reinstall from
-      installed: await this.buildInstalledSummary(row, undefined),
+      installed: await this.buildInstalledSummary(row, undefined, domainsById),
     };
   }
 
   private async buildInstalledSummary(
     row: InstalledApp,
     registryVersion: string | undefined,
+    domainsById: Map<string, string>,
   ): Promise<NonNullable<CatalogEntry['installed']>> {
     const manifest = row.manifest as AppManifest;
     const project = await this.projectsService.getProjectById(row.projectId);
@@ -316,7 +333,7 @@ export class AppCatalogService {
       projectId: row.projectId,
       projectName: `${project.owner}/${project.name}`,
       alias: row.alias,
-      appUrl: this.computeAppUrl(manifest, row),
+      appUrl: this.resolveAppUrl(row, domainsById),
       status: row.status,
       updateAvailable,
       manualSteps: this.applicableManualSteps(manifest),
@@ -367,23 +384,42 @@ export class AppCatalogService {
   }
 
   /**
-   * Only computable when this install owns a domain mapping — there is no
-   * persisted "default alias URL" on the row to fall back to (unlike the
-   * installer's in-flight `deployment.urls.default`), so a domain-less app
-   * simply has no catalog `appUrl` and the admin UI links to the deployment
-   * instead.
+   * Batch-fetches the `domain_mappings.domain` string for every row's
+   * `domainId` in one query, so `listCatalog` doesn't issue an N+1 lookup per
+   * installed row.
    */
-  private computeAppUrl(manifest: AppManifest, row: InstalledApp): string | undefined {
-    if (!row.domainId) return undefined;
-    const appHost = this.computeAppHost(manifest);
-    return appHost ? `https://${appHost}` : undefined;
+  private async fetchDomainsById(rows: InstalledApp[]): Promise<Map<string, string>> {
+    const domainIds = [...new Set(rows.map((row) => row.domainId).filter((id): id is string => Boolean(id)))];
+    if (domainIds.length === 0) return new Map();
+
+    const mappings = await db
+      .select({ id: domainMappings.id, domain: domainMappings.domain })
+      .from(domainMappings)
+      .where(inArray(domainMappings.id, domainIds));
+
+    return new Map(mappings.map((mapping) => [mapping.id, mapping.domain]));
   }
 
-  private computeAppHost(manifest: AppManifest): string | null {
-    const subdomain = manifest.install.domain?.subdomain;
-    if (!subdomain) return null;
-    const primaryDomain = this.configService.get<string>('PRIMARY_DOMAIN') || '';
-    return primaryDomain ? `${subdomain}.${primaryDomain}` : null;
+  /**
+   * The catalog card's "Open" link must point at wherever this install
+   * ACTUALLY lives — the domain row its install (or update) created — not at
+   * `manifest.install.domain.subdomain`, which is only the manifest's
+   * *default* suggestion. The operator may have overridden the subdomain at
+   * install time (e.g. manifest default `handoff`, operator chose `files`),
+   * and reading the manifest back here would silently ignore that override.
+   *
+   * Only computable when this install owns a domain mapping — there is no
+   * persisted "default alias URL" on the row to fall back to (unlike the
+   * installer's in-flight `deployment.urls.default`). If `domainId` points at
+   * a mapping that's since been deleted (operator removed it by hand), this
+   * also yields `undefined` rather than guessing from the manifest — a stale
+   * wrong link is worse than none, and the admin UI links to the deployment
+   * instead.
+   */
+  private resolveAppUrl(row: InstalledApp, domainsById: Map<string, string>): string | undefined {
+    if (!row.domainId) return undefined;
+    const domain = domainsById.get(row.domainId);
+    return domain ? `https://${domain}` : undefined;
   }
 
   private applicableManualSteps(manifest: AppManifest): AppManualStep[] {

--- a/apps/backend/src/app-catalog/app-cert-step.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-cert-step.service.spec.ts
@@ -1,0 +1,169 @@
+import { AppCertStepService } from './app-cert-step.service';
+import { loadInstanceConfig } from '../bootstrap/instance-config';
+
+jest.mock('../bootstrap/instance-config');
+
+const mockLoadInstanceConfig = loadInstanceConfig as jest.Mock;
+
+const APP_HOST = 'handoff.example.com';
+
+function makeDomainsService(exists = false) {
+  return {
+    getWildcardCertificateStatus: jest.fn().mockResolvedValue({ exists }),
+  };
+}
+
+function makePrimarySslService() {
+  return {
+    issueLetsEncrypt: jest.fn(),
+  };
+}
+
+function build(domainsExists = false) {
+  const domains = makeDomainsService(domainsExists);
+  const primarySsl = makePrimarySslService();
+  const svc = new AppCertStepService(domains as any, primarySsl as any);
+  return { svc, domains, primarySsl };
+}
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  jest.clearAllMocks();
+});
+
+describe('AppCertStepService.plan', () => {
+  it('branch 1: PLATFORM_MODE=true → platform/delegated', async () => {
+    process.env.PLATFORM_MODE = 'true';
+    delete process.env.SSL_MANAGED_EXTERNALLY;
+    const { svc } = build();
+    const plan = await svc.plan(APP_HOST);
+    expect(plan).toEqual({ model: 'platform', action: 'delegated' });
+  });
+
+  it('branch 1: SSL_MANAGED_EXTERNALLY=true → platform/delegated', async () => {
+    delete process.env.PLATFORM_MODE;
+    process.env.SSL_MANAGED_EXTERNALLY = 'true';
+    const { svc } = build();
+    const plan = await svc.plan(APP_HOST);
+    expect(plan).toEqual({ model: 'platform', action: 'delegated' });
+  });
+
+  it('branch 2: wildcard exists → wildcard/covered', async () => {
+    delete process.env.PLATFORM_MODE;
+    delete process.env.SSL_MANAGED_EXTERNALLY;
+    const { svc } = build(true);
+    const plan = await svc.plan(APP_HOST);
+    expect(plan).toEqual({ model: 'wildcard', action: 'covered' });
+  });
+
+  it('branch 3: loadInstanceConfig() null → unknown/report', async () => {
+    delete process.env.PLATFORM_MODE;
+    delete process.env.SSL_MANAGED_EXTERNALLY;
+    mockLoadInstanceConfig.mockReturnValue(null);
+    const { svc } = build(false);
+    const plan = await svc.plan(APP_HOST);
+    expect(plan).toEqual({ model: 'unknown', action: 'report' });
+  });
+
+  it('branch 4: proxyMode cloudflare → edge-terminated/none-needed', async () => {
+    delete process.env.PLATFORM_MODE;
+    delete process.env.SSL_MANAGED_EXTERNALLY;
+    mockLoadInstanceConfig.mockReturnValue({ proxyMode: 'cloudflare', sslMode: 'letsencrypt' });
+    const { svc } = build(false);
+    const plan = await svc.plan(APP_HOST);
+    expect(plan).toEqual({ model: 'edge-terminated', action: 'none-needed' });
+  });
+
+  it('branch 4: proxyMode proxy → edge-terminated/none-needed', async () => {
+    delete process.env.PLATFORM_MODE;
+    delete process.env.SSL_MANAGED_EXTERNALLY;
+    mockLoadInstanceConfig.mockReturnValue({ proxyMode: 'proxy', sslMode: 'letsencrypt' });
+    const { svc } = build(false);
+    const plan = await svc.plan(APP_HOST);
+    expect(plan).toEqual({ model: 'edge-terminated', action: 'none-needed' });
+  });
+
+  it('branch 4: sslMode selfsigned → edge-terminated/none-needed', async () => {
+    delete process.env.PLATFORM_MODE;
+    delete process.env.SSL_MANAGED_EXTERNALLY;
+    mockLoadInstanceConfig.mockReturnValue({ proxyMode: 'none', sslMode: 'selfsigned' });
+    const { svc } = build(false);
+    const plan = await svc.plan(APP_HOST);
+    expect(plan).toEqual({ model: 'edge-terminated', action: 'none-needed' });
+  });
+
+  it('branch 5: proxyMode none + sslMode letsencrypt → direct-le/stage-san-reissue', async () => {
+    delete process.env.PLATFORM_MODE;
+    delete process.env.SSL_MANAGED_EXTERNALLY;
+    mockLoadInstanceConfig.mockReturnValue({ proxyMode: 'none', sslMode: 'letsencrypt' });
+    const { svc } = build(false);
+    const plan = await svc.plan(APP_HOST);
+    expect(plan).toEqual({ model: 'direct-le', action: 'stage-san-reissue' });
+  });
+});
+
+describe('AppCertStepService.execute', () => {
+  it('delegated → skipped, never touches PrimarySslService', async () => {
+    const { svc, primarySsl } = build();
+    const result = await svc.execute({ model: 'platform', action: 'delegated' }, APP_HOST);
+    expect(result.status).toBe('skipped');
+    expect(primarySsl.issueLetsEncrypt).not.toHaveBeenCalled();
+  });
+
+  it('covered → done, never touches PrimarySslService', async () => {
+    const { svc, primarySsl } = build();
+    const result = await svc.execute({ model: 'wildcard', action: 'covered' }, APP_HOST);
+    expect(result.status).toBe('done');
+    expect(primarySsl.issueLetsEncrypt).not.toHaveBeenCalled();
+  });
+
+  it('none-needed → skipped, never touches PrimarySslService', async () => {
+    const { svc, primarySsl } = build();
+    const result = await svc.execute({ model: 'edge-terminated', action: 'none-needed' }, APP_HOST);
+    expect(result.status).toBe('skipped');
+    expect(primarySsl.issueLetsEncrypt).not.toHaveBeenCalled();
+  });
+
+  it('report (unknown) → never touches PrimarySslService', async () => {
+    const { svc, primarySsl } = build();
+    const result = await svc.execute({ model: 'unknown', action: 'report' }, APP_HOST);
+    expect(['skipped', 'action-required']).toContain(result.status);
+    expect(primarySsl.issueLetsEncrypt).not.toHaveBeenCalled();
+  });
+
+  it('stage-san-reissue success → action-required with the apply-ssl-cert manual step', async () => {
+    const { svc, primarySsl } = build();
+    primarySsl.issueLetsEncrypt.mockResolvedValue({ issued: true, sans: [APP_HOST], reused: false });
+    const result = await svc.execute({ model: 'direct-le', action: 'stage-san-reissue' }, APP_HOST);
+    expect(primarySsl.issueLetsEncrypt).toHaveBeenCalledWith({ extraSans: [APP_HOST] });
+    expect(result.status).toBe('action-required');
+    expect(result.manualStep).toEqual({
+      id: 'apply-ssl-cert',
+      title: 'Apply the updated certificate',
+      body: `A new certificate including ${APP_HOST} was issued and staged. Review and apply it, then confirm within the safety window.`,
+      deepLink: '/admin/settings/ssl',
+      appliesWhen: 'selfHosted',
+    });
+  });
+
+  it('stage-san-reissue failure → degrades to action-required, install not failed, both remediation routes named', async () => {
+    const { svc, primarySsl } = build();
+    primarySsl.issueLetsEncrypt.mockRejectedValue(new Error('DNS/port-80 preflight failed; not requesting a certificate'));
+    const result = await svc.execute({ model: 'direct-le', action: 'stage-san-reissue' }, APP_HOST);
+    expect(result.status).toBe('action-required');
+    expect(result.detail).toContain('DNS/port-80 preflight failed');
+    expect(result.manualStep).toBeDefined();
+    // Both remediation routes must be named: wildcard cert AND manual SSL page re-issue.
+    expect(result.manualStep!.body.toLowerCase()).toContain('wildcard');
+    expect(result.manualStep!.body.toLowerCase()).toContain('settings');
+    expect(result.manualStep!.deepLink).toBe('/admin/settings/ssl');
+  });
+
+  it('stage-san-reissue never throws — issuance failure is caught and returned, not raised', async () => {
+    const { svc, primarySsl } = build();
+    primarySsl.issueLetsEncrypt.mockRejectedValue(new Error('boom'));
+    await expect(svc.execute({ model: 'direct-le', action: 'stage-san-reissue' }, APP_HOST)).resolves.toBeDefined();
+  });
+});

--- a/apps/backend/src/app-catalog/app-cert-step.service.ts
+++ b/apps/backend/src/app-catalog/app-cert-step.service.ts
@@ -1,0 +1,147 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DomainsService } from '../domains/domains.service';
+import { PrimarySslService } from '../setup/primary-ssl/primary-ssl.service';
+import { loadInstanceConfig } from '../bootstrap/instance-config';
+import type { AppManualStep } from './app-manifest.types';
+
+export type CertPlan =
+  | { model: 'platform'; action: 'delegated' }
+  | { model: 'wildcard'; action: 'covered' }
+  | { model: 'edge-terminated'; action: 'none-needed' } // proxyMode cloudflare/proxy, or sslMode selfsigned
+  | { model: 'direct-le'; action: 'stage-san-reissue' }
+  | { model: 'unknown'; action: 'report' };
+
+export interface AppCertStepResult {
+  status: 'done' | 'action-required' | 'skipped';
+  detail: string;
+  manualStep?: AppManualStep;
+}
+
+/**
+ * AppCertStepService — Task 8 of the app-catalog spec. Decides how (or
+ * whether) this instance's serving model already covers a newly-installed
+ * app's host with TLS, and if not, stages a widened Let's Encrypt
+ * certificate (never live, never auto-applied) plus a manual step for the
+ * operator to review and confirm.
+ *
+ * A cert problem must NEVER fail the install — the app stays reachable over
+ * the wildcard/existing certificate or plain HTTP in the meantime. Every
+ * execute() branch degrades to `action-required`/`skipped`/`done`, never
+ * throws.
+ */
+@Injectable()
+export class AppCertStepService {
+  private readonly logger = new Logger(AppCertStepService.name);
+
+  constructor(
+    private readonly domainsService: DomainsService,
+    private readonly primarySslService: PrimarySslService,
+  ) {}
+
+  async plan(appHost: string): Promise<CertPlan> {
+    // 1. Platform mode / SSL managed externally — DomainsService.create()
+    // already forces sslEnabled: true and notifies the Control Plane; this
+    // instance never touches certs for its own apps either.
+    if (process.env.PLATFORM_MODE === 'true' || process.env.SSL_MANAGED_EXTERNALLY === 'true') {
+      return { model: 'platform', action: 'delegated' };
+    }
+
+    // 2. A genuine *.<primary> wildcard already covers every subdomain,
+    // including this app's.
+    const wildcard = await this.domainsService.getWildcardCertificateStatus();
+    if (wildcard?.exists) {
+      return { model: 'wildcard', action: 'covered' };
+    }
+
+    // 3. No bootstrap-managed instance config (legacy compose install) — we
+    // can't safely reason about the serving model here. Report only; never
+    // touch certs.
+    const cfg = loadInstanceConfig();
+    if (!cfg) {
+      return { model: 'unknown', action: 'report' };
+    }
+
+    // 4. Edge (Cloudflare/reverse proxy) or self-signed serving: the
+    // wildcard 443 block (or self-signed cert) already answers for
+    // *.<primary>, so there's nothing to issue for this specific host.
+    if (cfg.proxyMode === 'cloudflare' || cfg.proxyMode === 'proxy' || cfg.sslMode === 'selfsigned') {
+      return { model: 'edge-terminated', action: 'none-needed' };
+    }
+
+    // 5. Direct serving + Let's Encrypt (proxyMode 'none' + sslMode
+    // 'letsencrypt'): the primary cert's fixed SAN list doesn't cover this
+    // app's subdomain — stage a widened re-issue.
+    return { model: 'direct-le', action: 'stage-san-reissue' };
+  }
+
+  async execute(plan: CertPlan, appHost: string): Promise<AppCertStepResult> {
+    switch (plan.model) {
+      case 'platform':
+        return {
+          status: 'skipped',
+          detail: 'SSL is managed by the platform edge; no certificate action needed for this app.',
+        };
+      case 'wildcard':
+        return {
+          status: 'done',
+          detail: `The existing wildcard certificate already covers ${appHost}.`,
+        };
+      case 'edge-terminated':
+        return {
+          status: 'skipped',
+          detail:
+            'TLS for this host is terminated at the edge/proxy (or served self-signed); no certificate action needed.',
+        };
+      case 'unknown':
+        return {
+          status: 'skipped',
+          detail:
+            "Could not determine this instance's SSL configuration (no managed instance config found); " +
+            'skipping the automatic certificate step. Verify SSL for this app manually.',
+        };
+      case 'direct-le':
+        return this.executeStageSanReissue(appHost);
+    }
+  }
+
+  private async executeStageSanReissue(appHost: string): Promise<AppCertStepResult> {
+    try {
+      await this.primarySslService.issueLetsEncrypt({ extraSans: [appHost] });
+      return {
+        status: 'action-required',
+        detail: `A new certificate including ${appHost} was issued and staged.`,
+        manualStep: {
+          id: 'apply-ssl-cert',
+          title: 'Apply the updated certificate',
+          body:
+            `A new certificate including ${appHost} was issued and staged. Review and apply it, ` +
+            'then confirm within the safety window.',
+          deepLink: '/admin/settings/ssl',
+          appliesWhen: 'selfHosted',
+        },
+      };
+    } catch (error) {
+      // Never fail the install for a cert problem — the app remains
+      // reachable over the wildcard/existing certificate or plain HTTP
+      // meanwhile. Degrade to a manual step naming both remediation routes.
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(`Automatic Let's Encrypt SAN re-issue for ${appHost} failed: ${message}`);
+      return {
+        status: 'action-required',
+        detail: `Automatic certificate issuance for ${appHost} failed: ${message}.`,
+        manualStep: {
+          id: 'apply-ssl-cert',
+          title: 'Add SSL coverage for this app manually',
+          body:
+            `Automatic certificate issuance for ${appHost} failed (${message}). The app remains reachable ` +
+            'over the existing certificate/wildcard or plain HTTP meanwhile. Two ways to add coverage: ' +
+            "(1) provision a wildcard certificate — it will automatically cover this subdomain once enabled " +
+            'via "enable SSL for all subdomains"; or (2) go to Admin → Settings → SSL and re-issue ' +
+            `the primary certificate, including ${appHost}.`,
+          deepLink: '/admin/settings/ssl',
+          appliesWhen: 'selfHosted',
+        },
+      };
+    }
+  }
+}

--- a/apps/backend/src/app-catalog/app-install-jobs.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-install-jobs.service.spec.ts
@@ -1,0 +1,154 @@
+import { BadRequestException } from '@nestjs/common';
+import { AppInstallJobsService, type InstallStepId } from './app-install-jobs.service';
+
+const STEPS: InstallStepId[] = ['preflight', 'fetch', 'sync-rules', 'deploy', 'record'];
+
+describe('AppInstallJobsService', () => {
+  let service: AppInstallJobsService;
+
+  beforeEach(() => {
+    service = new AppInstallJobsService();
+  });
+
+  describe('create', () => {
+    it('creates a running job with every declared step pending, in order', () => {
+      const job = service.create('install', 'handoff', STEPS);
+
+      expect(job.id).toMatch(/^app-install-\d+/);
+      expect(job.kind).toBe('install');
+      expect(job.appId).toBe('handoff');
+      expect(job.projectId).toBeNull();
+      expect(job.status).toBe('running');
+      expect(job.steps.map((s) => s.id)).toEqual(STEPS);
+      expect(job.steps.every((s) => s.status === 'pending')).toBe(true);
+      expect(job.createdAt).toEqual(expect.any(String));
+      expect(job.finishedAt).toBeUndefined();
+    });
+
+    it('throws BadRequestException when another job is still running (single-flight)', () => {
+      service.create('install', 'handoff', STEPS);
+
+      expect(() => service.create('install', 'other-app', STEPS)).toThrow(BadRequestException);
+      expect(() => service.create('update', 'handoff', STEPS)).toThrow(/already/i);
+    });
+
+    it('allows a new job once the previous one finished', () => {
+      const first = service.create('install', 'handoff', STEPS);
+      service.finish(first.id, 'succeeded');
+
+      const second = service.create('update', 'handoff', STEPS);
+
+      expect(second.status).toBe('running');
+      expect(second.id).not.toBe(first.id);
+    });
+
+    it('gives concurrent-in-the-same-millisecond jobs distinct ids', () => {
+      const first = service.create('install', 'handoff', STEPS);
+      service.finish(first.id, 'succeeded');
+      const second = service.create('install', 'handoff', STEPS);
+      service.finish(second.id, 'succeeded');
+      const third = service.create('install', 'handoff', STEPS);
+
+      const ids = new Set([first.id, second.id, third.id]);
+      expect(ids.size).toBe(3);
+      expect(service.get(first.id)).not.toBeNull();
+      expect(service.get(second.id)).not.toBeNull();
+    });
+  });
+
+  describe('get', () => {
+    it('returns the job by id', () => {
+      const job = service.create('install', 'handoff', STEPS);
+      expect(service.get(job.id)).toBe(job);
+    });
+
+    it('returns null for an unknown id', () => {
+      expect(service.get('nope')).toBeNull();
+    });
+  });
+
+  describe('setStep', () => {
+    it('patches only the named step and leaves the others alone', () => {
+      const job = service.create('install', 'handoff', STEPS);
+
+      service.setStep(job.id, 'fetch', { status: 'running' });
+      service.setStep(job.id, 'fetch', { status: 'done', detail: 'cached' });
+
+      const fetchStep = service.get(job.id)!.steps.find((s) => s.id === 'fetch');
+      expect(fetchStep).toEqual({ id: 'fetch', status: 'done', detail: 'cached' });
+      expect(service.get(job.id)!.steps.find((s) => s.id === 'deploy')!.status).toBe('pending');
+    });
+
+    it('records failure detail on a step', () => {
+      const job = service.create('install', 'handoff', STEPS);
+
+      service.setStep(job.id, 'deploy', { status: 'failed', error: 'alias missing' });
+
+      expect(service.get(job.id)!.steps.find((s) => s.id === 'deploy')).toEqual({
+        id: 'deploy',
+        status: 'failed',
+        error: 'alias missing',
+      });
+    });
+
+    it('is a no-op for an unknown job or an unknown step', () => {
+      const job = service.create('install', 'handoff', STEPS);
+
+      expect(() => service.setStep('nope', 'fetch', { status: 'done' })).not.toThrow();
+      expect(() => service.setStep(job.id, 'domain', { status: 'done' })).not.toThrow();
+      expect(service.get(job.id)!.steps.map((s) => s.id)).toEqual(STEPS);
+    });
+  });
+
+  describe('finish', () => {
+    it('sets the terminal status, stamps finishedAt and merges the patch', () => {
+      const job = service.create('install', 'handoff', STEPS);
+
+      service.finish(job.id, 'succeeded', {
+        installedAppId: 'ia-1',
+        appUrl: 'https://handoff.example.com',
+        manualSteps: [{ id: 'bucket-cors', title: 'CORS', body: 'do it' }],
+      });
+
+      const finished = service.get(job.id)!;
+      expect(finished.status).toBe('succeeded');
+      expect(finished.finishedAt).toEqual(expect.any(String));
+      expect(finished.installedAppId).toBe('ia-1');
+      expect(finished.appUrl).toBe('https://handoff.example.com');
+      expect(finished.manualSteps).toHaveLength(1);
+    });
+
+    it('records the error on a failed job', () => {
+      const job = service.create('install', 'handoff', STEPS);
+
+      service.finish(job.id, 'failed', { error: 'boom' });
+
+      expect(service.get(job.id)!.status).toBe('failed');
+      expect(service.get(job.id)!.error).toBe('boom');
+    });
+
+    it('is a no-op for an unknown job id', () => {
+      expect(() => service.finish('nope', 'failed')).not.toThrow();
+    });
+  });
+
+  describe('getActive / findByInstalledApp', () => {
+    it('getActive returns the running job, and null once it finished', () => {
+      const job = service.create('install', 'handoff', STEPS);
+      expect(service.getActive()).toBe(job);
+
+      service.finish(job.id, 'succeeded');
+      expect(service.getActive()).toBeNull();
+    });
+
+    it('findByInstalledApp returns the most recent job for an installed app row', () => {
+      const first = service.create('install', 'handoff', STEPS);
+      service.finish(first.id, 'succeeded', { installedAppId: 'ia-1' });
+      const second = service.create('update', 'handoff', STEPS);
+      service.finish(second.id, 'succeeded', { installedAppId: 'ia-1' });
+
+      expect(service.findByInstalledApp('ia-1')?.id).toBe(second.id);
+      expect(service.findByInstalledApp('ia-2')).toBeNull();
+    });
+  });
+});

--- a/apps/backend/src/app-catalog/app-install-jobs.service.ts
+++ b/apps/backend/src/app-catalog/app-install-jobs.service.ts
@@ -1,0 +1,135 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import type { AppManualStep } from './app-manifest.types';
+
+export type InstallStepId =
+  | 'preflight'
+  | 'fetch'
+  | 'sync-rules'
+  | 'deploy'
+  | 'domain'
+  | 'certificate'
+  | 'schedules'
+  | 'record';
+
+export interface InstallStepState {
+  id: InstallStepId;
+  status: 'pending' | 'running' | 'done' | 'failed' | 'skipped' | 'action-required';
+  detail?: string;
+  error?: string;
+}
+
+export interface InstallJob {
+  id: string;
+  kind: 'install' | 'update';
+  appId: string;
+  /** null until the project is resolved (the `newProject` path). */
+  projectId: string | null;
+  status: 'running' | 'succeeded' | 'failed' | 'undone';
+  steps: InstallStepState[];
+  installedAppId?: string;
+  /** Manifest steps filtered by `manualStepApplies`, plus cert-synthesized ones. */
+  manualSteps?: AppManualStep[];
+  appUrl?: string;
+  error?: string;
+  createdAt: string;
+  finishedAt?: string;
+}
+
+/**
+ * AppInstallJobsService — in-memory install/update job registry (Task 9 of the
+ * app-catalog spec). Deliberately NOT persisted: a job is a live progress
+ * view, while the durable record of what happened is the `installed_apps` row
+ * the applier writes (which is what powers undo/resume across a restart).
+ *
+ * Single-flight by design: an app install touches nginx configs, aliases and
+ * certificates, so two concurrent runs could interleave destructively. The
+ * same shape as `StorageMigrationService` (one `currentMigration` at a time).
+ */
+@Injectable()
+export class AppInstallJobsService {
+  /** Bounded so a long-lived instance can't accumulate jobs forever. */
+  private readonly MAX_JOBS = 20;
+  private readonly jobs = new Map<string, InstallJob>();
+  private activeJobId: string | null = null;
+
+  create(kind: 'install' | 'update', appId: string, stepIds: InstallStepId[]): InstallJob {
+    const active = this.activeJobId ? this.jobs.get(this.activeJobId) : undefined;
+    if (active && active.status === 'running') {
+      throw new BadRequestException(
+        `An app ${active.kind} is already running (${active.appId}). Wait for it to finish before starting another.`,
+      );
+    }
+
+    const job: InstallJob = {
+      id: this.nextId(),
+      kind,
+      appId,
+      projectId: null,
+      status: 'running',
+      steps: stepIds.map((id) => ({ id, status: 'pending' })),
+      createdAt: new Date().toISOString(),
+    };
+
+    this.jobs.set(job.id, job);
+    this.activeJobId = job.id;
+    this.evictOldest();
+    return job;
+  }
+
+  get(jobId: string): InstallJob | null {
+    return this.jobs.get(jobId) ?? null;
+  }
+
+  /** The currently running job, if any — lets the UI resume polling after a reload. */
+  getActive(): InstallJob | null {
+    const active = this.activeJobId ? this.jobs.get(this.activeJobId) : undefined;
+    return active && active.status === 'running' ? active : null;
+  }
+
+  /** Most recent job that produced/targeted the given `installed_apps` row. */
+  findByInstalledApp(installedAppId: string): InstallJob | null {
+    let found: InstallJob | null = null;
+    for (const job of this.jobs.values()) {
+      if (job.installedAppId === installedAppId) found = job; // insertion order = chronological
+    }
+    return found;
+  }
+
+  /** Stamped once the applier has resolved (or created) the target project. */
+  setProjectId(jobId: string, projectId: string): void {
+    const job = this.jobs.get(jobId);
+    if (job) job.projectId = projectId;
+  }
+
+  setStep(jobId: string, step: InstallStepId, patch: Partial<InstallStepState>): void {
+    const job = this.jobs.get(jobId);
+    if (!job) return;
+    const index = job.steps.findIndex((s) => s.id === step);
+    if (index === -1) return;
+    job.steps[index] = { ...job.steps[index], ...patch, id: step };
+  }
+
+  finish(jobId: string, status: InstallJob['status'], patch: Partial<InstallJob> = {}): void {
+    const job = this.jobs.get(jobId);
+    if (!job) return;
+    Object.assign(job, patch, { status, finishedAt: new Date().toISOString() });
+    if (this.activeJobId === jobId) this.activeJobId = null;
+  }
+
+  private nextId(): string {
+    const base = `app-install-${Date.now()}`;
+    if (!this.jobs.has(base)) return base;
+    // Two jobs created inside the same millisecond (tests, fast retries).
+    let suffix = 1;
+    while (this.jobs.has(`${base}-${suffix}`)) suffix++;
+    return `${base}-${suffix}`;
+  }
+
+  private evictOldest(): void {
+    while (this.jobs.size > this.MAX_JOBS) {
+      const oldest = this.jobs.keys().next().value;
+      if (oldest === undefined || oldest === this.activeJobId) break;
+      this.jobs.delete(oldest);
+    }
+  }
+}

--- a/apps/backend/src/app-catalog/app-installer.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.spec.ts
@@ -436,6 +436,37 @@ describe('AppInstallerService', () => {
 
       expect(jobs.get(jobId)!.manualSteps!.map((s) => s.id)).toEqual(['bucket-cors']);
     });
+
+    it('does not treat a CachingStorageAdapter-wrapped local adapter as bucket storage (regression: live droplet Redis cache)', async () => {
+      // Shape observed live: STORAGE_ADAPTER is a CachingStorageAdapter wrapping the real
+      // LocalStorageAdapter. It has no getAdapterType(), so the old `getAdapterType?.() ??
+      // constructor.name` fallback resolved to 'CachingStorageAdapter' -> bucketStorage=true,
+      // wrongly surfacing the bucket-cors manual step on a local-FS install.
+      const wrappedLocalAdapter = {
+        supportsPresignedUrls: () => true,
+        getUnderlyingAdapter: () => ({ isLocalAdapter: true }),
+      };
+      const localService = new AppInstallerService(
+        jobs,
+        bundleService as never,
+        preflight as never,
+        certStep as never,
+        ruleSets as never,
+        deployments as never,
+        domains as never,
+        projects as never,
+        schedules as never,
+        schemas as never,
+        config as unknown as ConfigService,
+        wrappedLocalAdapter as never,
+      );
+      queueInstallDb();
+
+      const { jobId } = localService.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await localService.whenIdle();
+
+      expect(jobs.get(jobId)!.manualSteps!.map((s) => s.id)).toEqual([]);
+    });
   });
 
   describe('project resolution', () => {

--- a/apps/backend/src/app-catalog/app-installer.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.spec.ts
@@ -204,7 +204,7 @@ describe('AppInstallerService', () => {
     createSchedule: jest.Mock;
     deleteSchedule: jest.Mock;
   };
-  let schemas: { delete: jest.Mock };
+  let schemas: { delete: jest.Mock; getByIdWithCount: jest.Mock };
   let config: { get: jest.Mock };
 
   beforeEach(() => {
@@ -251,7 +251,12 @@ describe('AppInstallerService', () => {
       createSchedule: jest.fn().mockResolvedValue({ id: 'sched-1' }),
       deleteSchedule: jest.fn().mockResolvedValue(undefined),
     };
-    schemas = { delete: jest.fn().mockResolvedValue(undefined) };
+    schemas = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      getByIdWithCount: jest.fn((id: string) =>
+        Promise.resolve({ id, name: id, recordCount: 0 }),
+      ),
+    };
     config = {
       get: jest.fn((key: string) => (key === 'PRIMARY_DOMAIN' ? 'example.com' : undefined)),
     };
@@ -1024,30 +1029,113 @@ describe('AppInstallerService', () => {
       aliasName: 'handoff',
       deploymentId: 'dep-1',
       domainId: 'dom-1',
-      scheduleIds: [],
+      scheduleIds: ['sched-1'],
     };
 
-    it('keeps the created data-table schemas when deleteData is false', async () => {
-      mockDb.__queue([{ ...INSTALLED_ROW, createdResources: created }]);
-      mockDb.__queue([]);
+    beforeEach(() => {
+      schemas.getByIdWithCount = jest.fn((id: string) => {
+        if (id === 'sch-new') return Promise.resolve({ id, name: 'handoff_nodes', recordCount: 42 });
+        if (id === 'sch-reused') {
+          return Promise.resolve({ id, name: 'handoff_shared_table', recordCount: 7 });
+        }
+        return Promise.resolve(null);
+      });
+    });
+
+    it('by default removes rule sets, alias, domain, deployment, schedules and keeps ALL data tables', async () => {
+      mockDb.__queue([
+        {
+          ...INSTALLED_ROW,
+          // "rs-adopted" is attached to the app (in ruleSetIds) but was NOT
+          // created by this install (absent from createdResources.ruleSetIds)
+          // — the default uninstall removes it anyway (deviation 5).
+          ruleSetIds: ['rs-1', 'rs-adopted'],
+          schemaIds: ['sch-new', 'sch-reused'],
+          createdResources: created,
+        },
+      ]);
+      mockDb.__queue([]); // delete installed_apps row
 
       const summary = await service.uninstall('ia-1', 'user-1', { deleteData: false });
 
       expect(schemas.delete).not.toHaveBeenCalled();
-      expect(summary.dataDeleted).toBe(false);
-      expect(summary.kept).toEqual(expect.arrayContaining(['schema:sch-new']));
-      expect(summary.removed).toEqual(expect.arrayContaining(['domain:dom-1', 'ruleSet:rs-1']));
+      expect(ruleSets.delete).toHaveBeenCalledWith('rs-1', 'user-1', 'admin', null);
+      expect(ruleSets.delete).toHaveBeenCalledWith('rs-adopted', 'user-1', 'admin', null);
+      expect(deployments.deleteAlias).toHaveBeenCalledWith('acme/site', 'handoff', 'user-1', 'admin');
+      expect(deployments.deleteDeployment).toHaveBeenCalledWith('dep-1', 'user-1', 'admin');
+      expect(domains.remove).toHaveBeenCalledWith('dom-1', 'user-1', undefined, null);
+      expect(schedules.deleteSchedule).toHaveBeenCalledWith('sched-1', 'user-1', 'admin', null);
+
+      expect(summary.removed).toEqual({
+        ruleSets: 2,
+        alias: true,
+        domain: true,
+        deployment: true,
+        schedules: 1,
+      });
+      expect(summary.dataTables.deleted).toEqual([]);
+      expect(summary.dataTables.deletedRecordCounts).toEqual({});
+      expect(summary.dataTables.kept).toEqual(
+        expect.arrayContaining(['handoff_nodes', 'handoff_shared_table']),
+      );
+      expect(summary.dataTables.kept).toHaveLength(2);
+      expect(summary.note).toContain('acme/site');
+      expect(mockDb.delete).toHaveBeenCalled();
     });
 
-    it('deletes the created data-table schemas when deleteData is true', async () => {
-      mockDb.__queue([{ ...INSTALLED_ROW, createdResources: created }]);
+    it('with deleteData: true deletes only created tables, fetching counts first, and never deletes reused tables', async () => {
+      mockDb.__queue([
+        { ...INSTALLED_ROW, schemaIds: ['sch-new', 'sch-reused'], createdResources: created },
+      ]);
       mockDb.__queue([]);
 
       const summary = await service.uninstall('ia-1', 'user-1', { deleteData: true });
 
+      expect(schemas.getByIdWithCount).toHaveBeenCalledWith('sch-new', null);
       expect(schemas.delete).toHaveBeenCalledWith('sch-new', 'user-1', 'admin', null);
-      expect(summary.dataDeleted).toBe(true);
-      expect(summary.removed).toEqual(expect.arrayContaining(['schema:sch-new']));
+      expect(schemas.delete).not.toHaveBeenCalledWith('sch-reused', 'user-1', 'admin', null);
+      expect(schemas.getByIdWithCount.mock.invocationCallOrder[0]).toBeLessThan(
+        schemas.delete.mock.invocationCallOrder[0],
+      );
+
+      expect(summary.dataTables.deleted).toEqual(['handoff_nodes']);
+      expect(summary.dataTables.kept).toEqual(['handoff_shared_table']);
+      expect(summary.dataTables.deletedRecordCounts).toEqual({ handoff_nodes: 42 });
+    });
+
+    it('continues past an individual delete failure and reports accurate counts', async () => {
+      domains.remove.mockRejectedValue(new Error('domain gone'));
+      mockDb.__queue([{ ...INSTALLED_ROW, ruleSetIds: ['rs-1'], createdResources: created }]);
+      mockDb.__queue([]);
+
+      const summary = await service.uninstall('ia-1', 'user-1', { deleteData: false });
+
+      expect(summary.removed.domain).toBe(false);
+      expect(summary.removed.alias).toBe(true);
+      expect(ruleSets.delete).toHaveBeenCalled();
+    });
+  });
+
+  describe('uninstallPreview', () => {
+    it('returns per-table name, record count, and whether this install created it', async () => {
+      mockDb.__queue([
+        {
+          ...INSTALLED_ROW,
+          schemaIds: ['sch-new', 'sch-reused'],
+          createdResources: { schemaIdsCreated: ['sch-new'] },
+        },
+      ]);
+      schemas.getByIdWithCount = jest.fn((id: string) => {
+        if (id === 'sch-new') return Promise.resolve({ id, name: 'handoff_nodes', recordCount: 42 });
+        return Promise.resolve({ id, name: 'handoff_shared_table', recordCount: 7 });
+      });
+
+      const preview = await service.uninstallPreview('ia-1');
+
+      expect(preview.dataTables).toEqual([
+        { name: 'handoff_nodes', recordCount: 42, createdByInstall: true },
+        { name: 'handoff_shared_table', recordCount: 7, createdByInstall: false },
+      ]);
     });
   });
 });

--- a/apps/backend/src/app-catalog/app-installer.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.spec.ts
@@ -504,6 +504,25 @@ describe('AppInstallerService', () => {
       expect(dto.domain).toBe('my-app.example.com');
       expect(jobs.get(jobId)!.appUrl).toBe('https://my-app.example.com');
     });
+
+    it('names both the deployment alias and the serving host in the deploy step detail (manifest alias "handoff" != overridden subdomain "my-app")', async () => {
+      preflight.projectGates.mockResolvedValue({
+        gates: [{ id: 'dns', status: 'pass', message: 'ok' }],
+        syncPlans: [],
+        appHost: 'my-app.example.com',
+      });
+      queueInstallDb();
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1', 'my-app');
+      await service.whenIdle();
+
+      const deployStep = jobs.get(jobId)!.steps.find((s) => s.id === 'deploy')!;
+      // The alias genuinely stays "handoff" (a different namespace from the
+      // subdomain) — wording it alongside the actual serving host avoids
+      // reading like the override was ignored.
+      expect(deployStep.detail).toContain('alias "handoff"');
+      expect(deployStep.detail).toContain('my-app.example.com');
+    });
   });
 
   describe('project resolution', () => {
@@ -1064,6 +1083,62 @@ describe('AppInstallerService', () => {
       const finalUpdate = mockDb.set.mock.calls.at(-1)![0] as { version: string; status: string };
       expect(finalUpdate.status).toBe('installed');
       expect(finalUpdate.version).toBe('1.0.0'); // manifest version wins over the registry entry
+    });
+
+    describe('appUrl (regression: an update read the manifest default subdomain instead of the row it never touches)', () => {
+      // TEST_MANIFEST's install.domain.subdomain is "handoff" — an update
+      // never recreates the domain (no 'domain' step in UPDATE_STEPS), so the
+      // finished job's appUrl must come from the ORIGINAL install's stored
+      // domain row, even when that row's actual host ("files.example.com")
+      // differs from the manifest default.
+      it('resolves appUrl from the stored domain row, not the manifest default subdomain', async () => {
+        mockDb.__queue([{ domain: 'files.example.com' }]); // lookupDomainHost
+        mockDb.__queue([]); // final record update
+
+        const { jobId } = service.startUpdate(
+          { ...installed, domainId: 'dom-1' } as never,
+          { ...ENTRY, version: '1.1.0' },
+          'user-1',
+          { prune: false },
+        );
+        await service.whenIdle();
+
+        const job = jobs.get(jobId)!;
+        expect(job.status).toBe('succeeded');
+        expect(job.appUrl).toBe('https://files.example.com');
+      });
+
+      it('falls back to the deployment URL when domainId points at a since-deleted mapping', async () => {
+        mockDb.__queue([]); // lookupDomainHost: mapping gone
+        mockDb.__queue([]); // final record update
+
+        const { jobId } = service.startUpdate(
+          { ...installed, domainId: 'dom-gone' } as never,
+          { ...ENTRY, version: '1.1.0' },
+          'user-1',
+          { prune: false },
+        );
+        await service.whenIdle();
+
+        expect(jobs.get(jobId)!.appUrl).toBe('https://admin.example.com/alias/handoff');
+      });
+
+      it('names both the deployment alias and the serving host in the deploy step detail', async () => {
+        mockDb.__queue([{ domain: 'files.example.com' }]);
+        mockDb.__queue([]);
+
+        const { jobId } = service.startUpdate(
+          { ...installed, domainId: 'dom-1' } as never,
+          { ...ENTRY, version: '1.1.0' },
+          'user-1',
+          { prune: false },
+        );
+        await service.whenIdle();
+
+        const deployStep = jobs.get(jobId)!.steps.find((s) => s.id === 'deploy')!;
+        expect(deployStep.detail).toContain('alias "handoff"');
+        expect(deployStep.detail).toContain('files.example.com');
+      });
     });
   });
 

--- a/apps/backend/src/app-catalog/app-installer.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.spec.ts
@@ -455,6 +455,29 @@ describe('AppInstallerService', () => {
       expect(finalUpdate.createdResources.projectCreated).toBe(true);
     });
 
+    it('refuses a newProject target whose project already exists, rather than adopting it', async () => {
+      // Preflight's project-scoped gates are all skipped for a newProject
+      // target, so adopting an existing project would install into it
+      // unchecked — and its pre-existing alias would land in
+      // createdResources for a later undo to delete.
+      projects.projectExists.mockResolvedValue(true);
+
+      const { jobId } = service.startInstall(
+        ENTRY,
+        { newProject: { owner: 'acme', name: 'site' } },
+        'user-1',
+      );
+      await service.whenIdle();
+
+      const job = jobs.get(jobId)!;
+      expect(job.status).toBe('failed');
+      expect(job.error).toMatch(/already exists/i);
+      expect(job.error).toMatch(/picker/i);
+      expect(projects.findOrCreateProject).not.toHaveBeenCalled();
+      expect(mockDb.insert).not.toHaveBeenCalled();
+      expect(ruleSets.syncRuleSet).not.toHaveBeenCalled();
+    });
+
     it('inserts the installing row before any project-scoped write', async () => {
       queueInstallDb();
 
@@ -886,7 +909,7 @@ describe('AppInstallerService', () => {
   describe('startUpdate', () => {
     const installed = { ...INSTALLED_ROW, status: 'installed' as const, createdResources: {} };
 
-    it('runs only fetch → sync-rules → deploy → record, leaving the domain alone', async () => {
+    it('runs only preflight → fetch → sync-rules → deploy → record, leaving the domain alone', async () => {
       mockDb.__queue([]); // final record update
 
       const { jobId } = service.startUpdate(
@@ -900,10 +923,56 @@ describe('AppInstallerService', () => {
       const job = jobs.get(jobId)!;
       expect(job.kind).toBe('update');
       expect(job.status).toBe('succeeded');
-      expect(job.steps.map((s) => s.id)).toEqual(['fetch', 'sync-rules', 'deploy', 'record']);
+      expect(job.steps.map((s) => s.id)).toEqual([
+        'preflight',
+        'fetch',
+        'sync-rules',
+        'deploy',
+        'record',
+      ]);
       expect(domains.create).not.toHaveBeenCalled();
+      // Instance gates ARE re-verified; project gates would collide with this
+      // install's own alias/rule sets and are deliberately not run.
+      expect(preflight.instanceGates).toHaveBeenCalledWith(ENTRY.requires);
       expect(preflight.projectGates).not.toHaveBeenCalled();
       expect(schedules.createSchedule).not.toHaveBeenCalled();
+    });
+
+    it('refuses before any collaborator call when an instance gate now fails', async () => {
+      // A registry bump can raise requires.ceMin/presignedStorage: the
+      // previously-installed version says nothing about the new one.
+      preflight.instanceGates.mockResolvedValue([
+        {
+          id: 'ce-version',
+          status: 'fail',
+          message: 'CE 0.3.1 is below the required minimum 0.4.0',
+        },
+      ]);
+
+      const { jobId } = service.startUpdate(installed as never, ENTRY, 'user-1', { prune: false });
+      await service.whenIdle();
+
+      const job = jobs.get(jobId)!;
+      expect(job.status).toBe('failed');
+      expect(job.steps.find((s) => s.id === 'preflight')!.status).toBe('failed');
+      expect(job.error).toMatch(/below the required minimum 0\.4\.0/);
+      expect(bundleService.fetchBundle).not.toHaveBeenCalled();
+      expect(ruleSets.syncRuleSet).not.toHaveBeenCalled();
+      expect(deployments.createDeploymentFromZip).not.toHaveBeenCalled();
+    });
+
+    it('leaves the healthy installed row untouched when a gate refuses the update', async () => {
+      preflight.instanceGates.mockResolvedValue([
+        { id: 'storage', status: 'fail', message: 'no presigned support' },
+      ]);
+
+      service.startUpdate(installed as never, ENTRY, 'user-1', { prune: false });
+      await service.whenIdle();
+
+      // No write at all — in particular the row is NOT restamped 'failed',
+      // which would mislabel a still-working install.
+      expect(mockDb.update).not.toHaveBeenCalled();
+      expect(mockDb.set).not.toHaveBeenCalled();
     });
 
     it('passes the prune flag through to the sync and deploys to the same alias', async () => {

--- a/apps/backend/src/app-catalog/app-installer.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.spec.ts
@@ -469,6 +469,43 @@ describe('AppInstallerService', () => {
     });
   });
 
+  describe('subdomain override', () => {
+    it("passes the override straight through to the job's own re-preflight", async () => {
+      preflight.projectGates.mockResolvedValue({
+        gates: [{ id: 'dns', status: 'pass', message: 'ok' }],
+        syncPlans: [],
+        appHost: 'my-app.example.com',
+      });
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1', 'my-app');
+      await service.whenIdle();
+
+      expect(preflight.projectGates).toHaveBeenCalledWith(
+        expect.anything(),
+        { projectId: 'proj-1' },
+        'user-1',
+        'my-app',
+      );
+    });
+
+    it('creates the app domain at "<override>.<PRIMARY_DOMAIN>", not the manifest default', async () => {
+      preflight.projectGates.mockResolvedValue({
+        gates: [{ id: 'dns', status: 'pass', message: 'ok' }],
+        syncPlans: [],
+        appHost: 'my-app.example.com',
+      });
+      queueInstallDb();
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1', 'my-app');
+      await service.whenIdle();
+
+      const [dto] = domains.create.mock.calls[0];
+      expect(dto.domain).toBe('my-app.example.com');
+      expect(jobs.get(jobId)!.appUrl).toBe('https://my-app.example.com');
+    });
+  });
+
   describe('project resolution', () => {
     it('creates the project and flags projectCreated when it did not exist', async () => {
       projects.projectExists.mockResolvedValue(false);

--- a/apps/backend/src/app-catalog/app-installer.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.spec.ts
@@ -1,0 +1,934 @@
+// Thenable chainable db mock: every builder method returns the chain, and
+// awaiting consumes the next queued result in await order. Mirrors
+// pipeline-schedules.service.spec / app-preflight.service.spec (the house
+// pattern) — declared above imports.
+jest.mock('../db/client', () => {
+  const queued: unknown[] = [];
+  const methods = [
+    'select',
+    'from',
+    'innerJoin',
+    'where',
+    'orderBy',
+    'limit',
+    'insert',
+    'values',
+    'update',
+    'set',
+    'delete',
+    'returning',
+  ];
+  const chainable: Record<string, unknown> = {};
+  for (const method of methods) {
+    chainable[method] = jest.fn(() => chainable);
+  }
+  chainable.then = (
+    resolve: (value: unknown) => unknown,
+    reject: (reason: unknown) => unknown,
+  ) => Promise.resolve(queued.length > 0 ? queued.shift() : []).then(resolve, reject);
+  chainable.__queue = (result: unknown) => queued.push(result);
+  chainable.__reset = () => {
+    queued.length = 0;
+    for (const method of methods) {
+      (chainable[method] as jest.Mock).mockClear();
+    }
+  };
+  return { db: chainable };
+});
+
+import { ConfigService } from '@nestjs/config';
+import { db } from '../db/client';
+import { AppInstallJobsService } from './app-install-jobs.service';
+import { AppInstallerService } from './app-installer.service';
+import type { AppManifest, AppRegistryEntry } from './app-manifest.types';
+import type { LoadedBundle } from './app-bundle.service';
+import type { CreatedResources } from '../db/schema';
+
+const mockDb = db as unknown as Record<string, jest.Mock> & {
+  __queue: (result: unknown) => void;
+  __reset: () => void;
+};
+
+const TEST_MANIFEST: AppManifest = {
+  schemaVersion: 1,
+  id: 'handoff',
+  name: 'Handoff',
+  version: '1.0.0',
+  summary: 'Share files and folders with ACLs',
+  requires: { presignedStorage: true, ceMin: '0.3.15' },
+  install: {
+    alias: 'handoff',
+    deployment: { path: 'dist', basePath: '/apps/handoff/dist' },
+    ruleSets: [
+      { file: 'rulesets/handoff.json', attachToAlias: true },
+      { file: 'rulesets/handoff-rss-feed.json', attachToAlias: false },
+    ],
+    domain: { subdomain: 'handoff', isPublic: true, isSpa: true },
+    schedules: [],
+    manualSteps: [
+      {
+        id: 'bucket-cors',
+        title: 'Configure bucket CORS',
+        body: 'Allow PUT from your app origin on the storage bucket.',
+        appliesWhen: 'bucketStorage',
+      },
+      {
+        id: 'platform-only',
+        title: 'Platform only step',
+        body: 'Never applies on a self-hosted box.',
+        appliesWhen: 'platformMode',
+      },
+    ],
+  },
+  eject: {
+    repo: 'bffless/apps',
+    appPath: 'apps/handoff',
+    deployWorkflow: 'deploy-handoff.yml',
+    variables: ['BFFLESS_URL'],
+    secrets: ['BFFLESS_API_KEY'],
+  },
+};
+
+const ENTRY: AppRegistryEntry = {
+  id: 'handoff',
+  name: 'Handoff',
+  version: '1.0.0',
+  bundleUrl: 'https://example.com/handoff.zip',
+  sha256: 'a'.repeat(64),
+  requires: TEST_MANIFEST.requires,
+};
+
+function encode(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function makeBundle(overrides: Partial<AppManifest> = {}, ruleSetJson?: unknown): LoadedBundle {
+  const manifest = { ...TEST_MANIFEST, ...overrides } as AppManifest;
+  return {
+    manifest,
+    files: {
+      'rulesets/handoff.json': encode(
+        JSON.stringify(
+          ruleSetJson ?? {
+            version: 2,
+            kind: 'proxy-rule-set',
+            ruleSet: { name: 'handoff', description: 'Handoff API' },
+            rules: [{ pathPattern: '/api/nodes', method: 'GET', targetUrl: 'https://api.example.com' }],
+            schemas: [],
+          },
+        ),
+      ),
+      'rulesets/handoff-rss-feed.json': encode(
+        JSON.stringify({ ruleSet: { name: 'handoff-rss-feed' }, rules: [], schemas: [] }),
+      ),
+      'dist/index.html': encode('<!doctype html>ok'),
+      'dist/assets/app.js': encode('console.log(1)'),
+      'README.md': encode('not deployed'),
+    },
+    sha256: 'a'.repeat(64),
+  };
+}
+
+function syncResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    ruleSetId: 'rs-1',
+    created: [{ pathPattern: '/api/nodes', method: 'GET' }],
+    updated: [],
+    deleted: [],
+    unchanged: [],
+    pruneCandidates: [],
+    schemaResolutions: [],
+    missingSecrets: [],
+    warnings: [],
+    dryRun: false,
+    setCreated: true,
+    ...overrides,
+  };
+}
+
+function deployResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    deploymentId: 'dep-1',
+    commitSha: 'a'.repeat(40),
+    fileCount: 2,
+    totalSize: 100,
+    urls: { sha: 'https://admin.example.com/sha', default: 'https://admin.example.com/alias/handoff' },
+    aliases: ['handoff'],
+    ...overrides,
+  };
+}
+
+const INSTALLED_ROW = {
+  id: 'ia-1',
+  appId: 'handoff',
+  name: 'Handoff',
+  version: '1.0.0',
+  projectId: 'proj-1',
+  alias: 'handoff',
+  domainId: null,
+  deploymentId: null,
+  ruleSetIds: [] as string[],
+  schemaIds: [] as string[],
+  bundleSha256: 'a'.repeat(64),
+  manifest: TEST_MANIFEST,
+  manualStepsAcked: [] as string[],
+  status: 'installing',
+  createdResources: {} as CreatedResources,
+  installedBy: 'user-1',
+  installedAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('AppInstallerService', () => {
+  let jobs: AppInstallJobsService;
+  let service: AppInstallerService;
+  let bundleService: { fetchBundle: jest.Mock };
+  let preflight: { instanceGates: jest.Mock; projectGates: jest.Mock };
+  let certStep: { plan: jest.Mock; execute: jest.Mock };
+  let ruleSets: { syncRuleSet: jest.Mock; delete: jest.Mock };
+  let deployments: {
+    createDeploymentFromZip: jest.Mock;
+    deleteDeployment: jest.Mock;
+    deleteAlias: jest.Mock;
+  };
+  let domains: { create: jest.Mock; remove: jest.Mock };
+  let projects: {
+    findOrCreateProject: jest.Mock;
+    projectExists: jest.Mock;
+    getProjectById: jest.Mock;
+    deleteProject: jest.Mock;
+  };
+  let schedules: {
+    listPipelineRules: jest.Mock;
+    listSchedules: jest.Mock;
+    createSchedule: jest.Mock;
+    deleteSchedule: jest.Mock;
+  };
+  let schemas: { delete: jest.Mock };
+  let config: { get: jest.Mock };
+
+  beforeEach(() => {
+    mockDb.__reset();
+    jobs = new AppInstallJobsService();
+    bundleService = { fetchBundle: jest.fn().mockResolvedValue(makeBundle()) };
+    preflight = {
+      instanceGates: jest.fn().mockResolvedValue([{ id: 'storage', status: 'pass', message: 'ok' }]),
+      projectGates: jest.fn().mockResolvedValue({
+        gates: [{ id: 'dns', status: 'pass', message: 'ok' }],
+        syncPlans: [],
+        appHost: 'handoff.example.com',
+      }),
+    };
+    certStep = {
+      plan: jest.fn().mockResolvedValue({ model: 'wildcard', action: 'covered' }),
+      execute: jest.fn().mockResolvedValue({ status: 'done', detail: 'covered by wildcard' }),
+    };
+    ruleSets = {
+      syncRuleSet: jest
+        .fn()
+        .mockResolvedValueOnce(syncResponse({ ruleSetId: 'rs-1' }))
+        .mockResolvedValueOnce(syncResponse({ ruleSetId: 'rs-2' })),
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+    deployments = {
+      createDeploymentFromZip: jest.fn().mockResolvedValue(deployResponse()),
+      deleteDeployment: jest.fn().mockResolvedValue(undefined),
+      deleteAlias: jest.fn().mockResolvedValue(undefined),
+    };
+    domains = {
+      create: jest.fn().mockResolvedValue({ id: 'dom-1', domain: 'handoff.example.com', sslEnabled: true }),
+      remove: jest.fn().mockResolvedValue(undefined),
+    };
+    projects = {
+      findOrCreateProject: jest.fn().mockResolvedValue({ id: 'proj-1', owner: 'acme', name: 'site' }),
+      projectExists: jest.fn().mockResolvedValue(true),
+      getProjectById: jest.fn().mockResolvedValue({ id: 'proj-1', owner: 'acme', name: 'site' }),
+      deleteProject: jest.fn().mockResolvedValue(undefined),
+    };
+    schedules = {
+      listPipelineRules: jest.fn().mockResolvedValue([]),
+      listSchedules: jest.fn().mockResolvedValue([]),
+      createSchedule: jest.fn().mockResolvedValue({ id: 'sched-1' }),
+      deleteSchedule: jest.fn().mockResolvedValue(undefined),
+    };
+    schemas = { delete: jest.fn().mockResolvedValue(undefined) };
+    config = {
+      get: jest.fn((key: string) => (key === 'PRIMARY_DOMAIN' ? 'example.com' : undefined)),
+    };
+
+    service = new AppInstallerService(
+      jobs,
+      bundleService as never,
+      preflight as never,
+      certStep as never,
+      ruleSets as never,
+      deployments as never,
+      domains as never,
+      projects as never,
+      schedules as never,
+      schemas as never,
+      config as unknown as ConfigService,
+      { supportsPresignedUrls: () => true } as never,
+    );
+  });
+
+  /** Queue the three db awaits a successful install performs. */
+  function queueInstallDb(existing: unknown[] = []) {
+    mockDb.__queue(existing); // select existing installed_apps row
+    mockDb.__queue([INSTALLED_ROW]); // insert/update ... returning
+    mockDb.__queue([]); // final record update
+  }
+
+  describe('startInstall — happy path', () => {
+    it('runs every step, in order, and reports the job as succeeded', async () => {
+      queueInstallDb();
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const job = jobs.get(jobId)!;
+      expect(job.status).toBe('succeeded');
+      expect(job.steps.map((s) => s.id)).toEqual([
+        'preflight',
+        'fetch',
+        'sync-rules',
+        'deploy',
+        'domain',
+        'certificate',
+        'schedules',
+        'record',
+      ]);
+      expect(job.steps.filter((s) => s.status === 'failed')).toHaveLength(0);
+      expect(job.steps.find((s) => s.id === 'schedules')!.status).toBe('skipped');
+      expect(job.installedAppId).toBe('ia-1');
+      expect(job.projectId).toBe('proj-1');
+    });
+
+    it('syncs rule sets before deploying (a deploy cannot attach unsynced sets)', async () => {
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      expect(ruleSets.syncRuleSet).toHaveBeenCalledTimes(2);
+      expect(ruleSets.syncRuleSet.mock.invocationCallOrder[1]).toBeLessThan(
+        deployments.createDeploymentFromZip.mock.invocationCallOrder[0],
+      );
+      expect(deployments.createDeploymentFromZip.mock.invocationCallOrder[0]).toBeLessThan(
+        domains.create.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('syncs with dryRun off, prune off and manifest provenance, in manifest order', async () => {
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const [projectId, dto, userId, role] = ruleSets.syncRuleSet.mock.calls[0];
+      expect(projectId).toBe('proj-1');
+      expect(userId).toBe('user-1');
+      expect(role).toBe('admin');
+      expect(dto.ruleSet.name).toBe('handoff');
+      expect(dto.options).toEqual({ dryRun: false, prune: false });
+      expect(dto.source).toEqual({ repo: 'bffless/apps', path: 'rulesets/handoff.json' });
+      expect(ruleSets.syncRuleSet.mock.calls[1][1].ruleSet.name).toBe('handoff-rss-feed');
+    });
+
+    it('passes only attachToAlias rule set names to the deployment', async () => {
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const [file, dto, userId, role] = deployments.createDeploymentFromZip.mock.calls[0];
+      expect(dto.proxyRuleSetNames).toEqual(['handoff']);
+      expect(dto.repository).toBe('acme/site');
+      expect(dto.alias).toBe('handoff');
+      expect(dto.basePath).toBe('/apps/handoff/dist');
+      expect(dto.branch).toBe('app-catalog');
+      expect(dto.commitSha).toBe('a'.repeat(40));
+      expect(dto.source).toBe('manual');
+      expect(userId).toBe('user-1');
+      expect(role).toBe('admin');
+      expect(file.mimetype).toBe('application/zip');
+      expect(Buffer.isBuffer(file.buffer)).toBe(true);
+    });
+
+    it('uploads only the dist/ subtree, re-keyed under basePath', async () => {
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const { unzipSync } = jest.requireActual('fflate') as typeof import('fflate');
+      const file = deployments.createDeploymentFromZip.mock.calls[0][0];
+      const entries = Object.keys(unzipSync(new Uint8Array(file.buffer))).sort();
+      expect(entries).toEqual(['apps/handoff/dist/assets/app.js', 'apps/handoff/dist/index.html']);
+    });
+
+    it('creates the app domain with SSL and the manifest visibility flags', async () => {
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const [dto, userId, authToken, apiKeyProjectId] = domains.create.mock.calls[0];
+      expect(dto).toEqual({
+        projectId: 'proj-1',
+        alias: 'handoff',
+        path: '/apps/handoff/dist',
+        domain: 'handoff.example.com',
+        domainType: 'subdomain',
+        sslEnabled: true,
+        isPublic: true,
+        isSpa: true,
+      });
+      expect(userId).toBe('user-1');
+      expect(authToken).toBeUndefined();
+      expect(apiKeyProjectId).toBeNull();
+    });
+
+    it('records the created resources and marks the row installed', async () => {
+      queueInstallDb();
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const finalUpdate = mockDb.set.mock.calls.at(-1)![0] as {
+        status: string;
+        version: string;
+        bundleSha256: string;
+        createdResources: CreatedResources;
+        ruleSetIds: string[];
+        deploymentId: string;
+        domainId: string;
+      };
+      expect(finalUpdate.status).toBe('installed');
+      expect(finalUpdate.version).toBe('1.0.0');
+      expect(finalUpdate.bundleSha256).toBe('a'.repeat(64));
+      expect(finalUpdate.ruleSetIds).toEqual(['rs-1', 'rs-2']);
+      expect(finalUpdate.deploymentId).toBe('dep-1');
+      expect(finalUpdate.domainId).toBe('dom-1');
+      expect(finalUpdate.createdResources).toEqual({
+        projectCreated: false,
+        ruleSetIds: ['rs-1', 'rs-2'],
+        schemaIdsCreated: [],
+        aliasName: 'handoff',
+        deploymentId: 'dep-1',
+        domainId: 'dom-1',
+        scheduleIds: [],
+      });
+      expect(jobs.get(jobId)!.appUrl).toBe('https://handoff.example.com');
+    });
+
+    it('filters manifest manual steps by the instance context', async () => {
+      queueInstallDb();
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      expect(jobs.get(jobId)!.manualSteps!.map((s) => s.id)).toEqual(['bucket-cors']);
+    });
+  });
+
+  describe('project resolution', () => {
+    it('creates the project and flags projectCreated when it did not exist', async () => {
+      projects.projectExists.mockResolvedValue(false);
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { newProject: { owner: 'acme', name: 'site' } }, 'user-1');
+      await service.whenIdle();
+
+      expect(projects.projectExists).toHaveBeenCalledWith('acme', 'site');
+      expect(projects.findOrCreateProject).toHaveBeenCalledWith('acme', 'site', 'user-1');
+      expect(projects.projectExists.mock.invocationCallOrder[0]).toBeLessThan(
+        projects.findOrCreateProject.mock.invocationCallOrder[0],
+      );
+      const finalUpdate = mockDb.set.mock.calls.at(-1)![0] as { createdResources: CreatedResources };
+      expect(finalUpdate.createdResources.projectCreated).toBe(true);
+    });
+
+    it('inserts the installing row before any project-scoped write', async () => {
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const inserted = mockDb.values.mock.calls[0][0] as { status: string; appId: string };
+      expect(inserted.status).toBe('installing');
+      expect(inserted.appId).toBe('handoff');
+      expect(mockDb.insert.mock.invocationCallOrder[0]).toBeLessThan(
+        ruleSets.syncRuleSet.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('resumes an existing failed row instead of inserting a duplicate', async () => {
+      mockDb.__queue([{ ...INSTALLED_ROW, status: 'failed' }]);
+      mockDb.__queue([{ ...INSTALLED_ROW, status: 'installing' }]);
+      mockDb.__queue([]);
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      expect(mockDb.insert).not.toHaveBeenCalled();
+      expect(mockDb.update).toHaveBeenCalled();
+    });
+  });
+
+  describe('preflight and payload validation gates', () => {
+    it('fails the job before any write when an instance gate fails', async () => {
+      preflight.instanceGates.mockResolvedValue([
+        { id: 'storage', status: 'fail', message: 'no presigned support' },
+      ]);
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const job = jobs.get(jobId)!;
+      expect(job.status).toBe('failed');
+      expect(job.steps.find((s) => s.id === 'preflight')!.status).toBe('failed');
+      expect(job.error).toMatch(/no presigned support/);
+      expect(mockDb.insert).not.toHaveBeenCalled();
+      expect(ruleSets.syncRuleSet).not.toHaveBeenCalled();
+    });
+
+    it('fails the job when a project gate fails', async () => {
+      preflight.projectGates.mockResolvedValue({
+        gates: [{ id: 'name-collision', status: 'fail', message: 'alias taken' }],
+        syncPlans: [],
+        appHost: 'handoff.example.com',
+      });
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      expect(jobs.get(jobId)!.status).toBe('failed');
+      expect(jobs.get(jobId)!.error).toMatch(/alias taken/);
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it('aborts on the fetch step when a bundled rule set fails DTO validation (SSRF parity)', async () => {
+      bundleService.fetchBundle.mockResolvedValue(
+        makeBundle({}, {
+          ruleSet: { name: 'handoff' },
+          rules: [{ pathPattern: '/api/meta', method: 'GET', targetUrl: 'http://169.254.169.254/latest' }],
+          schemas: [],
+        }),
+      );
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const job = jobs.get(jobId)!;
+      expect(job.status).toBe('failed');
+      expect(job.steps.find((s) => s.id === 'fetch')!.status).toBe('failed');
+      expect(job.steps.find((s) => s.id === 'fetch')!.error).toMatch(/targetUrl/i);
+      expect(ruleSets.syncRuleSet).not.toHaveBeenCalled();
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sync results', () => {
+    it('keeps every resolved schema id but only records the created ones as ours', async () => {
+      ruleSets.syncRuleSet
+        .mockReset()
+        .mockResolvedValueOnce(
+          syncResponse({
+            ruleSetId: 'rs-1',
+            schemaResolutions: [
+              { name: 'handoff_nodes', action: 'create', targetSchemaId: 'sch-new', fieldMismatch: false },
+              { name: 'handoff_acl', action: 'reuse', targetSchemaId: 'sch-existing', fieldMismatch: false },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(syncResponse({ ruleSetId: 'rs-2', setCreated: false }));
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const finalUpdate = mockDb.set.mock.calls.at(-1)![0] as {
+        schemaIds: string[];
+        ruleSetIds: string[];
+        createdResources: CreatedResources;
+      };
+      expect(finalUpdate.schemaIds).toEqual(['sch-new', 'sch-existing']);
+      expect(finalUpdate.createdResources.schemaIdsCreated).toEqual(['sch-new']);
+      // rs-2 was adopted (setCreated false) — not ours to delete
+      expect(finalUpdate.ruleSetIds).toEqual(['rs-1', 'rs-2']);
+      expect(finalUpdate.createdResources.ruleSetIds).toEqual(['rs-1']);
+    });
+
+    it('surfaces missing secrets and warnings in the step detail', async () => {
+      ruleSets.syncRuleSet
+        .mockReset()
+        .mockResolvedValue(
+          syncResponse({ missingSecrets: ['STRIPE_KEY'], warnings: ['nginx reload skipped'] }),
+        );
+      queueInstallDb();
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const detail = jobs.get(jobId)!.steps.find((s) => s.id === 'sync-rules')!.detail!;
+      expect(detail).toMatch(/STRIPE_KEY/);
+      expect(detail).toMatch(/nginx reload skipped/);
+    });
+  });
+
+  describe('deploy verification', () => {
+    it('fails the step when the returned aliases do not include the app alias', async () => {
+      deployments.createDeploymentFromZip.mockResolvedValue(deployResponse({ aliases: [] }));
+      queueInstallDb();
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const job = jobs.get(jobId)!;
+      expect(job.status).toBe('failed');
+      expect(job.steps.find((s) => s.id === 'deploy')!.status).toBe('failed');
+      expect(job.steps.find((s) => s.id === 'deploy')!.error).toMatch(/alias/i);
+      expect(domains.create).not.toHaveBeenCalled();
+      const failedUpdate = mockDb.set.mock.calls.at(-1)![0] as { status: string };
+      expect(failedUpdate.status).toBe('failed');
+    });
+  });
+
+  describe('domain and certificate steps', () => {
+    it('skips both when the manifest declares no domain, and falls back to the deployment URL', async () => {
+      const noDomain = { ...TEST_MANIFEST.install };
+      delete (noDomain as { domain?: unknown }).domain;
+      bundleService.fetchBundle.mockResolvedValue(makeBundle({ install: noDomain }));
+      preflight.projectGates.mockResolvedValue({ gates: [], syncPlans: [], appHost: null });
+      queueInstallDb();
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const job = jobs.get(jobId)!;
+      expect(job.status).toBe('succeeded');
+      expect(job.steps.find((s) => s.id === 'domain')!.status).toBe('skipped');
+      expect(job.steps.find((s) => s.id === 'certificate')!.status).toBe('skipped');
+      expect(domains.create).not.toHaveBeenCalled();
+      expect(certStep.plan).not.toHaveBeenCalled();
+      expect(job.appUrl).toBe('https://admin.example.com/alias/handoff');
+    });
+
+    it('does not recreate a domain already recorded on this app row (re-run)', async () => {
+      mockDb.__queue([{ ...INSTALLED_ROW, status: 'failed', createdResources: { domainId: 'dom-1' } }]);
+      mockDb.__queue([{ ...INSTALLED_ROW, createdResources: { domainId: 'dom-1' } }]);
+      mockDb.__queue([]);
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      expect(domains.create).not.toHaveBeenCalled();
+      expect(jobs.get(jobId)!.steps.find((s) => s.id === 'domain')!.status).toBe('done');
+      const finalUpdate = mockDb.set.mock.calls.at(-1)![0] as { domainId: string };
+      expect(finalUpdate.domainId).toBe('dom-1');
+    });
+
+    it('succeeds with the synthesized manual step when the cert step needs action', async () => {
+      certStep.plan.mockResolvedValue({ model: 'direct-le', action: 'stage-san-reissue' });
+      certStep.execute.mockResolvedValue({
+        status: 'action-required',
+        detail: 'staged',
+        manualStep: {
+          id: 'apply-ssl-cert',
+          title: 'Apply the updated certificate',
+          body: 'review + apply',
+          appliesWhen: 'selfHosted',
+        },
+      });
+      queueInstallDb();
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const job = jobs.get(jobId)!;
+      expect(job.status).toBe('succeeded');
+      expect(job.steps.find((s) => s.id === 'certificate')!.status).toBe('action-required');
+      expect(job.manualSteps!.map((s) => s.id)).toEqual(['bucket-cors', 'apply-ssl-cert']);
+    });
+
+    it('notes a silently downgraded sslEnabled in the certificate detail', async () => {
+      domains.create.mockResolvedValue({ id: 'dom-1', domain: 'handoff.example.com', sslEnabled: false });
+      queueInstallDb();
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      expect(jobs.get(jobId)!.steps.find((s) => s.id === 'certificate')!.detail).toMatch(/ssl/i);
+    });
+
+    it('never fails the install when the cert step throws', async () => {
+      certStep.plan.mockRejectedValue(new Error('acme unreachable'));
+      queueInstallDb();
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const job = jobs.get(jobId)!;
+      expect(job.status).toBe('succeeded');
+      expect(job.steps.find((s) => s.id === 'certificate')!.status).toBe('skipped');
+      expect(job.steps.find((s) => s.id === 'certificate')!.detail).toMatch(/acme unreachable/);
+    });
+  });
+
+  describe('schedules step', () => {
+    const withSchedule = {
+      ...TEST_MANIFEST.install,
+      schedules: [
+        {
+          name: 'Refresh feeds',
+          cronExpression: '*/15 * * * *',
+          timezone: 'UTC',
+          targetRulePath: '/api/feeds/refresh',
+          targetRuleMethod: 'POST',
+        },
+      ],
+    };
+
+    it('creates a schedule against the matching pipeline rule', async () => {
+      bundleService.fetchBundle.mockResolvedValue(makeBundle({ install: withSchedule }));
+      schedules.listPipelineRules.mockResolvedValue([
+        { id: 'rule-other', pathPattern: '/api/nodes', method: 'GET' },
+        { id: 'rule-1', pathPattern: '/api/feeds/refresh', method: 'POST' },
+      ]);
+      queueInstallDb();
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      expect(schedules.createSchedule).toHaveBeenCalledWith(
+        'proj-1',
+        {
+          name: 'Refresh feeds',
+          targetProxyRuleId: 'rule-1',
+          cronExpression: '*/15 * * * *',
+          timezone: 'UTC',
+        },
+        'user-1',
+        'admin',
+        null,
+      );
+      expect(jobs.get(jobId)!.steps.find((s) => s.id === 'schedules')!.status).toBe('done');
+      const finalUpdate = mockDb.set.mock.calls.at(-1)![0] as { createdResources: CreatedResources };
+      expect(finalUpdate.createdResources.scheduleIds).toEqual(['sched-1']);
+    });
+
+    it('does not create a schedule that already exists by name (idempotent re-run)', async () => {
+      bundleService.fetchBundle.mockResolvedValue(makeBundle({ install: withSchedule }));
+      schedules.listPipelineRules.mockResolvedValue([
+        { id: 'rule-1', pathPattern: '/api/feeds/refresh', method: 'POST' },
+      ]);
+      schedules.listSchedules.mockResolvedValue([{ id: 'sched-existing', name: 'Refresh feeds' }]);
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      expect(schedules.createSchedule).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('startUpdate', () => {
+    const installed = { ...INSTALLED_ROW, status: 'installed' as const, createdResources: {} };
+
+    it('runs only fetch → sync-rules → deploy → record, leaving the domain alone', async () => {
+      mockDb.__queue([]); // final record update
+
+      const { jobId } = service.startUpdate(
+        installed as never,
+        { ...ENTRY, version: '1.1.0' },
+        'user-1',
+        { prune: false },
+      );
+      await service.whenIdle();
+
+      const job = jobs.get(jobId)!;
+      expect(job.kind).toBe('update');
+      expect(job.status).toBe('succeeded');
+      expect(job.steps.map((s) => s.id)).toEqual(['fetch', 'sync-rules', 'deploy', 'record']);
+      expect(domains.create).not.toHaveBeenCalled();
+      expect(preflight.projectGates).not.toHaveBeenCalled();
+      expect(schedules.createSchedule).not.toHaveBeenCalled();
+    });
+
+    it('passes the prune flag through to the sync and deploys to the same alias', async () => {
+      mockDb.__queue([]);
+
+      service.startUpdate(installed as never, ENTRY, 'user-1', { prune: true });
+      await service.whenIdle();
+
+      expect(ruleSets.syncRuleSet.mock.calls[0][1].options).toEqual({ dryRun: false, prune: true });
+      expect(deployments.createDeploymentFromZip.mock.calls[0][1].alias).toBe('handoff');
+    });
+
+    it('bumps the recorded version on the existing row', async () => {
+      mockDb.__queue([]);
+
+      service.startUpdate(installed as never, { ...ENTRY, version: '1.1.0' }, 'user-1', {
+        prune: false,
+      });
+      await service.whenIdle();
+
+      const finalUpdate = mockDb.set.mock.calls.at(-1)![0] as { version: string; status: string };
+      expect(finalUpdate.status).toBe('installed');
+      expect(finalUpdate.version).toBe('1.0.0'); // manifest version wins over the registry entry
+    });
+  });
+
+  describe('undo', () => {
+    const created: CreatedResources = {
+      projectCreated: false,
+      ruleSetIds: ['rs-1'],
+      schemaIdsCreated: ['sch-new'],
+      aliasName: 'handoff',
+      deploymentId: 'dep-1',
+      domainId: 'dom-1',
+      scheduleIds: ['sched-1'],
+    };
+
+    it('deletes only the created resources, in reverse order', async () => {
+      mockDb.__queue([{ ...INSTALLED_ROW, schemaIds: ['sch-new', 'sch-reused'], createdResources: created }]);
+      mockDb.__queue([]); // delete installed_apps row
+
+      const result = await service.undo('ia-1', 'user-1');
+
+      expect(schedules.deleteSchedule).toHaveBeenCalledWith('sched-1', 'user-1', 'admin', null);
+      expect(domains.remove).toHaveBeenCalledWith('dom-1', 'user-1', undefined, null);
+      expect(deployments.deleteAlias).toHaveBeenCalledWith('acme/site', 'handoff', 'user-1', 'admin');
+      expect(deployments.deleteDeployment).toHaveBeenCalledWith('dep-1', 'user-1', 'admin');
+      expect(ruleSets.delete).toHaveBeenCalledWith('rs-1', 'user-1', 'admin', null);
+      expect(schemas.delete).toHaveBeenCalledWith('sch-new', 'user-1', 'admin', null);
+
+      expect(schedules.deleteSchedule.mock.invocationCallOrder[0]).toBeLessThan(
+        domains.remove.mock.invocationCallOrder[0],
+      );
+      expect(domains.remove.mock.invocationCallOrder[0]).toBeLessThan(
+        deployments.deleteAlias.mock.invocationCallOrder[0],
+      );
+      expect(deployments.deleteDeployment.mock.invocationCallOrder[0]).toBeLessThan(
+        ruleSets.delete.mock.invocationCallOrder[0],
+      );
+      expect(ruleSets.delete.mock.invocationCallOrder[0]).toBeLessThan(
+        schemas.delete.mock.invocationCallOrder[0],
+      );
+      expect(result.removed).toEqual(
+        expect.arrayContaining(['schedule:sched-1', 'domain:dom-1', 'ruleSet:rs-1', 'schema:sch-new']),
+      );
+    });
+
+    it('never deletes a reused schema or a pre-existing rule set', async () => {
+      mockDb.__queue([
+        {
+          ...INSTALLED_ROW,
+          ruleSetIds: ['rs-1', 'rs-adopted'],
+          schemaIds: ['sch-new', 'sch-reused'],
+          createdResources: created,
+        },
+      ]);
+      mockDb.__queue([]);
+
+      await service.undo('ia-1', 'user-1');
+
+      expect(schemas.delete).toHaveBeenCalledTimes(1);
+      expect(schemas.delete).not.toHaveBeenCalledWith('sch-reused', 'user-1', 'admin', null);
+      expect(ruleSets.delete).toHaveBeenCalledTimes(1);
+      expect(ruleSets.delete).not.toHaveBeenCalledWith('rs-adopted', 'user-1', 'admin', null);
+    });
+
+    it('does not touch a domain or project it did not create', async () => {
+      mockDb.__queue([
+        { ...INSTALLED_ROW, domainId: 'dom-preexisting', createdResources: { ruleSetIds: ['rs-1'] } },
+      ]);
+      mockDb.__queue([]);
+
+      await service.undo('ia-1', 'user-1');
+
+      expect(domains.remove).not.toHaveBeenCalled();
+      expect(projects.deleteProject).not.toHaveBeenCalled();
+    });
+
+    it('deletes a project it created only when nothing else lives in it', async () => {
+      mockDb.__queue([{ ...INSTALLED_ROW, createdResources: { projectCreated: true } }]);
+      mockDb.__queue([]); // remaining aliases in project
+      mockDb.__queue([]); // remaining rule sets in project
+      mockDb.__queue([]); // delete installed_apps row
+
+      await service.undo('ia-1', 'user-1');
+
+      expect(projects.deleteProject).toHaveBeenCalledWith('proj-1');
+    });
+
+    it('keeps a project it created when other content remains', async () => {
+      mockDb.__queue([{ ...INSTALLED_ROW, createdResources: { projectCreated: true } }]);
+      mockDb.__queue([{ id: 'alias-other' }]); // remaining aliases
+      mockDb.__queue([]); // remaining rule sets
+      mockDb.__queue([]); // delete installed_apps row
+
+      await service.undo('ia-1', 'user-1');
+
+      expect(projects.deleteProject).not.toHaveBeenCalled();
+    });
+
+    it('marks the matching job undone and drops the installed_apps row', async () => {
+      const job = jobs.create('install', 'handoff', ['record']);
+      jobs.finish(job.id, 'succeeded', { installedAppId: 'ia-1' });
+      mockDb.__queue([{ ...INSTALLED_ROW, createdResources: {} }]);
+      mockDb.__queue([]);
+
+      await service.undo('ia-1', 'user-1');
+
+      expect(jobs.get(job.id)!.status).toBe('undone');
+      expect(mockDb.delete).toHaveBeenCalled();
+    });
+
+    it('continues past an individual delete failure and reports what it removed', async () => {
+      domains.remove.mockRejectedValue(new Error('domain gone'));
+      mockDb.__queue([{ ...INSTALLED_ROW, createdResources: created }]);
+      mockDb.__queue([]);
+
+      const result = await service.undo('ia-1', 'user-1');
+
+      expect(result.removed).not.toContain('domain:dom-1');
+      expect(ruleSets.delete).toHaveBeenCalled();
+    });
+  });
+
+  describe('uninstall', () => {
+    const created: CreatedResources = {
+      ruleSetIds: ['rs-1'],
+      schemaIdsCreated: ['sch-new'],
+      aliasName: 'handoff',
+      deploymentId: 'dep-1',
+      domainId: 'dom-1',
+      scheduleIds: [],
+    };
+
+    it('keeps the created data-table schemas when deleteData is false', async () => {
+      mockDb.__queue([{ ...INSTALLED_ROW, createdResources: created }]);
+      mockDb.__queue([]);
+
+      const summary = await service.uninstall('ia-1', 'user-1', { deleteData: false });
+
+      expect(schemas.delete).not.toHaveBeenCalled();
+      expect(summary.dataDeleted).toBe(false);
+      expect(summary.kept).toEqual(expect.arrayContaining(['schema:sch-new']));
+      expect(summary.removed).toEqual(expect.arrayContaining(['domain:dom-1', 'ruleSet:rs-1']));
+    });
+
+    it('deletes the created data-table schemas when deleteData is true', async () => {
+      mockDb.__queue([{ ...INSTALLED_ROW, createdResources: created }]);
+      mockDb.__queue([]);
+
+      const summary = await service.uninstall('ia-1', 'user-1', { deleteData: true });
+
+      expect(schemas.delete).toHaveBeenCalledWith('sch-new', 'user-1', 'admin', null);
+      expect(summary.dataDeleted).toBe(true);
+      expect(summary.removed).toEqual(expect.arrayContaining(['schema:sch-new']));
+    });
+  });
+});

--- a/apps/backend/src/app-catalog/app-installer.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.spec.ts
@@ -700,6 +700,31 @@ describe('AppInstallerService', () => {
       expect(firstWithDomain).toBeLessThan(writes.length - 1);
     });
 
+    it('stamps installedAppId on a failed job once a row exists, so it can still be undone by jobId', async () => {
+      deployments.createDeploymentFromZip.mockResolvedValue(deployResponse({ aliases: [] }));
+      queueInstallDb();
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const job = jobs.get(jobId)!;
+      expect(job.status).toBe('failed');
+      expect(job.installedAppId).toBe('ia-1');
+    });
+
+    it('leaves installedAppId unset on a failed job that never reached a row', async () => {
+      preflight.instanceGates.mockResolvedValue([
+        { id: 'storage', status: 'fail', message: 'no presigned support' },
+      ]);
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const job = jobs.get(jobId)!;
+      expect(job.status).toBe('failed');
+      expect(job.installedAppId).toBeUndefined();
+    });
+
     it('persists a failed update run too', async () => {
       deployments.createDeploymentFromZip.mockResolvedValue(deployResponse({ aliases: [] }));
 

--- a/apps/backend/src/app-catalog/app-installer.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.spec.ts
@@ -37,6 +37,7 @@ jest.mock('../db/client', () => {
 });
 
 import { ConfigService } from '@nestjs/config';
+import { NotFoundException } from '@nestjs/common';
 import { db } from '../db/client';
 import { AppInstallJobsService } from './app-install-jobs.service';
 import { AppInstallerService } from './app-installer.service';
@@ -1020,6 +1021,37 @@ describe('AppInstallerService', () => {
       expect(result.removed).not.toContain('domain:dom-1');
       expect(ruleSets.delete).toHaveBeenCalled();
     });
+
+    it('keeps the installed_apps row (status failed) instead of dropping it when a delete throws', async () => {
+      deployments.deleteAlias.mockRejectedValue(new Error('alias gone for real'));
+      mockDb.__queue([
+        { ...INSTALLED_ROW, schemaIds: ['sch-new', 'sch-reused'], createdResources: created },
+      ]);
+      mockDb.__queue([]); // the status-update, not a row delete
+
+      const result = await service.undo('ia-1', 'user-1');
+
+      expect(result.failures).toEqual(['alias:handoff']);
+      expect(result.removed).toEqual(
+        expect.arrayContaining([
+          'schedule:sched-1',
+          'domain:dom-1',
+          'deployment:dep-1',
+          'ruleSet:rs-1',
+          'schema:sch-new',
+        ]),
+      );
+      // Other deletions were still attempted despite the alias failure.
+      expect(schedules.deleteSchedule).toHaveBeenCalled();
+      expect(domains.remove).toHaveBeenCalled();
+      expect(deployments.deleteDeployment).toHaveBeenCalled();
+      expect(ruleSets.delete).toHaveBeenCalled();
+      expect(schemas.delete).toHaveBeenCalled();
+
+      expect(mockDb.delete).not.toHaveBeenCalled();
+      expect(mockDb.update).toHaveBeenCalled();
+      expect(mockDb.set).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }));
+    });
   });
 
   describe('uninstall', () => {
@@ -1103,6 +1135,23 @@ describe('AppInstallerService', () => {
       expect(summary.dataTables.deletedRecordCounts).toEqual({ handoff_nodes: 42 });
     });
 
+    it('also keeps the row when a data-table delete fails under deleteData: true', async () => {
+      schemas.delete.mockRejectedValue(new Error('schema delete failed for real'));
+      mockDb.__queue([
+        { ...INSTALLED_ROW, schemaIds: ['sch-new', 'sch-reused'], createdResources: created },
+      ]);
+      mockDb.__queue([]); // status update, not a row delete
+
+      const summary = await service.uninstall('ia-1', 'user-1', { deleteData: true });
+
+      expect(summary.failures).toEqual(['schema:sch-new']);
+      expect(summary.dataTables.deleted).toEqual([]);
+      expect(summary.dataTables.kept).toEqual(expect.arrayContaining(['handoff_nodes', 'handoff_shared_table']));
+      expect(summary.dataTables.deletedRecordCounts).toEqual({});
+      expect(mockDb.delete).not.toHaveBeenCalled();
+      expect(mockDb.set).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }));
+    });
+
     it('continues past an individual delete failure and reports accurate counts', async () => {
       domains.remove.mockRejectedValue(new Error('domain gone'));
       mockDb.__queue([{ ...INSTALLED_ROW, ruleSetIds: ['rs-1'], createdResources: created }]);
@@ -1113,6 +1162,65 @@ describe('AppInstallerService', () => {
       expect(summary.removed.domain).toBe(false);
       expect(summary.removed.alias).toBe(true);
       expect(ruleSets.delete).toHaveBeenCalled();
+    });
+
+    it('keeps the installed_apps row (status failed) and reports the failing label when a delete throws', async () => {
+      deployments.deleteAlias.mockRejectedValue(new Error('alias gone for real'));
+      mockDb.__queue([{ ...INSTALLED_ROW, ruleSetIds: ['rs-1'], createdResources: created }]);
+      mockDb.__queue([]); // the status-update, not a row delete
+
+      const summary = await service.uninstall('ia-1', 'user-1', { deleteData: false });
+
+      expect(summary.failures).toEqual(['alias:handoff']);
+      expect(summary.removed.alias).toBe(false);
+      // Other deletions were still attempted despite the alias failure.
+      expect(summary.removed.domain).toBe(true);
+      expect(summary.removed.deployment).toBe(true);
+      expect(summary.removed.schedules).toBe(1);
+      expect(summary.removed.ruleSets).toBe(1);
+      expect(schedules.deleteSchedule).toHaveBeenCalled();
+      expect(domains.remove).toHaveBeenCalled();
+      expect(deployments.deleteDeployment).toHaveBeenCalled();
+      expect(ruleSets.delete).toHaveBeenCalled();
+
+      expect(mockDb.delete).not.toHaveBeenCalled();
+      expect(mockDb.update).toHaveBeenCalled();
+      expect(mockDb.set).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }));
+    });
+
+    it('re-running after a partial failure is idempotent (already-removed resources do not block it) and completes by dropping the row', async () => {
+      // Pass 1: the alias delete throws a real error; everything else succeeds.
+      // Pass 2 (after whatever broke it is fixed): the alias delete succeeds,
+      // and the rule set — already deleted for real during pass 1 — now
+      // throws NotFoundException, standing in for "this object is already
+      // gone". Neither should block the retry from completing.
+      deployments.deleteAlias
+        .mockRejectedValueOnce(new Error('alias gone for real'))
+        .mockResolvedValueOnce(undefined);
+      ruleSets.delete
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new NotFoundException('rule set already gone'));
+
+      const row = { ...INSTALLED_ROW, ruleSetIds: ['rs-1'], createdResources: created };
+
+      mockDb.__queue([row]);
+      mockDb.__queue([]); // status update, not a delete
+      const first = await service.uninstall('ia-1', 'user-1', { deleteData: false });
+
+      expect(first.failures).toEqual(['alias:handoff']);
+      expect(mockDb.delete).not.toHaveBeenCalled();
+
+      mockDb.__reset(); // clears queued db results + call counts; service mocks (alias/ruleSets) are untouched
+      mockDb.__queue([row]);
+      mockDb.__queue([]); // this time, the final row delete
+
+      const second = await service.uninstall('ia-1', 'user-1', { deleteData: false });
+
+      expect(second.failures).toBeUndefined();
+      expect(second.removed.alias).toBe(true);
+      expect(second.removed.ruleSets).toBe(1); // NotFound on retry still counts as removed
+      expect(mockDb.delete).toHaveBeenCalled();
+      expect(mockDb.update).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/app-catalog/app-installer.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.spec.ts
@@ -527,6 +527,35 @@ describe('AppInstallerService', () => {
       expect(ruleSets.syncRuleSet).not.toHaveBeenCalled();
       expect(mockDb.insert).not.toHaveBeenCalled();
     });
+
+    it('aborts on a rule set carrying keys the sync DTO does not declare (HTTP parity)', async () => {
+      // `whitelist` alone would silently DELETE this key and sync a payload
+      // that is not what the bundle shipped; the HTTP endpoint 400s on it.
+      bundleService.fetchBundle.mockResolvedValue(
+        makeBundle({}, {
+          ruleSet: { name: 'handoff' },
+          rules: [
+            {
+              pathPattern: '/api/nodes',
+              method: 'GET',
+              targetUrl: 'https://api.example.com',
+              futureFeatureFlag: true,
+            },
+          ],
+          schemas: [],
+        }),
+      );
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const job = jobs.get(jobId)!;
+      expect(job.status).toBe('failed');
+      expect(job.steps.find((s) => s.id === 'fetch')!.status).toBe('failed');
+      expect(job.steps.find((s) => s.id === 'fetch')!.error).toMatch(/futureFeatureFlag/);
+      expect(ruleSets.syncRuleSet).not.toHaveBeenCalled();
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
   });
 
   describe('sync results', () => {
@@ -592,6 +621,96 @@ describe('AppInstallerService', () => {
       expect(domains.create).not.toHaveBeenCalled();
       const failedUpdate = mockDb.set.mock.calls.at(-1)![0] as { status: string };
       expect(failedUpdate.status).toBe('failed');
+    });
+  });
+
+  describe('progress persistence', () => {
+    it('writes the sync step results to the row before the deploy runs', async () => {
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      // The insert uses values(), so the FIRST set() is the post-sync flush.
+      const afterSync = mockDb.set.mock.calls[0][0] as {
+        ruleSetIds: string[];
+        createdResources: CreatedResources;
+        deploymentId: string | null;
+      };
+      expect(afterSync.ruleSetIds).toEqual(['rs-1', 'rs-2']);
+      expect(afterSync.createdResources.ruleSetIds).toEqual(['rs-1', 'rs-2']);
+      // Nothing deployed yet at that point.
+      expect(afterSync.deploymentId).toBeNull();
+      expect(mockDb.set.mock.invocationCallOrder[0]).toBeLessThan(
+        deployments.createDeploymentFromZip.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('carries what the sync created into the failure write, so undo can find it', async () => {
+      // Nothing hand-seeded: everything asserted here must have been produced
+      // by the run itself. A `failed` row with an empty createdResources would
+      // orphan the rule sets/schemas the sync just created.
+      ruleSets.syncRuleSet
+        .mockReset()
+        .mockResolvedValueOnce(
+          syncResponse({
+            ruleSetId: 'rs-1',
+            schemaResolutions: [
+              { name: 'handoff_nodes', action: 'create', targetSchemaId: 'sch-new', fieldMismatch: false },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(syncResponse({ ruleSetId: 'rs-2' }));
+      deployments.createDeploymentFromZip.mockResolvedValue(deployResponse({ aliases: [] }));
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const failureWrite = mockDb.set.mock.calls.at(-1)![0] as {
+        status: string;
+        ruleSetIds: string[];
+        schemaIds: string[];
+        createdResources: CreatedResources;
+      };
+      expect(failureWrite.status).toBe('failed');
+      expect(failureWrite.ruleSetIds).toEqual(['rs-1', 'rs-2']);
+      expect(failureWrite.schemaIds).toEqual(['sch-new']);
+      expect(failureWrite.createdResources.ruleSetIds).toEqual(['rs-1', 'rs-2']);
+      expect(failureWrite.createdResources.schemaIdsCreated).toEqual(['sch-new']);
+    });
+
+    it('persists the domain id as soon as the domain step created it', async () => {
+      certStep.plan.mockRejectedValue(new Error('boom')); // cert runs after domain
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const writes = mockDb.set.mock.calls.map((c) => c[0] as { domainId?: string | null });
+      const firstWithDomain = writes.findIndex((w) => w.domainId === 'dom-1');
+      expect(firstWithDomain).toBeGreaterThan(-1);
+      // Not only at the final record write.
+      expect(firstWithDomain).toBeLessThan(writes.length - 1);
+    });
+
+    it('persists a failed update run too', async () => {
+      deployments.createDeploymentFromZip.mockResolvedValue(deployResponse({ aliases: [] }));
+
+      service.startUpdate(
+        { ...INSTALLED_ROW, status: 'installed', createdResources: {} } as never,
+        ENTRY,
+        'user-1',
+        { prune: false },
+      );
+      await service.whenIdle();
+
+      const failureWrite = mockDb.set.mock.calls.at(-1)![0] as {
+        status: string;
+        createdResources: CreatedResources;
+      };
+      expect(failureWrite.status).toBe('failed');
+      expect(failureWrite.createdResources.ruleSetIds).toEqual(['rs-1', 'rs-2']);
     });
   });
 

--- a/apps/backend/src/app-catalog/app-installer.service.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.ts
@@ -1285,7 +1285,9 @@ export class AppInstallerService {
       }
     }
 
-    this.jobs.finish(jobId, 'failed', { error: message });
+    // Stamp installedAppId even on failure (when a row exists): the catalog's
+    // undo-by-jobId route (Task 11) has no other way to find what to undo.
+    this.jobs.finish(jobId, 'failed', { error: message, ...(rowId ? { installedAppId: rowId } : {}) });
   }
 
   private messageOf(error: unknown): string {

--- a/apps/backend/src/app-catalog/app-installer.service.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.ts
@@ -147,10 +147,21 @@ export class AppInstallerService {
     @Inject(STORAGE_ADAPTER) private readonly storageAdapter: IStorageAdapter,
   ) {}
 
-  /** Kicks off the background run; returns immediately (storage-migration shape). */
-  startInstall(entry: AppRegistryEntry, target: InstallTarget, userId: string): { jobId: string } {
+  /**
+   * Kicks off the background run; returns immediately (storage-migration
+   * shape). `subdomainOverride` is the SAME value the wizard's last preflight
+   * showed — it is passed straight through to the job's own re-preflight
+   * (`runInstall`), so the job never re-verifies a different host than the
+   * one the operator was shown.
+   */
+  startInstall(
+    entry: AppRegistryEntry,
+    target: InstallTarget,
+    userId: string,
+    subdomainOverride?: string,
+  ): { jobId: string } {
     const job = this.jobs.create('install', entry.id, INSTALL_STEPS);
-    this.currentRun = this.runInstall(job.id, entry, target, userId);
+    this.currentRun = this.runInstall(job.id, entry, target, userId, subdomainOverride);
     void this.currentRun;
     return { jobId: job.id };
   }
@@ -180,6 +191,7 @@ export class AppInstallerService {
     entry: AppRegistryEntry,
     target: InstallTarget,
     userId: string,
+    subdomainOverride?: string,
   ): Promise<void> {
     let step: InstallStepId = 'preflight';
     let rowId: string | undefined;
@@ -196,6 +208,7 @@ export class AppInstallerService {
         preflightBundle,
         this.toPreflightTarget(target),
         userId,
+        subdomainOverride,
       );
       this.assertGatesPass(projectGates.gates);
       this.jobs.setStep(jobId, step, { status: 'done', detail: 'All install gates passed.' });

--- a/apps/backend/src/app-catalog/app-installer.service.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.ts
@@ -1,0 +1,984 @@
+import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { plainToInstance } from 'class-transformer';
+import { validateSync, type ValidationError } from 'class-validator';
+import { and, eq } from 'drizzle-orm';
+import { zipSync } from 'fflate';
+import { db } from '../db/client';
+import {
+  deploymentAliases,
+  installedApps,
+  proxyRuleSets,
+  type CreatedResources,
+  type InstalledApp,
+} from '../db/schema';
+import { DeploymentsService } from '../deployments/deployments.service';
+import { DomainsService } from '../domains/domains.service';
+import { PipelineSchedulesService } from '../pipeline-schedules/pipeline-schedules.service';
+import { PipelineSchemasService } from '../pipelines/pipeline-schemas.service';
+import { ProjectsService } from '../projects/projects.service';
+import { ProxyRuleSetsService } from '../proxy-rules/proxy-rule-sets.service';
+import { SyncProxyRuleSetDto } from '../proxy-rules/dto/sync-proxy-rule-set.dto';
+import { IStorageAdapter, STORAGE_ADAPTER } from '../storage/storage.interface';
+import { AppBundleService, type LoadedBundle } from './app-bundle.service';
+import { AppCertStepService } from './app-cert-step.service';
+import { AppInstallJobsService, type InstallStepId } from './app-install-jobs.service';
+import { AppPreflightService, type GateResult } from './app-preflight.service';
+import { manualStepApplies } from './app-manifest.util';
+import type { AppManifest, AppManualStep, AppRegistryEntry } from './app-manifest.types';
+
+export interface InstallTarget {
+  projectId?: string;
+  newProject?: { owner: string; name: string };
+}
+
+export interface UninstallSummary {
+  /** Labels (`kind:id`) of objects actually deleted. */
+  removed: string[];
+  /** Objects deliberately left in place (e.g. data-table schemas when `deleteData` is false). */
+  kept: string[];
+  dataDeleted: boolean;
+}
+
+const INSTALL_STEPS: InstallStepId[] = [
+  'preflight',
+  'fetch',
+  'sync-rules',
+  'deploy',
+  'domain',
+  'certificate',
+  'schedules',
+  'record',
+];
+
+const UPDATE_STEPS: InstallStepId[] = ['fetch', 'sync-rules', 'deploy', 'record'];
+
+interface ParsedRuleSet {
+  file: string;
+  name: string;
+  /** Attach the synced set to the app's alias (manifest default: true). */
+  attach: boolean;
+  dto: SyncProxyRuleSetDto;
+}
+
+interface ProjectRef {
+  id: string;
+  owner: string;
+  name: string;
+}
+
+/**
+ * AppInstallerService — the applier behind 1-click install (Task 9 of the
+ * app-catalog spec).
+ *
+ * Every step is individually reported on the job AND individually idempotent,
+ * so re-running an install over a `failed` row is a resume rather than a
+ * duplicate. The durable record is the `installed_apps` row, written with
+ * `status: 'installing'` BEFORE the first project-scoped write — it survives a
+ * crash/restart and is what {@link undo} replays in reverse.
+ *
+ * Two invariants worth stating out loud:
+ *  - **Nothing is written that preflight didn't just re-verify.** The wizard
+ *    already showed the gates, but the job re-runs them; a `fail` aborts
+ *    before the row insert.
+ *  - **`createdResources` is the deletion boundary.** Only objects this
+ *    install actually created land there (a rule set the sync ADOPTED, or a
+ *    schema it REUSED, never does), so undo/uninstall can never delete a
+ *    user's pre-existing data.
+ */
+@Injectable()
+export class AppInstallerService {
+  private readonly logger = new Logger(AppInstallerService.name);
+  /** Resolves when the (single-flight) background run finishes. Never rejects. */
+  private currentRun: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly jobs: AppInstallJobsService,
+    private readonly bundleService: AppBundleService,
+    private readonly preflightService: AppPreflightService,
+    private readonly certStepService: AppCertStepService,
+    private readonly ruleSetsService: ProxyRuleSetsService,
+    private readonly deploymentsService: DeploymentsService,
+    private readonly domainsService: DomainsService,
+    private readonly projectsService: ProjectsService,
+    private readonly schedulesService: PipelineSchedulesService,
+    private readonly schemasService: PipelineSchemasService,
+    private readonly configService: ConfigService,
+    @Inject(STORAGE_ADAPTER) private readonly storageAdapter: IStorageAdapter,
+  ) {}
+
+  /** Kicks off the background run; returns immediately (storage-migration shape). */
+  startInstall(entry: AppRegistryEntry, target: InstallTarget, userId: string): { jobId: string } {
+    const job = this.jobs.create('install', entry.id, INSTALL_STEPS);
+    this.currentRun = this.runInstall(job.id, entry, target, userId);
+    void this.currentRun;
+    return { jobId: job.id };
+  }
+
+  startUpdate(
+    installed: InstalledApp,
+    entry: AppRegistryEntry,
+    userId: string,
+    opts: { prune: boolean },
+  ): { jobId: string } {
+    const job = this.jobs.create('update', entry.id, UPDATE_STEPS);
+    this.jobs.setProjectId(job.id, installed.projectId);
+    this.currentRun = this.runUpdate(job.id, installed, entry, userId, opts);
+    void this.currentRun;
+    return { jobId: job.id };
+  }
+
+  /** Awaits the in-flight background run (tests, graceful shutdown). */
+  async whenIdle(): Promise<void> {
+    await this.currentRun;
+  }
+
+  // ==================== install ====================
+
+  private async runInstall(
+    jobId: string,
+    entry: AppRegistryEntry,
+    target: InstallTarget,
+    userId: string,
+  ): Promise<void> {
+    let step: InstallStepId = 'preflight';
+    let rowId: string | undefined;
+
+    try {
+      // ---- 1. preflight: re-verify every gate before anything is written ----
+      this.jobs.setStep(jobId, step, { status: 'running' });
+      this.assertGatesPass(await this.preflightService.instanceGates(entry.requires));
+      const preflightBundle = await this.bundleService.fetchBundle(entry.bundleUrl, entry.sha256);
+      const projectGates = await this.preflightService.projectGates(
+        preflightBundle,
+        this.toPreflightTarget(target),
+        userId,
+      );
+      this.assertGatesPass(projectGates.gates);
+      this.jobs.setStep(jobId, step, { status: 'done', detail: 'All install gates passed.' });
+
+      // ---- 2. fetch (cache hit — preflight just downloaded it) + payload validation ----
+      step = 'fetch';
+      this.jobs.setStep(jobId, step, { status: 'running' });
+      const bundle = await this.bundleService.fetchBundle(entry.bundleUrl, entry.sha256);
+      const manifest = bundle.manifest;
+      const ruleSets = this.parseAndValidateRuleSets(bundle);
+      this.jobs.setStep(jobId, step, {
+        status: 'done',
+        detail: `Bundle ${bundle.sha256.slice(0, 12)} verified; ${ruleSets.length} rule set payload(s) validated.`,
+      });
+
+      const appHost = projectGates.appHost ?? this.computeAppHost(manifest);
+      const created: CreatedResources = {
+        ruleSetIds: [],
+        schemaIdsCreated: [],
+        scheduleIds: [],
+      };
+
+      // ---- 3. project resolution + the durable installing row ----
+      step = 'sync-rules';
+      this.jobs.setStep(jobId, step, { status: 'running' });
+      const project = await this.resolveProject(target, userId, created);
+      this.jobs.setProjectId(jobId, project.id);
+      const row = await this.loadOrCreateRow(manifest, project.id, bundle.sha256, userId);
+      rowId = row.id;
+      // Carry forward what a previous (failed) attempt already created.
+      this.mergeCreated(created, row.createdResources);
+
+      // ---- 4. sync-rules ----
+      const ruleSetIds: string[] = [...(row.ruleSetIds ?? [])];
+      const schemaIds: string[] = [...(row.schemaIds ?? [])];
+      const { missingSecrets, warnings } = await this.syncRuleSets(
+        ruleSets,
+        manifest,
+        project.id,
+        userId,
+        { prune: false },
+        { created, ruleSetIds, schemaIds },
+      );
+      this.jobs.setStep(jobId, step, {
+        status: 'done',
+        detail: this.syncDetail(ruleSets.length, missingSecrets, warnings),
+      });
+
+      // ---- 5. deploy ----
+      step = 'deploy';
+      this.jobs.setStep(jobId, step, { status: 'running' });
+      const deployment = await this.deployBundle(bundle, manifest, ruleSets, project, userId);
+      created.aliasName = manifest.install.alias;
+      created.deploymentId = deployment.deploymentId;
+      this.jobs.setStep(jobId, step, {
+        status: 'done',
+        detail: `Deployed ${deployment.fileCount} file(s) to alias "${manifest.install.alias}".`,
+      });
+
+      // ---- 6. domain ----
+      step = 'domain';
+      const domainOutcome = await this.applyDomainStep(jobId, manifest, row, project.id, appHost, userId);
+      if (domainOutcome.domainId) created.domainId = domainOutcome.domainId;
+
+      // ---- 7. certificate (never fails the install) ----
+      step = 'certificate';
+      const certManualSteps = await this.applyCertificateStep(
+        jobId,
+        appHost,
+        domainOutcome.sslDowngraded,
+      );
+
+      // ---- 8. schedules ----
+      step = 'schedules';
+      await this.applyScheduleStep(jobId, manifest, project.id, userId, created);
+
+      // ---- 9. record ----
+      step = 'record';
+      this.jobs.setStep(jobId, step, { status: 'running' });
+      const manualSteps = [...this.applicableManualSteps(manifest), ...certManualSteps];
+      const appUrl =
+        appHost && created.domainId ? `https://${appHost}` : deployment.urls?.default;
+
+      await db
+        .update(installedApps)
+        .set({
+          name: manifest.name,
+          version: manifest.version,
+          alias: manifest.install.alias,
+          bundleSha256: bundle.sha256,
+          manifest,
+          ruleSetIds,
+          schemaIds,
+          deploymentId: deployment.deploymentId,
+          domainId: created.domainId ?? null,
+          createdResources: created,
+          status: 'installed',
+          updatedAt: new Date(),
+        })
+        .where(eq(installedApps.id, row.id));
+
+      this.jobs.setStep(jobId, step, { status: 'done', detail: 'Install recorded.' });
+      this.jobs.finish(jobId, 'succeeded', { installedAppId: row.id, manualSteps, appUrl });
+      this.logger.log(`Installed app ${manifest.id} v${manifest.version} into project ${project.id}`);
+    } catch (error) {
+      await this.failJob(jobId, step, rowId, error);
+    }
+  }
+
+  // ==================== update ====================
+
+  private async runUpdate(
+    jobId: string,
+    installed: InstalledApp,
+    entry: AppRegistryEntry,
+    userId: string,
+    opts: { prune: boolean },
+  ): Promise<void> {
+    let step: InstallStepId = 'fetch';
+
+    try {
+      this.jobs.setStep(jobId, step, { status: 'running' });
+      const bundle = await this.bundleService.fetchBundle(entry.bundleUrl, entry.sha256);
+      const manifest = bundle.manifest;
+      const ruleSets = this.parseAndValidateRuleSets(bundle);
+      this.jobs.setStep(jobId, step, {
+        status: 'done',
+        detail: `Bundle ${bundle.sha256.slice(0, 12)} verified; ${ruleSets.length} rule set payload(s) validated.`,
+      });
+
+      const project = await this.projectsService.getProjectById(installed.projectId);
+      const created: CreatedResources = {
+        ruleSetIds: [],
+        schemaIdsCreated: [],
+        scheduleIds: [],
+      };
+      this.mergeCreated(created, installed.createdResources);
+
+      step = 'sync-rules';
+      this.jobs.setStep(jobId, step, { status: 'running' });
+      const ruleSetIds: string[] = [...(installed.ruleSetIds ?? [])];
+      const schemaIds: string[] = [...(installed.schemaIds ?? [])];
+      const { missingSecrets, warnings } = await this.syncRuleSets(
+        ruleSets,
+        manifest,
+        project.id,
+        userId,
+        { prune: opts.prune },
+        { created, ruleSetIds, schemaIds },
+      );
+      this.jobs.setStep(jobId, step, {
+        status: 'done',
+        detail: this.syncDetail(ruleSets.length, missingSecrets, warnings, opts.prune),
+      });
+
+      // Same alias: the alias's deployment history IS the rollback mechanism.
+      step = 'deploy';
+      this.jobs.setStep(jobId, step, { status: 'running' });
+      const deployment = await this.deployBundle(bundle, manifest, ruleSets, project, userId);
+      created.aliasName = manifest.install.alias;
+      created.deploymentId = deployment.deploymentId;
+      this.jobs.setStep(jobId, step, {
+        status: 'done',
+        detail: `Deployed ${deployment.fileCount} file(s) to alias "${manifest.install.alias}".`,
+      });
+
+      step = 'record';
+      this.jobs.setStep(jobId, step, { status: 'running' });
+      await db
+        .update(installedApps)
+        .set({
+          name: manifest.name,
+          version: manifest.version,
+          bundleSha256: bundle.sha256,
+          manifest,
+          ruleSetIds,
+          schemaIds,
+          deploymentId: deployment.deploymentId,
+          createdResources: created,
+          status: 'installed',
+          updatedAt: new Date(),
+        })
+        .where(eq(installedApps.id, installed.id));
+
+      const manualSteps = this.applicableManualSteps(manifest);
+      const appUrl = installed.domainId
+        ? `https://${this.computeAppHost(manifest) ?? ''}`
+        : deployment.urls?.default;
+      this.jobs.setStep(jobId, step, { status: 'done', detail: 'Update recorded.' });
+      this.jobs.finish(jobId, 'succeeded', {
+        installedAppId: installed.id,
+        manualSteps,
+        appUrl,
+      });
+    } catch (error) {
+      await this.failJob(jobId, step, installed.id, error);
+    }
+  }
+
+  // ==================== undo / uninstall ====================
+
+  /**
+   * Deletes ONLY this install's own created objects, in reverse creation
+   * order, then drops the `installed_apps` row. Never touches a reused schema,
+   * an adopted rule set, or a pre-existing domain.
+   */
+  async undo(installedAppId: string, userId: string): Promise<{ removed: string[] }> {
+    const row = await this.requireRow(installedAppId);
+    const removed = await this.deleteCreatedResources(row, userId, { includeSchemas: true });
+
+    await db.delete(installedApps).where(eq(installedApps.id, row.id));
+
+    const job = this.jobs.findByInstalledApp(row.id);
+    if (job) this.jobs.finish(job.id, 'undone');
+
+    this.logger.log(`Undid app install ${row.appId} (${row.id}): removed ${removed.join(', ') || 'nothing'}`);
+    return { removed };
+  }
+
+  /**
+   * Uninstall = undo, except the app's data-table schemas (which hold the
+   * user's records) are only dropped when `deleteData` is explicitly true.
+   */
+  async uninstall(
+    installedAppId: string,
+    userId: string,
+    opts: { deleteData: boolean },
+  ): Promise<UninstallSummary> {
+    const row = await this.requireRow(installedAppId);
+    const kept: string[] = [];
+    const removed = await this.deleteCreatedResources(row, userId, {
+      includeSchemas: opts.deleteData,
+      kept,
+    });
+
+    await db.delete(installedApps).where(eq(installedApps.id, row.id));
+
+    this.logger.log(
+      `Uninstalled app ${row.appId} (${row.id}); data ${opts.deleteData ? 'deleted' : 'kept'}`,
+    );
+    return { removed, kept, dataDeleted: opts.deleteData };
+  }
+
+  private async deleteCreatedResources(
+    row: InstalledApp,
+    userId: string,
+    opts: { includeSchemas: boolean; kept?: string[] },
+  ): Promise<string[]> {
+    const created: CreatedResources = row.createdResources ?? {};
+    const removed: string[] = [];
+
+    for (const scheduleId of created.scheduleIds ?? []) {
+      await this.tryDelete(removed, `schedule:${scheduleId}`, () =>
+        this.schedulesService.deleteSchedule(scheduleId, userId, 'admin', null),
+      );
+    }
+
+    if (created.domainId) {
+      await this.tryDelete(removed, `domain:${created.domainId}`, () =>
+        this.domainsService.remove(created.domainId!, userId, undefined, null),
+      );
+    }
+
+    if (created.aliasName) {
+      const project = await this.projectsService.getProjectById(row.projectId);
+      await this.tryDelete(removed, `alias:${created.aliasName}`, () =>
+        this.deploymentsService.deleteAlias(
+          `${project.owner}/${project.name}`,
+          created.aliasName!,
+          userId,
+          'admin',
+        ),
+      );
+    }
+
+    if (created.deploymentId) {
+      await this.tryDelete(removed, `deployment:${created.deploymentId}`, () =>
+        this.deploymentsService.deleteDeployment(created.deploymentId!, userId, 'admin'),
+      );
+    }
+
+    for (const ruleSetId of created.ruleSetIds ?? []) {
+      await this.tryDelete(removed, `ruleSet:${ruleSetId}`, () =>
+        this.ruleSetsService.delete(ruleSetId, userId, 'admin', null),
+      );
+    }
+
+    for (const schemaId of created.schemaIdsCreated ?? []) {
+      if (!opts.includeSchemas) {
+        opts.kept?.push(`schema:${schemaId}`);
+        continue;
+      }
+      await this.tryDelete(removed, `schema:${schemaId}`, () =>
+        this.schemasService.delete(schemaId, userId, 'admin', null),
+      );
+    }
+
+    if (created.projectCreated) {
+      if (await this.projectIsEmpty(row.projectId)) {
+        await this.tryDelete(removed, `project:${row.projectId}`, () =>
+          this.projectsService.deleteProject(row.projectId),
+        );
+      } else {
+        opts.kept?.push(`project:${row.projectId}`);
+      }
+    }
+
+    return removed;
+  }
+
+  /** A project we created is only removable if this app was its only content. */
+  private async projectIsEmpty(projectId: string): Promise<boolean> {
+    const aliases = await db
+      .select({ id: deploymentAliases.id })
+      .from(deploymentAliases)
+      .where(eq(deploymentAliases.projectId, projectId));
+    if (aliases.length > 0) return false;
+
+    const sets = await db
+      .select({ id: proxyRuleSets.id })
+      .from(proxyRuleSets)
+      .where(eq(proxyRuleSets.projectId, projectId));
+    return sets.length === 0;
+  }
+
+  private async tryDelete(
+    removed: string[],
+    label: string,
+    run: () => Promise<unknown>,
+  ): Promise<void> {
+    try {
+      await run();
+      removed.push(label);
+    } catch (error) {
+      // A partial failure must not strand the rest of the cleanup.
+      this.logger.warn(`Failed to remove ${label}: ${this.messageOf(error)}`);
+    }
+  }
+
+  // ==================== steps ====================
+
+  private async syncRuleSets(
+    ruleSets: ParsedRuleSet[],
+    manifest: AppManifest,
+    projectId: string,
+    userId: string,
+    options: { prune: boolean },
+    acc: { created: CreatedResources; ruleSetIds: string[]; schemaIds: string[] },
+  ): Promise<{ missingSecrets: string[]; warnings: string[] }> {
+    const missingSecrets: string[] = [];
+    const warnings: string[] = [];
+
+    for (const ruleSet of ruleSets) {
+      const response = await this.ruleSetsService.syncRuleSet(
+        projectId,
+        {
+          ...ruleSet.dto,
+          options: { dryRun: false, prune: options.prune },
+          source: { repo: manifest.eject?.repo, path: ruleSet.file },
+        } as SyncProxyRuleSetDto,
+        userId,
+        'admin',
+        null,
+      );
+
+      if (response.ruleSetId) {
+        pushUnique(acc.ruleSetIds, response.ruleSetId);
+        // Only a set we CREATED is ours to delete on undo.
+        if (response.setCreated) pushUnique(acc.created.ruleSetIds!, response.ruleSetId);
+      }
+
+      for (const resolution of response.schemaResolutions ?? []) {
+        if (!resolution.targetSchemaId) continue;
+        pushUnique(acc.schemaIds, resolution.targetSchemaId);
+        if (resolution.action === 'create') {
+          pushUnique(acc.created.schemaIdsCreated!, resolution.targetSchemaId);
+        }
+      }
+
+      missingSecrets.push(...(response.missingSecrets ?? []));
+      warnings.push(...(response.warnings ?? []));
+    }
+
+    return { missingSecrets, warnings };
+  }
+
+  private async deployBundle(
+    bundle: LoadedBundle,
+    manifest: AppManifest,
+    ruleSets: ParsedRuleSet[],
+    project: ProjectRef,
+    userId: string,
+  ) {
+    const zipped = this.buildDistZip(bundle, manifest);
+    const alias = manifest.install.alias;
+    const attachNames = ruleSets.filter((r) => r.attach).map((r) => r.name);
+
+    const response = await this.deploymentsService.createDeploymentFromZip(
+      {
+        buffer: zipped,
+        originalname: `${manifest.id}-bundle.zip`,
+        mimetype: 'application/zip',
+      } as Express.Multer.File,
+      {
+        repository: `${project.owner}/${project.name}`,
+        commitSha: bundle.sha256.slice(0, 40),
+        branch: 'app-catalog',
+        alias,
+        description: `App install: ${manifest.name} v${manifest.version}`,
+        basePath: manifest.install.deployment.basePath,
+        proxyRuleSetNames: attachNames,
+        source: 'manual',
+      },
+      userId,
+      'admin',
+    );
+
+    // An explicit-alias failure is swallowed upstream (deployments.service.ts:
+    // "Alias creation failure is non-critical"), so absence here is the ONLY
+    // signal that the app's URL would 404. Treat it as a step failure.
+    if (!response.aliases?.includes(alias)) {
+      throw new Error(
+        `Deployment ${response.deploymentId} did not receive the "${alias}" alias — the app would not be reachable.`,
+      );
+    }
+
+    return response;
+  }
+
+  private async applyDomainStep(
+    jobId: string,
+    manifest: AppManifest,
+    row: InstalledApp,
+    projectId: string,
+    appHost: string | null,
+    userId: string,
+  ): Promise<{ domainId?: string; sslDowngraded: boolean }> {
+    const domain = manifest.install.domain;
+    if (!domain || !appHost) {
+      this.jobs.setStep(jobId, 'domain', {
+        status: 'skipped',
+        detail: 'This app declares no domain; it is served from its alias URL.',
+      });
+      return { sslDowngraded: false };
+    }
+
+    this.jobs.setStep(jobId, 'domain', { status: 'running' });
+
+    // Idempotent re-run: this app already owns the mapping.
+    const ownDomainId = row.createdResources?.domainId ?? row.domainId ?? undefined;
+    if (ownDomainId) {
+      this.jobs.setStep(jobId, 'domain', {
+        status: 'done',
+        detail: `${appHost} is already mapped by this install.`,
+      });
+      return { domainId: ownDomainId, sslDowngraded: false };
+    }
+
+    const createdDomain = await this.domainsService.create(
+      {
+        projectId,
+        alias: manifest.install.alias,
+        path: manifest.install.deployment.basePath,
+        domain: appHost,
+        domainType: 'subdomain',
+        sslEnabled: true,
+        isPublic: domain.isPublic,
+        isSpa: domain.isSpa,
+      },
+      userId,
+      undefined,
+      null,
+    );
+
+    // A subdomain's sslEnabled is silently downgraded when no wildcard cert
+    // exists — read it back rather than assuming what we asked for.
+    const sslDowngraded = createdDomain?.sslEnabled === false;
+    this.jobs.setStep(jobId, 'domain', { status: 'done', detail: `${appHost} mapped to this app.` });
+    return { domainId: createdDomain.id, sslDowngraded };
+  }
+
+  private async applyCertificateStep(
+    jobId: string,
+    appHost: string | null,
+    sslDowngraded: boolean,
+  ): Promise<AppManualStep[]> {
+    if (!appHost) {
+      this.jobs.setStep(jobId, 'certificate', {
+        status: 'skipped',
+        detail: 'No app domain, so no certificate is needed.',
+      });
+      return [];
+    }
+
+    try {
+      const plan = await this.certStepService.plan(appHost);
+      const result = await this.certStepService.execute(plan, appHost);
+      const detail = sslDowngraded
+        ? `${result.detail} Note: the domain row came back with SSL disabled (no wildcard certificate covers ` +
+          `${appHost} yet), so HTTPS may not work until a certificate is applied.`
+        : result.detail;
+      this.jobs.setStep(jobId, 'certificate', { status: result.status, detail });
+      return result.manualStep ? [result.manualStep] : [];
+    } catch (error) {
+      // A cert problem must never fail an install — the app stays reachable
+      // over the existing certificate or plain HTTP meanwhile.
+      const message = this.messageOf(error);
+      this.logger.warn(`Certificate step for ${appHost} failed: ${message}`);
+      this.jobs.setStep(jobId, 'certificate', {
+        status: 'skipped',
+        detail: `Certificate step skipped: ${message}. Verify SSL for ${appHost} manually.`,
+      });
+      return [];
+    }
+  }
+
+  private async applyScheduleStep(
+    jobId: string,
+    manifest: AppManifest,
+    projectId: string,
+    userId: string,
+    created: CreatedResources,
+  ): Promise<void> {
+    const wanted = manifest.install.schedules ?? [];
+    if (wanted.length === 0) {
+      this.jobs.setStep(jobId, 'schedules', {
+        status: 'skipped',
+        detail: 'This app ships no scheduled pipelines.',
+      });
+      return;
+    }
+
+    this.jobs.setStep(jobId, 'schedules', { status: 'running' });
+    const rules = await this.schedulesService.listPipelineRules(projectId, userId, 'admin', null);
+    const existing = await this.schedulesService.listSchedules(projectId, userId, 'admin', null);
+
+    let createdCount = 0;
+    for (const schedule of wanted) {
+      // Schedules have no name-uniqueness constraint, so idempotency is the
+      // installer's own job.
+      if (existing.some((e) => e.name === schedule.name)) continue;
+
+      const wantedMethod = schedule.targetRuleMethod ?? null;
+      const rule = rules.find(
+        (r) => r.pathPattern === schedule.targetRulePath && (r.method ?? null) === wantedMethod,
+      );
+      if (!rule) {
+        throw new Error(
+          `No pipeline rule matching ${wantedMethod ?? 'ANY'} ${schedule.targetRulePath} was found ` +
+            `for schedule "${schedule.name}".`,
+        );
+      }
+
+      const row = await this.schedulesService.createSchedule(
+        projectId,
+        {
+          name: schedule.name,
+          targetProxyRuleId: rule.id,
+          cronExpression: schedule.cronExpression,
+          timezone: schedule.timezone ?? 'UTC',
+        },
+        userId,
+        'admin',
+        null,
+      );
+      pushUnique(created.scheduleIds!, row.id);
+      createdCount++;
+    }
+
+    this.jobs.setStep(jobId, 'schedules', {
+      status: 'done',
+      detail: `${createdCount} schedule(s) created, ${wanted.length - createdCount} already present.`,
+    });
+  }
+
+  // ==================== helpers ====================
+
+  private assertGatesPass(gates: GateResult[]): void {
+    const failures = gates.filter((gate) => gate.status === 'fail');
+    if (failures.length === 0) return;
+    throw new BadRequestException(
+      `Install blocked by preflight: ${failures.map((f) => f.message).join(' ')}`,
+    );
+  }
+
+  private toPreflightTarget(
+    target: InstallTarget,
+  ): { projectId: string } | { newProject: { owner: string; name: string } } {
+    if (target.projectId) return { projectId: target.projectId };
+    if (target.newProject) return { newProject: target.newProject };
+    throw new BadRequestException('An install target requires either projectId or newProject');
+  }
+
+  private async resolveProject(
+    target: InstallTarget,
+    userId: string,
+    created: CreatedResources,
+  ): Promise<ProjectRef> {
+    if (target.projectId) {
+      created.projectCreated = false;
+      const project = await this.projectsService.getProjectById(target.projectId);
+      return { id: project.id, owner: project.owner, name: project.name };
+    }
+    if (!target.newProject) {
+      throw new BadRequestException('An install target requires either projectId or newProject');
+    }
+
+    const { owner, name } = target.newProject;
+    // Check BEFORE creating — findOrCreateProject is idempotent, so afterwards
+    // we could no longer tell whether the project was ours.
+    const existedBefore = await this.projectsService.projectExists(owner, name);
+    const project = await this.projectsService.findOrCreateProject(owner, name, userId);
+    created.projectCreated = !existedBefore;
+    return { id: project.id, owner: project.owner, name: project.name };
+  }
+
+  /**
+   * The `installed_apps` row goes in with `status: 'installing'` BEFORE any
+   * project-scoped write, so a crash mid-install still leaves an undoable
+   * record. A row from a previous failed attempt is reused (resume), never
+   * duplicated — `(app_id, project_id)` is unique anyway.
+   */
+  private async loadOrCreateRow(
+    manifest: AppManifest,
+    projectId: string,
+    bundleSha256: string,
+    userId: string,
+  ): Promise<InstalledApp> {
+    const [existing] = await db
+      .select()
+      .from(installedApps)
+      .where(and(eq(installedApps.appId, manifest.id), eq(installedApps.projectId, projectId)))
+      .limit(1);
+
+    if (existing) {
+      const [updated] = await db
+        .update(installedApps)
+        .set({ status: 'installing', manifest, bundleSha256, updatedAt: new Date() })
+        .where(eq(installedApps.id, existing.id))
+        .returning();
+      return updated ?? existing;
+    }
+
+    const [inserted] = await db
+      .insert(installedApps)
+      .values({
+        appId: manifest.id,
+        name: manifest.name,
+        version: manifest.version,
+        projectId,
+        alias: manifest.install.alias,
+        bundleSha256,
+        manifest,
+        status: 'installing',
+        createdResources: {},
+        installedBy: userId,
+      })
+      .returning();
+
+    return inserted;
+  }
+
+  private async requireRow(installedAppId: string): Promise<InstalledApp> {
+    const [row] = await db
+      .select()
+      .from(installedApps)
+      .where(eq(installedApps.id, installedAppId))
+      .limit(1);
+    if (!row) throw new NotFoundException(`Installed app ${installedAppId} not found`);
+    return row;
+  }
+
+  private mergeCreated(target: CreatedResources, source?: CreatedResources | null): void {
+    if (!source) return;
+    for (const id of source.ruleSetIds ?? []) pushUnique(target.ruleSetIds!, id);
+    for (const id of source.schemaIdsCreated ?? []) pushUnique(target.schemaIdsCreated!, id);
+    for (const id of source.scheduleIds ?? []) pushUnique(target.scheduleIds!, id);
+    if (source.projectCreated !== undefined) target.projectCreated = source.projectCreated;
+    if (source.aliasName) target.aliasName = source.aliasName;
+    if (source.deploymentId) target.deploymentId = source.deploymentId;
+    if (source.domainId) target.domainId = source.domainId;
+  }
+
+  /**
+   * Runs every bundled rule-set payload through the REAL sync DTO pipeline
+   * (`plainToInstance` + `validateSync`) so a direct service call gets the
+   * same SSRF/shape validation an HTTP caller would (`IsValidSyncTargetUrl`
+   * and friends). Anything invalid aborts the install before a single write.
+   */
+  private parseAndValidateRuleSets(bundle: LoadedBundle): ParsedRuleSet[] {
+    return bundle.manifest.install.ruleSets.map((entry) => {
+      const bytes = bundle.files[entry.file];
+      if (!bytes) {
+        throw new BadRequestException(`Bundle is missing declared rule set file: ${entry.file}`);
+      }
+
+      let json: unknown;
+      try {
+        json = JSON.parse(new TextDecoder().decode(bytes));
+      } catch (error) {
+        throw new BadRequestException(`${entry.file} is not valid JSON: ${this.messageOf(error)}`);
+      }
+
+      const dto = plainToInstance(SyncProxyRuleSetDto, json);
+      const errors = validateSync(dto as object, { whitelist: true, forbidUnknownValues: false });
+      if (errors.length > 0) {
+        throw new BadRequestException(
+          `${entry.file} failed rule-set validation: ${flattenValidationErrors(errors).join('; ')}`,
+        );
+      }
+
+      return {
+        file: entry.file,
+        name: dto.ruleSet.name,
+        attach: entry.attachToAlias !== false,
+        dto,
+      };
+    });
+  }
+
+  /**
+   * The deployment carries only the manifest's `deployment.path` subtree,
+   * re-keyed under `basePath` (e.g. `dist/index.html` →
+   * `apps/handoff/dist/index.html`) so the alias's basePath resolves.
+   */
+  private buildDistZip(bundle: LoadedBundle, manifest: AppManifest): Buffer {
+    const prefix = `${manifest.install.deployment.path.replace(/\/+$/, '')}/`;
+    const base = manifest.install.deployment.basePath.replace(/^\/+/, '').replace(/\/+$/, '');
+
+    const entries: Record<string, Uint8Array> = {};
+    for (const [entryPath, bytes] of Object.entries(bundle.files)) {
+      if (!entryPath.startsWith(prefix)) continue;
+      const rest = entryPath.slice(prefix.length);
+      if (!rest) continue;
+      entries[base ? `${base}/${rest}` : rest] = bytes;
+    }
+
+    if (Object.keys(entries).length === 0) {
+      throw new Error(`Bundle has no files under ${manifest.install.deployment.path}/ to deploy`);
+    }
+
+    return Buffer.from(zipSync(entries));
+  }
+
+  private applicableManualSteps(manifest: AppManifest): AppManualStep[] {
+    const ctx = this.instanceContext();
+    return (manifest.install.manualSteps ?? []).filter((step) => manualStepApplies(step, ctx));
+  }
+
+  private instanceContext(): { bucketStorage: boolean; platformMode: boolean } {
+    const adapter = this.storageAdapter as IStorageAdapter & { getAdapterType?: () => string };
+    const adapterName = adapter.getAdapterType?.() ?? this.storageAdapter.constructor.name;
+    return {
+      bucketStorage: !adapterName.toLowerCase().includes('local'),
+      platformMode:
+        this.configService.get<string>('PLATFORM_MODE') === 'true' ||
+        process.env.PLATFORM_MODE === 'true',
+    };
+  }
+
+  private computeAppHost(manifest: AppManifest): string | null {
+    const subdomain = manifest.install.domain?.subdomain;
+    if (!subdomain) return null;
+    const primaryDomain = this.configService.get<string>('PRIMARY_DOMAIN') || '';
+    return primaryDomain ? `${subdomain}.${primaryDomain}` : null;
+  }
+
+  private syncDetail(
+    count: number,
+    missingSecrets: string[],
+    warnings: string[],
+    prune?: boolean,
+  ): string {
+    const parts = [`Synced ${count} rule set(s)${prune ? ' with prune enabled' : ''}.`];
+    if (missingSecrets.length > 0) {
+      parts.push(`Missing project secrets: ${[...new Set(missingSecrets)].join(', ')}.`);
+    }
+    if (warnings.length > 0) parts.push(`Warnings: ${warnings.join('; ')}.`);
+    return parts.join(' ');
+  }
+
+  private async failJob(
+    jobId: string,
+    step: InstallStepId,
+    rowId: string | undefined,
+    error: unknown,
+  ): Promise<void> {
+    const message = this.messageOf(error);
+    this.logger.error(`App install job ${jobId} failed at step "${step}": ${message}`);
+    this.jobs.setStep(jobId, step, { status: 'failed', error: message });
+
+    // Keep the row — it powers both undo and a resume-by-reinstall.
+    if (rowId) {
+      try {
+        await db
+          .update(installedApps)
+          .set({ status: 'failed', updatedAt: new Date() })
+          .where(eq(installedApps.id, rowId));
+      } catch (updateError) {
+        this.logger.error(`Could not mark install row ${rowId} failed: ${this.messageOf(updateError)}`);
+      }
+    }
+
+    this.jobs.finish(jobId, 'failed', { error: message });
+  }
+
+  private messageOf(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    return typeof error === 'string' ? error : 'Unknown error';
+  }
+}
+
+function pushUnique(list: string[], value: string): void {
+  if (!list.includes(value)) list.push(value);
+}
+
+function flattenValidationErrors(errors: ValidationError[], path = ''): string[] {
+  const messages: string[] = [];
+  for (const error of errors) {
+    const here = path ? `${path}.${error.property}` : error.property;
+    if (error.constraints) {
+      messages.push(`${here}: ${Object.values(error.constraints).join(', ')}`);
+    }
+    if (error.children?.length) {
+      messages.push(...flattenValidationErrors(error.children, here));
+    }
+  }
+  return messages;
+}

--- a/apps/backend/src/app-catalog/app-installer.service.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.ts
@@ -68,7 +68,15 @@ const INSTALL_STEPS: InstallStepId[] = [
   'record',
 ];
 
-const UPDATE_STEPS: InstallStepId[] = ['fetch', 'sync-rules', 'deploy', 'record'];
+/**
+ * An update re-verifies the INSTANCE gates only. A registry bump can raise
+ * `requires.ceMin`/`presignedStorage`, and an app that installed cleanly a
+ * month ago is not automatically still installable today. Project gates are
+ * deliberately absent: the target project, alias, domain and rule sets are
+ * this install's own by definition, so a collision check against them would
+ * fail on every update.
+ */
+const UPDATE_STEPS: InstallStepId[] = ['preflight', 'fetch', 'sync-rules', 'deploy', 'record'];
 
 interface ParsedRuleSet {
   file: string;
@@ -319,10 +327,21 @@ export class AppInstallerService {
     userId: string,
     opts: { prune: boolean },
   ): Promise<void> {
-    let step: InstallStepId = 'fetch';
+    let step: InstallStepId = 'preflight';
     let progress: InstallProgress | undefined;
+    // Stays undefined until the gates pass, so a refused update leaves the
+    // healthy `installed_apps` row exactly as it was — a gate failure writes
+    // nothing, and must not restamp a working install as `failed`.
+    let rowId: string | undefined;
 
     try {
+      // ---- 1. preflight: the instance may no longer satisfy this version's
+      // requirements, even though the previous version installed fine ----
+      this.jobs.setStep(jobId, step, { status: 'running' });
+      this.assertGatesPass(await this.preflightService.instanceGates(entry.requires), 'Update');
+      this.jobs.setStep(jobId, step, { status: 'done', detail: 'All instance gates passed.' });
+
+      step = 'fetch';
       this.jobs.setStep(jobId, step, { status: 'running' });
       const bundle = await this.bundleService.fetchBundle(entry.bundleUrl, entry.sha256);
       const manifest = bundle.manifest;
@@ -342,6 +361,9 @@ export class AppInstallerService {
 
       step = 'sync-rules';
       this.jobs.setStep(jobId, step, { status: 'running' });
+      // From here on the run can write; a failure past this point must carry
+      // the accumulated progress onto the row (see failJob).
+      rowId = installed.id;
       progress = {
         created,
         ruleSetIds: [...(installed.ruleSetIds ?? [])],
@@ -405,7 +427,7 @@ export class AppInstallerService {
         appUrl,
       });
     } catch (error) {
-      await this.failJob(jobId, step, installed.id, error, progress);
+      await this.failJob(jobId, step, rowId, error, progress);
     }
   }
 
@@ -1013,11 +1035,11 @@ export class AppInstallerService {
 
   // ==================== helpers ====================
 
-  private assertGatesPass(gates: GateResult[]): void {
+  private assertGatesPass(gates: GateResult[], kind: 'Install' | 'Update' = 'Install'): void {
     const failures = gates.filter((gate) => gate.status === 'fail');
     if (failures.length === 0) return;
     throw new BadRequestException(
-      `Install blocked by preflight: ${failures.map((f) => f.message).join(' ')}`,
+      `${kind} blocked by preflight: ${failures.map((f) => f.message).join(' ')}`,
     );
   }
 
@@ -1046,9 +1068,25 @@ export class AppInstallerService {
     const { owner, name } = target.newProject;
     // Check BEFORE creating — findOrCreateProject is idempotent, so afterwards
     // we could no longer tell whether the project was ours.
-    const existedBefore = await this.projectsService.projectExists(owner, name);
+    //
+    // An existing project is a REFUSAL, not an adoption: every project-scoped
+    // collision gate (rule-set names, the app's alias, the per-project install
+    // row) is skipped for a `newProject` target, and findOrCreateProject would
+    // quietly hand us someone else's project with its own alias — which would
+    // then land in `createdResources.aliasName` and be deleted by a later
+    // undo. Preflight already fails this (`name-collision`); repeating it here
+    // is defense in depth for any caller that reaches the installer directly.
+    // Retrying a failed newProject install is unaffected in substance: the
+    // project now exists, so the operator picks it from the picker and the
+    // full set of gates runs, recognising this app's own objects as its own.
+    if (await this.projectsService.projectExists(owner, name)) {
+      throw new BadRequestException(
+        `A project named "${owner}/${name}" already exists — select it from the project picker instead of ` +
+          'creating it, so the install can check its existing rule sets, aliases and data tables for collisions.',
+      );
+    }
     const project = await this.projectsService.findOrCreateProject(owner, name, userId);
-    created.projectCreated = !existedBefore;
+    created.projectCreated = true;
     return { id: project.id, owner: project.owner, name: project.name };
   }
 

--- a/apps/backend/src/app-catalog/app-installer.service.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.ts
@@ -33,11 +33,26 @@ export interface InstallTarget {
 }
 
 export interface UninstallSummary {
-  /** Labels (`kind:id`) of objects actually deleted. */
-  removed: string[];
-  /** Objects deliberately left in place (e.g. data-table schemas when `deleteData` is false). */
-  kept: string[];
-  dataDeleted: boolean;
+  removed: {
+    ruleSets: number;
+    alias: boolean;
+    domain: boolean;
+    deployment: boolean;
+    schedules: number;
+  };
+  dataTables: {
+    /** Table names left in place — every reused table, plus created tables when `deleteData` is false. */
+    kept: string[];
+    /** Table names actually dropped (`deleteData: true`, created-by-install tables only). */
+    deleted: string[];
+    /** Record count captured (via `getByIdWithCount`) BEFORE each deleted table was dropped. */
+    deletedRecordCounts: Record<string, number>;
+  };
+  note: string;
+}
+
+export interface UninstallPreview {
+  dataTables: Array<{ name: string; recordCount: number; createdByInstall: boolean }>;
 }
 
 const INSTALL_STEPS: InstallStepId[] = [
@@ -413,8 +428,19 @@ export class AppInstallerService {
   }
 
   /**
-   * Uninstall = undo, except the app's data-table schemas (which hold the
-   * user's records) are only dropped when `deleteData` is explicitly true.
+   * Uninstall treats the app's content as the USER's, not the installer's:
+   * it removes the app's own infrastructure (rule sets, alias, domain,
+   * deployment, schedules) but keeps every data table and stored object by
+   * default. `deleteData: true` additionally drops the tables this install
+   * itself created — a table the sync merely REUSED is never dropped, no
+   * matter what the flag says.
+   *
+   * One deliberate divergence from {@link undo}: rule-set removal here walks
+   * `row.ruleSetIds` (every rule set this app's rule-set files sync, whether
+   * created or adopted), not `createdResources.ruleSetIds`. `undo` unwinds a
+   * failed/in-progress install and must never touch a set it didn't create;
+   * a full uninstall is the user tearing the app down, and its rule sets
+   * (named after the app, not general-purpose) go with it.
    */
   async uninstall(
     installedAppId: string,
@@ -422,18 +448,149 @@ export class AppInstallerService {
     opts: { deleteData: boolean },
   ): Promise<UninstallSummary> {
     const row = await this.requireRow(installedAppId);
-    const kept: string[] = [];
-    const removed = await this.deleteCreatedResources(row, userId, {
-      includeSchemas: opts.deleteData,
-      kept,
-    });
+    const project = await this.projectsService.getProjectById(row.projectId);
+
+    const dataTables = await this.resolveUninstallDataTables(row, opts.deleteData, userId);
+    const removed = await this.removeLifecycleResources(row, userId, project, row.ruleSetIds ?? []);
 
     await db.delete(installedApps).where(eq(installedApps.id, row.id));
 
     this.logger.log(
       `Uninstalled app ${row.appId} (${row.id}); data ${opts.deleteData ? 'deleted' : 'kept'}`,
     );
-    return { removed, kept, dataDeleted: opts.deleteData };
+
+    return {
+      removed,
+      dataTables,
+      note: `Stored objects under project ${project.owner}/${project.name} remain; delete the project for full cleanup.`,
+    };
+  }
+
+  /**
+   * Powers the uninstall dialog's real counts ("this deletes 412 records
+   * across 3 tables") before the user commits to `deleteData: true`.
+   */
+  async uninstallPreview(installedAppId: string): Promise<UninstallPreview> {
+    const row = await this.requireRow(installedAppId);
+    const createdSchemaIds = new Set(row.createdResources?.schemaIdsCreated ?? []);
+
+    const dataTables: UninstallPreview['dataTables'] = [];
+    for (const id of row.schemaIds ?? []) {
+      const withCount = await this.schemasService.getByIdWithCount(id, null);
+      dataTables.push({
+        name: withCount?.name ?? id,
+        recordCount: withCount?.recordCount ?? 0,
+        createdByInstall: createdSchemaIds.has(id),
+      });
+    }
+
+    return { dataTables };
+  }
+
+  /**
+   * Splits `row.schemaIds` into kept/deleted for the uninstall summary. A
+   * table only ever moves to `deleted` when BOTH `deleteData` is true AND
+   * this install created it — reused tables are unconditionally kept.
+   * Record counts are fetched via `getByIdWithCount` before the delete call,
+   * so a partial failure still reports what would have been removed.
+   */
+  private async resolveUninstallDataTables(
+    row: InstalledApp,
+    deleteData: boolean,
+    userId: string,
+  ): Promise<UninstallSummary['dataTables']> {
+    const createdSchemaIds = new Set(row.createdResources?.schemaIdsCreated ?? []);
+    const kept: string[] = [];
+    const deleted: string[] = [];
+    const deletedRecordCounts: Record<string, number> = {};
+
+    for (const id of row.schemaIds ?? []) {
+      const withCount = await this.schemasService.getByIdWithCount(id, null);
+      const name = withCount?.name ?? id;
+
+      if (!deleteData || !createdSchemaIds.has(id)) {
+        kept.push(name);
+        continue;
+      }
+
+      deletedRecordCounts[name] = withCount?.recordCount ?? 0;
+      const ok = await this.tryRun(`schema:${id}`, () =>
+        this.schemasService.delete(id, userId, 'admin', null),
+      );
+      if (ok) {
+        deleted.push(name);
+      } else {
+        kept.push(name);
+        delete deletedRecordCounts[name];
+      }
+    }
+
+    return { kept, deleted, deletedRecordCounts };
+  }
+
+  /**
+   * Removes an installed app's own infrastructure — schedules, domain,
+   * alias, deployment, then rule sets — reporting a count/boolean per class
+   * for {@link UninstallSummary}. `ruleSetIds` is caller-supplied (see
+   * {@link uninstall}'s doc comment on why it differs from `undo`).
+   */
+  private async removeLifecycleResources(
+    row: InstalledApp,
+    userId: string,
+    project: ProjectRef,
+    ruleSetIds: string[],
+  ): Promise<UninstallSummary['removed']> {
+    const created: CreatedResources = row.createdResources ?? {};
+
+    let schedulesRemoved = 0;
+    for (const scheduleId of created.scheduleIds ?? []) {
+      const ok = await this.tryRun(`schedule:${scheduleId}`, () =>
+        this.schedulesService.deleteSchedule(scheduleId, userId, 'admin', null),
+      );
+      if (ok) schedulesRemoved++;
+    }
+
+    let domainRemoved = false;
+    if (created.domainId) {
+      domainRemoved = await this.tryRun(`domain:${created.domainId}`, () =>
+        this.domainsService.remove(created.domainId!, userId, undefined, null),
+      );
+    }
+
+    let aliasRemoved = false;
+    if (created.aliasName) {
+      aliasRemoved = await this.tryRun(`alias:${created.aliasName}`, () =>
+        this.deploymentsService.deleteAlias(
+          `${project.owner}/${project.name}`,
+          created.aliasName!,
+          userId,
+          'admin',
+        ),
+      );
+    }
+
+    let deploymentRemoved = false;
+    if (created.deploymentId) {
+      deploymentRemoved = await this.tryRun(`deployment:${created.deploymentId}`, () =>
+        this.deploymentsService.deleteDeployment(created.deploymentId!, userId, 'admin'),
+      );
+    }
+
+    let ruleSetsRemoved = 0;
+    for (const ruleSetId of ruleSetIds) {
+      const ok = await this.tryRun(`ruleSet:${ruleSetId}`, () =>
+        this.ruleSetsService.delete(ruleSetId, userId, 'admin', null),
+      );
+      if (ok) ruleSetsRemoved++;
+    }
+
+    return {
+      ruleSets: ruleSetsRemoved,
+      alias: aliasRemoved,
+      domain: domainRemoved,
+      deployment: deploymentRemoved,
+      schedules: schedulesRemoved,
+    };
   }
 
   private async deleteCreatedResources(
@@ -523,12 +680,17 @@ export class AppInstallerService {
     label: string,
     run: () => Promise<unknown>,
   ): Promise<void> {
+    if (await this.tryRun(label, run)) removed.push(label);
+  }
+
+  /** Runs `run`, swallowing (and logging) a failure so it can't strand the rest of a cleanup. */
+  private async tryRun(label: string, run: () => Promise<unknown>): Promise<boolean> {
     try {
       await run();
-      removed.push(label);
+      return true;
     } catch (error) {
-      // A partial failure must not strand the rest of the cleanup.
       this.logger.warn(`Failed to remove ${label}: ${this.messageOf(error)}`);
+      return false;
     }
   }
 

--- a/apps/backend/src/app-catalog/app-installer.service.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.ts
@@ -20,6 +20,7 @@ import { ProjectsService } from '../projects/projects.service';
 import { ProxyRuleSetsService } from '../proxy-rules/proxy-rule-sets.service';
 import { SyncProxyRuleSetDto } from '../proxy-rules/dto/sync-proxy-rule-set.dto';
 import { IStorageAdapter, STORAGE_ADAPTER } from '../storage/storage.interface';
+import { resolveLocalAdapter } from '../storage/local.adapter';
 import { AppBundleService, type LoadedBundle } from './app-bundle.service';
 import { AppCertStepService } from './app-cert-step.service';
 import { AppInstallJobsService, type InstallStepId } from './app-install-jobs.service';
@@ -1254,10 +1255,8 @@ export class AppInstallerService {
   }
 
   private instanceContext(): { bucketStorage: boolean; platformMode: boolean } {
-    const adapter = this.storageAdapter as IStorageAdapter & { getAdapterType?: () => string };
-    const adapterName = adapter.getAdapterType?.() ?? this.storageAdapter.constructor.name;
     return {
-      bucketStorage: !adapterName.toLowerCase().includes('local'),
+      bucketStorage: resolveLocalAdapter(this.storageAdapter) === null,
       platformMode:
         this.configService.get<string>('PLATFORM_MODE') === 'true' ||
         process.env.PLATFORM_MODE === 'true',

--- a/apps/backend/src/app-catalog/app-installer.service.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.ts
@@ -49,6 +49,8 @@ export interface UninstallSummary {
     deletedRecordCounts: Record<string, number>;
   };
   note: string;
+  /** `kind:id` labels of deletions that failed. Absent/omitted when everything succeeded. */
+  failures?: string[];
 }
 
 export interface UninstallPreview {
@@ -413,10 +415,30 @@ export class AppInstallerService {
    * Deletes ONLY this install's own created objects, in reverse creation
    * order, then drops the `installed_apps` row. Never touches a reused schema,
    * an adopted rule set, or a pre-existing domain.
+   *
+   * The row is only dropped when every attempted deletion succeeded. If any
+   * failed, the row is KEPT (`status: 'failed'`) rather than silently leaving
+   * a stranded, untracked resource with nothing left to retry it from — the
+   * caller sees which labels failed via `failures` and can call `undo` again
+   * (each `tryRun` treats an already-gone resource as success, so a retry
+   * only re-attempts what's still actually live).
    */
-  async undo(installedAppId: string, userId: string): Promise<{ removed: string[] }> {
+  async undo(installedAppId: string, userId: string): Promise<{ removed: string[]; failures?: string[] }> {
     const row = await this.requireRow(installedAppId);
-    const removed = await this.deleteCreatedResources(row, userId, { includeSchemas: true });
+    const { removed, failures } = await this.deleteCreatedResources(row, userId, { includeSchemas: true });
+
+    if (failures.length > 0) {
+      await db
+        .update(installedApps)
+        .set({ status: 'failed', updatedAt: new Date() })
+        .where(eq(installedApps.id, row.id));
+
+      this.logger.warn(
+        `Undo of app install ${row.appId} (${row.id}) left ${failures.length} object(s) undeleted ` +
+          `(${failures.join(', ')}); row kept for retry.`,
+      );
+      return { removed, failures };
+    }
 
     await db.delete(installedApps).where(eq(installedApps.id, row.id));
 
@@ -441,6 +463,13 @@ export class AppInstallerService {
    * failed/in-progress install and must never touch a set it didn't create;
    * a full uninstall is the user tearing the app down, and its rule sets
    * (named after the app, not general-purpose) go with it.
+   *
+   * Same row-retention rule as {@link undo}: the `installed_apps` row is only
+   * dropped once every attempted deletion (infrastructure AND, when
+   * `deleteData` is true, data tables) succeeded. A partial failure keeps the
+   * row (`status: 'failed'`) and reports which `kind:id` labels failed via
+   * `UninstallSummary.failures`, so a repeat call has something to retry from
+   * instead of orphaning whatever didn't get cleaned up.
    */
   async uninstall(
     installedAppId: string,
@@ -450,8 +479,32 @@ export class AppInstallerService {
     const row = await this.requireRow(installedAppId);
     const project = await this.projectsService.getProjectById(row.projectId);
 
-    const dataTables = await this.resolveUninstallDataTables(row, opts.deleteData, userId);
-    const removed = await this.removeLifecycleResources(row, userId, project, row.ruleSetIds ?? []);
+    const { dataTables, failures: dataTableFailures } = await this.resolveUninstallDataTables(
+      row,
+      opts.deleteData,
+      userId,
+    );
+    const { removed, failures: lifecycleFailures } = await this.removeLifecycleResources(
+      row,
+      userId,
+      project,
+      row.ruleSetIds ?? [],
+    );
+    const failures = [...dataTableFailures, ...lifecycleFailures];
+    const note = `Stored objects under project ${project.owner}/${project.name} remain; delete the project for full cleanup.`;
+
+    if (failures.length > 0) {
+      await db
+        .update(installedApps)
+        .set({ status: 'failed', updatedAt: new Date() })
+        .where(eq(installedApps.id, row.id));
+
+      this.logger.warn(
+        `Uninstall of app ${row.appId} (${row.id}) left ${failures.length} object(s) undeleted ` +
+          `(${failures.join(', ')}); row kept for retry.`,
+      );
+      return { removed, dataTables, note, failures };
+    }
 
     await db.delete(installedApps).where(eq(installedApps.id, row.id));
 
@@ -459,11 +512,7 @@ export class AppInstallerService {
       `Uninstalled app ${row.appId} (${row.id}); data ${opts.deleteData ? 'deleted' : 'kept'}`,
     );
 
-    return {
-      removed,
-      dataTables,
-      note: `Stored objects under project ${project.owner}/${project.name} remain; delete the project for full cleanup.`,
-    };
+    return { removed, dataTables, note };
   }
 
   /**
@@ -498,11 +547,12 @@ export class AppInstallerService {
     row: InstalledApp,
     deleteData: boolean,
     userId: string,
-  ): Promise<UninstallSummary['dataTables']> {
+  ): Promise<{ dataTables: UninstallSummary['dataTables']; failures: string[] }> {
     const createdSchemaIds = new Set(row.createdResources?.schemaIdsCreated ?? []);
     const kept: string[] = [];
     const deleted: string[] = [];
     const deletedRecordCounts: Record<string, number> = {};
+    const failures: string[] = [];
 
     for (const id of row.schemaIds ?? []) {
       const withCount = await this.schemasService.getByIdWithCount(id, null);
@@ -522,10 +572,11 @@ export class AppInstallerService {
       } else {
         kept.push(name);
         delete deletedRecordCounts[name];
+        failures.push(`schema:${id}`);
       }
     }
 
-    return { kept, deleted, deletedRecordCounts };
+    return { dataTables: { kept, deleted, deletedRecordCounts }, failures };
   }
 
   /**
@@ -539,8 +590,9 @@ export class AppInstallerService {
     userId: string,
     project: ProjectRef,
     ruleSetIds: string[],
-  ): Promise<UninstallSummary['removed']> {
+  ): Promise<{ removed: UninstallSummary['removed']; failures: string[] }> {
     const created: CreatedResources = row.createdResources ?? {};
+    const failures: string[] = [];
 
     let schedulesRemoved = 0;
     for (const scheduleId of created.scheduleIds ?? []) {
@@ -548,6 +600,7 @@ export class AppInstallerService {
         this.schedulesService.deleteSchedule(scheduleId, userId, 'admin', null),
       );
       if (ok) schedulesRemoved++;
+      else failures.push(`schedule:${scheduleId}`);
     }
 
     let domainRemoved = false;
@@ -555,6 +608,7 @@ export class AppInstallerService {
       domainRemoved = await this.tryRun(`domain:${created.domainId}`, () =>
         this.domainsService.remove(created.domainId!, userId, undefined, null),
       );
+      if (!domainRemoved) failures.push(`domain:${created.domainId}`);
     }
 
     let aliasRemoved = false;
@@ -567,6 +621,7 @@ export class AppInstallerService {
           'admin',
         ),
       );
+      if (!aliasRemoved) failures.push(`alias:${created.aliasName}`);
     }
 
     let deploymentRemoved = false;
@@ -574,6 +629,7 @@ export class AppInstallerService {
       deploymentRemoved = await this.tryRun(`deployment:${created.deploymentId}`, () =>
         this.deploymentsService.deleteDeployment(created.deploymentId!, userId, 'admin'),
       );
+      if (!deploymentRemoved) failures.push(`deployment:${created.deploymentId}`);
     }
 
     let ruleSetsRemoved = 0;
@@ -582,14 +638,18 @@ export class AppInstallerService {
         this.ruleSetsService.delete(ruleSetId, userId, 'admin', null),
       );
       if (ok) ruleSetsRemoved++;
+      else failures.push(`ruleSet:${ruleSetId}`);
     }
 
     return {
-      ruleSets: ruleSetsRemoved,
-      alias: aliasRemoved,
-      domain: domainRemoved,
-      deployment: deploymentRemoved,
-      schedules: schedulesRemoved,
+      removed: {
+        ruleSets: ruleSetsRemoved,
+        alias: aliasRemoved,
+        domain: domainRemoved,
+        deployment: deploymentRemoved,
+        schedules: schedulesRemoved,
+      },
+      failures,
     };
   }
 
@@ -597,25 +657,26 @@ export class AppInstallerService {
     row: InstalledApp,
     userId: string,
     opts: { includeSchemas: boolean; kept?: string[] },
-  ): Promise<string[]> {
+  ): Promise<{ removed: string[]; failures: string[] }> {
     const created: CreatedResources = row.createdResources ?? {};
     const removed: string[] = [];
+    const failures: string[] = [];
 
     for (const scheduleId of created.scheduleIds ?? []) {
-      await this.tryDelete(removed, `schedule:${scheduleId}`, () =>
+      await this.tryDelete(removed, failures, `schedule:${scheduleId}`, () =>
         this.schedulesService.deleteSchedule(scheduleId, userId, 'admin', null),
       );
     }
 
     if (created.domainId) {
-      await this.tryDelete(removed, `domain:${created.domainId}`, () =>
+      await this.tryDelete(removed, failures, `domain:${created.domainId}`, () =>
         this.domainsService.remove(created.domainId!, userId, undefined, null),
       );
     }
 
     if (created.aliasName) {
       const project = await this.projectsService.getProjectById(row.projectId);
-      await this.tryDelete(removed, `alias:${created.aliasName}`, () =>
+      await this.tryDelete(removed, failures, `alias:${created.aliasName}`, () =>
         this.deploymentsService.deleteAlias(
           `${project.owner}/${project.name}`,
           created.aliasName!,
@@ -626,13 +687,13 @@ export class AppInstallerService {
     }
 
     if (created.deploymentId) {
-      await this.tryDelete(removed, `deployment:${created.deploymentId}`, () =>
+      await this.tryDelete(removed, failures, `deployment:${created.deploymentId}`, () =>
         this.deploymentsService.deleteDeployment(created.deploymentId!, userId, 'admin'),
       );
     }
 
     for (const ruleSetId of created.ruleSetIds ?? []) {
-      await this.tryDelete(removed, `ruleSet:${ruleSetId}`, () =>
+      await this.tryDelete(removed, failures, `ruleSet:${ruleSetId}`, () =>
         this.ruleSetsService.delete(ruleSetId, userId, 'admin', null),
       );
     }
@@ -642,14 +703,14 @@ export class AppInstallerService {
         opts.kept?.push(`schema:${schemaId}`);
         continue;
       }
-      await this.tryDelete(removed, `schema:${schemaId}`, () =>
+      await this.tryDelete(removed, failures, `schema:${schemaId}`, () =>
         this.schemasService.delete(schemaId, userId, 'admin', null),
       );
     }
 
     if (created.projectCreated) {
       if (await this.projectIsEmpty(row.projectId)) {
-        await this.tryDelete(removed, `project:${row.projectId}`, () =>
+        await this.tryDelete(removed, failures, `project:${row.projectId}`, () =>
           this.projectsService.deleteProject(row.projectId),
         );
       } else {
@@ -657,7 +718,7 @@ export class AppInstallerService {
       }
     }
 
-    return removed;
+    return { removed, failures };
   }
 
   /** A project we created is only removable if this app was its only content. */
@@ -677,18 +738,38 @@ export class AppInstallerService {
 
   private async tryDelete(
     removed: string[],
+    failures: string[],
     label: string,
     run: () => Promise<unknown>,
   ): Promise<void> {
-    if (await this.tryRun(label, run)) removed.push(label);
+    if (await this.tryRun(label, run)) {
+      removed.push(label);
+    } else {
+      failures.push(label);
+    }
   }
 
-  /** Runs `run`, swallowing (and logging) a failure so it can't strand the rest of a cleanup. */
+  /**
+   * Runs `run`, swallowing (and logging) a failure so it can't strand the
+   * rest of a cleanup — EXCEPT a `NotFoundException`, which means the
+   * resource is already gone. That's the desired end state, not a failure:
+   * without this, a retry over a row kept alive by a PRIOR partial failure
+   * would re-throw on every already-deleted resource and could never
+   * complete, since every delete call here (`ProxyRuleSetsService.delete`,
+   * `PipelineSchemasService.delete`, `DomainsService.remove`,
+   * `DeploymentsService.deleteAlias`/`deleteDeployment`,
+   * `PipelineSchedulesService.deleteSchedule`) throws `NotFoundException` for
+   * a missing id.
+   */
   private async tryRun(label: string, run: () => Promise<unknown>): Promise<boolean> {
     try {
       await run();
       return true;
     } catch (error) {
+      if (error instanceof NotFoundException) {
+        this.logger.log(`${label} was already removed.`);
+        return true;
+      }
       this.logger.warn(`Failed to remove ${label}: ${this.messageOf(error)}`);
       return false;
     }

--- a/apps/backend/src/app-catalog/app-installer.service.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.ts
@@ -7,6 +7,7 @@ import { zipSync } from 'fflate';
 import { db } from '../db/client';
 import {
   deploymentAliases,
+  domainMappings,
   installedApps,
   proxyRuleSets,
   type CreatedResources,
@@ -274,7 +275,7 @@ export class AppInstallerService {
       await this.persistProgress(row.id, progress);
       this.jobs.setStep(jobId, step, {
         status: 'done',
-        detail: `Deployed ${deployment.fileCount} file(s) to alias "${manifest.install.alias}".`,
+        detail: this.deployDetail(deployment.fileCount, manifest.install.alias, appHost),
       });
 
       // ---- 6. domain ----
@@ -373,6 +374,13 @@ export class AppInstallerService {
       };
       this.mergeCreated(created, installed.createdResources);
 
+      // An update reuses the alias and domain the ORIGINAL install created
+      // (no 'domain' step in UPDATE_STEPS — see the "Same alias" comment on
+      // the deploy step below), so the serving host must be read back from
+      // that stored mapping, not recomputed from the manifest's default
+      // subdomain — the operator may have overridden it at install time.
+      const appHost = await this.lookupDomainHost(installed.domainId);
+
       step = 'sync-rules';
       this.jobs.setStep(jobId, step, { status: 'running' });
       // From here on the run can write; a failure past this point must carry
@@ -409,7 +417,7 @@ export class AppInstallerService {
       await this.persistProgress(installed.id, progress);
       this.jobs.setStep(jobId, step, {
         status: 'done',
-        detail: `Deployed ${deployment.fileCount} file(s) to alias "${manifest.install.alias}".`,
+        detail: this.deployDetail(deployment.fileCount, manifest.install.alias, appHost),
       });
 
       step = 'record';
@@ -431,9 +439,7 @@ export class AppInstallerService {
         .where(eq(installedApps.id, installed.id));
 
       const manualSteps = this.applicableManualSteps(manifest);
-      const appUrl = installed.domainId
-        ? `https://${this.computeAppHost(manifest) ?? ''}`
-        : deployment.urls?.default;
+      const appUrl = appHost ? `https://${appHost}` : deployment.urls?.default;
       this.jobs.setStep(jobId, step, { status: 'done', detail: 'Update recorded.' });
       this.jobs.finish(jobId, 'succeeded', {
         installedAppId: installed.id,
@@ -1276,11 +1282,46 @@ export class AppInstallerService {
     };
   }
 
+  /**
+   * The manifest's *default* subdomain suggestion — only meaningful as a
+   * fallback during `runInstall`, before any domain row exists (and even
+   * there `projectGates.appHost`, which already accounts for a
+   * `subdomainOverride`, wins first — see the `appHost` assignment above).
+   * Once an install exists, its actual serving host must be read back from
+   * the domain mapping it owns (`lookupDomainHost`, used by `runUpdate` and
+   * mirrored in `AppCatalogService.resolveAppUrl` for the catalog listing) —
+   * never recomputed from this manifest default, which the operator may
+   * have overridden.
+   */
   private computeAppHost(manifest: AppManifest): string | null {
     const subdomain = manifest.install.domain?.subdomain;
     if (!subdomain) return null;
     const primaryDomain = this.configService.get<string>('PRIMARY_DOMAIN') || '';
     return primaryDomain ? `${subdomain}.${primaryDomain}` : null;
+  }
+
+  /** Single-row read of a domain mapping's `domain` string; `undefined` if absent or since deleted. */
+  private async lookupDomainHost(domainId: string | null | undefined): Promise<string | undefined> {
+    if (!domainId) return undefined;
+    const [mapping] = await db
+      .select({ domain: domainMappings.domain })
+      .from(domainMappings)
+      .where(eq(domainMappings.id, domainId))
+      .limit(1);
+    return mapping?.domain;
+  }
+
+  /**
+   * The manifest's deployment `alias` (a rule-set/deployment identifier,
+   * e.g. "handoff") and the subdomain the operator chose for
+   * `install.domain.subdomain` (e.g. "files") are different namespaces —
+   * overriding the subdomain never changes the alias. Naming both here
+   * avoids reading like the override was ignored.
+   */
+  private deployDetail(fileCount: number, alias: string, appHost: string | null | undefined): string {
+    return appHost
+      ? `Deployed ${fileCount} file(s) to deployment alias "${alias}" (serving at ${appHost}).`
+      : `Deployed ${fileCount} file(s) to alias "${alias}".`;
   }
 
   private syncDetail(

--- a/apps/backend/src/app-catalog/app-installer.service.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.ts
@@ -68,6 +68,20 @@ interface ProjectRef {
 }
 
 /**
+ * Everything a step can produce that must survive a crash. Written to the
+ * `installed_apps` row at every step boundary AND on the failure path — undo
+ * walks `createdResources`, so state that only lived in memory would orphan
+ * whatever the failed run had already created.
+ */
+interface InstallProgress {
+  created: CreatedResources;
+  ruleSetIds: string[];
+  schemaIds: string[];
+  deploymentId?: string;
+  domainId?: string;
+}
+
+/**
  * AppInstallerService — the applier behind 1-click install (Task 9 of the
  * app-catalog spec).
  *
@@ -143,6 +157,9 @@ export class AppInstallerService {
   ): Promise<void> {
     let step: InstallStepId = 'preflight';
     let rowId: string | undefined;
+    // Accumulated state, persisted at every step boundary (see persistProgress)
+    // and carried into the failure write so a crashed install stays undoable.
+    let progress: InstallProgress | undefined;
 
     try {
       // ---- 1. preflight: re-verify every gate before anything is written ----
@@ -185,17 +202,24 @@ export class AppInstallerService {
       // Carry forward what a previous (failed) attempt already created.
       this.mergeCreated(created, row.createdResources);
 
+      progress = {
+        created,
+        ruleSetIds: [...(row.ruleSetIds ?? [])],
+        schemaIds: [...(row.schemaIds ?? [])],
+        deploymentId: row.deploymentId ?? undefined,
+        domainId: row.domainId ?? undefined,
+      };
+
       // ---- 4. sync-rules ----
-      const ruleSetIds: string[] = [...(row.ruleSetIds ?? [])];
-      const schemaIds: string[] = [...(row.schemaIds ?? [])];
       const { missingSecrets, warnings } = await this.syncRuleSets(
         ruleSets,
         manifest,
         project.id,
         userId,
         { prune: false },
-        { created, ruleSetIds, schemaIds },
+        progress,
       );
+      await this.persistProgress(row.id, progress);
       this.jobs.setStep(jobId, step, {
         status: 'done',
         detail: this.syncDetail(ruleSets.length, missingSecrets, warnings),
@@ -207,6 +231,8 @@ export class AppInstallerService {
       const deployment = await this.deployBundle(bundle, manifest, ruleSets, project, userId);
       created.aliasName = manifest.install.alias;
       created.deploymentId = deployment.deploymentId;
+      progress.deploymentId = deployment.deploymentId;
+      await this.persistProgress(row.id, progress);
       this.jobs.setStep(jobId, step, {
         status: 'done',
         detail: `Deployed ${deployment.fileCount} file(s) to alias "${manifest.install.alias}".`,
@@ -215,7 +241,11 @@ export class AppInstallerService {
       // ---- 6. domain ----
       step = 'domain';
       const domainOutcome = await this.applyDomainStep(jobId, manifest, row, project.id, appHost, userId);
-      if (domainOutcome.domainId) created.domainId = domainOutcome.domainId;
+      if (domainOutcome.domainId) {
+        created.domainId = domainOutcome.domainId;
+        progress.domainId = domainOutcome.domainId;
+      }
+      await this.persistProgress(row.id, progress);
 
       // ---- 7. certificate (never fails the install) ----
       step = 'certificate';
@@ -228,6 +258,7 @@ export class AppInstallerService {
       // ---- 8. schedules ----
       step = 'schedules';
       await this.applyScheduleStep(jobId, manifest, project.id, userId, created);
+      await this.persistProgress(row.id, progress);
 
       // ---- 9. record ----
       step = 'record';
@@ -244,8 +275,8 @@ export class AppInstallerService {
           alias: manifest.install.alias,
           bundleSha256: bundle.sha256,
           manifest,
-          ruleSetIds,
-          schemaIds,
+          ruleSetIds: progress.ruleSetIds,
+          schemaIds: progress.schemaIds,
           deploymentId: deployment.deploymentId,
           domainId: created.domainId ?? null,
           createdResources: created,
@@ -258,7 +289,7 @@ export class AppInstallerService {
       this.jobs.finish(jobId, 'succeeded', { installedAppId: row.id, manualSteps, appUrl });
       this.logger.log(`Installed app ${manifest.id} v${manifest.version} into project ${project.id}`);
     } catch (error) {
-      await this.failJob(jobId, step, rowId, error);
+      await this.failJob(jobId, step, rowId, error, progress);
     }
   }
 
@@ -272,6 +303,7 @@ export class AppInstallerService {
     opts: { prune: boolean },
   ): Promise<void> {
     let step: InstallStepId = 'fetch';
+    let progress: InstallProgress | undefined;
 
     try {
       this.jobs.setStep(jobId, step, { status: 'running' });
@@ -293,16 +325,22 @@ export class AppInstallerService {
 
       step = 'sync-rules';
       this.jobs.setStep(jobId, step, { status: 'running' });
-      const ruleSetIds: string[] = [...(installed.ruleSetIds ?? [])];
-      const schemaIds: string[] = [...(installed.schemaIds ?? [])];
+      progress = {
+        created,
+        ruleSetIds: [...(installed.ruleSetIds ?? [])],
+        schemaIds: [...(installed.schemaIds ?? [])],
+        deploymentId: installed.deploymentId ?? undefined,
+        domainId: installed.domainId ?? undefined,
+      };
       const { missingSecrets, warnings } = await this.syncRuleSets(
         ruleSets,
         manifest,
         project.id,
         userId,
         { prune: opts.prune },
-        { created, ruleSetIds, schemaIds },
+        progress,
       );
+      await this.persistProgress(installed.id, progress);
       this.jobs.setStep(jobId, step, {
         status: 'done',
         detail: this.syncDetail(ruleSets.length, missingSecrets, warnings, opts.prune),
@@ -314,6 +352,8 @@ export class AppInstallerService {
       const deployment = await this.deployBundle(bundle, manifest, ruleSets, project, userId);
       created.aliasName = manifest.install.alias;
       created.deploymentId = deployment.deploymentId;
+      progress.deploymentId = deployment.deploymentId;
+      await this.persistProgress(installed.id, progress);
       this.jobs.setStep(jobId, step, {
         status: 'done',
         detail: `Deployed ${deployment.fileCount} file(s) to alias "${manifest.install.alias}".`,
@@ -328,8 +368,8 @@ export class AppInstallerService {
           version: manifest.version,
           bundleSha256: bundle.sha256,
           manifest,
-          ruleSetIds,
-          schemaIds,
+          ruleSetIds: progress.ruleSetIds,
+          schemaIds: progress.schemaIds,
           deploymentId: deployment.deploymentId,
           createdResources: created,
           status: 'installed',
@@ -348,7 +388,7 @@ export class AppInstallerService {
         appUrl,
       });
     } catch (error) {
-      await this.failJob(jobId, step, installed.id, error);
+      await this.failJob(jobId, step, installed.id, error, progress);
     }
   }
 
@@ -500,7 +540,7 @@ export class AppInstallerService {
     projectId: string,
     userId: string,
     options: { prune: boolean },
-    acc: { created: CreatedResources; ruleSetIds: string[]; schemaIds: string[] },
+    acc: InstallProgress,
   ): Promise<{ missingSecrets: string[]; warnings: string[] }> {
     const missingSecrets: string[] = [];
     const warnings: string[] = [];
@@ -815,6 +855,26 @@ export class AppInstallerService {
     return inserted;
   }
 
+  /**
+   * Flushes accumulated progress to the row. Called after every step that
+   * creates something, so a crash (or a later step's failure) still leaves
+   * `createdResources` describing exactly what exists — which is what undo
+   * replays and what preflight reads to recognise a re-run's own objects.
+   */
+  private async persistProgress(rowId: string, progress: InstallProgress): Promise<void> {
+    await db
+      .update(installedApps)
+      .set({
+        ruleSetIds: progress.ruleSetIds,
+        schemaIds: progress.schemaIds,
+        deploymentId: progress.deploymentId ?? null,
+        domainId: progress.domainId ?? null,
+        createdResources: progress.created,
+        updatedAt: new Date(),
+      })
+      .where(eq(installedApps.id, rowId));
+  }
+
   private async requireRow(installedAppId: string): Promise<InstalledApp> {
     const [row] = await db
       .select()
@@ -857,7 +917,17 @@ export class AppInstallerService {
       }
 
       const dto = plainToInstance(SyncProxyRuleSetDto, json);
-      const errors = validateSync(dto as object, { whitelist: true, forbidUnknownValues: false });
+      // forbidNonWhitelisted mirrors main.ts's global ValidationPipe. Without
+      // it, `whitelist` would silently DELETE undecorated keys (a typo'd or
+      // newer-schema `pipelineConfig` key just vanishes) and the mutated
+      // object is what gets synced — installing a pipeline that is not the one
+      // the bundle shipped. The same payload 400s over HTTP; a stale bundle
+      // must abort here too, not install quietly altered.
+      const errors = validateSync(dto as object, {
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        forbidUnknownValues: false,
+      });
       if (errors.length > 0) {
         throw new BadRequestException(
           `${entry.file} failed rule-set validation: ${flattenValidationErrors(errors).join('; ')}`,
@@ -939,17 +1009,33 @@ export class AppInstallerService {
     step: InstallStepId,
     rowId: string | undefined,
     error: unknown,
+    progress?: InstallProgress,
   ): Promise<void> {
     const message = this.messageOf(error);
     this.logger.error(`App install job ${jobId} failed at step "${step}": ${message}`);
     this.jobs.setStep(jobId, step, { status: 'failed', error: message });
 
-    // Keep the row — it powers both undo and a resume-by-reinstall.
+    // Keep the row — it powers both undo and a resume-by-reinstall — and carry
+    // the accumulated state with it. The step that threw may have created
+    // things after the last persistProgress (e.g. schedules), and a row that
+    // says "failed" with an empty createdResources is an unrecoverable orphan.
     if (rowId) {
       try {
         await db
           .update(installedApps)
-          .set({ status: 'failed', updatedAt: new Date() })
+          .set({
+            status: 'failed',
+            ...(progress
+              ? {
+                  ruleSetIds: progress.ruleSetIds,
+                  schemaIds: progress.schemaIds,
+                  deploymentId: progress.deploymentId ?? null,
+                  domainId: progress.domainId ?? null,
+                  createdResources: progress.created,
+                }
+              : {}),
+            updatedAt: new Date(),
+          })
           .where(eq(installedApps.id, rowId));
       } catch (updateError) {
         this.logger.error(`Could not mark install row ${rowId} failed: ${this.messageOf(updateError)}`);

--- a/apps/backend/src/app-catalog/app-manifest.types.ts
+++ b/apps/backend/src/app-catalog/app-manifest.types.ts
@@ -1,0 +1,81 @@
+export type AppliesWhen =
+  | 'always'
+  | 'bucketStorage'
+  | 'localStorage'
+  | 'platformMode'
+  | 'selfHosted';
+
+export const APPLIES_WHEN_VALUES: readonly AppliesWhen[] = [
+  'always',
+  'bucketStorage',
+  'localStorage',
+  'platformMode',
+  'selfHosted',
+];
+
+export interface AppManualStep {
+  id: string;
+  title: string;
+  body: string;
+  deepLink?: string;
+  appliesWhen?: AppliesWhen;
+}
+
+export interface AppManifestRequires {
+  presignedStorage?: boolean;
+  ceMin?: string;
+}
+
+export interface AppManifestSchedule {
+  name: string;
+  cronExpression: string;
+  timezone?: string;
+  /** Locate the target pipeline rule after sync by (pathPattern, method). */
+  targetRulePath: string;
+  targetRuleMethod?: string;
+}
+
+export interface AppManifest {
+  schemaVersion: 1;
+  id: string;
+  name: string;
+  version: string;
+  summary?: string;
+  iconUrl?: string;
+  docsUrl?: string;
+  sourceUrl?: string;
+  requires?: AppManifestRequires;
+  install: {
+    alias: string;
+    deployment: { path: string; basePath: string };
+    ruleSets: Array<{ file: string; attachToAlias?: boolean }>;
+    domain?: { subdomain: string; isPublic?: boolean; isSpa?: boolean };
+    schedules?: AppManifestSchedule[];
+    manualSteps?: AppManualStep[];
+  };
+  eject?: {
+    repo: string;
+    appPath: string;
+    deployWorkflow: string;
+    variables: string[];
+    secrets: string[];
+  };
+}
+
+export interface AppRegistryEntry {
+  id: string;
+  name?: string;
+  version: string;
+  bundleUrl: string;
+  sha256: string;
+  summary?: string;
+  iconUrl?: string;
+  docsUrl?: string;
+  sourceUrl?: string;
+  requires?: AppManifestRequires;
+}
+
+export interface AppRegistry {
+  schemaVersion: 1;
+  apps: AppRegistryEntry[];
+}

--- a/apps/backend/src/app-catalog/app-manifest.util.spec.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.spec.ts
@@ -1,0 +1,222 @@
+import { validateAppManifest, validateRegistry, manualStepApplies } from './app-manifest.util';
+import { APPLIES_WHEN_VALUES, type AppManualStep } from './app-manifest.types';
+
+export const TEST_MANIFEST = {
+  schemaVersion: 1,
+  id: 'handoff',
+  name: 'Handoff',
+  version: '1.0.0',
+  summary: 'Share files and folders with ACLs',
+  requires: { presignedStorage: true, ceMin: '0.3.15' },
+  install: {
+    alias: 'handoff',
+    deployment: { path: 'dist', basePath: '/apps/handoff/dist' },
+    ruleSets: [
+      { file: 'rulesets/handoff.json', attachToAlias: true },
+      { file: 'rulesets/handoff-rss-feed.json', attachToAlias: true },
+    ],
+    domain: { subdomain: 'handoff', isPublic: true, isSpa: true },
+    schedules: [],
+    manualSteps: [
+      {
+        id: 'bucket-cors',
+        title: 'Configure bucket CORS',
+        body: 'Allow PUT from your app origin on the storage bucket.',
+        appliesWhen: 'bucketStorage',
+      },
+    ],
+  },
+  eject: {
+    repo: 'bffless/apps',
+    appPath: 'apps/handoff',
+    deployWorkflow: 'deploy-handoff.yml',
+    variables: ['BFFLESS_URL', 'BFFLESS_PROJECT'],
+    secrets: ['BFFLESS_API_KEY'],
+  },
+};
+
+describe('validateAppManifest', () => {
+  it('accepts a fully valid Handoff-shaped manifest and round-trips it', () => {
+    const result = validateAppManifest(TEST_MANIFEST);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest).toEqual(TEST_MANIFEST);
+    }
+  });
+
+  it('fails when schemaVersion is not 1', () => {
+    const result = validateAppManifest({ ...TEST_MANIFEST, schemaVersion: 2 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain('schemaVersion: must be 1');
+    }
+  });
+
+  it('fails when id is missing', () => {
+    const { id: _id, ...rest } = TEST_MANIFEST;
+    const result = validateAppManifest(rest);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.startsWith('id:'))).toBe(true);
+    }
+  });
+
+  it('fails when version is missing', () => {
+    const { version: _version, ...rest } = TEST_MANIFEST;
+    const result = validateAppManifest(rest);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.startsWith('version:'))).toBe(true);
+    }
+  });
+
+  it('fails when install.alias is missing', () => {
+    const { alias: _alias, ...restInstall } = TEST_MANIFEST.install;
+    const result = validateAppManifest({ ...TEST_MANIFEST, install: restInstall });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.startsWith('install.alias:'))).toBe(true);
+    }
+  });
+
+  it('fails when a ruleSets entry is missing file', () => {
+    const manifest = {
+      ...TEST_MANIFEST,
+      install: {
+        ...TEST_MANIFEST.install,
+        ruleSets: [{ attachToAlias: true }],
+      },
+    };
+    const result = validateAppManifest(manifest);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain('install.ruleSets[0].file: required string');
+    }
+  });
+
+  it('fails when a manualSteps entry has an appliesWhen outside the closed enum, naming the enum', () => {
+    const manifest = {
+      ...TEST_MANIFEST,
+      install: {
+        ...TEST_MANIFEST.install,
+        manualSteps: [
+          { id: 'x', title: 'X', body: 'Y', appliesWhen: 'sometimes' },
+        ],
+      },
+    };
+    const result = validateAppManifest(manifest);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const err = result.errors.find((e) => e.startsWith('install.manualSteps[0].appliesWhen:'));
+      expect(err).toBeDefined();
+      for (const value of APPLIES_WHEN_VALUES) {
+        expect(err).toContain(value);
+      }
+    }
+  });
+
+  it.each([
+    ['a dot', 'han.doff'],
+    ['uppercase', 'Handoff'],
+  ])('fails when subdomain contains %s', (_label, subdomain) => {
+    const manifest = {
+      ...TEST_MANIFEST,
+      install: {
+        ...TEST_MANIFEST.install,
+        domain: { ...TEST_MANIFEST.install.domain, subdomain },
+      },
+    };
+    const result = validateAppManifest(manifest);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.startsWith('install.domain.subdomain:'))).toBe(true);
+    }
+  });
+
+  it('fails when alias violates /^[a-zA-Z0-9_-]+$/', () => {
+    const manifest = {
+      ...TEST_MANIFEST,
+      install: { ...TEST_MANIFEST.install, alias: 'bad alias!' },
+    };
+    const result = validateAppManifest(manifest);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.startsWith('install.alias:'))).toBe(true);
+    }
+  });
+});
+
+describe('validateRegistry', () => {
+  const validRegistry = {
+    schemaVersion: 1,
+    apps: [
+      {
+        id: 'handoff',
+        name: 'Handoff',
+        version: '1.0.0',
+        bundleUrl: 'https://example.com/handoff.zip',
+        sha256: 'a'.repeat(64),
+      },
+    ],
+  };
+
+  it('accepts a valid registry and round-trips it', () => {
+    const result = validateRegistry(validRegistry);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.registry).toEqual(validRegistry);
+    }
+  });
+
+  it('fails when apps is not an array', () => {
+    const result = validateRegistry({ schemaVersion: 1, apps: {} });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain('apps: must be an array');
+    }
+  });
+
+  it('fails when a registry entry is missing sha256', () => {
+    const { sha256: _sha256, ...entry } = validRegistry.apps[0];
+    const result = validateRegistry({ schemaVersion: 1, apps: [entry] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain('apps[0].sha256: required string');
+    }
+  });
+});
+
+describe('manualStepApplies', () => {
+  const baseStep: AppManualStep = { id: 's', title: 'T', body: 'B' };
+
+  it('applies when appliesWhen is "always" or omitted', () => {
+    expect(manualStepApplies(baseStep, { bucketStorage: false, platformMode: false })).toBe(true);
+    expect(
+      manualStepApplies({ ...baseStep, appliesWhen: 'always' }, { bucketStorage: false, platformMode: false }),
+    ).toBe(true);
+  });
+
+  it('applies "bucketStorage" only when ctx.bucketStorage is true', () => {
+    const step: AppManualStep = { ...baseStep, appliesWhen: 'bucketStorage' };
+    expect(manualStepApplies(step, { bucketStorage: true, platformMode: false })).toBe(true);
+    expect(manualStepApplies(step, { bucketStorage: false, platformMode: false })).toBe(false);
+  });
+
+  it('applies "localStorage" only when ctx.bucketStorage is false', () => {
+    const step: AppManualStep = { ...baseStep, appliesWhen: 'localStorage' };
+    expect(manualStepApplies(step, { bucketStorage: false, platformMode: false })).toBe(true);
+    expect(manualStepApplies(step, { bucketStorage: true, platformMode: false })).toBe(false);
+  });
+
+  it('applies "platformMode" only when ctx.platformMode is true', () => {
+    const step: AppManualStep = { ...baseStep, appliesWhen: 'platformMode' };
+    expect(manualStepApplies(step, { bucketStorage: false, platformMode: true })).toBe(true);
+    expect(manualStepApplies(step, { bucketStorage: false, platformMode: false })).toBe(false);
+  });
+
+  it('applies "selfHosted" only when ctx.platformMode is false', () => {
+    const step: AppManualStep = { ...baseStep, appliesWhen: 'selfHosted' };
+    expect(manualStepApplies(step, { bucketStorage: false, platformMode: false })).toBe(true);
+    expect(manualStepApplies(step, { bucketStorage: false, platformMode: true })).toBe(false);
+  });
+});

--- a/apps/backend/src/app-catalog/app-manifest.util.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.ts
@@ -29,6 +29,11 @@ const RESERVED_SUBDOMAINS = [
   'minio',
 ];
 
+/** Shared with `PreflightRequestDto.subdomain`'s install-time override and `AppPreflightService`. */
+export function isReservedSubdomain(subdomain: string): boolean {
+  return RESERVED_SUBDOMAINS.includes(subdomain);
+}
+
 const ID_PATTERN = /^[a-z0-9-]+$/;
 // Matches CreateAliasDto/CreateDeploymentZipDto's alias rule.
 const ALIAS_PATTERN = /^[a-zA-Z0-9_-]+$/;
@@ -102,7 +107,7 @@ function validateDomain(domain: unknown, path: string, errors: string[]): void {
     errors.push(`${path}.subdomain: required string`);
   } else if (!SUBDOMAIN_PATTERN.test(domain.subdomain)) {
     errors.push(`${path}.subdomain: must match /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/`);
-  } else if (RESERVED_SUBDOMAINS.includes(domain.subdomain)) {
+  } else if (isReservedSubdomain(domain.subdomain)) {
     errors.push(`${path}.subdomain: is a reserved subdomain`);
   }
   if (domain.isPublic !== undefined && typeof domain.isPublic !== 'boolean') {

--- a/apps/backend/src/app-catalog/app-manifest.util.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.ts
@@ -1,0 +1,370 @@
+import { compareSemver } from './ce-version.util';
+import {
+  APPLIES_WHEN_VALUES,
+  type AppManifest,
+  type AppManualStep,
+  type AppRegistry,
+} from './app-manifest.types';
+
+/** Copied from apps/backend/src/domains/domains.service.ts:27-46 (not exported there).
+ * Keep in sync if that list changes. */
+const RESERVED_SUBDOMAINS = [
+  'www',
+  'api',
+  'admin',
+  'mail',
+  'ftp',
+  'smtp',
+  'pop',
+  'imap',
+  'dns',
+  'ns',
+  'mx',
+  'localhost',
+  'staging',
+  'dev',
+  'test',
+  'prod',
+  'production',
+  'minio',
+];
+
+const ID_PATTERN = /^[a-z0-9-]+$/;
+// Matches CreateAliasDto/CreateDeploymentZipDto's alias rule.
+const ALIAS_PATTERN = /^[a-zA-Z0-9_-]+$/;
+// Matches CreateDomainDto's path rule.
+const BASE_PATH_PATTERN = /^\/[a-zA-Z0-9/_-]*$/;
+const SUBDOMAIN_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+const RULE_SET_FILE_PATTERN = /^rulesets\/[a-zA-Z0-9._-]+\.json$/;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/i;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isParseableSemver(value: string): boolean {
+  return Number.isFinite(compareSemver(value, value));
+}
+
+function validateManifestRequires(requires: unknown, path: string, errors: string[]): void {
+  if (requires === undefined) return;
+  if (!isPlainObject(requires)) {
+    errors.push(`${path}: must be an object`);
+    return;
+  }
+  if (requires.presignedStorage !== undefined && typeof requires.presignedStorage !== 'boolean') {
+    errors.push(`${path}.presignedStorage: must be boolean`);
+  }
+  if (requires.ceMin !== undefined) {
+    if (typeof requires.ceMin !== 'string') {
+      errors.push(`${path}.ceMin: must be a string`);
+    } else if (!isParseableSemver(requires.ceMin)) {
+      errors.push(`${path}.ceMin: must be a parseable semver string`);
+    }
+  }
+}
+
+function validateRuleSets(ruleSets: unknown, path: string, errors: string[]): void {
+  if (!Array.isArray(ruleSets) || ruleSets.length === 0) {
+    errors.push(`${path}: required non-empty array`);
+    return;
+  }
+  ruleSets.forEach((entry, i) => {
+    const entryPath = `${path}[${i}]`;
+    if (!isPlainObject(entry)) {
+      errors.push(`${entryPath}: must be an object`);
+      return;
+    }
+    if (!isNonEmptyString(entry.file)) {
+      errors.push(`${entryPath}.file: required string`);
+    } else if (entry.file.includes('..') || !RULE_SET_FILE_PATTERN.test(entry.file)) {
+      errors.push(
+        `${entryPath}.file: must be a relative path matching /^rulesets\\/[a-zA-Z0-9._-]+\\.json$/ with no ".."`,
+      );
+    }
+    if (entry.attachToAlias !== undefined && typeof entry.attachToAlias !== 'boolean') {
+      errors.push(`${entryPath}.attachToAlias: must be boolean`);
+    }
+  });
+}
+
+function validateDomain(domain: unknown, path: string, errors: string[]): void {
+  if (domain === undefined) return;
+  if (!isPlainObject(domain)) {
+    errors.push(`${path}: must be an object`);
+    return;
+  }
+  if (!isNonEmptyString(domain.subdomain)) {
+    errors.push(`${path}.subdomain: required string`);
+  } else if (!SUBDOMAIN_PATTERN.test(domain.subdomain)) {
+    errors.push(`${path}.subdomain: must match /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/`);
+  } else if (RESERVED_SUBDOMAINS.includes(domain.subdomain)) {
+    errors.push(`${path}.subdomain: is a reserved subdomain`);
+  }
+  if (domain.isPublic !== undefined && typeof domain.isPublic !== 'boolean') {
+    errors.push(`${path}.isPublic: must be boolean`);
+  }
+  if (domain.isSpa !== undefined && typeof domain.isSpa !== 'boolean') {
+    errors.push(`${path}.isSpa: must be boolean`);
+  }
+}
+
+function validateSchedules(schedules: unknown, path: string, errors: string[]): void {
+  if (schedules === undefined) return;
+  if (!Array.isArray(schedules)) {
+    errors.push(`${path}: must be an array`);
+    return;
+  }
+  schedules.forEach((entry, i) => {
+    const entryPath = `${path}[${i}]`;
+    if (!isPlainObject(entry)) {
+      errors.push(`${entryPath}: must be an object`);
+      return;
+    }
+    if (!isNonEmptyString(entry.name)) {
+      errors.push(`${entryPath}.name: required string`);
+    }
+    if (!isNonEmptyString(entry.cronExpression)) {
+      errors.push(`${entryPath}.cronExpression: required string`);
+    }
+    if (entry.timezone !== undefined && typeof entry.timezone !== 'string') {
+      errors.push(`${entryPath}.timezone: must be string`);
+    }
+    if (!isNonEmptyString(entry.targetRulePath)) {
+      errors.push(`${entryPath}.targetRulePath: required string`);
+    }
+    if (entry.targetRuleMethod !== undefined && typeof entry.targetRuleMethod !== 'string') {
+      errors.push(`${entryPath}.targetRuleMethod: must be string`);
+    }
+  });
+}
+
+function validateManualSteps(manualSteps: unknown, path: string, errors: string[]): void {
+  if (manualSteps === undefined) return;
+  if (!Array.isArray(manualSteps)) {
+    errors.push(`${path}: must be an array`);
+    return;
+  }
+  manualSteps.forEach((entry, i) => {
+    const entryPath = `${path}[${i}]`;
+    if (!isPlainObject(entry)) {
+      errors.push(`${entryPath}: must be an object`);
+      return;
+    }
+    if (!isNonEmptyString(entry.id)) {
+      errors.push(`${entryPath}.id: required string`);
+    }
+    if (!isNonEmptyString(entry.title)) {
+      errors.push(`${entryPath}.title: required string`);
+    }
+    if (!isNonEmptyString(entry.body)) {
+      errors.push(`${entryPath}.body: required string`);
+    }
+    if (entry.deepLink !== undefined && typeof entry.deepLink !== 'string') {
+      errors.push(`${entryPath}.deepLink: must be string`);
+    }
+    if (
+      entry.appliesWhen !== undefined &&
+      !APPLIES_WHEN_VALUES.includes(entry.appliesWhen as (typeof APPLIES_WHEN_VALUES)[number])
+    ) {
+      errors.push(`${entryPath}.appliesWhen: must be one of ${APPLIES_WHEN_VALUES.join(', ')}`);
+    }
+  });
+}
+
+function validateInstall(install: unknown, path: string, errors: string[]): void {
+  if (!isPlainObject(install)) {
+    errors.push(`${path}: required object`);
+    return;
+  }
+
+  if (!isNonEmptyString(install.alias)) {
+    errors.push(`${path}.alias: required string`);
+  } else if (!ALIAS_PATTERN.test(install.alias)) {
+    errors.push(`${path}.alias: must match /^[a-zA-Z0-9_-]+$/`);
+  }
+
+  const deployment = install.deployment;
+  const deploymentPath = `${path}.deployment`;
+  if (!isPlainObject(deployment)) {
+    errors.push(`${deploymentPath}: required object`);
+  } else {
+    if (!isNonEmptyString(deployment.path)) {
+      errors.push(`${deploymentPath}.path: required string`);
+    }
+    if (!isNonEmptyString(deployment.basePath)) {
+      errors.push(`${deploymentPath}.basePath: required string`);
+    } else if (!BASE_PATH_PATTERN.test(deployment.basePath)) {
+      errors.push(`${deploymentPath}.basePath: must match /^\\/[a-zA-Z0-9/_-]*$/`);
+    }
+  }
+
+  validateRuleSets(install.ruleSets, `${path}.ruleSets`, errors);
+  validateDomain(install.domain, `${path}.domain`, errors);
+  validateSchedules(install.schedules, `${path}.schedules`, errors);
+  validateManualSteps(install.manualSteps, `${path}.manualSteps`, errors);
+}
+
+function validateEject(eject: unknown, path: string, errors: string[]): void {
+  if (eject === undefined) return;
+  if (!isPlainObject(eject)) {
+    errors.push(`${path}: must be an object`);
+    return;
+  }
+  if (!isNonEmptyString(eject.repo)) {
+    errors.push(`${path}.repo: required string`);
+  }
+  if (!isNonEmptyString(eject.appPath)) {
+    errors.push(`${path}.appPath: required string`);
+  }
+  if (!isNonEmptyString(eject.deployWorkflow)) {
+    errors.push(`${path}.deployWorkflow: required string`);
+  }
+  if (!Array.isArray(eject.variables) || !eject.variables.every((v) => typeof v === 'string')) {
+    errors.push(`${path}.variables: required string[]`);
+  }
+  if (!Array.isArray(eject.secrets) || !eject.secrets.every((v) => typeof v === 'string')) {
+    errors.push(`${path}.secrets: required string[]`);
+  }
+}
+
+export function validateAppManifest(
+  json: unknown,
+): { ok: true; manifest: AppManifest } | { ok: false; errors: string[] } {
+  const errors: string[] = [];
+
+  if (!isPlainObject(json)) {
+    return { ok: false, errors: ['root: must be an object'] };
+  }
+
+  if (json.schemaVersion !== 1) {
+    errors.push('schemaVersion: must be 1');
+  }
+
+  if (!isNonEmptyString(json.id)) {
+    errors.push('id: required string');
+  } else if (!ID_PATTERN.test(json.id)) {
+    errors.push('id: must match /^[a-z0-9-]+$/');
+  }
+
+  if (!isNonEmptyString(json.name)) {
+    errors.push('name: required string');
+  }
+
+  if (!isNonEmptyString(json.version)) {
+    errors.push('version: required string');
+  } else if (!isParseableSemver(json.version)) {
+    errors.push('version: must be a parseable semver string');
+  }
+
+  if (json.summary !== undefined && typeof json.summary !== 'string') {
+    errors.push('summary: must be string');
+  }
+  if (json.iconUrl !== undefined && typeof json.iconUrl !== 'string') {
+    errors.push('iconUrl: must be string');
+  }
+  if (json.docsUrl !== undefined && typeof json.docsUrl !== 'string') {
+    errors.push('docsUrl: must be string');
+  }
+  if (json.sourceUrl !== undefined && typeof json.sourceUrl !== 'string') {
+    errors.push('sourceUrl: must be string');
+  }
+
+  validateManifestRequires(json.requires, 'requires', errors);
+  validateInstall(json.install, 'install', errors);
+  validateEject(json.eject, 'eject', errors);
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+  return { ok: true, manifest: json as unknown as AppManifest };
+}
+
+export function validateRegistry(
+  json: unknown,
+): { ok: true; registry: AppRegistry } | { ok: false; errors: string[] } {
+  const errors: string[] = [];
+
+  if (!isPlainObject(json)) {
+    return { ok: false, errors: ['root: must be an object'] };
+  }
+
+  if (json.schemaVersion !== 1) {
+    errors.push('schemaVersion: must be 1');
+  }
+
+  if (!Array.isArray(json.apps)) {
+    errors.push('apps: must be an array');
+  } else {
+    json.apps.forEach((entry, i) => {
+      const path = `apps[${i}]`;
+      if (!isPlainObject(entry)) {
+        errors.push(`${path}: must be an object`);
+        return;
+      }
+      if (!isNonEmptyString(entry.id)) {
+        errors.push(`${path}.id: required string`);
+      } else if (!ID_PATTERN.test(entry.id)) {
+        errors.push(`${path}.id: must match /^[a-z0-9-]+$/`);
+      }
+      if (entry.name !== undefined && typeof entry.name !== 'string') {
+        errors.push(`${path}.name: must be string`);
+      }
+      if (!isNonEmptyString(entry.version)) {
+        errors.push(`${path}.version: required string`);
+      } else if (!isParseableSemver(entry.version)) {
+        errors.push(`${path}.version: must be a parseable semver string`);
+      }
+      if (!isNonEmptyString(entry.bundleUrl)) {
+        errors.push(`${path}.bundleUrl: required string`);
+      } else if (!/^https:\/\//.test(entry.bundleUrl)) {
+        errors.push(`${path}.bundleUrl: must be an https: URL`);
+      }
+      if (!isNonEmptyString(entry.sha256)) {
+        errors.push(`${path}.sha256: required string`);
+      } else if (!SHA256_PATTERN.test(entry.sha256)) {
+        errors.push(`${path}.sha256: must match /^[a-f0-9]{64}$/i`);
+      }
+      if (entry.summary !== undefined && typeof entry.summary !== 'string') {
+        errors.push(`${path}.summary: must be string`);
+      }
+      if (entry.iconUrl !== undefined && typeof entry.iconUrl !== 'string') {
+        errors.push(`${path}.iconUrl: must be string`);
+      }
+      if (entry.docsUrl !== undefined && typeof entry.docsUrl !== 'string') {
+        errors.push(`${path}.docsUrl: must be string`);
+      }
+      if (entry.sourceUrl !== undefined && typeof entry.sourceUrl !== 'string') {
+        errors.push(`${path}.sourceUrl: must be string`);
+      }
+      validateManifestRequires(entry.requires, `${path}.requires`, errors);
+    });
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+  return { ok: true, registry: json as unknown as AppRegistry };
+}
+
+export function manualStepApplies(
+  step: AppManualStep,
+  ctx: { bucketStorage: boolean; platformMode: boolean },
+): boolean {
+  switch (step.appliesWhen ?? 'always') {
+    case 'always':
+      return true;
+    case 'bucketStorage':
+      return ctx.bucketStorage;
+    case 'localStorage':
+      return !ctx.bucketStorage;
+    case 'platformMode':
+      return ctx.platformMode;
+    case 'selfHosted':
+      return !ctx.platformMode;
+  }
+}

--- a/apps/backend/src/app-catalog/app-preflight.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-preflight.service.spec.ts
@@ -1,0 +1,820 @@
+// Thenable chainable db mock: every builder method returns the chain, and
+// awaiting consumes the next queued result in await order. Mirrors
+// blocklist.service.spec / request-log.service.spec / pipeline-schedules.service.spec
+// (the house pattern) — declared above imports.
+jest.mock('../db/client', () => {
+  const queued: unknown[] = [];
+  const methods = [
+    'select',
+    'from',
+    'innerJoin',
+    'where',
+    'orderBy',
+    'limit',
+    'insert',
+    'values',
+    'update',
+    'set',
+    'delete',
+    'returning',
+  ];
+  const chainable: Record<string, unknown> = {};
+  for (const method of methods) {
+    chainable[method] = jest.fn(() => chainable);
+  }
+  chainable.then = (
+    resolve: (value: unknown) => unknown,
+    reject: (reason: unknown) => unknown,
+  ) => Promise.resolve(queued.length > 0 ? queued.shift() : []).then(resolve, reject);
+  chainable.__queue = (result: unknown) => queued.push(result);
+  chainable.__reset = () => {
+    queued.length = 0;
+    for (const method of methods) {
+      (chainable[method] as jest.Mock).mockClear();
+    }
+  };
+  return { db: chainable };
+});
+
+// getCeVersion is a free function (not injected), so it's mocked per-test;
+// satisfiesMin is kept real since it's pure and cheap to exercise for real.
+jest.mock('./ce-version.util', () => ({
+  getCeVersion: jest.fn(),
+  satisfiesMin: jest.requireActual('./ce-version.util').satisfiesMin,
+}));
+
+import { ConfigService } from '@nestjs/config';
+import { db } from '../db/client';
+import { getCeVersion } from './ce-version.util';
+import { AppPreflightService } from './app-preflight.service';
+import type { LoadedBundle } from './app-bundle.service';
+import type { AppManifest } from './app-manifest.types';
+import type { ProxyRuleSetsService } from '../proxy-rules/proxy-rule-sets.service';
+import type { BootstrapDnsPreflightService, PreflightCheck } from '../setup/bootstrap-dns-preflight.service';
+import type { IStorageAdapter } from '../storage/storage.interface';
+
+// Local fixture (not imported from app-manifest.util.spec.ts): that file's
+// module graph pulls in compareSemver from ce-version.util, which the
+// jest.mock above replaces with a bare getCeVersion/satisfiesMin stub and
+// would break its own suite if evaluated in this file's module registry.
+const TEST_MANIFEST: AppManifest = {
+  schemaVersion: 1,
+  id: 'handoff',
+  name: 'Handoff',
+  version: '1.0.0',
+  summary: 'Share files and folders with ACLs',
+  requires: { presignedStorage: true, ceMin: '0.3.15' },
+  install: {
+    alias: 'handoff',
+    deployment: { path: 'dist', basePath: '/apps/handoff/dist' },
+    ruleSets: [
+      { file: 'rulesets/handoff.json', attachToAlias: true },
+      { file: 'rulesets/handoff-rss-feed.json', attachToAlias: true },
+    ],
+    domain: { subdomain: 'handoff', isPublic: true, isSpa: true },
+    schedules: [],
+    manualSteps: [],
+  },
+};
+
+const mockDb = db as unknown as Record<string, jest.Mock> & {
+  __queue: (result: unknown) => void;
+  __reset: () => void;
+};
+
+function encode(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function makeBundle(manifestOverrides: Partial<AppManifest> = {}): LoadedBundle {
+  const manifest = { ...TEST_MANIFEST, ...manifestOverrides } as AppManifest;
+  return {
+    manifest,
+    files: {
+      'rulesets/handoff.json': encode(
+        JSON.stringify({
+          ruleSet: { name: 'handoff' },
+          rules: [{ pathPattern: '/api/nodes', method: 'GET' }],
+          schemas: [{ id: 's1', name: 'handoff_nodes', fields: [] }],
+        }),
+      ),
+      'rulesets/handoff-rss-feed.json': encode(
+        JSON.stringify({ ruleSet: { name: 'handoff-rss-feed' }, rules: [], schemas: [] }),
+      ),
+      'dist/index.html': encode('<!doctype html>ok'),
+    },
+    sha256: 'a'.repeat(64),
+  };
+}
+
+const EMPTY_SYNC_RESPONSE = {
+  ruleSetId: 'rs-1',
+  created: [],
+  updated: [],
+  deleted: [],
+  unchanged: [],
+  pruneCandidates: [],
+  schemaResolutions: [],
+  missingSecrets: [],
+  warnings: [],
+  dryRun: true,
+  setCreated: true,
+};
+
+function buildService(overrides: {
+  storageAdapter?: Partial<IStorageAdapter>;
+  configValues?: Record<string, string | undefined>;
+  dnsPreflight?: Partial<BootstrapDnsPreflightService>;
+  proxyRuleSetsService?: Partial<ProxyRuleSetsService>;
+} = {}) {
+  const storageAdapter = (overrides.storageAdapter ?? {}) as IStorageAdapter;
+  const configService = new ConfigService(overrides.configValues ?? {});
+  const dnsPreflight = {
+    probeHost: jest.fn(),
+    ...overrides.dnsPreflight,
+  } as unknown as BootstrapDnsPreflightService;
+  const proxyRuleSetsService = {
+    syncRuleSet: jest.fn(),
+    ...overrides.proxyRuleSetsService,
+  } as unknown as ProxyRuleSetsService;
+
+  const service = new AppPreflightService(
+    storageAdapter,
+    configService,
+    dnsPreflight,
+    proxyRuleSetsService,
+  );
+
+  return { service, storageAdapter, configService, dnsPreflight, proxyRuleSetsService };
+}
+
+describe('AppPreflightService', () => {
+  beforeEach(() => {
+    mockDb.__reset();
+    (getCeVersion as jest.Mock).mockReset();
+    (getCeVersion as jest.Mock).mockReturnValue('0.3.20');
+  });
+
+  describe('instanceGates > storage', () => {
+    it('passes through when requires omits presignedStorage', async () => {
+      const { service } = buildService();
+
+      const gates = await service.instanceGates(undefined);
+
+      const storage = gates.find((g) => g.id === 'storage');
+      expect(storage).toMatchObject({ id: 'storage', status: 'pass' });
+    });
+
+    it('passes when presignedStorage is required and the adapter supports it', async () => {
+      const { service } = buildService({
+        storageAdapter: { supportsPresignedUrls: () => true },
+      });
+
+      const gates = await service.instanceGates({ presignedStorage: true });
+
+      const storage = gates.find((g) => g.id === 'storage');
+      expect(storage).toMatchObject({ id: 'storage', status: 'pass' });
+    });
+
+    it('fails with remediation naming MinIO, a real bucket, and local FS when required and unsupported', async () => {
+      const { service } = buildService({ storageAdapter: {} }); // no supportsPresignedUrls at all -> ?? false
+
+      const gates = await service.instanceGates({ presignedStorage: true });
+
+      const storage = gates.find((g) => g.id === 'storage');
+      expect(storage?.status).toBe('fail');
+      expect(storage?.remediation).toMatch(/ENABLE_MINIO/);
+      expect(storage?.remediation).toMatch(/bucket/i);
+      expect(storage?.remediation).toMatch(/ENCRYPTION_KEY/);
+      expect(storage?.remediation).toMatch(/FEATURE_LOCAL_PRESIGNED_UPLOADS/);
+    });
+  });
+
+  describe('instanceGates > ce-version', () => {
+    it('passes when requires omits ceMin', async () => {
+      const { service } = buildService();
+
+      const gates = await service.instanceGates(undefined);
+
+      const version = gates.find((g) => g.id === 'ce-version');
+      expect(version).toMatchObject({ id: 'ce-version', status: 'pass' });
+    });
+
+    it('fails closed with an "could not be determined" message when the running version is unknown', async () => {
+      (getCeVersion as jest.Mock).mockReturnValue('unknown');
+      const { service } = buildService();
+
+      const gates = await service.instanceGates({ ceMin: '0.3.15' });
+
+      const version = gates.find((g) => g.id === 'ce-version');
+      expect(version?.status).toBe('fail');
+      expect(version?.message).toMatch(/could not be determined/i);
+    });
+
+    it('fails when the running version is below the minimum', async () => {
+      (getCeVersion as jest.Mock).mockReturnValue('0.3.10');
+      const { service } = buildService();
+
+      const gates = await service.instanceGates({ ceMin: '0.3.15' });
+
+      const version = gates.find((g) => g.id === 'ce-version');
+      expect(version?.status).toBe('fail');
+      expect(version?.remediation).toBeTruthy();
+    });
+
+    it('passes when the running version satisfies the minimum', async () => {
+      (getCeVersion as jest.Mock).mockReturnValue('0.3.15');
+      const { service } = buildService();
+
+      const gates = await service.instanceGates({ ceMin: '0.3.15' });
+
+      const version = gates.find((g) => g.id === 'ce-version');
+      expect(version).toMatchObject({ id: 'ce-version', status: 'pass' });
+    });
+  });
+
+  describe('instanceGates > platform-config', () => {
+    it('produces no platform-config gates when PLATFORM_MODE is not "true"', async () => {
+      const { service } = buildService({ configValues: {} });
+
+      const gates = await service.instanceGates(undefined);
+
+      expect(gates.filter((g) => g.id === 'platform-config')).toHaveLength(0);
+    });
+
+    it('fails the config check and adds the cert-coverage warn when platform mode lacks CONTROL_PLANE_URL/WORKSPACE_ID', async () => {
+      const { service } = buildService({ configValues: { PLATFORM_MODE: 'true' } });
+
+      const gates = await service.instanceGates(undefined);
+
+      const platformGates = gates.filter((g) => g.id === 'platform-config');
+      expect(platformGates).toHaveLength(2);
+      expect(platformGates.find((g) => g.status === 'fail')).toBeTruthy();
+      const warn = platformGates.find((g) => g.status === 'warn');
+      expect(warn?.message).toMatch(/wildcard/i);
+    });
+
+    it('passes the config check and still adds the cert-coverage warn when configured', async () => {
+      const { service } = buildService({
+        configValues: {
+          PLATFORM_MODE: 'true',
+          CONTROL_PLANE_URL: 'https://cp.example.com',
+          WORKSPACE_ID: 'ws-1',
+        },
+      });
+
+      const gates = await service.instanceGates(undefined);
+
+      const platformGates = gates.filter((g) => g.id === 'platform-config');
+      expect(platformGates).toHaveLength(2);
+      expect(platformGates.find((g) => g.status === 'fail')).toBeFalsy();
+      expect(platformGates.find((g) => g.status === 'pass')).toBeTruthy();
+      expect(platformGates.find((g) => g.status === 'warn')).toBeTruthy();
+    });
+  });
+
+  describe('projectGates > appHost', () => {
+    it('is null when the manifest declares no install.domain', async () => {
+      const bundle = makeBundle({
+        install: { ...TEST_MANIFEST.install, domain: undefined },
+      } as Partial<AppManifest>);
+      const { service, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      (proxyRuleSetsService.syncRuleSet as jest.Mock).mockResolvedValue(EMPTY_SYNC_RESPONSE);
+      mockDb.__queue([]); // installedApps lookup
+      mockDb.__queue([]); // ruleSet 1
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      expect(result.appHost).toBeNull();
+    });
+
+    it('is "<sub>.<PRIMARY_DOMAIN>" when the manifest declares install.domain', async () => {
+      const bundle = makeBundle();
+      const { service, proxyRuleSetsService, dnsPreflight } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      (dnsPreflight.probeHost as jest.Mock).mockResolvedValue({
+        host: 'handoff.example.com',
+        resolvedIps: ['1.2.3.4'],
+        probeOk: true,
+      } as PreflightCheck);
+      (proxyRuleSetsService.syncRuleSet as jest.Mock).mockResolvedValue({
+        ruleSetId: 'rs-1',
+        created: [],
+        updated: [],
+        deleted: [],
+        unchanged: [],
+        pruneCandidates: [],
+        schemaResolutions: [],
+        missingSecrets: [],
+        warnings: [],
+        dryRun: true,
+        setCreated: true,
+      });
+      mockDb.__queue([]); // installedApps lookup
+      mockDb.__queue([]); // ruleSet 1
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias
+      mockDb.__queue([]); // domain
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      expect(result.appHost).toBe('handoff.example.com');
+    });
+  });
+
+  describe('projectGates > dns', () => {
+    it('passes with a note when the manifest declares no install.domain (probeHost not called)', async () => {
+      const bundle = makeBundle({
+        install: { ...TEST_MANIFEST.install, domain: undefined },
+      } as Partial<AppManifest>);
+      const { service, dnsPreflight, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      (proxyRuleSetsService.syncRuleSet as jest.Mock).mockResolvedValue(EMPTY_SYNC_RESPONSE);
+      mockDb.__queue([]); // installedApps
+      mockDb.__queue([]); // ruleSet 1
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const dns = result.gates.find((g) => g.id === 'dns');
+      expect(dns).toMatchObject({ id: 'dns', status: 'pass' });
+      expect(dnsPreflight.probeHost).not.toHaveBeenCalled();
+    });
+
+    it('passes when probeHost succeeds', async () => {
+      const bundle = makeBundle();
+      const { service, dnsPreflight, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      (dnsPreflight.probeHost as jest.Mock).mockResolvedValue({
+        host: 'handoff.example.com',
+        resolvedIps: ['1.2.3.4'],
+        probeOk: true,
+      } as PreflightCheck);
+      (proxyRuleSetsService.syncRuleSet as jest.Mock).mockResolvedValue({
+        ruleSetId: 'rs-1',
+        created: [],
+        updated: [],
+        deleted: [],
+        unchanged: [],
+        pruneCandidates: [],
+        schemaResolutions: [],
+        missingSecrets: [],
+        warnings: [],
+        dryRun: true,
+        setCreated: true,
+      });
+      mockDb.__queue([]); // installedApps
+      mockDb.__queue([]); // ruleSet 1
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias
+      mockDb.__queue([]); // domain
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const dns = result.gates.find((g) => g.id === 'dns');
+      expect(dns).toMatchObject({ id: 'dns', status: 'pass' });
+      expect(dnsPreflight.probeHost).toHaveBeenCalledWith('handoff.example.com');
+    });
+
+    it('fails as retryable with the exact record to add and resolved IPs when probeHost fails', async () => {
+      const bundle = makeBundle();
+      const { service, dnsPreflight, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      (dnsPreflight.probeHost as jest.Mock).mockResolvedValue({
+        host: 'handoff.example.com',
+        resolvedIps: [],
+        probeOk: false,
+        error: 'Hostname does not resolve yet',
+      } as PreflightCheck);
+      (proxyRuleSetsService.syncRuleSet as jest.Mock).mockResolvedValue({
+        ruleSetId: 'rs-1',
+        created: [],
+        updated: [],
+        deleted: [],
+        unchanged: [],
+        pruneCandidates: [],
+        schemaResolutions: [],
+        missingSecrets: [],
+        warnings: [],
+        dryRun: true,
+        setCreated: true,
+      });
+      mockDb.__queue([]); // installedApps
+      mockDb.__queue([]); // ruleSet 1
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias
+      mockDb.__queue([]); // domain
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const dns = result.gates.find((g) => g.id === 'dns');
+      expect(dns?.status).toBe('fail');
+      expect(dns?.retryable).toBe(true);
+      expect(dns?.message).toMatch(/Hostname does not resolve yet/);
+      expect(dns?.message).toMatch(/resolved ips/i);
+      expect(dns?.remediation).toMatch(/CNAME/);
+      expect(dns?.remediation).toMatch(/handoff/);
+      expect(dns?.remediation).toMatch(/example\.com/);
+    });
+  });
+
+  describe('projectGates > name-collision (existing project target)', () => {
+    function queueNoDnsCall(dnsPreflight: BootstrapDnsPreflightService) {
+      (dnsPreflight.probeHost as jest.Mock).mockResolvedValue({
+        host: 'handoff.example.com',
+        resolvedIps: ['1.2.3.4'],
+        probeOk: true,
+      } as PreflightCheck);
+    }
+
+    function stubSyncRuleSetPassthrough(proxyRuleSetsService: ProxyRuleSetsService) {
+      (proxyRuleSetsService.syncRuleSet as jest.Mock).mockResolvedValue({
+        ruleSetId: 'rs-1',
+        created: [],
+        updated: [],
+        deleted: [],
+        unchanged: [],
+        pruneCandidates: [],
+        schemaResolutions: [],
+        missingSecrets: [],
+        warnings: [],
+        dryRun: true,
+        setCreated: true,
+      });
+    }
+
+    it('passes when nothing collides', async () => {
+      const bundle = makeBundle();
+      const { service, dnsPreflight, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      queueNoDnsCall(dnsPreflight);
+      stubSyncRuleSetPassthrough(proxyRuleSetsService);
+      mockDb.__queue([]); // installedApps
+      mockDb.__queue([]); // ruleSet 1
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias
+      mockDb.__queue([]); // domain
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const collision = result.gates.find((g) => g.id === 'name-collision');
+      expect(collision).toMatchObject({ id: 'name-collision', status: 'pass' });
+    });
+
+    it('fails when a same-named rule set exists and is not part of this app install', async () => {
+      const bundle = makeBundle();
+      const { service, dnsPreflight, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      queueNoDnsCall(dnsPreflight);
+      stubSyncRuleSetPassthrough(proxyRuleSetsService);
+      mockDb.__queue([]); // installedApps: no prior install
+      mockDb.__queue([{ id: 'rs-foreign', projectId: 'proj-1', name: 'handoff' }]); // ruleSet 1 collides
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias
+      mockDb.__queue([]); // domain
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const collision = result.gates.find((g) => g.id === 'name-collision');
+      expect(collision?.status).toBe('fail');
+      expect(collision?.remediation).toBeTruthy();
+    });
+
+    it('does not fail when the colliding rule set belongs to this app\'s existing install (update path)', async () => {
+      const bundle = makeBundle();
+      const { service, dnsPreflight, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      queueNoDnsCall(dnsPreflight);
+      stubSyncRuleSetPassthrough(proxyRuleSetsService);
+      mockDb.__queue([
+        { id: 'install-1', appId: 'handoff', projectId: 'proj-1', alias: 'handoff', domainId: null, ruleSetIds: ['rs-1'] },
+      ]); // installedApps: existing install owns rs-1
+      mockDb.__queue([{ id: 'rs-1', projectId: 'proj-1', name: 'handoff' }]); // ruleSet 1, owned
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias (no row -> pass, alias belongs to install anyway)
+      mockDb.__queue([]); // domain
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const collision = result.gates.find((g) => g.id === 'name-collision');
+      expect(collision).toMatchObject({ id: 'name-collision', status: 'pass' });
+    });
+
+    it('fails when the alias is already used by another deployment in the project', async () => {
+      const bundle = makeBundle();
+      const { service, dnsPreflight, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      queueNoDnsCall(dnsPreflight);
+      stubSyncRuleSetPassthrough(proxyRuleSetsService);
+      mockDb.__queue([]); // installedApps
+      mockDb.__queue([]); // ruleSet 1
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([{ id: 'alias-1', projectId: 'proj-1', alias: 'handoff' }]); // alias collides
+      mockDb.__queue([]); // domain
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const collision = result.gates.find((g) => g.id === 'name-collision');
+      expect(collision?.status).toBe('fail');
+    });
+
+    it('fails when the domain is already mapped and not owned by this app\'s install', async () => {
+      const bundle = makeBundle();
+      const { service, dnsPreflight, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      queueNoDnsCall(dnsPreflight);
+      stubSyncRuleSetPassthrough(proxyRuleSetsService);
+      mockDb.__queue([]); // installedApps
+      mockDb.__queue([]); // ruleSet 1
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias
+      mockDb.__queue([{ id: 'dom-1', domain: 'handoff.example.com', projectId: 'other-proj' }]); // domain collides
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const collision = result.gates.find((g) => g.id === 'name-collision');
+      expect(collision?.status).toBe('fail');
+    });
+
+    it('does not fail on a domain owned by this app\'s existing install', async () => {
+      const bundle = makeBundle();
+      const { service, dnsPreflight, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      queueNoDnsCall(dnsPreflight);
+      stubSyncRuleSetPassthrough(proxyRuleSetsService);
+      mockDb.__queue([
+        { id: 'install-1', appId: 'handoff', projectId: 'proj-1', alias: 'handoff', domainId: 'dom-1', ruleSetIds: [] },
+      ]); // installedApps: owns dom-1
+      mockDb.__queue([]); // ruleSet 1
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias
+      mockDb.__queue([{ id: 'dom-1', domain: 'handoff.example.com', projectId: 'proj-1' }]); // domain, owned
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const collision = result.gates.find((g) => g.id === 'name-collision');
+      expect(collision).toMatchObject({ id: 'name-collision', status: 'pass' });
+    });
+
+    it('fails via the cross-namespace trap when another project owns an alias matching the subdomain', async () => {
+      const bundle = makeBundle();
+      const { service, dnsPreflight, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      queueNoDnsCall(dnsPreflight);
+      stubSyncRuleSetPassthrough(proxyRuleSetsService);
+      mockDb.__queue([]); // installedApps
+      mockDb.__queue([]); // ruleSet 1
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias (no same-project collision)
+      mockDb.__queue([]); // domain
+      mockDb.__queue([{ id: 'alias-foreign', projectId: 'other-proj', alias: 'handoff' }]); // cross-namespace trap
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const collision = result.gates.find((g) => g.id === 'name-collision');
+      expect(collision?.status).toBe('fail');
+      expect(collision?.message).toMatch(/wildcard/i);
+    });
+  });
+
+  describe('projectGates > name-collision (newProject target)', () => {
+    it('only checks domain + cross-namespace collisions (no rule-set/alias db reads)', async () => {
+      const bundle = makeBundle();
+      const { service, dnsPreflight, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      (dnsPreflight.probeHost as jest.Mock).mockResolvedValue({
+        host: 'handoff.example.com',
+        resolvedIps: ['1.2.3.4'],
+        probeOk: true,
+      } as PreflightCheck);
+      (proxyRuleSetsService.syncRuleSet as jest.Mock).mockResolvedValue({});
+      mockDb.__queue([]); // domain
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(
+        bundle,
+        { newProject: { owner: 'acme', name: 'demo' } },
+        'user-1',
+      );
+
+      const collision = result.gates.find((g) => g.id === 'name-collision');
+      expect(collision).toMatchObject({ id: 'name-collision', status: 'pass' });
+      expect(proxyRuleSetsService.syncRuleSet).not.toHaveBeenCalled();
+      expect(mockDb.select).toHaveBeenCalledTimes(2);
+    });
+
+    it('fails when the domain is already mapped for a newProject target', async () => {
+      const bundle = makeBundle();
+      const { service, dnsPreflight } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      (dnsPreflight.probeHost as jest.Mock).mockResolvedValue({
+        host: 'handoff.example.com',
+        resolvedIps: ['1.2.3.4'],
+        probeOk: true,
+      } as PreflightCheck);
+      mockDb.__queue([{ id: 'dom-1', domain: 'handoff.example.com', projectId: 'other-proj' }]); // domain collides
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(
+        bundle,
+        { newProject: { owner: 'acme', name: 'demo' } },
+        'user-1',
+      );
+
+      const collision = result.gates.find((g) => g.id === 'name-collision');
+      expect(collision?.status).toBe('fail');
+    });
+  });
+
+  describe('projectGates > data-tables + syncPlans', () => {
+    it('summarizes a dryRun sync plan from the response, warning (not failing) on schema field mismatch', async () => {
+      const bundle = makeBundle();
+      const { service, dnsPreflight, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      (dnsPreflight.probeHost as jest.Mock).mockResolvedValue({
+        host: 'handoff.example.com',
+        resolvedIps: ['1.2.3.4'],
+        probeOk: true,
+      } as PreflightCheck);
+      (proxyRuleSetsService.syncRuleSet as jest.Mock)
+        .mockResolvedValueOnce({
+          ruleSetId: 'rs-1',
+          created: [{ pathPattern: '/api/nodes', method: 'GET' }],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          pruneCandidates: [],
+          schemaResolutions: [
+            { name: 'handoff_nodes', action: 'reuse', targetSchemaId: 'x', fieldMismatch: true },
+          ],
+          missingSecrets: [],
+          warnings: [],
+          dryRun: true,
+          setCreated: false,
+        })
+        .mockResolvedValueOnce({
+          ruleSetId: 'rs-2',
+          created: [],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          pruneCandidates: [],
+          schemaResolutions: [],
+          missingSecrets: [],
+          warnings: [],
+          dryRun: true,
+          setCreated: true,
+        });
+      mockDb.__queue([]); // installedApps
+      mockDb.__queue([]); // ruleSet 1
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias
+      mockDb.__queue([]); // domain
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      expect(result.syncPlans).toEqual([
+        {
+          ruleSet: 'handoff',
+          created: 1,
+          updated: 0,
+          unchanged: 0,
+          pruneCandidates: 0,
+          schemaResolutions: [{ name: 'handoff_nodes', action: 'reuse', fieldMismatch: true }],
+        },
+        {
+          ruleSet: 'handoff-rss-feed',
+          created: 0,
+          updated: 0,
+          unchanged: 0,
+          pruneCandidates: 0,
+          schemaResolutions: [],
+        },
+      ]);
+
+      expect(proxyRuleSetsService.syncRuleSet).toHaveBeenNthCalledWith(
+        1,
+        'proj-1',
+        expect.objectContaining({
+          ruleSet: { name: 'handoff' },
+          options: { dryRun: true },
+        }),
+        'user-1',
+        'admin',
+        null,
+      );
+
+      const dataTables = result.gates.find((g) => g.id === 'data-tables');
+      expect(dataTables?.status).toBe('warn');
+      expect(dataTables?.message).toMatch(/handoff_nodes/);
+    });
+
+    it('passes when no schema has a field mismatch', async () => {
+      const bundle = makeBundle();
+      const { service, dnsPreflight, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      (dnsPreflight.probeHost as jest.Mock).mockResolvedValue({
+        host: 'handoff.example.com',
+        resolvedIps: ['1.2.3.4'],
+        probeOk: true,
+      } as PreflightCheck);
+      (proxyRuleSetsService.syncRuleSet as jest.Mock).mockResolvedValue({
+        ruleSetId: 'rs-1',
+        created: [],
+        updated: [],
+        deleted: [],
+        unchanged: [],
+        pruneCandidates: [],
+        schemaResolutions: [],
+        missingSecrets: [],
+        warnings: [],
+        dryRun: true,
+        setCreated: false,
+      });
+      mockDb.__queue([]); // installedApps
+      mockDb.__queue([]); // ruleSet 1
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias
+      mockDb.__queue([]); // domain
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const dataTables = result.gates.find((g) => g.id === 'data-tables');
+      expect(dataTables).toMatchObject({ id: 'data-tables', status: 'pass' });
+    });
+
+    it('synthesizes all-create summaries for a newProject target without calling syncRuleSet', async () => {
+      const bundle = makeBundle();
+      const { service, dnsPreflight, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      (dnsPreflight.probeHost as jest.Mock).mockResolvedValue({
+        host: 'handoff.example.com',
+        resolvedIps: ['1.2.3.4'],
+        probeOk: true,
+      } as PreflightCheck);
+      mockDb.__queue([]); // domain
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(
+        bundle,
+        { newProject: { owner: 'acme', name: 'demo' } },
+        'user-1',
+      );
+
+      expect(proxyRuleSetsService.syncRuleSet).not.toHaveBeenCalled();
+      expect(result.syncPlans).toEqual([
+        {
+          ruleSet: 'handoff',
+          created: 1,
+          updated: 0,
+          unchanged: 0,
+          pruneCandidates: 0,
+          schemaResolutions: [{ name: 'handoff_nodes', action: 'create', fieldMismatch: false }],
+        },
+        {
+          ruleSet: 'handoff-rss-feed',
+          created: 0,
+          updated: 0,
+          unchanged: 0,
+          pruneCandidates: 0,
+          schemaResolutions: [],
+        },
+      ]);
+
+      const dataTables = result.gates.find((g) => g.id === 'data-tables');
+      expect(dataTables).toMatchObject({ id: 'data-tables', status: 'pass' });
+    });
+  });
+});

--- a/apps/backend/src/app-catalog/app-preflight.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-preflight.service.spec.ts
@@ -44,6 +44,7 @@ jest.mock('./ce-version.util', () => ({
 }));
 
 import { ConfigService } from '@nestjs/config';
+import { BadRequestException } from '@nestjs/common';
 import { db } from '../db/client';
 import { getCeVersion } from './ce-version.util';
 import { AppPreflightService } from './app-preflight.service';
@@ -341,6 +342,77 @@ describe('AppPreflightService', () => {
       const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
 
       expect(result.appHost).toBe('handoff.example.com');
+    });
+  });
+
+  describe('projectGates > subdomain override', () => {
+    it('uses the override for appHost and as the DNS probe target', async () => {
+      const bundle = makeBundle();
+      const { service, proxyRuleSetsService, dnsPreflight } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      (dnsPreflight.probeHost as jest.Mock).mockResolvedValue({
+        host: 'my-app.example.com',
+        resolvedIps: ['1.2.3.4'],
+        probeOk: true,
+      } as PreflightCheck);
+      (proxyRuleSetsService.syncRuleSet as jest.Mock).mockResolvedValue(EMPTY_SYNC_RESPONSE);
+      mockDb.__queue([]); // installedApps lookup
+      mockDb.__queue([]); // ruleSet 1
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias
+      mockDb.__queue([]); // domain
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(
+        bundle,
+        { projectId: 'proj-1' },
+        'user-1',
+        'my-app',
+      );
+
+      expect(result.appHost).toBe('my-app.example.com');
+      expect(dnsPreflight.probeHost).toHaveBeenCalledWith('my-app.example.com');
+      const dns = result.gates.find((g) => g.id === 'dns');
+      expect(dns?.status).toBe('pass');
+      const nameCollision = result.gates.find((g) => g.id === 'name-collision');
+      expect(nameCollision?.status).toBe('pass');
+    });
+
+    it('fails the name-collision gate with a clear message when the override is a reserved subdomain', async () => {
+      const bundle = makeBundle();
+      const { service, proxyRuleSetsService, dnsPreflight } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+      });
+      (dnsPreflight.probeHost as jest.Mock).mockResolvedValue({
+        host: 'admin.example.com',
+        resolvedIps: [],
+        probeOk: true,
+      } as PreflightCheck);
+      (proxyRuleSetsService.syncRuleSet as jest.Mock).mockResolvedValue(EMPTY_SYNC_RESPONSE);
+      mockDb.__queue([]); // installedApps lookup
+      mockDb.__queue([]); // ruleSet 1
+      mockDb.__queue([]); // ruleSet 2
+      mockDb.__queue([]); // alias
+      mockDb.__queue([]); // domain
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1', 'admin');
+
+      const nameCollision = result.gates.find((g) => g.id === 'name-collision');
+      expect(nameCollision?.status).toBe('fail');
+      expect(nameCollision?.message).toMatch(/reserved/i);
+    });
+
+    it('rejects an override when the manifest declares no install.domain', async () => {
+      const bundle = makeBundle({
+        install: { ...TEST_MANIFEST.install, domain: undefined },
+      } as Partial<AppManifest>);
+      const { service } = buildService({ configValues: { PRIMARY_DOMAIN: 'example.com' } });
+
+      await expect(
+        service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1', 'my-app'),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/apps/backend/src/app-catalog/app-preflight.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-preflight.service.spec.ts
@@ -49,6 +49,7 @@ import { getCeVersion } from './ce-version.util';
 import { AppPreflightService } from './app-preflight.service';
 import type { LoadedBundle } from './app-bundle.service';
 import type { AppManifest } from './app-manifest.types';
+import type { ProjectsService } from '../projects/projects.service';
 import type { ProxyRuleSetsService } from '../proxy-rules/proxy-rule-sets.service';
 import type { BootstrapDnsPreflightService, PreflightCheck } from '../setup/bootstrap-dns-preflight.service';
 import type { IStorageAdapter } from '../storage/storage.interface';
@@ -121,12 +122,15 @@ const EMPTY_SYNC_RESPONSE = {
   setCreated: true,
 };
 
-function buildService(overrides: {
-  storageAdapter?: Partial<IStorageAdapter>;
-  configValues?: Record<string, string | undefined>;
-  dnsPreflight?: Partial<BootstrapDnsPreflightService>;
-  proxyRuleSetsService?: Partial<ProxyRuleSetsService>;
-} = {}) {
+function buildService(
+  overrides: {
+    storageAdapter?: Partial<IStorageAdapter>;
+    configValues?: Record<string, string | undefined>;
+    dnsPreflight?: Partial<BootstrapDnsPreflightService>;
+    proxyRuleSetsService?: Partial<ProxyRuleSetsService>;
+    projectsService?: Partial<ProjectsService>;
+  } = {},
+) {
   const storageAdapter = (overrides.storageAdapter ?? {}) as IStorageAdapter;
   const configService = new ConfigService(overrides.configValues ?? {});
   const dnsPreflight = {
@@ -137,15 +141,27 @@ function buildService(overrides: {
     syncRuleSet: jest.fn(),
     ...overrides.proxyRuleSetsService,
   } as unknown as ProxyRuleSetsService;
+  const projectsService = {
+    projectExists: jest.fn().mockResolvedValue(false),
+    ...overrides.projectsService,
+  } as unknown as ProjectsService;
 
   const service = new AppPreflightService(
     storageAdapter,
     configService,
     dnsPreflight,
     proxyRuleSetsService,
+    projectsService,
   );
 
-  return { service, storageAdapter, configService, dnsPreflight, proxyRuleSetsService };
+  return {
+    service,
+    storageAdapter,
+    configService,
+    dnsPreflight,
+    proxyRuleSetsService,
+    projectsService,
+  };
 }
 
 describe('AppPreflightService', () => {
@@ -627,6 +643,37 @@ describe('AppPreflightService', () => {
       expect(collision).toMatchObject({ id: 'name-collision', status: 'pass' });
       expect(proxyRuleSetsService.syncRuleSet).not.toHaveBeenCalled();
       expect(mockDb.select).toHaveBeenCalledTimes(2);
+    });
+
+    it('fails when the "new" project already exists, pointing at the picker instead', async () => {
+      // Every project-scoped check (rule-set names, alias, this app's own
+      // install row) is skipped for a newProject target — adopting an
+      // existing project would sail past all of them, and its pre-existing
+      // alias would end up in createdResources for a later undo to delete.
+      const bundle = makeBundle();
+      const { service, dnsPreflight, projectsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+        projectsService: { projectExists: jest.fn().mockResolvedValue(true) },
+      });
+      (dnsPreflight.probeHost as jest.Mock).mockResolvedValue({
+        host: 'handoff.example.com',
+        resolvedIps: ['1.2.3.4'],
+        probeOk: true,
+      } as PreflightCheck);
+      mockDb.__queue([]); // domain
+      mockDb.__queue([]); // cross-namespace
+
+      const result = await service.projectGates(
+        bundle,
+        { newProject: { owner: 'acme', name: 'demo' } },
+        'user-1',
+      );
+
+      expect(projectsService.projectExists).toHaveBeenCalledWith('acme', 'demo');
+      const collision = result.gates.find((g) => g.id === 'name-collision');
+      expect(collision?.status).toBe('fail');
+      expect(collision?.message).toMatch(/project named "acme\/demo" already exists/i);
+      expect(collision?.remediation).toMatch(/picker/i);
     });
 
     it('fails when the domain is already mapped for a newProject target', async () => {

--- a/apps/backend/src/app-catalog/app-preflight.service.ts
+++ b/apps/backend/src/app-catalog/app-preflight.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { and, eq } from 'drizzle-orm';
 import { db } from '../db/client';
 import { deploymentAliases, domainMappings, installedApps, proxyRuleSets } from '../db/schema';
+import { ProjectsService } from '../projects/projects.service';
 import { ProxyRuleSetsService } from '../proxy-rules/proxy-rule-sets.service';
 import type {
   SyncProxyRuleSetDto,
@@ -71,6 +72,7 @@ export class AppPreflightService {
     private readonly configService: ConfigService,
     private readonly dnsPreflight: BootstrapDnsPreflightService,
     private readonly proxyRuleSetsService: ProxyRuleSetsService,
+    private readonly projectsService: ProjectsService,
   ) {}
 
   async instanceGates(requires?: AppManifestRequires): Promise<GateResult[]> {
@@ -248,6 +250,10 @@ export class AppPreflightService {
   ): Promise<GateResult> {
     const issues: string[] = [];
     let existingInstall: typeof installedApps.$inferSelect | undefined;
+    // A `newProject` target skips every project-scoped check below (there is
+    // no project id to scope them to). That is only sound while the project
+    // genuinely does not exist yet — see `projectAlreadyExists`.
+    let projectAlreadyExists = false;
 
     if ('projectId' in target) {
       const projectId = target.projectId;
@@ -281,6 +287,19 @@ export class AppPreflightService {
       const aliasOwnedByThisInstall = existingInstall?.alias === alias;
       if (existingAlias && !aliasOwnedByThisInstall) {
         issues.push(`An alias named "${alias}" already exists in this project.`);
+      }
+    } else {
+      // "Create new project" pointed at a project that ALREADY exists would
+      // sail past every check above — rule-set names, the app's alias, the
+      // per-project install row — and the installer's findOrCreateProject
+      // would silently adopt it. Worse, the adopted project's pre-existing
+      // alias lands in `createdResources.aliasName`, so a later undo would
+      // delete a resource this install never created. Refuse instead: the
+      // picker path runs all of those checks properly.
+      const { owner, name } = target.newProject;
+      projectAlreadyExists = await this.projectsService.projectExists(owner, name);
+      if (projectAlreadyExists) {
+        issues.push(`A project named "${owner}/${name}" already exists.`);
       }
     }
 
@@ -318,7 +337,10 @@ export class AppPreflightService {
         id: 'name-collision',
         status: 'fail',
         message: issues.join(' '),
-        remediation: 'Rename the conflicting resource, choose a different subdomain/alias, or target a different project.',
+        remediation: projectAlreadyExists
+          ? 'That project already exists — select it from the project picker instead of creating it, so the ' +
+            'install can check its existing rule sets, aliases and data tables for collisions.'
+          : 'Rename the conflicting resource, choose a different subdomain/alias, or target a different project.',
       };
     }
 

--- a/apps/backend/src/app-catalog/app-preflight.service.ts
+++ b/apps/backend/src/app-catalog/app-preflight.service.ts
@@ -1,0 +1,410 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../db/client';
+import { deploymentAliases, domainMappings, installedApps, proxyRuleSets } from '../db/schema';
+import { ProxyRuleSetsService } from '../proxy-rules/proxy-rule-sets.service';
+import type {
+  SyncProxyRuleSetDto,
+  SyncProxyRuleDto,
+  SyncSchemaDto,
+} from '../proxy-rules/dto/sync-proxy-rule-set.dto';
+import { BootstrapDnsPreflightService } from '../setup/bootstrap-dns-preflight.service';
+import { IStorageAdapter, STORAGE_ADAPTER } from '../storage/storage.interface';
+import { getCeVersion, satisfiesMin } from './ce-version.util';
+import type { AppManifest, AppManifestRequires } from './app-manifest.types';
+import type { LoadedBundle } from './app-bundle.service';
+
+export type GateStatus = 'pass' | 'fail' | 'warn';
+
+export interface GateResult {
+  id: 'storage' | 'ce-version' | 'platform-config' | 'dns' | 'name-collision' | 'data-tables';
+  status: GateStatus;
+  message: string;
+  remediation?: string;
+  deepLink?: string;
+  /** DNS is blocking-but-retryable; name collisions are not. */
+  retryable?: boolean;
+}
+
+export interface SyncSchemaResolutionLike {
+  name: string;
+  action: 'reuse' | 'create';
+  fieldMismatch: boolean;
+}
+
+export interface SyncPlanSummary {
+  ruleSet: string;
+  created: number;
+  updated: number;
+  unchanged: number;
+  pruneCandidates: number;
+  schemaResolutions: SyncSchemaResolutionLike[];
+}
+
+export type InstallTarget = { projectId: string } | { newProject: { owner: string; name: string } };
+
+interface ParsedRuleSetFile {
+  file: string;
+  dto: SyncProxyRuleSetDto;
+}
+
+/**
+ * AppPreflightService — computes the gate checks the install wizard shows
+ * before an app is actually installed (Task 7 of the app-catalog spec).
+ *
+ * Two independent surfaces:
+ *  - `instanceGates`: checks about THIS BFFless instance (storage backend,
+ *    CE version, platform-mode config) — same result regardless of target
+ *    project.
+ *  - `projectGates`: checks scoped to the install target (DNS, naming
+ *    collisions, and a dryRun preview of the data-table/rule-set sync).
+ *
+ * `projectGates` never writes anything: the proxy-rule-set sync always runs
+ * with `options.dryRun: true` (verified zero-write in
+ * `proxy-rule-sets.service.ts`), and all db reads here are plain selects.
+ */
+@Injectable()
+export class AppPreflightService {
+  constructor(
+    @Inject(STORAGE_ADAPTER) private readonly storageAdapter: IStorageAdapter,
+    private readonly configService: ConfigService,
+    private readonly dnsPreflight: BootstrapDnsPreflightService,
+    private readonly proxyRuleSetsService: ProxyRuleSetsService,
+  ) {}
+
+  async instanceGates(requires?: AppManifestRequires): Promise<GateResult[]> {
+    return [this.storageGate(requires), this.ceVersionGate(requires), ...this.platformConfigGates()];
+  }
+
+  async projectGates(
+    bundle: LoadedBundle,
+    target: InstallTarget,
+    userId: string,
+  ): Promise<{ gates: GateResult[]; syncPlans: SyncPlanSummary[]; appHost: string | null }> {
+    const manifest = bundle.manifest;
+    const subdomain = manifest.install.domain?.subdomain;
+    const primaryDomain = this.configService.get<string>('PRIMARY_DOMAIN') || '';
+    const appHost = subdomain ? `${subdomain}.${primaryDomain}` : null;
+    const ruleSets = this.parseBundledRuleSets(bundle);
+
+    const dns = await this.dnsGate(appHost, subdomain, primaryDomain);
+    const nameCollision = await this.nameCollisionGate(manifest, ruleSets, target, appHost, subdomain);
+    const { gate: dataTables, syncPlans } = await this.dataTablesGate(ruleSets, target, userId);
+
+    return { gates: [dns, nameCollision, dataTables], syncPlans, appHost };
+  }
+
+  // ---- instance gates -----------------------------------------------------
+
+  private storageGate(requires?: AppManifestRequires): GateResult {
+    if (!requires?.presignedStorage) {
+      return {
+        id: 'storage',
+        status: 'pass',
+        message: 'This app does not require presigned upload URLs.',
+      };
+    }
+
+    const supportsPresigned = this.storageAdapter.supportsPresignedUrls?.() ?? false;
+    if (supportsPresigned) {
+      return {
+        id: 'storage',
+        status: 'pass',
+        message: 'The active storage adapter supports presigned upload URLs.',
+      };
+    }
+
+    return {
+      id: 'storage',
+      status: 'fail',
+      message: 'This app requires presigned upload URLs, but the active storage adapter does not support them.',
+      remediation:
+        'Enable bundled MinIO storage (set ENABLE_MINIO=true and restart), or switch to a real S3-compatible ' +
+        'bucket. Since CE v0.3.15, local filesystem storage also supports presigned uploads when ENCRYPTION_KEY ' +
+        'is set and the FEATURE_LOCAL_PRESIGNED_UPLOADS flag is not disabled — this failure usually means that ' +
+        'flag was turned off or ENCRYPTION_KEY is missing.',
+    };
+  }
+
+  private ceVersionGate(requires?: AppManifestRequires): GateResult {
+    if (!requires?.ceMin) {
+      return {
+        id: 'ce-version',
+        status: 'pass',
+        message: 'This app has no minimum CE version requirement.',
+      };
+    }
+
+    const version = getCeVersion();
+    if (version === 'unknown') {
+      return {
+        id: 'ce-version',
+        status: 'fail',
+        message:
+          `This instance's CE version could not be determined, so we cannot confirm it satisfies the ` +
+          `required minimum (${requires.ceMin}).`,
+        remediation: 'Verify this is a genuine BFFless CE deployment with an intact root package.json.',
+      };
+    }
+
+    if (!satisfiesMin(version, requires.ceMin)) {
+      return {
+        id: 'ce-version',
+        status: 'fail',
+        message: `This instance is running CE ${version}, which is below the required minimum ${requires.ceMin}.`,
+        remediation: `Upgrade this BFFless CE instance to v${requires.ceMin} or later.`,
+      };
+    }
+
+    return {
+      id: 'ce-version',
+      status: 'pass',
+      message: `This instance is running CE ${version}, which satisfies the required minimum ${requires.ceMin}.`,
+    };
+  }
+
+  private platformConfigGates(): GateResult[] {
+    const platformMode = this.configService.get<string>('PLATFORM_MODE') === 'true';
+    if (!platformMode) return [];
+
+    const gates: GateResult[] = [];
+    const controlPlaneUrl = this.configService.get<string>('CONTROL_PLANE_URL');
+    const workspaceId = this.configService.get<string>('WORKSPACE_ID');
+
+    if (!controlPlaneUrl || !workspaceId) {
+      gates.push({
+        id: 'platform-config',
+        status: 'fail',
+        message: 'Platform mode is enabled but CONTROL_PLANE_URL and/or WORKSPACE_ID is not configured.',
+        remediation: "Set CONTROL_PLANE_URL and WORKSPACE_ID in this workspace's environment.",
+      });
+    } else {
+      gates.push({
+        id: 'platform-config',
+        status: 'pass',
+        message: 'CONTROL_PLANE_URL and WORKSPACE_ID are configured.',
+      });
+    }
+
+    gates.push({
+      id: 'platform-config',
+      status: 'warn',
+      message:
+        "This app's subdomain resolves under <sub>.<workspace>.<platform-domain> — a two-label subdomain that " +
+        'is NOT covered by a *.<platform-domain> wildcard certificate.',
+      remediation:
+        "Provision a certificate covering <workspace>.<platform-domain>'s wildcard, or a dedicated certificate " +
+        "for this app's host.",
+    });
+
+    return gates;
+  }
+
+  // ---- project gates -------------------------------------------------------
+
+  private async dnsGate(
+    appHost: string | null,
+    subdomain: string | undefined,
+    primaryDomain: string,
+  ): Promise<GateResult> {
+    if (!appHost) {
+      return {
+        id: 'dns',
+        status: 'pass',
+        message: 'This app does not declare a domain; DNS check skipped.',
+      };
+    }
+
+    const check = await this.dnsPreflight.probeHost(appHost);
+    if (check.probeOk) {
+      return {
+        id: 'dns',
+        status: 'pass',
+        message: `${appHost} resolves and answered the preflight probe.`,
+      };
+    }
+
+    const resolvedIps = check.resolvedIps.length ? check.resolvedIps.join(', ') : 'none';
+    return {
+      id: 'dns',
+      status: 'fail',
+      retryable: true,
+      message:
+        `DNS check failed for ${appHost}: ${check.error ?? 'probe did not succeed'}. ` +
+        `Resolved IPs: ${resolvedIps}.`,
+      remediation:
+        `Add a CNAME record "${subdomain}" pointing to "${primaryDomain}" (or an A record matching ` +
+        `${primaryDomain}'s IP), then retry.`,
+    };
+  }
+
+  private async nameCollisionGate(
+    manifest: AppManifest,
+    ruleSets: ParsedRuleSetFile[],
+    target: InstallTarget,
+    appHost: string | null,
+    subdomain: string | undefined,
+  ): Promise<GateResult> {
+    const issues: string[] = [];
+    let existingInstall: typeof installedApps.$inferSelect | undefined;
+
+    if ('projectId' in target) {
+      const projectId = target.projectId;
+      [existingInstall] = await db
+        .select()
+        .from(installedApps)
+        .where(and(eq(installedApps.appId, manifest.id), eq(installedApps.projectId, projectId)))
+        .limit(1);
+
+      for (const { dto } of ruleSets) {
+        const name = dto.ruleSet.name;
+        const [existingSet] = await db
+          .select()
+          .from(proxyRuleSets)
+          .where(and(eq(proxyRuleSets.projectId, projectId), eq(proxyRuleSets.name, name)))
+          .limit(1);
+        const ownedByThisInstall = existingInstall?.ruleSetIds?.includes(existingSet?.id) ?? false;
+        if (existingSet && !ownedByThisInstall) {
+          issues.push(
+            `A rule set named "${name}" already exists in this project and is not part of this app's install.`,
+          );
+        }
+      }
+
+      const alias = manifest.install.alias;
+      const [existingAlias] = await db
+        .select()
+        .from(deploymentAliases)
+        .where(and(eq(deploymentAliases.projectId, projectId), eq(deploymentAliases.alias, alias)))
+        .limit(1);
+      const aliasOwnedByThisInstall = existingInstall?.alias === alias;
+      if (existingAlias && !aliasOwnedByThisInstall) {
+        issues.push(`An alias named "${alias}" already exists in this project.`);
+      }
+    }
+
+    if (appHost) {
+      const [existingDomain] = await db
+        .select()
+        .from(domainMappings)
+        .where(eq(domainMappings.domain, appHost))
+        .limit(1);
+      const domainOwnedByThisInstall = existingInstall?.domainId === existingDomain?.id;
+      if (existingDomain && !domainOwnedByThisInstall) {
+        issues.push(`The domain "${appHost}" is already mapped and does not belong to this app's install.`);
+      }
+    }
+
+    if (subdomain) {
+      const crossNamespaceRows = await db
+        .select()
+        .from(deploymentAliases)
+        .where(eq(deploymentAliases.alias, subdomain));
+      const foreign = crossNamespaceRows.filter((row: { projectId: string }) => {
+        if (!('projectId' in target)) return true;
+        return row.projectId !== target.projectId;
+      });
+      if (foreign.length > 0) {
+        issues.push(
+          `An alias named "${subdomain}" exists in another project and would be reachable at ${appHost} via ` +
+            'the wildcard subdomain route, colliding with this app.',
+        );
+      }
+    }
+
+    if (issues.length > 0) {
+      return {
+        id: 'name-collision',
+        status: 'fail',
+        message: issues.join(' '),
+        remediation: 'Rename the conflicting resource, choose a different subdomain/alias, or target a different project.',
+      };
+    }
+
+    return { id: 'name-collision', status: 'pass', message: 'No naming collisions detected.' };
+  }
+
+  private async dataTablesGate(
+    ruleSets: ParsedRuleSetFile[],
+    target: InstallTarget,
+    userId: string,
+  ): Promise<{ gate: GateResult; syncPlans: SyncPlanSummary[] }> {
+    const syncPlans: SyncPlanSummary[] = [];
+    const mismatchedSchemas: string[] = [];
+
+    for (const { dto } of ruleSets) {
+      if ('projectId' in target) {
+        const response = await this.proxyRuleSetsService.syncRuleSet(
+          target.projectId,
+          dto,
+          userId,
+          'admin',
+          null,
+        );
+        const schemaResolutions: SyncSchemaResolutionLike[] = response.schemaResolutions.map((r) => ({
+          name: r.name,
+          action: r.action,
+          fieldMismatch: r.fieldMismatch,
+        }));
+        for (const resolution of schemaResolutions) {
+          if (resolution.fieldMismatch) mismatchedSchemas.push(resolution.name);
+        }
+        syncPlans.push({
+          ruleSet: dto.ruleSet.name,
+          created: response.created.length,
+          updated: response.updated.length,
+          unchanged: response.unchanged.length,
+          pruneCandidates: response.pruneCandidates.length,
+          schemaResolutions,
+        });
+      } else {
+        const schemas = dto.schemas ?? [];
+        syncPlans.push({
+          ruleSet: dto.ruleSet.name,
+          created: dto.rules.length,
+          updated: 0,
+          unchanged: 0,
+          pruneCandidates: 0,
+          schemaResolutions: schemas.map((schema) => ({
+            name: schema.name,
+            action: 'create' as const,
+            fieldMismatch: false,
+          })),
+        });
+      }
+    }
+
+    const gate: GateResult =
+      mismatchedSchemas.length > 0
+        ? {
+            id: 'data-tables',
+            status: 'warn',
+            message: `Some reused data table schemas have mismatched field definitions: ${mismatchedSchemas.join(', ')}.`,
+            remediation: 'Review the schema differences — reuse is the documented adoption path; this will not block install.',
+          }
+        : { id: 'data-tables', status: 'pass', message: 'Data table schemas are compatible.' };
+
+    return { gate, syncPlans };
+  }
+
+  // ---- helpers --------------------------------------------------------------
+
+  private parseBundledRuleSets(bundle: LoadedBundle): ParsedRuleSetFile[] {
+    return bundle.manifest.install.ruleSets.map((entry) => {
+      const bytes = bundle.files[entry.file];
+      const parsed = JSON.parse(new TextDecoder().decode(bytes)) as {
+        ruleSet: { name: string; description?: string; environment?: string };
+        rules?: unknown[];
+        schemas?: unknown[];
+      };
+      const dto: SyncProxyRuleSetDto = {
+        ruleSet: parsed.ruleSet,
+        rules: (parsed.rules ?? []) as unknown as SyncProxyRuleDto[],
+        schemas: parsed.schemas as unknown as SyncSchemaDto[] | undefined,
+        options: { dryRun: true },
+      };
+      return { file: entry.file, dto };
+    });
+  }
+}

--- a/apps/backend/src/app-catalog/app-preflight.service.ts
+++ b/apps/backend/src/app-catalog/app-preflight.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { and, eq } from 'drizzle-orm';
 import { db } from '../db/client';
@@ -13,6 +13,7 @@ import type {
 import { BootstrapDnsPreflightService } from '../setup/bootstrap-dns-preflight.service';
 import { IStorageAdapter, STORAGE_ADAPTER } from '../storage/storage.interface';
 import { getCeVersion, satisfiesMin } from './ce-version.util';
+import { isReservedSubdomain } from './app-manifest.util';
 import type { AppManifest, AppManifestRequires } from './app-manifest.types';
 import type { LoadedBundle } from './app-bundle.service';
 
@@ -79,19 +80,42 @@ export class AppPreflightService {
     return [this.storageGate(requires), this.ceVersionGate(requires), ...this.platformConfigGates()];
   }
 
+  /**
+   * `subdomainOverride` lets the wizard replace the manifest's
+   * `install.domain.subdomain` default for THIS install only — the manifest
+   * itself is never mutated. An override against a manifest that declares no
+   * `install.domain` at all is meaningless (there is nothing to override), so
+   * that's rejected outright rather than silently ignored. A reserved-name
+   * override is instead surfaced as a `name-collision` gate failure (not an
+   * exception) — it's a preview-time concern the wizard shows next to every
+   * other naming conflict.
+   */
   async projectGates(
     bundle: LoadedBundle,
     target: InstallTarget,
     userId: string,
+    subdomainOverride?: string,
   ): Promise<{ gates: GateResult[]; syncPlans: SyncPlanSummary[]; appHost: string | null }> {
     const manifest = bundle.manifest;
-    const subdomain = manifest.install.domain?.subdomain;
+    if (subdomainOverride !== undefined && !manifest.install.domain) {
+      throw new BadRequestException(
+        `App "${manifest.id}" does not declare an install domain, so a subdomain override does not apply.`,
+      );
+    }
+    const subdomain = subdomainOverride ?? manifest.install.domain?.subdomain;
     const primaryDomain = this.configService.get<string>('PRIMARY_DOMAIN') || '';
     const appHost = subdomain ? `${subdomain}.${primaryDomain}` : null;
     const ruleSets = this.parseBundledRuleSets(bundle);
 
     const dns = await this.dnsGate(appHost, subdomain, primaryDomain);
-    const nameCollision = await this.nameCollisionGate(manifest, ruleSets, target, appHost, subdomain);
+    const nameCollision = await this.nameCollisionGate(
+      manifest,
+      ruleSets,
+      target,
+      appHost,
+      subdomain,
+      subdomainOverride,
+    );
     const { gate: dataTables, syncPlans } = await this.dataTablesGate(ruleSets, target, userId);
 
     return { gates: [dns, nameCollision, dataTables], syncPlans, appHost };
@@ -247,8 +271,12 @@ export class AppPreflightService {
     target: InstallTarget,
     appHost: string | null,
     subdomain: string | undefined,
+    subdomainOverride?: string,
   ): Promise<GateResult> {
     const issues: string[] = [];
+    if (subdomainOverride !== undefined && isReservedSubdomain(subdomainOverride)) {
+      issues.push(`The subdomain "${subdomainOverride}" is reserved and cannot be used.`);
+    }
     let existingInstall: typeof installedApps.$inferSelect | undefined;
     // A `newProject` target skips every project-scoped check below (there is
     // no project id to scope them to). That is only sound while the project

--- a/apps/backend/src/app-catalog/apps-registry.service.spec.ts
+++ b/apps/backend/src/app-catalog/apps-registry.service.spec.ts
@@ -1,0 +1,121 @@
+import { ConfigService } from '@nestjs/config';
+import { AppsRegistryService } from './apps-registry.service';
+import { TEST_MANIFEST } from './app-manifest.util.spec';
+
+const VALID_REGISTRY = {
+  schemaVersion: 1,
+  apps: [
+    {
+      id: TEST_MANIFEST.id,
+      name: TEST_MANIFEST.name,
+      version: TEST_MANIFEST.version,
+      bundleUrl: 'https://example.com/handoff.zip',
+      sha256: 'a'.repeat(64),
+    },
+  ],
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('AppsRegistryService', () => {
+  let configService: ConfigService;
+  let service: AppsRegistryService;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    configService = new ConfigService({});
+    service = new AppsRegistryService(configService);
+    fetchSpy = jest.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('returns parsed registry on 200 with valid JSON', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(VALID_REGISTRY));
+
+    const result = await service.getRegistry();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.registry).toEqual(VALID_REGISTRY);
+      expect(typeof result.fetchedAt).toBe('string');
+    }
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refetch within the TTL', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(VALID_REGISTRY));
+
+    await service.getRegistry();
+    await service.getRegistry();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches when force is true', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(VALID_REGISTRY));
+
+    await service.getRegistry();
+    await service.getRegistry(true);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('degrades to ok:false on network error with no prior cache', async () => {
+    fetchSpy.mockRejectedValue(new Error('network down'));
+
+    const result = await service.getRegistry();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeTruthy();
+    }
+  });
+
+  it('degrades to ok:false on non-200 response with no prior cache', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({}, 500));
+
+    const result = await service.getRegistry();
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('degrades to ok:false on invalid registry JSON with no prior cache', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ schemaVersion: 1, apps: 'not-an-array' }));
+
+    const result = await service.getRegistry();
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('serves the stale cache with ok:true when a later refresh fails, even past TTL', async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(VALID_REGISTRY));
+    const first = await service.getRegistry();
+    expect(first.ok).toBe(true);
+
+    // Simulate TTL expiry by forcing a refetch attempt that fails.
+    fetchSpy.mockRejectedValueOnce(new Error('registry blip'));
+    const second = await service.getRegistry(true);
+
+    expect(second.ok).toBe(true);
+    if (second.ok) {
+      expect(second.registry).toEqual(VALID_REGISTRY);
+    }
+
+    // A non-200 blip after that must also serve the stale cache.
+    fetchSpy.mockResolvedValueOnce(jsonResponse({}, 503));
+    const third = await service.getRegistry(true);
+    expect(third.ok).toBe(true);
+    if (third.ok) {
+      expect(third.registry).toEqual(VALID_REGISTRY);
+    }
+  });
+});

--- a/apps/backend/src/app-catalog/apps-registry.service.ts
+++ b/apps/backend/src/app-catalog/apps-registry.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { getCeVersion } from './ce-version.util';
+import { validateRegistry } from './app-manifest.util';
+import type { AppRegistry } from './app-manifest.types';
+
+export type RegistryResult =
+  | { ok: true; registry: AppRegistry; fetchedAt: string }
+  | { ok: false; error: string };
+
+interface RegistryCache {
+  registry: AppRegistry;
+  fetchedAt: number;
+}
+
+/**
+ * AppsRegistryService — fetches and caches the app catalog registry.
+ *
+ * Stale-while-error: once a fetch has succeeded, any later failed refresh
+ * (network error, non-200, or invalid JSON) — even past the TTL — serves the
+ * last-known-good cache with `ok: true` rather than surfacing the failure.
+ * Installed apps must keep working when the registry endpoint blips.
+ */
+@Injectable()
+export class AppsRegistryService {
+  private readonly logger = new Logger(AppsRegistryService.name);
+  private readonly url: string;
+  private readonly TTL_MS = 3600_000;
+  private readonly REQUEST_TIMEOUT_MS = 10_000;
+  private cache: RegistryCache | null = null;
+
+  constructor(private readonly configService: ConfigService) {
+    this.url =
+      this.configService.get<string>('APPS_REGISTRY_URL') || 'https://apps.bffless.dev/registry.json';
+  }
+
+  async getRegistry(force?: boolean): Promise<RegistryResult> {
+    if (!force && this.cache && Date.now() - this.cache.fetchedAt < this.TTL_MS) {
+      return { ok: true, registry: this.cache.registry, fetchedAt: new Date(this.cache.fetchedAt).toISOString() };
+    }
+
+    try {
+      const registry = await this.fetchAndValidate();
+      this.cache = { registry, fetchedAt: Date.now() };
+      return { ok: true, registry, fetchedAt: new Date(this.cache.fetchedAt).toISOString() };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'unknown error';
+      if (this.cache) {
+        this.logger.warn(`Registry refresh failed, serving stale cache: ${message}`);
+        return {
+          ok: true,
+          registry: this.cache.registry,
+          fetchedAt: new Date(this.cache.fetchedAt).toISOString(),
+        };
+      }
+      this.logger.warn(`Registry fetch failed with no cache available: ${message}`);
+      return { ok: false, error: message };
+    }
+  }
+
+  private async fetchAndValidate(): Promise<AppRegistry> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.REQUEST_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await fetch(this.url, {
+        headers: { 'User-Agent': `bffless-ce-app-catalog/${getCeVersion()}` },
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (!res.ok) {
+      throw new Error(`Registry fetch returned HTTP ${res.status}`);
+    }
+
+    const json = await res.json();
+    const result = validateRegistry(json);
+    if (!result.ok) {
+      throw new Error(`Registry failed validation: ${result.errors.join('; ')}`);
+    }
+    return result.registry;
+  }
+}

--- a/apps/backend/src/app-catalog/ce-version.util.spec.ts
+++ b/apps/backend/src/app-catalog/ce-version.util.spec.ts
@@ -1,0 +1,37 @@
+import { compareSemver, satisfiesMin, getCeVersion, resolveCeVersion } from './ce-version.util';
+
+describe('compareSemver', () => {
+  it('orders plain versions', () => {
+    expect(compareSemver('0.3.15', '0.2.0')).toBeGreaterThan(0);
+    expect(compareSemver('0.3.15', '0.3.15')).toBe(0);
+    expect(compareSemver('0.3.9', '0.3.15')).toBeLessThan(0);
+  });
+  it('handles v-prefix and prerelease suffix by ignoring the suffix', () => {
+    expect(compareSemver('v1.0.0', '1.0.0')).toBe(0);
+    expect(compareSemver('1.0.0-rc.1', '1.0.0')).toBe(0);
+  });
+});
+
+describe('satisfiesMin', () => {
+  it('passes when equal or newer', () => {
+    expect(satisfiesMin('0.3.15', '0.3.15')).toBe(true);
+    expect(satisfiesMin('0.4.0', '0.3.15')).toBe(true);
+    expect(satisfiesMin('0.3.14', '0.3.15')).toBe(false);
+  });
+  it('fails closed on unparseable running version', () => {
+    expect(satisfiesMin('unknown', '0.3.15')).toBe(false);
+  });
+});
+
+describe('resolveCeVersion', () => {
+  it('picks the first candidate whose package name is @bffless/ce', () => {
+    const version = resolveCeVersion([
+      { name: 'backend', version: '1.0.0' },
+      { name: '@bffless/ce', version: '0.3.15' },
+    ]);
+    expect(version).toBe('0.3.15');
+  });
+  it('returns "unknown" when no candidate matches', () => {
+    expect(resolveCeVersion([{ name: 'backend', version: '1.0.0' }])).toBe('unknown');
+  });
+});

--- a/apps/backend/src/app-catalog/ce-version.util.ts
+++ b/apps/backend/src/app-catalog/ce-version.util.ts
@@ -1,0 +1,57 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** Package identity check: the CE release version lives in the ROOT package.json
+ * ("@bffless/ce"). apps/backend/package.json is a never-bumped 1.0.0 — matching
+ * on the name is what keeps us from repeating telemetry's bug. */
+export function resolveCeVersion(
+  candidates: Array<{ name?: string; version?: string }>,
+): string {
+  for (const pkg of candidates) {
+    if (pkg?.name === '@bffless/ce' && pkg.version) return String(pkg.version);
+  }
+  return 'unknown';
+}
+
+let cached: string | null = null;
+
+export function getCeVersion(): string {
+  if (cached) return cached;
+  const files = [
+    path.join(process.cwd(), '..', '..', 'package.json'), // /app/apps/backend -> /app (docker), repo root (dev)
+    path.join(__dirname, '..', '..', '..', '..', 'package.json'), // dist/app-catalog -> repo root fallback
+    '/app/package.json',
+  ];
+  const candidates: Array<{ name?: string; version?: string }> = [];
+  for (const file of files) {
+    try {
+      candidates.push(JSON.parse(fs.readFileSync(file, 'utf8')));
+    } catch {
+      /* try next */
+    }
+  }
+  cached = resolveCeVersion(candidates);
+  return cached;
+}
+
+function parse(v: string): [number, number, number] | null {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)/.exec(v.trim());
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+export function compareSemver(a: string, b: string): number {
+  const pa = parse(a);
+  const pb = parse(b);
+  if (!pa || !pb) return NaN;
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+/** Fail closed: an unparseable running version does NOT satisfy any minimum. */
+export function satisfiesMin(version: string, min: string): boolean {
+  const cmp = compareSemver(version, min);
+  return Number.isFinite(cmp) && cmp >= 0;
+}

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -45,6 +45,7 @@ import { ApiKeyGuard } from './auth/api-key.guard';
 import { McpToolsModule } from './mcp/mcp-tools.module';
 import { TelemetryModule } from './telemetry/telemetry.module';
 import { TrafficModule } from './traffic/traffic.module';
+import { AppCatalogModule } from './app-catalog/app-catalog.module';
 
 @Module({
   imports: [
@@ -175,6 +176,8 @@ import { TrafficModule } from './traffic/traffic.module';
     McpToolsModule,
     TelemetryModule,
     TrafficModule,
+    // App catalog for 1-click installs (own prefix, no ordering constraint)
+    AppCatalogModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/backend/src/assets/assets.service.ts
+++ b/apps/backend/src/assets/assets.service.ts
@@ -12,6 +12,8 @@ import { assets, Asset } from '../db/schema';
 import { STORAGE_ADAPTER } from '../storage/storage.module';
 import { IStorageAdapter } from '../storage/storage.interface';
 import { StorageQuotaService } from '../storage/storage-quota.service';
+import { resolveLocalAdapter } from '../storage/local.adapter';
+import { MAX_EXPIRES_IN_SECONDS } from '../storage/presign.util';
 import {
   UploadAssetDto,
   UpdateAssetDto,
@@ -451,12 +453,20 @@ export class AssetsService implements OnModuleInit {
     // Get URL from storage adapter
     const url = await this.storageAdapter.getUrl(asset.storageKey, expiresIn);
 
-    // Calculate expiration if provided
-    // Note: For local storage, expiresIn is ignored (URLs are permanent)
-    // For MinIO/S3, if expiresIn is undefined, the adapter uses its default
+    // Calculate expiration if provided.
+    //
+    // Local storage no longer ignores expiresIn — it mints a real signed URL
+    // that genuinely stops working at `exp` — but it CLAMPS the lifetime to
+    // MAX_EXPIRES_IN_SECONDS. Reporting the unclamped request back would tell
+    // a caller their link lasts a day when it dies in an hour, so mirror the
+    // adapter's clamp here. Bucket adapters honour longer lifetimes, so this
+    // only applies when the active backend resolves to local.
     let expiresAt: string | undefined;
     if (expiresIn !== undefined) {
-      expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
+      const effective = resolveLocalAdapter(this.storageAdapter)
+        ? Math.min(Math.max(1, Math.floor(expiresIn)), MAX_EXPIRES_IN_SECONDS)
+        : expiresIn;
+      expiresAt = new Date(Date.now() + effective * 1000).toISOString();
     }
 
     return { url, expiresAt };

--- a/apps/backend/src/common/utils/download-filename.util.ts
+++ b/apps/backend/src/common/utils/download-filename.util.ts
@@ -1,0 +1,30 @@
+/**
+ * Reduce an arbitrary value to a filename safe to interpolate into a
+ * `Content-Disposition` header value. THE choke point: every adapter trusts
+ * that `SignedUrlOptions.downloadFilename` came through here.
+ *
+ * Strips path separators (basename only), then control characters, double
+ * quotes and backslashes — the characters that could break out of the quoted
+ * header value or inject a second header. Returns `undefined` when nothing
+ * usable survives, which makes callers omit the disposition entirely.
+ *
+ * Lives in `common/` rather than beside the `signed_url` pipeline handler that
+ * originally owned it because the local-filesystem download route
+ * (`storage/local-presigned-download.controller.ts`) is the other side of the
+ * same contract: it re-sanitizes the `dl` query param before writing the
+ * header, since a signed URL is minted once but replayed by an untrusted
+ * client. A `storage/` → `pipelines/` import would invert the dependency
+ * direction for a five-line pure function.
+ */
+export function sanitizeDownloadFilename(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined;
+
+  const basename = raw.split(/[/\\]/).pop() ?? '';
+  const cleaned = basename
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f"\\]/g, '')
+    .trim()
+    .slice(0, 200);
+
+  return cleaned || undefined;
+}

--- a/apps/backend/src/common/utils/download-filename.util.ts
+++ b/apps/backend/src/common/utils/download-filename.util.ts
@@ -28,3 +28,60 @@ export function sanitizeDownloadFilename(raw: unknown): string | undefined {
 
   return cleaned || undefined;
 }
+
+/**
+ * Percent-encode a filename for the RFC 5987 `ext-value` production used by
+ * `filename*`.
+ *
+ * `encodeURIComponent` leaves `!'()*` unescaped, but RFC 5987's `attr-char`
+ * set excludes them, so they are escaped here too.
+ */
+function encodeExtValue(filename: string): string {
+  return encodeURIComponent(filename).replace(
+    /['()!*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+/**
+ * Build a `Content-Disposition: attachment` header value that is safe to hand
+ * to `res.setHeader` for ANY filename, including non-ASCII ones.
+ *
+ * Node validates header values against `[\t\x20-\x7e\x80-\xff]` and throws
+ * `ERR_INVALID_CHAR` on anything outside it — so a filename containing U+202F
+ * (every macOS screenshot carries one between the time and AM/PM) or CJK text
+ * turns a signed download into a 500. Latin-1 characters don't throw but are
+ * mis-decoded by browsers, which is the same class of bug one step quieter.
+ *
+ * So: anything non-ASCII gets the RFC 6266 dual form — a folded ASCII
+ * `filename="..."` that legacy clients can still read, plus the real name in
+ * `filename*=UTF-8''...` which every current browser prefers. A purely ASCII
+ * filename is emitted in the plain quoted form alone, byte-identical to what
+ * a client saw before this existed.
+ *
+ * @param filename MUST already be through {@link sanitizeDownloadFilename} —
+ *                 quotes, backslashes and control characters are assumed gone.
+ */
+export function formatAttachmentDisposition(filename: string): string {
+  // eslint-disable-next-line no-control-regex
+  const nonAscii = /[^\x20-\x7e]/;
+  if (!nonAscii.test(filename)) {
+    return `attachment; filename="${filename}"`;
+  }
+
+  // Fold every run of non-ASCII to a single `_` so the fallback stays
+  // recognisable (`Screenshot 7.44.31_AM.png`) rather than becoming a
+  // run-together mess.
+  const stripped = filename
+    .replace(new RegExp(nonAscii.source, 'g'), '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .trim();
+
+  // A wholly non-ASCII name leaves nothing (`文件` → ``) or a bare extension
+  // (`文件.png` → `.png`). Neither is a filename a client should be offered,
+  // so give the fallback a real stem while keeping any extension.
+  const folded = !stripped || stripped.startsWith('.') ? `download${stripped}` : stripped;
+
+  return `attachment; filename="${folded}"; filename*=UTF-8''${encodeExtValue(filename)}`;
+}

--- a/apps/backend/src/db/schema/index.ts
+++ b/apps/backend/src/db/schema/index.ts
@@ -8,6 +8,7 @@ export * from './deployment-aliases.schema';
 export * from './alias-proxy-rule-sets.schema';
 export * from './project-default-proxy-rule-sets.schema';
 export * from './projects.schema';
+export * from './installed-apps.schema';
 export * from './project-secrets.schema';
 export * from './user-groups.schema';
 export * from './project-permissions.schema';

--- a/apps/backend/src/db/schema/installed-apps.schema.ts
+++ b/apps/backend/src/db/schema/installed-apps.schema.ts
@@ -1,0 +1,79 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  timestamp,
+  jsonb,
+  index,
+  unique,
+} from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { projects } from './projects.schema';
+import { users } from './users.schema';
+
+export type InstalledAppStatus = 'installing' | 'installed' | 'failed';
+
+/** Objects this install created (vs adopted) — the undo/uninstall boundary. */
+export interface CreatedResources {
+  projectCreated?: boolean;
+  ruleSetIds?: string[];
+  /** Only schemas the sync CREATED (action === 'create'); reused ones are never ours to delete. */
+  schemaIdsCreated?: string[];
+  aliasName?: string;
+  domainId?: string;
+  deploymentId?: string;
+  scheduleIds?: string[];
+}
+
+export const installedApps = pgTable(
+  'installed_apps',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    appId: varchar('app_id', { length: 100 }).notNull(),
+    name: varchar('name', { length: 200 }).notNull(),
+    version: varchar('version', { length: 50 }).notNull(),
+    projectId: uuid('project_id')
+      .references(() => projects.id, { onDelete: 'cascade' })
+      .notNull(),
+    alias: varchar('alias', { length: 100 }).notNull(),
+    domainId: uuid('domain_id'),
+    deploymentId: uuid('deployment_id'),
+    ruleSetIds: jsonb('rule_set_ids').$type<string[]>().notNull().default([]),
+    schemaIds: jsonb('schema_ids').$type<string[]>().notNull().default([]),
+    bundleSha256: varchar('bundle_sha256', { length: 64 }).notNull(),
+    /** Full manifest at install time — powers eject + manual steps without refetching. */
+    manifest: jsonb('manifest').notNull(),
+    manualStepsAcked: jsonb('manual_steps_acked').$type<string[]>().notNull().default([]),
+    status: varchar('status', { length: 20 })
+      .$type<InstalledAppStatus>()
+      .notNull()
+      .default('installing'),
+    createdResources: jsonb('created_resources')
+      .$type<CreatedResources>()
+      .notNull()
+      .default({}),
+    installedBy: uuid('installed_by')
+      .references(() => users.id)
+      .notNull(),
+    installedAt: timestamp('installed_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => [
+    index('installed_apps_project_id_idx').on(table.projectId),
+    unique('installed_apps_app_project_unique').on(table.appId, table.projectId),
+  ],
+);
+
+export const installedAppsRelations = relations(installedApps, ({ one }) => ({
+  project: one(projects, {
+    fields: [installedApps.projectId],
+    references: [projects.id],
+  }),
+  installedByUser: one(users, {
+    fields: [installedApps.installedBy],
+    references: [users.id],
+  }),
+}));
+
+export type InstalledApp = typeof installedApps.$inferSelect;
+export type NewInstalledApp = typeof installedApps.$inferInsert;

--- a/apps/backend/src/deployments/deployments.controller.ts
+++ b/apps/backend/src/deployments/deployments.controller.ts
@@ -542,15 +542,16 @@ export class DeploymentsController {
             .where(and(eq(assets.projectId, project.id), eq(assets.commitSha, commitSha)));
 
     // Check if storage supports presigned URLs. Local storage always takes
-    // the fallback branch below (the `${PUBLIC_URL}/api/files/...` URL, a
-    // few lines down) regardless of what supportsPresignedUrls() reports:
-    // LocalStorageAdapter.getUrl() ignores the expiry argument entirely and
-    // returns `${baseUrl}/${key}`, where baseUrl defaults to the vestigial
-    // `http://localhost:3000/files` (see the @TODO on LocalStorageAdapter's
-    // baseUrl field). That is not a real presigned URL, so calling getUrl()
-    // here for local storage would leak localhost into download URLs on any
-    // real install. Same predicate and reasoning as prepareBatchUpload
-    // above, mirrored for the download direction.
+    // the fallback branch below (the `${PUBLIC_URL}/api/files/...` URL, a few
+    // lines down) regardless of what supportsPresignedUrls() reports.
+    //
+    // LocalStorageAdapter.getUrl() DOES now mint a real signed, expiring URL
+    // (see local-presigned-download.controller.ts), but a RELATIVE one, to be
+    // resolved by the browser against the host that served the page. This
+    // response is consumed by CI / the CLI — non-browser callers with no page
+    // origin to resolve against — so the absolute `${PUBLIC_URL}/api/files/...`
+    // fallback stays correct here. Same predicate and reasoning as
+    // prepareBatchUpload above, mirrored for the download direction.
     const isLocalAdapter = resolveLocalAdapter(this.storageAdapter) !== null;
     const supportsPresigned =
       !isLocalAdapter && (this.storageAdapter.supportsPresignedUrls?.() ?? false);

--- a/apps/backend/src/feature-flags/feature-flags.definitions.ts
+++ b/apps/backend/src/feature-flags/feature-flags.definitions.ts
@@ -343,6 +343,17 @@ export const FLAG_DEFINITIONS: Record<string, FlagDefinition> = {
     exposeToClient: true,
   },
 
+  ENABLE_APP_CATALOG: {
+    envKey: 'FEATURE_APP_CATALOG',
+    defaultValue: true,
+    type: 'boolean',
+    description:
+      'Show the Admin → Apps catalog for 1-click installs of first-party BFFless apps. ' +
+      'Disable to hide the catalog and refuse install endpoints.',
+    category: 'features',
+    exposeToClient: true,
+  },
+
   ENABLE_BOOTSTRAP_SETUP: {
     envKey: 'FEATURE_BOOTSTRAP_SETUP',
     defaultValue: true,

--- a/apps/backend/src/feature-flags/feature-flags.definitions.ts
+++ b/apps/backend/src/feature-flags/feature-flags.definitions.ts
@@ -100,8 +100,10 @@ export const FLAG_DEFINITIONS: Record<string, FlagDefinition> = {
     defaultValue: true,
     type: 'boolean',
     description:
-      'Allow presigned (direct) uploads when local filesystem storage is active. ' +
-      'Exposes a signature-authorized PUT route; disable to require proxied uploads.',
+      'Allow presigned (direct) uploads AND signed downloads when local filesystem ' +
+      'storage is active. Exposes one signature-authorized route ' +
+      '(PUT /api/storage/presigned/local to upload, GET to download); disable to ' +
+      'require proxied uploads and to turn off signed download links.',
     category: 'features',
     exposeToClient: true,
   },

--- a/apps/backend/src/pipelines/handlers/signed-url.handler.ts
+++ b/apps/backend/src/pipelines/handlers/signed-url.handler.ts
@@ -6,6 +6,7 @@ import { PipelineContext, StepResult } from '../execution/pipeline-context.inter
 import { PipelineStep } from '../types';
 import { ConfigurationError } from '../errors';
 import { IStorageAdapter, STORAGE_ADAPTER } from '../../storage/storage.interface';
+import { sanitizeDownloadFilename } from '../../common/utils/download-filename.util';
 
 export interface SignedUrlHandlerConfig {
   /**
@@ -31,27 +32,12 @@ export interface SignedUrlHandlerConfig {
 }
 
 /**
- * Reduce an arbitrary value to a filename safe to interpolate into a
- * `Content-Disposition` header value. THE choke point: every adapter trusts
- * that `SignedUrlOptions.downloadFilename` came through here.
- *
- * Strips path separators (basename only), then control characters, double
- * quotes and backslashes — the characters that could break out of the quoted
- * header value or inject a second header. Returns `undefined` when nothing
- * usable survives, which makes the handler omit the disposition entirely.
+ * Re-exported from `common/utils/download-filename.util` so existing importers
+ * (and the handler's own spec) keep working. The implementation moved out of
+ * this file because the local-filesystem signed-download route in `storage/`
+ * needs the same sanitizer, and `storage/` must not import from `pipelines/`.
  */
-export function sanitizeDownloadFilename(raw: unknown): string | undefined {
-  if (typeof raw !== 'string') return undefined;
-
-  const basename = raw.split(/[/\\]/).pop() ?? '';
-  const cleaned = basename
-    // eslint-disable-next-line no-control-regex
-    .replace(/[\u0000-\u001f\u007f"\\]/g, '')
-    .trim()
-    .slice(0, 200);
-
-  return cleaned || undefined;
-}
+export { sanitizeDownloadFilename };
 
 /**
  * Signed URL Handler

--- a/apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
+++ b/apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
@@ -100,4 +100,22 @@ describe('BootstrapDnsPreflightService', () => {
       expect(options.path).toMatch(/^\/\.well-known\/acme-challenge\//);
     });
   });
+
+  describe('probeHost extraction', () => {
+    it('probeHost probes exactly the given host', async () => {
+      const resolveA = jest.spyOn(service as never, 'resolveA' as never).mockResolvedValue(['203.0.113.7'] as never);
+      jest.spyOn(service as never, 'fetchProbe' as never).mockResolvedValue('irrelevant' as never);
+      const check = await service.probeHost('handoff.example.com');
+      expect(check.host).toBe('handoff.example.com');
+      expect(resolveA).toHaveBeenCalledTimes(1);
+    });
+
+    it('run() still fans out to apex + www + admin via probeHost', async () => {
+      const probe = jest
+        .spyOn(service, 'probeHost')
+        .mockResolvedValue({ host: 'x', resolvedIps: [], probeOk: true });
+      await service.run('example.com');
+      expect(probe.mock.calls.map((c) => c[0])).toEqual(['example.com', 'www.example.com', 'admin.example.com']);
+    });
+  });
 });

--- a/apps/backend/src/setup/bootstrap-dns-preflight.service.ts
+++ b/apps/backend/src/setup/bootstrap-dns-preflight.service.ts
@@ -54,6 +54,11 @@ export class BootstrapDnsPreflightService {
 
   async run(domain: string): Promise<PreflightResult> {
     const hosts = [domain, `www.${domain}`, `admin.${domain}`];
+    const checks = await Promise.all(hosts.map((host) => this.probeHost(host)));
+    return { ok: checks.every((c) => c.probeOk), checks };
+  }
+
+  async probeHost(host: string): Promise<PreflightCheck> {
     const token = `preflight-${crypto.randomBytes(16).toString('hex')}`;
     const content = token; // body == token: cheap, unguessable, self-describing
     const filePath = path.join(this.webroot(), '.well-known', 'acme-challenge', token);
@@ -61,28 +66,23 @@ export class BootstrapDnsPreflightService {
     await fs.mkdir(path.dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, content);
     try {
-      const checks: PreflightCheck[] = [];
-      for (const host of hosts) {
-        const resolvedIps = await this.resolveA(host);
-        if (resolvedIps.some((ip) => isDisallowedProbeIp(ip))) {
-          checks.push({ host, resolvedIps, probeOk: false, error: 'resolves to a private or reserved address' });
-          continue;
-        }
-        let probeOk = false;
-        let error: string | undefined;
-        try {
-          const body = await this.fetchProbe(host, resolvedIps[0], token, content);
-          probeOk = body === content;
-          if (!probeOk) error = 'Another server answered on port 80 for this hostname';
-        } catch (e) {
-          error = e instanceof Error ? e.message : 'Unreachable over HTTP';
-        }
-        if (!probeOk && resolvedIps.length === 0 && !error) {
-          error = 'Hostname does not resolve yet';
-        }
-        checks.push({ host, resolvedIps, probeOk, error: probeOk ? undefined : error });
+      const resolvedIps = await this.resolveA(host);
+      if (resolvedIps.some((ip) => isDisallowedProbeIp(ip))) {
+        return { host, resolvedIps, probeOk: false, error: 'resolves to a private or reserved address' };
       }
-      return { ok: checks.every((c) => c.probeOk), checks };
+      let probeOk = false;
+      let error: string | undefined;
+      try {
+        const body = await this.fetchProbe(host, resolvedIps[0], token, content);
+        probeOk = body === content;
+        if (!probeOk) error = 'Another server answered on port 80 for this hostname';
+      } catch (e) {
+        error = e instanceof Error ? e.message : 'Unreachable over HTTP';
+      }
+      if (!probeOk && resolvedIps.length === 0 && !error) {
+        error = 'Hostname does not resolve yet';
+      }
+      return { host, resolvedIps, probeOk, error: probeOk ? undefined : error };
     } finally {
       await fs.rm(filePath, { force: true });
     }

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
@@ -16,7 +16,10 @@ const makeDeps = () => ({
     assertStagedCertificateCovers: jest.fn(),
   },
   ssl: { requestPrimaryDomainCertificate: jest.fn() },
-  preflight: { run: jest.fn().mockResolvedValue({ ok: true, checks: [] }) },
+  preflight: {
+    run: jest.fn().mockResolvedValue({ ok: true, checks: [] }),
+    probeHost: jest.fn().mockResolvedValue({ host: 'extra.a.com', resolvedIps: ['1.2.3.4'], probeOk: true }),
+  },
   info: {
     getWildcardCertInfo: jest.fn().mockResolvedValue({ type: 'wildcard', expiresAt: new Date(), isValid: true }),
     getServedPrimaryCertInfo: jest.fn().mockResolvedValue({ type: 'individual', expiresAt: new Date(), isValid: true }),
@@ -374,6 +377,42 @@ describe('PrimarySslService.issueLetsEncrypt', () => {
     d.snap.readPendingRevert.mockReturnValue({ deadlineMs: Date.now() + 1000, appliedAt: Date.now() });
     await expect(svc.issueLetsEncrypt()).rejects.toThrow();
     expect(d.snap.snapshotForChangeCycle).not.toHaveBeenCalled();
+    expect(d.ssl.requestPrimaryDomainCertificate).not.toHaveBeenCalled();
+  });
+
+  // Regression (Task 8): no-opts callers must produce the exact same call
+  // shape as before extraSans threading existed.
+  it('regression: without opts, calls requestPrimaryDomainCertificate with the same args as before extraSans existed', async () => {
+    const { d, svc } = build();
+    d.ssl.requestPrimaryDomainCertificate.mockResolvedValue({ success: true, sans: ['a.com'] });
+    await svc.issueLetsEncrypt();
+    expect(d.ssl.requestPrimaryDomainCertificate).toHaveBeenCalledWith('a.com', { target: 'staging' });
+    expect(d.preflight.probeHost).not.toHaveBeenCalled();
+  });
+
+  it('with extraSans: probes the extra host(s) and passes extraSans through to requestPrimaryDomainCertificate', async () => {
+    const { d, svc } = build();
+    d.ssl.requestPrimaryDomainCertificate.mockResolvedValue({ success: true, sans: ['a.com', 'handoff.example.com'] });
+    const r = await svc.issueLetsEncrypt({ extraSans: ['handoff.example.com'] });
+    expect(d.preflight.probeHost).toHaveBeenCalledWith('handoff.example.com');
+    expect(d.ssl.requestPrimaryDomainCertificate).toHaveBeenCalledWith('a.com', {
+      target: 'staging',
+      extraSans: ['handoff.example.com'],
+    });
+    expect(r.sans).toContain('handoff.example.com');
+  });
+
+  it('with extraSans: the original [apex, www, admin] preflight still runs unreduced', async () => {
+    const { d, svc } = build();
+    d.ssl.requestPrimaryDomainCertificate.mockResolvedValue({ success: true, sans: ['a.com'] });
+    await svc.issueLetsEncrypt({ extraSans: ['handoff.example.com'] });
+    expect(d.preflight.run).toHaveBeenCalledWith('a.com');
+  });
+
+  it('with extraSans: throws (does not issue) when the extra host fails its preflight probe', async () => {
+    const { d, svc } = build();
+    d.preflight.probeHost.mockResolvedValue({ host: 'handoff.example.com', resolvedIps: [], probeOk: false, error: 'does not resolve' });
+    await expect(svc.issueLetsEncrypt({ extraSans: ['handoff.example.com'] })).rejects.toThrow();
     expect(d.ssl.requestPrimaryDomainCertificate).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
@@ -117,7 +117,7 @@ export class PrimarySslService {
     );
   }
 
-  async issueLetsEncrypt(): Promise<{ issued: boolean; sans: string[]; reused: boolean }> {
+  async issueLetsEncrypt(opts?: { extraSans?: string[] }): Promise<{ issued: boolean; sans: string[]; reused: boolean }> {
     this.assertEnabled();
     const domain = this.requireDomain();
     if (this.snap.readPendingRevert()) {
@@ -127,7 +127,26 @@ export class PrimarySslService {
     if (!pre.ok) {
       throw new BadRequestException('DNS/port-80 preflight failed; not requesting a certificate');
     }
-    const res = await this.ssl.requestPrimaryDomainCertificate(domain, { target: 'staging' });
+    // Extra SANs (e.g. an app-catalog subdomain) get their own preflight
+    // probe on top of the fixed [apex, www, admin] set above — never a
+    // reduction of the existing hard gate, purely additive.
+    const extraSans = opts?.extraSans ?? [];
+    if (extraSans.length > 0) {
+      const extraChecks = await Promise.all(extraSans.map((host) => this.preflightSvc.probeHost(host)));
+      const failed = extraChecks.filter((c) => !c.probeOk);
+      if (failed.length > 0) {
+        throw new BadRequestException(
+          `DNS/port-80 preflight failed for additional host(s): ${failed.map((c) => c.host).join(', ')}`,
+        );
+      }
+    }
+    // Keep the call shape byte-identical to before when no extraSans are
+    // requested (no-opts callers, and the existing regression tests, expect
+    // exactly `{ target: 'staging' }`).
+    const res = await this.ssl.requestPrimaryDomainCertificate(
+      domain,
+      extraSans.length > 0 ? { target: 'staging', extraSans } : { target: 'staging' },
+    );
     if (!res.success) {
       throw new BadRequestException(res.error || 'Certificate issuance failed');
     }

--- a/apps/backend/src/setup/setup.module.ts
+++ b/apps/backend/src/setup/setup.module.ts
@@ -33,6 +33,9 @@ import { PrimarySslRevertService } from './primary-ssl/primary-ssl-revert.servic
     PrimarySslSnapshotService,
     PrimarySslRevertService,
   ],
-  exports: [SetupService],
+  // PrimarySslService is exported for AppCatalogModule's AppCertStepService
+  // (Task 8): it needs `issueLetsEncrypt({ extraSans })` to stage a widened
+  // cert for a newly-installed app's subdomain.
+  exports: [SetupService, PrimarySslService],
 })
 export class SetupModule {}

--- a/apps/backend/src/storage/__tests__/integration/storage-integration.spec.ts
+++ b/apps/backend/src/storage/__tests__/integration/storage-integration.spec.ts
@@ -105,9 +105,18 @@ describe('Storage Integration Tests', () => {
       expect(typeof (metadata.lastModified as Date).getTime).toBe('function');
     });
 
-    it('should generate presigned/signed/SAS URL', async () => {
+    it('should generate a signed download URL', async () => {
+      // Local storage mints a RELATIVE, same-origin signed URL (the browser
+      // resolves it against the host that served the page) rather than an
+      // absolute bucket URL — see LocalStorageAdapter.getUrl.
       const url = await adapter.getUrl(testKey, 300);
-      expect(url).toMatch(/^https?:\/\//);
+      expect(url).toMatch(/^\/api\/storage\/presigned\/local\?/);
+      expect(
+        Buffer.from(
+          new URL(url, 'https://app.example').searchParams.get('key')!,
+          'base64url',
+        ).toString('utf8'),
+      ).toBe(testKey);
     });
 
     it('should list keys with prefix', async () => {

--- a/apps/backend/src/storage/dynamic-storage.adapter.spec.ts
+++ b/apps/backend/src/storage/dynamic-storage.adapter.spec.ts
@@ -150,6 +150,19 @@ describe('DynamicStorageAdapter', () => {
 
         expect(mockAdapter.getUrl).toHaveBeenCalledWith(key, undefined, undefined);
       });
+
+      // Regression guard: a wrapper that drops an argument is exactly how the
+      // downloadStream production bug happened. On local storage `options`
+      // now carries the download filename signed into the URL, so dropping it
+      // here would silently strip Content-Disposition from every signed
+      // download.
+      it('should forward the full (key, expiresIn, options) triple', async () => {
+        await adapter.getUrl('test/key.txt', 600, { downloadFilename: 'my-video.mp4' });
+
+        expect(mockAdapter.getUrl).toHaveBeenCalledWith('test/key.txt', 600, {
+          downloadFilename: 'my-video.mp4',
+        });
+      });
     });
 
     describe('listKeys', () => {

--- a/apps/backend/src/storage/local-presigned-download.controller.spec.ts
+++ b/apps/backend/src/storage/local-presigned-download.controller.spec.ts
@@ -100,6 +100,24 @@ describe('LocalPresignedDownloadController', () => {
       await get(rawQuery({ key: encodeKey(KEY), exp: 'soon', sig: 'x'.repeat(64) })).expect(400);
     });
 
+    // Express's query parser hands back an object for `dl[a]=b` and an array
+    // for a repeated param. Before the type guard those reached
+    // canonicalDownloadString, where Buffer.from(object) threw INSIDE the
+    // signature computation — an unauthenticated 500 on a pre-auth path.
+    it.each([
+      ['object', 'dl[a]=b'],
+      ['array', 'dl=one&dl=two'],
+      ['object key', 'key[a]=b&exp=1800000000&sig=x'],
+    ])('400s (not 500) on a structured %s parameter', async (_label, fragment) => {
+      const base = new URLSearchParams((await mint()).slice(1));
+      base.delete(fragment.startsWith('key') ? 'key' : 'dl');
+      const res = await get(`?${base.toString()}&${fragment}`).expect(400);
+
+      // Pins the failure to the type guard specifically, not to some other
+      // 400 further down the handler.
+      expect(res.body.message).toBe('Malformed signed download parameters');
+    });
+
     it('403s on a tampered signature', async () => {
       const query = await mint();
       await get(query.replace(/sig=[0-9a-f]{64}/, `sig=${'a'.repeat(64)}`)).expect(403);
@@ -205,6 +223,38 @@ describe('LocalPresignedDownloadController', () => {
       expect(res.headers['content-disposition']).toBe('attachment; filename="Holiday Clip.mp4"');
     });
 
+    // Live 500: sanitizeDownloadFilename leaves non-Latin-1 characters intact
+    // and res.setHeader throws ERR_INVALID_CHAR on anything above U+00FF.
+    // EVERY macOS screenshot carries U+202F between the time and AM/PM, and
+    // Studio's sign rule passes the user's own filename straight through, so
+    // this was reachable with a completely ordinary file.
+    it('serves a U+202F filename as RFC 6266 dual form instead of 500ing', async () => {
+      const res = await get(
+        await mint(KEY, 600, { downloadFilename: 'Screenshot 7.44.31\u202fAM.png' }),
+      ).expect(200);
+
+      expect(res.headers['content-disposition']).toBe(
+        `attachment; filename="Screenshot 7.44.31_AM.png"; filename*=UTF-8''Screenshot%207.44.31%E2%80%AFAM.png`,
+      );
+      expect(Buffer.from(res.body)).toEqual(BODY);
+    });
+
+    it('serves a CJK filename as RFC 6266 dual form with a usable ASCII fallback', async () => {
+      const res = await get(await mint(KEY, 600, { downloadFilename: '文件.png' })).expect(200);
+
+      expect(res.headers['content-disposition']).toBe(
+        `attachment; filename="download.png"; filename*=UTF-8''%E6%96%87%E4%BB%B6.png`,
+      );
+    });
+
+    it('leaves a pure-ASCII filename in the plain quoted form (no filename*)', async () => {
+      const res = await get(
+        await mint(KEY, 600, { downloadFilename: 'Holiday Clip.mp4' }),
+      ).expect(200);
+
+      expect(res.headers['content-disposition']).not.toContain('filename*');
+    });
+
     it('sanitizes a hostile dl before it reaches the header', async () => {
       const res = await get(
         await mint(KEY, 600, { downloadFilename: 'a/b/ev"il\r\nX-Evil: 1.mp4' }),
@@ -229,6 +279,29 @@ describe('LocalPresignedDownloadController', () => {
 
       expect(res.headers['content-range']).toBe(`bytes 8-${BODY.length - 1}/${BODY.length}`);
       expect(Buffer.from(res.body)).toEqual(BODY.subarray(8));
+    });
+
+    // RFC 9110 §14.1.2: `bytes=-N` is the SUFFIX form — the last N bytes.
+    // Reading the empty first group as a defaulted 0 served bytes 0..N and
+    // mislabelled them in Content-Range, which a player renders as garbage.
+    it('serves a suffix range as the LAST N bytes (curl -r -5)', async () => {
+      const res = await get(await mint()).set('Range', 'bytes=-5').expect(206);
+
+      expect(res.headers['content-range']).toBe(`bytes 11-15/${BODY.length}`);
+      expect(res.headers['content-length']).toBe('5');
+      expect(Buffer.from(res.body)).toEqual(BODY.subarray(BODY.length - 5));
+    });
+
+    it('serves the whole file when the suffix exceeds its size', async () => {
+      const res = await get(await mint()).set('Range', 'bytes=-999').expect(206);
+
+      expect(res.headers['content-range']).toBe(`bytes 0-${BODY.length - 1}/${BODY.length}`);
+      expect(Buffer.from(res.body)).toEqual(BODY);
+    });
+
+    it('416s a zero-length suffix range', async () => {
+      const res = await get(await mint()).set('Range', 'bytes=-0').expect(416);
+      expect(res.headers['content-range']).toBe(`bytes */${BODY.length}`);
     });
 
     it('416s an unsatisfiable range', async () => {

--- a/apps/backend/src/storage/local-presigned-download.controller.spec.ts
+++ b/apps/backend/src/storage/local-presigned-download.controller.spec.ts
@@ -1,0 +1,244 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { LocalPresignedDownloadController } from './local-presigned-download.controller';
+import { LocalStorageAdapter, LOCAL_PRESIGN_PATH } from './local.adapter';
+import {
+  derivePresignKey,
+  deriveDownloadKey,
+  signLocalDownload,
+  signLocalUpload,
+} from './presign.util';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import { STORAGE_ADAPTER } from './storage.interface';
+
+describe('LocalPresignedDownloadController', () => {
+  const presignKey = derivePresignKey({ ENCRYPTION_KEY: 'test' });
+  const downloadKey = deriveDownloadKey(presignKey);
+  const KEY = 'o/r/uploads/content/clip.mp4';
+  const BODY = Buffer.from('0123456789abcdef');
+
+  let basePath: string;
+  let app: INestApplication;
+  let local: LocalStorageAdapter;
+  let storageAdapter: any;
+  let flags: { isEnabled: jest.Mock };
+
+  /** Build the query the adapter would mint, so route and adapter stay in lockstep. */
+  const mint = async (key = KEY, expiresIn = 600, options?: { downloadFilename: string }) =>
+    (await local.getUrl(key, expiresIn, options)).slice(LOCAL_PRESIGN_PATH.length);
+
+  const get = (query: string) => request(app.getHttpServer()).get(`${LOCAL_PRESIGN_PATH}${query}`);
+
+  const rawQuery = (params: Record<string, string>) =>
+    `?${new URLSearchParams(params).toString()}`;
+
+  const encodeKey = (key: string) => Buffer.from(key, 'utf8').toString('base64url');
+
+  beforeEach(async () => {
+    basePath = await fs.mkdtemp(path.join(os.tmpdir(), 'presign-dl-'));
+    await fs.mkdir(path.join(basePath, path.dirname(KEY)), { recursive: true });
+    await fs.writeFile(path.join(basePath, KEY), BODY);
+
+    local = new LocalStorageAdapter({ localPath: basePath, presignKey });
+    // Wrapped exactly as production wraps it, so resolveLocalAdapter is exercised.
+    storageAdapter = { getUnderlyingAdapter: () => local };
+    flags = { isEnabled: jest.fn().mockResolvedValue(true) };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [LocalPresignedDownloadController],
+      providers: [
+        { provide: STORAGE_ADAPTER, useValue: storageAdapter },
+        { provide: FeatureFlagsService, useValue: flags },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await fs.rm(basePath, { recursive: true, force: true });
+  });
+
+  describe('gating', () => {
+    it('404s when the feature flag is off', async () => {
+      flags.isEnabled.mockResolvedValue(false);
+      await get(await mint()).expect(404);
+    });
+
+    it('checks the same flag the upload route does', async () => {
+      await get(await mint()).expect(200);
+      expect(flags.isEnabled).toHaveBeenCalledWith('ENABLE_LOCAL_PRESIGNED_UPLOADS');
+    });
+
+    it('404s when the active storage backend is not local', async () => {
+      const query = await mint();
+      storageAdapter.getUnderlyingAdapter = () => ({ isLocalAdapter: false });
+      await get(query).expect(404);
+    });
+
+    it('404s when the local adapter cannot presign (dev-fallback secret only)', async () => {
+      const query = await mint();
+      jest.spyOn(local, 'supportsPresignedUrls').mockReturnValue(false);
+      await get(query).expect(404);
+    });
+  });
+
+  describe('parameters and signature', () => {
+    it('400s when required parameters are missing', async () => {
+      await get('').expect(400);
+      await get(rawQuery({ key: encodeKey(KEY) })).expect(400);
+      await get(rawQuery({ key: encodeKey(KEY), exp: '1800000000' })).expect(400);
+    });
+
+    it('400s on a non-numeric exp', async () => {
+      await get(rawQuery({ key: encodeKey(KEY), exp: 'soon', sig: 'x'.repeat(64) })).expect(400);
+    });
+
+    it('403s on a tampered signature', async () => {
+      const query = await mint();
+      await get(query.replace(/sig=[0-9a-f]{64}/, `sig=${'a'.repeat(64)}`)).expect(403);
+    });
+
+    it('403s when the key is swapped under a valid signature', async () => {
+      await fs.writeFile(path.join(basePath, 'o/r/uploads/content/other.mp4'), BODY);
+      const params = new URLSearchParams((await mint()).slice(1));
+      params.set('key', encodeKey('o/r/uploads/content/other.mp4'));
+      await get(`?${params.toString()}`).expect(403);
+    });
+
+    it('403s on an expired URL, without touching the filesystem', async () => {
+      const exp = Math.floor(Date.now() / 1000) - 1;
+      await get(
+        rawQuery({
+          key: encodeKey(KEY),
+          exp: String(exp),
+          sig: signLocalDownload({ key: KEY, exp }, downloadKey),
+        }),
+      ).expect(403);
+    });
+
+    it('403s on an UPLOAD signature presented to the download route', async () => {
+      // Domain separation: an attacker holding a presigned PUT URL for a key
+      // must not be able to turn it into a GET of that key.
+      const exp = Math.floor(Date.now() / 1000) + 600;
+      await get(
+        rawQuery({
+          key: encodeKey(KEY),
+          exp: String(exp),
+          sig: signLocalUpload({ key: KEY, exp, max: 1024 }, presignKey),
+        }),
+      ).expect(403);
+    });
+
+    it('403s when dl is added to a signature minted without one', async () => {
+      const params = new URLSearchParams((await mint()).slice(1));
+      params.set('dl', 'anything.mp4');
+      await get(`?${params.toString()}`).expect(403);
+    });
+  });
+
+  describe('key confinement', () => {
+    it.each([
+      ['traversal', 'o/r/../../../etc/passwd'],
+      ['leading slash', '/etc/passwd'],
+      ['trailing slash', 'o/r/dir/'],
+      ['null byte', 'o/r/a\0.txt'],
+    ])('400s on a %s key even with a valid signature', async (_label, key) => {
+      const exp = Math.floor(Date.now() / 1000) + 600;
+      await get(
+        rawQuery({
+          key: encodeKey(key),
+          exp: String(exp),
+          sig: signLocalDownload({ key, exp }, downloadKey),
+        }),
+      ).expect(400);
+    });
+  });
+
+  describe('serving', () => {
+    it('404s (not 403) for a missing file under a valid signature', async () => {
+      const exp = Math.floor(Date.now() / 1000) + 600;
+      const key = 'o/r/uploads/content/gone.mp4';
+      await get(
+        rawQuery({
+          key: encodeKey(key),
+          exp: String(exp),
+          sig: signLocalDownload({ key, exp }, downloadKey),
+        }),
+      ).expect(404);
+    });
+
+    it('streams the bytes with the extension-derived Content-Type', async () => {
+      const res = await get(await mint()).expect(200);
+
+      expect(res.headers['content-type']).toBe('video/mp4');
+      expect(res.headers['content-length']).toBe(String(BODY.length));
+      expect(res.headers['accept-ranges']).toBe('bytes');
+      expect(res.headers['cache-control']).toContain('private');
+      expect(Buffer.from(res.body)).toEqual(BODY);
+    });
+
+    it('falls back to application/octet-stream for an unknown extension', async () => {
+      const key = 'o/r/uploads/content/blob.weirdext';
+      await fs.writeFile(path.join(basePath, key), BODY);
+      const res = await get(await mint(key)).expect(200);
+
+      expect(res.headers['content-type']).toBe('application/octet-stream');
+    });
+
+    it('serves inline (no Content-Disposition) without dl', async () => {
+      const res = await get(await mint()).expect(200);
+      expect(res.headers['content-disposition']).toBeUndefined();
+    });
+
+    it('sets Content-Disposition attachment when dl is signed in', async () => {
+      const res = await get(
+        await mint(KEY, 600, { downloadFilename: 'Holiday Clip.mp4' }),
+      ).expect(200);
+
+      expect(res.headers['content-disposition']).toBe('attachment; filename="Holiday Clip.mp4"');
+    });
+
+    it('sanitizes a hostile dl before it reaches the header', async () => {
+      const res = await get(
+        await mint(KEY, 600, { downloadFilename: 'a/b/ev"il\r\nX-Evil: 1.mp4' }),
+      ).expect(200);
+
+      expect(res.headers['content-disposition']).toBe('attachment; filename="evilX-Evil: 1.mp4"');
+      expect(res.headers['x-evil']).toBeUndefined();
+    });
+  });
+
+  describe('range requests', () => {
+    it('serves a byte range as 206 with Content-Range', async () => {
+      const res = await get(await mint()).set('Range', 'bytes=4-7').expect(206);
+
+      expect(res.headers['content-range']).toBe(`bytes 4-7/${BODY.length}`);
+      expect(res.headers['content-length']).toBe('4');
+      expect(Buffer.from(res.body)).toEqual(BODY.subarray(4, 8));
+    });
+
+    it('serves an open-ended range to the end of the file', async () => {
+      const res = await get(await mint()).set('Range', 'bytes=8-').expect(206);
+
+      expect(res.headers['content-range']).toBe(`bytes 8-${BODY.length - 1}/${BODY.length}`);
+      expect(Buffer.from(res.body)).toEqual(BODY.subarray(8));
+    });
+
+    it('416s an unsatisfiable range', async () => {
+      const res = await get(await mint()).set('Range', 'bytes=999-1200').expect(416);
+      expect(res.headers['content-range']).toBe(`bytes */${BODY.length}`);
+    });
+
+    it('ignores a malformed Range header shape it cannot parse', async () => {
+      const res = await get(await mint()).set('Range', 'items=1-2').expect(200);
+      expect(Buffer.from(res.body)).toEqual(BODY);
+    });
+  });
+});

--- a/apps/backend/src/storage/local-presigned-download.controller.ts
+++ b/apps/backend/src/storage/local-presigned-download.controller.ts
@@ -1,0 +1,210 @@
+import {
+  Controller,
+  Get,
+  Query,
+  Req,
+  Res,
+  Inject,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiExcludeEndpoint } from '@nestjs/swagger';
+import { Request, Response } from 'express';
+import * as fs from 'fs/promises';
+import * as fsSync from 'fs';
+import * as path from 'path';
+import { IStorageAdapter, STORAGE_ADAPTER } from './storage.interface';
+import { verifyLocalDownload } from './presign.util';
+import { resolveLocalAdapter } from './local.adapter';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import { resolveContentType } from '../common/utils/content-type.util';
+import { sanitizeDownloadFilename } from '../common/utils/download-filename.util';
+
+interface PresignDownloadQuery {
+  key?: string;
+  exp?: string;
+  sig?: string;
+  dl?: string;
+}
+
+/**
+ * Signature-authorized DOWNLOAD route for local filesystem storage — the GET
+ * sibling of {@link LocalPresignedUploadController}, mounted at the SAME path
+ * (`/api/storage/presigned/local`) deliberately.
+ *
+ * Same path, because the per-vhost nginx `location = /api/storage/presigned/local`
+ * blocks added for the upload feature proxy this path to the backend
+ * unrewritten on every vhost that can serve a local-storage app (deployment
+ * subdomains, custom domains, the CE primary domain, the wildcard catch-all
+ * and admin). None of them restricts the method (`limit_except` appears
+ * nowhere in the nginx templates), so a GET on the same path inherits that
+ * reachability with zero nginx changes. Any NEW path would have needed five
+ * template edits before a single signed link worked.
+ *
+ * Like the upload route, this has NO auth guard: authorization IS the HMAC
+ * signature minted by `LocalStorageAdapter.getUrl`, exactly as an S3 presigned
+ * GET carries its own. No cookie, session or API key is consulted, so it can't
+ * act as a confused deputy. The signature is verified BEFORE any filesystem
+ * access.
+ */
+@ApiTags('Storage')
+@Controller('api/storage/presigned')
+export class LocalPresignedDownloadController {
+  private readonly logger = new Logger(LocalPresignedDownloadController.name);
+
+  constructor(
+    @Inject(STORAGE_ADAPTER) private readonly storageAdapter: IStorageAdapter,
+    private readonly featureFlags: FeatureFlagsService,
+  ) {}
+
+  @Get('local')
+  @ApiExcludeEndpoint()
+  @ApiOperation({ summary: 'Download bytes from local storage using a signed URL' })
+  @ApiResponse({ status: 200, description: 'File contents' })
+  async download(
+    @Query() query: PresignDownloadQuery,
+    @Req() req: Request,
+    @Res() res: Response,
+  ): Promise<void> {
+    // 1. Flag — one "local presigned URLs" capability covers both directions,
+    //    so the route 404s (rather than advertising itself) when it's off.
+    if (!(await this.featureFlags.isEnabled('ENABLE_LOCAL_PRESIGNED_UPLOADS'))) {
+      throw new NotFoundException();
+    }
+
+    // 2. Active adapter must be local AND willing to mint signed URLs at all.
+    //    Same predicate as the upload route: an install whose only signing
+    //    material is the public dev-fallback constant must not HONOUR
+    //    signatures forged with it either.
+    const local = resolveLocalAdapter(this.storageAdapter);
+    if (!local || !local.supportsPresignedUrls()) throw new NotFoundException();
+
+    // 3. Params.
+    const { key: encodedKey, exp: expRaw, sig, dl } = query;
+    if (!encodedKey || !expRaw || !sig) {
+      throw new BadRequestException('Missing signed download parameters');
+    }
+    const exp = Number(expRaw);
+    if (!Number.isFinite(exp)) {
+      throw new BadRequestException('Malformed signed download parameters');
+    }
+
+    let storageKey: string;
+    try {
+      storageKey = Buffer.from(encodedKey, 'base64url').toString('utf8');
+    } catch {
+      throw new BadRequestException('Malformed key parameter');
+    }
+
+    // 4. Signature — before ANY filesystem access, so an unsigned request can
+    //    never probe for the existence of a key.
+    if (
+      !verifyLocalDownload({ key: storageKey, exp, dl }, sig, local.getDownloadPresignKey())
+    ) {
+      this.logger.warn(`Rejected signed download with invalid signature for key: ${storageKey}`);
+      throw new ForbiddenException('Invalid download signature');
+    }
+
+    // 5. Expiry.
+    if (exp < Math.floor(Date.now() / 1000)) {
+      throw new ForbiddenException('Download URL has expired');
+    }
+
+    // 6. Key confinement — defence in depth; the signature already binds the
+    //    key, so reaching here means the key was minted by us. Mirrors the
+    //    upload route's rejections exactly (`..`, NUL, leading/trailing
+    //    slashes), plus a resolved-path check against the storage root so a
+    //    form this normalization didn't anticipate still cannot escape.
+    if (storageKey !== this.normalizeKey(storageKey)) {
+      throw new BadRequestException('Invalid storage key');
+    }
+    const basePath = local.getStorageBasePath();
+    const fullPath = path.resolve(basePath, storageKey);
+    if (fullPath !== basePath && !fullPath.startsWith(`${basePath}${path.sep}`)) {
+      throw new BadRequestException('Invalid storage key');
+    }
+
+    // 7. The file itself. 404 (not 403) — the signature was valid, there is
+    //    simply nothing there.
+    let size: number;
+    let lastModified: Date;
+    try {
+      const stats = await fs.stat(fullPath);
+      if (!stats.isFile()) throw new NotFoundException();
+      size = stats.size;
+      lastModified = stats.mtime;
+    } catch (err) {
+      if (err instanceof NotFoundException) throw err;
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') throw new NotFoundException();
+      throw err;
+    }
+
+    res.setHeader('Content-Type', resolveContentType(storageKey));
+    res.setHeader('Accept-Ranges', 'bytes');
+    res.setHeader('Last-Modified', lastModified.toUTCString());
+    // Signed and time-bounded: never store it in a shared cache, and never
+    // let a private cache outlive the signature.
+    const remaining = Math.max(0, exp - Math.floor(Date.now() / 1000));
+    res.setHeader('Cache-Control', `private, max-age=${remaining}`);
+
+    // `dl` is re-sanitized here, not trusted from the query: a signed URL is
+    // minted once and then replayed by an untrusted client, and this value is
+    // interpolated straight into a header.
+    const filename = sanitizeDownloadFilename(dl);
+    if (filename) {
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    }
+
+    // 8. Range — videos need seeking, and fs.createReadStream gives inclusive
+    //    start/end offsets for free (same mechanism LocalStorageAdapter.
+    //    downloadStream uses).
+    const rangeHeader = req.headers.range;
+    if (rangeHeader) {
+      const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+      if (match && (match[1] || match[2])) {
+        const start = match[1] ? parseInt(match[1], 10) : 0;
+        const end = match[2] ? Math.min(parseInt(match[2], 10), size - 1) : size - 1;
+
+        if (start >= size || start > end) {
+          res.status(416).setHeader('Content-Range', `bytes */${size}`);
+          res.end();
+          return;
+        }
+
+        res.status(206);
+        res.setHeader('Content-Range', `bytes ${start}-${end}/${size}`);
+        res.setHeader('Content-Length', end - start + 1);
+        this.pipe(fsSync.createReadStream(fullPath, { start, end }), res, storageKey);
+        return;
+      }
+      // A Range header this route can't parse (or an unsupported unit) falls
+      // through to the full 200 response, which RFC 9110 permits.
+    }
+
+    res.setHeader('Content-Length', size);
+    this.pipe(fsSync.createReadStream(fullPath), res, storageKey);
+  }
+
+  /** Mirrors LocalStorageAdapter.sanitizeKey's normalization. */
+  private normalizeKey(key: string): string {
+    if (key.includes('..') || key.includes('\0')) return '';
+    return key.replace(/^\/+|\/+$/g, '');
+  }
+
+  /**
+   * Pipe to the response, destroying the read stream if the client goes away
+   * mid-transfer (a seeking video player cancels in-flight range requests
+   * constantly) so the fd isn't held open.
+   */
+  private pipe(stream: fsSync.ReadStream, res: Response, storageKey: string): void {
+    stream.on('error', (err) => {
+      this.logger.error(`Failed streaming ${storageKey}: ${(err as Error).message}`);
+      if (!res.headersSent) res.status(500);
+      res.end();
+    });
+    res.on('close', () => stream.destroy());
+    stream.pipe(res);
+  }
+}

--- a/apps/backend/src/storage/local-presigned-download.controller.ts
+++ b/apps/backend/src/storage/local-presigned-download.controller.ts
@@ -20,13 +20,22 @@ import { verifyLocalDownload } from './presign.util';
 import { resolveLocalAdapter } from './local.adapter';
 import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 import { resolveContentType } from '../common/utils/content-type.util';
-import { sanitizeDownloadFilename } from '../common/utils/download-filename.util';
+import {
+  sanitizeDownloadFilename,
+  formatAttachmentDisposition,
+} from '../common/utils/download-filename.util';
 
+/**
+ * Deliberately `unknown`, not `string`: Express's query parser yields objects
+ * (`?dl[a]=b`) and arrays (`?dl=1&dl=2`) as well as strings, and typing these
+ * as `string` would be a lie the compiler then stops us from checking. The
+ * handler narrows them before use.
+ */
 interface PresignDownloadQuery {
-  key?: string;
-  exp?: string;
-  sig?: string;
-  dl?: string;
+  key?: unknown;
+  exp?: unknown;
+  sig?: unknown;
+  dl?: unknown;
 }
 
 /**
@@ -82,7 +91,22 @@ export class LocalPresignedDownloadController {
     if (!local || !local.supportsPresignedUrls()) throw new NotFoundException();
 
     // 3. Params.
+    //
+    // TYPES FIRST. Express's query parser turns `?dl[a]=b` into an object and
+    // `?dl=1&dl=2` into an array, so nothing here is a string until proven
+    // one. Without this guard a structured `dl` reaches
+    // `canonicalDownloadString`, where `Buffer.from(object)` throws INSIDE the
+    // signature computation — i.e. an unauthenticated 500, reachable before
+    // any signature is validated.
     const { key: encodedKey, exp: expRaw, sig, dl } = query;
+    if (
+      typeof encodedKey !== 'string' ||
+      typeof expRaw !== 'string' ||
+      typeof sig !== 'string' ||
+      (dl !== undefined && typeof dl !== 'string')
+    ) {
+      throw new BadRequestException('Malformed signed download parameters');
+    }
     if (!encodedKey || !expRaw || !sig) {
       throw new BadRequestException('Missing signed download parameters');
     }
@@ -152,9 +176,15 @@ export class LocalPresignedDownloadController {
     // `dl` is re-sanitized here, not trusted from the query: a signed URL is
     // minted once and then replayed by an untrusted client, and this value is
     // interpolated straight into a header.
+    //
+    // formatAttachmentDisposition, not raw interpolation: a filename with any
+    // character above U+00FF makes res.setHeader throw ERR_INVALID_CHAR, and
+    // EVERY macOS screenshot carries U+202F between the time and AM/PM. Those
+    // names arrive here for real — Studio's sign rule passes the user's own
+    // filename straight through — so this path 500'd on a very ordinary file.
     const filename = sanitizeDownloadFilename(dl);
     if (filename) {
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      res.setHeader('Content-Disposition', formatAttachmentDisposition(filename));
     }
 
     // 8. Range — videos need seeking, and fs.createReadStream gives inclusive
@@ -164,8 +194,23 @@ export class LocalPresignedDownloadController {
     if (rangeHeader) {
       const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
       if (match && (match[1] || match[2])) {
-        const start = match[1] ? parseInt(match[1], 10) : 0;
-        const end = match[2] ? Math.min(parseInt(match[2], 10), size - 1) : size - 1;
+        let start: number;
+        let end: number;
+
+        if (match[1]) {
+          start = parseInt(match[1], 10);
+          end = match[2] ? Math.min(parseInt(match[2], 10), size - 1) : size - 1;
+        } else {
+          // SUFFIX form. `bytes=-N` (what `curl -r -N` sends) means the LAST N
+          // bytes, not bytes 0..N — RFC 9110 §14.1.2. Reading match[1] as a
+          // defaulted 0 would serve the wrong bytes AND mislabel them in
+          // Content-Range, which a video player would happily render as
+          // garbage. A zero-length suffix is unsatisfiable by definition and
+          // falls into the 416 below via start > end.
+          const suffix = parseInt(match[2], 10);
+          start = Math.max(0, size - suffix);
+          end = suffix === 0 ? -1 : size - 1;
+        }
 
         if (start >= size || start > end) {
           res.status(416).setHeader('Content-Range', `bytes */${size}`);

--- a/apps/backend/src/storage/local.adapter.spec.ts
+++ b/apps/backend/src/storage/local.adapter.spec.ts
@@ -1,5 +1,11 @@
 import { LocalStorageAdapter, LOCAL_PRESIGN_PATH, resolveLocalAdapter } from './local.adapter';
-import { derivePresignKey, signLocalUpload, DEFAULT_MAX_UPLOAD_BYTES } from './presign.util';
+import {
+  derivePresignKey,
+  deriveDownloadKey,
+  signLocalUpload,
+  verifyLocalDownload,
+  DEFAULT_MAX_UPLOAD_BYTES,
+} from './presign.util';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
@@ -153,38 +159,123 @@ describe('LocalStorageAdapter', () => {
   });
 
   describe('getUrl', () => {
-    it('should generate correct URL', async () => {
+    // Resolve against an arbitrary host so URL/searchParams can parse the
+    // relative shape the adapter now returns.
+    const parse = (url: string) => new URL(url, 'https://app.example');
+    const decodeKey = (url: string) =>
+      Buffer.from(parse(url).searchParams.get('key')!, 'base64url').toString('utf8');
+
+    it('returns a relative, signed download URL on the presigned route', async () => {
       const key = 'owner/repo/abc123/test.txt';
       const url = await adapter.getUrl(key);
 
-      expect(url).toBe('http://localhost:3000/files/owner/repo/abc123/test.txt');
+      expect(url.startsWith(`${LOCAL_PRESIGN_PATH}?`)).toBe(true);
+      expect(url).not.toMatch(/^https?:\/\//);
+      expect(url).not.toContain('localhost:3000/files');
+
+      const params = parse(url).searchParams;
+      expect(decodeKey(url)).toBe(key);
+      expect(params.get('sig')).toMatch(/^[0-9a-f]{64}$/);
+      expect(Number(params.get('exp'))).toBeGreaterThan(Math.floor(Date.now() / 1000));
+      expect(params.get('dl')).toBeNull();
     });
 
-    it('leaves a plain-ASCII sha-path key byte-identical to the pre-encoding behavior', async () => {
-      // encodeURIComponent leaves unreserved characters (A-Za-z0-9 - _ . ! ~ * ' ( ))
-      // untouched, so a typical storage key round-trips unchanged.
+    it('signs the URL so it verifies under the adapter download key', async () => {
+      const key = 'owner/repo/abc123/test.txt';
+      const url = await adapter.getUrl(key);
+      const params = parse(url).searchParams;
+
+      expect(
+        verifyLocalDownload(
+          { key, exp: Number(params.get('exp')) },
+          params.get('sig')!,
+          deriveDownloadKey(adapter.getPresignKey()),
+        ),
+      ).toBe(true);
+    });
+
+    it('signs the PREFIXED key when a keyPrefix is configured', async () => {
+      const prefixed = new LocalStorageAdapter({
+        localPath: testBasePath,
+        keyPrefix: 'ws1',
+        presignKey: derivePresignKey({ ENCRYPTION_KEY: 'test' }),
+      });
+      const url = await prefixed.getUrl('owner/repo/a.txt');
+      expect(decodeKey(url)).toBe('ws1/owner/repo/a.txt');
+    });
+
+    it('leaves a plain-ASCII sha-path key intact through the round trip', async () => {
       const key = 'sahp/handoff/uploads/content/abc123-def_456.file~name!(1).png';
       const url = await adapter.getUrl(key);
 
-      expect(url).toBe(`http://localhost:3000/files/${key}`);
+      expect(decodeKey(url)).toBe(key);
     });
 
-    it('percent-encodes a key containing a raw space and U+202F narrow no-break space (regression: macOS screenshot filename 500)', async () => {
+    it('encodes a key containing a raw space and U+202F narrow no-break space (regression: macOS screenshot filename 500)', async () => {
       // Live bug: a macOS screenshot filename contains U+202F between the time
       // and "AM"/"PM". The unencoded URL was later used as a redirect Location
       // header, and Node's setHeader throws ERR_INVALID_CHAR on raw spaces /
       // U+202F, 500-ing every /r/* raw-file link on local-FS installs.
-      const key = 'sahp/handoff/uploads/content/Screenshot 2026-07-31 at 7.44.31 AM.png';
+      const key = 'sahp/handoff/uploads/content/Screenshot 2026-07-31 at 7.44.31\u202fAM.png';
       const url = await adapter.getUrl(key);
 
+      expect(url).not.toContain('\u202f');
       expect(url).not.toContain(' ');
-      expect(url).not.toContain(' ');
+      // Round-trips: URLSearchParams handles all of the encoding.
+      expect(decodeKey(url)).toBe(key);
+    });
 
-      // Resolution must be unchanged: decoding each `/`-delimited segment
-      // round-trips to the original key, since only segments (not `/`) are encoded.
-      const withoutBase = url.slice('http://localhost:3000/files/'.length);
-      const decoded = withoutBase.split('/').map(decodeURIComponent).join('/');
-      expect(decoded).toBe(key);
+    it('honours expiresIn and clamps it to the one-hour ceiling', async () => {
+      const now = Math.floor(Date.now() / 1000);
+
+      const short = parse(await adapter.getUrl('k', 60));
+      expect(Number(short.searchParams.get('exp'))).toBeGreaterThanOrEqual(now + 59);
+      expect(Number(short.searchParams.get('exp'))).toBeLessThanOrEqual(now + 61);
+
+      const def = parse(await adapter.getUrl('k'));
+      expect(Number(def.searchParams.get('exp'))).toBeGreaterThanOrEqual(now + 3599);
+      expect(Number(def.searchParams.get('exp'))).toBeLessThanOrEqual(now + 3601);
+
+      const clamped = parse(await adapter.getUrl('k', 999_999));
+      expect(Number(clamped.searchParams.get('exp'))).toBeLessThanOrEqual(now + 3601);
+
+      const floored = parse(await adapter.getUrl('k', -5));
+      expect(Number(floored.searchParams.get('exp'))).toBeGreaterThanOrEqual(now + 1);
+    });
+
+    it('rejects a non-finite expiresIn', async () => {
+      await expect(adapter.getUrl('k', NaN)).rejects.toThrow(/finite number/i);
+    });
+
+    it('carries and signs a downloadFilename as the dl param', async () => {
+      const url = await adapter.getUrl('o/r/a.mp4', 600, { downloadFilename: 'my video.mp4' });
+      const params = parse(url).searchParams;
+
+      expect(params.get('dl')).toBe('my video.mp4');
+      expect(url).not.toContain(' ');
+      expect(
+        verifyLocalDownload(
+          { key: 'o/r/a.mp4', exp: Number(params.get('exp')), dl: 'my video.mp4' },
+          params.get('sig')!,
+          deriveDownloadKey(adapter.getPresignKey()),
+        ),
+      ).toBe(true);
+    });
+
+    it('returns an absolute URL when publicOrigin is configured', async () => {
+      const absolute = new LocalStorageAdapter({
+        localPath: testBasePath,
+        publicOrigin: 'https://ce.example/',
+        presignKey: derivePresignKey({ ENCRYPTION_KEY: 'test' }),
+      });
+      const url = await absolute.getUrl('o/r/a.txt');
+
+      expect(url.startsWith(`https://ce.example${LOCAL_PRESIGN_PATH}?`)).toBe(true);
+      expect(decodeKey(url)).toBe('o/r/a.txt');
+    });
+
+    it('rejects a path-traversal key instead of signing it', async () => {
+      await expect(adapter.getUrl('../../etc/passwd')).rejects.toThrow(/path traversal/i);
     });
   });
 

--- a/apps/backend/src/storage/local.adapter.spec.ts
+++ b/apps/backend/src/storage/local.adapter.spec.ts
@@ -159,6 +159,33 @@ describe('LocalStorageAdapter', () => {
 
       expect(url).toBe('http://localhost:3000/files/owner/repo/abc123/test.txt');
     });
+
+    it('leaves a plain-ASCII sha-path key byte-identical to the pre-encoding behavior', async () => {
+      // encodeURIComponent leaves unreserved characters (A-Za-z0-9 - _ . ! ~ * ' ( ))
+      // untouched, so a typical storage key round-trips unchanged.
+      const key = 'sahp/handoff/uploads/content/abc123-def_456.file~name!(1).png';
+      const url = await adapter.getUrl(key);
+
+      expect(url).toBe(`http://localhost:3000/files/${key}`);
+    });
+
+    it('percent-encodes a key containing a raw space and U+202F narrow no-break space (regression: macOS screenshot filename 500)', async () => {
+      // Live bug: a macOS screenshot filename contains U+202F between the time
+      // and "AM"/"PM". The unencoded URL was later used as a redirect Location
+      // header, and Node's setHeader throws ERR_INVALID_CHAR on raw spaces /
+      // U+202F, 500-ing every /r/* raw-file link on local-FS installs.
+      const key = 'sahp/handoff/uploads/content/Screenshot 2026-07-31 at 7.44.31 AM.png';
+      const url = await adapter.getUrl(key);
+
+      expect(url).not.toContain(' ');
+      expect(url).not.toContain(' ');
+
+      // Resolution must be unchanged: decoding each `/`-delimited segment
+      // round-trips to the original key, since only segments (not `/`) are encoded.
+      const withoutBase = url.slice('http://localhost:3000/files/'.length);
+      const decoded = withoutBase.split('/').map(decodeURIComponent).join('/');
+      expect(decoded).toBe(key);
+    });
   });
 
   describe('listKeys', () => {

--- a/apps/backend/src/storage/local.adapter.ts
+++ b/apps/backend/src/storage/local.adapter.ts
@@ -236,7 +236,14 @@ export class LocalStorageAdapter implements IStorageAdapter {
     const sanitizedKey = this.sanitizeKey(key);
     // For local storage, we'll serve files through the backend API
     // The URL format will be: {baseUrl}/{key} (unprefixed for external access)
-    return `${this.baseUrl}/${sanitizedKey}`;
+    // Percent-encode each path segment (not the whole key, which would also
+    // encode the `/` separators): a raw key can contain characters that are
+    // invalid in an HTTP header when this URL is later used as a redirect
+    // Location (e.g. a macOS screenshot filename with U+202F narrow no-break
+    // space), which throws ERR_INVALID_CHAR from Node's setHeader. Express
+    // decodes route params on the serving side, so resolution is unchanged.
+    const encodedKey = sanitizedKey.split('/').map(encodeURIComponent).join('/');
+    return `${this.baseUrl}/${encodedKey}`;
   }
 
   /**

--- a/apps/backend/src/storage/local.adapter.ts
+++ b/apps/backend/src/storage/local.adapter.ts
@@ -4,6 +4,7 @@ import {
   FileMetadata,
   StreamDownloadResult,
   DownloadStreamOptions,
+  SignedUrlOptions,
 } from './storage.interface';
 import * as fs from 'fs/promises';
 import * as fsSync from 'fs';
@@ -11,7 +12,9 @@ import * as path from 'path';
 import * as crypto from 'crypto';
 import {
   derivePresignKey,
+  deriveDownloadKey,
   signLocalUpload,
+  signLocalDownload,
   hasRealPresignSecret,
   DEFAULT_MAX_UPLOAD_BYTES,
   MAX_EXPIRES_IN_SECONDS,
@@ -34,6 +37,7 @@ export class LocalStorageAdapter implements IStorageAdapter {
   private readonly keyPrefix: string;
   private readonly publicOrigin: string | null;
   private readonly presignKey: Buffer;
+  private readonly downloadKey: Buffer;
   private readonly hasExplicitPresignKey: boolean;
   private readonly maxUploadBytes: number;
 
@@ -54,6 +58,7 @@ export class LocalStorageAdapter implements IStorageAdapter {
     // silently mint localhost URLs on a real install.
     this.publicOrigin = config.publicOrigin?.replace(/\/+$/, '') ?? null;
     this.presignKey = config.presignKey ?? derivePresignKey();
+    this.downloadKey = deriveDownloadKey(this.presignKey);
     this.hasExplicitPresignKey = config.presignKey !== undefined;
     this.maxUploadBytes = config.maxUploadBytes ?? DEFAULT_MAX_UPLOAD_BYTES;
 
@@ -226,24 +231,71 @@ export class LocalStorageAdapter implements IStorageAdapter {
   }
 
   /**
-   * Local storage serves files through the backend API rather than presigning,
-   * so there is no signature to embed a `Content-Disposition` into. A
-   * `SignedUrlOptions.downloadFilename` passed here is deliberately IGNORED —
-   * the browser will render the object inline. Presigned-only apps (e.g. Studio,
-   * whose uploads bypass the 1 MB body cap) cannot run on local storage anyway.
+   * Mint a signed, time-bounded DOWNLOAD URL — the GET sibling of
+   * `getPresignedUploadUrl` below, and the read half of the same "local
+   * presigned URLs" capability.
+   *
+   * This used to return `${baseUrl}/${key}`, i.e. the vestigial
+   * `http://localhost:3000/files/...`. That URL dead-ended on every real
+   * install: nginx proxies `/api`, `/auth` and `/public` but never `/files`,
+   * and `FilesController` additionally requires a BARE `LocalStorageAdapter`
+   * (`instanceof`), which production never has — it is wrapped in
+   * `DynamicStorageAdapter`/`CachingStorageAdapter`. So every signed-URL flow
+   * (Handoff share links, the in-app file viewer) was broken on local-FS
+   * storage.
+   *
+   * Shape mirrors `getPresignedUploadUrl` exactly: RELATIVE
+   * (`/api/storage/presigned/local?...`) so the browser resolves it against
+   * whichever host served the page — the same host whose nginx vhost proxies
+   * this exact path unrewritten — unless `publicOrigin` (`PUBLIC_ORIGIN`) was
+   * explicitly configured, in which case the URL is absolute for callers with
+   * no page origin to resolve against.
+   *
+   * Every parameter goes through `URLSearchParams`, which handles all
+   * encoding. This supersedes the previous per-segment `encodeURIComponent`
+   * pass: the key now travels base64url-encoded in a query param, so
+   * characters that are invalid in an HTTP header (a raw space, U+202F from a
+   * macOS screenshot filename) can no longer reach a `Location` header at all.
+   *
+   * `options.downloadFilename` is SIGNED IN (as `dl`), not merely appended, so
+   * a holder of the URL cannot rewrite the filename the response is served
+   * under; the route re-sanitizes it before it reaches the header regardless.
    */
-  async getUrl(key: string): Promise<string> {
-    const sanitizedKey = this.sanitizeKey(key);
-    // For local storage, we'll serve files through the backend API
-    // The URL format will be: {baseUrl}/{key} (unprefixed for external access)
-    // Percent-encode each path segment (not the whole key, which would also
-    // encode the `/` separators): a raw key can contain characters that are
-    // invalid in an HTTP header when this URL is later used as a redirect
-    // Location (e.g. a macOS screenshot filename with U+202F narrow no-break
-    // space), which throws ERR_INVALID_CHAR from Node's setHeader. Express
-    // decodes route params on the serving side, so resolution is unchanged.
-    const encodedKey = sanitizedKey.split('/').map(encodeURIComponent).join('/');
-    return `${this.baseUrl}/${encodedKey}`;
+  async getUrl(key: string, expiresIn = MAX_EXPIRES_IN_SECONDS, options?: SignedUrlOptions): Promise<string> {
+    if (!Number.isFinite(expiresIn)) {
+      throw new TypeError('expiresIn must be a finite number');
+    }
+
+    // Signed against the PREFIXED key so it matches exactly what the route
+    // will read off disk, same as the upload direction.
+    const storageKey = this.prefixKey(this.sanitizeKey(key));
+    const ttl = Math.min(Math.max(1, Math.floor(expiresIn)), MAX_EXPIRES_IN_SECONDS);
+    const exp = Math.floor(Date.now() / 1000) + ttl;
+    const dl = options?.downloadFilename;
+    const sig = signLocalDownload({ key: storageKey, exp, dl }, this.getDownloadPresignKey());
+
+    const params = new URLSearchParams();
+    params.set('key', Buffer.from(storageKey, 'utf8').toString('base64url'));
+    params.set('exp', String(exp));
+    params.set('sig', sig);
+    if (dl) params.set('dl', dl);
+
+    if (!this.publicOrigin) {
+      return `${LOCAL_PRESIGN_PATH}?${params.toString()}`;
+    }
+
+    const url = new URL(LOCAL_PRESIGN_PATH, this.publicOrigin);
+    url.search = params.toString();
+    return url.toString();
+  }
+
+  /**
+   * Signing key for the download direction. Derived one-way from the upload
+   * presign key under a distinct domain label, so a presigned PUT signature
+   * can never authorize a GET (or vice versa) — see `deriveDownloadKey`.
+   */
+  getDownloadPresignKey(): Buffer {
+    return this.downloadKey;
   }
 
   /**

--- a/apps/backend/src/storage/presign.util.spec.ts
+++ b/apps/backend/src/storage/presign.util.spec.ts
@@ -3,6 +3,9 @@ import {
   explicitPublicOrigin,
   signLocalUpload,
   verifyLocalUpload,
+  deriveDownloadKey,
+  signLocalDownload,
+  verifyLocalDownload,
   hasRealPresignSecret,
   DEFAULT_MAX_UPLOAD_BYTES,
   MAX_EXPIRES_IN_SECONDS,
@@ -244,5 +247,96 @@ describe('every LocalStorageAdapter construction site: relative by default, PRIM
     const url = await dynamic.getPresignedUploadUrl!('o/r/uploads/content/a.bin');
     expect(url.startsWith(LOCAL_PRESIGN_PATH)).toBe(true);
     expect(url).not.toMatch(/^https?:\/\//);
+  });
+});
+
+describe('local download presigning', () => {
+  const root = derivePresignKey({ ENCRYPTION_KEY: 'test-secret' });
+  const dlKey = deriveDownloadKey(root);
+  const KEY = 'o/r/uploads/content/a.mp4';
+  const EXP = 1_800_000_000;
+
+  it('derives a download key distinct from the upload key it is derived from', () => {
+    expect(dlKey.equals(root)).toBe(false);
+    expect(dlKey.length).toBe(32);
+  });
+
+  it('derives the same download key deterministically', () => {
+    expect(deriveDownloadKey(root).equals(dlKey)).toBe(true);
+  });
+
+  it('round-trips a signature', () => {
+    const sig = signLocalDownload({ key: KEY, exp: EXP }, dlKey);
+    expect(verifyLocalDownload({ key: KEY, exp: EXP }, sig, dlKey)).toBe(true);
+  });
+
+  it('round-trips a signature carrying a download filename', () => {
+    const sig = signLocalDownload({ key: KEY, exp: EXP, dl: 'my video.mp4' }, dlKey);
+    expect(verifyLocalDownload({ key: KEY, exp: EXP, dl: 'my video.mp4' }, sig, dlKey)).toBe(true);
+  });
+
+  it('rejects a tampered key', () => {
+    const sig = signLocalDownload({ key: KEY, exp: EXP }, dlKey);
+    expect(verifyLocalDownload({ key: 'o/r/other.mp4', exp: EXP }, sig, dlKey)).toBe(false);
+  });
+
+  it('rejects a tampered expiry', () => {
+    const sig = signLocalDownload({ key: KEY, exp: EXP }, dlKey);
+    expect(verifyLocalDownload({ key: KEY, exp: EXP + 1 }, sig, dlKey)).toBe(false);
+  });
+
+  it('rejects a tampered download filename', () => {
+    const sig = signLocalDownload({ key: KEY, exp: EXP, dl: 'a.mp4' }, dlKey);
+    expect(verifyLocalDownload({ key: KEY, exp: EXP, dl: 'b.mp4' }, sig, dlKey)).toBe(false);
+    // Adding a filename to a signature minted without one must also fail.
+    const bare = signLocalDownload({ key: KEY, exp: EXP }, dlKey);
+    expect(verifyLocalDownload({ key: KEY, exp: EXP, dl: 'b.mp4' }, bare, dlKey)).toBe(false);
+  });
+
+  it('rejects a malformed / wrong-length signature without throwing', () => {
+    expect(verifyLocalDownload({ key: KEY, exp: EXP }, 'deadbeef', dlKey)).toBe(false);
+    expect(verifyLocalDownload({ key: KEY, exp: EXP }, '', dlKey)).toBe(false);
+    expect(verifyLocalDownload({ key: KEY, exp: EXP }, 'z'.repeat(64), dlKey)).toBe(false);
+  });
+
+  it('rejects a signature minted under a different presign key', () => {
+    const otherDl = deriveDownloadKey(derivePresignKey({ ENCRYPTION_KEY: 'other' }));
+    const sig = signLocalDownload({ key: KEY, exp: EXP }, otherDl);
+    expect(verifyLocalDownload({ key: KEY, exp: EXP }, sig, dlKey)).toBe(false);
+  });
+
+  it('requires a finite exp', () => {
+    expect(() => signLocalDownload({ key: KEY, exp: NaN }, dlKey)).toThrow(TypeError);
+    expect(() => verifyLocalDownload({ key: KEY, exp: NaN }, 'x', dlKey)).toThrow(TypeError);
+  });
+
+  // CROSS-DOMAIN SEPARATION. An upload signature must never authorize a
+  // download and vice versa: the two are minted under keys that differ by a
+  // one-way, domain-labelled derivation, so neither verifier can be satisfied
+  // by the other's output even when every signed field lines up.
+  describe('upload/download domain separation', () => {
+    it('does not accept an UPLOAD signature on the download verifier', () => {
+      const uploadSig = signLocalUpload({ key: KEY, exp: EXP, max: 1024 }, root);
+      expect(verifyLocalDownload({ key: KEY, exp: EXP }, uploadSig, dlKey)).toBe(false);
+      expect(verifyLocalDownload({ key: KEY, exp: EXP, dl: '1024' }, uploadSig, dlKey)).toBe(false);
+      // Nor when the download verifier is (mistakenly) handed the upload key.
+      expect(verifyLocalDownload({ key: KEY, exp: EXP }, uploadSig, root)).toBe(false);
+    });
+
+    it('does not accept a DOWNLOAD signature on the upload verifier', () => {
+      const dlSig = signLocalDownload({ key: KEY, exp: EXP }, dlKey);
+      expect(verifyLocalUpload({ key: KEY, exp: EXP, max: 1024 }, dlSig, root)).toBe(false);
+      expect(verifyLocalUpload({ key: KEY, exp: EXP, max: 1024 }, dlSig, dlKey)).toBe(false);
+    });
+
+    it('is immune to delimiter injection through the key or filename', () => {
+      // Both variable-length fields are length-safe-encoded before signing, so
+      // shifting a `|` from one field into another cannot produce the same
+      // canonical string under a different (key, exp, dl) triple.
+      const a = signLocalDownload({ key: 'a|1800000000', exp: 1, dl: '' }, dlKey);
+      const b = signLocalDownload({ key: 'a', exp: 1_800_000_000, dl: '1|' }, dlKey);
+      expect(a).not.toBe(b);
+      expect(verifyLocalDownload({ key: 'a', exp: 1_800_000_000, dl: '1|' }, a, dlKey)).toBe(false);
+    });
   });
 });

--- a/apps/backend/src/storage/presign.util.ts
+++ b/apps/backend/src/storage/presign.util.ts
@@ -3,6 +3,16 @@ import { createHash, createHmac, timingSafeEqual } from 'crypto';
 /** Domain-separation label. Distinct from function-runner's 'pipeline-fn-sign'. */
 export const PRESIGN_DOMAIN_LABEL = 'local-presign-v1';
 
+/**
+ * Domain-separation label for the signed DOWNLOAD (GET) direction.
+ *
+ * Deliberately distinct from {@link PRESIGN_DOMAIN_LABEL}: it is mixed into a
+ * separate HMAC key (see {@link deriveDownloadKey}) rather than into the signed
+ * message, so an upload signature and a download signature can never satisfy
+ * each other's verifier no matter how the signed fields line up.
+ */
+export const DOWNLOAD_PRESIGN_DOMAIN_LABEL = 'local-presign-dl-v1';
+
 /** Default per-upload size ceiling (100 MB), matching nginx's client_max_body_size. */
 export const DEFAULT_MAX_UPLOAD_BYTES = 104_857_600;
 
@@ -98,6 +108,71 @@ export function signLocalUpload(params: LocalPresignParams, presignKey: Buffer):
     throw new TypeError(`max must be a finite number, got ${typeof params.max}`);
   }
   return createHmac('sha256', presignKey).update(canonicalString(params)).digest('hex');
+}
+
+/**
+ * Derive the DOWNLOAD signing key from the upload presign key.
+ *
+ * Domain separation is done at the KEY, not in the message. Prefixing the
+ * signed string with a label would leave the two schemes sharing one HMAC key,
+ * and both schemes contain attacker-influenceable variable-length fields (the
+ * storage key is derived from pipeline config / request input) — so a crafted
+ * key could make an upload canonical string byte-identical to a download one
+ * and cross-authorize. A one-way, labelled re-hash makes that structurally
+ * impossible instead of relying on the two canonical formats never colliding.
+ *
+ * Taking the upload key (rather than the environment) as input keeps this
+ * working for the `presignKey`-injected construction sites too, which have no
+ * `LOCAL_PRESIGN_SECRET`/`ENCRYPTION_KEY` of their own to derive from.
+ */
+export function deriveDownloadKey(presignKey: Buffer): Buffer {
+  return createHash('sha256').update(presignKey).update(DOWNLOAD_PRESIGN_DOMAIN_LABEL).digest();
+}
+
+export interface LocalDownloadParams {
+  key: string;
+  exp: number;
+  /** Optional filename to force `Content-Disposition: attachment` under. */
+  dl?: string;
+}
+
+/**
+ * Canonical string for the download direction.
+ *
+ * Both variable-length fields are base64url-encoded before joining. base64url's
+ * alphabet excludes `|`, so no value of `key` or `dl` can shift where a field
+ * boundary is read — the delimiter-injection hazard documented on
+ * {@link canonicalString} above cannot occur here at all, rather than being
+ * held off by validating the numeric field.
+ */
+function canonicalDownloadString({ key, exp, dl }: LocalDownloadParams): string {
+  const b64 = (s: string) => Buffer.from(s, 'utf8').toString('base64url');
+  return `${b64(key)}|${exp}|${b64(dl ?? '')}`;
+}
+
+export function signLocalDownload(params: LocalDownloadParams, downloadKey: Buffer): string {
+  if (typeof params.exp !== 'number' || !Number.isFinite(params.exp)) {
+    throw new TypeError(`exp must be a finite number, got ${typeof params.exp}`);
+  }
+  return createHmac('sha256', downloadKey).update(canonicalDownloadString(params)).digest('hex');
+}
+
+export function verifyLocalDownload(
+  params: LocalDownloadParams,
+  sig: string,
+  downloadKey: Buffer,
+): boolean {
+  if (typeof params.exp !== 'number' || !Number.isFinite(params.exp)) {
+    throw new TypeError(`exp must be a finite number, got ${typeof params.exp}`);
+  }
+  const expected = signLocalDownload(params, downloadKey);
+  // timingSafeEqual throws on length mismatch, so guard before comparing.
+  if (typeof sig !== 'string' || sig.length !== expected.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(sig, 'hex'), Buffer.from(expected, 'hex'));
+  } catch {
+    return false;
+  }
 }
 
 export function verifyLocalUpload(

--- a/apps/backend/src/storage/storage.module.ts
+++ b/apps/backend/src/storage/storage.module.ts
@@ -12,6 +12,7 @@ import { CachingStorageAdapter } from './cache/caching-storage.adapter';
 import { CACHE_ADAPTER, ICacheAdapter, CacheConfig } from './cache/cache.interface';
 import { explicitPublicOrigin } from './presign.util';
 import { LocalPresignedUploadController } from './local-presigned-upload.controller';
+import { LocalPresignedDownloadController } from './local-presigned-download.controller';
 import { LocalUploadWriterService } from './local-upload-writer.service';
 import { StorageUsageModule } from './storage-usage.module';
 
@@ -61,7 +62,12 @@ export class StorageModule {
     return {
       module: StorageModule,
       imports: [StorageUsageModule],
-      controllers: [FilesController, CacheController, LocalPresignedUploadController],
+      controllers: [
+        FilesController,
+        CacheController,
+        LocalPresignedUploadController,
+        LocalPresignedDownloadController,
+      ],
       providers: [storageProvider, LocalUploadWriterService],
       exports: [STORAGE_ADAPTER, LocalUploadWriterService],
     };
@@ -144,7 +150,12 @@ export class StorageModule {
     return {
       module: StorageModule,
       imports: [...(options.imports || []), StorageUsageModule],
-      controllers: [FilesController, CacheController, LocalPresignedUploadController],
+      controllers: [
+        FilesController,
+        CacheController,
+        LocalPresignedUploadController,
+        LocalPresignedDownloadController,
+      ],
       providers: [dynamicAdapterProvider, storageAdapterProvider, LocalUploadWriterService],
       exports: [STORAGE_ADAPTER, DYNAMIC_STORAGE_ADAPTER, LocalUploadWriterService],
     };

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import { InfrastructureTab } from '@/pages/admin-settings/InfrastructureTab';
 import { SslTab } from '@/pages/admin-settings/SslTab';
 import { DomainsPage } from '@/pages/DomainsPage';
 import { TrafficPage } from '@/pages/TrafficPage';
+import { AppsPage } from '@/pages/AppsPage';
 import { HomePage } from '@/pages/HomePage';
 import { LoginPage } from '@/pages/LoginPage';
 import { LogoutPage } from '@/pages/LogoutPage';
@@ -138,6 +139,9 @@ function App() {
 
           {/* Traffic route (admin only) */}
           <Route path="/traffic" element={<ProtectedRoute requireAdmin><TrafficPage /></ProtectedRoute>} />
+
+          {/* Apps route (admin only) */}
+          <Route path="/apps" element={<ProtectedRoute requireAdmin><AppsPage /></ProtectedRoute>} />
           </Routes>
           <Toaster />
         </div>

--- a/apps/frontend/src/components/app-catalog/AppCard.tsx
+++ b/apps/frontend/src/components/app-catalog/AppCard.tsx
@@ -1,0 +1,288 @@
+import { useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useToast } from '@/hooks/use-toast';
+import {
+  useGetUninstallPreviewQuery,
+  useLazyGetEjectPayloadQuery,
+  useUninstallAppMutation,
+  useUpdateAppMutation,
+  type CatalogEntry,
+} from '@/services/appCatalogApi';
+import { ExternalLink, MoreVertical, HelpCircle, Copy, Check } from 'lucide-react';
+
+interface AppCardProps {
+  entry: CatalogEntry;
+  /** Opens the install wizard dialog (Task 13/14) for this app. */
+  onInstall: (entry: CatalogEntry) => void;
+}
+
+/**
+ * AppCard — the catalog grid tile for a single app (Task 12 of the
+ * app-catalog spec). Implements the CTA state machine from the spec:
+ *
+ * - not installed, no failing instance gate → "Install" (opens the wizard
+ *   dialog via `onInstall`, built out in Tasks 13-14).
+ * - not installed, a gate fails → disabled CTA showing the gate's message,
+ *   plus a "Why?" popover with the gate's remediation/deepLink.
+ * - installed → "Installed · v{version}" badge, an "Open" link to `appUrl`,
+ *   and an overflow menu (Update, Uninstall, Eject).
+ * - installed + update available → an additional primary "Update to
+ *   v{registryVersion}" button.
+ *
+ * Update/Uninstall/Eject are simple one-shot admin actions, so this card
+ * wires them directly to `appCatalogApi` mutations rather than deferring to
+ * the wizard dialog (which owns the multi-step preflight → install → job
+ * progress flow).
+ */
+export function AppCard({ entry, onInstall }: AppCardProps) {
+  const { toast } = useToast();
+  const { installed } = entry;
+  const failedGate = entry.gates.find((gate) => gate.status === 'fail');
+
+  const [updateApp, { isLoading: isUpdating }] = useUpdateAppMutation();
+  const [uninstallApp, { isLoading: isUninstalling }] = useUninstallAppMutation();
+  const [ejectOpen, setEjectOpen] = useState(false);
+  const [uninstallOpen, setUninstallOpen] = useState(false);
+  const { data: uninstallPreview } = useGetUninstallPreviewQuery(installed?.installedAppId ?? '', {
+    skip: !installed || !uninstallOpen,
+  });
+  const [triggerEject, { data: ejectPayload, isFetching: isEjecting }] = useLazyGetEjectPayloadQuery();
+  const [copiedField, setCopiedField] = useState<string | null>(null);
+
+  const handleUpdate = async () => {
+    if (!installed) return;
+    try {
+      await updateApp({ id: installed.installedAppId }).unwrap();
+      toast({ title: 'Update started', description: `Updating ${entry.name}…` });
+    } catch (err) {
+      const message = (err as { data?: { message?: string } })?.data?.message ?? 'Update failed';
+      toast({ title: 'Error', description: message, variant: 'destructive' });
+    }
+  };
+
+  const handleUninstall = async () => {
+    if (!installed) return;
+    try {
+      await uninstallApp({ id: installed.installedAppId }).unwrap();
+      toast({ title: 'Uninstalled', description: `${entry.name} was uninstalled.` });
+      setUninstallOpen(false);
+    } catch (err) {
+      const message = (err as { data?: { message?: string } })?.data?.message ?? 'Uninstall failed';
+      toast({ title: 'Error', description: message, variant: 'destructive' });
+    }
+  };
+
+  const handleEject = () => {
+    if (!installed) return;
+    setEjectOpen(true);
+    void triggerEject(installed.installedAppId);
+  };
+
+  const copyToClipboard = async (text: string, field: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedField(field);
+      setTimeout(() => setCopiedField(null), 2000);
+    } catch {
+      toast({ title: 'Failed to copy', description: 'Could not copy to clipboard', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <Card className="flex flex-col">
+      <CardHeader className="flex-row items-start gap-3 space-y-0">
+        {entry.iconUrl && (
+          <img src={entry.iconUrl} alt="" className="h-10 w-10 rounded-md object-cover" />
+        )}
+        <div className="min-w-0">
+          <h3 className="font-semibold leading-tight truncate">{entry.name}</h3>
+          {entry.summary && (
+            <p className="text-sm text-muted-foreground mt-1 line-clamp-2">{entry.summary}</p>
+          )}
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex-1">
+        {installed && (
+          <Badge variant="secondary">{`Installed · v${installed.version}`}</Badge>
+        )}
+      </CardContent>
+
+      <CardFooter className="flex flex-wrap items-center gap-2">
+        {!installed && !failedGate && (
+          <Button disabled={!entry.installable} onClick={() => onInstall(entry)}>
+            Install
+          </Button>
+        )}
+
+        {!installed && failedGate && (
+          <>
+            <Button disabled aria-label={failedGate.message}>
+              {failedGate.message}
+            </Button>
+            {(failedGate.remediation || failedGate.deepLink) && (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button variant="ghost" size="sm" aria-label="Why?">
+                    <HelpCircle className="h-4 w-4 mr-1" />
+                    Why?
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent>
+                  {failedGate.remediation && <p className="text-sm">{failedGate.remediation}</p>}
+                  {failedGate.deepLink && (
+                    <a
+                      href={failedGate.deepLink}
+                      className="text-sm text-primary underline mt-2 inline-block"
+                    >
+                      Fix it now
+                    </a>
+                  )}
+                </PopoverContent>
+              </Popover>
+            )}
+          </>
+        )}
+
+        {installed && (
+          <>
+            {installed.updateAvailable && entry.registryVersion && (
+              <Button onClick={handleUpdate} disabled={isUpdating}>
+                {`Update to v${entry.registryVersion}`}
+              </Button>
+            )}
+
+            {installed.appUrl && (
+              <Button asChild variant={installed.updateAvailable ? 'outline' : 'default'}>
+                <a href={installed.appUrl} target="_blank" rel="noopener noreferrer">
+                  Open
+                  <ExternalLink className="h-4 w-4 ml-1" />
+                </a>
+              </Button>
+            )}
+
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" aria-label="More actions">
+                  <MoreVertical className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onSelect={() => setUninstallOpen(true)}>Uninstall</DropdownMenuItem>
+                <DropdownMenuItem onSelect={handleEject}>Eject</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            <AlertDialog open={uninstallOpen} onOpenChange={setUninstallOpen}>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>{`Uninstall ${entry.name}?`}</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {uninstallPreview && uninstallPreview.dataTables.length > 0
+                      ? `This app created ${uninstallPreview.dataTables.length} data table(s). Data is kept by default; you can delete it from Data Tables afterward if you no longer need it.`
+                      : 'This removes the proxy rules, alias, and domain this install created. Data tables are kept by default.'}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleUninstall} disabled={isUninstalling}>
+                    Uninstall
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+
+            <Dialog open={ejectOpen} onOpenChange={setEjectOpen}>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>{`Eject ${entry.name}`}</DialogTitle>
+                  <DialogDescription>
+                    Fork the app's source repo and deploy it yourself — you'll own upkeep from here on.
+                  </DialogDescription>
+                </DialogHeader>
+                {isEjecting && <p className="text-sm text-muted-foreground">Loading…</p>}
+                {ejectPayload && (
+                  <div className="space-y-3 text-sm">
+                    <p>{ejectPayload.note}</p>
+                    <div className="flex items-center justify-between gap-2 rounded-md border p-2">
+                      <code className="truncate">{ejectPayload.repo}</code>
+                      <a
+                        href={ejectPayload.forkUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary underline whitespace-nowrap"
+                      >
+                        Fork on GitHub
+                      </a>
+                    </div>
+                    {Object.keys(ejectPayload.variables).length > 0 && (
+                      <div>
+                        <p className="font-medium mb-1">Actions variables</p>
+                        <ul className="space-y-1">
+                          {Object.entries(ejectPayload.variables).map(([key, value]) => (
+                            <li
+                              key={key}
+                              className="flex items-center justify-between gap-2 rounded-md border p-2"
+                            >
+                              <code className="truncate">
+                                {key}={value}
+                              </code>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => copyToClipboard(`${key}=${value}`, key)}
+                                aria-label={`Copy ${key}`}
+                              >
+                                {copiedField === key ? (
+                                  <Check className="h-4 w-4" />
+                                ) : (
+                                  <Copy className="h-4 w-4" />
+                                )}
+                              </Button>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                    {ejectPayload.secrets.length > 0 && (
+                      <div>
+                        <p className="font-medium mb-1">Actions secrets to set</p>
+                        <p className="text-muted-foreground">{ejectPayload.secrets.join(', ')}</p>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </DialogContent>
+            </Dialog>
+          </>
+        )}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/app-catalog/AppCard.tsx
+++ b/apps/frontend/src/components/app-catalog/AppCard.tsx
@@ -12,7 +12,11 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useToast } from '@/hooks/use-toast';
-import { useUpdateAppMutation, type CatalogEntry } from '@/services/appCatalogApi';
+import {
+  useUpdateAppMutation,
+  type CatalogEntry,
+  type GateResult,
+} from '@/services/appCatalogApi';
 import { UninstallDialog } from './UninstallDialog';
 import { EjectPanel } from './EjectPanel';
 import { ExternalLink, MoreVertical, HelpCircle } from 'lucide-react';
@@ -30,6 +34,41 @@ interface AppCardProps {
 }
 
 /**
+ * The disabled CTA a failing instance gate produces: the gate's own message
+ * IS the button label, with its remediation behind a "Why?" popover. Shared
+ * by the Install and Update CTAs — the same gates block both (an update
+ * re-runs `instanceGates` server-side and would fail the job), so they must
+ * present the blockage identically.
+ */
+function GateBlockedCta({ gate }: { gate: GateResult }) {
+  return (
+    <>
+      <Button disabled aria-label={gate.message}>
+        {gate.message}
+      </Button>
+      {(gate.remediation || gate.deepLink) && (
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="ghost" size="sm" aria-label="Why?">
+              <HelpCircle className="h-4 w-4 mr-1" />
+              Why?
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent>
+            {gate.remediation && <p className="text-sm">{gate.remediation}</p>}
+            {gate.deepLink && (
+              <a href={gate.deepLink} className="text-sm text-primary underline mt-2 inline-block">
+                Fix it now
+              </a>
+            )}
+          </PopoverContent>
+        </Popover>
+      )}
+    </>
+  );
+}
+
+/**
  * AppCard — the catalog grid tile for a single app (Task 12 of the
  * app-catalog spec, lifecycle actions completed in Task 14). Implements the
  * CTA state machine from the spec:
@@ -42,7 +81,9 @@ interface AppCardProps {
  *   and an overflow menu (Update, Uninstall, Eject).
  * - installed + update available → an additional primary "Update to
  *   v{registryVersion}" button that opens a confirm popover (prune toggle,
- *   default off) before firing the update.
+ *   default off) before firing the update — unless an instance gate fails, in
+ *   which case the update is blocked by the same disabled gate CTA as install
+ *   (the update job re-runs those gates and would refuse anyway).
  *
  * Uninstall and Eject are delegated to dedicated dialogs (`UninstallDialog`,
  * `EjectPanel`) that each load their own preview/payload data; Update fires
@@ -100,38 +141,21 @@ export function AppCard({ entry, onInstall, onUpdateStarted }: AppCardProps) {
           </Button>
         )}
 
-        {!installed && failedGate && (
-          <>
-            <Button disabled aria-label={failedGate.message}>
-              {failedGate.message}
-            </Button>
-            {(failedGate.remediation || failedGate.deepLink) && (
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button variant="ghost" size="sm" aria-label="Why?">
-                    <HelpCircle className="h-4 w-4 mr-1" />
-                    Why?
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent>
-                  {failedGate.remediation && <p className="text-sm">{failedGate.remediation}</p>}
-                  {failedGate.deepLink && (
-                    <a
-                      href={failedGate.deepLink}
-                      className="text-sm text-primary underline mt-2 inline-block"
-                    >
-                      Fix it now
-                    </a>
-                  )}
-                </PopoverContent>
-              </Popover>
-            )}
-          </>
-        )}
+        {!installed && failedGate && <GateBlockedCta gate={failedGate} />}
 
         {installed && (
           <>
-            {installed.updateAvailable && entry.registryVersion && (
+            {/*
+              A failing instance gate blocks the update the same way it blocks
+              an install — the job would refuse at its preflight step — so the
+              Update CTA becomes the same disabled, explained button rather
+              than an action that only fails after the user commits to it.
+            */}
+            {installed.updateAvailable && entry.registryVersion && failedGate && (
+              <GateBlockedCta gate={failedGate} />
+            )}
+
+            {installed.updateAvailable && entry.registryVersion && !failedGate && (
               <Popover open={updatePopoverOpen} onOpenChange={setUpdatePopoverOpen}>
                 <PopoverTrigger asChild>
                   <Button disabled={isUpdating}>{`Update to v${entry.registryVersion}`}</Button>

--- a/apps/frontend/src/components/app-catalog/AppCard.tsx
+++ b/apps/frontend/src/components/app-catalog/AppCard.tsx
@@ -3,23 +3,8 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -27,90 +12,64 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useToast } from '@/hooks/use-toast';
-import {
-  useGetUninstallPreviewQuery,
-  useLazyGetEjectPayloadQuery,
-  useUninstallAppMutation,
-  useUpdateAppMutation,
-  type CatalogEntry,
-} from '@/services/appCatalogApi';
-import { ExternalLink, MoreVertical, HelpCircle, Copy, Check } from 'lucide-react';
+import { useUpdateAppMutation, type CatalogEntry } from '@/services/appCatalogApi';
+import { UninstallDialog } from './UninstallDialog';
+import { EjectPanel } from './EjectPanel';
+import { ExternalLink, MoreVertical, HelpCircle } from 'lucide-react';
 
 interface AppCardProps {
   entry: CatalogEntry;
   /** Opens the install wizard dialog (Task 13/14) for this app. */
   onInstall: (entry: CatalogEntry) => void;
+  /**
+   * Fired once `useUpdateAppMutation` returns a jobId — the parent mounts
+   * `InstallDialog` in `mode="update"` with that jobId so the update run
+   * reuses the same Working/Done job-progress screens as install.
+   */
+  onUpdateStarted: (entry: CatalogEntry, jobId: string) => void;
 }
 
 /**
  * AppCard — the catalog grid tile for a single app (Task 12 of the
- * app-catalog spec). Implements the CTA state machine from the spec:
+ * app-catalog spec, lifecycle actions completed in Task 14). Implements the
+ * CTA state machine from the spec:
  *
  * - not installed, no failing instance gate → "Install" (opens the wizard
- *   dialog via `onInstall`, built out in Tasks 13-14).
+ *   dialog via `onInstall`).
  * - not installed, a gate fails → disabled CTA showing the gate's message,
  *   plus a "Why?" popover with the gate's remediation/deepLink.
  * - installed → "Installed · v{version}" badge, an "Open" link to `appUrl`,
  *   and an overflow menu (Update, Uninstall, Eject).
  * - installed + update available → an additional primary "Update to
- *   v{registryVersion}" button.
+ *   v{registryVersion}" button that opens a confirm popover (prune toggle,
+ *   default off) before firing the update.
  *
- * Update/Uninstall/Eject are simple one-shot admin actions, so this card
- * wires them directly to `appCatalogApi` mutations rather than deferring to
- * the wizard dialog (which owns the multi-step preflight → install → job
- * progress flow).
+ * Uninstall and Eject are delegated to dedicated dialogs (`UninstallDialog`,
+ * `EjectPanel`) that each load their own preview/payload data; Update fires
+ * `useUpdateAppMutation` here and hands the job off to the shared
+ * `InstallDialog` (mounted by the page) for progress.
  */
-export function AppCard({ entry, onInstall }: AppCardProps) {
+export function AppCard({ entry, onInstall, onUpdateStarted }: AppCardProps) {
   const { toast } = useToast();
   const { installed } = entry;
   const failedGate = entry.gates.find((gate) => gate.status === 'fail');
 
   const [updateApp, { isLoading: isUpdating }] = useUpdateAppMutation();
-  const [uninstallApp, { isLoading: isUninstalling }] = useUninstallAppMutation();
+  const [updatePopoverOpen, setUpdatePopoverOpen] = useState(false);
+  const [prune, setPrune] = useState(false);
   const [ejectOpen, setEjectOpen] = useState(false);
   const [uninstallOpen, setUninstallOpen] = useState(false);
-  const { data: uninstallPreview } = useGetUninstallPreviewQuery(installed?.installedAppId ?? '', {
-    skip: !installed || !uninstallOpen,
-  });
-  const [triggerEject, { data: ejectPayload, isFetching: isEjecting }] = useLazyGetEjectPayloadQuery();
-  const [copiedField, setCopiedField] = useState<string | null>(null);
 
-  const handleUpdate = async () => {
+  const handleConfirmUpdate = async () => {
     if (!installed) return;
     try {
-      await updateApp({ id: installed.installedAppId }).unwrap();
-      toast({ title: 'Update started', description: `Updating ${entry.name}…` });
+      const result = await updateApp({ id: installed.installedAppId, prune }).unwrap();
+      setUpdatePopoverOpen(false);
+      setPrune(false);
+      onUpdateStarted(entry, result.jobId);
     } catch (err) {
       const message = (err as { data?: { message?: string } })?.data?.message ?? 'Update failed';
       toast({ title: 'Error', description: message, variant: 'destructive' });
-    }
-  };
-
-  const handleUninstall = async () => {
-    if (!installed) return;
-    try {
-      await uninstallApp({ id: installed.installedAppId }).unwrap();
-      toast({ title: 'Uninstalled', description: `${entry.name} was uninstalled.` });
-      setUninstallOpen(false);
-    } catch (err) {
-      const message = (err as { data?: { message?: string } })?.data?.message ?? 'Uninstall failed';
-      toast({ title: 'Error', description: message, variant: 'destructive' });
-    }
-  };
-
-  const handleEject = () => {
-    if (!installed) return;
-    setEjectOpen(true);
-    void triggerEject(installed.installedAppId);
-  };
-
-  const copyToClipboard = async (text: string, field: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopiedField(field);
-      setTimeout(() => setCopiedField(null), 2000);
-    } catch {
-      toast({ title: 'Failed to copy', description: 'Could not copy to clipboard', variant: 'destructive' });
     }
   };
 
@@ -173,9 +132,26 @@ export function AppCard({ entry, onInstall }: AppCardProps) {
         {installed && (
           <>
             {installed.updateAvailable && entry.registryVersion && (
-              <Button onClick={handleUpdate} disabled={isUpdating}>
-                {`Update to v${entry.registryVersion}`}
-              </Button>
+              <Popover open={updatePopoverOpen} onOpenChange={setUpdatePopoverOpen}>
+                <PopoverTrigger asChild>
+                  <Button disabled={isUpdating}>{`Update to v${entry.registryVersion}`}</Button>
+                </PopoverTrigger>
+                <PopoverContent className="space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <Label htmlFor={`prune-${entry.id}`} className="font-normal">
+                      Reset to the app&apos;s shipped rules (prune)
+                    </Label>
+                    <Switch
+                      id={`prune-${entry.id}`}
+                      checked={prune}
+                      onCheckedChange={setPrune}
+                    />
+                  </div>
+                  <Button className="w-full" onClick={handleConfirmUpdate} disabled={isUpdating}>
+                    {isUpdating ? 'Starting…' : 'Confirm update'}
+                  </Button>
+                </PopoverContent>
+              </Popover>
             )}
 
             {installed.appUrl && (
@@ -195,91 +171,12 @@ export function AppCard({ entry, onInstall }: AppCardProps) {
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem onSelect={() => setUninstallOpen(true)}>Uninstall</DropdownMenuItem>
-                <DropdownMenuItem onSelect={handleEject}>Eject</DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => setEjectOpen(true)}>Eject</DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
 
-            <AlertDialog open={uninstallOpen} onOpenChange={setUninstallOpen}>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>{`Uninstall ${entry.name}?`}</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    {uninstallPreview && uninstallPreview.dataTables.length > 0
-                      ? `This app created ${uninstallPreview.dataTables.length} data table(s). Data is kept by default; you can delete it from Data Tables afterward if you no longer need it.`
-                      : 'This removes the proxy rules, alias, and domain this install created. Data tables are kept by default.'}
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction onClick={handleUninstall} disabled={isUninstalling}>
-                    Uninstall
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-
-            <Dialog open={ejectOpen} onOpenChange={setEjectOpen}>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>{`Eject ${entry.name}`}</DialogTitle>
-                  <DialogDescription>
-                    Fork the app's source repo and deploy it yourself — you'll own upkeep from here on.
-                  </DialogDescription>
-                </DialogHeader>
-                {isEjecting && <p className="text-sm text-muted-foreground">Loading…</p>}
-                {ejectPayload && (
-                  <div className="space-y-3 text-sm">
-                    <p>{ejectPayload.note}</p>
-                    <div className="flex items-center justify-between gap-2 rounded-md border p-2">
-                      <code className="truncate">{ejectPayload.repo}</code>
-                      <a
-                        href={ejectPayload.forkUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary underline whitespace-nowrap"
-                      >
-                        Fork on GitHub
-                      </a>
-                    </div>
-                    {Object.keys(ejectPayload.variables).length > 0 && (
-                      <div>
-                        <p className="font-medium mb-1">Actions variables</p>
-                        <ul className="space-y-1">
-                          {Object.entries(ejectPayload.variables).map(([key, value]) => (
-                            <li
-                              key={key}
-                              className="flex items-center justify-between gap-2 rounded-md border p-2"
-                            >
-                              <code className="truncate">
-                                {key}={value}
-                              </code>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={() => copyToClipboard(`${key}=${value}`, key)}
-                                aria-label={`Copy ${key}`}
-                              >
-                                {copiedField === key ? (
-                                  <Check className="h-4 w-4" />
-                                ) : (
-                                  <Copy className="h-4 w-4" />
-                                )}
-                              </Button>
-                            </li>
-                          ))}
-                        </ul>
-                      </div>
-                    )}
-                    {ejectPayload.secrets.length > 0 && (
-                      <div>
-                        <p className="font-medium mb-1">Actions secrets to set</p>
-                        <p className="text-muted-foreground">{ejectPayload.secrets.join(', ')}</p>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </DialogContent>
-            </Dialog>
+            <UninstallDialog entry={entry} open={uninstallOpen} onOpenChange={setUninstallOpen} />
+            <EjectPanel entry={entry} open={ejectOpen} onOpenChange={setEjectOpen} />
           </>
         )}
       </CardFooter>

--- a/apps/frontend/src/components/app-catalog/EjectPanel.tsx
+++ b/apps/frontend/src/components/app-catalog/EjectPanel.tsx
@@ -1,0 +1,208 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useToast } from '@/hooks/use-toast';
+import { useGetEjectPayloadQuery, type CatalogEntry } from '@/services/appCatalogApi';
+import { useCreateApiKeyMutation } from '@/services/apiKeysApi';
+import { Check, Copy, ExternalLink, Key } from 'lucide-react';
+
+interface EjectPanelProps {
+  entry: CatalogEntry;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * EjectPanel — "own it yourself" flow (Task 14 of the app-catalog spec).
+ * Replaces the inline eject Dialog that shipped in AppCard for Task 12:
+ * this version renders the exact Actions variables table with copy
+ * buttons and lets the user mint the deploy API key for the secrets list
+ * inline, without leaving the panel.
+ */
+export function EjectPanel({ entry, open, onOpenChange }: EjectPanelProps) {
+  const { toast } = useToast();
+  const { installed } = entry;
+  const [copiedField, setCopiedField] = useState<string | null>(null);
+  const [mintedKeys, setMintedKeys] = useState<Record<string, string>>({});
+
+  const { data: payload, isFetching } = useGetEjectPayloadQuery(installed?.installedAppId ?? '', {
+    skip: !open || !installed,
+  });
+  const [createApiKey, { isLoading: isMinting }] = useCreateApiKeyMutation();
+
+  const copyToClipboard = async (text: string, field: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedField(field);
+      setTimeout(() => setCopiedField(null), 2000);
+    } catch {
+      toast({
+        title: 'Failed to copy',
+        description: 'Could not copy to clipboard',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleMint = async (secretName: string) => {
+    try {
+      const response = await createApiKey({
+        name: `${entry.name} eject — ${secretName}`,
+        repository: installed?.projectName,
+      }).unwrap();
+      setMintedKeys((prev) => ({ ...prev, [secretName]: response.key }));
+      toast({
+        title: 'API key minted',
+        description: "Copy it now — it won't be shown again.",
+      });
+    } catch (err) {
+      const message = (err as { data?: { message?: string } })?.data?.message ?? 'Failed to mint API key';
+      toast({ title: 'Error', description: message, variant: 'destructive' });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{`Eject ${entry.name}`}</DialogTitle>
+          <DialogDescription>
+            Fork the app&apos;s source repo and deploy it yourself — you&apos;ll own upkeep from
+            here on.
+          </DialogDescription>
+        </DialogHeader>
+
+        {isFetching && !payload && <p className="text-sm text-muted-foreground">Loading…</p>}
+
+        {payload && (
+          <div className="space-y-4 text-sm">
+            <div className="flex items-center justify-between gap-2 rounded-md border p-2">
+              <code className="truncate">{payload.repo}</code>
+              <a
+                href={payload.forkUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 whitespace-nowrap text-primary underline"
+              >
+                Fork on GitHub
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
+
+            {Object.keys(payload.variables).length > 0 && (
+              <div>
+                <p className="mb-1 font-medium">Actions variables</p>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Name</TableHead>
+                      <TableHead>Value</TableHead>
+                      <TableHead className="text-right">Copy</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {Object.entries(payload.variables).map(([key, value]) => (
+                      <TableRow key={key}>
+                        <TableCell className="font-mono text-xs">{key}</TableCell>
+                        <TableCell className="max-w-[220px] truncate font-mono text-xs">
+                          {value}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => copyToClipboard(value, key)}
+                            aria-label={`Copy ${key}`}
+                          >
+                            {copiedField === key ? (
+                              <Check className="h-4 w-4" />
+                            ) : (
+                              <Copy className="h-4 w-4" />
+                            )}
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+
+            {payload.secrets.length > 0 && (
+              <div>
+                <p className="mb-1 font-medium">Actions secrets to set</p>
+                <ul className="space-y-2">
+                  {payload.secrets.map((secretName) => (
+                    <li
+                      key={secretName}
+                      className="flex items-center justify-between gap-2 rounded-md border p-2"
+                    >
+                      <div className="min-w-0">
+                        <code className="block truncate">{secretName}</code>
+                        {mintedKeys[secretName] && (
+                          <div className="mt-1 flex items-center gap-2">
+                            <code className="truncate text-xs">{mintedKeys[secretName]}</code>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => copyToClipboard(mintedKeys[secretName], secretName)}
+                              aria-label={`Copy ${secretName} value`}
+                            >
+                              {copiedField === secretName ? (
+                                <Check className="h-4 w-4" />
+                              ) : (
+                                <Copy className="h-4 w-4" />
+                              )}
+                            </Button>
+                          </div>
+                        )}
+                      </div>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleMint(secretName)}
+                        disabled={isMinting}
+                      >
+                        <Key className="mr-1 h-4 w-4" />
+                        Mint API key
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {installed?.projectName
+                    ? `Scoped to ${installed.projectName}.`
+                    : 'Minted as a global key — no project scope available for this install.'}
+                </p>
+              </div>
+            )}
+
+            <div>
+              <p className="mb-1 font-medium">Workflow to run</p>
+              <code className="text-xs">{payload.deployWorkflow}</code>
+            </div>
+
+            <p className="text-muted-foreground">
+              The workflow&apos;s first deploy lands on this same alias — your install becomes
+              the fork&apos;s deploy target.
+            </p>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/app-catalog/InstallDialog.tsx
+++ b/apps/frontend/src/components/app-catalog/InstallDialog.tsx
@@ -41,6 +41,15 @@ interface InstallDialogProps {
   entry: CatalogEntry;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /**
+   * 'update' reuses this dialog's Working/Done screens for the Update flow
+   * (AppCard fires `useUpdateAppMutation` itself and hands the resulting
+   * jobId here via `initialJobId`) — the Review/project-picker screen is
+   * install-only and is skipped entirely in this mode.
+   */
+  mode?: 'install' | 'update';
+  /** When set, the dialog opens directly on the Working/Done screen for this job instead of Review. */
+  initialJobId?: string;
 }
 
 const NEW_PROJECT_VALUE = 'new';
@@ -89,14 +98,23 @@ function StepIcon({ status }: { status: InstallStepState['status'] }) {
  * `appCatalogApi` hooks; nothing is installed until the user has seen the
  * preflight plan and clicked Install.
  */
-export function InstallDialog({ entry, open, onOpenChange }: InstallDialogProps) {
+export function InstallDialog({
+  entry,
+  open,
+  onOpenChange,
+  mode = 'install',
+  initialJobId,
+}: InstallDialogProps) {
   const { toast } = useToast();
+  const isUpdate = mode === 'update';
 
   const [selectedProjectId, setSelectedProjectId] = useState<string | undefined>(undefined);
   const [creatingNew, setCreatingNew] = useState(false);
   const [newOwner, setNewOwner] = useState('');
   const [newName, setNewName] = useState('');
-  const [jobId, setJobId] = useState<string | null>(null);
+  // Update mode is handed an already-running job — seed it directly so the
+  // very first render lands on Working/Done, skipping Review entirely.
+  const [jobId, setJobId] = useState<string | null>(initialJobId ?? null);
   const [installBody, setInstallBody] = useState<PreflightRequest | null>(null);
 
   const { data: reposData } = useGetMyRepositoriesQuery();
@@ -134,11 +152,13 @@ export function InstallDialog({ entry, open, onOpenChange }: InstallDialogProps)
       setLastJobStatus(undefined);
       return;
     }
-    if (repositories.length === 1 && !selectedProjectId && !creatingNew) {
+    // Update mode never shows Review, so there's no project to preselect —
+    // and preselecting one would trigger a pointless preflight call.
+    if (!isUpdate && repositories.length === 1 && !selectedProjectId && !creatingNew) {
       setSelectedProjectId(repositories[0].id);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, repositories.length]);
+  }, [open, repositories.length, isUpdate]);
 
   const preflightBody: PreflightRequest | null = creatingNew
     ? newOwner.trim() && newName.trim()
@@ -227,7 +247,11 @@ export function InstallDialog({ entry, open, onOpenChange }: InstallDialogProps)
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>
-            {screen === 'done' ? `${entry.name} installed` : `Install ${entry.name}`}
+            {screen === 'done'
+              ? `${entry.name} ${isUpdate ? 'updated' : 'installed'}`
+              : isUpdate
+                ? `Updating ${entry.name}`
+                : `Install ${entry.name}`}
           </DialogTitle>
           {screen === 'review' && (
             <DialogDescription>
@@ -381,7 +405,7 @@ export function InstallDialog({ entry, open, onOpenChange }: InstallDialogProps)
                     {step.detail && <p className="text-xs text-muted-foreground">{step.detail}</p>}
                     {step.error && <p className="text-xs text-destructive">{step.error}</p>}
                   </div>
-                  {step.status === 'action-required' && (
+                  {step.status === 'action-required' && !isUpdate && (
                     <Button variant="outline" size="sm" onClick={handleRetryInstall}>
                       Retry
                     </Button>
@@ -400,7 +424,7 @@ export function InstallDialog({ entry, open, onOpenChange }: InstallDialogProps)
                     Close
                   </Button>
                   <Button variant="destructive" onClick={handleUndo} disabled={isUndoing}>
-                    Undo this install
+                    {isUpdate ? 'Undo this update' : 'Undo this install'}
                   </Button>
                 </DialogFooter>
               </>

--- a/apps/frontend/src/components/app-catalog/InstallDialog.tsx
+++ b/apps/frontend/src/components/app-catalog/InstallDialog.tsx
@@ -45,6 +45,9 @@ interface InstallDialogProps {
 
 const NEW_PROJECT_VALUE = 'new';
 
+/** Job statuses that will never change again — polling past this point is wasted work. */
+const TERMINAL_JOB_STATUSES = new Set(['succeeded', 'failed', 'undone']);
+
 const STEP_LABELS: Record<string, string> = {
   preflight: 'Preflight checks',
   fetch: 'Fetch app bundle',
@@ -97,11 +100,25 @@ export function InstallDialog({ entry, open, onOpenChange }: InstallDialogProps)
   const [installBody, setInstallBody] = useState<PreflightRequest | null>(null);
 
   const { data: reposData } = useGetMyRepositoriesQuery();
-  const [preflight, { data: preflightData, isLoading: isPreflighting }] = usePreflightAppMutation();
+  const [preflight, { data: preflightData, isLoading: isPreflighting, reset: resetPreflight }] =
+    usePreflightAppMutation();
   const [installApp, { isLoading: isInstalling }] = useInstallAppMutation();
-  const { data: job } = useGetInstallJobQuery(jobId ?? '', { pollingInterval: 1000, skip: !jobId });
   const [undoJob, { isLoading: isUndoing }] = useUndoJobMutation();
   const [ackManualStep] = useAckManualStepMutation();
+
+  // Stop polling once the job reaches a terminal state. `lastJobStatus` is
+  // corrected synchronously during render (not in an effect) so the very
+  // poll that observes the terminal status is also the one that disables
+  // further polling — no one-more-poll-after-done straggler.
+  const [lastJobStatus, setLastJobStatus] = useState<string | undefined>(undefined);
+  const jobPollingInterval = lastJobStatus && TERMINAL_JOB_STATUSES.has(lastJobStatus) ? 0 : 1000;
+  const { data: job } = useGetInstallJobQuery(jobId ?? '', {
+    pollingInterval: jobPollingInterval,
+    skip: !jobId,
+  });
+  if (job?.status !== lastJobStatus) {
+    setLastJobStatus(job?.status);
+  }
 
   const repositories = reposData?.repositories ?? [];
 
@@ -114,6 +131,7 @@ export function InstallDialog({ entry, open, onOpenChange }: InstallDialogProps)
       setNewOwner('');
       setNewName('');
       setSelectedProjectId(undefined);
+      setLastJobStatus(undefined);
       return;
     }
     if (repositories.length === 1 && !selectedProjectId && !creatingNew) {
@@ -136,6 +154,10 @@ export function InstallDialog({ entry, open, onOpenChange }: InstallDialogProps)
 
   useEffect(() => {
     if (preflightBody) {
+      // Clear the previous selection's result immediately so stale gates/plan
+      // (and a stale "clean" verdict) can't be shown — or acted on — against
+      // the newly selected project while the new preflight is in flight.
+      resetPreflight();
       runPreflight(preflightBody);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -435,7 +457,7 @@ export function InstallDialog({ entry, open, onOpenChange }: InstallDialogProps)
             <Button variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button onClick={handleInstall} disabled={!canInstall || isInstalling}>
+            <Button onClick={handleInstall} disabled={!canInstall || isInstalling || isPreflighting}>
               {isInstalling ? 'Installing…' : 'Install'}
             </Button>
           </DialogFooter>

--- a/apps/frontend/src/components/app-catalog/InstallDialog.tsx
+++ b/apps/frontend/src/components/app-catalog/InstallDialog.tsx
@@ -14,6 +14,8 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useToast } from '@/hooks/use-toast';
+import { useAppDispatch } from '@/store/hooks';
+import { api } from '@/services/api';
 import {
   usePreflightAppMutation,
   useInstallAppMutation,
@@ -115,6 +117,7 @@ export function InstallDialog({
   initialJobId,
 }: InstallDialogProps) {
   const { toast } = useToast();
+  const dispatch = useAppDispatch();
   const isUpdate = mode === 'update';
 
   const [selectedProjectId, setSelectedProjectId] = useState<string | undefined>(undefined);
@@ -155,6 +158,23 @@ export function InstallDialog({
   if (job?.status !== lastJobStatus) {
     setLastJobStatus(job?.status);
   }
+
+  // The catalog card (badge, version, "Update to vX") and this dialog's own
+  // Done screen both read from the LIVE catalog entry (`entry.installed`),
+  // which `installApp`/`updateApp` invalidate at DISPATCH time — before the
+  // background job has done anything. Nothing re-invalidates when the job
+  // actually finishes, so the card is stuck showing pre-update state until a
+  // manual reload. Fix: invalidate again here, once per job, the moment a
+  // poll observes a terminal status. Keyed by job id (not just status) so a
+  // retried job that lands on the same terminal status as the one before it
+  // still gets its own invalidation.
+  const invalidatedJobIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!job || !TERMINAL_JOB_STATUSES.has(job.status)) return;
+    if (invalidatedJobIdRef.current === job.id) return;
+    invalidatedJobIdRef.current = job.id;
+    dispatch(api.util.invalidateTags(['AppCatalog', 'InstalledApp']));
+  }, [job, dispatch]);
 
   const repositories = reposData?.repositories ?? [];
 

--- a/apps/frontend/src/components/app-catalog/InstallDialog.tsx
+++ b/apps/frontend/src/components/app-catalog/InstallDialog.tsx
@@ -417,15 +417,32 @@ export function InstallDialog({
             {job.status === 'failed' && (
               <>
                 <Alert variant="destructive">
-                  <AlertDescription>{job.error ?? 'Install failed.'}</AlertDescription>
+                  <AlertDescription>
+                    {job.error ?? (isUpdate ? 'Update failed.' : 'Install failed.')}
+                  </AlertDescription>
                 </Alert>
+                {/*
+                  Undo is install-only. A failed update's row carries the
+                  ORIGINAL install's created resources, so undoing it would
+                  delete that install outright — data tables included. An
+                  update rolls back through the alias's deployment history
+                  instead, which costs nothing and loses nothing.
+                */}
+                {isUpdate && (
+                  <p className="text-sm text-muted-foreground">
+                    Nothing was removed. The previous version is still in the alias&apos;s deployment
+                    history — roll back there, or run the update again once the cause is fixed.
+                  </p>
+                )}
                 <DialogFooter>
                   <Button variant="outline" onClick={() => onOpenChange(false)}>
                     Close
                   </Button>
-                  <Button variant="destructive" onClick={handleUndo} disabled={isUndoing}>
-                    {isUpdate ? 'Undo this update' : 'Undo this install'}
-                  </Button>
+                  {!isUpdate && (
+                    <Button variant="destructive" onClick={handleUndo} disabled={isUndoing}>
+                      Undo this install
+                    </Button>
+                  )}
                 </DialogFooter>
               </>
             )}

--- a/apps/frontend/src/components/app-catalog/InstallDialog.tsx
+++ b/apps/frontend/src/components/app-catalog/InstallDialog.tsx
@@ -1,0 +1,446 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useToast } from '@/hooks/use-toast';
+import {
+  usePreflightAppMutation,
+  useInstallAppMutation,
+  useGetInstallJobQuery,
+  useUndoJobMutation,
+  useAckManualStepMutation,
+  type CatalogEntry,
+  type GateResult,
+  type InstallStepState,
+  type PreflightRequest,
+} from '@/services/appCatalogApi';
+import { useGetMyRepositoriesQuery } from '@/services/repositoriesApi';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Circle,
+  ExternalLink,
+  HelpCircle,
+  Loader2,
+  MinusCircle,
+  XCircle,
+} from 'lucide-react';
+
+interface InstallDialogProps {
+  entry: CatalogEntry;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const NEW_PROJECT_VALUE = 'new';
+
+const STEP_LABELS: Record<string, string> = {
+  preflight: 'Preflight checks',
+  fetch: 'Fetch app bundle',
+  'sync-rules': 'Sync proxy rules',
+  deploy: 'Deploy',
+  domain: 'Configure domain',
+  certificate: 'Provision certificate',
+  schedules: 'Set up schedules',
+  record: 'Record install',
+};
+
+function GateIcon({ status }: { status: GateResult['status'] }) {
+  if (status === 'fail') return <XCircle className="h-4 w-4 text-destructive shrink-0" />;
+  if (status === 'warn') return <AlertTriangle className="h-4 w-4 text-yellow-500 shrink-0" />;
+  return <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0" />;
+}
+
+function StepIcon({ status }: { status: InstallStepState['status'] }) {
+  switch (status) {
+    case 'done':
+      return <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0" />;
+    case 'failed':
+      return <XCircle className="h-4 w-4 text-destructive shrink-0" />;
+    case 'running':
+      return <Loader2 className="h-4 w-4 animate-spin text-blue-500 shrink-0" />;
+    case 'action-required':
+      return <AlertTriangle className="h-4 w-4 text-yellow-500 shrink-0" />;
+    case 'skipped':
+      return <MinusCircle className="h-4 w-4 text-muted-foreground shrink-0" />;
+    default:
+      return <Circle className="h-4 w-4 text-muted-foreground shrink-0" />;
+  }
+}
+
+/**
+ * InstallDialog — the three-screen 1-click install wizard (Task 13 of the
+ * app-catalog spec): Review (project pick + preflight) -> Working (live job
+ * progress) -> Done (app URL + manual-steps checklist). Consumes Task 12's
+ * `appCatalogApi` hooks; nothing is installed until the user has seen the
+ * preflight plan and clicked Install.
+ */
+export function InstallDialog({ entry, open, onOpenChange }: InstallDialogProps) {
+  const { toast } = useToast();
+
+  const [selectedProjectId, setSelectedProjectId] = useState<string | undefined>(undefined);
+  const [creatingNew, setCreatingNew] = useState(false);
+  const [newOwner, setNewOwner] = useState('');
+  const [newName, setNewName] = useState('');
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [installBody, setInstallBody] = useState<PreflightRequest | null>(null);
+
+  const { data: reposData } = useGetMyRepositoriesQuery();
+  const [preflight, { data: preflightData, isLoading: isPreflighting }] = usePreflightAppMutation();
+  const [installApp, { isLoading: isInstalling }] = useInstallAppMutation();
+  const { data: job } = useGetInstallJobQuery(jobId ?? '', { pollingInterval: 1000, skip: !jobId });
+  const [undoJob, { isLoading: isUndoing }] = useUndoJobMutation();
+  const [ackManualStep] = useAckManualStepMutation();
+
+  const repositories = reposData?.repositories ?? [];
+
+  // Preselect the sole project; reset all wizard state whenever the dialog closes.
+  useEffect(() => {
+    if (!open) {
+      setJobId(null);
+      setInstallBody(null);
+      setCreatingNew(false);
+      setNewOwner('');
+      setNewName('');
+      setSelectedProjectId(undefined);
+      return;
+    }
+    if (repositories.length === 1 && !selectedProjectId && !creatingNew) {
+      setSelectedProjectId(repositories[0].id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, repositories.length]);
+
+  const preflightBody: PreflightRequest | null = creatingNew
+    ? newOwner.trim() && newName.trim()
+      ? { newProject: { owner: newOwner.trim(), name: newName.trim() } }
+      : null
+    : selectedProjectId
+      ? { projectId: selectedProjectId }
+      : null;
+
+  const runPreflight = (body: PreflightRequest) => {
+    preflight({ appId: entry.id, body });
+  };
+
+  useEffect(() => {
+    if (preflightBody) {
+      runPreflight(preflightBody);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedProjectId, creatingNew, newOwner, newName]);
+
+  const handleProjectChange = (value: string) => {
+    if (value === NEW_PROJECT_VALUE) {
+      setCreatingNew(true);
+      setSelectedProjectId(undefined);
+    } else {
+      setCreatingNew(false);
+      setSelectedProjectId(value);
+    }
+  };
+
+  const hasFailingGate = (preflightData?.gates ?? []).some((gate) => gate.status === 'fail');
+  const canInstall = Boolean(preflightData) && !hasFailingGate && Boolean(preflightBody);
+
+  const handleInstall = async () => {
+    if (!preflightBody) return;
+    try {
+      const result = await installApp({ appId: entry.id, body: preflightBody }).unwrap();
+      setInstallBody(preflightBody);
+      setJobId(result.jobId);
+    } catch (err) {
+      const message = (err as { data?: { message?: string } })?.data?.message ?? 'Install failed';
+      toast({ title: 'Error', description: message, variant: 'destructive' });
+    }
+  };
+
+  const handleRetryInstall = () => {
+    if (!installBody) return;
+    installApp({ appId: entry.id, body: installBody })
+      .unwrap()
+      .then((result) => setJobId(result.jobId))
+      .catch(() => undefined);
+  };
+
+  const handleUndo = () => {
+    if (!jobId) return;
+    undoJob(jobId);
+  };
+
+  const installedAppId = entry.installed?.installedAppId ?? job?.installedAppId;
+  const manualSteps = entry.installed?.manualSteps ?? job?.manualSteps ?? [];
+  const manualStepsAcked = entry.installed?.manualStepsAcked ?? [];
+  const doneAppUrl = entry.installed?.appUrl ?? job?.appUrl;
+
+  const handleAck = (stepId: string, checked: boolean) => {
+    if (!checked || !installedAppId) return;
+    ackManualStep({ id: installedAppId, stepId });
+  };
+
+  const screen: 'review' | 'working' | 'done' = !jobId
+    ? 'review'
+    : job?.status === 'succeeded'
+      ? 'done'
+      : 'working';
+
+  const allResolutions = (preflightData?.syncPlans ?? []).flatMap((plan) => plan.schemaResolutions);
+  const reusedCount = allResolutions.filter((r) => r.action === 'reuse').length;
+  const createdCount = allResolutions.filter((r) => r.action === 'create').length;
+  const mismatches = allResolutions.filter((r) => r.fieldMismatch);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {screen === 'done' ? `${entry.name} installed` : `Install ${entry.name}`}
+          </DialogTitle>
+          {screen === 'review' && (
+            <DialogDescription>
+              Review what will change before anything is written.
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        {screen === 'review' && (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="install-project">Project</Label>
+              <select
+                id="install-project"
+                aria-label="Project"
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
+                value={creatingNew ? NEW_PROJECT_VALUE : (selectedProjectId ?? '')}
+                onChange={(e) => handleProjectChange(e.target.value)}
+              >
+                <option value="" disabled>
+                  Choose a project
+                </option>
+                {repositories.map((repo) => (
+                  <option key={repo.id} value={repo.id}>
+                    {`${repo.owner}/${repo.name}`}
+                  </option>
+                ))}
+                <option value={NEW_PROJECT_VALUE}>Create new project…</option>
+              </select>
+            </div>
+
+            {creatingNew && (
+              <div className="space-y-3 rounded-md border p-3">
+                <div className="space-y-2">
+                  <Label htmlFor="install-new-owner">Owner</Label>
+                  <Input
+                    id="install-new-owner"
+                    value={newOwner}
+                    onChange={(e) => setNewOwner(e.target.value)}
+                    placeholder="your-org"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="install-new-name">Name</Label>
+                  <Input
+                    id="install-new-name"
+                    value={newName}
+                    onChange={(e) => setNewName(e.target.value)}
+                    placeholder="handoff"
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  A project&apos;s owner/name can never be renamed.
+                </p>
+              </div>
+            )}
+
+            {isPreflighting && !preflightData && (
+              <p className="text-sm text-muted-foreground">Checking…</p>
+            )}
+
+            {preflightData && (
+              <>
+                {preflightData.appUrl && (
+                  <p className="text-sm">
+                    App URL: <code className="text-xs">{preflightData.appUrl}</code>
+                  </p>
+                )}
+
+                <div className="space-y-2">
+                  {preflightData.gates.map((gate) => (
+                    <div key={gate.id} className="flex items-start gap-2 rounded-md border p-2">
+                      <GateIcon status={gate.status} />
+                      <p className="flex-1 text-sm">{gate.message}</p>
+                      {(gate.remediation || gate.deepLink) && (
+                        <Popover>
+                          <PopoverTrigger asChild>
+                            <Button variant="ghost" size="sm" aria-label="Why?">
+                              <HelpCircle className="h-4 w-4 mr-1" />
+                              Why?
+                            </Button>
+                          </PopoverTrigger>
+                          <PopoverContent>
+                            {gate.remediation && <p className="text-sm">{gate.remediation}</p>}
+                            {gate.deepLink && (
+                              <a
+                                href={gate.deepLink}
+                                className="text-sm text-primary underline mt-2 inline-block"
+                              >
+                                Fix it now
+                              </a>
+                            )}
+                          </PopoverContent>
+                        </Popover>
+                      )}
+                      {gate.retryable && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={isPreflighting || !preflightBody}
+                          onClick={() => preflightBody && runPreflight(preflightBody)}
+                        >
+                          Retry
+                        </Button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+
+                {preflightData.syncPlans.length > 0 && (
+                  <div className="space-y-2">
+                    {preflightData.syncPlans.map((plan) => (
+                      <div key={plan.ruleSet} className="text-sm">
+                        <span className="font-medium">{plan.ruleSet}</span>
+                        {': '}
+                        <span className="text-muted-foreground">
+                          {`${plan.created} rules created · ${plan.updated} updated`}
+                        </span>
+                      </div>
+                    ))}
+
+                    {allResolutions.length > 0 && (
+                      <p className="text-sm text-muted-foreground">
+                        {`${allResolutions.length} data tables: ${reusedCount} reused, ${createdCount} created`}
+                      </p>
+                    )}
+
+                    {mismatches.map((resolution) => (
+                      <Alert key={resolution.name}>
+                        <AlertTriangle className="h-4 w-4" />
+                        <AlertDescription>
+                          {`${resolution.name}: existing schema has a field mismatch — install won't overwrite it.`}
+                        </AlertDescription>
+                      </Alert>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        )}
+
+        {screen === 'working' && job && (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              {job.steps.map((step) => (
+                <div key={step.id} className="flex items-start gap-2 rounded-md border p-2">
+                  <StepIcon status={step.status} />
+                  <div className="flex-1">
+                    <p className="text-sm">{STEP_LABELS[step.id] ?? step.id}</p>
+                    {step.detail && <p className="text-xs text-muted-foreground">{step.detail}</p>}
+                    {step.error && <p className="text-xs text-destructive">{step.error}</p>}
+                  </div>
+                  {step.status === 'action-required' && (
+                    <Button variant="outline" size="sm" onClick={handleRetryInstall}>
+                      Retry
+                    </Button>
+                  )}
+                </div>
+              ))}
+            </div>
+
+            {job.status === 'failed' && (
+              <>
+                <Alert variant="destructive">
+                  <AlertDescription>{job.error ?? 'Install failed.'}</AlertDescription>
+                </Alert>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => onOpenChange(false)}>
+                    Close
+                  </Button>
+                  <Button variant="destructive" onClick={handleUndo} disabled={isUndoing}>
+                    Undo this install
+                  </Button>
+                </DialogFooter>
+              </>
+            )}
+          </div>
+        )}
+
+        {screen === 'done' && (
+          <div className="space-y-4">
+            {doneAppUrl && (
+              <Button asChild>
+                <a href={doneAppUrl} target="_blank" rel="noopener noreferrer">
+                  Open
+                  <ExternalLink className="h-4 w-4 ml-1" />
+                </a>
+              </Button>
+            )}
+
+            {manualSteps.length > 0 && (
+              <div className="space-y-3">
+                <p className="text-sm font-medium">Finish setting up</p>
+                {manualSteps.map((step) => (
+                  <div key={step.id} className="flex items-start gap-2 rounded-md border p-2">
+                    <Checkbox
+                      id={`manual-step-${step.id}`}
+                      aria-label={step.title}
+                      checked={manualStepsAcked.includes(step.id)}
+                      onCheckedChange={(checked) => handleAck(step.id, checked === true)}
+                    />
+                    <div className="flex-1">
+                      <Label htmlFor={`manual-step-${step.id}`} className="font-medium">
+                        {step.title}
+                      </Label>
+                      <p className="text-sm text-muted-foreground">{step.body}</p>
+                      {step.deepLink && (
+                        <a href={step.deepLink} className="text-sm text-primary underline">
+                          Go
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <DialogFooter>
+              <Button onClick={() => onOpenChange(false)}>Close</Button>
+            </DialogFooter>
+          </div>
+        )}
+
+        {screen === 'review' && (
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleInstall} disabled={!canInstall || isInstalling}>
+              {isInstalling ? 'Installing…' : 'Install'}
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/app-catalog/InstallDialog.tsx
+++ b/apps/frontend/src/components/app-catalog/InstallDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -53,6 +53,15 @@ interface InstallDialogProps {
 }
 
 const NEW_PROJECT_VALUE = 'new';
+
+/**
+ * Delay before a Review-screen keystroke (subdomain field, or the new-project
+ * owner/name fields) re-fires preflight. `resetPreflight()` still runs
+ * synchronously on every keystroke — that's what makes `canInstall` (which
+ * requires `preflightData`) false for the whole debounce window, not just the
+ * network round trip.
+ */
+const PREFLIGHT_DEBOUNCE_MS = 500;
 
 /** Job statuses that will never change again — polling past this point is wasted work. */
 const TERMINAL_JOB_STATUSES = new Set(['succeeded', 'failed', 'undone']);
@@ -112,6 +121,15 @@ export function InstallDialog({
   const [creatingNew, setCreatingNew] = useState(false);
   const [newOwner, setNewOwner] = useState('');
   const [newName, setNewName] = useState('');
+  // Editable override for the manifest's default install subdomain. Starts
+  // empty — the manifest default is only shown as a placeholder (see
+  // `defaultSubdomainLabel` below), never forced into the field's value.
+  const [subdomain, setSubdomain] = useState('');
+  // Seeded once from the FIRST preflight response's appHost, so later
+  // preflights (e.g. after a project change) don't keep overwriting a
+  // placeholder the operator is already looking at.
+  const [defaultSubdomainLabel, setDefaultSubdomainLabel] = useState<string | undefined>(undefined);
+  const preflightDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Update mode is handed an already-running job — seed it directly so the
   // very first render lands on Working/Done, skipping Review entirely.
   const [jobId, setJobId] = useState<string | null>(initialJobId ?? null);
@@ -148,8 +166,11 @@ export function InstallDialog({
       setCreatingNew(false);
       setNewOwner('');
       setNewName('');
+      setSubdomain('');
+      setDefaultSubdomainLabel(undefined);
       setSelectedProjectId(undefined);
       setLastJobStatus(undefined);
+      if (preflightDebounceRef.current) clearTimeout(preflightDebounceRef.current);
       return;
     }
     // Update mode never shows Review, so there's no project to preselect —
@@ -160,12 +181,19 @@ export function InstallDialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, repositories.length, isUpdate]);
 
+  const trimmedSubdomain = subdomain.trim();
   const preflightBody: PreflightRequest | null = creatingNew
     ? newOwner.trim() && newName.trim()
-      ? { newProject: { owner: newOwner.trim(), name: newName.trim() } }
+      ? {
+          newProject: { owner: newOwner.trim(), name: newName.trim() },
+          ...(trimmedSubdomain ? { subdomain: trimmedSubdomain } : {}),
+        }
       : null
     : selectedProjectId
-      ? { projectId: selectedProjectId }
+      ? {
+          projectId: selectedProjectId,
+          ...(trimmedSubdomain ? { subdomain: trimmedSubdomain } : {}),
+        }
       : null;
 
   const runPreflight = (body: PreflightRequest) => {
@@ -173,15 +201,34 @@ export function InstallDialog({
   };
 
   useEffect(() => {
-    if (preflightBody) {
-      // Clear the previous selection's result immediately so stale gates/plan
-      // (and a stale "clean" verdict) can't be shown — or acted on — against
-      // the newly selected project while the new preflight is in flight.
-      resetPreflight();
+    if (!preflightBody) return;
+    // Clear the previous result IMMEDIATELY (not debounced) so stale
+    // gates/plan (and a stale "clean" verdict) can't be shown — or acted on
+    // — against the newly-typed target while the debounced re-fire is
+    // pending. `canInstall` requires `preflightData`, so this alone is what
+    // keeps Install disabled for the whole debounce window, not just the
+    // network round trip that follows it.
+    resetPreflight();
+    if (preflightDebounceRef.current) clearTimeout(preflightDebounceRef.current);
+    preflightDebounceRef.current = setTimeout(() => {
       runPreflight(preflightBody);
+    }, PREFLIGHT_DEBOUNCE_MS);
+    return () => {
+      if (preflightDebounceRef.current) clearTimeout(preflightDebounceRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedProjectId, creatingNew, newOwner, newName, trimmedSubdomain]);
+
+  // Seed the placeholder default from the first preflight response only —
+  // the manifest's default subdomain doesn't change across projects, so
+  // later responses (from a project change, or the operator's own override)
+  // must not keep stomping a placeholder already on screen.
+  useEffect(() => {
+    if (defaultSubdomainLabel === undefined && preflightData?.appHost) {
+      setDefaultSubdomainLabel(preflightData.appHost.split('.')[0]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedProjectId, creatingNew, newOwner, newName]);
+  }, [preflightData?.appHost]);
 
   const handleProjectChange = (value: string) => {
     if (value === NEW_PROJECT_VALUE) {
@@ -309,18 +356,29 @@ export function InstallDialog({
               </div>
             )}
 
+            {preflightData?.appHost !== null && (
+              <div className="space-y-2">
+                <Label htmlFor="install-subdomain">Subdomain</Label>
+                <Input
+                  id="install-subdomain"
+                  value={subdomain}
+                  onChange={(e) => setSubdomain(e.target.value)}
+                  placeholder={defaultSubdomainLabel}
+                />
+                {preflightData?.appUrl && (
+                  <p className="text-xs text-muted-foreground">
+                    Will be available at <code className="text-xs">{preflightData.appUrl}</code>
+                  </p>
+                )}
+              </div>
+            )}
+
             {isPreflighting && !preflightData && (
               <p className="text-sm text-muted-foreground">Checking…</p>
             )}
 
             {preflightData && (
               <>
-                {preflightData.appUrl && (
-                  <p className="text-sm">
-                    App URL: <code className="text-xs">{preflightData.appUrl}</code>
-                  </p>
-                )}
-
                 <div className="space-y-2">
                   {preflightData.gates.map((gate) => (
                     <div key={gate.id} className="flex items-start gap-2 rounded-md border p-2">

--- a/apps/frontend/src/components/app-catalog/UninstallDialog.tsx
+++ b/apps/frontend/src/components/app-catalog/UninstallDialog.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { useToast } from '@/hooks/use-toast';
+import {
+  useGetUninstallPreviewQuery,
+  useUninstallAppMutation,
+  type CatalogEntry,
+} from '@/services/appCatalogApi';
+
+interface UninstallDialogProps {
+  entry: CatalogEntry;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * UninstallDialog — the dedicated uninstall confirmation (Task 14 of the
+ * app-catalog spec). Replaces the simple confirm-only AlertDialog that
+ * shipped inline in AppCard for Task 12: this version loads the real
+ * preview (`useGetUninstallPreviewQuery`) so the "delete data tables"
+ * checkbox can show the actual record counts before the user commits.
+ */
+export function UninstallDialog({ entry, open, onOpenChange }: UninstallDialogProps) {
+  const { toast } = useToast();
+  const { installed } = entry;
+  const [deleteData, setDeleteData] = useState(false);
+
+  const { data: preview } = useGetUninstallPreviewQuery(installed?.installedAppId ?? '', {
+    skip: !open || !installed,
+  });
+  const [uninstallApp, { isLoading }] = useUninstallAppMutation();
+
+  const dataTables = preview?.dataTables ?? [];
+  const deletableTables = dataTables.filter((table) => table.createdByInstall);
+  const keptTables = dataTables.filter((table) => !table.createdByInstall);
+  const deletableRecordCount = deletableTables.reduce((sum, table) => sum + table.recordCount, 0);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setDeleteData(false);
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const handleConfirm = async () => {
+    if (!installed) return;
+    try {
+      const summary = await uninstallApp({ id: installed.installedAppId, deleteData }).unwrap();
+      toast({ title: `${entry.name} uninstalled`, description: summary.note });
+      handleOpenChange(false);
+    } catch (err) {
+      const message = (err as { data?: { message?: string } })?.data?.message ?? 'Uninstall failed';
+      toast({ title: 'Error', description: message, variant: 'destructive' });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{`Uninstall ${entry.name}?`}</DialogTitle>
+          <DialogDescription>
+            Removes the app&apos;s rule sets, alias, domain, and deployment. Your data tables
+            and uploaded files are kept.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="flex items-start gap-2">
+            <Checkbox
+              id="uninstall-delete-data"
+              checked={deleteData}
+              onCheckedChange={(checked) => setDeleteData(checked === true)}
+            />
+            <Label htmlFor="uninstall-delete-data" className="font-normal">
+              Also delete the app&apos;s data tables
+            </Label>
+          </div>
+
+          {deleteData && (
+            <p className="text-sm text-muted-foreground">
+              {deletableTables.length > 0
+                ? `this deletes ${deletableRecordCount} records across ${deletableTables.length} tables`
+                : "This install didn't create any data tables of its own — nothing extra to delete."}
+            </p>
+          )}
+
+          {keptTables.length > 0 && (
+            <div className="text-sm">
+              <p className="font-medium">Kept regardless (reused, not created by this install):</p>
+              <ul className="mt-1 list-disc pl-5 text-muted-foreground">
+                {keptTables.map((table) => (
+                  <li key={table.name}>{`${table.name} (${table.recordCount} records)`}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={handleConfirm} disabled={isLoading || !installed}>
+            {isLoading ? 'Uninstalling…' : 'Uninstall'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/app-catalog/UninstallDialog.tsx
+++ b/apps/frontend/src/components/app-catalog/UninstallDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
@@ -34,6 +35,7 @@ export function UninstallDialog({ entry, open, onOpenChange }: UninstallDialogPr
   const { toast } = useToast();
   const { installed } = entry;
   const [deleteData, setDeleteData] = useState(false);
+  const [failures, setFailures] = useState<string[] | null>(null);
 
   const { data: preview } = useGetUninstallPreviewQuery(installed?.installedAppId ?? '', {
     skip: !open || !installed,
@@ -48,6 +50,7 @@ export function UninstallDialog({ entry, open, onOpenChange }: UninstallDialogPr
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
       setDeleteData(false);
+      setFailures(null);
     }
     onOpenChange(nextOpen);
   };
@@ -56,6 +59,19 @@ export function UninstallDialog({ entry, open, onOpenChange }: UninstallDialogPr
     if (!installed) return;
     try {
       const summary = await uninstallApp({ id: installed.installedAppId, deleteData }).unwrap();
+      // The backend deliberately keeps the installed_apps row when some
+      // cleanup steps fail, so the user can retry — don't tell them it
+      // succeeded, and don't close the dialog out from under a retry.
+      if (summary.failures && summary.failures.length > 0) {
+        setFailures(summary.failures);
+        toast({
+          title: 'Uninstall incomplete',
+          description: `Failed to remove: ${summary.failures.join(', ')}. The install was kept — retry when ready.`,
+          variant: 'destructive',
+        });
+        return;
+      }
+      setFailures(null);
       toast({ title: `${entry.name} uninstalled`, description: summary.note });
       handleOpenChange(false);
     } catch (err) {
@@ -76,6 +92,14 @@ export function UninstallDialog({ entry, open, onOpenChange }: UninstallDialogPr
         </DialogHeader>
 
         <div className="space-y-3">
+          {failures && failures.length > 0 && (
+            <Alert variant="destructive">
+              <AlertDescription>
+                {`Uninstall incomplete — failed to remove: ${failures.join(', ')}. The install was kept so you can retry.`}
+              </AlertDescription>
+            </Alert>
+          )}
+
           <div className="flex items-start gap-2">
             <Checkbox
               id="uninstall-delete-data"
@@ -112,7 +136,7 @@ export function UninstallDialog({ entry, open, onOpenChange }: UninstallDialogPr
             Cancel
           </Button>
           <Button variant="destructive" onClick={handleConfirm} disabled={isLoading || !installed}>
-            {isLoading ? 'Uninstalling…' : 'Uninstall'}
+            {isLoading ? 'Uninstalling…' : failures ? 'Retry uninstall' : 'Uninstall'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
@@ -1,13 +1,23 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 import { AppCard } from '../AppCard';
 import type { CatalogEntry } from '@/services/appCatalogApi';
 
+const updateTrigger = vi.fn();
+
 vi.mock('@/services/appCatalogApi', () => ({
-  useUpdateAppMutation: () => [vi.fn(), { isLoading: false }],
+  useUpdateAppMutation: () => [updateTrigger, { isLoading: false }],
   useUninstallAppMutation: () => [vi.fn(), { isLoading: false }],
-  useGetUninstallPreviewQuery: () => ({ data: undefined, isLoading: false }),
-  useLazyGetEjectPayloadQuery: () => [vi.fn(), { data: undefined, isLoading: false }],
+  useGetUninstallPreviewQuery: () => ({ data: undefined }),
+  useGetEjectPayloadQuery: () => ({ data: undefined, isFetching: false }),
+}));
+
+vi.mock('@/services/apiKeysApi', () => ({
+  useCreateApiKeyMutation: () => [vi.fn(), { isLoading: false }],
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
 }));
 
 const baseEntry: CatalogEntry = {
@@ -18,9 +28,13 @@ const baseEntry: CatalogEntry = {
   installable: true,
 };
 
+beforeEach(() => {
+  updateTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({ jobId: 'job-1' }) });
+});
+
 describe('AppCard', () => {
   it('renders an enabled Install button when installable', () => {
-    render(<AppCard entry={baseEntry} onInstall={vi.fn()} />);
+    render(<AppCard entry={baseEntry} onInstall={vi.fn()} onUpdateStarted={vi.fn()} />);
 
     const button = screen.getByRole('button', { name: /install/i });
     expect(button).toBeEnabled();
@@ -41,7 +55,7 @@ describe('AppCard', () => {
       ],
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onUpdateStarted={vi.fn()} />);
 
     expect(screen.getByText('Requires bucket storage')).toBeInTheDocument();
     const button = screen.getByRole('button', { name: /requires bucket storage/i });
@@ -66,7 +80,7 @@ describe('AppCard', () => {
       },
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onUpdateStarted={vi.fn()} />);
 
     expect(screen.getByText('Installed · v1.2.0')).toBeInTheDocument();
     const openLink = screen.getByRole('link', { name: /open/i });
@@ -91,8 +105,70 @@ describe('AppCard', () => {
       },
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onUpdateStarted={vi.fn()} />);
 
     expect(screen.getByRole('button', { name: /update to v2\.0\.0/i })).toBeInTheDocument();
+  });
+
+  it('opens a confirm popover with the prune toggle defaulted off, and fires the update with prune: false', async () => {
+    const onUpdateStarted = vi.fn();
+    const entry: CatalogEntry = {
+      ...baseEntry,
+      registryVersion: '2.0.0',
+      installed: {
+        installedAppId: 'installed-1',
+        version: '1.2.0',
+        projectId: 'proj-1',
+        projectName: 'acme/handoff',
+        alias: 'production',
+        appUrl: 'https://handoff.example.com',
+        status: 'installed',
+        updateAvailable: true,
+        manualSteps: [],
+        manualStepsAcked: [],
+      },
+    };
+
+    render(<AppCard entry={entry} onInstall={vi.fn()} onUpdateStarted={onUpdateStarted} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /update to v2\.0\.0/i }));
+
+    const pruneToggle = screen.getByRole('switch', { name: /reset to the app's shipped rules \(prune\)/i });
+    expect(pruneToggle).not.toBeChecked();
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm update/i }));
+
+    expect(updateTrigger).toHaveBeenCalledWith({ id: 'installed-1', prune: false });
+    await vi.waitFor(() => {
+      expect(onUpdateStarted).toHaveBeenCalledWith(entry, 'job-1');
+    });
+  });
+
+  it('fires the update with prune: true when the toggle is switched on', async () => {
+    const onUpdateStarted = vi.fn();
+    const entry: CatalogEntry = {
+      ...baseEntry,
+      registryVersion: '2.0.0',
+      installed: {
+        installedAppId: 'installed-1',
+        version: '1.2.0',
+        projectId: 'proj-1',
+        projectName: 'acme/handoff',
+        alias: 'production',
+        appUrl: 'https://handoff.example.com',
+        status: 'installed',
+        updateAvailable: true,
+        manualSteps: [],
+        manualStepsAcked: [],
+      },
+    };
+
+    render(<AppCard entry={entry} onInstall={vi.fn()} onUpdateStarted={onUpdateStarted} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /update to v2\.0\.0/i }));
+    fireEvent.click(screen.getByRole('switch', { name: /reset to the app's shipped rules \(prune\)/i }));
+    fireEvent.click(screen.getByRole('button', { name: /confirm update/i }));
+
+    expect(updateTrigger).toHaveBeenCalledWith({ id: 'installed-1', prune: true });
   });
 });

--- a/apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { AppCard } from '../AppCard';
+import type { CatalogEntry } from '@/services/appCatalogApi';
+
+vi.mock('@/services/appCatalogApi', () => ({
+  useUpdateAppMutation: () => [vi.fn(), { isLoading: false }],
+  useUninstallAppMutation: () => [vi.fn(), { isLoading: false }],
+  useGetUninstallPreviewQuery: () => ({ data: undefined, isLoading: false }),
+  useLazyGetEjectPayloadQuery: () => [vi.fn(), { data: undefined, isLoading: false }],
+}));
+
+const baseEntry: CatalogEntry = {
+  id: 'handoff',
+  name: 'Handoff',
+  summary: 'Share files with clients',
+  gates: [],
+  installable: true,
+};
+
+describe('AppCard', () => {
+  it('renders an enabled Install button when installable', () => {
+    render(<AppCard entry={baseEntry} onInstall={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: /install/i });
+    expect(button).toBeEnabled();
+  });
+
+  it('disables the CTA with the failing gate message when a gate fails', () => {
+    const entry: CatalogEntry = {
+      ...baseEntry,
+      installable: false,
+      gates: [
+        {
+          id: 'storage',
+          status: 'fail',
+          message: 'Requires bucket storage',
+          remediation: 'Switch to S3/MinIO/GCS/Azure storage in Admin Settings.',
+          deepLink: '/admin/settings/infrastructure',
+        },
+      ],
+    };
+
+    render(<AppCard entry={entry} onInstall={vi.fn()} />);
+
+    expect(screen.getByText('Requires bucket storage')).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: /requires bucket storage/i });
+    expect(button).toBeDisabled();
+    expect(screen.getByRole('button', { name: /why\?/i })).toBeInTheDocument();
+  });
+
+  it('shows the Installed badge and an Open link when installed', () => {
+    const entry: CatalogEntry = {
+      ...baseEntry,
+      installed: {
+        installedAppId: 'installed-1',
+        version: '1.2.0',
+        projectId: 'proj-1',
+        projectName: 'acme/handoff',
+        alias: 'production',
+        appUrl: 'https://handoff.example.com',
+        status: 'installed',
+        updateAvailable: false,
+        manualSteps: [],
+        manualStepsAcked: [],
+      },
+    };
+
+    render(<AppCard entry={entry} onInstall={vi.fn()} />);
+
+    expect(screen.getByText('Installed · v1.2.0')).toBeInTheDocument();
+    const openLink = screen.getByRole('link', { name: /open/i });
+    expect(openLink).toHaveAttribute('href', 'https://handoff.example.com');
+  });
+
+  it('shows the Update CTA when an update is available', () => {
+    const entry: CatalogEntry = {
+      ...baseEntry,
+      registryVersion: '2.0.0',
+      installed: {
+        installedAppId: 'installed-1',
+        version: '1.2.0',
+        projectId: 'proj-1',
+        projectName: 'acme/handoff',
+        alias: 'production',
+        appUrl: 'https://handoff.example.com',
+        status: 'installed',
+        updateAvailable: true,
+        manualSteps: [],
+        manualStepsAcked: [],
+      },
+    };
+
+    render(<AppCard entry={entry} onInstall={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /update to v2\.0\.0/i })).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
@@ -110,6 +110,43 @@ describe('AppCard', () => {
     expect(screen.getByRole('button', { name: /update to v2\.0\.0/i })).toBeInTheDocument();
   });
 
+  it('disables the Update CTA with the gate message when an instance gate fails', () => {
+    // An update re-runs the instance gates server-side and would refuse at
+    // its preflight step, so the CTA must not look actionable.
+    const entry: CatalogEntry = {
+      ...baseEntry,
+      installable: false,
+      registryVersion: '2.0.0',
+      gates: [
+        {
+          id: 'ce-version',
+          status: 'fail',
+          message: 'Requires CE v0.4.0 or later',
+          remediation: 'Upgrade this BFFless CE instance to v0.4.0 or later.',
+        },
+      ],
+      installed: {
+        installedAppId: 'installed-1',
+        version: '1.2.0',
+        projectId: 'proj-1',
+        projectName: 'acme/handoff',
+        alias: 'production',
+        appUrl: 'https://handoff.example.com',
+        status: 'installed',
+        updateAvailable: true,
+        manualSteps: [],
+        manualStepsAcked: [],
+      },
+    };
+
+    render(<AppCard entry={entry} onInstall={vi.fn()} onUpdateStarted={vi.fn()} />);
+
+    expect(screen.queryByRole('button', { name: /update to v2\.0\.0/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /requires ce v0\.4\.0 or later/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /why\?/i })).toBeInTheDocument();
+    expect(updateTrigger).not.toHaveBeenCalled();
+  });
+
   it('opens a confirm popover with the prune toggle defaulted off, and fires the update with prune: false', async () => {
     const onUpdateStarted = vi.fn();
     const entry: CatalogEntry = {

--- a/apps/frontend/src/components/app-catalog/__tests__/EjectPanel.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/EjectPanel.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { EjectPanel } from '../EjectPanel';
+import type { CatalogEntry, EjectPayload } from '@/services/appCatalogApi';
+import type { CreateApiKeyResponse } from '@/services/apiKeysApi';
+
+const getEjectPayloadQueryMock = vi.fn<
+  (id: string, options?: { skip?: boolean }) => { data?: EjectPayload; isFetching: boolean }
+>(() => ejectState);
+const createApiKeyTrigger = vi.fn();
+
+let ejectState: { data?: EjectPayload; isFetching: boolean } = { data: undefined, isFetching: false };
+let createApiKeyState: { isLoading: boolean } = { isLoading: false };
+const toastMock = vi.fn();
+
+vi.mock('@/services/appCatalogApi', () => ({
+  useGetEjectPayloadQuery: (id: string, options?: { skip?: boolean }) =>
+    getEjectPayloadQueryMock(id, options),
+}));
+
+vi.mock('@/services/apiKeysApi', () => ({
+  useCreateApiKeyMutation: () => [createApiKeyTrigger, createApiKeyState],
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText: vi.fn().mockResolvedValue(undefined) },
+  configurable: true,
+});
+
+const entry: CatalogEntry = {
+  id: 'handoff',
+  name: 'Handoff',
+  gates: [],
+  installable: true,
+  installed: {
+    installedAppId: 'installed-1',
+    version: '1.2.0',
+    projectId: 'proj-1',
+    projectName: 'acme/handoff',
+    alias: 'production',
+    appUrl: 'https://handoff.example.com',
+    status: 'installed',
+    updateAvailable: false,
+    manualSteps: [],
+    manualStepsAcked: [],
+  },
+};
+
+function makePayload(overrides: Partial<EjectPayload> = {}): EjectPayload {
+  return {
+    repo: 'bffless/handoff',
+    appPath: 'apps/handoff',
+    deployWorkflow: 'deploy-handoff.yml',
+    forkUrl: 'https://github.com/bffless/handoff/fork',
+    variables: {
+      BFFLESS_URL: 'https://admin.example.com',
+      BFFLESS_PROJECT: 'acme/handoff',
+    },
+    secrets: ['BFFLESS_API_KEY'],
+    alias: 'production',
+    note: "The workflow's first deploy lands on this same alias.",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  getEjectPayloadQueryMock.mockClear();
+  ejectState = { data: makePayload(), isFetching: false };
+  createApiKeyState = { isLoading: false };
+  toastMock.mockReset();
+  createApiKeyTrigger.mockReset();
+});
+
+describe('EjectPanel', () => {
+  it('renders the fork link and Actions variables with copy buttons', () => {
+    render(<EjectPanel entry={entry} open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByRole('link', { name: /fork on github/i })).toHaveAttribute(
+      'href',
+      'https://github.com/bffless/handoff/fork',
+    );
+    expect(screen.getByText('BFFLESS_URL')).toBeInTheDocument();
+    expect(screen.getByText('https://admin.example.com')).toBeInTheDocument();
+    expect(screen.getByText('BFFLESS_PROJECT')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /copy bffless_url/i })).toBeInTheDocument();
+  });
+
+  it('renders the secrets list with an inline Mint API key button', () => {
+    render(<EjectPanel entry={entry} open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText('BFFLESS_API_KEY')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /mint api key/i })).toBeInTheDocument();
+  });
+
+  it('mints an API key scoped to the app project when clicked', async () => {
+    const response: CreateApiKeyResponse = {
+      message: 'ok',
+      data: { id: 'key-1', name: 'x', projectId: 'proj-1', expiresAt: null, createdAt: '2026-07-30' },
+      key: 'bffless_sk_abc123',
+    };
+    createApiKeyTrigger.mockReturnValue({ unwrap: () => Promise.resolve(response) });
+
+    render(<EjectPanel entry={entry} open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /mint api key/i }));
+
+    expect(createApiKeyTrigger).toHaveBeenCalledWith(
+      expect.objectContaining({ repository: 'acme/handoff' }),
+    );
+    expect(await screen.findByText('bffless_sk_abc123')).toBeInTheDocument();
+  });
+
+  it('renders the workflow name to run', () => {
+    render(<EjectPanel entry={entry} open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText('deploy-handoff.yml')).toBeInTheDocument();
+  });
+
+  it('renders the continuity note verbatim', () => {
+    render(<EjectPanel entry={entry} open onOpenChange={vi.fn()} />);
+
+    expect(
+      screen.getByText(
+        "The workflow's first deploy lands on this same alias — your install becomes the fork's deploy target.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
@@ -8,9 +8,11 @@ import type {
 } from '@/services/appCatalogApi';
 
 const preflightTrigger = vi.fn();
+const resetPreflightMock = vi.fn();
 const installTrigger = vi.fn();
 const undoTrigger = vi.fn();
 const ackTrigger = vi.fn();
+const getInstallJobQueryMock = vi.fn((_jobId: string, _options?: { pollingInterval?: number; skip?: boolean }) => jobQueryResult);
 
 let preflightState: { data?: PreflightResponse; isLoading: boolean } = {
   data: undefined,
@@ -22,9 +24,15 @@ let undoState: { isLoading: boolean } = { isLoading: false };
 let ackState: { isLoading: boolean } = { isLoading: false };
 
 vi.mock('@/services/appCatalogApi', () => ({
-  usePreflightAppMutation: () => [preflightTrigger, preflightState],
+  usePreflightAppMutation: () => [
+    preflightTrigger,
+    { ...preflightState, reset: resetPreflightMock },
+  ],
   useInstallAppMutation: () => [installTrigger, installState],
-  useGetInstallJobQuery: () => jobQueryResult,
+  useGetInstallJobQuery: (
+    jobId: string,
+    options?: { pollingInterval?: number; skip?: boolean },
+  ) => getInstallJobQueryMock(jobId, options),
   useUndoJobMutation: () => [undoTrigger, undoState],
   useAckManualStepMutation: () => [ackTrigger, ackState],
 }));
@@ -92,9 +100,11 @@ function makeJob(overrides: Partial<InstallJob> = {}): InstallJob {
 
 beforeEach(() => {
   preflightTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve(makePreflight()) });
+  resetPreflightMock.mockReset();
   installTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({ jobId: 'job-1' }) });
   undoTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({}) });
   ackTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({ acked: [] }) });
+  getInstallJobQueryMock.mockClear();
   preflightState = { data: makePreflight(), isLoading: false };
   installState = { isLoading: false };
   jobQueryResult = { data: undefined };
@@ -187,6 +197,36 @@ describe('InstallDialog — Review screen', () => {
     expect(screen.getByRole('button', { name: /^install$/i })).toBeEnabled();
   });
 
+  it('disables Install while a new preflight is in flight, even against clean stale data from the previous selection', () => {
+    // RTK Query mutation hooks keep the previous `data` around until the new
+    // request settles — `isLoading` flips to true well before `data` is
+    // replaced. Reproduce that: the still-clean, all-pass preflight from the
+    // prior selection is still sitting in `data` while a new one is pending.
+    preflightState = { data: makePreflight(), isLoading: true };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /^install$/i })).toBeDisabled();
+  });
+
+  it('resets the preflight result when the selection changes, before requesting a new one', () => {
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    // The initial mount already ran a preflight for the preselected project;
+    // isolate the assertion to the effect of the selection actually changing.
+    resetPreflightMock.mockClear();
+    preflightTrigger.mockClear();
+
+    fireEvent.change(screen.getByRole('combobox', { name: /project/i }), {
+      target: { value: 'new' },
+    });
+    fireEvent.change(screen.getByLabelText(/owner/i), { target: { value: 'acme' } });
+    fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: 'new-site' } });
+
+    expect(resetPreflightMock).toHaveBeenCalled();
+    expect(preflightTrigger).toHaveBeenCalled();
+  });
+
   it('shows the "Why?" remediation for a failed gate', () => {
     preflightState = {
       data: makePreflight({
@@ -242,6 +282,30 @@ describe('InstallDialog — Working screen', () => {
     expect(await screen.findByText(/fetch app bundle/i)).toBeInTheDocument();
     expect(screen.getByText(/sync proxy rules/i)).toBeInTheDocument();
     expect(screen.getByText(/^deploy$/i)).toBeInTheDocument();
+  });
+
+  it('keeps polling (pollingInterval 1000) while the job is still running', async () => {
+    jobQueryResult = { data: makeJob({ status: 'running' }) };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+
+    await screen.findByText(/sync proxy rules/i);
+
+    const lastCall = getInstallJobQueryMock.mock.calls.at(-1);
+    expect(lastCall?.[1]).toMatchObject({ pollingInterval: 1000, skip: false });
+  });
+
+  it('stops polling (pollingInterval 0) once the job reaches a terminal status', async () => {
+    jobQueryResult = { data: makeJob({ status: 'succeeded', appUrl: 'https://handoff.example.com' }) };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+
+    await screen.findByRole('link', { name: /open/i });
+
+    const lastCall = getInstallJobQueryMock.mock.calls.at(-1);
+    expect(lastCall?.[1]).toMatchObject({ pollingInterval: 0 });
   });
 
   it('shows the detail text for an action-required step', async () => {

--- a/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen, fireEvent, within } from '@testing-library/react';
 import { vi } from 'vitest';
 import { InstallDialog } from '../InstallDialog';
+import { api } from '@/services/api';
 import type {
   CatalogEntry,
   InstallJob,
@@ -55,6 +56,12 @@ vi.mock('@/hooks/use-toast', () => ({
   useToast: () => ({ toast: vi.fn() }),
 }));
 
+const dispatchMock = vi.fn();
+
+vi.mock('@/store/hooks', () => ({
+  useAppDispatch: () => dispatchMock,
+}));
+
 const baseEntry: CatalogEntry = {
   id: 'handoff',
   name: 'Handoff',
@@ -107,6 +114,7 @@ beforeEach(() => {
   undoTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({}) });
   ackTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({ acked: [] }) });
   getInstallJobQueryMock.mockClear();
+  dispatchMock.mockClear();
   preflightState = { data: makePreflight(), isLoading: false };
   installState = { isLoading: false };
   jobQueryResult = { data: undefined };
@@ -614,5 +622,91 @@ describe('InstallDialog — update mode reuse', () => {
     );
 
     expect(screen.getByText(`${baseEntry.name} updated`)).toBeInTheDocument();
+  });
+});
+
+describe('InstallDialog — catalog cache invalidation on job completion', () => {
+  // Regression coverage for the live-test bug: installApp/updateApp
+  // invalidate ['AppCatalog', 'InstalledApp'] at DISPATCH time, before the
+  // background job has done anything, so the catalog card is stuck showing
+  // pre-update state until a manual reload. The dialog must invalidate again
+  // itself, once, the moment its polling observes a terminal job status.
+
+  it('dispatches invalidateTags exactly once when the job transitions running -> succeeded', async () => {
+    jobQueryResult = { data: makeJob({ status: 'running' }) };
+    const { rerender } = render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+    await screen.findByText(/sync proxy rules/i);
+    expect(dispatchMock).not.toHaveBeenCalled();
+
+    jobQueryResult = {
+      data: makeJob({ status: 'succeeded', appUrl: 'https://handoff.example.com' }),
+    };
+    rerender(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+    await screen.findByRole('link', { name: /open/i });
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      api.util.invalidateTags(['AppCatalog', 'InstalledApp']),
+    );
+  });
+
+  it('does not dispatch invalidateTags again across further re-renders while the job stays terminal', async () => {
+    jobQueryResult = {
+      data: makeJob({ status: 'succeeded', appUrl: 'https://handoff.example.com' }),
+    };
+    const { rerender } = render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+    await screen.findByRole('link', { name: /open/i });
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    dispatchMock.mockClear();
+
+    // Further poll ticks / re-renders that keep observing the same terminal
+    // job (still status 'succeeded', same job id) must not invalidate again.
+    rerender(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+    rerender(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatches invalidateTags once when the job transitions to 'undone'", async () => {
+    jobQueryResult = { data: makeJob({ status: 'running' }) };
+    const { rerender } = render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+    await screen.findByText(/sync proxy rules/i);
+    expect(dispatchMock).not.toHaveBeenCalled();
+
+    jobQueryResult = { data: makeJob({ status: 'undone' }) };
+    rerender(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      api.util.invalidateTags(['AppCatalog', 'InstalledApp']),
+    );
+  });
+
+  it('never dispatches invalidateTags while the job stays running', async () => {
+    jobQueryResult = { data: makeJob({ status: 'running' }) };
+    const { rerender } = render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+    await screen.findByText(/sync proxy rules/i);
+    expect(dispatchMock).not.toHaveBeenCalled();
+
+    // Simulate more poll ticks — still running, just further along.
+    jobQueryResult = {
+      data: makeJob({
+        status: 'running',
+        steps: [
+          { id: 'preflight', status: 'done' },
+          { id: 'fetch', status: 'done' },
+          { id: 'sync-rules', status: 'done' },
+          { id: 'deploy', status: 'running' },
+        ],
+      }),
+    };
+    rerender(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+    await screen.findByText(/^deploy$/i);
+
+    expect(dispatchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
@@ -12,7 +12,9 @@ const resetPreflightMock = vi.fn();
 const installTrigger = vi.fn();
 const undoTrigger = vi.fn();
 const ackTrigger = vi.fn();
-const getInstallJobQueryMock = vi.fn((_jobId: string, _options?: { pollingInterval?: number; skip?: boolean }) => jobQueryResult);
+const getInstallJobQueryMock = vi.fn<
+  (jobId: string, options?: { pollingInterval?: number; skip?: boolean }) => { data?: InstallJob }
+>(() => jobQueryResult);
 
 let preflightState: { data?: PreflightResponse; isLoading: boolean } = {
   data: undefined,
@@ -406,5 +408,43 @@ describe('InstallDialog — Done screen', () => {
 
     const checkbox = await screen.findByRole('checkbox', { name: /set the signing_secret/i });
     expect(checkbox).toBeChecked();
+  });
+});
+
+describe('InstallDialog — update mode reuse', () => {
+  it('skips the Review screen and goes straight to Working when opened with an initialJobId', () => {
+    jobQueryResult = { data: makeJob({ kind: 'update', status: 'running' }) };
+
+    render(
+      <InstallDialog
+        entry={baseEntry}
+        open
+        onOpenChange={vi.fn()}
+        mode="update"
+        initialJobId="job-1"
+      />,
+    );
+
+    expect(screen.getByText(/sync proxy rules/i)).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: /project/i })).not.toBeInTheDocument();
+    expect(screen.getByText(`Updating ${baseEntry.name}`)).toBeInTheDocument();
+  });
+
+  it('shows the "updated" title on the Done screen', () => {
+    jobQueryResult = {
+      data: makeJob({ kind: 'update', status: 'succeeded', appUrl: 'https://handoff.example.com' }),
+    };
+
+    render(
+      <InstallDialog
+        entry={baseEntry}
+        open
+        onOpenChange={vi.fn()}
+        mode="update"
+        initialJobId="job-1"
+      />,
+    );
+
+    expect(screen.getByText(`${baseEntry.name} updated`)).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { act, render, screen, fireEvent, within } from '@testing-library/react';
 import { vi } from 'vitest';
 import { InstallDialog } from '../InstallDialog';
 import type {
@@ -211,22 +211,39 @@ describe('InstallDialog — Review screen', () => {
     expect(screen.getByRole('button', { name: /^install$/i })).toBeDisabled();
   });
 
-  it('resets the preflight result when the selection changes, before requesting a new one', () => {
-    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+  it('resets the preflight result immediately on selection change, debouncing the re-fire', () => {
+    vi.useFakeTimers();
+    try {
+      render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
 
-    // The initial mount already ran a preflight for the preselected project;
-    // isolate the assertion to the effect of the selection actually changing.
-    resetPreflightMock.mockClear();
-    preflightTrigger.mockClear();
+      // The initial mount already ran a preflight for the preselected project;
+      // isolate the assertion to the effect of the selection actually changing.
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      resetPreflightMock.mockClear();
+      preflightTrigger.mockClear();
 
-    fireEvent.change(screen.getByRole('combobox', { name: /project/i }), {
-      target: { value: 'new' },
-    });
-    fireEvent.change(screen.getByLabelText(/owner/i), { target: { value: 'acme' } });
-    fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: 'new-site' } });
+      fireEvent.change(screen.getByRole('combobox', { name: /project/i }), {
+        target: { value: 'new' },
+      });
+      fireEvent.change(screen.getByLabelText(/owner/i), { target: { value: 'acme' } });
+      fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: 'new-site' } });
 
-    expect(resetPreflightMock).toHaveBeenCalled();
-    expect(preflightTrigger).toHaveBeenCalled();
+      // The reset (which clears stale `preflightData`, so `canInstall` is
+      // false) is synchronous — it must not wait for the debounce.
+      expect(resetPreflightMock).toHaveBeenCalled();
+      // But the actual network re-fire is debounced — not yet.
+      expect(preflightTrigger).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+
+      expect(preflightTrigger).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('shows the "Why?" remediation for a failed gate', () => {
@@ -270,6 +287,127 @@ describe('InstallDialog — Review screen', () => {
     expect(
       screen.getByText("A project's owner/name can never be renamed."),
     ).toBeInTheDocument();
+  });
+
+  it('shows the subdomain field empty, placeholder-defaulted from the first preflight appHost', () => {
+    preflightState = { data: makePreflight({ appHost: 'handoff.example.com' }), isLoading: false };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    const input = screen.getByLabelText(/subdomain/i) as HTMLInputElement;
+    expect(input.value).toBe('');
+    expect(input.placeholder).toBe('handoff');
+  });
+
+  it('shows the resulting URL from the preflight response next to the subdomain field', () => {
+    preflightState = {
+      data: makePreflight({ appHost: 'handoff.example.com', appUrl: 'https://handoff.example.com' }),
+      isLoading: false,
+    };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText('https://handoff.example.com')).toBeInTheDocument();
+  });
+
+  it('debounces the subdomain field: resets immediately, re-fires preflight only after the delay, with subdomain in the body', () => {
+    vi.useFakeTimers();
+    try {
+      render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      resetPreflightMock.mockClear();
+      preflightTrigger.mockClear();
+
+      fireEvent.change(screen.getByLabelText(/subdomain/i), { target: { value: 'my-app' } });
+
+      expect(resetPreflightMock).toHaveBeenCalled();
+      expect(preflightTrigger).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+
+      expect(preflightTrigger).toHaveBeenCalledTimes(1);
+      expect(preflightTrigger).toHaveBeenCalledWith({
+        appId: 'handoff',
+        body: { projectId: 'proj-1', subdomain: 'my-app' },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('omits subdomain from the preflight body when the field is left empty', () => {
+    vi.useFakeTimers();
+    try {
+      render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+
+      expect(preflightTrigger).toHaveBeenCalledWith({
+        appId: 'handoff',
+        body: { projectId: 'proj-1' },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps Install disabled for the whole debounce window after a subdomain keystroke', () => {
+    vi.useFakeTimers();
+    try {
+      const { rerender } = render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+      // Mount's own preflight settles against the seeded `preflightState`
+      // (untouched so far); Install starts enabled.
+      expect(screen.getByRole('button', { name: /^install$/i })).toBeEnabled();
+
+      // From here on, mirror the real RTK Query mutation: reset() clears
+      // `data`, which is exactly what makes `canInstall` false — the mocked
+      // hook otherwise has no reactivity of its own to observe.
+      resetPreflightMock.mockImplementation(() => {
+        preflightState = { ...preflightState, data: undefined };
+      });
+      preflightTrigger.mockClear();
+
+      fireEvent.change(screen.getByLabelText(/subdomain/i), { target: { value: 'my-app' } });
+      rerender(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+      expect(screen.getByRole('button', { name: /^install$/i })).toBeDisabled();
+      expect(preflightTrigger).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+      expect(preflightTrigger).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('sends the same subdomain the last preflight showed when installing', async () => {
+    preflightState = {
+      data: makePreflight({ appHost: 'my-app.example.com', appUrl: 'https://my-app.example.com' }),
+      isLoading: false,
+    };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/subdomain/i), { target: { value: 'my-app' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+    });
+
+    expect(installTrigger).toHaveBeenCalledWith({
+      appId: 'handoff',
+      body: { projectId: 'proj-1', subdomain: 'my-app' },
+    });
   });
 });
 

--- a/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
@@ -430,6 +430,36 @@ describe('InstallDialog — update mode reuse', () => {
     expect(screen.getByText(`Updating ${baseEntry.name}`)).toBeInTheDocument();
   });
 
+  it('offers Close but never Undo when a failed job is an update', () => {
+    // Undo tears down the whole install from its cumulative createdResources
+    // — data tables included — so it must not be one click away from a failed
+    // update. The alias's deployment history is the rollback path instead.
+    jobQueryResult = {
+      data: makeJob({ kind: 'update', status: 'failed', error: 'Fetch failed: socket hang up' }),
+    };
+
+    render(
+      <InstallDialog
+        entry={baseEntry}
+        open
+        onOpenChange={vi.fn()}
+        mode="update"
+        initialJobId="job-1"
+      />,
+    );
+
+    expect(screen.getByText('Fetch failed: socket hang up')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /undo/i })).not.toBeInTheDocument();
+    // The dialog chrome's own X also exposes an accessible name of "Close" —
+    // the footer button is the one without the sr-only label.
+    const footerClose = screen
+      .getAllByRole('button', { name: /^close$/i })
+      .find((button) => !button.querySelector('.sr-only'));
+    expect(footerClose).toBeDefined();
+    expect(screen.getByText(/nothing was removed/i)).toBeInTheDocument();
+    expect(undoTrigger).not.toHaveBeenCalled();
+  });
+
   it('shows the "updated" title on the Done screen', () => {
     jobQueryResult = {
       data: makeJob({ kind: 'update', status: 'succeeded', appUrl: 'https://handoff.example.com' }),

--- a/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
@@ -1,0 +1,346 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { vi } from 'vitest';
+import { InstallDialog } from '../InstallDialog';
+import type {
+  CatalogEntry,
+  InstallJob,
+  PreflightResponse,
+} from '@/services/appCatalogApi';
+
+const preflightTrigger = vi.fn();
+const installTrigger = vi.fn();
+const undoTrigger = vi.fn();
+const ackTrigger = vi.fn();
+
+let preflightState: { data?: PreflightResponse; isLoading: boolean } = {
+  data: undefined,
+  isLoading: false,
+};
+let installState: { isLoading: boolean } = { isLoading: false };
+let jobQueryResult: { data?: InstallJob } = { data: undefined };
+let undoState: { isLoading: boolean } = { isLoading: false };
+let ackState: { isLoading: boolean } = { isLoading: false };
+
+vi.mock('@/services/appCatalogApi', () => ({
+  usePreflightAppMutation: () => [preflightTrigger, preflightState],
+  useInstallAppMutation: () => [installTrigger, installState],
+  useGetInstallJobQuery: () => jobQueryResult,
+  useUndoJobMutation: () => [undoTrigger, undoState],
+  useAckManualStepMutation: () => [ackTrigger, ackState],
+}));
+
+vi.mock('@/services/repositoriesApi', () => ({
+  useGetMyRepositoriesQuery: () => ({
+    data: {
+      total: 1,
+      repositories: [
+        { id: 'proj-1', owner: 'acme', name: 'handoff-site', permissionType: 'owner', role: 'admin' },
+      ],
+    },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+const baseEntry: CatalogEntry = {
+  id: 'handoff',
+  name: 'Handoff',
+  summary: 'Share files with clients',
+  gates: [],
+  installable: true,
+};
+
+function makePreflight(overrides: Partial<PreflightResponse> = {}): PreflightResponse {
+  return {
+    gates: [{ id: 'storage', status: 'pass', message: 'Storage looks good' }],
+    syncPlans: [
+      {
+        ruleSet: 'handoff-api',
+        created: 2,
+        updated: 0,
+        unchanged: 1,
+        pruneCandidates: 0,
+        schemaResolutions: [{ name: 'files', action: 'create', fieldMismatch: false }],
+      },
+    ],
+    appHost: 'handoff.example.com',
+    appUrl: 'https://handoff.example.com',
+    ...overrides,
+  };
+}
+
+function makeJob(overrides: Partial<InstallJob> = {}): InstallJob {
+  return {
+    id: 'job-1',
+    kind: 'install',
+    appId: 'handoff',
+    projectId: 'proj-1',
+    status: 'running',
+    steps: [
+      { id: 'preflight', status: 'done' },
+      { id: 'fetch', status: 'done' },
+      { id: 'sync-rules', status: 'running' },
+      { id: 'deploy', status: 'pending' },
+    ],
+    createdAt: '2026-07-30T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  preflightTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve(makePreflight()) });
+  installTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({ jobId: 'job-1' }) });
+  undoTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({}) });
+  ackTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({ acked: [] }) });
+  preflightState = { data: makePreflight(), isLoading: false };
+  installState = { isLoading: false };
+  jobQueryResult = { data: undefined };
+  undoState = { isLoading: false };
+  ackState = { isLoading: false };
+});
+
+describe('InstallDialog — Review screen', () => {
+  it('renders the per-rule-set plan language', () => {
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText('2 rules created · 0 updated')).toBeInTheDocument();
+  });
+
+  it('renders the aggregated data tables summary', () => {
+    preflightState = {
+      data: makePreflight({
+        syncPlans: [
+          {
+            ruleSet: 'handoff-api',
+            created: 1,
+            updated: 0,
+            unchanged: 0,
+            pruneCandidates: 0,
+            schemaResolutions: [
+              { name: 'files', action: 'create', fieldMismatch: false },
+              { name: 'shares', action: 'reuse', fieldMismatch: false },
+            ],
+          },
+        ],
+      }),
+      isLoading: false,
+    };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText('2 data tables: 1 reused, 1 created')).toBeInTheDocument();
+  });
+
+  it('renders a warning row for schema resolutions with a field mismatch', () => {
+    preflightState = {
+      data: makePreflight({
+        syncPlans: [
+          {
+            ruleSet: 'handoff-api',
+            created: 0,
+            updated: 1,
+            unchanged: 0,
+            pruneCandidates: 0,
+            schemaResolutions: [{ name: 'shares', action: 'reuse', fieldMismatch: true }],
+          },
+        ],
+      }),
+      isLoading: false,
+    };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText(/shares/)).toBeInTheDocument();
+    expect(screen.getByText(/field mismatch/i)).toBeInTheDocument();
+  });
+
+  it('disables Install when a gate has failed', () => {
+    preflightState = {
+      data: makePreflight({
+        gates: [
+          { id: 'storage', status: 'pass', message: 'Storage looks good' },
+          {
+            id: 'dns',
+            status: 'fail',
+            message: 'DNS record missing',
+            remediation: 'Add the CNAME record shown below.',
+            retryable: true,
+          },
+        ],
+      }),
+      isLoading: false,
+    };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText('DNS record missing')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^install$/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it('enables Install when every gate passes', () => {
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /^install$/i })).toBeEnabled();
+  });
+
+  it('shows the "Why?" remediation for a failed gate', () => {
+    preflightState = {
+      data: makePreflight({
+        gates: [
+          {
+            id: 'dns',
+            status: 'fail',
+            message: 'DNS record missing',
+            remediation: 'Add the CNAME record shown below.',
+            deepLink: '/admin/settings/domains',
+          },
+        ],
+      }),
+      isLoading: false,
+    };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /why\?/i }));
+    expect(screen.getByText('Add the CNAME record shown below.')).toBeInTheDocument();
+  });
+
+  it('preselects the project when exactly one exists and shows a "Create new project" option', () => {
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    const select = screen.getByRole('combobox', { name: /project/i }) as HTMLSelectElement;
+    expect(select.value).toBe('proj-1');
+    expect(within(select).getByText(/create new project/i)).toBeInTheDocument();
+  });
+
+  it('shows owner/name inputs and the immutability warning when creating a new project', () => {
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    const select = screen.getByRole('combobox', { name: /project/i });
+    fireEvent.change(select, { target: { value: 'new' } });
+
+    expect(screen.getByLabelText(/owner/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument();
+    expect(
+      screen.getByText("A project's owner/name can never be renamed."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('InstallDialog — Working screen', () => {
+  it('renders step statuses from the polled job', async () => {
+    jobQueryResult = { data: makeJob() };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+
+    expect(await screen.findByText(/fetch app bundle/i)).toBeInTheDocument();
+    expect(screen.getByText(/sync proxy rules/i)).toBeInTheDocument();
+    expect(screen.getByText(/^deploy$/i)).toBeInTheDocument();
+  });
+
+  it('shows the detail text for an action-required step', async () => {
+    jobQueryResult = {
+      data: makeJob({
+        steps: [
+          {
+            id: 'domain',
+            status: 'action-required',
+            detail: 'Add a CNAME record for handoff.example.com pointing to app.bffless.dev',
+          },
+        ],
+      }),
+    };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+
+    expect(
+      await screen.findByText(/Add a CNAME record for handoff\.example\.com/i),
+    ).toBeInTheDocument();
+  });
+
+  it('offers Undo and Close when the job fails', async () => {
+    jobQueryResult = {
+      data: makeJob({ status: 'failed', error: 'Deploy step failed: timed out' }),
+    };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+
+    expect(await screen.findByText('Deploy step failed: timed out')).toBeInTheDocument();
+    const undoButton = screen.getByRole('button', { name: /undo this install/i });
+    expect(undoButton).toBeInTheDocument();
+    const footer = undoButton.parentElement as HTMLElement;
+    expect(within(footer).getByRole('button', { name: /^close$/i })).toBeInTheDocument();
+
+    fireEvent.click(undoButton);
+    expect(undoTrigger).toHaveBeenCalledWith('job-1');
+  });
+});
+
+describe('InstallDialog — Done screen', () => {
+  it('renders the app URL, an Open link, and the manual steps checklist, firing ack on check', async () => {
+    jobQueryResult = {
+      data: makeJob({
+        status: 'succeeded',
+        installedAppId: 'installed-1',
+        appUrl: 'https://handoff.example.com',
+        manualSteps: [
+          {
+            id: 'set-env',
+            title: 'Set the SIGNING_SECRET',
+            body: 'Add SIGNING_SECRET to your environment before sharing links.',
+          },
+        ],
+      }),
+    };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+
+    const openLink = await screen.findByRole('link', { name: /open/i });
+    expect(openLink).toHaveAttribute('href', 'https://handoff.example.com');
+
+    expect(screen.getByText('Set the SIGNING_SECRET')).toBeInTheDocument();
+    const checkbox = screen.getByRole('checkbox', { name: /set the signing_secret/i });
+    expect(checkbox).not.toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(ackTrigger).toHaveBeenCalledWith({ id: 'installed-1', stepId: 'set-env' });
+  });
+
+  it('prefers the durable entry.installed manual-step ack state over the job', async () => {
+    const entryWithInstall: CatalogEntry = {
+      ...baseEntry,
+      installed: {
+        installedAppId: 'installed-1',
+        version: '1.0.0',
+        projectId: 'proj-1',
+        projectName: 'acme/handoff-site',
+        alias: 'production',
+        appUrl: 'https://handoff.example.com',
+        status: 'installed',
+        updateAvailable: false,
+        manualSteps: [
+          { id: 'set-env', title: 'Set the SIGNING_SECRET', body: 'Add it before sharing links.' },
+        ],
+        manualStepsAcked: ['set-env'],
+      },
+    };
+    jobQueryResult = {
+      data: makeJob({ status: 'succeeded', installedAppId: 'installed-1' }),
+    };
+
+    render(<InstallDialog entry={entryWithInstall} open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+
+    const checkbox = await screen.findByRole('checkbox', { name: /set the signing_secret/i });
+    expect(checkbox).toBeChecked();
+  });
+});

--- a/apps/frontend/src/components/app-catalog/__tests__/UninstallDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/UninstallDialog.test.tsx
@@ -128,4 +128,38 @@ describe('UninstallDialog', () => {
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
+
+  it('surfaces partial-failure uninstall as a destructive toast, keeps the dialog open, and lets retry re-fire the mutation', async () => {
+    const onOpenChange = vi.fn();
+    const partialSummary: UninstallSummary = {
+      ...baseSummary,
+      failures: ['ruleSet:handoff-api', 'domain:handoff.example.com'],
+    };
+    uninstallTrigger.mockReturnValue({ unwrap: () => Promise.resolve(partialSummary) });
+
+    render(<UninstallDialog entry={entry} open onOpenChange={onOpenChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^uninstall$/i }));
+
+    await vi.waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Uninstall incomplete',
+          variant: 'destructive',
+        }),
+      );
+    });
+
+    // Dialog stays open — onOpenChange is never told to close.
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+    // Failures are surfaced in the dialog body too.
+    expect(screen.getByText(/ruleSet:handoff-api/)).toBeInTheDocument();
+    expect(screen.getByText(/domain:handoff\.example\.com/)).toBeInTheDocument();
+
+    // Retrying re-fires the same mutation.
+    uninstallTrigger.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /retry uninstall/i }));
+    expect(uninstallTrigger).toHaveBeenCalledWith({ id: 'installed-1', deleteData: false });
+  });
 });

--- a/apps/frontend/src/components/app-catalog/__tests__/UninstallDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/UninstallDialog.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { UninstallDialog } from '../UninstallDialog';
+import type { CatalogEntry, UninstallPreview, UninstallSummary } from '@/services/appCatalogApi';
+
+const uninstallTrigger = vi.fn();
+const getUninstallPreviewQueryMock = vi.fn<
+  (id: string, options?: { skip?: boolean }) => { data?: UninstallPreview }
+>(() => previewState);
+
+let previewState: { data?: UninstallPreview } = { data: undefined };
+let uninstallState: { isLoading: boolean } = { isLoading: false };
+const toastMock = vi.fn();
+
+vi.mock('@/services/appCatalogApi', () => ({
+  useGetUninstallPreviewQuery: (id: string, options?: { skip?: boolean }) =>
+    getUninstallPreviewQueryMock(id, options),
+  useUninstallAppMutation: () => [uninstallTrigger, uninstallState],
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+const baseSummary: UninstallSummary = {
+  removed: { ruleSets: 1, alias: true, domain: true, deployment: true, schedules: 0 },
+  dataTables: { kept: [], deleted: [], deletedRecordCounts: {} },
+  note: 'Handoff was uninstalled.',
+};
+
+const entry: CatalogEntry = {
+  id: 'handoff',
+  name: 'Handoff',
+  gates: [],
+  installable: true,
+  installed: {
+    installedAppId: 'installed-1',
+    version: '1.2.0',
+    projectId: 'proj-1',
+    projectName: 'acme/handoff',
+    alias: 'production',
+    appUrl: 'https://handoff.example.com',
+    status: 'installed',
+    updateAvailable: false,
+    manualSteps: [],
+    manualStepsAcked: [],
+  },
+};
+
+function makePreview(overrides: Partial<UninstallPreview> = {}): UninstallPreview {
+  return {
+    dataTables: [
+      { name: 'files', recordCount: 42, createdByInstall: true },
+      { name: 'shares', recordCount: 7, createdByInstall: true },
+      { name: 'users', recordCount: 100, createdByInstall: false },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  uninstallTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve(baseSummary) });
+  getUninstallPreviewQueryMock.mockClear();
+  previewState = { data: makePreview() };
+  uninstallState = { isLoading: false };
+  toastMock.mockReset();
+});
+
+describe('UninstallDialog', () => {
+  it('shows the default keeps-data copy without the checkbox checked', () => {
+    render(<UninstallDialog entry={entry} open onOpenChange={vi.fn()} />);
+
+    expect(
+      screen.getByText(
+        "Removes the app's rule sets, alias, domain, and deployment. Your data tables and uploaded files are kept.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /also delete the app's data tables/i })).not.toBeChecked();
+    expect(screen.queryByText(/this deletes/i)).not.toBeInTheDocument();
+  });
+
+  it('reveals the real record counts only after the checkbox is checked', () => {
+    render(<UninstallDialog entry={entry} open onOpenChange={vi.fn()} />);
+
+    const checkbox = screen.getByRole('checkbox', { name: /also delete the app's data tables/i });
+    fireEvent.click(checkbox);
+
+    // 42 + 7 = 49 records across the 2 tables createdByInstall: true
+    expect(screen.getByText('this deletes 49 records across 2 tables')).toBeInTheDocument();
+  });
+
+  it('lists reused tables as kept regardless of the checkbox', () => {
+    render(<UninstallDialog entry={entry} open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText(/users/)).toBeInTheDocument();
+
+    const checkbox = screen.getByRole('checkbox', { name: /also delete the app's data tables/i });
+    fireEvent.click(checkbox);
+
+    expect(screen.getByText(/users/)).toBeInTheDocument();
+  });
+
+  it('confirms uninstall with deleteData: false by default', () => {
+    render(<UninstallDialog entry={entry} open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^uninstall$/i }));
+
+    expect(uninstallTrigger).toHaveBeenCalledWith({ id: 'installed-1', deleteData: false });
+  });
+
+  it('confirms uninstall with deleteData: true when the checkbox is checked', () => {
+    render(<UninstallDialog entry={entry} open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /also delete the app's data tables/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^uninstall$/i }));
+
+    expect(uninstallTrigger).toHaveBeenCalledWith({ id: 'installed-1', deleteData: true });
+  });
+
+  it('shows a summary toast and closes the dialog on success', async () => {
+    const onOpenChange = vi.fn();
+    render(<UninstallDialog entry={entry} open onOpenChange={onOpenChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^uninstall$/i }));
+
+    await vi.waitFor(() => {
+      expect(toastMock).toHaveBeenCalled();
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/apps/frontend/src/pages/AppsPage.test.tsx
+++ b/apps/frontend/src/pages/AppsPage.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { AppsPage } from './AppsPage';
+import type { CatalogEntry, CatalogListResult, InstallJob } from '@/services/appCatalogApi';
+
+// --- appCatalogApi -----------------------------------------------------
+// `catalogResult` is reassigned between renders to simulate the RTK Query
+// cache refreshing after a mutation invalidates the `AppCatalog` tag (e.g.
+// ackManualStep). Because it's read fresh on every call, re-rendering
+// AppsPage after reassigning it is equivalent to a real refetch.
+let catalogResult: { data?: CatalogListResult; isLoading: boolean; isError: boolean };
+const refetchMock = vi.fn();
+const updateTrigger = vi.fn();
+const ackTrigger = vi.fn();
+const getInstallJobQueryMock = vi.fn<
+  (jobId: string, options?: { pollingInterval?: number; skip?: boolean }) => { data?: InstallJob }
+>();
+let jobQueryResult: { data?: InstallJob };
+
+vi.mock('@/services/appCatalogApi', () => ({
+  useGetAppCatalogQuery: () => ({ ...catalogResult, refetch: refetchMock }),
+  useUpdateAppMutation: () => [updateTrigger, { isLoading: false }],
+  useUninstallAppMutation: () => [vi.fn(), { isLoading: false }],
+  useGetUninstallPreviewQuery: () => ({ data: undefined }),
+  useGetEjectPayloadQuery: () => ({ data: undefined, isFetching: false }),
+  usePreflightAppMutation: () => [vi.fn(), { data: undefined, isLoading: false, reset: vi.fn() }],
+  useInstallAppMutation: () => [vi.fn(), { isLoading: false }],
+  useGetInstallJobQuery: (
+    jobId: string,
+    options?: { pollingInterval?: number; skip?: boolean },
+  ) => getInstallJobQueryMock(jobId, options),
+  useUndoJobMutation: () => [vi.fn(), { isLoading: false }],
+  useAckManualStepMutation: () => [ackTrigger, { isLoading: false }],
+}));
+
+vi.mock('@/services/apiKeysApi', () => ({
+  useCreateApiKeyMutation: () => [vi.fn(), { isLoading: false }],
+}));
+
+vi.mock('@/services/repositoriesApi', () => ({
+  useGetMyRepositoriesQuery: () => ({ data: { total: 0, repositories: [] }, isLoading: false }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function makeEntry(manualStepsAcked: string[]): CatalogEntry {
+  return {
+    id: 'handoff',
+    name: 'Handoff',
+    summary: 'Share files with clients',
+    gates: [],
+    installable: true,
+    registryVersion: '2.0.0',
+    installed: {
+      installedAppId: 'installed-1',
+      version: '1.0.0',
+      projectId: 'proj-1',
+      projectName: 'acme/handoff-site',
+      alias: 'production',
+      appUrl: 'https://handoff.example.com',
+      status: 'installed',
+      updateAvailable: true,
+      manualSteps: [
+        { id: 'bucket-cors', title: 'Configure bucket CORS', body: 'Allow PUT from your app origin.' },
+      ],
+      manualStepsAcked,
+    },
+  };
+}
+
+function makeJob(): InstallJob {
+  return {
+    id: 'job-1',
+    kind: 'update',
+    appId: 'handoff',
+    projectId: 'proj-1',
+    status: 'succeeded',
+    steps: [],
+    installedAppId: 'installed-1',
+    appUrl: 'https://handoff.example.com',
+    createdAt: '2026-07-30T00:00:00.000Z',
+  };
+}
+
+beforeEach(() => {
+  catalogResult = { data: { data: [makeEntry([])] }, isLoading: false, isError: false };
+  refetchMock.mockReset();
+  updateTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({ jobId: 'job-1' }) });
+  ackTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({ acked: ['bucket-cors'] }) });
+  jobQueryResult = { data: makeJob() };
+  getInstallJobQueryMock.mockReset().mockImplementation(() => jobQueryResult);
+});
+
+describe('AppsPage — Done-screen ack checkbox stays live (regression)', () => {
+  it('re-derives the InstallDialog entry from the current catalog query, so acking a manual step checks the box once the catalog refetches', async () => {
+    const { rerender } = render(<AppsPage />);
+
+    // Open the update dialog straight onto the Done screen (job already succeeded).
+    fireEvent.click(screen.getByRole('button', { name: /update to v2\.0\.0/i }));
+    fireEvent.click(screen.getByRole('button', { name: /confirm update/i }));
+
+    const checkbox = await screen.findByRole('checkbox', { name: /configure bucket cors/i });
+    expect(checkbox).not.toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(ackTrigger).toHaveBeenCalledWith({ id: 'installed-1', stepId: 'bucket-cors' });
+
+    // Simulate the server ack completing and ackManualStep's `invalidatesTags`
+    // causing `useGetAppCatalogQuery` to refetch with the updated entry, then
+    // force AppsPage to re-render against that new query result (mirroring
+    // the re-render RTK Query itself triggers on a real cache update). If
+    // AppsPage were still holding a point-in-time snapshot of `entry` (the
+    // bug), this new catalog data would never reach InstallDialog and the
+    // checkbox would stay unchecked forever.
+    catalogResult = { data: { data: [makeEntry(['bucket-cors'])] }, isLoading: false, isError: false };
+    rerender(<AppsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: /configure bucket cors/i })).toBeChecked();
+    });
+  });
+});

--- a/apps/frontend/src/pages/AppsPage.test.tsx
+++ b/apps/frontend/src/pages/AppsPage.test.tsx
@@ -45,6 +45,14 @@ vi.mock('@/hooks/use-toast', () => ({
   useToast: () => ({ toast: vi.fn() }),
 }));
 
+// InstallDialog dispatches `api.util.invalidateTags` directly (via
+// `useAppDispatch`) once a polled job reaches a terminal status — this page
+// isn't wrapped in a redux <Provider>, so stub the hook the same way
+// InstallDialog.test.tsx does.
+vi.mock('@/store/hooks', () => ({
+  useAppDispatch: () => vi.fn(),
+}));
+
 function makeEntry(manualStepsAcked: string[]): CatalogEntry {
   return {
     id: 'handoff',

--- a/apps/frontend/src/pages/AppsPage.tsx
+++ b/apps/frontend/src/pages/AppsPage.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import { AppCard } from '@/components/app-catalog/AppCard';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useGetAppCatalogQuery, type CatalogEntry } from '@/services/appCatalogApi';
+import { AlertTriangle, LayoutGrid, X } from 'lucide-react';
+
+/**
+ * AppsPage — the app catalog admin page (Task 12 of the app-catalog spec).
+ * Lists every app the registry knows about, each rendered as an `AppCard`
+ * with its own install/manage CTA. Registry fetch failures don't block the
+ * page — already-installed apps still render (`registryError` becomes a
+ * dismissable notice instead of an error state).
+ */
+export function AppsPage() {
+  const { data, isLoading, isError, refetch } = useGetAppCatalogQuery();
+  const [registryNoticeDismissed, setRegistryNoticeDismissed] = useState(false);
+  const [installTarget, setInstallTarget] = useState<CatalogEntry | null>(null);
+
+  const entries = data?.data ?? [];
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold">Apps</h1>
+        <p className="text-muted-foreground mt-1">
+          1-click install apps built on top of BFFless
+        </p>
+      </div>
+
+      {data?.registryError && !registryNoticeDismissed && (
+        <Alert className="mb-6">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle className="flex items-start justify-between gap-3">
+            <span>Catalog unavailable — installed apps unaffected</span>
+            <button
+              onClick={() => setRegistryNoticeDismissed(true)}
+              aria-label="Dismiss"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </AlertTitle>
+          <AlertDescription>{data.registryError}</AlertDescription>
+        </Alert>
+      )}
+
+      {isLoading && (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <Skeleton className="h-48 w-full" />
+          <Skeleton className="h-48 w-full" />
+          <Skeleton className="h-48 w-full" />
+        </div>
+      )}
+
+      {isError && !isLoading && (
+        <Alert variant="destructive">
+          <AlertDescription>
+            Failed to load the app catalog.{' '}
+            <Button variant="link" className="p-0 h-auto" onClick={() => refetch()}>
+              Try again
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {!isLoading && !isError && entries.length === 0 && (
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16 text-center">
+          <LayoutGrid className="h-10 w-10 text-muted-foreground mb-3" />
+          <h2 className="text-lg font-semibold">No apps available</h2>
+          <p className="text-muted-foreground mt-1 max-w-sm">
+            The app catalog is empty right now — check back later.
+          </p>
+        </div>
+      )}
+
+      {!isLoading && entries.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {entries.map((entry) => (
+            <AppCard key={entry.id} entry={entry} onInstall={setInstallTarget} />
+          ))}
+        </div>
+      )}
+
+      {/* TODO(Task 13/14): replace with the full install wizard (preflight ->
+          install -> job progress -> manual steps). */}
+      <Dialog open={installTarget !== null} onOpenChange={(open) => !open && setInstallTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{`Install ${installTarget?.name ?? ''}`}</DialogTitle>
+            <DialogDescription>
+              The install wizard is coming soon — this will walk through project selection,
+              preflight checks, and install progress.
+            </DialogDescription>
+          </DialogHeader>
+          <Button variant="outline" onClick={() => setInstallTarget(null)}>
+            Close
+          </Button>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/AppsPage.tsx
+++ b/apps/frontend/src/pages/AppsPage.tsx
@@ -17,12 +17,32 @@ import { AlertTriangle, LayoutGrid, X } from 'lucide-react';
 export function AppsPage() {
   const { data, isLoading, isError, refetch } = useGetAppCatalogQuery();
   const [registryNoticeDismissed, setRegistryNoticeDismissed] = useState(false);
-  const [installTarget, setInstallTarget] = useState<CatalogEntry | null>(null);
-  const [updateTarget, setUpdateTarget] = useState<{ entry: CatalogEntry; jobId: string } | null>(
-    null,
-  );
+  // These hold the entry captured at open time — used only as an id lookup
+  // key and as a fallback if the app disappears from the catalog while the
+  // dialog is open. The dialog is actually handed the LIVE entry (derived
+  // below from the current `data`), not this snapshot: server-side mutations
+  // like ackManualStep invalidate the `AppCatalog` tag and refetch `data`,
+  // and a stale snapshot here would never pick that up (the Done screen's
+  // ack checkboxes would appear permanently unchecked/disabled).
+  const [installTargetSnapshot, setInstallTargetSnapshot] = useState<CatalogEntry | null>(null);
+  const [updateTargetSnapshot, setUpdateTargetSnapshot] = useState<{
+    entry: CatalogEntry;
+    jobId: string;
+  } | null>(null);
 
   const entries = data?.data ?? [];
+
+  const installTarget = installTargetSnapshot
+    ? (entries.find((e) => e.id === installTargetSnapshot.id) ?? installTargetSnapshot)
+    : null;
+  const updateTarget = updateTargetSnapshot
+    ? {
+        entry:
+          entries.find((e) => e.id === updateTargetSnapshot.entry.id) ??
+          updateTargetSnapshot.entry,
+        jobId: updateTargetSnapshot.jobId,
+      }
+    : null;
 
   return (
     <div className="container mx-auto py-8">
@@ -85,8 +105,10 @@ export function AppsPage() {
             <AppCard
               key={entry.id}
               entry={entry}
-              onInstall={setInstallTarget}
-              onUpdateStarted={(updatedEntry, jobId) => setUpdateTarget({ entry: updatedEntry, jobId })}
+              onInstall={setInstallTargetSnapshot}
+              onUpdateStarted={(updatedEntry, jobId) =>
+                setUpdateTargetSnapshot({ entry: updatedEntry, jobId })
+              }
             />
           ))}
         </div>
@@ -96,7 +118,7 @@ export function AppsPage() {
         <InstallDialog
           entry={installTarget}
           open={installTarget !== null}
-          onOpenChange={(open) => !open && setInstallTarget(null)}
+          onOpenChange={(open) => !open && setInstallTargetSnapshot(null)}
         />
       )}
 
@@ -104,7 +126,7 @@ export function AppsPage() {
         <InstallDialog
           entry={updateTarget.entry}
           open={updateTarget !== null}
-          onOpenChange={(open) => !open && setUpdateTarget(null)}
+          onOpenChange={(open) => !open && setUpdateTargetSnapshot(null)}
           mode="update"
           initialJobId={updateTarget.jobId}
         />

--- a/apps/frontend/src/pages/AppsPage.tsx
+++ b/apps/frontend/src/pages/AppsPage.tsx
@@ -1,14 +1,8 @@
 import { useState } from 'react';
 import { AppCard } from '@/components/app-catalog/AppCard';
+import { InstallDialog } from '@/components/app-catalog/InstallDialog';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGetAppCatalogQuery, type CatalogEntry } from '@/services/appCatalogApi';
 import { AlertTriangle, LayoutGrid, X } from 'lucide-react';
@@ -90,22 +84,13 @@ export function AppsPage() {
         </div>
       )}
 
-      {/* TODO(Task 13/14): replace with the full install wizard (preflight ->
-          install -> job progress -> manual steps). */}
-      <Dialog open={installTarget !== null} onOpenChange={(open) => !open && setInstallTarget(null)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{`Install ${installTarget?.name ?? ''}`}</DialogTitle>
-            <DialogDescription>
-              The install wizard is coming soon — this will walk through project selection,
-              preflight checks, and install progress.
-            </DialogDescription>
-          </DialogHeader>
-          <Button variant="outline" onClick={() => setInstallTarget(null)}>
-            Close
-          </Button>
-        </DialogContent>
-      </Dialog>
+      {installTarget && (
+        <InstallDialog
+          entry={installTarget}
+          open={installTarget !== null}
+          onOpenChange={(open) => !open && setInstallTarget(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/pages/AppsPage.tsx
+++ b/apps/frontend/src/pages/AppsPage.tsx
@@ -18,6 +18,9 @@ export function AppsPage() {
   const { data, isLoading, isError, refetch } = useGetAppCatalogQuery();
   const [registryNoticeDismissed, setRegistryNoticeDismissed] = useState(false);
   const [installTarget, setInstallTarget] = useState<CatalogEntry | null>(null);
+  const [updateTarget, setUpdateTarget] = useState<{ entry: CatalogEntry; jobId: string } | null>(
+    null,
+  );
 
   const entries = data?.data ?? [];
 
@@ -79,7 +82,12 @@ export function AppsPage() {
       {!isLoading && entries.length > 0 && (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {entries.map((entry) => (
-            <AppCard key={entry.id} entry={entry} onInstall={setInstallTarget} />
+            <AppCard
+              key={entry.id}
+              entry={entry}
+              onInstall={setInstallTarget}
+              onUpdateStarted={(updatedEntry, jobId) => setUpdateTarget({ entry: updatedEntry, jobId })}
+            />
           ))}
         </div>
       )}
@@ -89,6 +97,16 @@ export function AppsPage() {
           entry={installTarget}
           open={installTarget !== null}
           onOpenChange={(open) => !open && setInstallTarget(null)}
+        />
+      )}
+
+      {updateTarget && (
+        <InstallDialog
+          entry={updateTarget.entry}
+          open={updateTarget !== null}
+          onOpenChange={(open) => !open && setUpdateTarget(null)}
+          mode="update"
+          initialJobId={updateTarget.jobId}
         />
       )}
     </div>

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -314,6 +314,11 @@ export function HomePage() {
               <Button asChild variant="outline" className="border-[#4a4a4a]/20 hover:border-[#d96459]/50 hover:bg-[#ede8dd] dark:hover:bg-accent">
                 <Link to="/traffic">Traffic</Link>
               </Button>
+              {isEnabled('ENABLE_APP_CATALOG') && (
+                <Button asChild variant="outline" className="border-[#4a4a4a]/20 hover:border-[#d96459]/50 hover:bg-[#ede8dd] dark:hover:bg-accent">
+                  <Link to="/apps">Apps</Link>
+                </Button>
+              )}
             </div>
           </div>
         )}

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -219,6 +219,8 @@ export const api = createApi({
     'BlocklistSettings',
     'PipelineSchedule',
     'PrimarySsl',
+    'AppCatalog',
+    'InstalledApp',
   ],
   endpoints: () => ({}),
 });

--- a/apps/frontend/src/services/appCatalogApi.ts
+++ b/apps/frontend/src/services/appCatalogApi.ts
@@ -82,6 +82,8 @@ export interface NewProjectInput {
 export interface PreflightRequest {
   projectId?: string;
   newProject?: NewProjectInput;
+  /** Overrides the manifest's default `install.domain.subdomain` for this install. */
+  subdomain?: string;
 }
 
 export interface SyncSchemaResolutionLike {

--- a/apps/frontend/src/services/appCatalogApi.ts
+++ b/apps/frontend/src/services/appCatalogApi.ts
@@ -1,0 +1,267 @@
+import { api } from './api';
+
+/**
+ * RTK Query slice for the admin app-catalog surface (Task 12 of the
+ * app-catalog spec). Mirrors the backend shapes 1:1 — see
+ * `apps/backend/src/app-catalog/app-catalog.service.ts`,
+ * `app-preflight.service.ts`, `app-installer.service.ts`, and
+ * `app-install-jobs.service.ts` for the source of truth.
+ *
+ * `preflightApp`/`installApp`/`getInstallJob`/`undoJob`/`ackManualStep` back
+ * the 1-click install wizard dialog (Tasks 13–14 wire them up); this task
+ * only wires `getAppCatalog` (catalog page) and the simpler one-shot actions
+ * (`updateApp`, `uninstallApp`, `getEjectPayload`) directly into `AppCard`.
+ */
+
+export type GateStatus = 'pass' | 'fail' | 'warn';
+
+export interface GateResult {
+  id: 'storage' | 'ce-version' | 'platform-config' | 'dns' | 'name-collision' | 'data-tables';
+  status: GateStatus;
+  message: string;
+  remediation?: string;
+  deepLink?: string;
+  /** DNS is blocking-but-retryable; name collisions are not. */
+  retryable?: boolean;
+}
+
+export type AppliesWhen =
+  | 'always'
+  | 'bucketStorage'
+  | 'localStorage'
+  | 'platformMode'
+  | 'selfHosted';
+
+export interface AppManualStep {
+  id: string;
+  title: string;
+  body: string;
+  deepLink?: string;
+  appliesWhen?: AppliesWhen;
+}
+
+export type InstalledAppStatus = 'installing' | 'installed' | 'failed';
+
+export interface CatalogEntry {
+  id: string;
+  name: string;
+  summary?: string;
+  iconUrl?: string;
+  docsUrl?: string;
+  sourceUrl?: string;
+  /** Absent when the registry is unavailable, or this app isn't (or no longer) listed in it. */
+  registryVersion?: string;
+  /** Instance-level gates only (storage/CE-version/platform-config) — project gates are preflight-only. */
+  gates: GateResult[];
+  /** Every instance gate passed AND the app is present in the registry. */
+  installable: boolean;
+  installed?: {
+    installedAppId: string;
+    version: string;
+    projectId: string;
+    projectName: string;
+    alias: string;
+    appUrl?: string;
+    status: InstalledAppStatus;
+    updateAvailable: boolean;
+    manualSteps: AppManualStep[];
+    manualStepsAcked: string[];
+  };
+}
+
+export interface CatalogListResult {
+  data: CatalogEntry[];
+  registryError?: string;
+}
+
+export interface NewProjectInput {
+  owner: string;
+  name: string;
+}
+
+export interface PreflightRequest {
+  projectId?: string;
+  newProject?: NewProjectInput;
+}
+
+export interface SyncSchemaResolutionLike {
+  name: string;
+  action: 'reuse' | 'create';
+  fieldMismatch: boolean;
+}
+
+export interface SyncPlanSummary {
+  ruleSet: string;
+  created: number;
+  updated: number;
+  unchanged: number;
+  pruneCandidates: number;
+  schemaResolutions: SyncSchemaResolutionLike[];
+}
+
+export interface PreflightResponse {
+  gates: GateResult[];
+  syncPlans: SyncPlanSummary[];
+  appHost: string | null;
+  appUrl?: string;
+}
+
+export type InstallStepId =
+  | 'preflight'
+  | 'fetch'
+  | 'sync-rules'
+  | 'deploy'
+  | 'domain'
+  | 'certificate'
+  | 'schedules'
+  | 'record';
+
+export interface InstallStepState {
+  id: InstallStepId;
+  status: 'pending' | 'running' | 'done' | 'failed' | 'skipped' | 'action-required';
+  detail?: string;
+  error?: string;
+}
+
+export interface InstallJob {
+  id: string;
+  kind: 'install' | 'update';
+  appId: string;
+  /** null until the project is resolved (the `newProject` path). */
+  projectId: string | null;
+  status: 'running' | 'succeeded' | 'failed' | 'undone';
+  steps: InstallStepState[];
+  installedAppId?: string;
+  /** Manifest steps filtered by `manualStepApplies`, plus cert-synthesized ones. */
+  manualSteps?: AppManualStep[];
+  appUrl?: string;
+  error?: string;
+  createdAt: string;
+  finishedAt?: string;
+}
+
+export interface UninstallPreview {
+  dataTables: Array<{ name: string; recordCount: number; createdByInstall: boolean }>;
+}
+
+export interface UninstallSummary {
+  removed: {
+    ruleSets: number;
+    alias: boolean;
+    domain: boolean;
+    deployment: boolean;
+    schedules: number;
+  };
+  dataTables: {
+    /** Table names left in place — every reused table, plus created tables when `deleteData` is false. */
+    kept: string[];
+    /** Table names actually dropped (`deleteData: true`, created-by-install tables only). */
+    deleted: string[];
+    /** Record count captured (via `getByIdWithCount`) BEFORE each deleted table was dropped. */
+    deletedRecordCounts: Record<string, number>;
+  };
+  note: string;
+  /** `kind:id` labels of deletions that failed. Absent/omitted when everything succeeded. */
+  failures?: string[];
+}
+
+export interface EjectPayload {
+  repo: string;
+  appPath: string;
+  deployWorkflow: string;
+  /** https://github.com/<repo>/fork */
+  forkUrl: string;
+  variables: Record<string, string>;
+  secrets: string[];
+  alias: string;
+  note: string;
+}
+
+export const appCatalogApi = api.injectEndpoints({
+  endpoints: (builder) => ({
+    getAppCatalog: builder.query<CatalogListResult, void>({
+      query: () => '/api/admin/apps',
+      providesTags: ['AppCatalog'],
+    }),
+
+    preflightApp: builder.mutation<PreflightResponse, { appId: string; body: PreflightRequest }>({
+      query: ({ appId, body }) => ({
+        url: `/api/admin/apps/${appId}/preflight`,
+        method: 'POST',
+        body,
+      }),
+    }),
+
+    installApp: builder.mutation<{ jobId: string }, { appId: string; body: PreflightRequest }>({
+      query: ({ appId, body }) => ({
+        url: `/api/admin/apps/${appId}/install`,
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: ['AppCatalog', 'InstalledApp'],
+    }),
+
+    getInstallJob: builder.query<InstallJob, string>({
+      query: (jobId) => `/api/admin/apps/jobs/${jobId}`,
+      // no tags — polling replaces invalidation (migrationApi precedent)
+    }),
+
+    undoJob: builder.mutation<InstallJob, string>({
+      query: (jobId) => ({
+        url: `/api/admin/apps/jobs/${jobId}/undo`,
+        method: 'POST',
+      }),
+      invalidatesTags: ['AppCatalog', 'InstalledApp'],
+    }),
+
+    updateApp: builder.mutation<{ jobId: string }, { id: string; prune?: boolean }>({
+      query: ({ id, prune }) => ({
+        url: `/api/admin/apps/installed/${id}/update`,
+        method: 'POST',
+        body: { prune },
+      }),
+      invalidatesTags: ['AppCatalog', 'InstalledApp'],
+    }),
+
+    getUninstallPreview: builder.query<UninstallPreview, string>({
+      query: (id) => `/api/admin/apps/installed/${id}/uninstall-preview`,
+    }),
+
+    uninstallApp: builder.mutation<UninstallSummary, { id: string; deleteData?: boolean }>({
+      query: ({ id, deleteData }) => ({
+        url: `/api/admin/apps/installed/${id}`,
+        method: 'DELETE',
+        params: deleteData === undefined ? undefined : { deleteData },
+      }),
+      invalidatesTags: ['AppCatalog', 'InstalledApp'],
+    }),
+
+    getEjectPayload: builder.query<EjectPayload, string>({
+      query: (id) => `/api/admin/apps/installed/${id}/eject`,
+    }),
+
+    ackManualStep: builder.mutation<{ acked: string[] }, { id: string; stepId: string }>({
+      query: ({ id, stepId }) => ({
+        url: `/api/admin/apps/installed/${id}/ack-manual-step`,
+        method: 'POST',
+        body: { stepId },
+      }),
+      invalidatesTags: ['AppCatalog', 'InstalledApp'],
+    }),
+  }),
+});
+
+export const {
+  useGetAppCatalogQuery,
+  usePreflightAppMutation,
+  useInstallAppMutation,
+  useGetInstallJobQuery,
+  useUndoJobMutation,
+  useUpdateAppMutation,
+  useGetUninstallPreviewQuery,
+  useLazyGetUninstallPreviewQuery,
+  useUninstallAppMutation,
+  useGetEjectPayloadQuery,
+  useLazyGetEjectPayloadQuery,
+  useAckManualStepMutation,
+} = appCatalogApi;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -376,6 +376,11 @@ services:
       FEATURE_WILDCARD_SSL: ${FEATURE_WILDCARD_SSL:-}
       FEATURE_WILDCARD_SSL_BANNER: ${FEATURE_WILDCARD_SSL_BANNER:-}
       FEATURE_DOMAIN_SSL_TOGGLE: ${FEATURE_DOMAIN_SSL_TOGGLE:-}
+      FEATURE_APP_CATALOG: ${FEATURE_APP_CATALOG:-}
+
+      # App catalog registry (Admin → Apps) — override for air-gapped or
+      # self-published catalogs; see .env.example
+      APPS_REGISTRY_URL: ${APPS_REGISTRY_URL:-}
     ports:
       - '3000:3000'
     depends_on:

--- a/docs/superpowers/plans/2026-07-30-app-catalog-1-click-install.md
+++ b/docs/superpowers/plans/2026-07-30-app-catalog-1-click-install.md
@@ -1,0 +1,1339 @@
+# App Catalog / 1-Click App Install — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Admin → Apps catalog that installs a first-party app (Handoff) onto this CE instance in one click — deploy + rule sets + data tables + domain — with tracked installs supporting update, uninstall, and eject.
+
+**Architecture:** A new backend `app-catalog` module orchestrates *existing* services server-side (`ProxyRuleSetsService.syncRuleSet`, `DeploymentsService.createDeploymentFromZip`, `DomainsService.create`) over a CI-prebuilt bundle fetched from a registry. Install runs as an in-memory background job (storage-migration pattern) with per-step progress polled by the UI; a persistent `installed_apps` row powers lifecycle. The spec is `docs/superpowers/specs/2026-07-30-app-catalog-1-click-install-design.md` — read it first; this plan implements it with the deviations listed below.
+
+**Tech Stack:** NestJS + Drizzle (backend), React + RTK Query (frontend), `fflate` for zip, native `fetch` for registry/bundle downloads. No new runtime dependencies.
+
+## Deviations from the spec (deliberate, record in PR)
+
+1. **Applier order: sync rule sets BEFORE deploy.** The spec lists deploy (step 3) then sync (step 4), but `resolveProxyRuleSetIds` throws `BadRequestException` on an unknown `proxyRuleSetNames[]` entry (`deployments.service.ts:123-180`), so the names must exist first. Order here: preflight → fetch → sync → deploy → domain → certificate → schedules → record.
+2. **`ceMin` for Handoff is `0.3.15`, not `0.2.0`.** Rationale: any CE that has the catalog at all post-dates v0.3.15 (which made local-FS presigned work), so both floors are satisfied by construction; declaring 0.3.15 documents the real stock-install floor without inventing a conditional two-floor mechanism. The 0.2.0 people-picker floor (`GET /api/users/directory`) is subsumed.
+3. **Direct+Let's Encrypt cert branch is issue-to-staging + human apply, not full-auto.** `PrimarySslService.apply()` deliberately enters a provisional confirm window for cert changes on `proxyMode: 'none'` (a bad cert would break `admin.<domain>`), and `confirm()` requires a human browser check. Full-auto re-issue is impossible by design. The installer issues the staged cert with the app subdomain added to the SANs, then surfaces "apply & confirm in Admin → Settings → SSL" as a manual step with a deep link.
+4. **Backend "integration" tests use the house drizzle-mock, not a real Postgres.** The spec asks for a fixture bundle "applied against a real database", but CE has no real-DB test harness (`test:e2e` points at a `test/` dir that does not exist; `jest.integration.config.js` is for cloud-storage creds only). The fixture bundle IS committed and driven through the full applier with the house thenable db mock; real-DB verification moves to the live droplet checklist.
+5. **Destructive uninstall deletes app data tables (with record counts), not stored objects.** CE cannot enumerate which storage objects an app created (uploads land under content-addressed keys with no app tag). Tables the install *created* are deletable with counts shown first; *reused* tables are never deleted (same principle as undo); stored objects remain and the UI says so. Full cleanup path remains "delete the project".
+6. **The apps-repo half (bundle CI + registry publish) is a separate PR in `bffless/apps`** (Task 15). CE ships self-contained: fixture-bundle tests, and graceful "catalog unavailable" until the registry URL is live.
+
+## Global Constraints
+
+- **Never run `pnpm lint`** — it is `eslint --fix` repo-wide. Lint single files: `cd apps/backend && npx eslint src/app-catalog/<file>.ts` (same from `apps/frontend`).
+- **Backend tests run in the FOREGROUND** and take ~30–60 s (coverage is always on). Single spec: `cd apps/backend && pnpm test -- <pattern>`.
+- **NEVER run `pnpm db:generate`** (interactive drizzle-kit; the operator runs it) and NEVER hand-write migration SQL. Task 2 has an explicit user checkpoint.
+- **curl commands on a single line** (no backslash continuations); heredoc for JSON bodies.
+- Git: work only in this worktree (`repos/ce/.claude/worktrees/app-catalog`, branch `spec/app-catalog-1-click-install`); push only with `--force-with-lease`; commit per task with conventional-commit messages.
+- Feature flag: `ENABLE_APP_CATALOG`, env `FEATURE_APP_CATALOG`, default `true`, `exposeToClient: true`, category `features`.
+- Registry URL config: `APPS_REGISTRY_URL`, default `https://apps.bffless.dev/registry.json` (plain env + `ConfigService`, NOT a feature flag — infrastructure value).
+- All new backend code lives in `apps/backend/src/app-catalog/` (module class `AppCatalogModule`); HTTP surface is `/api/admin/apps` per the spec.
+- New RTK Query tag types: `'AppCatalog'`, `'InstalledApp'` (must be added to the `tagTypes` array in `apps/frontend/src/services/api.ts` — injected slices cannot declare new tags).
+- `@Global()` modules (`StorageModule`, `FeatureFlagsModule`, `PlatformModule`) must NOT appear in `AppCatalogModule.imports`; `StorageUsageModule` is NOT global and must be imported if used.
+- Service-call convention for system-initiated work: pass the initiating admin's `userId`, `userRole: 'admin'`, `apiKeyProjectId: null`.
+- Backend list endpoints wrap responses in `{ data: [...] }`; frontend slices `transformResponse` accordingly.
+
+## File Structure
+
+**Backend — create (all under `apps/backend/src/`):**
+
+| File | Responsibility |
+|---|---|
+| `app-catalog/app-manifest.types.ts` | Manifest/registry TS types + `AppliesWhen` enum |
+| `app-catalog/app-manifest.util.ts` | Pure validation: `validateAppManifest`, `validateRegistry`, `manualStepApplies` |
+| `app-catalog/ce-version.util.ts` | `getCeVersion()`, `compareSemver()`, `satisfiesMin()` |
+| `app-catalog/apps-registry.service.ts` | Fetch + 1h-cache `registry.json`, degrade gracefully |
+| `app-catalog/app-bundle.service.ts` | Download bundle, sha256-verify, fflate-unzip, validate manifest |
+| `app-catalog/app-preflight.service.ts` | Instance gates + project-scoped gates + dryRun sync plans |
+| `app-catalog/app-cert-step.service.ts` | Serving-model detection → cert plan/execute |
+| `app-catalog/app-install-jobs.service.ts` | In-memory job registry (steps, single-flight, undo bookkeeping) |
+| `app-catalog/app-installer.service.ts` | The applier: sync → deploy → domain → cert → schedules → record; update; uninstall; undo |
+| `app-catalog/app-catalog.service.ts` | Catalog assembly (registry ∪ installed + gate verdicts), eject payload |
+| `app-catalog/app-catalog.controller.ts` | `/api/admin/apps` routes, guards, DTOs |
+| `app-catalog/app-catalog.dtos.ts` | Request/response DTOs (class-validator) |
+| `app-catalog/app-catalog.module.ts` | Module wiring |
+| `db/schema/installed-apps.schema.ts` | `installed_apps` table |
+| `app-catalog/__fixtures__/` | Committed fixture bundles (v1 + v2) |
+
+**Backend — modify:**
+
+- `feature-flags/feature-flags.definitions.ts` — add `ENABLE_APP_CATALOG`
+- `db/schema/index.ts` — export installed-apps schema (after `projects.schema`)
+- `app.module.ts` — register `AppCatalogModule` at the end of imports (own `/api/admin/apps` prefix; no route-ordering constraint)
+- `setup/bootstrap-dns-preflight.service.ts` — extract public `probeHost(host)` from `run()`
+- `setup/primary-ssl/primary-ssl.service.ts` + `domains/ssl-certificate.service.ts` — thread optional `extraSans` through Let's Encrypt issuance
+- `../../.env.example` (repo root) — document `APPS_REGISTRY_URL`
+
+**Frontend — create (all under `apps/frontend/src/`):**
+
+| File | Responsibility |
+|---|---|
+| `services/appCatalogApi.ts` | RTK Query slice (catalog, preflight, install, jobs, lifecycle) |
+| `pages/AppsPage.tsx` | Catalog page: cards + state-derived CTAs |
+| `components/app-catalog/AppCard.tsx` | One app card |
+| `components/app-catalog/InstallDialog.tsx` | 3-screen dialog: Review / Working / Done |
+| `components/app-catalog/UninstallDialog.tsx` | Keep-vs-delete-data uninstall |
+| `components/app-catalog/EjectPanel.tsx` | Take-ownership panel from eject payload |
+
+**Frontend — modify:** `services/api.ts` (tagTypes), `App.tsx` (route `/apps`, `requireAdmin`), `pages/HomePage.tsx` (admin "Apps" button behind flag).
+
+**apps repo (`/home/rico/bffless/repos/apps`, separate PR — Task 15):** `apps/handoff/bffless-app.json`, `scripts/build-app-bundle.mjs`, `scripts/check-app-conventions.mjs` (extend), `.github/workflows/app-bundles.yml`, registry publish step, README bucket-claim fix.
+
+---
+
+### Task 1: Module skeleton, feature flag, config
+
+**Files:**
+- Create: `apps/backend/src/app-catalog/app-catalog.module.ts`, `app-catalog.controller.ts`, `app-catalog.service.ts` (stub), `apps/backend/src/app-catalog/app-catalog.controller.spec.ts`
+- Modify: `apps/backend/src/feature-flags/feature-flags.definitions.ts`, `apps/backend/src/app.module.ts`, `/home/rico/bffless/repos/ce/.claude/worktrees/app-catalog/.env.example`
+
+**Interfaces:**
+- Produces: `AppCatalogModule` (registered in `app.module.ts`), `AppCatalogController` guard stack, `ENABLE_APP_CATALOG` flag, `APPS_REGISTRY_URL` env doc. Later tasks add providers to this module and routes to this controller.
+
+- [ ] **Step 1: Write the failing guard test**
+
+`apps/backend/src/app-catalog/app-catalog.controller.spec.ts` — controller unit test verifying decorator metadata (the house style for guard checks is metadata assertion, cheap and fast):
+
+```ts
+import { AppCatalogController } from './app-catalog.controller';
+import { REQUIRED_FLAGS_KEY } from '../feature-flags/feature-flag.guard';
+
+describe('AppCatalogController guards', () => {
+  it('requires the ENABLE_APP_CATALOG feature flag', () => {
+    const flags = Reflect.getMetadata(REQUIRED_FLAGS_KEY, AppCatalogController);
+    expect(flags).toEqual(['ENABLE_APP_CATALOG']);
+  });
+
+  it('requires the admin role', () => {
+    const roles = Reflect.getMetadata('roles', AppCatalogController);
+    expect(roles).toEqual(['admin']);
+  });
+});
+```
+
+Check the actual metadata key used by `RolesGuard` in `apps/backend/src/auth/decorators/roles.decorator.ts` first — if it isn't the string `'roles'`, import and use the exported constant.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/backend && pnpm test -- app-catalog.controller`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement the skeleton**
+
+`app-catalog.controller.ts` — copy the `PrimarySslController` stack exactly (`setup/primary-ssl/primary-ssl.controller.ts:10-15`):
+
+```ts
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { FeatureFlagGuard, RequireFeatureFlags } from '../feature-flags/feature-flag.guard';
+import { AppCatalogService } from './app-catalog.service';
+
+@ApiTags('Admin - App Catalog')
+@Controller('api/admin/apps')
+@UseGuards(SessionAuthGuard, RolesGuard, FeatureFlagGuard)
+@Roles('admin')
+@RequireFeatureFlags('ENABLE_APP_CATALOG')
+export class AppCatalogController {
+  constructor(private readonly catalog: AppCatalogService) {}
+
+  @Get()
+  async list() {
+    return { data: await this.catalog.listCatalog() };
+  }
+}
+```
+
+(Adjust import paths to the real barrel exports — `../auth` re-exports `RolesGuard, Roles`; `FeatureFlagGuard`/`RequireFeatureFlags` come from `../feature-flags/feature-flag.guard`.)
+
+`app-catalog.service.ts` stub:
+
+```ts
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppCatalogService {
+  async listCatalog(): Promise<unknown[]> {
+    return [];
+  }
+}
+```
+
+`app-catalog.module.ts`:
+
+```ts
+import { Module } from '@nestjs/common';
+import { AppCatalogController } from './app-catalog.controller';
+import { AppCatalogService } from './app-catalog.service';
+
+@Module({
+  imports: [],
+  controllers: [AppCatalogController],
+  providers: [AppCatalogService],
+})
+export class AppCatalogModule {}
+```
+
+Flag definition — append to `FLAG_DEFINITIONS` in `feature-flags.definitions.ts`, next to `ENABLE_PRIMARY_SSL_MANAGEMENT` (`:336-344`):
+
+```ts
+  ENABLE_APP_CATALOG: {
+    envKey: 'FEATURE_APP_CATALOG',
+    defaultValue: true,
+    type: 'boolean',
+    description:
+      'Show the Admin → Apps catalog for 1-click installs of first-party BFFless apps. ' +
+      'Disable to hide the catalog and refuse install endpoints.',
+    category: 'features',
+    exposeToClient: true,
+  },
+```
+
+`app.module.ts`: add `AppCatalogModule` to the imports array **after `TrafficModule`** (own prefix, no ordering constraint) with a comment saying so.
+
+`.env.example` (repo root) — append near the `FEATURE_LOCAL_PRESIGNED_UPLOADS` block, house style (commented, with rationale):
+
+```
+# App catalog registry. The Admin → Apps catalog fetches its index of installable
+# first-party apps from this URL (cached ~1h; the catalog degrades to
+# "unavailable" if unreachable). Override for air-gapped or self-published
+# catalogs. There is deliberately no arbitrary-URL install field in the UI.
+# APPS_REGISTRY_URL=https://apps.bffless.dev/registry.json
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/backend && pnpm test -- app-catalog.controller`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `cd apps/backend && pnpm exec tsc --noEmit` (from `apps/backend`; use the repo's `pnpm --filter backend exec tsc --noEmit` from root if preferred).
+
+```bash
+git add apps/backend/src/app-catalog apps/backend/src/feature-flags/feature-flags.definitions.ts apps/backend/src/app.module.ts .env.example
+git commit -m "feat(app-catalog): module skeleton, ENABLE_APP_CATALOG flag, registry config"
+```
+
+---
+
+### Task 2: `installed_apps` table (USER CHECKPOINT for migration)
+
+**Files:**
+- Create: `apps/backend/src/db/schema/installed-apps.schema.ts`
+- Modify: `apps/backend/src/db/schema/index.ts`
+
+**Interfaces:**
+- Produces: `installedApps` table, types `InstalledApp` / `NewInstalledApp`, `CreatedResources`, `InstalledAppStatus`. Consumed by Tasks 9–11.
+
+- [ ] **Step 1: Write the schema**
+
+`installed-apps.schema.ts` (match `pipeline-schedules.schema.ts` idioms: uuid PK `defaultRandom`, `timestamp().defaultNow().notNull()`, status as `varchar().$type<...>()` not `pgEnum`, jsonb with `$type`):
+
+```ts
+import {
+  pgTable,
+  uuid,
+  varchar,
+  timestamp,
+  jsonb,
+  index,
+  unique,
+} from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { projects } from './projects.schema';
+
+export type InstalledAppStatus = 'installing' | 'installed' | 'failed';
+
+/** Objects this install created (vs adopted) — the undo/uninstall boundary. */
+export interface CreatedResources {
+  projectCreated?: boolean;
+  ruleSetIds?: string[];
+  /** Only schemas the sync CREATED (action === 'create'); reused ones are never ours to delete. */
+  schemaIdsCreated?: string[];
+  aliasName?: string;
+  domainId?: string;
+  deploymentId?: string;
+  scheduleIds?: string[];
+}
+
+export const installedApps = pgTable(
+  'installed_apps',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    appId: varchar('app_id', { length: 100 }).notNull(),
+    name: varchar('name', { length: 200 }).notNull(),
+    version: varchar('version', { length: 50 }).notNull(),
+    projectId: uuid('project_id')
+      .references(() => projects.id, { onDelete: 'cascade' })
+      .notNull(),
+    alias: varchar('alias', { length: 100 }).notNull(),
+    domainId: uuid('domain_id'),
+    deploymentId: uuid('deployment_id'),
+    ruleSetIds: jsonb('rule_set_ids').$type<string[]>().notNull().default([]),
+    schemaIds: jsonb('schema_ids').$type<string[]>().notNull().default([]),
+    bundleSha256: varchar('bundle_sha256', { length: 64 }).notNull(),
+    /** Full manifest at install time — powers eject + manual steps without refetching. */
+    manifest: jsonb('manifest').notNull(),
+    manualStepsAcked: jsonb('manual_steps_acked').$type<string[]>().notNull().default([]),
+    status: varchar('status', { length: 20 })
+      .$type<InstalledAppStatus>()
+      .notNull()
+      .default('installing'),
+    createdResources: jsonb('created_resources')
+      .$type<CreatedResources>()
+      .notNull()
+      .default({}),
+    installedBy: uuid('installed_by').notNull(),
+    installedAt: timestamp('installed_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => [
+    index('installed_apps_project_id_idx').on(table.projectId),
+    unique('installed_apps_app_project_unique').on(table.appId, table.projectId),
+  ],
+);
+
+export const installedAppsRelations = relations(installedApps, ({ one }) => ({
+  project: one(projects, {
+    fields: [installedApps.projectId],
+    references: [projects.id],
+  }),
+}));
+
+export type InstalledApp = typeof installedApps.$inferSelect;
+export type NewInstalledApp = typeof installedApps.$inferInsert;
+```
+
+Before writing, check how `projects.schema.ts` types its `createdBy` column and mirror that style for `installedBy` (plain uuid, no FK to the users table, if that is the house pattern — verify, don't assume).
+
+Add to `db/schema/index.ts` after the `projects.schema` export line:
+
+```ts
+export * from './installed-apps.schema';
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd apps/backend && pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: USER CHECKPOINT — migration generation**
+
+STOP and ask the user (reachable via Claude remote) to run:
+
+```bash
+cd /home/rico/bffless/repos/ce/.claude/worktrees/app-catalog/apps/backend
+pnpm db:generate   # suggest migration name: add-installed-apps
+pnpm db:migrate    # if a local dev DB is running
+```
+
+Expected prompts: drizzle shows a diff creating `installed_apps`; no destructive changes. After the user reports back, review the generated SQL in `apps/backend/drizzle/` (CREATE TABLE with the columns above, the unique constraint, and the index) before continuing. **Implementation of Tasks 3–8 may proceed in parallel with this checkpoint — nothing before Task 9's spec run needs a live table.**
+
+- [ ] **Step 4: Commit (schema + generated migration together)**
+
+```bash
+git add apps/backend/src/db/schema/installed-apps.schema.ts apps/backend/src/db/schema/index.ts apps/backend/drizzle
+git commit -m "feat(app-catalog): installed_apps table"
+```
+
+---
+
+### Task 3: CE version + semver utilities
+
+**Files:**
+- Create: `apps/backend/src/app-catalog/ce-version.util.ts`, `apps/backend/src/app-catalog/ce-version.util.spec.ts`
+
+**Interfaces:**
+- Produces: `getCeVersion(): string`, `compareSemver(a: string, b: string): number`, `satisfiesMin(version: string, min: string): boolean`. Consumed by Task 7 (ceMin gate) and Task 11 (catalog payload).
+
+**Background (from exploration):** there is NO reliable version source today. The real CE version lives in the ROOT `package.json` (`@bffless/ce`, release-please-managed). In Docker, root `package.json` is copied to `/app/package.json` (`docker/backend.Dockerfile:10,46`) but the backend's cwd is `/app/apps/backend`, whose own `package.json` is a never-bumped `1.0.0`. Telemetry's private `getAppVersion()` therefore reports `1.0.0` in prod — do not copy its candidate list; fix it here.
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { compareSemver, satisfiesMin, getCeVersion, resolveCeVersion } from './ce-version.util';
+
+describe('compareSemver', () => {
+  it('orders plain versions', () => {
+    expect(compareSemver('0.3.15', '0.2.0')).toBeGreaterThan(0);
+    expect(compareSemver('0.3.15', '0.3.15')).toBe(0);
+    expect(compareSemver('0.3.9', '0.3.15')).toBeLessThan(0);
+  });
+  it('handles v-prefix and prerelease suffix by ignoring the suffix', () => {
+    expect(compareSemver('v1.0.0', '1.0.0')).toBe(0);
+    expect(compareSemver('1.0.0-rc.1', '1.0.0')).toBe(0);
+  });
+});
+
+describe('satisfiesMin', () => {
+  it('passes when equal or newer', () => {
+    expect(satisfiesMin('0.3.15', '0.3.15')).toBe(true);
+    expect(satisfiesMin('0.4.0', '0.3.15')).toBe(true);
+    expect(satisfiesMin('0.3.14', '0.3.15')).toBe(false);
+  });
+  it('fails closed on unparseable running version', () => {
+    expect(satisfiesMin('unknown', '0.3.15')).toBe(false);
+  });
+});
+
+describe('resolveCeVersion', () => {
+  it('picks the first candidate whose package name is @bffless/ce', () => {
+    const version = resolveCeVersion([
+      { name: 'backend', version: '1.0.0' },
+      { name: '@bffless/ce', version: '0.3.15' },
+    ]);
+    expect(version).toBe('0.3.15');
+  });
+  it('returns "unknown" when no candidate matches', () => {
+    expect(resolveCeVersion([{ name: 'backend', version: '1.0.0' }])).toBe('unknown');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/backend && pnpm test -- ce-version`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+```ts
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** Package identity check: the CE release version lives in the ROOT package.json
+ * ("@bffless/ce"). apps/backend/package.json is a never-bumped 1.0.0 — matching
+ * on the name is what keeps us from repeating telemetry's bug. */
+export function resolveCeVersion(
+  candidates: Array<{ name?: string; version?: string }>,
+): string {
+  for (const pkg of candidates) {
+    if (pkg?.name === '@bffless/ce' && pkg.version) return String(pkg.version);
+  }
+  return 'unknown';
+}
+
+let cached: string | null = null;
+
+export function getCeVersion(): string {
+  if (cached) return cached;
+  const files = [
+    path.join(process.cwd(), '..', '..', 'package.json'), // /app/apps/backend -> /app (docker), repo root (dev)
+    path.join(__dirname, '..', '..', '..', '..', 'package.json'), // dist/app-catalog -> repo root fallback
+    '/app/package.json',
+  ];
+  const candidates: Array<{ name?: string; version?: string }> = [];
+  for (const file of files) {
+    try {
+      candidates.push(JSON.parse(fs.readFileSync(file, 'utf8')));
+    } catch {
+      /* try next */
+    }
+  }
+  cached = resolveCeVersion(candidates);
+  return cached;
+}
+
+function parse(v: string): [number, number, number] | null {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)/.exec(v.trim());
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+export function compareSemver(a: string, b: string): number {
+  const pa = parse(a);
+  const pb = parse(b);
+  if (!pa || !pb) return NaN;
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+/** Fail closed: an unparseable running version does NOT satisfy any minimum. */
+export function satisfiesMin(version: string, min: string): boolean {
+  const cmp = compareSemver(version, min);
+  return Number.isFinite(cmp) && cmp >= 0;
+}
+```
+
+- [ ] **Step 4: Run tests, verify PASS. Then verify the docker path assumption**
+
+Run: `cd apps/backend && pnpm test -- ce-version`
+
+Also verify against `docker/backend.Dockerfile` that the root `package.json` really lands at `/app/package.json` and `WORKDIR` is `/app/apps/backend` (lines ~10, ~46, ~77) — if not, fix the candidate list to match reality.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/app-catalog/ce-version.util.ts apps/backend/src/app-catalog/ce-version.util.spec.ts
+git commit -m "feat(app-catalog): CE version resolution + semver compare (fail-closed)"
+```
+
+---
+
+### Task 4: Manifest & registry validation
+
+**Files:**
+- Create: `apps/backend/src/app-catalog/app-manifest.types.ts`, `app-manifest.util.ts`, `app-manifest.util.spec.ts`
+
+**Interfaces:**
+- Produces:
+  - Types: `AppManifest`, `AppManifestRequires`, `AppManualStep`, `AppliesWhen`, `AppRegistry`, `AppRegistryEntry`
+  - `validateAppManifest(json: unknown): { ok: true; manifest: AppManifest } | { ok: false; errors: string[] }`
+  - `validateRegistry(json: unknown): { ok: true; registry: AppRegistry } | { ok: false; errors: string[] }`
+  - `manualStepApplies(step: AppManualStep, ctx: { bucketStorage: boolean; platformMode: boolean }): boolean`
+- Consumed by Tasks 5, 7, 9, 11.
+
+- [ ] **Step 1: Write failing tests**
+
+Cover (one `it` each, table-driven where natural): a fully valid Handoff-shaped manifest passes and round-trips; wrong `schemaVersion` fails; missing `id`/`version`/`install.alias` fails; a `ruleSets` entry without `file` fails; `manualSteps` entry with `appliesWhen: 'sometimes'` fails naming the closed enum; `subdomain` containing a dot or uppercase fails; `alias` violating `/^[a-zA-Z0-9_-]+$/` fails; registry with non-array `apps` fails; registry entry missing `sha256` fails; `manualStepApplies` for each enum value (`always`+omitted → true; `bucketStorage` true only when `ctx.bucketStorage`; `localStorage` only when `!ctx.bucketStorage`; `platformMode`/`selfHosted` on `ctx.platformMode`).
+
+Valid fixture manifest for the tests (Handoff-shaped, reused by later tasks — export it from the spec file as `TEST_MANIFEST`):
+
+```ts
+export const TEST_MANIFEST = {
+  schemaVersion: 1,
+  id: 'handoff',
+  name: 'Handoff',
+  version: '1.0.0',
+  summary: 'Share files and folders with ACLs',
+  requires: { presignedStorage: true, ceMin: '0.3.15' },
+  install: {
+    alias: 'handoff',
+    deployment: { path: 'dist', basePath: '/apps/handoff/dist' },
+    ruleSets: [
+      { file: 'rulesets/handoff.json', attachToAlias: true },
+      { file: 'rulesets/handoff-rss-feed.json', attachToAlias: true },
+    ],
+    domain: { subdomain: 'handoff', isPublic: true, isSpa: true },
+    schedules: [],
+    manualSteps: [
+      {
+        id: 'bucket-cors',
+        title: 'Configure bucket CORS',
+        body: 'Allow PUT from your app origin on the storage bucket.',
+        appliesWhen: 'bucketStorage',
+      },
+    ],
+  },
+  eject: {
+    repo: 'bffless/apps',
+    appPath: 'apps/handoff',
+    deployWorkflow: 'deploy-handoff.yml',
+    variables: ['BFFLESS_URL', 'BFFLESS_PROJECT'],
+    secrets: ['BFFLESS_API_KEY'],
+  },
+};
+```
+
+- [ ] **Step 2: Run to verify failure** — `cd apps/backend && pnpm test -- app-manifest`
+
+- [ ] **Step 3: Implement types + validators**
+
+`app-manifest.types.ts`:
+
+```ts
+export type AppliesWhen =
+  | 'always'
+  | 'bucketStorage'
+  | 'localStorage'
+  | 'platformMode'
+  | 'selfHosted';
+
+export const APPLIES_WHEN_VALUES: readonly AppliesWhen[] = [
+  'always',
+  'bucketStorage',
+  'localStorage',
+  'platformMode',
+  'selfHosted',
+];
+
+export interface AppManualStep {
+  id: string;
+  title: string;
+  body: string;
+  deepLink?: string;
+  appliesWhen?: AppliesWhen;
+}
+
+export interface AppManifestRequires {
+  presignedStorage?: boolean;
+  ceMin?: string;
+}
+
+export interface AppManifestSchedule {
+  name: string;
+  cronExpression: string;
+  timezone?: string;
+  /** Locate the target pipeline rule after sync by (pathPattern, method). */
+  targetRulePath: string;
+  targetRuleMethod?: string;
+}
+
+export interface AppManifest {
+  schemaVersion: 1;
+  id: string;
+  name: string;
+  version: string;
+  summary?: string;
+  iconUrl?: string;
+  docsUrl?: string;
+  sourceUrl?: string;
+  requires?: AppManifestRequires;
+  install: {
+    alias: string;
+    deployment: { path: string; basePath: string };
+    ruleSets: Array<{ file: string; attachToAlias?: boolean }>;
+    domain?: { subdomain: string; isPublic?: boolean; isSpa?: boolean };
+    schedules?: AppManifestSchedule[];
+    manualSteps?: AppManualStep[];
+  };
+  eject?: {
+    repo: string;
+    appPath: string;
+    deployWorkflow: string;
+    variables: string[];
+    secrets: string[];
+  };
+}
+
+export interface AppRegistryEntry {
+  id: string;
+  name?: string;
+  version: string;
+  bundleUrl: string;
+  sha256: string;
+  summary?: string;
+  iconUrl?: string;
+  docsUrl?: string;
+  sourceUrl?: string;
+  requires?: AppManifestRequires;
+}
+
+export interface AppRegistry {
+  schemaVersion: 1;
+  apps: AppRegistryEntry[];
+}
+```
+
+`app-manifest.util.ts` — hand-rolled validators (no new deps; class-validator is for HTTP DTOs, this is internal JSON). Collect ALL errors into `errors: string[]` with dotted paths (`install.ruleSets[0].file: required string`). Validation rules: `schemaVersion === 1`; `id` matches `/^[a-z0-9-]+$/`; `version` parseable by Task 3's `parse` regex (import `compareSemver` and check `Number.isFinite(compareSemver(v, v))`); `install.alias` matches `/^[a-zA-Z0-9_-]+$/` (the `CreateDeploymentZipDto` alias rule); `install.deployment.basePath` matches `/^\/[a-zA-Z0-9/_-]*$/` (the `CreateDomainDto.path` rule); `install.domain.subdomain` matches `/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/` and is NOT in a copied `RESERVED_SUBDOMAINS` list (import it from `domains.service.ts` if exported, else re-declare with a comment pointing at `domains.service.ts:27-46`); `ruleSets` non-empty, each `file` a relative path with no `..` and matching `/^rulesets\/[a-zA-Z0-9._-]+\.json$/`; `manualSteps[].appliesWhen` ∈ `APPLIES_WHEN_VALUES`; `sha256` in registry entries matches `/^[a-f0-9]{64}$/i`; `bundleUrl` must be `https:`.
+
+`manualStepApplies`:
+
+```ts
+export function manualStepApplies(
+  step: AppManualStep,
+  ctx: { bucketStorage: boolean; platformMode: boolean },
+): boolean {
+  switch (step.appliesWhen ?? 'always') {
+    case 'always':
+      return true;
+    case 'bucketStorage':
+      return ctx.bucketStorage;
+    case 'localStorage':
+      return !ctx.bucketStorage;
+    case 'platformMode':
+      return ctx.platformMode;
+    case 'selfHosted':
+      return !ctx.platformMode;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests, verify PASS** — `pnpm test -- app-manifest`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/app-catalog/app-manifest.types.ts apps/backend/src/app-catalog/app-manifest.util.ts apps/backend/src/app-catalog/app-manifest.util.spec.ts
+git commit -m "feat(app-catalog): manifest + registry validation (closed appliesWhen enum)"
+```
+
+---
+
+### Task 5: Registry service + bundle fetch/verify/extract
+
+**Files:**
+- Create: `apps/backend/src/app-catalog/apps-registry.service.ts`, `apps-registry.service.spec.ts`, `app-bundle.service.ts`, `app-bundle.service.spec.ts`
+- Modify: `app-catalog.module.ts` (add providers)
+
+**Interfaces:**
+- Produces:
+
+```ts
+// apps-registry.service.ts
+export type RegistryResult =
+  | { ok: true; registry: AppRegistry; fetchedAt: string }
+  | { ok: false; error: string };
+export class AppsRegistryService {
+  async getRegistry(force?: boolean): Promise<RegistryResult>;
+}
+
+// app-bundle.service.ts
+export interface LoadedBundle {
+  manifest: AppManifest;
+  /** entry path -> bytes; directory entries stripped */
+  files: Record<string, Uint8Array>;
+  sha256: string;
+}
+export class AppBundleService {
+  async fetchBundle(url: string, expectedSha256: string): Promise<LoadedBundle>; // throws BadRequestException on mismatch
+  async loadFromBuffer(buf: Uint8Array, expectedSha256?: string): Promise<LoadedBundle>; // fixture/test path
+}
+```
+
+- Consumed by Tasks 7, 9, 11 (and the fixture tests).
+
+- [ ] **Step 1: Write failing tests**
+
+Registry (mock global `fetch` with `jest.spyOn(globalThis, 'fetch')`):
+- returns parsed registry on 200 with valid JSON
+- caches: second call within TTL does NOT refetch (assert fetch called once); `force: true` refetches
+- degrades: network error → `{ ok: false, error }`; non-200 → `{ ok: false }`; invalid registry JSON (fails `validateRegistry`) → `{ ok: false }`
+- a failed refresh after a successful cache serves the STALE cache with `ok: true` (installed apps must not break when the registry blips) — assert this explicitly
+
+Bundle (build a real zip in-test with `fflate.zipSync`):
+
+```ts
+import { zipSync, strToU8 } from 'fflate';
+import { createHash } from 'crypto';
+import { TEST_MANIFEST } from './app-manifest.util.spec'; // or duplicate a minimal valid manifest
+
+function makeBundle(manifest: unknown = TEST_MANIFEST): { buf: Uint8Array; sha256: string } {
+  const buf = zipSync({
+    'bffless-app.json': strToU8(JSON.stringify(manifest)),
+    'rulesets/handoff.json': strToU8(JSON.stringify({ ruleSet: { name: 'handoff' }, rules: [], schemas: [] })),
+    'rulesets/handoff-rss-feed.json': strToU8(JSON.stringify({ ruleSet: { name: 'handoff-rss-feed' }, rules: [], schemas: [] })),
+    'dist/index.html': strToU8('<!doctype html>ok'),
+  });
+  return { buf, sha256: createHash('sha256').update(buf).digest('hex') };
+}
+```
+
+- `loadFromBuffer` with matching sha → manifest parsed, `files['dist/index.html']` present
+- sha mismatch → throws `BadRequestException` mentioning sha256, BEFORE any parse
+- missing `bffless-app.json` → throws
+- manifest that fails `validateAppManifest` → throws with the validator's errors
+- a `ruleSets` entry whose `file` is absent from the zip → throws ("declared file missing")
+- `fetchBundle`: mocked fetch returning the zip bytes → same assertions; oversized body (> 200 MiB cap) → throws before hashing completes (enforce via `Content-Length` when present AND a streamed/accumulated byte cap)
+
+- [ ] **Step 2: Run to verify failure** — `pnpm test -- 'apps-registry|app-bundle'`
+
+- [ ] **Step 3: Implement**
+
+`AppsRegistryService` — constructor `(private readonly configService: ConfigService)`; fields `url = configService.get<string>('APPS_REGISTRY_URL') || 'https://apps.bffless.dev/registry.json'`, `cache: { registry: AppRegistry; fetchedAt: number } | null`, `TTL_MS = 3600_000`. Fetch with the telemetry-style AbortController timeout (10 s), `User-Agent: bffless-ce-app-catalog/${getCeVersion()}`. On success: `validateRegistry`, store cache. On any failure: if a cache exists (even expired) return it with `ok: true` (stale-while-error), else `{ ok: false, error }`.
+
+`AppBundleService` — `MAX_BUNDLE_BYTES = 200 * 1024 * 1024`. `fetchBundle`: fetch (30 s timeout), check `Content-Length` against cap when present, read `arrayBuffer()`, check byte length against cap, delegate to `loadFromBuffer(bytes, expectedSha256)`. `loadFromBuffer`: sha256 first (`createHash('sha256')`), compare case-insensitively, throw on mismatch; unzip with the fflate promise wrapper copied from `deployments.service.ts:241-252`; skip directory entries (trailing `/`); parse + `validateAppManifest(files['bffless-app.json'])`; assert every `install.ruleSets[].file` exists in `files`; assert at least one entry under `${manifest.install.deployment.path}/`. Keep an in-memory `Map<sha256, LoadedBundle>` (max 3 entries, LRU-ish) so preflight and install don't download twice.
+
+Register both in `AppCatalogModule.providers`.
+
+- [ ] **Step 4: Run tests, verify PASS. Typecheck.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/app-catalog
+git commit -m "feat(app-catalog): registry fetch/cache + bundle download with sha256 verification"
+```
+
+---
+
+### Task 6: DNS preflight — extract a single-host probe
+
+**Files:**
+- Modify: `apps/backend/src/setup/bootstrap-dns-preflight.service.ts`
+- Test: extend its existing spec (find it via `ls apps/backend/src/setup/*preflight*`; if none exists, create `bootstrap-dns-preflight.service.spec.ts`)
+
+**Interfaces:**
+- Produces: `async probeHost(host: string): Promise<PreflightCheck>` — public, probes exactly ONE hostname (token drop in webroot → resolve A → refuse disallowed IPs → HTTP fetch by pinned IP with Host header). `run(domain)` refactored to `Promise.all([domain, www.domain, admin.domain].map(h => this.probeHost(h)))` with behavior byte-identical to today.
+- Consumed by Task 7 (probe `<sub>.<primary>` only, no www/admin fan-out).
+
+- [ ] **Step 1: Read `run()` (`bootstrap-dns-preflight.service.ts:55-89`) and write the failing test**
+
+Mock the private seams (`resolveA`, `fetchProbe`, `webroot`) via `jest.spyOn(service as any, ...)`:
+
+```ts
+it('probeHost probes exactly the given host', async () => {
+  const service = new BootstrapDnsPreflightService();
+  jest.spyOn(service as any, 'webroot').mockReturnValue('/tmp/webroot-test');
+  const resolveA = jest.spyOn(service as any, 'resolveA').mockResolvedValue(['203.0.113.7']);
+  jest.spyOn(service as any, 'fetchProbe').mockResolvedValue(true);
+  const check = await service.probeHost('handoff.example.com');
+  expect(check).toMatchObject({ host: 'handoff.example.com', probeOk: true });
+  expect(resolveA).toHaveBeenCalledTimes(1);
+});
+
+it('run() still fans out to apex + www + admin', async () => {
+  const service = new BootstrapDnsPreflightService();
+  const probe = jest.spyOn(service, 'probeHost').mockResolvedValue({ host: 'x', resolvedIps: [], probeOk: true });
+  await service.run('example.com');
+  expect(probe.mock.calls.map((c) => c[0])).toEqual(['example.com', 'www.example.com', 'admin.example.com']);
+});
+```
+
+Note: `webroot()` writes a token file — if extraction keeps the token write inside `probeHost`, mock `fs` or point webroot at a temp dir (`mkdtemp`). Match however the existing spec (if any) already isolates it.
+
+- [ ] **Step 2: Run to verify failure** — `pnpm test -- bootstrap-dns-preflight`
+
+- [ ] **Step 3: Refactor**
+
+Move the per-host body of `run()`'s loop into `probeHost(host)` verbatim (token write + resolve + `isDisallowedProbeIp` + pinned-IP fetch + `finally` cleanup). `run()` becomes the 3-host fan-out plus `ok: checks.every(...)`. Do NOT change any probe semantics (5 s timeout, redirects not followed).
+
+- [ ] **Step 4: Run the setup module's full spec set to catch regressions**
+
+Run: `pnpm test -- 'setup/'` — expected: all PASS (this service is load-bearing for web bootstrap; treat any behavior diff as a bug in the refactor, not the tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/setup
+git commit -m "refactor(setup): extract single-host probeHost() from DNS preflight fan-out"
+```
+
+---
+
+### Task 7: Preflight service (instance + project gates)
+
+**Files:**
+- Create: `apps/backend/src/app-catalog/app-preflight.service.ts`, `app-preflight.service.spec.ts`
+- Modify: `app-catalog.module.ts` (provider + `BootstrapDnsPreflightService` in providers — it is NOT exported by `SetupModule`; zero-dep constructor, same pattern `SetupModule` uses for `SslCertificateService`)
+
+**Interfaces:**
+- Produces:
+
+```ts
+export type GateStatus = 'pass' | 'fail' | 'warn';
+export interface GateResult {
+  id: 'storage' | 'ce-version' | 'platform-config' | 'dns' | 'name-collision' | 'data-tables';
+  status: GateStatus;
+  message: string;
+  remediation?: string;
+  deepLink?: string;
+  /** DNS is blocking-but-retryable; name collisions are not. */
+  retryable?: boolean;
+}
+export interface SyncPlanSummary {
+  ruleSet: string;
+  created: number;
+  updated: number;
+  unchanged: number;
+  pruneCandidates: number;
+  schemaResolutions: SyncSchemaResolutionLike[]; // { name, action: 'reuse'|'create', fieldMismatch }
+}
+export class AppPreflightService {
+  async instanceGates(requires?: AppManifestRequires): Promise<GateResult[]>;
+  async projectGates(
+    bundle: LoadedBundle,
+    target: { projectId: string } | { newProject: { owner: string; name: string } },
+    userId: string,
+  ): Promise<{ gates: GateResult[]; syncPlans: SyncPlanSummary[]; appHost: string | null }>;
+}
+```
+
+- Consumes: `STORAGE_ADAPTER` (`@Inject`, global), `getCeVersion`/`satisfiesMin` (Task 3), `BootstrapDnsPreflightService.probeHost` (Task 6), `ProxyRuleSetsService.syncRuleSet` with `options.dryRun` (exported by `ProxyRulesModule`), `DomainsService` + db reads for collisions, `ConfigService`.
+- Consumed by Tasks 9, 11 and the preflight endpoint.
+
+**Gate semantics (from the spec table, updated post-#565):**
+
+| Gate | Scope | Logic |
+|---|---|---|
+| `storage` | instance | `requires.presignedStorage` && !(`storageAdapter.supportsPresignedUrls?.() ?? false`) → **fail**. Remediation names both routes: bundled MinIO (`ENABLE_MINIO=true` + restart) and a real bucket, AND — since v0.3.15 — notes local FS passes when `ENCRYPTION_KEY` is set and `FEATURE_LOCAL_PRESIGNED_UPLOADS` isn't disabled (so a fail usually means the flag was turned off or the key is missing). |
+| `ce-version` | instance | `requires.ceMin` && !`satisfiesMin(getCeVersion(), ceMin)` → **fail** (fail-closed on `unknown`, message says the version could not be determined). |
+| `platform-config` | instance | Only when `process.env.PLATFORM_MODE === 'true'`: require `CONTROL_PLANE_URL` + `WORKSPACE_ID` (fail if missing); always add a **warn** gate reporting the two-label subdomain certificate-coverage constraint (`<sub>.<workspace>.<platform>` is not covered by `*.<platform>`). |
+| `dns` | project | `probeHost('<sub>.<PRIMARY_DOMAIN>')`; failure → **fail** with `retryable: true`, message includes the exact A/CNAME record to add and the resolved-vs-expected IPs from `PreflightCheck`. Skip (pass with note) when the manifest declares no `install.domain`. |
+| `name-collision` | project | Refuse-rather-than-clobber. Existing same-name **rule set** in target project NOT recorded in an `installed_apps` row for this app → fail. Existing **alias** row `(projectId, alias)` → fail. Existing **domain_mappings** row for `<sub>.<primary>` (global uniqueness) → fail unless owned by this app's install. ALSO the cross-namespace trap: an alias named `<sub>` in ANY project is reachable at `<sub>.<primary>` via the wildcard block — query `deployment_aliases` for `alias === subdomain` across projects and fail with an explanatory message. New-project target: only the domain + cross-namespace checks apply. |
+| `data-tables` | project | Run `syncRuleSet(projectId, dto, userId, 'admin', null)` with `options: { dryRun: true }` per bundled rule set (ZERO writes — verified in `proxy-rule-sets.service.ts`). `schemaResolutions[].fieldMismatch === true` → **warn** (reuse is the documented adoption path), never fail. For `newProject` targets skip the dryRun (no project yet) and synthesize all-create summaries from the bundle JSON (`rules.length` created, each schema `action: 'create'`). |
+
+- [ ] **Step 1: Write failing tests** — house pattern: construct the service with hand-mocked collaborators (plain objects with `jest.fn()`), db via the thenable-chainable mock from `pipeline-schedules.service.spec.ts:1-46` if direct db reads are used. One describe per gate; assert exact `GateResult.id`/`status` and that remediation text is present on failures. Include: storage pass-through when `requires` omits `presignedStorage`; dryRun plans summarized correctly from a mocked `SyncProxyRuleSetResponseDto` (`created: [..], updated: [], schemaResolutions: [{ name: 'handoff_nodes', action: 'reuse', targetSchemaId: 'x', fieldMismatch: false }]`).
+
+- [ ] **Step 2: Run to verify failure** — `pnpm test -- app-preflight`
+
+- [ ] **Step 3: Implement.** `appHost` = `install.domain ? `${subdomain}.${process.env.PRIMARY_DOMAIN}` : null`. Collision reads: prefer existing service methods (`ProxyRuleSetsService` has a private `findByName` — use a direct db select instead, matching its query shape; alias probe = select on `deployment_aliases` by `(projectId, alias)` and by `alias` alone; domain probe = select on `domain_mappings` by `domain`). Exclude collisions that belong to an existing `installed_apps` row for the same `appId` (that's the update path, not a clobber).
+
+- [ ] **Step 4: Run tests, verify PASS. Typecheck.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/app-catalog
+git commit -m "feat(app-catalog): instance + project preflight gates with dryRun sync plans"
+```
+
+---
+
+### Task 8: Certificate step — serving-model plan + `extraSans` threading
+
+**Files:**
+- Create: `apps/backend/src/app-catalog/app-cert-step.service.ts`, `app-cert-step.service.spec.ts`
+- Modify: `apps/backend/src/setup/primary-ssl/primary-ssl.service.ts` (add `opts?: { extraSans?: string[] }` to `issueLetsEncrypt`), `apps/backend/src/domains/ssl-certificate.service.ts` (thread `extraSans` into `requestPrimaryDomainCertificate`'s SAN list), plus their existing specs.
+
+**Interfaces:**
+- Produces:
+
+```ts
+export type CertPlan =
+  | { model: 'platform'; action: 'delegated' }
+  | { model: 'wildcard'; action: 'covered' }
+  | { model: 'edge-terminated'; action: 'none-needed' } // proxyMode cloudflare/proxy, or sslMode selfsigned
+  | { model: 'direct-le'; action: 'stage-san-reissue' }
+  | { model: 'unknown'; action: 'report' };
+export class AppCertStepService {
+  async plan(appHost: string): Promise<CertPlan>;
+  /** Executes the plan; returns a GateResult-shaped outcome plus an optional
+   *  synthesized manual step ("apply & confirm in Admin → Settings → SSL"). */
+  async execute(plan: CertPlan, appHost: string): Promise<{
+    status: 'done' | 'action-required' | 'skipped';
+    detail: string;
+    manualStep?: AppManualStep;
+  }>;
+}
+```
+
+- Consumes: `loadInstanceConfig()` from `bootstrap/instance-config.ts` (`proxyMode`/`sslMode`), `DomainsService.getWildcardCertificateStatus()`, `PrimarySslService` (`assertEnabled` throw = platform/external → `delegated`; `issueLetsEncrypt({ extraSans })`).
+- Consumed by Task 9 (applier step 6).
+
+**Branch logic for `plan()`:**
+1. `process.env.PLATFORM_MODE === 'true'` or `SSL_MANAGED_EXTERNALLY === 'true'` → `{ model: 'platform', action: 'delegated' }` (`DomainsService.create` already forces `sslEnabled: true` and notifies the Control Plane).
+2. `getWildcardCertificateStatus().exists` → `{ model: 'wildcard', action: 'covered' }`.
+3. `loadInstanceConfig()` null (no bootstrap-managed box, e.g. legacy compose) → `{ model: 'unknown', action: 'report' }` — report-only, never touch certs.
+4. `proxyMode` is `'cloudflare' | 'proxy'` OR `sslMode === 'selfsigned'` → `edge-terminated` (edge/self-signed serves `*.<primary>` via the wildcard 443 block; nothing to issue).
+5. else (`proxyMode 'none'` + `sslMode 'letsencrypt'`) → `stage-san-reissue`.
+
+**`execute` for `stage-san-reissue`:** call `primarySslService.issueLetsEncrypt({ extraSans: [appHost] })` (stages to `target: 'staging'`, never live). On success return `action-required` with a manual step `{ id: 'apply-ssl-cert', title: 'Apply the updated certificate', body: 'A new certificate including <appHost> was issued and staged. Review and apply it, then confirm within the safety window.', deepLink: '/admin/settings/ssl', appliesWhen: 'selfHosted' }`. On `issueLetsEncrypt` failure (its preflight hard-gate probes apex/www/admin and can fail for reasons unrelated to the app): degrade to `action-required` with body naming the failure and BOTH remediation routes (wildcard cert — auto-upgrades the subdomain later via `enableSslForAllSubdomains`; or manual SSL page re-issue). Never fail the install for a cert problem — the app is reachable over the wildcard/HTTP meanwhile.
+
+**`extraSans` threading:** read `requestPrimaryDomainCertificate` in `ssl-certificate.service.ts` first; add the optional SANs to wherever the `-d` domain list / CSR SAN list is built, default `[]`, behavior byte-identical when absent. Extend `issueLetsEncrypt(opts?)` to pass through AND to include `extraSans` in its preflight probe list (reuse `probeHost` from Task 6 if its current preflight uses `BootstrapDnsPreflightService.run`; only add a probe for the extra hosts, don't reduce existing checks). Update `PrimarySslStatus.wildcardCovered`-adjacent tests only if they break; add focused new tests: `issueLetsEncrypt()` without opts produces the same SAN list as before (regression), with `extraSans: ['handoff.example.com']` the SAN list includes it.
+
+- [ ] **Step 1: Write failing tests** for `plan()` (each of the 5 branches, mocking `loadInstanceConfig` via `jest.mock('../bootstrap/instance-config')` and a stub DomainsService) and `execute()` (`stage-san-reissue` success → `action-required` + manualStep with deepLink `/admin/settings/ssl`; issue failure → `action-required` degraded, install not failed; `covered`/`delegated`/`none-needed` → `done`/`skipped` without touching PrimarySslService — assert the mock was NOT called).
+- [ ] **Step 2: Run to verify failure** — `pnpm test -- app-cert-step`
+- [ ] **Step 3: Implement `AppCertStepService`, then the `extraSans` threading with its regression tests.**
+- [ ] **Step 4: Run** `pnpm test -- 'app-cert-step|primary-ssl|ssl-certificate'` — all PASS.
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/app-catalog apps/backend/src/setup/primary-ssl apps/backend/src/domains
+git commit -m "feat(app-catalog): serving-model cert step; optional extraSans on LE issuance"
+```
+
+---
+
+### Task 9: Install jobs + the applier
+
+**Files:**
+- Create: `apps/backend/src/app-catalog/app-install-jobs.service.ts`, `app-installer.service.ts`, `app-installer.service.spec.ts`, `app-install-jobs.service.spec.ts`
+- Modify: `app-catalog.module.ts` — this is where the cross-module imports land:
+
+```ts
+@Module({
+  imports: [
+    forwardRef(() => ProxyRulesModule), // ProxyRuleSetsService (module forwardRefs internally)
+    DeploymentsModule,                  // DeploymentsService
+    DomainsModule,                      // DomainsService
+    ProjectsModule,                     // ProjectsService
+    PipelineSchedulesModule,            // PipelineSchedulesService
+    PipelinesModule,                    // PipelineSchemasService (uninstall counts)
+  ],
+  controllers: [AppCatalogController],
+  providers: [
+    AppCatalogService, AppsRegistryService, AppBundleService,
+    AppPreflightService, AppCertStepService,
+    AppInstallJobsService, AppInstallerService,
+    BootstrapDnsPreflightService, // not exported by SetupModule; zero-dep
+  ],
+})
+```
+
+**Interfaces:**
+- Produces:
+
+```ts
+// app-install-jobs.service.ts — in-memory, storage-migration pattern
+export type InstallStepId =
+  | 'preflight' | 'fetch' | 'sync-rules' | 'deploy'
+  | 'domain' | 'certificate' | 'schedules' | 'record';
+export interface InstallStepState {
+  id: InstallStepId;
+  status: 'pending' | 'running' | 'done' | 'failed' | 'skipped' | 'action-required';
+  detail?: string;
+  error?: string;
+}
+export interface InstallJob {
+  id: string;                      // `app-install-${Date.now()}`
+  kind: 'install' | 'update';
+  appId: string;
+  projectId: string | null;        // null until project resolved (newProject path)
+  status: 'running' | 'succeeded' | 'failed' | 'undone';
+  steps: InstallStepState[];
+  installedAppId?: string;
+  manualSteps?: AppManualStep[];   // filtered by manualStepApplies at completion
+  appUrl?: string;
+  error?: string;
+  createdAt: string;
+  finishedAt?: string;
+}
+export class AppInstallJobsService {
+  create(kind: 'install' | 'update', appId: string, stepIds: InstallStepId[]): InstallJob; // throws BadRequestException if a job is already running
+  get(jobId: string): InstallJob | null;
+  setStep(jobId: string, step: InstallStepId, patch: Partial<InstallStepState>): void;
+  finish(jobId: string, status: InstallJob['status'], patch?: Partial<InstallJob>): void;
+}
+
+// app-installer.service.ts
+export interface InstallTarget {
+  projectId?: string;
+  newProject?: { owner: string; name: string };
+}
+export class AppInstallerService {
+  /** Kicks off the background run; returns immediately. */
+  startInstall(entry: AppRegistryEntry, target: InstallTarget, userId: string): { jobId: string };
+  startUpdate(installed: InstalledApp, entry: AppRegistryEntry, userId: string, opts: { prune: boolean }): { jobId: string };
+  /** Deletes ONLY this job's created objects (from the installed_apps row's createdResources). */
+  undo(installedAppId: string, userId: string): Promise<{ removed: string[] }>;
+  uninstall(installedAppId: string, userId: string, opts: { deleteData: boolean }): Promise<UninstallSummary>;
+}
+```
+
+- Consumes (exact signatures from exploration — do not re-derive):
+  - `ProxyRuleSetsService.syncRuleSet(projectId, dto, userId, userRole, apiKeyProjectId?)` → `SyncProxyRuleSetResponseDto` (`proxy-rule-sets.service.ts:889`)
+  - `DeploymentsService.createDeploymentFromZip(file, dto, userId, userRole?)` (`deployments.service.ts:185`) — `file` needs only `{ buffer, originalname, mimetype }`
+  - `DomainsService.create(createDomainDto, userId, authToken?, apiKeyProjectId?)` (`domains.service.ts:525`) — **read back `sslEnabled` from the returned row**; a subdomain's `sslEnabled: true` is silently downgraded when no wildcard cert exists
+  - `ProjectsService.findOrCreateProject(owner, name, createdBy)` (idempotent) / `projectExists(owner, name)`
+  - `PipelineSchedulesService.createSchedule(projectId, dto, userId, userRole?, apiKeyProjectId?)` and `listPipelineRules(...)` to find the target rule by `(pathPattern, method)`
+  - Task 5's `AppBundleService`, Task 7's `AppPreflightService`, Task 8's `AppCertStepService`
+- Consumed by: Task 10 (uninstall/update endpoints), Task 11 (controller), Task 13 (UI polling contract).
+
+**Applier step semantics (each step idempotent, individually reported):**
+
+1. **`preflight`** — re-run `instanceGates` + `projectGates`; any `fail` → job fails before any write. (The UI already showed these, but the job re-checks — nothing is written that wasn't re-verified.)
+2. **`fetch`** — `AppBundleService.fetchBundle(entry.bundleUrl, entry.sha256)` (cache hit if preflight just fetched). Then **validate each bundled rule-set JSON through the real DTO pipeline**: `plainToInstance(SyncProxyRuleSetDto, json)` + `validateSync` (class-transformer/-validator are already backend deps) so direct service calls get the same SSRF/shape validation as HTTP callers (`IsValidSyncTargetUrl` etc.). Abort on errors.
+3. **project resolution** (inside `sync-rules` step start): `newProject` → `findOrCreateProject(owner, name, userId)`; set `createdResources.projectCreated = !await projectExists(...)` (check BEFORE creating). Insert the `installed_apps` row now with `status: 'installing'` — it survives restarts and powers undo.
+4. **`sync-rules`** — per bundled rule set, in manifest order: `syncRuleSet(projectId, { ...parsedJson, options: { dryRun: false, prune: false }, source: { repo: manifest.eject?.repo, path: ruleSetEntry.file } }, userId, 'admin', null)`. Record `ruleSetId` into both `ruleSetIds` and `createdResources.ruleSetIds` (only when `setCreated === true` for the latter); collect `schemaResolutions` — `targetSchemaId`s into `schemaIds`, and `action === 'create'` ids into `createdResources.schemaIdsCreated`. Surface `missingSecrets`/`warnings` into the step's `detail`.
+5. **`deploy`** — build a dist-only zip: for each bundle entry under `dist/`, re-key to `${basePath.slice(1)}/${rest}` (e.g. `dist/index.html` → `apps/handoff/dist/index.html`), `fflate.zipSync` the map, then `createDeploymentFromZip({ buffer: Buffer.from(zip), originalname: `${appId}-bundle.zip`, mimetype: 'application/zip' } as Express.Multer.File, dto, userId, 'admin')` with dto `{ repository: `${owner}/${name}`, commitSha: bundleSha256.slice(0, 40), branch: 'app-catalog', alias: manifest.install.alias, description: `App install: ${name} v${version}`, basePath: manifest.install.deployment.basePath, proxyRuleSetNames: ruleSets.filter(r => r.attachToAlias !== false).map(namesFromSyncResponses), source: 'manual' }`. **Assert the returned `aliases[]` includes the alias** — explicit-alias failure is swallowed upstream (`deployments.service.ts:393-396`); treat absence as step failure. Record `deploymentId`, `aliasName`.
+6. **`domain`** — skip (status `skipped`) when manifest has no `install.domain`. Else `DomainsService.create({ projectId, alias, path: basePath, domain: appHost, domainType: 'subdomain', sslEnabled: true, isPublic, isSpa }, userId, undefined, null)`. Record `domainId` into row + `createdResources`. Idempotency: if the domain already exists AND is recorded in this app's own `installed_apps` row (re-run), skip.
+7. **`certificate`** — `AppCertStepService.plan(appHost)` → `execute`; `action-required` outcomes append the synthesized manual step to the job's `manualSteps`. Also: if the domain step's returned row had `sslEnabled === false` on a non-platform box, note it in `detail`.
+8. **`schedules`** — for each manifest schedule: find the rule via `listPipelineRules` matching `(targetRulePath, targetRuleMethod)`, list existing schedules and match by `name` (schedules have no name-uniqueness — the installer enforces idempotency itself), create if absent, record ids in `createdResources.scheduleIds`. Handoff ships `schedules: []` — the step reports `skipped` when empty.
+9. **`record`** — update the `installed_apps` row: `status: 'installed'`, final `version`, `bundleSha256`, `updatedAt`. Compute `manualSteps` = manifest steps filtered by `manualStepApplies` with `ctx = { bucketStorage: !(storage adapter is local), platformMode }` + any cert-step synthesized ones; set `appUrl` (`https://${appHost}` when domain created, else the deployment's alias URL from `createDeploymentResponse.urls.default`).
+
+**Failure handling:** any step throw → step `failed` with `error`, job `failed`, `installed_apps.status = 'failed'` (row kept — powers undo + resume). `undo()` deletes only `createdResources` in reverse order (schedules → domain → alias → deployment → rule sets → created schemas → project if `projectCreated` and it has no other content), then deletes the row and marks the job `undone`. Never touches reused schemas or pre-existing domains. Re-running install on a `failed` row is allowed (idempotent steps make it a resume).
+
+**Update job** (`kind: 'update'`, steps `fetch → sync-rules → deploy → record`): re-sync with `prune` from opts (default false — user rules survive; `prune: true` is the explicit "reset to shipped rules" toggle), deploy new dist to the SAME alias (alias history = instant rollback), domain/schedules untouched, row version bumped. No preflight DNS/collision gates (already installed).
+
+- [ ] **Step 1: Write failing tests for `AppInstallJobsService`** — create/get/single-flight (second `create` while running throws), `setStep` transitions, `finish`.
+- [ ] **Step 2: Write failing tests for `AppInstallerService`** — the meat. House db mock for `installed_apps` reads/writes + `jest.fn()` stubs for every collaborator, returning realistic shapes (reuse `TEST_MANIFEST` + `makeBundle` from Tasks 4–5). Cases:
+  - happy path: collaborators called in order (sync before deploy — assert call order via `mock.invocationCallOrder`), `proxyRuleSetNames` passed to deploy match synced set names, `createdResources` recorded correctly, row ends `installed`
+  - deploy response missing the alias in `aliases[]` → step failed, job failed, row `failed`
+  - sync `schemaResolutions` mixing reuse/create → only created ids land in `createdResources.schemaIdsCreated`, all land in `schemaIds`
+  - no `install.domain` in manifest → domain + certificate steps `skipped`, `appUrl` falls back to deployment URL
+  - cert step `action-required` → job succeeds with the manual step present
+  - undo: deletes only created resources, reverse order, never calls schema-delete for reused ids
+  - update: prune flag passed through; domain service NOT called
+- [ ] **Step 3: Run to verify failure** — `pnpm test -- 'app-install'`
+- [ ] **Step 4: Implement both services.** Job kickoff is fire-and-forget (`void this.runInstall(...)` with a top-level try/catch that always `finish()`es — copy the migration service's shape, `migration.service.ts:93-94`), with `setImmediate` yields between steps unnecessary (few steps, each awaits I/O).
+- [ ] **Step 5: Run tests, verify PASS. Typecheck. Boot check:** `cd apps/backend && pnpm exec tsc --noEmit` then start the backend briefly if a local stack is available (`pnpm dev` from repo root) to catch Nest DI wiring errors (forwardRef cycles surface at boot, not compile). If no local stack, note it for the live checklist.
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/backend/src/app-catalog
+git commit -m "feat(app-catalog): background install job + idempotent applier with undo"
+```
+
+---
+
+### Task 10: Lifecycle backend — uninstall, eject, manual-step ack
+
+**Files:**
+- Modify: `apps/backend/src/app-catalog/app-installer.service.ts` (uninstall), `app-catalog.service.ts` (eject payload, ack), and their specs
+
+**Interfaces:**
+- Produces:
+
+```ts
+export interface UninstallSummary {
+  removed: { ruleSets: number; alias: boolean; domain: boolean; deployment: boolean; schedules: number };
+  dataTables: { kept: string[]; deleted: string[]; deletedRecordCounts: Record<string, number> };
+  note: string; // "stored objects under project X remain; delete the project for full cleanup"
+}
+export interface UninstallPreview {
+  dataTables: Array<{ name: string; recordCount: number; createdByInstall: boolean }>;
+}
+// app-catalog.service.ts
+export interface EjectPayload {
+  repo: string; appPath: string; deployWorkflow: string;
+  forkUrl: string;                       // https://github.com/<repo>/fork
+  variables: Record<string, string>;     // { BFFLESS_URL: <admin origin>, BFFLESS_PROJECT: "<owner>/<name>" }
+  secrets: string[];                     // ['BFFLESS_API_KEY']
+  alias: string;
+  note: string;                          // "the workflow's first deploy lands on this same alias"
+}
+async ejectPayload(installedAppId: string): Promise<EjectPayload>;
+async ackManualStep(installedAppId: string, stepId: string): Promise<string[]>; // returns updated acked list
+async uninstallPreview(installedAppId: string): Promise<UninstallPreview>;
+```
+
+**Uninstall semantics (spec §Lifecycle + deviation 5):** default removes rule sets (only ids in `ruleSetIds`), alias (`DeploymentsService.deleteAlias`), domain (only `createdResources.domainId`), deployment (find the delete method on `DeploymentsService` — it exists; the MCP `delete_deployment` tool fronts it), schedules (`createdResources.scheduleIds`). Keeps ALL data tables and stored objects. With `deleteData: true`: additionally delete tables in `createdResources.schemaIdsCreated` via `PipelineSchemasService.delete`, having first fetched `recordCount` per table (`getByIdWithCount`) for the summary; reused tables are NEVER deleted regardless of the flag. Finally delete the `installed_apps` row. `uninstallPreview` powers the dialog's real counts ("this deletes 412 records across 3 tables").
+
+**Eject:** `BFFLESS_URL` = `PUBLIC_ORIGIN` env if set, else `https://admin.${PRIMARY_DOMAIN}`. Manifest comes from the stored `installed_apps.manifest` jsonb (no registry fetch — eject works offline). API-key minting stays in the frontend via the EXISTING api-keys endpoints (`createApiKey` slice already exists) — no new backend surface.
+
+- [ ] **Step 1: Write failing tests:** uninstall default keeps tables (schema delete NOT called) but removes the four object classes; `deleteData: true` deletes only created tables with counts collected first; reused-table protection; eject payload derives variables correctly (with and without `PUBLIC_ORIGIN`); ack appends idempotently (double-ack no duplicate).
+- [ ] **Step 2: Run to verify failure** — `pnpm test -- 'app-installer|app-catalog.service'`
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Run tests, verify PASS.**
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/app-catalog
+git commit -m "feat(app-catalog): uninstall (data kept by default), eject payload, manual-step ack"
+```
+
+---
+
+### Task 11: Controller routes, catalog assembly, fixture bundle, orchestration spec
+
+**Files:**
+- Create: `apps/backend/src/app-catalog/app-catalog.dtos.ts`, `app-catalog/__fixtures__/make-fixture-bundle.ts` (test helper building v1/v2 bundles in-memory with `zipSync` — committed as code, not binary), `app-catalog.e2e-ish.spec.ts` (orchestration spec)
+- Modify: `app-catalog.controller.ts`, `app-catalog.service.ts`, their specs
+
+**Interfaces:**
+- Produces the full HTTP surface (all under the Task 1 guard stack; `@CurrentUser() user: CurrentUserData` everywhere):
+
+| Route | Handler | Request | Response |
+|---|---|---|---|
+| `GET /api/admin/apps` | `list` | — | `{ data: CatalogEntry[], registryError?: string }` |
+| `POST /api/admin/apps/:appId/preflight` | `preflight` | `PreflightRequestDto` | `{ gates, syncPlans, appHost, appUrl }` |
+| `POST /api/admin/apps/:appId/install` | `install` | `PreflightRequestDto` | `{ jobId }` |
+| `GET /api/admin/apps/jobs/:jobId` | `getJob` | — | `InstallJob` (404 unknown) |
+| `POST /api/admin/apps/jobs/:jobId/undo` | `undoJob` | — | `{ removed: string[] }` |
+| `POST /api/admin/apps/installed/:id/update` | `update` | `{ prune?: boolean }` | `{ jobId }` |
+| `GET /api/admin/apps/installed/:id/uninstall-preview` | `uninstallPreview` | — | `UninstallPreview` |
+| `DELETE /api/admin/apps/installed/:id` | `uninstall` | query `deleteData=true\|false` | `UninstallSummary` |
+| `GET /api/admin/apps/installed/:id/eject` | `eject` | — | `EjectPayload` |
+| `POST /api/admin/apps/installed/:id/ack-manual-step` | `ack` | `{ stepId: string }` | `{ acked: string[] }` |
+
+```ts
+export class PreflightRequestDto {
+  @IsOptional() @IsUUID() projectId?: string;
+  @IsOptional() @ValidateNested() @Type(() => NewProjectDto) newProject?: NewProjectDto;
+}
+export class NewProjectDto {
+  @IsString() @Matches(/^[a-zA-Z0-9_-]+$/) owner: string;
+  @IsString() @Matches(/^[a-zA-Z0-9_-]+$/) name: string;
+}
+export interface CatalogEntry {
+  id: string; name: string; summary?: string; iconUrl?: string; docsUrl?: string; sourceUrl?: string;
+  registryVersion?: string;         // absent when registry unavailable but app installed
+  gates: GateResult[];              // instance-level only
+  installable: boolean;             // every instance gate passed && registry present
+  installed?: {
+    installedAppId: string; version: string; projectId: string; projectName: string;
+    alias: string; appUrl?: string; status: InstalledAppStatus;
+    updateAvailable: boolean;       // compareSemver(registryVersion, version) > 0
+    manualSteps: AppManualStep[]; manualStepsAcked: string[];
+  };
+}
+```
+
+`listCatalog` = registry (`AppsRegistryService.getRegistry()`) ∪ installed rows: registry entries get `instanceGates(entry.requires)`; installed-but-not-in-registry apps still render (from the stored manifest) with a note; registry failure sets top-level `registryError` and the catalog still lists installed apps ("degrades to catalog-unavailable without affecting installed apps").
+
+**Fixture bundle + orchestration spec** (deviation 4 — house db mock, not real PG): `make-fixture-bundle.ts` exports `makeFixtureBundle(version: '1.0.0' | '2.0.0')` — v1: manifest + 2 tiny rule sets (2 rules, 2 schemas incl. one shared name for the reuse path) + `dist/index.html`; v2 bumps version, adds a rule, changes `dist`. The orchestration spec drives `AppInstallerService` with REAL `AppBundleService` + REAL manifest validation + REAL zip bytes, mocked externals (sync/deploy/domains/projects returning realistic shapes), and asserts end-to-end: install v1 → row `installed` with correct bookkeeping; update to v2 → same alias redeployed, prune false; uninstall keep-data → tables kept; uninstall delete-data → only created tables deleted. This is the closest CE-side approximation of the spec's integration suite; the real-DB pass happens on the live droplet (Task 16 checklist).
+
+- [ ] **Step 1: Write failing controller + orchestration tests** (controller: route handlers delegate with the right args; 404 on unknown job; ValidationPipe shapes via DTO metadata tests are optional).
+- [ ] **Step 2: Run to verify failure** — `pnpm test -- app-catalog`
+- [ ] **Step 3: Implement DTOs, controller routes, `listCatalog` assembly.**
+- [ ] **Step 4: Run the whole new-module suite + typecheck:** `pnpm test -- 'app-catalog|app-install|app-preflight|app-cert|app-bundle|apps-registry|app-manifest|ce-version'` — all PASS.
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/app-catalog
+git commit -m "feat(app-catalog): full admin API, catalog assembly, fixture-driven orchestration spec"
+```
+
+---
+
+### Task 12: Frontend — API slice, route, catalog page
+
+**Files:**
+- Create: `apps/frontend/src/services/appCatalogApi.ts`, `apps/frontend/src/pages/AppsPage.tsx`, `apps/frontend/src/components/app-catalog/AppCard.tsx`, `apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx`
+- Modify: `apps/frontend/src/services/api.ts` (add `'AppCatalog', 'InstalledApp'` to `tagTypes`), `apps/frontend/src/App.tsx` (route), `apps/frontend/src/pages/HomePage.tsx` (admin button)
+
+**Interfaces:**
+- Produces `appCatalogApi` hooks: `useGetAppCatalogQuery`, `usePreflightAppMutation`, `useInstallAppMutation`, `useGetInstallJobQuery`, `useUndoJobMutation`, `useUpdateAppMutation`, `useGetUninstallPreviewQuery`, `useUninstallAppMutation`, `useGetEjectPayloadQuery`, `useAckManualStepMutation`. TypeScript mirrors of `CatalogEntry`, `GateResult`, `InstallJob`, `SyncPlanSummary`, `EjectPayload`, `UninstallPreview`, `UninstallSummary` (copy the shapes from Tasks 7/9/10/11 — keep field names identical).
+- Consumed by Tasks 13–14.
+
+Slice skeleton (follow `pipelineSchedulesApi.ts` structure exactly — interfaces, envelope transform, per-scope tags):
+
+```ts
+import { api } from './api';
+// ... interface definitions mirroring backend shapes ...
+
+export const appCatalogApi = api.injectEndpoints({
+  endpoints: (builder) => ({
+    getAppCatalog: builder.query<{ data: CatalogEntry[]; registryError?: string }, void>({
+      query: () => '/api/admin/apps',
+      providesTags: ['AppCatalog'],
+    }),
+    preflightApp: builder.mutation<PreflightResponse, { appId: string; body: PreflightRequest }>({
+      query: ({ appId, body }) => ({ url: `/api/admin/apps/${appId}/preflight`, method: 'POST', body }),
+    }),
+    installApp: builder.mutation<{ jobId: string }, { appId: string; body: PreflightRequest }>({
+      query: ({ appId, body }) => ({ url: `/api/admin/apps/${appId}/install`, method: 'POST', body }),
+      invalidatesTags: ['AppCatalog', 'InstalledApp'],
+    }),
+    getInstallJob: builder.query<InstallJob, string>({
+      query: (jobId) => `/api/admin/apps/jobs/${jobId}`,
+      // no tags — polling replaces invalidation (migrationApi precedent)
+    }),
+    // ... update / uninstallPreview / uninstall / eject / ackManualStep,
+    // lifecycle mutations invalidate ['AppCatalog', 'InstalledApp']
+  }),
+});
+```
+
+`AppsPage`: admin-only page (route `/apps` wrapped in `<ProtectedRoute requireAdmin>`), header + card grid from `useGetAppCatalogQuery`, `registryError` rendered as a dismissable notice ("Catalog unavailable — installed apps unaffected"), empty state, and while any card has a running job, `pollingInterval` on the catalog query is unnecessary (job polling lives in the dialog).
+
+`AppCard` CTA state machine (spec table): preflight clean → **Install** (opens dialog); any instance gate `fail` → disabled button with the gate's `message` (*"Requires bucket storage"*, *"Requires CE ≥ 0.3.15"*) + a "Why?" popover showing `remediation` + `deepLink`; `installed` → badge `Installed · v{version}` + **Open ↗** (`appUrl`) + overflow menu (Update available?, Uninstall, Eject); `updateAvailable` → **Update to v{registryVersion}** primary.
+
+HomePage admin section (`HomePage.tsx:301-320`): add
+
+```tsx
+{isEnabled('ENABLE_APP_CATALOG') && (
+  <Button asChild variant="outline"><Link to="/apps">Apps</Link></Button>
+)}
+```
+
+(the section is already `user?.role === 'admin'`-gated; `useFeatureFlags` is already imported on this page).
+
+- [ ] **Step 1: Write failing `AppCard` tests** — house pattern (mock the slice module wholesale, `vi.mock('@/services/appCatalogApi', ...)`): renders Install when installable; disabled with gate message when a gate fails; Installed badge + Open link when installed; Update CTA when `updateAvailable`.
+- [ ] **Step 2: Run to verify failure** — `cd apps/frontend && pnpm test -- AppCard`
+- [ ] **Step 3: Implement slice + page + card + route + HomePage button + tagTypes.**
+- [ ] **Step 4: Run tests + typecheck** — `pnpm test -- AppCard && pnpm exec tsc --noEmit`
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/frontend/src
+git commit -m "feat(app-catalog): Apps page, catalog cards, RTK Query slice"
+```
+
+---
+
+### Task 13: Frontend — Install dialog (Review / Working / Done)
+
+**Files:**
+- Create: `apps/frontend/src/components/app-catalog/InstallDialog.tsx`, `__tests__/InstallDialog.test.tsx`
+
+**Interfaces:**
+- Consumes Task 12's hooks. Props: `{ entry: CatalogEntry; open: boolean; onOpenChange: (o: boolean) => void }`.
+
+**Screen 1 — Review.** Project picker: existing projects from the existing projects/repositories query (find the hook used by HomePage/repo pages — likely `getMyRepositories` in `repoApi`; reuse it, do not add an endpoint) + a "Create new project" option with owner/name inputs and the immutability warning verbatim: *"A project's owner/name can never be renamed."* Preselect when exactly one project exists. On selection change → `usePreflightAppMutation`; render: the app URL it will get (`appUrl`), each `GateResult` as a row (icon by status, message, "Why?" → remediation/deepLink, Retry button when `retryable`), and the dryRun plan in the spec's plain language — per rule set `"{created} rules created · {updated} updated"` and aggregated `"N data tables: X reused, Y created"` from `syncPlans[].schemaResolutions` (`fieldMismatch` renders a warning row). Install button enabled only when no gate is `fail`. Nothing is written that wasn't shown first.
+
+**Screen 2 — Working.** After `useInstallAppMutation` → `{ jobId }`: `useGetInstallJobQuery(jobId, { pollingInterval: 1000, skip: !jobId })` (MigrationProgress precedent). Step list renders `job.steps` with status icons; `action-required` steps show their `detail`; DNS-failed preflight inside the job renders the exact record to add with a Retry (re-`install` — idempotent). Job `failed` → error + **Undo this install** (`useUndoJobMutation`) + Close.
+
+**Screen 3 — Done.** `job.status === 'succeeded'`: app URL + **Open ↗**, and the `manualSteps` checklist — each with title/body/deepLink and an ack checkbox wired to `useAckManualStepMutation` (checked state from `manualStepsAcked`).
+
+- [ ] **Step 1: Write failing tests** (mock hooks module; simulate job states): Review shows plan language "2 rules created" and disables Install on a failed gate; Working renders step statuses from a polled job object; Done renders manual steps and fires ack on check; failed job offers Undo.
+- [ ] **Step 2: Run to verify failure** — `pnpm test -- InstallDialog`
+- [ ] **Step 3: Implement** (Radix Dialog + existing `Progress`/`Checkbox`/`Button` ui components; match ProxyRuleSetsPage's dialog idioms).
+- [ ] **Step 4: Run tests + typecheck.**
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/frontend/src
+git commit -m "feat(app-catalog): three-screen install dialog with live job progress"
+```
+
+---
+
+### Task 14: Frontend — lifecycle UI (update, uninstall, eject)
+
+**Files:**
+- Create: `apps/frontend/src/components/app-catalog/UninstallDialog.tsx`, `EjectPanel.tsx`, `__tests__/UninstallDialog.test.tsx`, `__tests__/EjectPanel.test.tsx`
+- Modify: `AppCard.tsx` (wire overflow menu), `AppsPage.tsx` (mount dialogs)
+
+**UninstallDialog:** loads `useGetUninstallPreviewQuery`; default mode copy: *"Removes the app's rule sets, alias, domain, and deployment. Your data tables and uploaded files are kept."* Checkbox *"Also delete the app's data tables"* reveals the real counts from the preview (*"this deletes {sum} records across {n} tables"*; reused tables listed as kept regardless). Confirm → `useUninstallAppMutation({ deleteData })` → summary toast.
+
+**EjectPanel** (dialog or card section from `useGetEjectPayloadQuery`): fork link (`forkUrl`), the exact variables table (`BFFLESS_URL`, `BFFLESS_PROJECT` with copy buttons), secrets list with an inline **Mint API key** button using the EXISTING api-key creation hook (find it in `services/` — the ApiKeys settings page uses it) scoped to the app's project when supported, the workflow name to run, and the continuity note verbatim: *"The workflow's first deploy lands on this same alias — your install becomes the fork's deploy target."*
+
+**Update:** AppCard's Update CTA → confirm popover with a *"Reset to the app's shipped rules (prune)"* toggle default OFF → `useUpdateAppMutation({ prune })` → reuse InstallDialog's Working screen (same job endpoint).
+
+- [ ] **Step 1: Write failing tests:** UninstallDialog keeps-data copy by default and shows counts only after checkbox; Eject renders variables + note; update fires with `prune: false` by default.
+- [ ] **Step 2: Run to verify failure.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Full frontend suite + typecheck:** `cd apps/frontend && pnpm test && pnpm exec tsc --noEmit` (lint the touched files with `npx eslint`, never `pnpm lint`).
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/frontend/src
+git commit -m "feat(app-catalog): update, uninstall (data kept by default), eject panel"
+```
+
+---
+
+### Task 15: `bffless/apps` — Handoff manifest, bundle build, registry (SEPARATE REPO + PR)
+
+Work in `/home/rico/bffless/repos/apps` on a new branch `feat/app-catalog-bundles` (it IS a git repo; branch from `main`). This task is independent of CE tasks 1–14 and may run in parallel after Task 4 freezes the manifest shape.
+
+**Files:**
+- Create: `apps/handoff/bffless-app.json`, `scripts/build-app-bundle.mjs`, `.github/workflows/app-bundles.yml`
+- Modify: `scripts/check-app-conventions.mjs` (validate manifest presence + shape for apps that ship one), `apps/handoff/bffless/README.md` (fix the stale claim), `docs/app-pipelines-convention.md` (document the manifest)
+
+**Facts from exploration that shape this task:**
+- There is NO release machinery: no tags, no releases, no release-please; `apps/handoff/package.json` is a pinned `0.0.0`. **The manifest's `version` field in `apps/handoff/bffless-app.json` becomes the per-app version source of truth**, bumped by hand in PRs (start at `1.0.0`).
+- Built rule-set JSON is produced by `npx bffless rules build <set-dir> -o <file>` (nothing in CI does this today; `dist/.gitignore` is `*`). Output envelope: `{ version: 2, exportedAt, kind, ruleSet, rules, schemas }` — `exportedAt` is non-deterministic and CE's sync ignores it; `schemas[].id` carries SOURCE-project UUIDs, which is fine because CE's sync resolves by NAME (the id is only the in-payload reference key). Do NOT strip ids.
+- `deploy-handoff.yml:26-67` already builds `dist` env-free (no VITE_ vars) — the bundle's dist is instance-agnostic.
+- Registry publish precedent: Studio's second `upload-artifact` step with explicit `base-path` (`deploy-studio.yml:65-77`).
+
+**`bffless-app.json`** — exactly the `TEST_MANIFEST` shape from CE Task 4 with real values: `id: handoff`, `name: Handoff`, `version: 1.0.0`, summary/docsUrl/sourceUrl, `requires: { presignedStorage: true, ceMin: "0.3.15" }`, install block (alias `handoff`, deployment `{ path: "dist", basePath: "/apps/handoff/dist" }`, both rule sets `attachToAlias: true`, domain `{ subdomain: "handoff", isPublic: true, isSpa: true }`, `schedules: []`), manualSteps: `bucket-cors` (`appliesWhen: "bucketStorage"`) + an `iframe-headers` step mirroring the README's COOP/COEP exception (`appliesWhen: "always"`), eject block per the spec example.
+
+**`build-app-bundle.mjs`** — `node scripts/build-app-bundle.mjs handoff` → `dist-bundles/handoff-v<version>.bundle.zip` + `dist-bundles/handoff-v<version>.sha256`:
+1. read + JSON-validate `apps/handoff/bffless-app.json` (basic checks: schemaVersion 1, id/version present, files referenced exist after build)
+2. `pnpm --filter handoff build`
+3. per rule set dir under `apps/handoff/.bffless/proxy-rules/*`: `npx --yes bffless@latest rules build <dir> -o <tmp>/rulesets/<name>.json`
+4. assemble zip: `bffless-app.json` + `rulesets/*.json` + `dist/**` (entry paths exactly `dist/...`)
+5. sha256 to the sidecar file; print both paths
+
+**`app-bundles.yml`** — `workflow_dispatch` (input: app id) + `push: tags: ['handoff-v*']`. Steps: checkout → pnpm/node setup (copy from `deploy-handoff.yml:26-40`) → run the build script → `gh release create <tag> dist-bundles/*.zip --notes` (or upload to the existing tag's release) → build `registry.json` (small inline node step: read every `apps/*/bffless-app.json` that exists, emit `{ schemaVersion: 1, apps: [{ id, name, version, bundleUrl: <the release asset URL>, sha256: <from sidecar>, summary, iconUrl, requires }] }`) → publish it with `bffless/upload-artifact@v1` (`path` = a staging dir containing only `registry.json`, `alias: app-registry`, `api-url: ${{ vars.BFFLESS_URL }}`, `api-key: ${{ secrets.BFFLESS_API_KEY }}`). **Operator step (not CI):** map `apps.bffless.dev` to that alias on the target instance + a cache rule (~1h TTL) — record as a PR-description checklist item.
+
+**`check-app-conventions.mjs`:** add — if `apps/<app>/bffless-app.json` exists, validate: parses, `schemaVersion === 1`, `id === <app>`, semver `version`, every `install.ruleSets[].file` maps to an authored set dir (`rulesets/<name>.json` ↔ `.bffless/proxy-rules/<name>/`), `install.alias` and `install.domain.subdomain` non-empty. (Handoff must pass; Studio/Reader without manifests must still pass — presence is optional, the catalog is opt-in per app.)
+
+**README fix:** `apps/handoff/bffless/README.md` §1 — replace the "bucket REQUIRED / will not work on local file storage" block: as of CE v0.3.15 local-FS presigned uploads work on a stock install (`ENCRYPTION_KEY` + default-on `FEATURE_LOCAL_PRESIGNED_UPLOADS`); a real bucket is *recommended for production*. Keep the CORS instructions under a "bucket backends" heading.
+
+- [ ] **Step 1:** Write `bffless-app.json` + extend `check-app-conventions.mjs`; run `pnpm apps:check` → PASS.
+- [ ] **Step 2:** Write `build-app-bundle.mjs`; run it locally; unzip the output and verify layout (`bffless-app.json`, `rulesets/handoff.json` with 27 rules, `rulesets/handoff-rss-feed.json` with 2, `dist/index.html`); verify the sha256 sidecar matches.
+- [ ] **Step 3:** Cross-check: feed the real produced bundle to CE's `AppBundleService.loadFromBuffer` via a one-off script against the CE worktree (`node -e` or a scratch spec) — the real Handoff bundle must pass CE validation. This is the contract seam; if it fails, fix whichever side is wrong.
+- [ ] **Step 4:** Write the workflow + README/convention-doc updates.
+- [ ] **Step 5:** Commit on the branch, push, open PR in `bffless/apps` titled `feat: app-catalog bundle build + registry publish (handoff v1.0.0)`; PR body lists the operator steps (create `apps.bffless.dev` mapping, set cache rule, cut the first `handoff-v1.0.0` tag). **Ask the user before pushing/opening the PR** if not already blanket-approved.
+
+---
+
+### Task 16: Finalize — whole-branch review, live checklist, PR #567
+
+- [ ] **Step 1: Full verification in the CE worktree**
+
+```bash
+cd /home/rico/bffless/repos/ce/.claude/worktrees/app-catalog
+pnpm --filter backend exec tsc --noEmit && pnpm --filter frontend exec tsc --noEmit
+cd apps/backend && pnpm test          # foreground; ~minutes with coverage
+cd ../frontend && pnpm test
+```
+
+All green before proceeding (pre-existing failures on main are the baseline — `git stash`-check if unsure a failure is ours).
+
+- [ ] **Step 2: Whole-branch review** — superpowers:requesting-code-review against the full diff (`git diff main...HEAD`), plus `/security-review` (the installer fetches remote zips and executes nothing, but writes rule sets containing handler code — the sha256 + first-party-registry + DTO-validation story must hold up; this was also flagged as possibly skipped on #565).
+- [ ] **Step 3: Live droplet checklist** (goes in the PR body as unchecked boxes — live validation is the only real test for nginx/vhost reachability, per the #565 lesson):
+  - install Handoff on a stock local-FS droplet (wildcard absent): app serves at `handoff.<domain>` via the wildcard 443 block; SPA deep links work; presigned upload round-trips
+  - wildcard-cert box: `sslEnabled` true on the created mapping; HTTPS direct
+  - proxied/Cloudflare box; direct+LE box (staged SAN re-issue → apply → confirm)
+  - platform-mode workspace: delegated cert path + two-label constraint reported
+  - update v1→v2 keeps user-added rules (prune off) and alias history rollback works
+  - uninstall keep-data leaves tables; delete-data removes only created tables
+- [ ] **Step 4: Update PR #567** — push with `--force-with-lease` only if history was rewritten (otherwise plain push), then `gh pr edit 567 --title "feat(apps): app catalog — 1-click app install" --body-file -` (heredoc; `--body-file -`, never `--body -`) with: spec link, the 6 deviations, screenshots (localdev-tools/shot.mjs against `pnpm dev`), the live checklist, and the note that `bffless/apps` PR + registry DNS are follow-ups. Keep it draft until live validation. **Ask the user before merging anything, ever.**
+
+## Self-Review (done at planning time)
+
+- **Spec coverage:** trigger/catalog UI (T12), general mechanism + manifest (T4), GitHub-release bundles (T15), first-party registry + sha256 (T5, T15), project picker with immutability warning (T13), tracked installs + update/uninstall (T2, T9, T10, T14), eject (T10, T14), preflight split instance/project (T7, T11), background job + polling (T9, T13), cert branches incl. platform delegation (T8), manualSteps + appliesWhen closed enum (T4, T9, T13), failure→undo (T9), flag gating (T1), testing pyramid (unit per task, fixture orchestration T11, contract T15 step 3, live T16). Out-of-scope items honored: no arbitrary URLs, no drift detection, no path-mount serving, no MinIO auto-enable, Handoff only.
+- **Known open risk:** `issueLetsEncrypt` preflight internals (T8) and the deployments delete-method name (T10) are described by behavior, not quoted signature — implementers must read those call sites first; both tasks say so.
+- **Type consistency:** `GateResult`/`SyncPlanSummary` defined in T7, reused in T11–T13; `InstallJob`/`InstallStepId` defined in T9, reused in T11/T13; `CreatedResources` in T2, reused in T9/T10; `TEST_MANIFEST` in T4, reused in T5/T9/T15. Manifest shape identical in T4 (types) and T15 (real file).
+
+
+

--- a/docs/superpowers/specs/2026-07-30-app-catalog-1-click-install-design.md
+++ b/docs/superpowers/specs/2026-07-30-app-catalog-1-click-install-design.md
@@ -1,0 +1,243 @@
+# App Catalog — 1-Click App Install — Design Spec
+
+**Date:** 2026-07-30
+**Status:** Draft for review
+**Scope:** `repos/ce` (new backend `apps` module, `installed_apps` table, admin **Apps** page), `repos/apps` (bundle-build CI job, manifest per app, registry publish)
+**Depends on:** `2026-07-30-local-fs-presigned-uploads-design.md` — **ship that first.** It's what lets Handoff pass the storage preflight on a stock install instead of being permanently gated behind a bucket decision.
+
+## Problem
+
+Installing Handoff onto a self-hosted CE today means: fork `bffless/apps`, set two repo variables and a secret, register the BFFless MCP against your instance, provision a project in the admin panel, import a rule set and attach it to an alias, create data tables by hand, run a GitHub Actions workflow, and configure a domain mapping. `GETTING-STARTED.md` walks through it in seven numbered steps with a variables checklist.
+
+That flow has real teaching value and stays supported. But it is a poor first experience: a new CE install has nothing running on it, and the shortest path to seeing the platform actually *do something* runs through GitHub. An app that installs from the dashboard in one click is a far better demo, and it doubles as a worked reference configuration the user can read — real pipelines, real data tables, real ACLs — rather than a blank project.
+
+Concretely, a Handoff install has seven obligations (from `apps/handoff/bffless/README.md`):
+
+1. A project (`owner/name`)
+2. Two rule sets — `handoff` (27 rules) and `handoff-rss-feed` (2) — attached to an alias
+3. Three data tables — `handoff_nodes`, `handoff_share_links`, `handoff_comments`
+4. A deployment: the built `dist/` on the `handoff` alias
+5. A domain mapping at `handoff.<primary>`, `isPublic`, `isSpa`, path `/apps/handoff/dist`
+6. Presigned-capable storage
+7. CE new enough to have `GET /api/users/directory`
+
+## What already exists (and why this is smaller than it looks)
+
+The single most important finding: **CE already has the applier for rule sets.**
+
+`PUT /api/proxy-rule-sets/project/:projectId/sync` (`proxy-rules/proxy-rule-sets.controller.ts:119`) is the declarative rules-as-code endpoint. Per its own description it is idempotent, matches rules on `(pathPattern, method)`, writes only real differences, deletes live-only rules **only** under `options.prune`, **resolves bundled schemas by name**, preserves live secrets on blank header values, returns a full change plan under `options.dryRun`, stamps `repo`/`path`/`gitSha` provenance, and regenerates nginx when anything changed. `schema-sync.util.ts` implements resolve-or-create-by-name with field-mismatch reporting (`SchemaResolution`).
+
+`bffless rules push` is a thin client over this endpoint. So the "remap the source project's table UUIDs by hand" chore that a dashboard import suffers is already solved server-side — the installer calls the same endpoint the CLI does, and there is no second implementation to keep in sync.
+
+Also already present:
+
+- `POST /api/deployments/zip` accepts `proxyRuleSetNames[]` / `proxyRuleSetIds[]` (`deployments/deployments.dto.ts:152,163`) — so *upload the dist*, *set the alias*, and *attach the rule sets* are *one* call, the same one `upload-artifact` makes.
+- `POST /api/domains` takes `domainType: 'subdomain'`, `path`, `isPublic`, `isSpa` (`domains/dto/create-domain.dto.ts`).
+- `bootstrap-dns-preflight.service.ts` — a self-probe that reports whether a hostname actually reaches this server.
+- `pipeline-schemas` (data tables) and `pipeline-schedules` modules, for apps that declare schedules.
+- The feature-flag registry (`FLAG_DEFINITIONS`, `@RequireFeatureFlags`, client exposure) — `ENABLE_PRIMARY_SSL_MANAGEMENT` is the shape to copy.
+
+## Scope decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Trigger | **Admin → Apps catalog, 1-click** | Not first-boot seeding: an install has real preconditions (storage, DNS) that deserve a preflight and an opt-in, and a catalog generalizes to Studio/Reader. |
+| Generality | **General mechanism, Handoff as the first entry** | The apps repo already enforces a per-app convention (`pnpm apps:check`, `docs/app-pipelines-convention.md`) that makes a shared manifest tractable. |
+| Bundle source | **Fetched from a GitHub release** | Keeps the CE image small and decouples app releases from CE releases. |
+| Registry | **Remote index, first-party apps only** | No arbitrary-URL install field. An app bundle contains server-side executable handler code, so the trust surface stays curated. |
+| Target project | **Picker with a sensible default** | A project's `owner/name` can never be renamed, so auto-creating one the user didn't choose is a permanent decision made on their behalf. |
+| Lifecycle | **Tracked record: version, update, uninstall** | What makes it a catalog rather than a one-off importer. Drift detection is deliberately out. |
+| Relationship to forking | **An "eject to your own repo" path** | 1-click to try; fork when you want to change it. The install becomes the fork's deploy target, so ejecting is continuous. |
+| App URL | **Subdomain + serving-model-aware cert step** | Reuse the DNS preflight, then branch on how the box serves TLS. |
+| Engine | **CE applier over a CI-prebuilt bundle** | CI compiles (the CLI already does), CE applies. No node runtime in the backend container; no duplicated push semantics. |
+| Platform mode | **Supported, with the cert step delegated** | See below — this was corrected during review. |
+
+### On `PLATFORM_MODE`
+
+An earlier draft disabled the feature in platform mode by analogy with the bootstrap/SSL work. That was wrong. Domain mappings are a first-class platform-mode feature: `nginx-config.service.ts` has dedicated `generateCustomDomainConfigPlatformMode` (:419) and `generateSubdomainConfigPlatformMode` (:618) branches, and `domains.service.ts` notifies the Control Plane to provision SSL for platform domains (:333, :405) including deferred SSL (:1498).
+
+The only genuinely platform-incompatible piece is **primary-domain certificate issuance**, which `primary-ssl.service.ts:41` and `setup.service.ts:231` already refuse under `PLATFORM_MODE || SSL_MANAGED_EXTERNALLY` because there it is Traefik's job.
+
+So: the catalog is **available in platform mode**, and the applier's cert step becomes *delegate to the Control Plane* — which is what `domains.service.create` already does. The preflight additionally requires `CONTROL_PLANE_URL` and `WORKSPACE_ID` to be configured, and reports one honest constraint rather than papering over it: a workspace serves at `<workspace>.<platform>`, so a subdomain mapping is `handoff.<workspace>.<platform>` — **two labels deep, which a `*.<platform>` wildcard does not cover.** The preflight surfaces the resulting certificate-coverage question instead of assuming it resolves.
+
+## The bundle (produced by `repos/apps` CI)
+
+On release, a new CI job emits `<app>-v<version>.bundle.zip`:
+
+```
+bffless-app.json          # manifest, schemaVersion: 1
+rulesets/
+  handoff.json            # exactly `bffless rules build` output
+  handoff-rss-feed.json
+dist/                     # what deploy-handoff.yml uploads today
+```
+
+The manifest declares four things:
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "id": "handoff", "name": "Handoff", "version": "1.4.0",
+  "summary": "…", "iconUrl": "…", "docsUrl": "…", "sourceUrl": "…",
+
+  "requires": { "presignedStorage": true, "ceMin": "0.2.0" },
+
+  "install": {
+    "alias": "handoff",
+    "deployment": { "path": "dist", "basePath": "/apps/handoff/dist" },
+    "ruleSets": [
+      { "file": "rulesets/handoff.json",          "attachToAlias": true },
+      { "file": "rulesets/handoff-rss-feed.json", "attachToAlias": true }
+    ],
+    "domain":    { "subdomain": "handoff", "isPublic": true, "isSpa": true },
+    "schedules": [],
+    "manualSteps": [
+      { "id": "bucket-cors", "title": "…", "body": "…", "deepLink": "…",
+        "appliesWhen": "bucketStorage" }
+    ]
+  },
+
+  "eject": {
+    "repo": "bffless/apps", "appPath": "apps/handoff",
+    "deployWorkflow": "deploy-handoff.yml",
+    "variables": ["BFFLESS_URL", "BFFLESS_PROJECT"],
+    "secrets": ["BFFLESS_API_KEY"]
+  }
+}
+```
+
+Notes on the shape:
+
+- **`requires` is read only by the preflight**, so a future app that needs no bucket simply omits `presignedStorage`. `ceMin: "0.2.0"` is Handoff's real floor: the people-picker's `GET /api/users/directory` landed in ce#368, whose first containing tag is `bffless-v0.2.0`.
+- **`manualSteps`** carries the human-only residue each app's README documents — AI provider tokens, bucket CORS, response-header rules — rendered as a post-install checklist instead of being silently skipped. `appliesWhen` keeps the checklist honest: after the presigned prerequisite ships, a local-FS install is same-origin and the bucket-CORS step genuinely doesn't apply.
+
+  `appliesWhen` is a **closed enum evaluated by CE**, not an expression language — `always` (the default when omitted), `bucketStorage`, `localStorage`, `platformMode`, `selfHosted`. Anything else fails manifest validation. A mini-expression evaluator would be an unbounded, and unnecessary, surface.
+- **`eject`** exists so the take-ownership panel is generated per app rather than hand-written.
+- **The built rule-set JSON, not the authored `.fn.js`/YAML tree.** The sync endpoint's payload *is* the built form and `bffless rules build` already produces it, so CI does the compiling and CE never parses YAML or handler source.
+
+## The registry
+
+Published from the apps repo by CI as a static deployment at `apps.bffless.dev/registry.json` — which dogfoods the product and gives a stable URL with its own cache rules.
+
+```jsonc
+{ "schemaVersion": 1,
+  "apps": [ { "id": "handoff", "version": "1.4.0",
+              "bundleUrl": "https://github.com/bffless/apps/releases/download/…/handoff-v1.4.0.bundle.zip",
+              "sha256": "…", "summary": "…", "iconUrl": "…", "requires": { … } } ] }
+```
+
+CE caches it (~1 h TTL) and degrades to "catalog unavailable" without affecting installed apps. The URL is pinned in config as `APPS_REGISTRY_URL`, overridable for air-gapped or self-published catalogs — but there is no arbitrary-URL field in the UI. The `sha256` is verified after download; a mismatch aborts before anything is written.
+
+## CE `apps` module
+
+Gated by `ENABLE_APP_CATALOG` (client-exposed, following `ENABLE_PRIMARY_SSL_MANAGEMENT`).
+
+### State
+
+An `installed_apps` row per install: `appId`, `version`, `projectId`, `alias`, `domainId`, `ruleSetIds[]`, `schemaIds[]` (captured from the sync response's `schemaResolutions`), `bundleSha256`, `installedAt`, `installedBy`, `manualStepsAcked`, `status`. This is what powers the update badge, uninstall, and eject.
+
+### Endpoints
+
+Admin-only — `SessionAuthGuard` + `RolesGuard` + `FeatureFlagGuard`.
+
+| Route | Purpose |
+|---|---|
+| `GET /api/admin/apps` | catalog: registry ∪ installed, each with its **instance-level** gate verdicts |
+| `POST /api/admin/apps/:appId/preflight` | the **project-scoped** checks for a chosen project; verdicts + remediation |
+| `POST /api/admin/apps/:appId/install` | start job → `{ jobId }` |
+| `GET /api/admin/apps/jobs/:jobId` | step-by-step progress |
+| `POST /api/admin/apps/installed/:id/update` | update to the registry version |
+| `DELETE /api/admin/apps/installed/:id` | uninstall |
+| `GET /api/admin/apps/installed/:id/eject` | take-ownership payload |
+
+Install runs as a **background job** — two network fetches plus roughly six writes is too long for a request — with a progress record the UI polls, one entry per step.
+
+### Applier steps
+
+Each step is idempotent and individually reported:
+
+1. **Preflight** (below).
+2. **Fetch** the bundle, verify `sha256`, unzip to a temp dir, validate the manifest.
+3. **`POST /api/deployments/zip`** with `dist/`, the alias, and `proxyRuleSetNames[]` — one call covering deploy, alias, and rule-set attachment.
+4. **Per rule set: `PUT /api/proxy-rule-sets/project/:id/sync`**, with **`dryRun` first** so the plan is shown before anything is written. Capture `schemaResolutions` into `installed_apps.schemaIds`.
+5. **Domain**: create the `<sub>.<primary>` subdomain mapping with `path`, `isPublic`, `isSpa`.
+6. **Certificate**, branching on how the box serves TLS:
+   - wildcard cert present → use it (this is already what `domains.service.ts:681-686` requires: it *silently ignores* `sslEnabled` for a subdomain when no wildcard exists)
+   - proxied / self-signed origin → nothing needed
+   - direct + Let's Encrypt → re-issue the primary cert with the app subdomain added to the SANs
+   - `PLATFORM_MODE` → delegate to the Control Plane, as `domains.service.create` already does
+7. **Schedules**, if declared.
+8. **Record**: write `installed_apps`; surface the `manualSteps` checklist.
+
+### Preflight gates
+
+The gates split by what they need to know, and the two endpoints above reflect that split:
+
+- **Instance-level** gates — storage, CE version, platform mode — depend only on the instance, so `GET /api/admin/apps` can evaluate them for every card. These are what drive the disabled *"Requires bucket storage"* CTA.
+- **Project-scoped** gates — name collisions, data-table reuse, DNS for `<sub>.<primary>` — cannot be evaluated until the user has picked a target project, so they run in the install dialog via `POST …/preflight`.
+
+Getting this split wrong would mean either a catalog that can't render its own CTA states or one that claims a verdict it had no information to reach.
+
+Each gate returns a verdict plus remediation text and a deep link.
+
+| Check | Scope | Behaviour |
+|---|---|---|
+| Presigned storage (`supportsPresignedUrls()`) | instance | **Hard refuse.** Once the prerequisite spec ships, local FS passes this and a stock install needs no storage decision. Until then, remediation names both routes — bundled MinIO (`ENABLE_MINIO=true` + restart) and a real bucket — as *instructions*, because the backend cannot flip a compose profile. |
+| CE version ≥ `requires.ceMin` | instance | Hard refuse. |
+| Platform mode | instance | Requires `CONTROL_PLANE_URL` + `WORKSPACE_ID`; reports the two-label subdomain certificate-coverage constraint. |
+| DNS | project | `bootstrap-dns-preflight.service` probe of `<sub>.<primary>`. **Blocking but retryable** — "add this record, then Retry" — not fatal. |
+| Name collisions | project | An existing alias, domain, or rule set of the same name not owned by an install → **refuse rather than clobber.** |
+| Data-table collision | project | **Warning, not a block.** Reusing a same-named table is the documented adoption path, so a `fieldMismatch` from the sync response is surfaced, not fatal. |
+
+### Failure handling
+
+Not a transaction. The job records what it created, so a failure past step 3 offers an undo that deletes **only this job's** objects — never a reused data table, never a pre-existing domain. Beyond that the answer is resume/re-run, which the idempotent sync endpoint makes safe.
+
+## Admin UI
+
+New admin-only nav item **Apps** — `pages/AppsPage.tsx` plus an `appsApi` RTK Query slice, wired like `ProxyRuleSetsPage` / `PipelineSchedulesPage`.
+
+One card per app, with a state-derived call to action:
+
+| State | CTA |
+|---|---|
+| preflight clean | **Install** |
+| gate failed | disabled — *"Requires bucket storage"* / *"Requires CE ≥ 0.3.4"*, plus a "Why?" link to remediation |
+| installed | **Installed · v1.4.0** + **Open ↗** |
+| newer in registry | **Update to v1.5.0** |
+
+**Install dialog, three screens.**
+
+*Review* — the target project (picker over existing projects plus "create new", preselected when exactly one exists, noting that a project name can never be renamed), the URL the app will get, the preflight results, and the **`dryRun` sync plan** in plain language: *"27 rules created · 3 data tables: 1 reused, 2 created."* Nothing is written that wasn't shown first.
+
+*Working* — the job's step list with live status. The DNS step can sit in a retryable "waiting for DNS" state displaying the exact record to add.
+
+*Done* — the app URL, an Open button, and the `manualSteps` checklist with acknowledgement checkboxes.
+
+## Lifecycle
+
+**Update** reuses the same job machinery: fetch the new bundle, deploy the new `dist/` to the same alias (existing alias history then gives instant rollback for free), re-sync the rule sets. `prune: false` by default so a user's own added rules survive; prune is an explicit *"reset to the app's shipped rules"* toggle. Data tables are never dropped and the domain is untouched.
+
+**Uninstall** treats the app's content as the user's, not the installer's. The default removes rule sets, alias, domain, and deployment while **keeping** `handoff_nodes` / `handoff_share_links` / `handoff_comments` and every stored object. A separate checkbox also deletes those, showing a real count first — *"this deletes 412 files"*.
+
+**Eject** renders from the manifest's `eject` block: the fork link, the exact `BFFLESS_URL` / `BFFLESS_PROJECT` variables and `BFFLESS_API_KEY` secret (with a button to mint the API key inline, since CE can do that), the workflow to run, and a note that its first deploy lands on **this same alias**. That last property is what makes ejecting continuous rather than a restart: the 1-click install becomes the fork's deploy target.
+
+## Testing
+
+**Backend unit** — manifest validation (bad `schemaVersion`, missing declared files, `sha256` mismatch); each preflight gate in isolation; applier step ordering and undo bookkeeping; flag-off refusal; platform-mode cert delegation instead of issuance.
+
+**Backend integration** — a **fixture bundle committed to CE**, applied against a real database: rule sets synced, data tables resolved by name on *both* the reuse and create paths, deployment/alias/domain rows written, `installed_apps` correct. Then update to a v2 fixture. Then uninstall both ways (content kept, content deleted).
+
+**Contract, in `repos/apps`** — the bundle CI job validates its output against the manifest schema, and `pnpm apps:check` gains a "every app produces a valid bundle" assertion. This is the seam that stops CE and the apps repo from drifting.
+
+**Frontend** — catalog states driven by mocked preflight verdicts; job-progress rendering; an MSW-backed install happy path.
+
+**Live** — install Handoff on a real droplet across **all three serving models** (wildcard, proxied/self-signed, direct + Let's Encrypt), plus one platform-mode workspace. The certificate branch is exactly the class of thing that passed every unit test and was still dead on arrival twice during the bootstrap work; the only test that catches it is a real HTTPS request.
+
+## Out of scope
+
+- **Arbitrary bundle URLs / third-party registries** — the trust surface is deliberately curated, since a bundle carries server-side executable code.
+- **Drift detection** on installed apps (the problem `rules-drift-check.yml` solves in CI). Tracked installs without drift was the explicit choice.
+- **Path-mount serving** (`<primary>/handoff/`) and the runtime-configurable admin URL it would require, since Handoff derives its admin host from its own hostname and `VITE_ADMIN_URL` is build-time.
+- **Auto-enabling MinIO from the backend** — no docker socket, by design.
+- **Studio and Reader bundles.** The mechanism is general and their manifests are straightforward, but Handoff is the only bundle this ships.


### PR DESCRIPTION
Implements the app catalog / 1-click install design spec (`docs/superpowers/specs/2026-07-30-app-catalog-1-click-install-design.md`). Plan: `docs/superpowers/plans/2026-07-30-app-catalog-1-click-install.md`. 32 commits, each task TDD'd and reviewed, whole-branch reviewed, security-reviewed, **and live-tested on a real droplet** (which found 6 defects — see below).

## What ships

**Backend (`apps/backend/src/app-catalog/`)** — `ENABLE_APP_CATALOG`-gated, admin-only `/api/admin/apps`:
- Registry fetch (`APPS_REGISTRY_URL`, 1h cache, stale-while-error, graceful "catalog unavailable"); bundle download with pinned sha256 verified before parsing; manifest validation (closed `appliesWhen` enum, https-only URLs, reserved-subdomain checks)
- Preflight gates: instance-level (presigned storage, `ceMin` fail-closed, platform config) and project-scoped (DNS probe, refuse-not-clobber collisions incl. cross-namespace, `dryRun` sync plans)
- Background install job driving the **existing** applier services — rule-set sync through the real DTO validation pipeline, one-call deploy+alias+attach, subdomain domain mapping, serving-model-aware cert step, schedules
- `installed_apps` with per-step-persisted `createdResources` as the undo/uninstall ownership boundary; update (prune off by default, gates re-verified); uninstall keeps data by default, destructive mode shows real counts, partial failures keep the row and retry converges; eject payload works offline
- **Install-time subdomain override** (live-test feedback): the manifest's subdomain is a default, editable per install, validated and threaded through every gate, the job's internal re-preflight, and the domain step
- **Signed downloads on local filesystem storage** (live-test discovery): HMAC-signed, domain-separated GET route sharing the presigned-PUT path (inherits nginx vhost coverage); relative URLs; RFC 6266/5987 filenames; Range support. Without this, every signed-URL flow dead-ended in a vestigial `localhost:3000/files` URL, so **file viewing and share links were broken on local-FS installs** — the exact configuration the catalog targets.

**Frontend** — admin `/apps` page, card CTA state machine, three-screen install dialog (Review with project picker + editable subdomain + dry-run plan, debounced preflight; Working with job polling that stops at terminal states; Done with manual-steps checklist), uninstall dialog with preview counts and partial-failure surfacing, eject panel with inline API-key minting, update flow reusing the job screen.

## Live testing (droplet, local-FS + Cloudflare-proxied)
Passing end to end: catalog degrade → install → custom subdomain → app serves at the chosen host (and correctly **404s** at the manifest default — the domain mapping is the only public path) → uploads → share links → downloads with non-ASCII filenames → uninstall (project + data deliberately retained).

Defects found live and fixed on-branch — all invisible to 3,400+ passing unit tests:
1. `APPS_REGISTRY_URL`/`FEATURE_APP_CATALOG` never passed into the backend container (documented in `.env.example`, absent from `docker-compose.yml`)
2. `bucketStorage` misdetected through `CachingStorageAdapter`, showing the bucket-CORS step on local-FS installs
3. `getUrl` built unencoded URLs — a macOS screenshot's U+202F crashed the `Location` header (500 on every raw-file link)
4. Done-screen ack checkboxes never updated (dialog held a stale catalog snapshot)
5. Local-FS signed downloads didn't exist (see above)
6. Card's Open link + update job's appUrl derived the host from the manifest default instead of the created domain row

## Recorded deviations from the spec (rationale in the plan header)
Sync-before-deploy ordering · Handoff `ceMin` 0.3.15 · direct-LE cert staged for human apply · fixture-driven orchestration tests instead of a real-PG harness · destructive uninstall drops created tables but not stored objects · the `bffless/apps` half ships separately (**[apps#271](https://github.com/bffless/apps/pull/271)** — bundle build CI, registry publish, Handoff manifest; its real bundle validates against CE's actual loader and strict sync DTO)

## Verification
Backend 155 suites / 2,609 tests · frontend 75 files / 809 tests · both `tsc --noEmit` clean · whole-branch review (1 Critical + 2 Important found and fixed: update-undo data-loss trap, `newProject` collision bypass, gate-free updates) · security review: **no findings**

## Remaining before merge
- [ ] Update to v1.0.1 on the live droplet (bundle + test registry staged)
- [ ] Other serving models: wildcard cert, direct + Let's Encrypt, platform-mode workspace
- [ ] UI screenshots for the PR
- [ ] Merge [apps#271](https://github.com/bffless/apps/pull/271), then operator steps: map `apps.bffless.dev` → `app-registry` alias, ~1h cache rule, cut `handoff-v1.0.0`

## Deferred follow-ups
Bundle body-read timeout + decompressed-size cap · `..` rejection in dist re-keying (storage adapters currently backstop) · `deepLink` scheme allowlist · preflight dryRun should mirror the installer's DTO validation · silent preflight-error UI in the install dialog · `undoJob` frontend return-type drift · dead `getActive()` + orphaned-job-view UX · duplicate `platform-config` gate keys · failed-update row status reads misleading · preflight 500-not-400 on malformed bundle JSON · `gitSha` provenance · delete the unguarded, unreachable `storage/files.controller.ts` (NOT `api/files`, which is guarded and used by upload-artifact) · harden the presigned-upload controller's query typing like the download route · `listCatalog` 500s if the domains query throws (pre-existing class) · `MigrationProgress.tsx` perpetual-poll anti-pattern (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019abzHPfQ6mEk8rh7bYme27
