### PR TITLE
fix(frontend): group detail page crashes when a group has members

### DIFF
--- a/apps/frontend/src/pages/GroupDetailPage.test.tsx
+++ b/apps/frontend/src/pages/GroupDetailPage.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { GroupDetailPage } from './GroupDetailPage';
+import type { UserGroupMember } from '@/services/userGroupsApi';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useParams: () => ({ groupId: 'group-1' }), useNavigate: () => vi.fn() };
+});
+
+vi.mock('@/services/authApi', () => ({
+  useGetSessionQuery: () => ({
+    data: { user: { id: 'admin-1', email: 'admin@example.com', role: 'admin' } },
+    isLoading: false,
+  }),
+}));
+
+const member: UserGroupMember = {
+  id: 'membership-1',
+  groupId: 'group-1',
+  userId: 'user-2',
+  addedBy: 'admin-1',
+  addedAt: '2026-07-30T11:05:57.000Z',
+  user: { id: 'user-2', email: 'member@example.com', name: null },
+};
+
+vi.mock('@/services/userGroupsApi', () => ({
+  useGetGroupQuery: () => ({
+    data: { id: 'group-1', name: 'cutover-smoke', description: 'e2e', createdBy: 'admin-1' },
+    isLoading: false,
+    error: undefined,
+  }),
+  useGetGroupMembersQuery: () => ({
+    data: [member],
+    isLoading: false,
+    error: undefined,
+  }),
+  useUpdateGroupMutation: () => [vi.fn(), { isLoading: false }],
+  useAddMemberMutation: () => [vi.fn(), { isLoading: false }],
+  useRemoveMemberMutation: () => [vi.fn(), { isLoading: false }],
+}));
+
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+describe('GroupDetailPage', () => {
+  // Regression for #569: the per-member remove button used Dialog's `DialogTrigger`
+  // inside an `AlertDialog`, so rendering ANY member row threw
+  // "`DialogTrigger` must be used within `Dialog`" and crashed the page.
+  it('renders a group with members without throwing', () => {
+    render(
+      <MemoryRouter>
+        <GroupDetailPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('member@example.com')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/pages/GroupDetailPage.tsx
+++ b/apps/frontend/src/pages/GroupDetailPage.tsx
@@ -44,6 +44,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 
 /**
@@ -386,7 +387,7 @@ export function GroupDetailPage() {
                             setRemovingMember(open ? member.userId : null)
                           }
                         >
-                          <DialogTrigger asChild>
+                          <AlertDialogTrigger asChild>
                             <Button
                               variant="ghost"
                               size="sm"
@@ -394,7 +395,7 @@ export function GroupDetailPage() {
                             >
                               <Trash2 className="h-4 w-4 text-destructive" />
                             </Button>
-                          </DialogTrigger>
+                          </AlertDialogTrigger>
                           <AlertDialogContent>
                             <AlertDialogHeader>
                               <AlertDialogTitle>Remove Member</AlertDialogTitle>


### PR DESCRIPTION
## Summary

Fixes #569. `GroupDetailPage.tsx` used Dialog's `DialogTrigger` inside the per-member-row `AlertDialog`, so rendering any member row threw `` `DialogTrigger` must be used within `Dialog` `` and the page crashed to the error boundary. Zero-member groups rendered fine (no member rows), which is why it went unnoticed until a group gained its first member.

- Swap to `AlertDialogTrigger` (and import it) at the remove-member button.
- Add a render regression test with a one-member fixture that reproduces the exact production error pre-fix (verified RED→GREEN).

The Add Member dialog's `DialogTrigger` is inside a proper `Dialog` and is untouched; no other `AlertDialog`+`DialogTrigger` mismatches exist in `UserGroupsPage.tsx` / `ProjectGroupsTab.tsx`.

## Verification

- `vitest run src/pages/GroupDetailPage.test.tsx` — fails with the production error before the fix, passes after.
- `pnpm build` (tsc + vite) clean; both changed files eslint-clean (`--max-warnings 0`). Note: `pnpm lint` at the app level currently fails on 4 pre-existing unused-var errors in untouched `e2e/*.spec.ts` files — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1FwQsg44yeeF9Zcyu1oFx
