### PR TITLE
fix(frontend): user typeahead in group Add Member dialog

### DIFF
--- a/apps/frontend/src/pages/GroupDetailPage.test.tsx
+++ b/apps/frontend/src/pages/GroupDetailPage.test.tsx
@@ -1,8 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { GroupDetailPage } from './GroupDetailPage';
 import type { UserGroupMember } from '@/services/userGroupsApi';
+import { useAddMemberMutation } from '@/services/userGroupsApi';
+import { useSearchDirectoryQuery } from '@/services/usersApi';
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
@@ -37,11 +40,31 @@ vi.mock('@/services/userGroupsApi', () => ({
     error: undefined,
   }),
   useUpdateGroupMutation: () => [vi.fn(), { isLoading: false }],
-  useAddMemberMutation: () => [vi.fn(), { isLoading: false }],
+  useAddMemberMutation: vi.fn(),
   useRemoveMemberMutation: () => [vi.fn(), { isLoading: false }],
 }));
 
+vi.mock('@/services/usersApi', () => ({
+  useSearchDirectoryQuery: vi.fn(),
+}));
+
+// Radix Popover doesn't play well with happy-dom; render trigger + content flat.
+// (Same workaround used by ResponseHandlerConfig.test.tsx / DomainBlocklistsSection.test.tsx.)
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: any) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: any) => <div>{children}</div>,
+  PopoverContent: ({ children }: any) => <div>{children}</div>,
+}));
+
 vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+beforeEach(() => {
+  vi.mocked(useAddMemberMutation).mockReturnValue([
+    vi.fn().mockReturnValue({ unwrap: () => Promise.resolve() }),
+    { isLoading: false },
+  ] as any);
+  vi.mocked(useSearchDirectoryQuery).mockReturnValue({ data: undefined, isFetching: false } as any);
+});
 
 describe('GroupDetailPage', () => {
   // Regression for #569: the per-member remove button used Dialog's `DialogTrigger`
@@ -55,5 +78,79 @@ describe('GroupDetailPage', () => {
     );
 
     expect(screen.getByText('member@example.com')).toBeInTheDocument();
+  });
+});
+
+describe('GroupDetailPage Add Member dialog', () => {
+  async function openDialog() {
+    render(
+      <MemoryRouter>
+        <GroupDetailPage />
+      </MemoryRouter>,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /add member/i }));
+    return screen.getByRole('dialog');
+  }
+
+  it('shows directory results for a typed search term (#572)', async () => {
+    vi.mocked(useSearchDirectoryQuery).mockReturnValue({
+      data: { users: [{ id: 'user-10', email: 'jane@example.com' }] },
+      isFetching: false,
+    } as any);
+
+    const dialog = await openDialog();
+    const searchInput = within(dialog).getByPlaceholderText(/search by email/i);
+    await userEvent.type(searchInput, 'jane');
+
+    await waitFor(() => {
+      expect(within(dialog).getByText('jane@example.com')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a no-matches state for a term with no results', async () => {
+    vi.mocked(useSearchDirectoryQuery).mockReturnValue({
+      data: { users: [] },
+      isFetching: false,
+    } as any);
+
+    const dialog = await openDialog();
+    const searchInput = within(dialog).getByPlaceholderText(/search by email/i);
+    await userEvent.type(searchInput, 'nobody');
+
+    await waitFor(() => {
+      expect(within(dialog).getByText(/no users found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('disables Add Member until a directory result is selected', async () => {
+    const dialog = await openDialog();
+    expect(within(dialog).getByRole('button', { name: /add member/i })).toBeDisabled();
+  });
+
+  it('selecting a result and submitting posts the selected user id, not the email (#572)', async () => {
+    const mockAddMember = vi.fn().mockReturnValue({ unwrap: () => Promise.resolve() });
+    vi.mocked(useAddMemberMutation).mockReturnValue([mockAddMember, { isLoading: false }] as any);
+    vi.mocked(useSearchDirectoryQuery).mockReturnValue({
+      data: { users: [{ id: 'user-10', email: 'jane@example.com' }] },
+      isFetching: false,
+    } as any);
+
+    const dialog = await openDialog();
+    const searchInput = within(dialog).getByPlaceholderText(/search by email/i);
+    await userEvent.type(searchInput, 'jane');
+
+    await waitFor(() => {
+      expect(within(dialog).getByText('jane@example.com')).toBeInTheDocument();
+    });
+    await userEvent.click(within(dialog).getByText('jane@example.com'));
+
+    const submitButton = within(dialog).getByRole('button', { name: /add member/i });
+    expect(submitButton).toBeEnabled();
+    await userEvent.click(submitButton);
+
+    expect(mockAddMember).toHaveBeenCalledWith({
+      groupId: 'group-1',
+      dto: { userId: 'user-10' },
+    });
   });
 });

--- a/apps/frontend/src/pages/GroupDetailPage.tsx
+++ b/apps/frontend/src/pages/GroupDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useGetSessionQuery } from '@/services/authApi';
 import {
   useGetGroupQuery,
@@ -9,6 +10,7 @@ import {
   useAddMemberMutation,
   useRemoveMemberMutation,
 } from '@/services/userGroupsApi';
+import { useSearchDirectoryQuery, type DirectoryUser } from '@/services/usersApi';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -30,9 +32,26 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { AlertCircle, UserPlus, Trash2, ArrowLeft, Edit, Save } from 'lucide-react';
+import {
+  AlertCircle,
+  UserPlus,
+  Trash2,
+  ArrowLeft,
+  Edit,
+  Save,
+  ChevronsUpDown,
+} from 'lucide-react';
 
 import { useToast } from '@/hooks/use-toast';
 import {
@@ -72,7 +91,9 @@ export function GroupDetailPage() {
   const [groupDescription, setGroupDescription] = useState('');
   const [addMemberDialogOpen, setAddMemberDialogOpen] = useState(false);
   const [removingMember, setRemovingMember] = useState<string | null>(null);
-  const [newMemberEmail, setNewMemberEmail] = useState('');
+  const [memberSearch, setMemberSearch] = useState('');
+  const [selectedMemberUser, setSelectedMemberUser] = useState<DirectoryUser | null>(null);
+  const [memberPickerOpen, setMemberPickerOpen] = useState(false);
 
   // Fetch group details
   const {
@@ -94,6 +115,14 @@ export function GroupDetailPage() {
   const [updateGroup, { isLoading: isUpdating }] = useUpdateGroupMutation();
   const [addMember, { isLoading: isAddingMember }] = useAddMemberMutation();
   const [removeMember, { isLoading: isRemovingMember }] = useRemoveMemberMutation();
+
+  // Directory search for the Add Member typeahead
+  const debouncedMemberSearch = useDebouncedValue(memberSearch, 300).trim();
+  const { data: directoryData, isFetching: isSearchingUsers } = useSearchDirectoryQuery(
+    { search: debouncedMemberSearch, limit: 10 },
+    { skip: !debouncedMemberSearch },
+  );
+  const directoryUsers = directoryData?.users ?? [];
 
   // Initialize form state when group loads
   if (group && !groupName && !editMode) {
@@ -135,11 +164,29 @@ export function GroupDetailPage() {
     }
   };
 
+  const resetAddMemberForm = () => {
+    setMemberSearch('');
+    setSelectedMemberUser(null);
+    setMemberPickerOpen(false);
+  };
+
+  const handleAddMemberDialogOpenChange = (open: boolean) => {
+    setAddMemberDialogOpen(open);
+    if (!open) {
+      resetAddMemberForm();
+    }
+  };
+
+  const handleSelectMemberUser = (user: DirectoryUser) => {
+    setSelectedMemberUser(user);
+    setMemberPickerOpen(false);
+  };
+
   const handleAddMember = async () => {
-    if (!groupId || !newMemberEmail.trim()) {
+    if (!groupId || !selectedMemberUser) {
       toast({
         title: 'Error',
-        description: 'Please enter a user email',
+        description: 'Please select a user',
         variant: 'destructive',
       });
       return;
@@ -148,16 +195,15 @@ export function GroupDetailPage() {
     try {
       await addMember({
         groupId,
-        dto: { userId: newMemberEmail }, // Backend should lookup user by email
+        dto: { userId: selectedMemberUser.id },
       }).unwrap();
 
       toast({
         title: 'Member added',
-        description: `${newMemberEmail} has been added to the group`,
+        description: `${selectedMemberUser.email} has been added to the group`,
       });
 
-      setAddMemberDialogOpen(false);
-      setNewMemberEmail('');
+      handleAddMemberDialogOpenChange(false);
     } catch (error: any) {
       toast({
         title: 'Error',
@@ -317,7 +363,7 @@ export function GroupDetailPage() {
                   Users in this group ({members?.length || 0})
                 </CardDescription>
               </div>
-              <Dialog open={addMemberDialogOpen} onOpenChange={setAddMemberDialogOpen}>
+              <Dialog open={addMemberDialogOpen} onOpenChange={handleAddMemberDialogOpenChange}>
                 <DialogTrigger asChild>
                   <Button>
                     <UserPlus className="h-4 w-4 mr-2" />
@@ -333,21 +379,76 @@ export function GroupDetailPage() {
                   </DialogHeader>
                   <div className="space-y-4 py-4">
                     <div className="space-y-2">
-                      <Label htmlFor="email">User Email</Label>
-                      <Input
-                        id="email"
-                        type="email"
-                        placeholder="user@example.com"
-                        value={newMemberEmail}
-                        onChange={(e) => setNewMemberEmail(e.target.value)}
-                      />
+                      <Label htmlFor="add-member-user-trigger">User</Label>
+                      <Popover open={memberPickerOpen} onOpenChange={setMemberPickerOpen}>
+                        <PopoverTrigger asChild>
+                          <Button
+                            id="add-member-user-trigger"
+                            type="button"
+                            variant="outline"
+                            role="combobox"
+                            aria-expanded={memberPickerOpen}
+                            className="w-full justify-between font-normal"
+                          >
+                            {selectedMemberUser ? (
+                              <span className="truncate">{selectedMemberUser.email}</span>
+                            ) : (
+                              <span className="text-muted-foreground">Search by email...</span>
+                            )}
+                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent
+                          className="w-[--radix-popover-trigger-width] p-0"
+                          align="start"
+                        >
+                          <Command shouldFilter={false}>
+                            <CommandInput
+                              placeholder="Search by email..."
+                              value={memberSearch}
+                              onValueChange={setMemberSearch}
+                            />
+                            <CommandList>
+                              {!debouncedMemberSearch ? (
+                                <div className="py-6 text-center text-sm text-muted-foreground">
+                                  Type an email to search
+                                </div>
+                              ) : isSearchingUsers ? (
+                                <div className="py-6 text-center text-sm text-muted-foreground">
+                                  Searching...
+                                </div>
+                              ) : directoryUsers.length === 0 ? (
+                                <CommandEmpty>No users found</CommandEmpty>
+                              ) : (
+                                <CommandGroup>
+                                  {directoryUsers.map((user) => (
+                                    <CommandItem
+                                      key={user.id}
+                                      value={user.email}
+                                      onSelect={() => handleSelectMemberUser(user)}
+                                    >
+                                      {user.email}
+                                    </CommandItem>
+                                  ))}
+                                </CommandGroup>
+                              )}
+                            </CommandList>
+                          </Command>
+                        </PopoverContent>
+                      </Popover>
                     </div>
                   </div>
                   <DialogFooter>
-                    <Button variant="outline" onClick={() => setAddMemberDialogOpen(false)}>
+                    <Button
+                      variant="outline"
+                      onClick={() => handleAddMemberDialogOpenChange(false)}
+                    >
                       Cancel
                     </Button>
-                    <Button onClick={handleAddMember} disabled={isAddingMember}>
+                    <Button
+                      onClick={handleAddMember}
+                      disabled={isAddingMember || !selectedMemberUser}
+                    >
                       {isAddingMember ? 'Adding...' : 'Add Member'}
                     </Button>
                   </DialogFooter>

--- a/apps/frontend/src/services/usersApi.ts
+++ b/apps/frontend/src/services/usersApi.ts
@@ -45,6 +45,20 @@ export interface UserResponse {
   user: User;
 }
 
+export interface DirectoryUser {
+  id: string;
+  email: string;
+}
+
+export interface DirectoryResponse {
+  users: DirectoryUser[];
+}
+
+export interface SearchDirectoryParams {
+  search: string;
+  limit?: number;
+}
+
 export interface DeleteUserResponse {
   message: string;
   userId: string;
@@ -76,6 +90,17 @@ export const usersApi = api.injectEndpoints({
     getUser: builder.query<User, string>({
       query: (id) => `/api/users/${id}`,
       providesTags: (_result, _error, id) => [{ type: 'User' as const, id }],
+    }),
+
+    // Member-accessible directory search (id + email only) for people-pickers.
+    // Not admin-gated — any authenticated user can resolve a colleague by email.
+    searchDirectory: builder.query<DirectoryResponse, SearchDirectoryParams>({
+      query: ({ search, limit }) => {
+        const searchParams = new URLSearchParams();
+        searchParams.set('search', search);
+        if (limit) searchParams.set('limit', String(limit));
+        return `/api/users/directory?${searchParams.toString()}`;
+      },
     }),
 
     updateUserRole: builder.mutation<UserResponse, { id: string; role: UserRole }>({
@@ -128,6 +153,7 @@ export const usersApi = api.injectEndpoints({
 export const {
   useListUsersQuery,
   useGetUserQuery,
+  useSearchDirectoryQuery,
   useUpdateUserRoleMutation,
   useDeleteUserMutation,
   useDisableUserMutation,


### PR DESCRIPTION
## Summary

Fixes #572. The group Add Member dialog labeled its field "User Email" but posted the typed string as `userId`, which `AddMemberDto`'s `@IsUUID()` rejects — adding by email never worked (400 "userId must be a UUID"), and there was no user search.

The free-text input is now a debounced (300ms) directory-backed combobox (shadcn `Popover`+`Command`, `shouldFilter={false}` for server-filtered results — same composition as `AIHandlerConfig`/`CreateAliasDialog`): typing searches the member-accessible `GET /api/users/directory` (skip on blank term), selecting stores `{id, email}`, and submit posts `dto: { userId: selected.id }`. Add Member stays disabled until a selection exists; "No users found" empty state; full state reset on close/success. `AddMemberDto` stays strict — frontend-only change; the old `// Backend should lookup user by email` wish-comment is gone with the code it apologized for.

## Verification

- TDD in `GroupDetailPage.test.tsx`: RED 4 → GREEN 5 — including a direct assertion that `addMember` receives the selected user's **UUID** (the actual #572 regression), plus results-render, disabled-without-selection, and no-matches states. The #569 crash-regression test is untouched and passing.
- Full frontend suite 70 files / 763 tests green; `pnpm build` clean; changed files eslint-clean (`--max-warnings 0`).
- Review verified the hook contract against the backend controller/service (param names, blank-term behavior, limit cap, member-accessibility) and grepped out any stale `newMemberEmail`/old-UI references.

Deferred minors from review: debounce/skip wiring is verified by inspection rather than a dedicated test; a `UserDirectoryCombobox` extraction becomes worthwhile if a second consumer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1FwQsg44yeeF9Zcyu1oFx
