### PR TITLE
chore: release CE 0.4.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -338,6 +338,7 @@ MINIO_USE_SSL=false
 # first-party apps from this URL (cached ~1h; the catalog degrades to
 # "unavailable" if unreachable). Override for air-gapped or self-published
 # catalogs. There is deliberately no arbitrary-URL install field in the UI.
+# Available from CE 0.4.0.
 # APPS_REGISTRY_URL=https://apps.bffless.dev/registry.json
 
 


### PR DESCRIPTION
Makes the next CE release **0.4.0** instead of 0.3.16.

## Why

The app catalog (#567) is a user-facing feature addition, and it lands alongside signed downloads on local filesystem storage — a minor bump reads honestly to anyone scanning the changelog. The release-please config sets `bump-minor-pre-major` **and** `bump-patch-for-minor-pre-major` on both components, so pre-1.0 a `feat:` only produces a patch; forcing the minor needs a `Release-As:` footer.

## Why it touches a file instead of being an empty commit

release-please attributes a **pathless** commit to every package in the manifest, which is how a previous `Release-As` empty commit dragged `packages/cli` to the same version. This commit touches `.env.example` (root component only), so the directive is scoped to `.` and the CLI stays on its own 0.3.x line.

The one-line change is also genuinely useful: it records the CE version that introduced `APPS_REGISTRY_URL`.

## After merge — verify

The release-please PR that opens should propose:
- `.` → **0.4.0**
- `packages/bffless` (CLI) → **unchanged at 0.3.1**

If the CLI moved, fix it before that release PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019abzHPfQ6mEk8rh7bYme27
