### PR TITLE
fix(test): make the DNS preflight TOCTOU spec order-independent

### DIFF
--- a/apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
+++ b/apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
@@ -83,21 +83,35 @@ describe('BootstrapDnsPreflightService', () => {
 
       await service.run('example.com');
 
-      expect(transportSpy).toHaveBeenCalled();
-      const options = transportSpy.mock.calls[0][0] as {
+      // `run()` probes apex/www/admin CONCURRENTLY, so the order calls land in
+      // is not deterministic — assert over the whole set rather than calls[0],
+      // which raced and failed intermittently in CI.
+      expect(transportSpy).toHaveBeenCalledTimes(3);
+      type ProbeOptions = {
         host: string;
         headers: Record<string, string>;
         path: string;
       };
-      // Connection target must be the already-vetted IP — never the raw
-      // hostname, which would let the HTTP client re-resolve DNS itself and
-      // reopen the resolve/connect TOCTOU window.
-      expect(options.host).toBe('93.184.216.34');
-      expect(options.host).not.toBe('example.com');
+      const calls = (transportSpy.mock.calls as unknown as Array<[ProbeOptions]>).map(
+        ([options]) => options,
+      );
+
+      for (const options of calls) {
+        // Connection target must be the already-vetted IP — never the raw
+        // hostname, which would let the HTTP client re-resolve DNS itself and
+        // reopen the resolve/connect TOCTOU window. This must hold for EVERY
+        // probed host, not just the first one to fire.
+        expect(options.host).toBe('93.184.216.34');
+        expect(options.path).toMatch(/^\/\.well-known\/acme-challenge\//);
+      }
+
       // The hostname still travels via the Host header so ACME webroot
       // vhost routing on the target server keeps working.
-      expect(options.headers.Host).toBe('example.com');
-      expect(options.path).toMatch(/^\/\.well-known\/acme-challenge\//);
+      expect(calls.map((options) => options.headers.Host).sort()).toEqual([
+        'admin.example.com',
+        'example.com',
+        'www.example.com',
+      ]);
     });
   });
 


### PR DESCRIPTION
Fixes the flaky test that failed the **v0.4.0 release run** ([run 30669206258](https://github.com/bffless/ce/actions/runs/30669206258)).

## What broke

```
● BootstrapDnsPreflightService › m6 TOCTOU fix › pins the connection to the resolved IP …
  Expected: "example.com"
  Received: "www.example.com"
```

The spec asserted on `transportSpy.mock.calls[0]` — the *first* probe to fire. That was deterministic while `run()` probed apex → www → admin sequentially. #567 refactored `run()` into a concurrent `Promise.all` fan-out (so `probeHost()` could be reused to probe a single arbitrary host for app installs), which made call order a race. It passes most runs and lost the coin flip on the release.

## Why it's test-only

Production behaviour is unchanged: `Promise.all` preserves *result* order, and every caller (`bootstrap-setup.controller`, `primary-ssl.service`) reads `result.ok` / `result.checks[]`, never probe timing. Each host also gets its own token file, so there's no shared-state hazard between the concurrent probes.

## The fix

Assert over the whole call set rather than one racy index. This is strictly stronger than what it replaces — the TOCTOU property (*connect to the vetted IP, carry the hostname in the `Host` header*) must hold for **every** probed host, not just whichever fired first:

- every call pins `host` to the resolved IP and targets an ACME challenge path
- the three `Host` headers, sorted, are exactly apex/www/admin

## Verification

- The spec, 6 consecutive runs: 13/13 each time
- Full setup suite: 12 suites / 211 tests green
- `tsc --noEmit` clean; lint unchanged from baseline (8 pre-existing prettier errors in this file both before and after)

Once merged, re-running the release workflow should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019abzHPfQ6mEk8rh7bYme27
