### PR TITLE
fix(app-catalog): probe HTTPS for the DNS gate on proxied instances

### DIFF
--- a/apps/backend/src/app-catalog/app-preflight.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-preflight.service.spec.ts
@@ -372,7 +372,9 @@ describe('AppPreflightService', () => {
       );
 
       expect(result.appHost).toBe('my-app.example.com');
-      expect(dnsPreflight.probeHost).toHaveBeenCalledWith('my-app.example.com');
+      expect(dnsPreflight.probeHost).toHaveBeenCalledWith('my-app.example.com', {
+        mode: 'reachability',
+      });
       const dns = result.gates.find((g) => g.id === 'dns');
       expect(dns?.status).toBe('pass');
       const nameCollision = result.gates.find((g) => g.id === 'name-collision');
@@ -471,7 +473,10 @@ describe('AppPreflightService', () => {
 
       const dns = result.gates.find((g) => g.id === 'dns');
       expect(dns).toMatchObject({ id: 'dns', status: 'pass' });
-      expect(dnsPreflight.probeHost).toHaveBeenCalledWith('handoff.example.com');
+      // Reachability mode, not the ACME gate — see dnsGate's comment.
+      expect(dnsPreflight.probeHost).toHaveBeenCalledWith('handoff.example.com', {
+        mode: 'reachability',
+      });
     });
 
     it('fails as retryable with the exact record to add and resolved IPs when probeHost fails', async () => {
@@ -515,6 +520,79 @@ describe('AppPreflightService', () => {
       expect(dns?.remediation).toMatch(/CNAME/);
       expect(dns?.remediation).toMatch(/handoff/);
       expect(dns?.remediation).toMatch(/example\.com/);
+    });
+
+    // A proxied instance can only ever get the weaker HTTPS answer, so the
+    // gate's wording has to stop over-claiming. These lock that in.
+    function buildDnsCase(check: PreflightCheck) {
+      const bundle = makeBundle();
+      const built = buildService({ configValues: { PRIMARY_DOMAIN: 'example.com' } });
+      (built.dnsPreflight.probeHost as jest.Mock).mockResolvedValue(check);
+      (built.proxyRuleSetsService.syncRuleSet as jest.Mock).mockResolvedValue(EMPTY_SYNC_RESPONSE);
+      for (let i = 0; i < 6; i++) mockDb.__queue([]);
+      return { bundle, ...built };
+    }
+
+    it('on a proxied instance, a passing HTTPS probe says HTTPS and admits it cannot prove the origin', async () => {
+      const { service, bundle } = buildDnsCase({
+        host: 'handoff.example.com',
+        resolvedIps: ['104.21.1.1'],
+        probeOk: true,
+        probeKind: 'https-reachability',
+        status: 404,
+      });
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const dns = result.gates.find((g) => g.id === 'dns');
+      expect(dns?.status).toBe('pass');
+      expect(dns?.message).toMatch(/HTTPS/);
+      expect(dns?.message).toMatch(/HTTP 404/);
+      expect(dns?.message).toMatch(/cannot prove/i);
+      expect(dns?.message).toMatch(/104\.21\.1\.1/);
+    });
+
+    it('a Cloudflare 520 fails with an origin-down message, not a "fix your DNS" message', async () => {
+      const { service, bundle } = buildDnsCase({
+        host: 'handoff.example.com',
+        resolvedIps: ['104.21.1.1'],
+        probeOk: false,
+        probeKind: 'https-reachability',
+        status: 520,
+        failure: 'origin-error',
+        error:
+          'The proxy in front of handoff.example.com returned HTTP 520 — it could not reach an origin',
+      });
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const dns = result.gates.find((g) => g.id === 'dns');
+      expect(dns?.status).toBe('fail');
+      expect(dns?.retryable).toBe(true);
+      expect(dns?.message).toMatch(/HTTP 520/);
+      expect(dns?.message).toMatch(/DNS is fine/i);
+      expect(dns?.remediation).toMatch(/serving handoff\.example\.com/);
+      // Still names the exact record, in case the record really is missing.
+      expect(dns?.remediation).toMatch(/CNAME/);
+    });
+
+    it('a refused connection keeps the DNS-record remediation', async () => {
+      const { service, bundle } = buildDnsCase({
+        host: 'handoff.example.com',
+        resolvedIps: [],
+        probeOk: false,
+        probeKind: 'https-reachability',
+        failure: 'no-response',
+        error: 'connect ECONNREFUSED 104.21.1.1:443',
+      });
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const dns = result.gates.find((g) => g.id === 'dns');
+      expect(dns?.status).toBe('fail');
+      expect(dns?.retryable).toBe(true);
+      expect(dns?.message).toMatch(/ECONNREFUSED/);
+      expect(dns?.remediation).toMatch(/CNAME record "handoff"/);
     });
   });
 

--- a/apps/backend/src/app-catalog/app-preflight.service.ts
+++ b/apps/backend/src/app-catalog/app-preflight.service.ts
@@ -242,16 +242,50 @@ export class AppPreflightService {
       };
     }
 
-    const check = await this.dnsPreflight.probeHost(appHost);
+    // Reachability mode, NOT the ACME gate. The question here is "will an app
+    // served at this hostname be reachable?", and on a Cloudflare/reverse-proxy
+    // instance the ACME answer is unobtainable: those instances render no
+    // acme-challenge location and serve nothing at all on origin port 80, so
+    // the port-80 token echo fails even when everything is perfectly healthy.
+    const check = await this.dnsPreflight.probeHost(appHost, { mode: 'reachability' });
+    const resolvedIps = check.resolvedIps.length ? check.resolvedIps.join(', ') : 'none';
+    const dnsRemediation =
+      `Add a CNAME record "${subdomain}" pointing to "${primaryDomain}" (or an A record matching ` +
+      `${primaryDomain}'s IP), then retry.`;
+
     if (check.probeOk) {
+      // Be honest about what each probe actually proved. The HTTPS probe is
+      // deliberately weaker: a proxied edge terminates TLS, so a green result
+      // says the hostname reaches a live server, not that it reaches THIS one.
+      // A 404 is the expected answer at this point — the app has no domain
+      // mapping until the install creates one.
+      const message =
+        check.probeKind === 'https-reachability'
+          ? `${appHost} resolves to ${resolvedIps} and answered over HTTPS` +
+            (check.status ? ` (HTTP ${check.status})` : '') +
+            `. This instance serves behind a proxy or with port 80 closed, so the probe confirms the ` +
+            `hostname reaches a live server — it cannot prove that server is this origin, because the ` +
+            `proxy terminates TLS. A 404 here is expected: the app has no domain mapping until it is installed.`
+          : `${appHost} resolves and answered the preflight probe on port 80.`;
+      return { id: 'dns', status: 'pass', message };
+    }
+
+    if (check.failure === 'origin-error') {
       return {
         id: 'dns',
-        status: 'pass',
-        message: `${appHost} resolves and answered the preflight probe.`,
+        status: 'fail',
+        retryable: true,
+        message:
+          `${appHost} resolves to ${resolvedIps} and the proxy in front of it answered, but with ` +
+          `HTTP ${check.status ?? '5xx'} — a Cloudflare-style origin error. DNS is fine; the proxy could ` +
+          `not reach an origin for this hostname.`,
+        remediation:
+          `Check that this server is running and serving ${appHost} (and, on Cloudflare, that the ` +
+          `record for "${subdomain}" is proxied to the same origin as ${primaryDomain}), then retry. ` +
+          `If the record is missing entirely, ${dnsRemediation}`,
       };
     }
 
-    const resolvedIps = check.resolvedIps.length ? check.resolvedIps.join(', ') : 'none';
     return {
       id: 'dns',
       status: 'fail',
@@ -259,9 +293,7 @@ export class AppPreflightService {
       message:
         `DNS check failed for ${appHost}: ${check.error ?? 'probe did not succeed'}. ` +
         `Resolved IPs: ${resolvedIps}.`,
-      remediation:
-        `Add a CNAME record "${subdomain}" pointing to "${primaryDomain}" (or an A record matching ` +
-        `${primaryDomain}'s IP), then retry.`,
+      remediation: dnsRemediation,
     };
   }
 

--- a/apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
+++ b/apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
@@ -1,3 +1,13 @@
+// The serving model steers which port the reachability probe uses, so it is a
+// mocked seam here (house pattern: primary-ssl.service.spec does the same).
+// `deriveKnobs` stays real — the v1/env-adopted defaulting it encodes is
+// exactly what we want exercised.
+let mockInstanceConfig: unknown = null;
+jest.mock('../bootstrap/instance-config', () => ({
+  loadInstanceConfig: () => mockInstanceConfig,
+  deriveKnobs: jest.requireActual('../bootstrap/instance-config').deriveKnobs,
+}));
+
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -10,10 +20,13 @@ describe('BootstrapDnsPreflightService', () => {
   beforeEach(() => {
     webroot = fs.mkdtempSync(path.join(os.tmpdir(), 'bffless-webroot-'));
     process.env.CERTBOT_WEBROOT = webroot;
+    delete process.env.PROXY_MODE;
+    mockInstanceConfig = null;
     service = new BootstrapDnsPreflightService();
   });
   afterEach(() => {
     delete process.env.CERTBOT_WEBROOT;
+    delete process.env.PROXY_MODE;
     fs.rmSync(webroot, { recursive: true, force: true });
   });
 
@@ -130,6 +143,225 @@ describe('BootstrapDnsPreflightService', () => {
         .mockResolvedValue({ host: 'x', resolvedIps: [], probeOk: true });
       await service.run('example.com');
       expect(probe.mock.calls.map((c) => c[0])).toEqual(['example.com', 'www.example.com', 'admin.example.com']);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // The ACME gate must never be weakened by the reachability work. Everything
+  // in this block is a regression fence around run(): it stays on port 80 with
+  // a token echo REGARDLESS of the serving model, because that is the exact
+  // route Let's Encrypt's HTTP-01 validator takes.
+  // ---------------------------------------------------------------------------
+  describe('run(): ACME semantics are unconditional', () => {
+    it.each([
+      ['direct', null],
+      ['cloudflare', { version: 2, state: 'applied', proxyMode: 'cloudflare', port80: 'closed' }],
+      ['proxy', { version: 2, state: 'applied', proxyMode: 'proxy', port80: 'redirect' }],
+    ])('probes port 80 over plain HTTP with a token echo (%s instance)', async (_label, cfg) => {
+      mockInstanceConfig = cfg;
+      jest
+        .spyOn(service as never, 'resolveA' as never)
+        .mockResolvedValue(['93.184.216.34'] as never);
+      const httpSpy = jest
+        .spyOn(service as never, 'sendProbeRequest' as never)
+        .mockImplementation((async (options: { path: string }) => ({
+          statusCode: 200,
+          // Echo the token back out of the request path, i.e. exactly what a
+          // correctly-serving webroot does.
+          body: options.path.replace('/.well-known/acme-challenge/', ''),
+        })) as never);
+      const httpsSpy = jest.spyOn(service as never, 'sendSecureProbeRequest' as never);
+
+      const res = await service.run('example.com');
+
+      expect(res.ok).toBe(true);
+      expect(httpsSpy).not.toHaveBeenCalled();
+      expect(httpSpy).toHaveBeenCalledTimes(3);
+      type ProbeOptions = {
+        host: string;
+        port: number;
+        path: string;
+        headers: Record<string, string>;
+      };
+      const calls = (httpSpy.mock.calls as unknown as Array<[ProbeOptions]>).map(([o]) => o);
+      for (const options of calls) {
+        expect(options.port).toBe(80);
+        expect(options.path).toMatch(/^\/\.well-known\/acme-challenge\//);
+        // TOCTOU: connect to the vetted IP, carry the hostname in Host.
+        expect(options.host).toBe('93.184.216.34');
+      }
+      expect(calls.map((o) => o.headers.Host).sort()).toEqual([
+        'admin.example.com',
+        'example.com',
+        'www.example.com',
+      ]);
+      expect(res.checks.every((c) => c.probeKind === 'acme')).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Reachability mode: the app catalog's question, not the CA's.
+  // ---------------------------------------------------------------------------
+  describe('probeHost({ mode: "reachability" })', () => {
+    function stubResolve(ip = '93.184.216.34') {
+      jest.spyOn(service as never, 'resolveA' as never).mockResolvedValue([ip] as never);
+    }
+    function stubHttps(statusCode: number) {
+      return jest
+        .spyOn(service as never, 'sendSecureProbeRequest' as never)
+        .mockResolvedValue({ statusCode, body: '' } as never);
+    }
+
+    it.each([
+      ['proxyMode cloudflare', { version: 2, state: 'applied', proxyMode: 'cloudflare' }],
+      ['proxyMode proxy', { version: 2, state: 'applied', proxyMode: 'proxy' }],
+      // port80 'closed' on its own is enough: whatever the proxyMode label
+      // says, nginx renders `return 444` and no ACME location there.
+      ['port80 closed', { version: 2, state: 'applied', proxyMode: 'none', port80: 'closed' }],
+    ])('probes HTTPS on 443 when %s', async (_label, cfg) => {
+      mockInstanceConfig = cfg;
+      stubResolve();
+      const httpsSpy = stubHttps(404);
+      const httpSpy = jest.spyOn(service as never, 'sendProbeRequest' as never);
+
+      const check = await service.probeHost('handoff.example.com', { mode: 'reachability' });
+
+      expect(httpSpy).not.toHaveBeenCalled();
+      expect(httpsSpy).toHaveBeenCalledTimes(1);
+      expect((httpsSpy.mock.calls[0] as unknown as [{ port: number }])[0].port).toBe(443);
+      expect(check.probeKind).toBe('https-reachability');
+    });
+
+    it('falls back to the stronger port-80 token echo on a direct-serving instance', async () => {
+      mockInstanceConfig = { version: 2, state: 'applied', proxyMode: 'none', port80: 'redirect' };
+      stubResolve();
+      const httpsSpy = jest.spyOn(service as never, 'sendSecureProbeRequest' as never);
+      const httpSpy = jest
+        .spyOn(service as never, 'sendProbeRequest' as never)
+        .mockImplementation((async (options: { path: string }) => ({
+          statusCode: 200,
+          body: options.path.replace('/.well-known/acme-challenge/', ''),
+        })) as never);
+
+      const check = await service.probeHost('handoff.example.com', { mode: 'reachability' });
+
+      expect(httpsSpy).not.toHaveBeenCalled();
+      expect((httpSpy.mock.calls[0] as unknown as [{ port: number }])[0].port).toBe(80);
+      expect(check.probeKind).toBe('acme');
+      expect(check.probeOk).toBe(true);
+    });
+
+    it('derives the serving model from PROXY_MODE when there is no instance.json', async () => {
+      mockInstanceConfig = null;
+      process.env.PROXY_MODE = 'cloudflare';
+      stubResolve();
+      const httpsSpy = stubHttps(404);
+
+      await service.probeHost('handoff.example.com', { mode: 'reachability' });
+
+      expect(httpsSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('treats a 404 over HTTPS as success — the app has no mapping yet by definition', async () => {
+      mockInstanceConfig = { version: 2, state: 'applied', proxyMode: 'cloudflare' };
+      stubResolve();
+      stubHttps(404);
+
+      const check = await service.probeHost('handoff.example.com', { mode: 'reachability' });
+
+      expect(check.probeOk).toBe(true);
+      expect(check.status).toBe(404);
+      expect(check.error).toBeUndefined();
+    });
+
+    it.each([200, 301, 403, 500])('treats HTTP %s as a reachable answer', async (statusCode) => {
+      mockInstanceConfig = { version: 2, state: 'applied', proxyMode: 'cloudflare' };
+      stubResolve();
+      stubHttps(statusCode);
+
+      const check = await service.probeHost('handoff.example.com', { mode: 'reachability' });
+      expect(check.probeOk).toBe(true);
+    });
+
+    it.each([520, 521, 522, 523, 524, 525, 526, 527])(
+      'fails a Cloudflare origin error (%s) with an origin-error classification',
+      async (statusCode) => {
+        mockInstanceConfig = { version: 2, state: 'applied', proxyMode: 'cloudflare' };
+        stubResolve();
+        stubHttps(statusCode);
+
+        const check = await service.probeHost('handoff.example.com', { mode: 'reachability' });
+
+        expect(check.probeOk).toBe(false);
+        expect(check.failure).toBe('origin-error');
+        expect(check.status).toBe(statusCode);
+        expect(check.error).toMatch(/could not reach an origin/i);
+      },
+    );
+
+    it('fails with no-response when the connection is refused', async () => {
+      mockInstanceConfig = { version: 2, state: 'applied', proxyMode: 'cloudflare' };
+      stubResolve();
+      jest
+        .spyOn(service as never, 'sendSecureProbeRequest' as never)
+        .mockRejectedValue(new Error('connect ECONNREFUSED 93.184.216.34:443') as never);
+
+      const check = await service.probeHost('handoff.example.com', { mode: 'reachability' });
+
+      expect(check.probeOk).toBe(false);
+      expect(check.failure).toBe('no-response');
+      expect(check.error).toMatch(/ECONNREFUSED/);
+    });
+
+    it('fails with no-dns when the hostname does not resolve, without opening a socket', async () => {
+      mockInstanceConfig = { version: 2, state: 'applied', proxyMode: 'cloudflare' };
+      jest.spyOn(service as never, 'resolveA' as never).mockResolvedValue([] as never);
+      const httpsSpy = jest.spyOn(service as never, 'sendSecureProbeRequest' as never);
+
+      const check = await service.probeHost('handoff.example.com', { mode: 'reachability' });
+
+      expect(check.probeOk).toBe(false);
+      expect(check.failure).toBe('no-dns');
+      expect(httpsSpy).not.toHaveBeenCalled();
+    });
+
+    it('refuses a private/reserved resolution before connecting (SSRF guard holds in both modes)', async () => {
+      mockInstanceConfig = { version: 2, state: 'applied', proxyMode: 'cloudflare' };
+      stubResolve('169.254.169.254');
+      const httpsSpy = jest.spyOn(service as never, 'sendSecureProbeRequest' as never);
+
+      const check = await service.probeHost('metadata.example.com', { mode: 'reachability' });
+
+      expect(check.probeOk).toBe(false);
+      expect(check.failure).toBe('private-ip');
+      expect(check.error).toContain('private or reserved');
+      expect(httpsSpy).not.toHaveBeenCalled();
+    });
+
+    it('pins the HTTPS connection to the vetted IP and carries the hostname in SNI + Host', async () => {
+      mockInstanceConfig = { version: 2, state: 'applied', proxyMode: 'cloudflare' };
+      stubResolve('93.184.216.34');
+      const httpsSpy = stubHttps(404);
+
+      await service.probeHost('handoff.example.com', { mode: 'reachability' });
+
+      const [options] = httpsSpy.mock.calls[0] as unknown as [
+        {
+          host: string;
+          servername: string;
+          headers: Record<string, string>;
+          rejectUnauthorized: boolean;
+        },
+      ];
+      // TOCTOU: never re-resolve — connect to the address we already vetted.
+      expect(options.host).toBe('93.184.216.34');
+      // SNI + Host still carry the hostname so the right vhost answers.
+      expect(options.servername).toBe('handoff.example.com');
+      expect(options.headers.Host).toBe('handoff.example.com');
+      // Connecting by IP can never satisfy hostname verification, and origins
+      // behind a proxy routinely serve self-signed certs — the probe proves
+      // reachability, not authenticity.
+      expect(options.rejectUnauthorized).toBe(false);
     });
   });
 });

--- a/apps/backend/src/setup/bootstrap-dns-preflight.service.ts
+++ b/apps/backend/src/setup/bootstrap-dns-preflight.service.ts
@@ -3,18 +3,51 @@ import { promises as dns } from 'dns';
 import * as crypto from 'crypto';
 import * as fs from 'fs/promises';
 import * as http from 'http';
+import * as https from 'https';
 import * as path from 'path';
+import { deriveKnobs, loadInstanceConfig, type ProxyMode } from '../bootstrap/instance-config';
+
+/**
+ * What a probe is being asked to prove.
+ *
+ * - `acme` (default, and the ONLY thing `run()` ever uses): "will Let's
+ *   Encrypt's HTTP-01 validator succeed against this host?" — port 80 plus a
+ *   token echo out of the certbot webroot. Never weaken this path; the wizard
+ *   hard-gates issuance on it precisely because it walks the CA's own route.
+ * - `reachability`: "does this hostname reach this server, so an app served
+ *   here will work?" — a strictly weaker, differently-shaped question that the
+ *   app catalog asks about a not-yet-mapped app subdomain.
+ */
+export type ProbeMode = 'acme' | 'reachability';
+
+export interface ProbeOptions {
+  mode?: ProbeMode;
+}
+
+/** How a reachability probe failed, so callers can word remediation honestly. */
+export type ProbeFailure = 'no-dns' | 'private-ip' | 'origin-error' | 'no-response';
 
 export interface PreflightCheck {
   host: string;
   resolvedIps: string[];
   probeOk: boolean;
   error?: string;
+  /** Which probe actually ran (absent on nothing — always set from here on). */
+  probeKind?: 'acme' | 'https-reachability';
+  /** Failure classification; only populated for the reachability probe. */
+  failure?: ProbeFailure;
+  /** HTTP status the host answered with, when it answered at all. */
+  status?: number;
 }
 
 export interface PreflightResult {
   ok: boolean;
   checks: PreflightCheck[];
+}
+
+/** Cloudflare's origin-error range: the edge answered, the origin did not. */
+function isProxyOriginError(status: number): boolean {
+  return status >= 520 && status <= 527;
 }
 
 // SSRF guard (v0.2.18 review, m6): the probe is a blind GET to a
@@ -52,13 +85,54 @@ export function isDisallowedProbeIp(ip: string): boolean {
 export class BootstrapDnsPreflightService {
   private readonly logger = new Logger(BootstrapDnsPreflightService.name);
 
+  /**
+   * ACME gate. Deliberately takes no options: issuance preflight must always
+   * be the port-80 token echo, never the weaker reachability probe.
+   */
   async run(domain: string): Promise<PreflightResult> {
     const hosts = [domain, `www.${domain}`, `admin.${domain}`];
     const checks = await Promise.all(hosts.map((host) => this.probeHost(host)));
     return { ok: checks.every((c) => c.probeOk), checks };
   }
 
-  async probeHost(host: string): Promise<PreflightCheck> {
+  /**
+   * Default mode is `acme` — every existing caller (run(), and
+   * PrimarySslService's extraSans checks, which ARE about ACME) keeps the
+   * port-80 token-echo semantics unchanged.
+   *
+   * `reachability` mode answers a different question and, on instances that
+   * serve behind a proxy or with port 80 closed, uses an HTTPS probe instead:
+   * those instances render NO acme-challenge location at all (see
+   * render-main-conf.sh's PORT80=closed branch), so the token echo is not
+   * merely inconvenient there, it is impossible. Direct-serving instances DO
+   * render it, so they keep the strictly stronger port-80 proof.
+   */
+  async probeHost(host: string, opts: ProbeOptions = {}): Promise<PreflightCheck> {
+    if (opts.mode === 'reachability' && this.shouldProbeHttps()) {
+      return this.httpsReachabilityProbe(host);
+    }
+    return this.acmeProbe(host);
+  }
+
+  /**
+   * Mirrors render-main-conf.sh's resolution order exactly: instance.env (i.e.
+   * instance.json here) wins, otherwise PROXY_MODE from the environment with
+   * 'none' as the default, and the knobs derive from that. Keeping the two in
+   * step matters — if we probe a port nginx isn't listening on, the gate lies.
+   */
+  private shouldProbeHttps(): boolean {
+    const cfg = loadInstanceConfig();
+    const envProxyMode = process.env.PROXY_MODE;
+    const proxyMode: ProxyMode =
+      cfg?.proxyMode ??
+      (envProxyMode === 'cloudflare' || envProxyMode === 'proxy' || envProxyMode === 'none'
+        ? envProxyMode
+        : 'none');
+    const { port80 } = deriveKnobs({ ...(cfg ?? { version: 2, state: 'applied' }), proxyMode });
+    return proxyMode === 'cloudflare' || proxyMode === 'proxy' || port80 === 'closed';
+  }
+
+  private async acmeProbe(host: string): Promise<PreflightCheck> {
     const token = `preflight-${crypto.randomBytes(16).toString('hex')}`;
     const content = token; // body == token: cheap, unguessable, self-describing
     const filePath = path.join(this.webroot(), '.well-known', 'acme-challenge', token);
@@ -68,7 +142,13 @@ export class BootstrapDnsPreflightService {
     try {
       const resolvedIps = await this.resolveA(host);
       if (resolvedIps.some((ip) => isDisallowedProbeIp(ip))) {
-        return { host, resolvedIps, probeOk: false, error: 'resolves to a private or reserved address' };
+        return {
+          host,
+          resolvedIps,
+          probeOk: false,
+          error: 'resolves to a private or reserved address',
+          probeKind: 'acme',
+        };
       }
       let probeOk = false;
       let error: string | undefined;
@@ -82,9 +162,77 @@ export class BootstrapDnsPreflightService {
       if (!probeOk && resolvedIps.length === 0 && !error) {
         error = 'Hostname does not resolve yet';
       }
-      return { host, resolvedIps, probeOk, error: probeOk ? undefined : error };
+      return { host, resolvedIps, probeOk, error: probeOk ? undefined : error, probeKind: 'acme' };
     } finally {
       await fs.rm(filePath, { force: true });
+    }
+  }
+
+  /**
+   * Reachability probe for proxied / port-80-closed instances: GET https://<host>/
+   * and accept ANY real HTTP answer. A 404 is a SUCCESS here — at preflight
+   * time the app's subdomain has no mapping yet by definition, so 404 is the
+   * expected shape of "yes, this hostname lands on a server that will serve
+   * the app once installed".
+   *
+   * What this does NOT prove: that the answering origin is *this* CE instance.
+   * A proxied edge terminates TLS and we deliberately skip certificate
+   * validation below, so authenticity is out of reach on this path; callers
+   * must word their messages accordingly. Cloudflare's 520–527 range is the
+   * one shape we reject: the edge answered but the origin behind it did not.
+   */
+  private async httpsReachabilityProbe(host: string): Promise<PreflightCheck> {
+    const resolvedIps = await this.resolveA(host);
+    if (resolvedIps.some((ip) => isDisallowedProbeIp(ip))) {
+      return {
+        host,
+        resolvedIps,
+        probeOk: false,
+        error: 'resolves to a private or reserved address',
+        probeKind: 'https-reachability',
+        failure: 'private-ip',
+      };
+    }
+    if (resolvedIps.length === 0) {
+      return {
+        host,
+        resolvedIps,
+        probeOk: false,
+        error: 'Hostname does not resolve yet',
+        probeKind: 'https-reachability',
+        failure: 'no-dns',
+      };
+    }
+
+    try {
+      const { statusCode } = await this.fetchReachabilityProbe(host, resolvedIps[0]);
+      if (isProxyOriginError(statusCode)) {
+        return {
+          host,
+          resolvedIps,
+          probeOk: false,
+          status: statusCode,
+          error: `The proxy in front of ${host} returned HTTP ${statusCode} — it could not reach an origin`,
+          probeKind: 'https-reachability',
+          failure: 'origin-error',
+        };
+      }
+      return {
+        host,
+        resolvedIps,
+        probeOk: true,
+        status: statusCode,
+        probeKind: 'https-reachability',
+      };
+    } catch (e) {
+      return {
+        host,
+        resolvedIps,
+        probeOk: false,
+        error: e instanceof Error ? e.message : 'Unreachable over HTTPS',
+        probeKind: 'https-reachability',
+        failure: 'no-response',
+      };
     }
   }
 
@@ -129,9 +277,53 @@ export class BootstrapDnsPreflightService {
     return body;
   }
 
+  // Same TOCTOU pinning as fetchProbe: connect to the already-vetted IPv4
+  // address, carry the hostname in SNI (`servername`) AND the Host header so
+  // both TLS and vhost selection land on the right server block, and never let
+  // the HTTP client re-resolve. Redirects are not followed — a 3xx is simply
+  // an answer, which is all reachability mode needs.
+  //
+  // rejectUnauthorized:false is deliberate and load-bearing. We connect BY IP,
+  // so the presented certificate would fail hostname verification even when it
+  // is perfectly valid, and a direct origin behind Cloudflare commonly serves a
+  // self-signed or CF-origin cert that no public root chains to. This probe
+  // proves REACHABILITY, not AUTHENTICITY: nothing from the response is
+  // trusted, echoed back, or stored — only the status code is read — and the
+  // IP was already vetted by isDisallowedProbeIp() before we got here, so the
+  // usual SSRF risk of skipping validation does not apply.
+  private async fetchReachabilityProbe(
+    host: string,
+    ip: string | undefined,
+  ): Promise<{ statusCode: number }> {
+    if (!ip) throw new Error('No resolved address to probe');
+    return this.sendSecureProbeRequest({
+      host: ip,
+      servername: host,
+      port: 443,
+      path: '/',
+      method: 'GET',
+      headers: { Host: host },
+      timeout: 5000,
+      rejectUnauthorized: false,
+    });
+  }
+
   private sendProbeRequest(options: http.RequestOptions): Promise<{ statusCode: number; body: string }> {
+    return this.consumeProbeResponse(http.request(options), options);
+  }
+
+  private sendSecureProbeRequest(
+    options: https.RequestOptions,
+  ): Promise<{ statusCode: number; body: string }> {
+    return this.consumeProbeResponse(https.request(options), options);
+  }
+
+  private consumeProbeResponse(
+    req: http.ClientRequest,
+    options: http.RequestOptions,
+  ): Promise<{ statusCode: number; body: string }> {
     return new Promise((resolve, reject) => {
-      const req = http.request(options, (res) => {
+      req.on('response', (res) => {
         const chunks: Buffer[] = [];
         res.on('data', (chunk: Buffer) => chunks.push(chunk));
         res.on('end', () =>


### PR DESCRIPTION
The app catalog is **unusable on Cloudflare-proxied instances**: every install fails its DNS gate. Found live on `admin.bffless.dev` (CE 0.4.1) while installing Handoff.

```
DNS check failed for handoff.bffless.dev: HTTP 520 from handoff.bffless.dev.
Resolved 104.21.74.112, 172.67.157.2
```

## Diagnosis

DNS was correct (`*.bffless.dev` A → the droplet, proxied). The probe was wrong.

`BootstrapDnsPreflightService.fetchProbe` hardcodes `port: 80` + plain HTTP, then requires a token echo from the ACME webroot. That instance terminates TLS at Cloudflare and serves **nothing** on origin `:80` — verified with a direct request to the origin IP, which returns an empty reply even for the apex — so Cloudflare answers `520` for any `http://` request to the zone. Over HTTPS the host is perfectly reachable: `https://handoff.bffless.dev` → 404 (correct, no mapping yet), apex and admin → 200.

**The token echo can never work there, at any port:** CE deliberately renders no acme-challenge location in Cloudflare mode — see `docker/nginx/render-main-conf.sh` and its guard at `render-main-conf.test.sh:43` (`'cloudflare: no ACME location'`).

The real mistake was upstream of the symptom. `probeHost()` was extracted from the bootstrap wizard's preflight (#567, Task 6) and reused by the catalog without asking whether an **ACME-shaped test still answered the catalog's question**. It doesn't — they're two different questions sharing one helper:

- **Let's Encrypt HTTP-01**: the CA will fetch `http://host/.well-known/acme-challenge/<token>` on port 80. Probing port 80 there isn't a proxy for reachability, it's a faithful dry-run. Probing 443 would prove nothing and burn LE rate limits.
- **App install**: "does this hostname reach this server so the app works?" HTTPS answers that honestly, and on a proxied box it's the *only* thing that can.

## The fix

`probeHost(host, opts?)` gains a mode. The default — and `run(domain)`, which takes no options so no caller can downgrade it — stays byte-for-byte the port-80 token echo. **The ACME path is untouched**; `primary-ssl.service.ts`'s `extraSans` probes keep ACME semantics.

Reachability mode (used only by the catalog's dns gate) reads the serving model via `loadInstanceConfig()`/`deriveKnobs`, with the same `PROXY_MODE` fallback `render-main-conf.sh` uses:

| Serving model | Probe |
|---|---|
| `proxyMode` cloudflare/proxy, or `port80: closed` | HTTPS/443 — any non-Cloudflare-error response counts, **404 is success** (an unmapped host is the expected state at preflight) |
| direct (`proxyMode: none`) | port 80 + token echo, unchanged — strictly stronger, and those instances do render the ACME location |

The pinned-IP TOCTOU property holds in both modes: resolve → vet the IP → connect to *that IP*, with the hostname carried in SNI/`Host`, never re-resolved by the client. `rejectUnauthorized: false` applies to this probe alone (the origin may be self-signed and we connect by IP) — it proves reachability, not authenticity, and the IP was already vetted; reasoned at the call site.

Gate messages now state what was actually verified and distinguish *"the proxy couldn't reach an origin"* from *"no response at all — check the DNS record"*, still retryable, still naming the exact record to add.

## Honest limitation

On a proxied instance we can prove the host **answers**, not that it's **this** origin — a wildcard pointed at an unrelated live host would pass. That's forced by the absent ACME location, and the gate text now admits it rather than over-claiming. A CE-specific marker (e.g. a header from `SecurityHeadersMiddleware`, which survives Cloudflare) would restore the stronger proof, but it can't be *required* without breaking older instances — worth a follow-up, not a blocker.

Judgement call worth surfacing: `proxyMode: 'proxy'` *does* render an ACME location on the origin, so routing it to HTTPS isn't forced. Public port 80 there belongs to the front proxy, which generally won't forward to origin `:80`, so the port-80 probe would fail for a healthy instance.

## Verification

- `npx jest src/setup src/app-catalog` → 24 suites / 504 tests
- Full backend suite → 156 suites / 2,664 passed, 0 failed
- `tsc --noEmit` clean; `docker/nginx/render-main-conf.test.sh` → ALL PASSED (guard: no nginx changes)
- eslint: no new problems (30 pre-existing prettier errors in these files; baseline on main was 31)

New tests cover mode selection per serving model, 404-as-success, 520-as-failure with the origin message, connection-refused as the DNS message, the unchanged ACME fan-out, and the connect-target/SNI split in both modes.

**Not yet verified live.** A `pr-dns-gate` backend image is built; deploying it to `admin.bffless.dev` should turn Handoff's DNS gate green with a message quoting `HTTP 404`. That's the real proof and I'd like it before merge — this is the third defect in this feature that only a real instance could surface (see #584).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019abzHPfQ6mEk8rh7bYme27
