### PR TITLE
fix(app-catalog): treat 502/503/504 as origin errors behind a proxy

### DIFF
--- a/apps/backend/src/app-catalog/app-preflight.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-preflight.service.spec.ts
@@ -576,6 +576,32 @@ describe('AppPreflightService', () => {
       expect(dns?.remediation).toMatch(/CNAME/);
     });
 
+    it('a 502 behind a generic proxy fails with a backend-down message, not an origin-unreachable one', async () => {
+      const { service, bundle } = buildDnsCase({
+        host: 'handoff.example.com',
+        resolvedIps: ['203.0.113.7'],
+        probeOk: false,
+        probeKind: 'https-reachability',
+        status: 502,
+        failure: 'origin-down',
+        error:
+          'The proxy in front of handoff.example.com returned HTTP 502 — it reached this server, but ' +
+          'the backend behind it did not return a valid response',
+      });
+
+      const result = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const dns = result.gates.find((g) => g.id === 'dns');
+      expect(dns?.status).toBe('fail');
+      expect(dns?.retryable).toBe(true);
+      expect(dns?.message).toMatch(/HTTP 502/);
+      expect(dns?.message).toMatch(/DNS is fine/i);
+      expect(dns?.message).toMatch(/backend is not serving requests/i);
+      // Different remedy from the Cloudflare 520 case: fix the backend, not DNS.
+      expect(dns?.remediation).toMatch(/backend is running/i);
+      expect(dns?.remediation).not.toMatch(/CNAME/);
+    });
+
     it('a refused connection keeps the DNS-record remediation', async () => {
       const { service, bundle } = buildDnsCase({
         host: 'handoff.example.com',

--- a/apps/backend/src/app-catalog/app-preflight.service.ts
+++ b/apps/backend/src/app-catalog/app-preflight.service.ts
@@ -270,6 +270,10 @@ export class AppPreflightService {
       return { id: 'dns', status: 'pass', message };
     }
 
+    // Three failures need three different remedies, so they get three
+    // different messages: the proxy could not find an origin at all
+    // (Cloudflare 520–527), the proxy found this server but the backend behind
+    // it did not answer (502/503/504), or nothing answered at all.
     if (check.failure === 'origin-error') {
       return {
         id: 'dns',
@@ -283,6 +287,21 @@ export class AppPreflightService {
           `Check that this server is running and serving ${appHost} (and, on Cloudflare, that the ` +
           `record for "${subdomain}" is proxied to the same origin as ${primaryDomain}), then retry. ` +
           `If the record is missing entirely, ${dnsRemediation}`,
+      };
+    }
+
+    if (check.failure === 'origin-down') {
+      return {
+        id: 'dns',
+        status: 'fail',
+        retryable: true,
+        message:
+          `${appHost} resolves to ${resolvedIps} and the proxy in front of it reached this server, but ` +
+          `the backend behind it answered HTTP ${check.status ?? '5xx'}. DNS is fine; the BFFless ` +
+          `backend is not serving requests.`,
+        remediation:
+          `Check that the BFFless backend is running and healthy (for a Docker install: ` +
+          `\`docker compose ps\` and \`docker compose logs backend\`), then retry.`,
       };
     }
 

--- a/apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
+++ b/apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
@@ -299,6 +299,73 @@ describe('BootstrapDnsPreflightService', () => {
       },
     );
 
+    // Generic reverse proxies (nginx/Traefik/HAProxy) answer with plain
+    // 502/503/504 when the backend is down — a strong backend-down signal that
+    // must not read as "reachable". Scoped to proxied serving models: with no
+    // proxy in the path a gateway status is the application's own answer.
+    describe.each([
+      ['cloudflare', { version: 2, state: 'applied', proxyMode: 'cloudflare' }],
+      ['proxy', { version: 2, state: 'applied', proxyMode: 'proxy' }],
+    ])('behind a %s proxy', (_label, cfg) => {
+      it.each([502, 503, 504])('fails HTTP %s as origin-down', async (statusCode) => {
+        mockInstanceConfig = cfg;
+        stubResolve();
+        stubHttps(statusCode);
+
+        const check = await service.probeHost('handoff.example.com', { mode: 'reachability' });
+
+        expect(check.probeOk).toBe(false);
+        expect(check.failure).toBe('origin-down');
+        expect(check.status).toBe(statusCode);
+        expect(check.error).toMatch(/reached this server/i);
+        expect(check.error).toMatch(/backend behind it did not return a valid response/i);
+      });
+
+      it.each([520, 524])('still fails Cloudflare %s as origin-error', async (statusCode) => {
+        mockInstanceConfig = cfg;
+        stubResolve();
+        stubHttps(statusCode);
+
+        const check = await service.probeHost('handoff.example.com', { mode: 'reachability' });
+        expect(check.failure).toBe('origin-error');
+      });
+    });
+
+    // The one direct-serving config that still takes the HTTPS path: nothing
+    // listens on 80, but no proxy sits in front either, so a 502 here is the
+    // app's own response and still proves the hostname reaches this server.
+    describe('direct-serving instance with port 80 closed', () => {
+      const DIRECT_PORT80_CLOSED = {
+        version: 2,
+        state: 'applied',
+        proxyMode: 'none',
+        port80: 'closed',
+      };
+
+      it.each([502, 503, 504])('treats HTTP %s as a reachable answer', async (statusCode) => {
+        mockInstanceConfig = DIRECT_PORT80_CLOSED;
+        stubResolve();
+        stubHttps(statusCode);
+
+        const check = await service.probeHost('handoff.example.com', { mode: 'reachability' });
+
+        expect(check.probeOk).toBe(true);
+        expect(check.failure).toBeUndefined();
+        expect(check.status).toBe(statusCode);
+      });
+
+      it('still fails a Cloudflare 520 — those are unambiguous whatever the model', async () => {
+        mockInstanceConfig = DIRECT_PORT80_CLOSED;
+        stubResolve();
+        stubHttps(520);
+
+        const check = await service.probeHost('handoff.example.com', { mode: 'reachability' });
+
+        expect(check.probeOk).toBe(false);
+        expect(check.failure).toBe('origin-error');
+      });
+    });
+
     it('fails with no-response when the connection is refused', async () => {
       mockInstanceConfig = { version: 2, state: 'applied', proxyMode: 'cloudflare' };
       stubResolve();

--- a/apps/backend/src/setup/bootstrap-dns-preflight.service.ts
+++ b/apps/backend/src/setup/bootstrap-dns-preflight.service.ts
@@ -5,7 +5,12 @@ import * as fs from 'fs/promises';
 import * as http from 'http';
 import * as https from 'https';
 import * as path from 'path';
-import { deriveKnobs, loadInstanceConfig, type ProxyMode } from '../bootstrap/instance-config';
+import {
+  deriveKnobs,
+  loadInstanceConfig,
+  type Port80Mode,
+  type ProxyMode,
+} from '../bootstrap/instance-config';
 
 /**
  * What a probe is being asked to prove.
@@ -24,8 +29,16 @@ export interface ProbeOptions {
   mode?: ProbeMode;
 }
 
-/** How a reachability probe failed, so callers can word remediation honestly. */
-export type ProbeFailure = 'no-dns' | 'private-ip' | 'origin-error' | 'no-response';
+/**
+ * How a reachability probe failed, so callers can word remediation honestly.
+ *
+ * `origin-error` and `origin-down` are both "DNS is fine, the proxy answered"
+ * but they need different remedies:
+ *  - `origin-error` (Cloudflare 520–527): the edge could not reach ANY origin.
+ *  - `origin-down` (502/503/504): the proxy reached this server but the
+ *    backend behind it did not return a valid response.
+ */
+export type ProbeFailure = 'no-dns' | 'private-ip' | 'origin-error' | 'origin-down' | 'no-response';
 
 export interface PreflightCheck {
   host: string;
@@ -45,9 +58,33 @@ export interface PreflightResult {
   checks: PreflightCheck[];
 }
 
-/** Cloudflare's origin-error range: the edge answered, the origin did not. */
-function isProxyOriginError(status: number): boolean {
-  return status >= 520 && status <= 527;
+/** The serving model the probe has to work with — see resolveServingModel(). */
+interface ServingModel {
+  proxyMode: ProxyMode;
+  port80: Port80Mode;
+  /** A proxy/edge sits in the request path and terminates TLS. */
+  proxied: boolean;
+  /** Reachability mode must use HTTPS/443 rather than the port-80 token echo. */
+  probeHttps: boolean;
+}
+
+/**
+ * Classify a status as "something in front answered, the origin behind it did
+ * not". Two families, scoped differently on purpose:
+ *
+ *  - 520–527 are Cloudflare-specific and unambiguous — no application emits
+ *    them — so they are always an origin error, whatever the serving model.
+ *  - 502/503/504 are standard gateway statuses. Behind a generic reverse proxy
+ *    (nginx/Traefik/HAProxy) they mean the proxy could not get a valid answer
+ *    out of the backend, which is a strong backend-down signal and must NOT
+ *    read as "reachable". On a direct-serving instance, though, there is no
+ *    proxy in the path: a 502 there is the application's own response, which
+ *    still proves the hostname reaches this server. Hence the `proxied` scope.
+ */
+function classifyOriginError(status: number, proxied: boolean): ProbeFailure | null {
+  if (status >= 520 && status <= 527) return 'origin-error';
+  if (proxied && (status === 502 || status === 503 || status === 504)) return 'origin-down';
+  return null;
 }
 
 // SSRF guard (v0.2.18 review, m6): the probe is a blind GET to a
@@ -108,8 +145,9 @@ export class BootstrapDnsPreflightService {
    * render it, so they keep the strictly stronger port-80 proof.
    */
   async probeHost(host: string, opts: ProbeOptions = {}): Promise<PreflightCheck> {
-    if (opts.mode === 'reachability' && this.shouldProbeHttps()) {
-      return this.httpsReachabilityProbe(host);
+    if (opts.mode === 'reachability') {
+      const model = this.resolveServingModel();
+      if (model.probeHttps) return this.httpsReachabilityProbe(host, model);
     }
     return this.acmeProbe(host);
   }
@@ -119,8 +157,13 @@ export class BootstrapDnsPreflightService {
    * instance.json here) wins, otherwise PROXY_MODE from the environment with
    * 'none' as the default, and the knobs derive from that. Keeping the two in
    * step matters — if we probe a port nginx isn't listening on, the gate lies.
+   *
+   * `proxied` and `probeHttps` are deliberately NOT the same predicate:
+   * a direct-serving instance with port 80 closed must be probed over HTTPS
+   * (nothing answers on 80), but it has no proxy in the request path, so a
+   * gateway status it returns is the application's own answer.
    */
-  private shouldProbeHttps(): boolean {
+  private resolveServingModel(): ServingModel {
     const cfg = loadInstanceConfig();
     const envProxyMode = process.env.PROXY_MODE;
     const proxyMode: ProxyMode =
@@ -129,7 +172,8 @@ export class BootstrapDnsPreflightService {
         ? envProxyMode
         : 'none');
     const { port80 } = deriveKnobs({ ...(cfg ?? { version: 2, state: 'applied' }), proxyMode });
-    return proxyMode === 'cloudflare' || proxyMode === 'proxy' || port80 === 'closed';
+    const proxied = proxyMode === 'cloudflare' || proxyMode === 'proxy';
+    return { proxyMode, port80, proxied, probeHttps: proxied || port80 === 'closed' };
   }
 
   private async acmeProbe(host: string): Promise<PreflightCheck> {
@@ -178,10 +222,11 @@ export class BootstrapDnsPreflightService {
    * What this does NOT prove: that the answering origin is *this* CE instance.
    * A proxied edge terminates TLS and we deliberately skip certificate
    * validation below, so authenticity is out of reach on this path; callers
-   * must word their messages accordingly. Cloudflare's 520–527 range is the
-   * one shape we reject: the edge answered but the origin behind it did not.
+   * must word their messages accordingly. The shapes we reject are the
+   * "something in front answered, the origin behind it did not" ones — see
+   * classifyOriginError for why 502/503/504 only count when proxied.
    */
-  private async httpsReachabilityProbe(host: string): Promise<PreflightCheck> {
+  private async httpsReachabilityProbe(host: string, model: ServingModel): Promise<PreflightCheck> {
     const resolvedIps = await this.resolveA(host);
     if (resolvedIps.some((ip) => isDisallowedProbeIp(ip))) {
       return {
@@ -206,15 +251,20 @@ export class BootstrapDnsPreflightService {
 
     try {
       const { statusCode } = await this.fetchReachabilityProbe(host, resolvedIps[0]);
-      if (isProxyOriginError(statusCode)) {
+      const failure = classifyOriginError(statusCode, model.proxied);
+      if (failure) {
         return {
           host,
           resolvedIps,
           probeOk: false,
           status: statusCode,
-          error: `The proxy in front of ${host} returned HTTP ${statusCode} — it could not reach an origin`,
+          error:
+            failure === 'origin-error'
+              ? `The proxy in front of ${host} returned HTTP ${statusCode} — it could not reach an origin`
+              : `The proxy in front of ${host} returned HTTP ${statusCode} — it reached this server, ` +
+                `but the backend behind it did not return a valid response`,
           probeKind: 'https-reachability',
-          failure: 'origin-error',
+          failure,
         };
       }
       return {


### PR DESCRIPTION
Follow-up to #585 (review Minor, raised after that PR had already been squash-merged — hence a new PR rather than a push to the old one).

## The problem

The reachability probe added in #585 only rejected Cloudflare's `520–527`. Under `proxyMode: 'proxy'` — a generic reverse proxy (nginx/Traefik/HAProxy) in front — a down origin answers with a standard **502/503/504**, which fell through to the "any real HTTP answer means reachable" success path.

Net effect: a genuinely-down origin behind a generic proxy produced a **green** DNS gate quoting "HTTP 502". The hedged wording stopped that being an outright lie, but those statuses are strong backend-down signals, and reading them as success is materially misleading — worse than the Cloudflare case the check was designed for.

## The fix

Scoped, not blanket. `isProxyOriginError(status)` becomes `classifyOriginError(status, proxied)`:

- **520–527 → `'origin-error'`, always.** Cloudflare-specific and unambiguous; no application emits them, so the serving model is irrelevant.
- **502/503/504 → `'origin-down'`, only when `proxied`.** Behind a real proxy these mean the proxy could not get a valid answer out of the backend. On a direct-serving instance there is no proxy in the path, so a 502 is the application's *own* response and still proves the hostname reaches this server.

`shouldProbeHttps(): boolean` is widened into `resolveServingModel(): ServingModel`, so the serving-model signal is computed once and handed to the probe rather than re-derived.

`proxied` and `probeHttps` are deliberately **different** predicates (commented in the code): `probeHttps = proxied || port80 === 'closed'`. A direct-serving instance with port 80 closed must be probed over HTTPS because nothing listens on 80, yet has no proxy in front — exactly the gap the scoping protects.

## Gate messaging

Three failures, three remedies:

| Failure | Meaning | Remedy the gate gives |
| --- | --- | --- |
| `origin-error` (520–527) | The edge could not reach **any** origin | Check the server is up and serving this host; check the CF record proxies to the same origin — plus the CNAME, in case the record is simply missing |
| `origin-down` (502/503/504, proxied only) | The proxy reached this server; the **backend** did not answer | Check the BFFless backend is running and healthy (`docker compose ps` / `logs backend`). Deliberately does **not** mention DNS or CNAME |
| `no-response` / `no-dns` | Nothing answered at all | The original "check the DNS record" + exact CNAME |

## Tests

- `describe.each` over **cloudflare** and **proxy** models: each of 502/503/504 fails as `origin-down` with the "reached this server / backend did not return a valid response" wording; 520 and 524 still classify as `origin-error` under both.
- Direct-serving instance with `port80: 'closed'` (the one direct config that still takes the HTTPS path): 502/503/504 all remain **success** with no `failure` set, while a 520 still fails as `origin-error`.
- The pre-existing "200/301/403/500 are reachable answers" case is untouched and green — 500 is the app's own error, not a gateway status, so it stays a success even when proxied.
- Gate-level: a 502 with `failure: 'origin-down'` produces the backend-down message and `backend is running` remediation, asserting the remediation does **not** mention CNAME.

## Verification (foreground)

| Command | Result |
| --- | --- |
| `npx jest src/setup src/app-catalog --no-coverage` | 24 suites / **519 passed** (was 504) |
| `npx tsc --noEmit` (backend) | clean |
| `npx eslint` on the 4 touched files | **0 new problems** vs the `origin/main` baseline |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019abzHPfQ6mEk8rh7bYme27
