### PR TITLE
fix(app-catalog): never install an app that could only be served over HTTP

### DIFF
--- a/apps/backend/src/app-catalog/app-catalog.module.ts
+++ b/apps/backend/src/app-catalog/app-catalog.module.ts
@@ -14,7 +14,6 @@ import { DomainsModule } from '../domains/domains.module';
 import { ProjectsModule } from '../projects/projects.module';
 import { PipelineSchedulesModule } from '../pipeline-schedules/pipeline-schedules.module';
 import { PipelinesModule } from '../pipelines/pipelines.module';
-import { SetupModule } from '../setup/setup.module';
 
 @Module({
   // The applier (Task 9) is where the cross-module edges land: it drives the
@@ -29,7 +28,6 @@ import { SetupModule } from '../setup/setup.module';
   //  - ProjectsModule:        ProjectsService (findOrCreate/exists/delete)
   //  - PipelineSchedulesModule: PipelineSchedulesService (manifest schedules)
   //  - PipelinesModule:       PipelineSchemasService (created-schema cleanup)
-  //  - SetupModule:           PrimarySslService for AppCertStepService
   imports: [
     forwardRef(() => ProxyRulesModule),
     forwardRef(() => DeploymentsModule),
@@ -37,7 +35,6 @@ import { SetupModule } from '../setup/setup.module';
     forwardRef(() => ProjectsModule),
     PipelineSchedulesModule,
     forwardRef(() => PipelinesModule),
-    SetupModule,
   ],
   controllers: [AppCatalogController],
   providers: [
@@ -48,11 +45,11 @@ import { SetupModule } from '../setup/setup.module';
     AppCertStepService,
     AppInstallJobsService,
     AppInstallerService,
-    // BootstrapDnsPreflightService is NOT exported by SetupModule (only
-    // SetupService/PrimarySslService are), so even though SetupModule is
-    // imported above (for PrimarySslService), we still provide a second
-    // instance directly here — same pattern SetupModule itself uses for
-    // SslCertificateService. Safe: probeHost is stateless (only reads/writes
+    // BootstrapDnsPreflightService is NOT exported by SetupModule, so we
+    // provide an instance directly here — same pattern SetupModule itself uses
+    // for SslCertificateService. (ce#584 dropped this module's SetupModule
+    // import along with AppCertStepService's PrimarySslService dependency:
+    // the cert step no longer issues anything.) Safe: probeHost is stateless (only reads/writes
     // a per-call temp ACME challenge file), so the two instances share all
     // durable state through the filesystem, not in-memory state.
     BootstrapDnsPreflightService,

--- a/apps/backend/src/app-catalog/app-catalog.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.spec.ts
@@ -119,6 +119,7 @@ describe('AppCatalogService', () => {
     uninstallPreview: jest.Mock;
   };
   let jobs: { get: jest.Mock };
+  let certStep: { schemeFor: jest.Mock };
   let storageAdapter: {
     supportsPresignedUrls: jest.Mock;
     isLocalAdapter?: boolean;
@@ -151,6 +152,10 @@ describe('AppCatalogService', () => {
       uninstallPreview: jest.fn().mockResolvedValue({ dataTables: [] }),
     };
     jobs = { get: jest.fn() };
+    // Default serving model for these tests: a certificate covers the app host,
+    // so URLs are https. Scheme selection itself is covered in
+    // app-cert-step.service.spec.ts.
+    certStep = { schemeFor: jest.fn().mockResolvedValue('https') };
     storageAdapter = {
       supportsPresignedUrls: jest.fn().mockReturnValue(true),
       // Brands as local the way `resolveLocalAdapter` expects (see local.adapter.ts):
@@ -166,6 +171,7 @@ describe('AppCatalogService', () => {
       preflight as never,
       installer as never,
       jobs as never,
+      certStep as never,
       storageAdapter as never,
     );
   });
@@ -392,6 +398,35 @@ describe('AppCatalogService', () => {
 
         const result = await service.listCatalog();
 
+        expect(result.data[0].installed!.appUrl).toBe('https://files.example.com');
+      });
+
+      it('links http:// when the serving model has no certificate for the host yet (ce#584)', async () => {
+        registry.getRegistry.mockResolvedValue({
+          ok: true,
+          registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+        });
+        mockDb.__queue([{ ...ROW, manifest: MANIFEST_WITH_DOMAIN, domainId: 'dom-1' }]);
+        mockDb.__queue([{ id: 'dom-1', domain: 'files.example.com', sslEnabled: false }]);
+        certStep.schemeFor.mockResolvedValue('http');
+
+        const result = await service.listCatalog();
+
+        expect(certStep.schemeFor).toHaveBeenCalledWith('files.example.com', false);
+        expect(result.data[0].installed!.appUrl).toBe('http://files.example.com');
+      });
+
+      it('passes the row\'s sslEnabled through, so an edge-terminated install still links https', async () => {
+        registry.getRegistry.mockResolvedValue({
+          ok: true,
+          registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+        });
+        mockDb.__queue([{ ...ROW, manifest: MANIFEST_WITH_DOMAIN, domainId: 'dom-1' }]);
+        mockDb.__queue([{ id: 'dom-1', domain: 'files.example.com', sslEnabled: true }]);
+
+        const result = await service.listCatalog();
+
+        expect(certStep.schemeFor).toHaveBeenCalledWith('files.example.com', true);
         expect(result.data[0].installed!.appUrl).toBe('https://files.example.com');
       });
 

--- a/apps/backend/src/app-catalog/app-catalog.service.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.ts
@@ -26,10 +26,17 @@ import {
   type UninstallSummary,
 } from './app-installer.service';
 import { AppInstallJobsService, type InstallJob } from './app-install-jobs.service';
+import { AppCertStepService } from './app-cert-step.service';
 import { compareSemver } from './ce-version.util';
 import { manualStepApplies } from './app-manifest.util';
 import type { AppManifest, AppManualStep, AppRegistryEntry } from './app-manifest.types';
 import type { PreflightRequestDto } from './app-catalog.dtos';
+
+/** A resolved domain row: the host plus whether THIS origin terminates TLS for it. */
+interface DomainRef {
+  domain: string;
+  sslEnabled: boolean;
+}
 
 export interface EjectPayload {
   repo: string;
@@ -99,6 +106,7 @@ export class AppCatalogService {
     private readonly preflightService: AppPreflightService,
     private readonly installerService: AppInstallerService,
     private readonly jobsService: AppInstallJobsService,
+    private readonly certStepService: AppCertStepService,
     @Inject(STORAGE_ADAPTER) private readonly storageAdapter: IStorageAdapter,
   ) {}
 
@@ -275,7 +283,7 @@ export class AppCatalogService {
   private async buildRegistryEntry(
     entry: AppRegistryEntry,
     rows: InstalledApp[],
-    domainsById: Map<string, string>,
+    domainsById: Map<string, DomainRef>,
   ): Promise<CatalogEntry> {
     const gates = await this.preflightService.instanceGates(entry.requires);
     const base: CatalogEntry = {
@@ -298,7 +306,7 @@ export class AppCatalogService {
   /** An installed app whose app id isn't (or no longer is) in the registry. */
   private async buildManifestOnlyEntry(
     rows: InstalledApp[],
-    domainsById: Map<string, string>,
+    domainsById: Map<string, DomainRef>,
   ): Promise<CatalogEntry> {
     const row = pickPrimaryRow(rows);
     const manifest = row.manifest as AppManifest;
@@ -320,7 +328,7 @@ export class AppCatalogService {
   private async buildInstalledSummary(
     row: InstalledApp,
     registryVersion: string | undefined,
-    domainsById: Map<string, string>,
+    domainsById: Map<string, DomainRef>,
   ): Promise<NonNullable<CatalogEntry['installed']>> {
     const manifest = row.manifest as AppManifest;
     const project = await this.projectsService.getProjectById(row.projectId);
@@ -333,7 +341,7 @@ export class AppCatalogService {
       projectId: row.projectId,
       projectName: `${project.owner}/${project.name}`,
       alias: row.alias,
-      appUrl: this.resolveAppUrl(row, domainsById),
+      appUrl: await this.resolveAppUrl(row, domainsById),
       status: row.status,
       updateAvailable,
       manualSteps: this.applicableManualSteps(manifest),
@@ -388,16 +396,25 @@ export class AppCatalogService {
    * `domainId` in one query, so `listCatalog` doesn't issue an N+1 lookup per
    * installed row.
    */
-  private async fetchDomainsById(rows: InstalledApp[]): Promise<Map<string, string>> {
+  private async fetchDomainsById(rows: InstalledApp[]): Promise<Map<string, DomainRef>> {
     const domainIds = [...new Set(rows.map((row) => row.domainId).filter((id): id is string => Boolean(id)))];
     if (domainIds.length === 0) return new Map();
 
     const mappings = await db
-      .select({ id: domainMappings.id, domain: domainMappings.domain })
+      .select({
+        id: domainMappings.id,
+        domain: domainMappings.domain,
+        sslEnabled: domainMappings.sslEnabled,
+      })
       .from(domainMappings)
       .where(inArray(domainMappings.id, domainIds));
 
-    return new Map(mappings.map((mapping) => [mapping.id, mapping.domain]));
+    return new Map(
+      mappings.map((mapping) => [
+        mapping.id,
+        { domain: mapping.domain, sslEnabled: Boolean(mapping.sslEnabled) },
+      ]),
+    );
   }
 
   /**
@@ -416,10 +433,17 @@ export class AppCatalogService {
    * wrong link is worse than none, and the admin UI links to the deployment
    * instead.
    */
-  private resolveAppUrl(row: InstalledApp, domainsById: Map<string, string>): string | undefined {
+  private async resolveAppUrl(
+    row: InstalledApp,
+    domainsById: Map<string, DomainRef>,
+  ): Promise<string | undefined> {
     if (!row.domainId) return undefined;
-    const domain = domainsById.get(row.domainId);
-    return domain ? `https://${domain}` : undefined;
+    const ref = domainsById.get(row.domainId);
+    if (!ref) return undefined;
+    // Same scheme rule as the install job: a direct-serving instance with no
+    // certificate for this host serves it over plain HTTP (ce#584).
+    const scheme = await this.certStepService.schemeFor(ref.domain, ref.sslEnabled);
+    return `${scheme}://${ref.domain}`;
   }
 
   private applicableManualSteps(manifest: AppManifest): AppManualStep[] {

--- a/apps/backend/src/app-catalog/app-cert-step.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-cert-step.service.spec.ts
@@ -13,17 +13,10 @@ function makeDomainsService(exists = false) {
   };
 }
 
-function makePrimarySslService() {
-  return {
-    issueLetsEncrypt: jest.fn(),
-  };
-}
-
 function build(domainsExists = false) {
   const domains = makeDomainsService(domainsExists);
-  const primarySsl = makePrimarySslService();
-  const svc = new AppCertStepService(domains as any, primarySsl as any);
-  return { svc, domains, primarySsl };
+  const svc = new AppCertStepService(domains as any);
+  return { svc, domains };
 }
 
 const ORIGINAL_ENV = { ...process.env };
@@ -94,76 +87,150 @@ describe('AppCertStepService.plan', () => {
     expect(plan).toEqual({ model: 'edge-terminated', action: 'none-needed' });
   });
 
-  it('branch 5: proxyMode none + sslMode letsencrypt → direct-le/stage-san-reissue', async () => {
+  // Umbrel packages CE behind a Cloudflare Tunnel: its nginx listens on a
+  // plain port with no TLS at all, and the public URL is HTTPS via the tunnel.
+  // These are the reserved instance-config values for that profile — they must
+  // read as edge-terminated, never as "provision a wildcard" (ce#584).
+  it.each([
+    [{ proxyMode: 'cloudflare-tunnel', sslMode: 'external' }],
+    [{ proxyMode: 'cloudflare-tunnel', sslMode: 'letsencrypt' }],
+    [{ proxyMode: 'none', sslMode: 'external' }],
+  ])('branch 4: tunnel/external profile %o → edge-terminated/none-needed', async (cfg) => {
+    delete process.env.PLATFORM_MODE;
+    mockLoadInstanceConfig.mockReturnValue(cfg);
+    const { svc } = build(false);
+    await expect(svc.plan(APP_HOST)).resolves.toEqual({
+      model: 'edge-terminated',
+      action: 'none-needed',
+    });
+    // and its app URL stays https — the tunnel terminates TLS
+    await expect(svc.schemeFor(APP_HOST, false)).resolves.toBe('https');
+  });
+
+  it('branch 5: proxyMode none + sslMode letsencrypt, no wildcard → direct-no-wildcard/report', async () => {
     delete process.env.PLATFORM_MODE;
     delete process.env.SSL_MANAGED_EXTERNALLY;
     mockLoadInstanceConfig.mockReturnValue({ proxyMode: 'none', sslMode: 'letsencrypt' });
     const { svc } = build(false);
     const plan = await svc.plan(APP_HOST);
-    expect(plan).toEqual({ model: 'direct-le', action: 'stage-san-reissue' });
+    expect(plan).toEqual({ model: 'direct-no-wildcard', action: 'report' });
   });
 });
 
 describe('AppCertStepService.execute', () => {
-  it('delegated → skipped, never touches PrimarySslService', async () => {
-    const { svc, primarySsl } = build();
+  it('delegated → skipped', async () => {
+    const { svc } = build();
     const result = await svc.execute({ model: 'platform', action: 'delegated' }, APP_HOST);
     expect(result.status).toBe('skipped');
-    expect(primarySsl.issueLetsEncrypt).not.toHaveBeenCalled();
   });
 
-  it('covered → done, never touches PrimarySslService', async () => {
-    const { svc, primarySsl } = build();
+  it('covered → done', async () => {
+    const { svc } = build();
     const result = await svc.execute({ model: 'wildcard', action: 'covered' }, APP_HOST);
     expect(result.status).toBe('done');
-    expect(primarySsl.issueLetsEncrypt).not.toHaveBeenCalled();
   });
 
-  it('none-needed → skipped, never touches PrimarySslService', async () => {
-    const { svc, primarySsl } = build();
+  it('none-needed → skipped', async () => {
+    const { svc } = build();
     const result = await svc.execute({ model: 'edge-terminated', action: 'none-needed' }, APP_HOST);
     expect(result.status).toBe('skipped');
-    expect(primarySsl.issueLetsEncrypt).not.toHaveBeenCalled();
   });
 
   it('report (unknown) → never touches PrimarySslService', async () => {
-    const { svc, primarySsl } = build();
+    const { svc } = build();
     const result = await svc.execute({ model: 'unknown', action: 'report' }, APP_HOST);
     expect(['skipped', 'action-required']).toContain(result.status);
-    expect(primarySsl.issueLetsEncrypt).not.toHaveBeenCalled();
   });
 
-  it('stage-san-reissue success → action-required with the apply-ssl-cert manual step', async () => {
-    const { svc, primarySsl } = build();
-    primarySsl.issueLetsEncrypt.mockResolvedValue({ issued: true, sans: [APP_HOST], reused: false });
-    const result = await svc.execute({ model: 'direct-le', action: 'stage-san-reissue' }, APP_HOST);
-    expect(primarySsl.issueLetsEncrypt).toHaveBeenCalledWith({ extraSans: [APP_HOST] });
-    expect(result.status).toBe('action-required');
-    expect(result.manualStep).toEqual({
-      id: 'apply-ssl-cert',
-      title: 'Apply the updated certificate',
-      body: `A new certificate including ${APP_HOST} was issued and staged. Review and apply it, then confirm within the safety window.`,
-      deepLink: '/admin/settings/ssl',
-      appliesWhen: 'selfHosted',
-    });
-  });
+  it('direct serving without a wildcard → action-required naming the wildcard as the route to HTTPS', async () => {
+    const { svc } = build();
+    const result = await svc.execute({ model: 'direct-no-wildcard', action: 'report' }, APP_HOST);
 
-  it('stage-san-reissue failure → degrades to action-required, install not failed, both remediation routes named', async () => {
-    const { svc, primarySsl } = build();
-    primarySsl.issueLetsEncrypt.mockRejectedValue(new Error('DNS/port-80 preflight failed; not requesting a certificate'));
-    const result = await svc.execute({ model: 'direct-le', action: 'stage-san-reissue' }, APP_HOST);
     expect(result.status).toBe('action-required');
-    expect(result.detail).toContain('DNS/port-80 preflight failed');
-    expect(result.manualStep).toBeDefined();
-    // Both remediation routes must be named: wildcard cert AND manual SSL page re-issue.
+    // The app is reachable — over HTTP — and the operator must be told exactly that.
+    expect(result.detail).toContain(APP_HOST);
+    expect(result.detail.toLowerCase()).toContain('http');
+    expect(result.manualStep).toEqual(
+      expect.objectContaining({ id: 'provision-wildcard-cert', deepLink: '/domains', appliesWhen: 'selfHosted' }),
+    );
     expect(result.manualStep!.body.toLowerCase()).toContain('wildcard');
-    expect(result.manualStep!.body.toLowerCase()).toContain('settings');
-    expect(result.manualStep!.deepLink).toBe('/admin/settings/ssl');
   });
 
-  it('stage-san-reissue never throws — issuance failure is caught and returned, not raised', async () => {
-    const { svc, primarySsl } = build();
-    primarySsl.issueLetsEncrypt.mockRejectedValue(new Error('boom'));
-    await expect(svc.execute({ model: 'direct-le', action: 'stage-san-reissue' }, APP_HOST)).resolves.toBeDefined();
+  /**
+   * ce#584: the old branch re-issued the PRIMARY certificate with the app host
+   * as an extra SAN, staged it, and asked the operator to apply + confirm
+   * inside a 5-minute window. Even on full success the app stayed HTTP-only:
+   * `DomainsService.create` only sets `sslEnabled` for a subdomain when a
+   * WILDCARD exists, and `getSslCertPath` resolves a subdomain of the primary
+   * domain to the wildcard file — so the app vhost never gained a 443 block,
+   * and would have pointed at a file that does not exist if it had. The path
+   * spent an issuance and rewrote the certificate serving admin for nothing.
+   */
+  it('never touches the primary certificate — that path could not deliver HTTPS for a subdomain', async () => {
+    const { svc } = build();
+    // The service no longer depends on PrimarySslService at all; constructing
+    // it with a single argument (above) is the structural proof.
+    expect(AppCertStepService.length).toBe(1);
+    await expect(
+      svc.execute({ model: 'direct-no-wildcard', action: 'report' }, APP_HOST),
+    ).resolves.toBeDefined();
+  });
+
+  it('execute never throws for any plan — a cert problem must never fail an install', async () => {
+    const { svc } = build();
+    const plans = [
+      { model: 'platform', action: 'delegated' },
+      { model: 'wildcard', action: 'covered' },
+      { model: 'edge-terminated', action: 'none-needed' },
+      { model: 'unknown', action: 'report' },
+      { model: 'direct-no-wildcard', action: 'report' },
+    ] as const;
+    for (const plan of plans) {
+      await expect(svc.execute(plan as never, APP_HOST)).resolves.toBeDefined();
+    }
+  });
+});
+
+describe('AppCertStepService.schemeFor (ce#584: the "Open" link must not promise HTTPS that does not exist)', () => {
+  it('direct serving with no wildcard → http (the vhost has no 443 block at all)', async () => {
+    delete process.env.PLATFORM_MODE;
+    delete process.env.SSL_MANAGED_EXTERNALLY;
+    mockLoadInstanceConfig.mockReturnValue({ proxyMode: 'none', sslMode: 'letsencrypt' });
+    const { svc } = build(false);
+    await expect(svc.schemeFor(APP_HOST, false)).resolves.toBe('http');
+  });
+
+  it('direct serving once the domain row carries SSL → https', async () => {
+    delete process.env.PLATFORM_MODE;
+    mockLoadInstanceConfig.mockReturnValue({ proxyMode: 'none', sslMode: 'letsencrypt' });
+    const { svc } = build(false);
+    await expect(svc.schemeFor(APP_HOST, true)).resolves.toBe('https');
+  });
+
+  it('behind Cloudflare → https even though the origin vhost is plain HTTP (edge terminates)', async () => {
+    delete process.env.PLATFORM_MODE;
+    mockLoadInstanceConfig.mockReturnValue({ proxyMode: 'cloudflare', sslMode: 'paste' });
+    const { svc } = build(false);
+    await expect(svc.schemeFor(APP_HOST, false)).resolves.toBe('https');
+  });
+
+  it('platform mode → https (cert delegated to the platform edge)', async () => {
+    process.env.PLATFORM_MODE = 'true';
+    const { svc } = build(false);
+    await expect(svc.schemeFor(APP_HOST, false)).resolves.toBe('https');
+  });
+
+  it('wildcard present → https', async () => {
+    delete process.env.PLATFORM_MODE;
+    mockLoadInstanceConfig.mockReturnValue({ proxyMode: 'none', sslMode: 'letsencrypt' });
+    const { svc } = build(true);
+    await expect(svc.schemeFor(APP_HOST, false)).resolves.toBe('https');
+  });
+
+  it('unknown serving model (legacy compose, no instance config) → https, unchanged from before', async () => {
+    delete process.env.PLATFORM_MODE;
+    mockLoadInstanceConfig.mockReturnValue(null);
+    const { svc } = build(false);
+    await expect(svc.schemeFor(APP_HOST, false)).resolves.toBe('https');
   });
 });

--- a/apps/backend/src/app-catalog/app-cert-step.service.ts
+++ b/apps/backend/src/app-catalog/app-cert-step.service.ts
@@ -1,6 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { DomainsService } from '../domains/domains.service';
-import { PrimarySslService } from '../setup/primary-ssl/primary-ssl.service';
 import { loadInstanceConfig } from '../bootstrap/instance-config';
 import type { AppManualStep } from './app-manifest.types';
 
@@ -8,7 +7,7 @@ export type CertPlan =
   | { model: 'platform'; action: 'delegated' }
   | { model: 'wildcard'; action: 'covered' }
   | { model: 'edge-terminated'; action: 'none-needed' } // proxyMode cloudflare/proxy, or sslMode selfsigned
-  | { model: 'direct-le'; action: 'stage-san-reissue' }
+  | { model: 'direct-no-wildcard'; action: 'report' }
   | { model: 'unknown'; action: 'report' };
 
 export interface AppCertStepResult {
@@ -20,9 +19,17 @@ export interface AppCertStepResult {
 /**
  * AppCertStepService — Task 8 of the app-catalog spec. Decides how (or
  * whether) this instance's serving model already covers a newly-installed
- * app's host with TLS, and if not, stages a widened Let's Encrypt
- * certificate (never live, never auto-applied) plus a manual step for the
- * operator to review and confirm.
+ * app's host with TLS, and reports honestly when it does not.
+ *
+ * It deliberately issues NOTHING. An app always lives at a subdomain of the
+ * primary domain, and such a host can only ever be served with the wildcard
+ * certificate: `DomainsService.create` enables `sslEnabled` on a subdomain
+ * only when a wildcard exists, and `NginxConfigService`'s cert path for a
+ * subdomain of the primary domain IS the wildcard file. A per-app certificate
+ * therefore cannot reach the vhost that would serve it — the original design
+ * re-issued the PRIMARY certificate with the app host as an extra SAN, which
+ * spent an issuance and demanded a timed operator confirmation while leaving
+ * the app on HTTP regardless (ce#584).
  *
  * A cert problem must NEVER fail the install — the app stays reachable over
  * the wildcard/existing certificate or plain HTTP in the meantime. Every
@@ -31,12 +38,7 @@ export interface AppCertStepResult {
  */
 @Injectable()
 export class AppCertStepService {
-  private readonly logger = new Logger(AppCertStepService.name);
-
-  constructor(
-    private readonly domainsService: DomainsService,
-    private readonly primarySslService: PrimarySslService,
-  ) {}
+  constructor(private readonly domainsService: DomainsService) {}
 
   async plan(appHost: string): Promise<CertPlan> {
     // 1. Platform mode / SSL managed externally — DomainsService.create()
@@ -61,17 +63,60 @@ export class AppCertStepService {
       return { model: 'unknown', action: 'report' };
     }
 
-    // 4. Edge (Cloudflare/reverse proxy) or self-signed serving: the
-    // wildcard 443 block (or self-signed cert) already answers for
-    // *.<primary>, so there's nothing to issue for this specific host.
-    if (cfg.proxyMode === 'cloudflare' || cfg.proxyMode === 'proxy' || cfg.sslMode === 'selfsigned') {
+    // 4. Edge serving — Cloudflare, a reverse proxy, a Cloudflare Tunnel, an
+    // externally-managed certificate, or self-signed behind a verify-off CDN.
+    // TLS is somebody else's job: the origin answers plain HTTP while the
+    // public URL is still HTTPS, so there is nothing to issue for this host
+    // and a wildcard would not help.
+    //
+    // 'cloudflare-tunnel'/'external' are the RESERVED values documented in
+    // instance-config.ts for the deferred Umbrel/tunnel profile — compared as
+    // strings because they are not in the ProxyMode/SslMode unions yet.
+    // Without them a tunnel install falls through to branch 5 and gets told to
+    // provision a wildcard it neither needs nor can use.
+    const proxyMode: string | undefined = cfg.proxyMode;
+    const sslMode: string | undefined = cfg.sslMode;
+    if (
+      proxyMode === 'cloudflare' ||
+      proxyMode === 'proxy' ||
+      proxyMode === 'cloudflare-tunnel' ||
+      sslMode === 'selfsigned' ||
+      sslMode === 'external'
+    ) {
       return { model: 'edge-terminated', action: 'none-needed' };
     }
 
-    // 5. Direct serving + Let's Encrypt (proxyMode 'none' + sslMode
-    // 'letsencrypt'): the primary cert's fixed SAN list doesn't cover this
-    // app's subdomain — stage a widened re-issue.
-    return { model: 'direct-le', action: 'stage-san-reissue' };
+    // 5. Direct serving, no wildcard: nginx terminates TLS here, and nothing
+    // covers this app's subdomain. A per-app certificate is NOT an option —
+    // `DomainsService.create` only enables SSL on a subdomain when a wildcard
+    // exists, and `NginxConfigService.getSslCertPath` resolves any subdomain
+    // of the primary domain to the wildcard file — so the app's vhost cannot
+    // serve 443 until a wildcard is provisioned. Report it honestly instead of
+    // re-issuing the primary certificate for a result that never lands
+    // (ce#584).
+    return { model: 'direct-no-wildcard', action: 'report' };
+  }
+
+  /**
+   * Which scheme an app's own URL should use — the "Open" link on the catalog
+   * card and the install job's `appUrl`.
+   *
+   * `sslEnabled` on the domain row only says whether THIS origin's nginx
+   * terminates TLS for the host. It is deliberately false on every
+   * edge-terminated deployment (Cloudflare, another proxy, platform mode),
+   * where the origin vhost is plain HTTP but the public URL is still HTTPS —
+   * so the row alone cannot decide the scheme. Reuse the same serving-model
+   * branches `plan()` walks: only a direct-serving instance with no
+   * certificate covering the host is genuinely HTTP-only (ce#584).
+   *
+   * `unknown` (legacy compose install with no bootstrap config) stays HTTPS:
+   * we cannot reason about that serving model, and assuming HTTP there would
+   * downgrade links that work today.
+   */
+  async schemeFor(appHost: string, domainSslEnabled: boolean): Promise<'http' | 'https'> {
+    if (domainSslEnabled) return 'https';
+    const plan = await this.plan(appHost);
+    return plan.model === 'direct-no-wildcard' ? 'http' : 'https';
   }
 
   async execute(plan: CertPlan, appHost: string): Promise<AppCertStepResult> {
@@ -99,49 +144,26 @@ export class AppCertStepService {
             "Could not determine this instance's SSL configuration (no managed instance config found); " +
             'skipping the automatic certificate step. Verify SSL for this app manually.',
         };
-      case 'direct-le':
-        return this.executeStageSanReissue(appHost);
+      case 'direct-no-wildcard':
+        return {
+          status: 'action-required',
+          detail:
+            `${appHost} is served over HTTP: this instance terminates TLS itself and no wildcard ` +
+            'certificate covers it yet. The app works meanwhile; HTTPS needs a wildcard.',
+          manualStep: {
+            id: 'provision-wildcard-cert',
+            title: 'Provision a wildcard certificate to serve this app over HTTPS',
+            body:
+              `${appHost} is reachable now, over HTTP. On this serving model a wildcard certificate ` +
+              "for *.<your domain> is what gives app subdomains HTTPS — it's the only certificate an " +
+              'app subdomain can be served with, and one wildcard covers every app you install later. ' +
+              'Provision it on the Domains page (a DNS TXT record proves ownership); the app switches ' +
+              'to HTTPS once it is issued.',
+            deepLink: '/domains',
+            appliesWhen: 'selfHosted',
+          },
+        };
     }
   }
 
-  private async executeStageSanReissue(appHost: string): Promise<AppCertStepResult> {
-    try {
-      await this.primarySslService.issueLetsEncrypt({ extraSans: [appHost] });
-      return {
-        status: 'action-required',
-        detail: `A new certificate including ${appHost} was issued and staged.`,
-        manualStep: {
-          id: 'apply-ssl-cert',
-          title: 'Apply the updated certificate',
-          body:
-            `A new certificate including ${appHost} was issued and staged. Review and apply it, ` +
-            'then confirm within the safety window.',
-          deepLink: '/admin/settings/ssl',
-          appliesWhen: 'selfHosted',
-        },
-      };
-    } catch (error) {
-      // Never fail the install for a cert problem — the app remains
-      // reachable over the wildcard/existing certificate or plain HTTP
-      // meanwhile. Degrade to a manual step naming both remediation routes.
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      this.logger.warn(`Automatic Let's Encrypt SAN re-issue for ${appHost} failed: ${message}`);
-      return {
-        status: 'action-required',
-        detail: `Automatic certificate issuance for ${appHost} failed: ${message}.`,
-        manualStep: {
-          id: 'apply-ssl-cert',
-          title: 'Add SSL coverage for this app manually',
-          body:
-            `Automatic certificate issuance for ${appHost} failed (${message}). The app remains reachable ` +
-            'over the existing certificate/wildcard or plain HTTP meanwhile. Two ways to add coverage: ' +
-            "(1) provision a wildcard certificate — it will automatically cover this subdomain once enabled " +
-            'via "enable SSL for all subdomains"; or (2) go to Admin → Settings → SSL and re-issue ' +
-            `the primary certificate, including ${appHost}.`,
-          deepLink: '/admin/settings/ssl',
-          appliesWhen: 'selfHosted',
-        },
-      };
-    }
-  }
 }

--- a/apps/backend/src/app-catalog/app-installer.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.spec.ts
@@ -185,7 +185,7 @@ describe('AppInstallerService', () => {
   let service: AppInstallerService;
   let bundleService: { fetchBundle: jest.Mock };
   let preflight: { instanceGates: jest.Mock; projectGates: jest.Mock };
-  let certStep: { plan: jest.Mock; execute: jest.Mock };
+  let certStep: { plan: jest.Mock; execute: jest.Mock; schemeFor: jest.Mock };
   let ruleSets: { syncRuleSet: jest.Mock; delete: jest.Mock };
   let deployments: {
     createDeploymentFromZip: jest.Mock;
@@ -223,6 +223,9 @@ describe('AppInstallerService', () => {
     certStep = {
       plan: jest.fn().mockResolvedValue({ model: 'wildcard', action: 'covered' }),
       execute: jest.fn().mockResolvedValue({ status: 'done', detail: 'covered by wildcard' }),
+      // Default: a certificate covers the app host, so app URLs are https.
+      // Scheme selection itself is covered in app-cert-step.service.spec.ts.
+      schemeFor: jest.fn().mockResolvedValue('https'),
     };
     ruleSets = {
       syncRuleSet: jest
@@ -426,6 +429,46 @@ describe('AppInstallerService', () => {
         scheduleIds: [],
       });
       expect(jobs.get(jobId)!.appUrl).toBe('https://handoff.example.com');
+    });
+
+    // ce#584: the dialog disables Install on a failing gate, but the job
+    // re-runs projectGates itself — an API caller must be stopped too, before
+    // anything is written.
+    it('aborts before any write when the app host could only be served over http://', async () => {
+      preflight.projectGates.mockResolvedValue({
+        gates: [
+          {
+            id: 'app-host-tls',
+            status: 'fail',
+            message: 'handoff.example.com could only be served over http://',
+            retryable: true,
+          },
+        ],
+        syncPlans: [],
+        appHost: 'handoff.example.com',
+      });
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const job = jobs.get(jobId)!;
+      expect(job.status).toBe('failed');
+      expect(ruleSets.syncRuleSet).not.toHaveBeenCalled();
+      expect(domains.create).not.toHaveBeenCalled();
+    });
+
+    // ce#584: on a direct-serving instance with no certificate covering the app
+    // host, the origin serves it over plain HTTP. Linking https:// there lands
+    // the operator on the default vhost — certificate mismatch, then 404.
+    it('links http:// when the cert step reports no certificate covers the host yet', async () => {
+      queueInstallDb();
+      certStep.schemeFor.mockResolvedValue('http');
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      expect(jobs.get(jobId)!.status).toBe('succeeded');
+      expect(jobs.get(jobId)!.appUrl).toBe('http://handoff.example.com');
     });
 
     it('filters manifest manual steps by the instance context', async () => {

--- a/apps/backend/src/app-catalog/app-installer.service.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.ts
@@ -304,8 +304,14 @@ export class AppInstallerService {
       step = 'record';
       this.jobs.setStep(jobId, step, { status: 'running' });
       const manualSteps = [...this.applicableManualSteps(manifest), ...certManualSteps];
+      // Scheme follows the serving model, not wishful thinking: a direct+LE
+      // instance with no certificate covering this host yet serves it over
+      // plain HTTP, and linking to https:// there lands the operator on the
+      // default vhost's certificate mismatch + 404 (ce#584).
       const appUrl =
-        appHost && created.domainId ? `https://${appHost}` : deployment.urls?.default;
+        appHost && created.domainId
+          ? `${await this.certStepService.schemeFor(appHost, !domainOutcome.sslDowngraded)}://${appHost}`
+          : deployment.urls?.default;
 
       await db
         .update(installedApps)
@@ -379,7 +385,8 @@ export class AppInstallerService {
       // the deploy step below), so the serving host must be read back from
       // that stored mapping, not recomputed from the manifest's default
       // subdomain — the operator may have overridden it at install time.
-      const appHost = await this.lookupDomainHost(installed.domainId);
+      const domainRow = await this.lookupDomainRow(installed.domainId);
+      const appHost = domainRow?.domain;
 
       step = 'sync-rules';
       this.jobs.setStep(jobId, step, { status: 'running' });
@@ -439,7 +446,9 @@ export class AppInstallerService {
         .where(eq(installedApps.id, installed.id));
 
       const manualSteps = this.applicableManualSteps(manifest);
-      const appUrl = appHost ? `https://${appHost}` : deployment.urls?.default;
+      const appUrl = appHost
+        ? `${await this.certStepService.schemeFor(appHost, domainRow!.sslEnabled)}://${appHost}`
+        : deployment.urls?.default;
       this.jobs.setStep(jobId, step, { status: 'done', detail: 'Update recorded.' });
       this.jobs.finish(jobId, 'succeeded', {
         installedAppId: installed.id,
@@ -1302,13 +1311,24 @@ export class AppInstallerService {
 
   /** Single-row read of a domain mapping's `domain` string; `undefined` if absent or since deleted. */
   private async lookupDomainHost(domainId: string | null | undefined): Promise<string | undefined> {
+    return (await this.lookupDomainRow(domainId))?.domain;
+  }
+
+  /**
+   * `sslEnabled` comes back alongside the host because the update job's
+   * `appUrl` needs the same scheme decision the install job makes — see
+   * `AppCertStepService.schemeFor`.
+   */
+  private async lookupDomainRow(
+    domainId: string | null | undefined,
+  ): Promise<{ domain: string; sslEnabled: boolean } | undefined> {
     if (!domainId) return undefined;
     const [mapping] = await db
-      .select({ domain: domainMappings.domain })
+      .select({ domain: domainMappings.domain, sslEnabled: domainMappings.sslEnabled })
       .from(domainMappings)
       .where(eq(domainMappings.id, domainId))
       .limit(1);
-    return mapping?.domain;
+    return mapping ? { domain: mapping.domain, sslEnabled: Boolean(mapping.sslEnabled) } : undefined;
   }
 
   /**

--- a/apps/backend/src/app-catalog/app-preflight.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-preflight.service.spec.ts
@@ -123,6 +123,28 @@ const EMPTY_SYNC_RESPONSE = {
   setCreated: true,
 };
 
+function stubProjectGateDeps(proxyRuleSetsService: ProxyRuleSetsService): void {
+  (proxyRuleSetsService.syncRuleSet as jest.Mock).mockResolvedValue({
+    ruleSetId: 'rs-1',
+    created: [],
+    updated: [],
+    deleted: [],
+    unchanged: [],
+    pruneCandidates: [],
+    schemaResolutions: [],
+    missingSecrets: [],
+    warnings: [],
+    dryRun: true,
+    setCreated: true,
+  });
+  mockDb.__queue([]); // installedApps lookup
+  mockDb.__queue([]); // ruleSet 1
+  mockDb.__queue([]); // ruleSet 2
+  mockDb.__queue([]); // alias
+  mockDb.__queue([]); // domain
+  mockDb.__queue([]); // cross-namespace
+}
+
 function buildService(
   overrides: {
     storageAdapter?: Partial<IStorageAdapter>;
@@ -130,6 +152,7 @@ function buildService(
     dnsPreflight?: Partial<BootstrapDnsPreflightService>;
     proxyRuleSetsService?: Partial<ProxyRuleSetsService>;
     projectsService?: Partial<ProjectsService>;
+    certStepService?: { plan?: jest.Mock };
   } = {},
 ) {
   const storageAdapter = (overrides.storageAdapter ?? {}) as IStorageAdapter;
@@ -147,12 +170,19 @@ function buildService(
     ...overrides.projectsService,
   } as unknown as ProjectsService;
 
+  const certStepService = {
+    // Default: nothing to warn about (a wildcard covers the app host).
+    plan: jest.fn().mockResolvedValue({ model: 'wildcard', action: 'covered' }),
+    ...overrides.certStepService,
+  } as never;
+
   const service = new AppPreflightService(
     storageAdapter,
     configService,
     dnsPreflight,
     proxyRuleSetsService,
     projectsService,
+    certStepService,
   );
 
   return {
@@ -256,7 +286,7 @@ describe('AppPreflightService', () => {
 
       const gates = await service.instanceGates(undefined);
 
-      expect(gates.filter((g) => g.id === 'platform-config')).toHaveLength(0);
+      expect(gates.filter((g) => g.id.startsWith('platform-'))).toHaveLength(0);
     });
 
     it('fails the config check and adds the cert-coverage warn when platform mode lacks CONTROL_PLANE_URL/WORKSPACE_ID', async () => {
@@ -264,10 +294,11 @@ describe('AppPreflightService', () => {
 
       const gates = await service.instanceGates(undefined);
 
-      const platformGates = gates.filter((g) => g.id === 'platform-config');
+      const platformGates = gates.filter((g) => g.id.startsWith('platform-'));
       expect(platformGates).toHaveLength(2);
-      expect(platformGates.find((g) => g.status === 'fail')).toBeTruthy();
+      expect(platformGates.find((g) => g.status === 'fail')?.id).toBe('platform-config');
       const warn = platformGates.find((g) => g.status === 'warn');
+      expect(warn?.id).toBe('platform-cert-scope');
       expect(warn?.message).toMatch(/wildcard/i);
     });
 
@@ -282,11 +313,110 @@ describe('AppPreflightService', () => {
 
       const gates = await service.instanceGates(undefined);
 
-      const platformGates = gates.filter((g) => g.id === 'platform-config');
+      const platformGates = gates.filter((g) => g.id.startsWith('platform-'));
       expect(platformGates).toHaveLength(2);
       expect(platformGates.find((g) => g.status === 'fail')).toBeFalsy();
-      expect(platformGates.find((g) => g.status === 'pass')).toBeTruthy();
-      expect(platformGates.find((g) => g.status === 'warn')).toBeTruthy();
+      expect(platformGates.find((g) => g.status === 'pass')?.id).toBe('platform-config');
+      expect(platformGates.find((g) => g.status === 'warn')?.id).toBe('platform-cert-scope');
+    });
+
+    // ce#584: both platform gates shipped with id 'platform-config', and the
+    // install dialog renders `key={gate.id}` — duplicate React keys on the one
+    // path where two gates always appear together.
+    it('gives every emitted gate a unique id', async () => {
+      const { service } = buildService({
+        configValues: {
+          PLATFORM_MODE: 'true',
+          CONTROL_PLANE_URL: 'https://cp.example.com',
+          WORKSPACE_ID: 'ws-1',
+        },
+      });
+
+      const gates = await service.instanceGates(undefined);
+
+      const ids = gates.map((g) => g.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+
+  // ce#584: on a direct-serving instance with no wildcard, an app subdomain
+  // CANNOT be served over HTTPS — a per-app certificate never reaches its
+  // vhost. The operator must learn that in the install dialog, BEFORE
+  // committing, not from a manual step afterwards. Warn, never block.
+  describe('projectGates > app-host-tls (ce#584)', () => {
+    it('BLOCKS when direct serving has no wildcard: an app must never be served over plain HTTP', async () => {
+      const bundle = makeBundle();
+      const { service, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+        dnsPreflight: { probeHost: jest.fn().mockResolvedValue({ host: 'h', resolvedIps: [], probeOk: true }) },
+        certStepService: {
+          plan: jest.fn().mockResolvedValue({ model: 'direct-no-wildcard', action: 'report' }),
+        },
+      });
+
+      stubProjectGateDeps(proxyRuleSetsService);
+      const { gates } = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      const tls = gates.find((g) => g.id === 'app-host-tls');
+      expect(tls).toBeDefined();
+      expect(tls!.status).toBe('fail');
+      expect(tls!.message.toLowerCase()).toContain('http');
+      expect(tls!.remediation?.toLowerCase()).toContain('wildcard');
+      expect(tls!.deepLink).toBe('/domains');
+      // Retryable: provisioning a wildcard is minutes away, and re-running the
+      // same preflight then passes — unlike a name collision.
+      expect(tls!.retryable).toBe(true);
+    });
+
+    it.each([
+      ['wildcard', { model: 'wildcard', action: 'covered' }],
+      ['edge-terminated', { model: 'edge-terminated', action: 'none-needed' }],
+      ['platform', { model: 'platform', action: 'delegated' }],
+      ['unknown', { model: 'unknown', action: 'report' }],
+    ])('emits no TLS warning on a %s instance — HTTPS already works there', async (_label, plan) => {
+      const bundle = makeBundle();
+      const { service, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+        dnsPreflight: { probeHost: jest.fn().mockResolvedValue({ host: 'h', resolvedIps: [], probeOk: true }) },
+        certStepService: { plan: jest.fn().mockResolvedValue(plan) },
+      });
+
+      stubProjectGateDeps(proxyRuleSetsService);
+      const { gates } = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      expect(gates.find((g) => g.id === 'app-host-tls')).toBeUndefined();
+    });
+
+    it('emits no TLS gate when the app declares no domain at all', async () => {
+      const bundle = makeBundle({
+        install: { ...TEST_MANIFEST.install, domain: undefined },
+      } as Partial<AppManifest>);
+      const certPlan = jest.fn();
+      const { service, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+        certStepService: { plan: certPlan },
+      });
+
+      stubProjectGateDeps(proxyRuleSetsService);
+      const { gates } = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      expect(gates.find((g) => g.id === 'app-host-tls')).toBeUndefined();
+      expect(certPlan).not.toHaveBeenCalled();
+    });
+
+    it('never fails the preflight when the cert plan itself throws', async () => {
+      const bundle = makeBundle();
+      const { service, proxyRuleSetsService } = buildService({
+        configValues: { PRIMARY_DOMAIN: 'example.com' },
+        dnsPreflight: { probeHost: jest.fn().mockResolvedValue({ host: 'h', resolvedIps: [], probeOk: true }) },
+        certStepService: { plan: jest.fn().mockRejectedValue(new Error('boom')) },
+      });
+
+      stubProjectGateDeps(proxyRuleSetsService);
+      const { gates } = await service.projectGates(bundle, { projectId: 'proj-1' }, 'user-1');
+
+      expect(gates.find((g) => g.id === 'app-host-tls')).toBeUndefined();
+      expect(gates.some((g) => g.status === 'fail')).toBe(false);
     });
   });
 

--- a/apps/backend/src/app-catalog/app-preflight.service.ts
+++ b/apps/backend/src/app-catalog/app-preflight.service.ts
@@ -11,6 +11,7 @@ import type {
   SyncSchemaDto,
 } from '../proxy-rules/dto/sync-proxy-rule-set.dto';
 import { BootstrapDnsPreflightService } from '../setup/bootstrap-dns-preflight.service';
+import { AppCertStepService } from './app-cert-step.service';
 import { IStorageAdapter, STORAGE_ADAPTER } from '../storage/storage.interface';
 import { getCeVersion, satisfiesMin } from './ce-version.util';
 import { isReservedSubdomain } from './app-manifest.util';
@@ -20,7 +21,18 @@ import type { LoadedBundle } from './app-bundle.service';
 export type GateStatus = 'pass' | 'fail' | 'warn';
 
 export interface GateResult {
-  id: 'storage' | 'ce-version' | 'platform-config' | 'dns' | 'name-collision' | 'data-tables';
+  id:
+    | 'storage'
+    | 'ce-version'
+    | 'platform-config'
+    /** Distinct from `platform-config` so the two platform gates never collide
+     *  as React list keys — the install dialog renders gates keyed by id. */
+    | 'platform-cert-scope'
+    | 'dns'
+    /** Blocking: the app host cannot be served over HTTPS on this instance yet. */
+    | 'app-host-tls'
+    | 'name-collision'
+    | 'data-tables';
   status: GateStatus;
   message: string;
   remediation?: string;
@@ -74,6 +86,7 @@ export class AppPreflightService {
     private readonly dnsPreflight: BootstrapDnsPreflightService,
     private readonly proxyRuleSetsService: ProxyRuleSetsService,
     private readonly projectsService: ProjectsService,
+    private readonly certStepService: AppCertStepService,
   ) {}
 
   async instanceGates(requires?: AppManifestRequires): Promise<GateResult[]> {
@@ -117,8 +130,13 @@ export class AppPreflightService {
       subdomainOverride,
     );
     const { gate: dataTables, syncPlans } = await this.dataTablesGate(ruleSets, target, userId);
+    const tls = await this.appHostTlsGate(appHost);
 
-    return { gates: [dns, nameCollision, dataTables], syncPlans, appHost };
+    return {
+      gates: [dns, ...(tls ? [tls] : []), nameCollision, dataTables],
+      syncPlans,
+      appHost,
+    };
   }
 
   // ---- instance gates -----------------------------------------------------
@@ -214,7 +232,7 @@ export class AppPreflightService {
     }
 
     gates.push({
-      id: 'platform-config',
+      id: 'platform-cert-scope',
       status: 'warn',
       message:
         "This app's subdomain resolves under <sub>.<workspace>.<platform-domain> — a two-label subdomain that " +
@@ -228,6 +246,44 @@ export class AppPreflightService {
   }
 
   // ---- project gates -------------------------------------------------------
+
+  /**
+   * ce#584 — refuse to install an app that could only be served over plain
+   * HTTP.
+   *
+   * On a direct-serving instance with no wildcard, the app's subdomain can
+   * only ever be served over HTTP: `DomainsService.create` enables SSL on a
+   * subdomain solely when a wildcard exists, and a subdomain of the primary
+   * domain resolves to the wildcard certificate file. Rather than deploy an
+   * app to an insecure origin, block until a wildcard exists — `retryable`,
+   * because provisioning one is a few minutes away on the Domains page and
+   * the same preflight then passes.
+   *
+   * Returns null (no gate) on every other serving model, where HTTPS already
+   * works, and swallows any error from `plan()`: a certificate question must
+   * never break a preflight.
+   */
+  private async appHostTlsGate(appHost: string | null): Promise<GateResult | null> {
+    if (!appHost) return null;
+    try {
+      const plan = await this.certStepService.plan(appHost);
+      if (plan.model !== 'direct-no-wildcard') return null;
+      return {
+        id: 'app-host-tls',
+        status: 'fail',
+        message:
+          `${appHost} could only be served over http:// — this instance terminates TLS itself and no ` +
+          'wildcard certificate covers app subdomains yet.',
+        remediation:
+          'Provision a wildcard certificate on the Domains page (a DNS TXT record proves ownership), ' +
+          'then run this check again. One wildcard covers this app and every app you install later.',
+        deepLink: '/domains',
+        retryable: true,
+      };
+    } catch {
+      return null;
+    }
+  }
 
   private async dnsGate(
     appHost: string | null,

--- a/apps/backend/src/domains/nginx-templates.spec.ts
+++ b/apps/backend/src/domains/nginx-templates.spec.ts
@@ -1,0 +1,75 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as Handlebars from 'handlebars';
+
+/**
+ * Renders the REAL shipped nginx templates.
+ *
+ * `nginx-config.service.spec.ts` stubs `fs.readFile` with tiny inline
+ * fixtures, so nothing in that suite can see what the shipped `.hbs` files
+ * actually contain. That blind spot is how ce#584 shipped: the subdomain
+ * template had no ACME challenge location, so an app installed at
+ * `<app>.<primary>` on a direct-serving instance answered
+ * `/.well-known/acme-challenge/*` with the app's SPA fallback instead of the
+ * challenge file — making HTTP-01 issuance (and renewal) impossible for that
+ * host, while every unit test passed.
+ */
+const TEMPLATE_DIR = path.join(__dirname, '../../templates/nginx');
+
+async function render(file: string, ctx: Record<string, unknown>): Promise<string> {
+  const raw = await fs.readFile(path.join(TEMPLATE_DIR, file), 'utf-8');
+  return Handlebars.compile(raw)(ctx);
+}
+
+const baseCtx = {
+  domain: 'handoff.example.com',
+  id: 'mapping-1',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  listenPort: 80,
+  backendHost: 'backend',
+  backendPort: 3000,
+  alias: 'handoff',
+  project: { owner: 'acme', name: 'handoff' },
+  sslCertPath: '/etc/nginx/ssl/wildcard.example.com.crt',
+  sslCertKeyPath: '/etc/nginx/ssl/wildcard.example.com.key',
+  blocklistRules: '',
+  isSpa: true,
+};
+
+/** nginx serves the challenge from the certbot webroot — the exact pairing
+ *  `render-main-conf.sh` emits for the primary server block. */
+function expectAcmeLocation(config: string): void {
+  expect(config).toContain('location /.well-known/acme-challenge/');
+  expect(config).toMatch(/location \/\.well-known\/acme-challenge\/ \{\s*root \/var\/www\/certbot;/);
+}
+
+describe('shipped nginx templates: ACME challenge reachability', () => {
+  describe.each([
+    ['subdomain.conf.hbs'],
+    ['custom-domain.conf.hbs'],
+  ])('%s', (template) => {
+    it('serves the ACME challenge on the HTTP server block when SSL is off', async () => {
+      const config = await render(template, { ...baseCtx, sslEnabled: false });
+      expectAcmeLocation(config);
+    });
+
+    it('serves the ACME challenge on the HTTP block when SSL is on (renewal path)', async () => {
+      const config = await render(template, { ...baseCtx, sslEnabled: true });
+      expectAcmeLocation(config);
+    });
+  });
+
+  it('keeps the ACME location ahead of the HTTPS redirect, so the challenge is not 301d away', async () => {
+    const config = await render('subdomain.conf.hbs', { ...baseCtx, sslEnabled: true });
+    const acmeAt = config.indexOf('location /.well-known/acme-challenge/');
+    const redirectAt = config.indexOf('return 301 https://$host$request_uri');
+    expect(acmeAt).toBeGreaterThan(-1);
+    expect(redirectAt).toBeGreaterThan(-1);
+    expect(acmeAt).toBeLessThan(redirectAt);
+  });
+
+  it('still serves app content from the catch-all location (ACME must not shadow the app)', async () => {
+    const config = await render('subdomain.conf.hbs', { ...baseCtx, sslEnabled: false });
+    expect(config).toContain('/public/acme/handoff/alias/handoff');
+  });
+});

--- a/apps/backend/src/feature-flags/feature-flags.service.spec.ts
+++ b/apps/backend/src/feature-flags/feature-flags.service.spec.ts
@@ -1,0 +1,57 @@
+import { ConfigService } from '@nestjs/config';
+import { FeatureFlagsService } from './feature-flags.service';
+
+/**
+ * ce#584 — `setup.sh`'s Cloudflare branch writes `FEATURE_WILDCARD_SSL=false`
+ * into `.env`. When the instance later moves to direct serving, that line kept
+ * hiding the wildcard certificate flow — the only way to give an app subdomain
+ * a certificate on that serving model.
+ */
+describe('FeatureFlagsService.reconcileWildcardSslVisibility', () => {
+  let service: FeatureFlagsService;
+  let setFlag: jest.SpyInstance;
+  let getSources: jest.SpyInstance;
+
+  beforeEach(() => {
+    service = new FeatureFlagsService({ get: jest.fn(() => './config/features.json') } as unknown as ConfigService);
+    setFlag = jest.spyOn(service, 'setFlag').mockResolvedValue({} as never);
+    getSources = jest.spyOn(service as never, 'getSources' as never);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('re-enables the flag when moving to direct serving and env is what disabled it', async () => {
+    getSources.mockResolvedValue({ env: false, source: 'env' });
+
+    await service.reconcileWildcardSslVisibility('none');
+
+    expect(setFlag).toHaveBeenCalledWith('ENABLE_WILDCARD_SSL', true);
+  });
+
+  it('leaves an explicit database override alone — the operator meant it', async () => {
+    getSources.mockResolvedValue({ env: false, database: false, source: 'database' });
+
+    await service.reconcileWildcardSslVisibility('none');
+
+    expect(setFlag).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the flag is not disabled at all', async () => {
+    getSources.mockResolvedValue({ default: true, source: 'default' });
+
+    await service.reconcileWildcardSslVisibility('none');
+
+    expect(setFlag).not.toHaveBeenCalled();
+  });
+
+  it.each(['cloudflare', 'proxy'] as const)(
+    'never disables anything when moving to %s — one-directional by design',
+    async (proxyMode) => {
+      getSources.mockResolvedValue({ env: false, source: 'env' });
+
+      await service.reconcileWildcardSslVisibility(proxyMode);
+
+      expect(setFlag).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/apps/backend/src/feature-flags/feature-flags.service.ts
+++ b/apps/backend/src/feature-flags/feature-flags.service.ts
@@ -263,6 +263,36 @@ export class FeatureFlagsService implements OnModuleInit {
   /**
    * Set multiple flags at once
    */
+  /**
+   * ce#584: `setup.sh`'s Cloudflare branch appends
+   * `FEATURE_WILDCARD_SSL=false` ("Cloudflare handles SSL at edge") to `.env`.
+   * Nothing revisits that line when the instance later moves to direct
+   * serving via the bootstrap wizard or Admin → Settings → SSL, so the
+   * wildcard certificate flow stays hidden exactly when it becomes the only
+   * way to give an app subdomain a certificate.
+   *
+   * Deliberately ONE-DIRECTIONAL: it clears a stale env-sourced *disable*
+   * when the instance starts terminating TLS itself, and never disables
+   * anything. An operator who wants the wildcard UI off on a direct install
+   * can still turn it off — a database override wins over env, and we only
+   * write one when env is the reason it is off.
+   */
+  async reconcileWildcardSslVisibility(proxyMode: 'cloudflare' | 'proxy' | 'none'): Promise<void> {
+    if (proxyMode !== 'none') return;
+
+    const sources = await this.getSources('ENABLE_WILDCARD_SSL', getFlagDefinition('ENABLE_WILDCARD_SSL')!);
+    const disabledByEnv = sources.env === false && sources.database === undefined;
+    if (!disabledByEnv) return;
+
+    await this.setFlag('ENABLE_WILDCARD_SSL', true);
+    this.logger.warn(
+      'ENABLE_WILDCARD_SSL was disabled by FEATURE_WILDCARD_SSL=false in .env (written for an ' +
+        'edge-terminated install). This instance now terminates TLS itself, where a wildcard ' +
+        'certificate is the only way to cover app subdomains — re-enabled via a database override. ' +
+        'Remove the .env line to keep the two in step.',
+    );
+  }
+
   async setFlags(
     flags: Array<{ key: string; value: boolean | string | number | object; enabled?: boolean }>,
   ): Promise<FeatureFlag[]> {

--- a/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.spec.ts
@@ -63,7 +63,8 @@ describe('BootstrapSetupController', () => {
     svc.unfinalizeSetup.mockResolvedValue(undefined);
     preflight.run.mockResolvedValue({ ok: true, checks: [] });
     sslCert.initialize.mockResolvedValue(undefined);
-    controller = new BootstrapSetupController(svc as any, preflight as any, sslCert as any);
+    const featureFlags = { reconcileWildcardSslVisibility: jest.fn().mockResolvedValue(undefined) };
+    controller = new BootstrapSetupController(svc as any, preflight as any, sslCert as any, featureFlags as any);
     (controller as any).scheduleExit = exitFn; // do not actually exit in tests
   });
 
@@ -444,7 +445,12 @@ describe('BootstrapSetupController', () => {
         return undefined as never;
       }) as unknown) as (code?: number) => never);
 
-      const freshController = new BootstrapSetupController(svc as any, preflight as any, sslCert as any);
+      const freshController = new BootstrapSetupController(
+        svc as any,
+        preflight as any,
+        sslCert as any,
+        { reconcileWildcardSslVisibility: jest.fn().mockResolvedValue(undefined) } as any,
+      );
       (freshController as any).scheduleExit();
 
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 500);

--- a/apps/backend/src/setup/bootstrap-setup.controller.ts
+++ b/apps/backend/src/setup/bootstrap-setup.controller.ts
@@ -11,6 +11,7 @@ import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
 import { extractClientIp } from '../common/utils/request-ip.util';
 import { BootstrapSetupService } from './bootstrap-setup.service';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 import { BootstrapDnsPreflightService, PreflightResult } from './bootstrap-dns-preflight.service';
 import { SslCertificateService } from '../domains/ssl-certificate.service';
 import { writeInstanceConfig } from '../bootstrap/instance-config';
@@ -26,6 +27,7 @@ export class BootstrapSetupController {
     private readonly bootstrap: BootstrapSetupService,
     private readonly preflight: BootstrapDnsPreflightService,
     private readonly sslCert: SslCertificateService,
+    private readonly featureFlags: FeatureFlagsService,
   ) {}
 
   // Overridable in tests (assigned as an own property on the instance, which
@@ -33,6 +35,18 @@ export class BootstrapSetupController {
   // Docker's restart policy revive the backend, which re-runs main.ts
   // hydration and adopts the new identity. There is no docker socket here,
   // so a file write + process exit is the only way to "apply" the change.
+  private async reconcileWildcardSslVisibility(proxyMode: 'cloudflare' | 'proxy' | 'none'): Promise<void> {
+    try {
+      await this.featureFlags.reconcileWildcardSslVisibility(proxyMode);
+    } catch (err) {
+      this.logger.warn(
+        `Could not reconcile wildcard-SSL visibility after apply: ${
+          err instanceof Error ? err.message : 'unknown error'
+        }`,
+      );
+    }
+  }
+
   private scheduleExit(): void {
     setTimeout(() => {
       this.logger.log('[bootstrap] apply complete — exiting for identity restart');
@@ -134,6 +148,10 @@ export class BootstrapSetupController {
         port80: applied.port80,
         realIp: applied.realIp,
       });
+      // ce#584: an install set up for Cloudflare carries
+      // FEATURE_WILDCARD_SSL=false in .env; landing on direct serving must not
+      // leave the wildcard flow hidden. Never fail apply over this.
+      await this.reconcileWildcardSslVisibility(applied.proxyMode);
     } catch (err) {
       // Failed fs write with setup already finalized = permanently dead
       // wizard AND no identity (M3). Log the original (more actionable) disk

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.integration.service.spec.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.integration.service.spec.ts
@@ -92,7 +92,8 @@ describe('PrimarySslService cert staging (real BootstrapSetupService + snapshot 
     const preflight = { run: jest.fn().mockResolvedValue({ ok: true, checks: [] }) };
     const info = { getWildcardCertInfo: jest.fn().mockResolvedValue(null) };
     const snap = new PrimarySslSnapshotService();
-    svc = new PrimarySslService(bootstrap, ssl as any, preflight as any, info as any, snap);
+    const featureFlags = { reconcileWildcardSslVisibility: jest.fn().mockResolvedValue(undefined) };
+    svc = new PrimarySslService(bootstrap, ssl as any, preflight as any, info as any, snap, featureFlags as any);
   });
 
   afterEach(() => {

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.spec.ts
@@ -8,6 +8,7 @@ const domain = 'a.com';
 let mockCur: any;
 
 const makeDeps = () => ({
+  featureFlags: { reconcileWildcardSslVisibility: jest.fn().mockResolvedValue(undefined) },
   bootstrap: {
     validateCertificatePair: jest.fn().mockReturnValue({ sans: ['a.com', '*.a.com'], wildcardCovered: true }),
     saveCertificates: jest.fn(),
@@ -43,7 +44,7 @@ jest.mock('../ssl-staging', () => ({
   discardStagedCertificates: jest.fn(),
 }));
 
-const build = () => { const d = makeDeps(); return { d, svc: new PrimarySslService(d.bootstrap as any, d.ssl as any, d.preflight as any, d.info as any, d.snap as any) }; };
+const build = () => { const d = makeDeps(); return { d, svc: new PrimarySslService(d.bootstrap as any, d.ssl as any, d.preflight as any, d.info as any, d.snap as any, d.featureFlags as any) }; };
 
 beforeEach(() => {
   mockCur = { version: 2, state: 'applied', primaryDomain: 'a.com', proxyMode: 'none', sslMode: 'paste', port80: 'redirect', realIp: null };

--- a/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
+++ b/apps/backend/src/setup/primary-ssl/primary-ssl.service.ts
@@ -4,6 +4,7 @@ import { SslCertificateService } from '../../domains/ssl-certificate.service';
 import { BootstrapDnsPreflightService, PreflightResult } from '../bootstrap-dns-preflight.service';
 import { SslInfoService, SslCertificateInfo } from '../../domains/ssl-info.service';
 import { PrimarySslSnapshotService } from './primary-ssl-snapshot.service';
+import { FeatureFlagsService } from '../../feature-flags/feature-flags.service';
 import { deriveKnobs, loadInstanceConfig, writeInstanceConfig, InstanceConfig, ProxyMode } from '../../bootstrap/instance-config';
 import { PrimarySslPasteDto, PrimarySslApplyDto } from './primary-ssl.dto';
 import {
@@ -35,6 +36,7 @@ export class PrimarySslService {
     private readonly preflightSvc: BootstrapDnsPreflightService,
     private readonly info: SslInfoService,
     private readonly snap: PrimarySslSnapshotService,
+    private readonly featureFlags: FeatureFlagsService,
   ) {}
 
   assertEnabled(): void {
@@ -230,6 +232,18 @@ export class PrimarySslService {
       promoteStagedCertificates();
     }
     writeInstanceConfig(next); // watcher re-renders main.conf + reloads (~3s); no restart
+    // ce#584: same reconciliation as the bootstrap apply — a day-2 switch to
+    // direct serving must not leave Cloudflare-era .env flags hiding the
+    // wildcard certificate flow. Best-effort; never fails the apply.
+    try {
+      if (next.proxyMode) await this.featureFlags.reconcileWildcardSslVisibility(next.proxyMode);
+    } catch (err) {
+      this.logger.warn(
+        `Could not reconcile wildcard-SSL visibility after apply: ${
+          err instanceof Error ? err.message : 'unknown error'
+        }`,
+      );
+    }
 
     if (needsConfirm) {
       const deadlineMs = Date.now() + this.confirmTimeoutMs();

--- a/apps/backend/templates/nginx/subdomain.conf.hbs
+++ b/apps/backend/templates/nginx/subdomain.conf.hbs
@@ -149,17 +149,37 @@ server {
     }
 }
 
-# HTTP server - redirect to HTTPS
+# HTTP server - redirect to HTTPS (allows ACME challenges)
 server {
     listen {{listenPort}};
     server_name {{domain}};
-    return 301 https://$host$request_uri;
+
+    # ACME challenge for Let's Encrypt certificate renewal.
+    # Must stay ahead of the catch-all redirect below: an HTTP-01 validator
+    # follows no redirects, so a 301 here fails renewal for this host.
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    # Redirect all other traffic to HTTPS
+    location / {
+        return 301 https://$host$request_uri;
+    }
 }
 {{else}}
 # HTTP only server - no SSL
 server {
     listen {{listenPort}};
     server_name {{domain}};
+
+    # ACME challenge for Let's Encrypt.
+    # Declared before the catch-all `location /` below, which rewrites every
+    # path into the deployment and (in SPA mode) falls back to index.html —
+    # without this, an HTTP-01 challenge for this host is answered with the
+    # app's HTML and issuance can never succeed (ce#584).
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
 
     # Security headers are set by the NestJS backend (SecurityHeadersMiddleware)
 

--- a/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
@@ -201,6 +201,40 @@ describe('InstallDialog — Review screen', () => {
     expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
   });
 
+  // ce#584: a direct-serving instance with no wildcard certificate cannot serve
+  // the app over HTTPS at all. Rather than deploy an app to a plain-HTTP
+  // origin, the install is blocked until a wildcard exists.
+  it('blocks Install when the app host could only be served over http://', () => {
+    preflightState = {
+      data: makePreflight({
+        gates: [
+          { id: 'storage', status: 'pass', message: 'Storage looks good' },
+          {
+            id: 'app-host-tls',
+            status: 'fail',
+            message: 'handoff.example.com could only be served over http:// — no wildcard certificate yet.',
+            remediation: 'Provision a wildcard certificate on the Domains page.',
+            deepLink: '/domains',
+            retryable: true,
+          },
+        ],
+      }),
+      isLoading: false,
+    };
+
+    render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
+
+    expect(
+      screen.getByText(/could only be served over http:\/\/ — no wildcard certificate yet\./),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^install$/i })).toBeDisabled();
+    // retryable: provisioning a wildcard is minutes away, so offer the re-check
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /why\?/i }));
+    expect(screen.getByText('Provision a wildcard certificate on the Domains page.')).toBeInTheDocument();
+  });
+
   it('enables Install when every gate passes', () => {
     render(<InstallDialog entry={baseEntry} open onOpenChange={vi.fn()} />);
 

--- a/apps/frontend/src/services/appCatalogApi.ts
+++ b/apps/frontend/src/services/appCatalogApi.ts
@@ -16,7 +16,16 @@ import { api } from './api';
 export type GateStatus = 'pass' | 'fail' | 'warn';
 
 export interface GateResult {
-  id: 'storage' | 'ce-version' | 'platform-config' | 'dns' | 'name-collision' | 'data-tables';
+  // Mirrors GateResult['id'] in apps/backend/src/app-catalog/app-preflight.service.ts.
+  id:
+    | 'storage'
+    | 'ce-version'
+    | 'platform-config'
+    | 'platform-cert-scope'
+    | 'dns'
+    | 'app-host-tls'
+    | 'name-collision'
+    | 'data-tables';
   status: GateStatus;
   message: string;
   remediation?: string;

--- a/setup.sh
+++ b/setup.sh
@@ -934,11 +934,15 @@ create_env_file() {
     # ─────────────────────────────────────────────────────────────────────────
     if [ "$PROXY_MODE" = "cloudflare" ]; then
         uncomment_and_set "PROXY_MODE" "cloudflare"
-        # Cloudflare handles SSL at the edge (Universal SSL covers *.domain.com)
-        # so disable the Let's Encrypt wildcard SSL flow and related UI elements
+        # Cloudflare handles SSL at the edge (Universal SSL covers *.domain.com),
+        # so quieten the SSL nag and the per-domain toggle for this install.
         echo "" >> .env
-        echo "# Cloudflare SSL - disabled because Cloudflare handles SSL at edge" >> .env
-        echo "FEATURE_WILDCARD_SSL=false" >> .env
+        echo "# Cloudflare SSL - edge terminates TLS, so the origin needs no cert of its own." >> .env
+        echo "# Only the NAG (banner) and the per-domain toggle are turned off here." >> .env
+        echo "# FEATURE_WILDCARD_SSL is deliberately NOT disabled (ce#584): the serving" >> .env
+        echo "# model can change later (Cloudflare -> direct), and on direct serving a" >> .env
+        echo "# wildcard certificate is the only way to cover app subdomains. Disabling" >> .env
+        echo "# the capability here left it hidden exactly when it was needed." >> .env
         echo "FEATURE_WILDCARD_SSL_BANNER=false" >> .env
         echo "FEATURE_DOMAIN_SSL_TOGGLE=false" >> .env
         # Set platform IP (Cloudflare proxies DNS, so we need the real server IP)


### PR DESCRIPTION
Closes #584.

Live validation of the remaining serving models found the direct-serving path **structurally broken, not merely buggy** — so this replaces it rather than repairing it.

## What was wrong

An app always lives at a subdomain of the primary domain, and such a host can only ever be served with the **wildcard** certificate: `DomainsService.create` enables `sslEnabled` on a subdomain solely when a wildcard exists (`domains.service.ts:679-688`), and `NginxConfigService.getSslCertPath` resolves any subdomain of the primary domain to the wildcard file (`nginx-config.service.ts:1812-1817`).

The old cert step re-issued the **primary** certificate with the app host as an extra SAN, staged it, and asked the operator to apply and confirm inside a 5-minute window — spending a Let's Encrypt issuance and rewriting the certificate that serves admin, while the app **stayed on plain HTTP regardless**, because its vhost never gained a 443 block.

It could not even get that far. The `domain` step installs the app's vhost *before* the `certificate` step runs, and that vhost had no ACME location, so `/.well-known/acme-challenge/*` was answered by the app's SPA fallback. Proven on a live droplet — one token file, three hosts:

```
sahp.app          → tok584          # primary block has the ACME location
www.sahp.app      → tok584
handoff.sahp.app  → <!doctype html> # app vhost swallowed it
```

Real HTTP-01 validation fetches that same URL, so no app subdomain could ever be issued *or renewed* a certificate.

## What ships

- **`AppCertStepService` issues nothing.** `direct-le/stage-san-reissue` → `direct-no-wildcard/report`; the `PrimarySslService` dependency and this module's `SetupModule` import are gone.
- **New blocking `app-host-tls` preflight gate.** On direct serving with no wildcard the install is refused — `retryable`, deep-linked to `/domains`. The install job re-runs project gates itself, so an API caller is stopped as firmly as the UI.
- **Tunnel-safe.** The reserved `cloudflare-tunnel` / `external` values now read as edge-terminated, so the deferred Umbrel/tunnel profile is never told to provision a wildcard it cannot use.
- **App URLs follow the serving model** instead of hardcoding `https://` — an edge-terminated origin still links https; a direct origin without a certificate links http. (Matters for installs predating this change and for legacy installs whose serving model can't be determined.)
- **Subdomain nginx template serves the ACME challenge**, matching `custom-domain.conf.hbs`, which already did. Required for renewal of any per-host certificate.
- **`setup.sh` no longer writes `FEATURE_WILDCARD_SSL=false`** for Cloudflare installs — it survived a later switch to direct serving and hid the wildcard flow exactly when it became the only route. Existing installs self-heal: a serving-model apply clears a stale env-sourced disable (one-directional; an explicit database override is never overwritten).
- **The two platform gates get distinct ids** — they shared one React key in the install dialog.
- **`nginx-templates.spec.ts` renders the REAL templates.** The existing suite stubs `fs.readFile` with inline fixtures, which is precisely why this shipped.

## Live validation (droplet, direct + Let's Encrypt, `sahp.app`)

Run against this branch's backend image (`ce-backend:fix584`):

| Check | Result |
|---|---|
| Install **with** wildcard | succeeded; `certificate: done`; `https://handoff.sahp.app` → **200, `ssl_verify_result=0`** |
| ACME challenge on the app host | `tok584b` echoed (returned SPA HTML before this branch) |
| Preflight **without** wildcard | `app-host-tls: fail`, retryable, remediation + `/domains` link |
| Install attempt anyway (direct API call) | job **failed at preflight**; every later step `pending`; **no project, rule set, alias or domain created** |
| Restore wildcard → re-run preflight | failing gates: **none** — the retry promise holds |

Wildcard absence was simulated by moving the cert files aside (no nginx reload), then restoring them.

## Verification

Backend 158 suites / 2696 tests · frontend 75 files / 814 tests · both `tsc --noEmit` clean · `setup.sh` passes `bash -n`.

## Deliberately not in scope

- `extraSans` stays on `PrimarySslService` — `ssl-renewal.service.ts:232` uses it legitimately.
- The `direct-no-wildcard` execute branch remains as a safety net for a wildcard deleted between preflight and the certificate step.
- **CE still serves plain HTTP elsewhere** — any hand-created subdomain mapping on a direct-serving instance without a wildcard takes the same `sslEnabled: false` path. Making HTTPS mandatory platform-wide is a larger change (bootstrap mode and Umbrel/LAN installs depend on plain HTTP) and deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019abzHPfQ6mEk8rh7bYme27
