### PR TITLE
fix(app-catalog): reachability gate must never run the ACME token echo

### DIFF
--- a/apps/backend/src/app-catalog/app-preflight.service.ts
+++ b/apps/backend/src/app-catalog/app-preflight.service.ts
@@ -315,14 +315,25 @@ export class AppPreflightService {
       // says the hostname reaches a live server, not that it reaches THIS one.
       // A 404 is the expected answer at this point — the app has no domain
       // mapping until the install creates one.
-      const message =
-        check.probeKind === 'https-reachability'
-          ? `${appHost} resolves to ${resolvedIps} and answered over HTTPS` +
-            (check.status ? ` (HTTP ${check.status})` : '') +
-            `. This instance serves behind a proxy or with port 80 closed, so the probe confirms the ` +
-            `hostname reaches a live server — it cannot prove that server is this origin, because the ` +
-            `proxy terminates TLS. A 404 here is expected: the app has no domain mapping until it is installed.`
-          : `${appHost} resolves and answered the preflight probe on port 80.`;
+      const status = check.status ? ` (HTTP ${check.status})` : '';
+      const expected404 =
+        ' A 404 here is expected: the app has no domain mapping until it is installed.';
+      let message: string;
+      if (check.probeKind === 'https-reachability') {
+        message =
+          `${appHost} resolves to ${resolvedIps} and answered over HTTPS${status}. ` +
+          `This instance serves behind a proxy or with port 80 closed, so the probe confirms the ` +
+          `hostname reaches a live server — it cannot prove that server is this origin, because the ` +
+          `proxy terminates TLS.${expected404}`;
+      } else if (check.probeKind === 'http-reachability') {
+        // Direct serving: no proxy in the path, so the answer came from this
+        // origin itself — a stronger result than the proxied case.
+        message =
+          `${appHost} resolves to ${resolvedIps} and answered on port 80${status}, so the hostname ` +
+          `reaches this server.${expected404}`;
+      } else {
+        message = `${appHost} resolves and answered the preflight probe on port 80.`;
+      }
       return { id: 'dns', status: 'pass', message };
     }
 

--- a/apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
+++ b/apps/backend/src/setup/bootstrap-dns-preflight.service.spec.ts
@@ -232,23 +232,67 @@ describe('BootstrapDnsPreflightService', () => {
       expect(check.probeKind).toBe('https-reachability');
     });
 
-    it('falls back to the stronger port-80 token echo on a direct-serving instance', async () => {
+    // Reachability mode must NEVER run the ACME token echo, on ANY serving
+    // model. That probe answers "could Let's Encrypt validate this host?",
+    // which is a different and strictly harder question — wrong in both
+    // directions for this gate:
+    //
+    //  - FALSE FAILURES. Behind a Cloudflare Tunnel (Umbrel) an unmapped
+    //    subdomain answers 404, and fetchProbe rejects every non-2xx
+    //    ("HTTP 404 from <host>"), so the install gate blocked permanently on
+    //    a host that was perfectly reachable.
+    //  - FALSE PASSES. On a direct-serving instance the echo only succeeded
+    //    because the request fell through to the PRIMARY vhost's ACME
+    //    location; it never measured the app host at all, and the same probe
+    //    fails once that host has a vhost of its own (ce#584).
+    it('probes port 80 for reachability on a direct-serving instance, not the token echo', async () => {
       mockInstanceConfig = { version: 2, state: 'applied', proxyMode: 'none', port80: 'redirect' };
       stubResolve();
       const httpsSpy = jest.spyOn(service as never, 'sendSecureProbeRequest' as never);
       const httpSpy = jest
         .spyOn(service as never, 'sendProbeRequest' as never)
-        .mockImplementation((async (options: { path: string }) => ({
-          statusCode: 200,
-          body: options.path.replace('/.well-known/acme-challenge/', ''),
-        })) as never);
+        .mockResolvedValue({ statusCode: 404, body: '' } as never);
 
       const check = await service.probeHost('handoff.example.com', { mode: 'reachability' });
 
       expect(httpsSpy).not.toHaveBeenCalled();
-      expect((httpSpy.mock.calls[0] as unknown as [{ port: number }])[0].port).toBe(80);
-      expect(check.probeKind).toBe('acme');
+      const opts = (httpSpy.mock.calls[0] as unknown as [{ port: number; path: string }])[0];
+      expect(opts.port).toBe(80);
+      // Plain '/', NOT an acme-challenge token path.
+      expect(opts.path).toBe('/');
+      expect(check.probeKind).toBe('http-reachability');
+      // A 404 from our own server still proves the hostname arrives here.
       expect(check.probeOk).toBe(true);
+      expect(check.status).toBe(404);
+    });
+
+    it('passes on the 404 an unmapped subdomain returns behind a tunnel (the Umbrel case)', async () => {
+      // Umbrel writes no instance.json and sets no PROXY_MODE, so the serving
+      // model resolves to 'none' — the branch that used to take the echo.
+      mockInstanceConfig = null;
+      delete process.env.PROXY_MODE;
+      stubResolve('104.21.37.118');
+      jest
+        .spyOn(service as never, 'sendProbeRequest' as never)
+        .mockResolvedValue({ statusCode: 404, body: '' } as never);
+
+      const check = await service.probeHost('handoff.toshimoto.dev', { mode: 'reachability' });
+
+      expect(check.probeOk).toBe(true);
+      expect(check.status).toBe(404);
+      expect(check.error).toBeUndefined();
+    });
+
+    it('never writes an ACME challenge file in reachability mode', async () => {
+      mockInstanceConfig = { version: 2, state: 'applied', proxyMode: 'none', port80: 'redirect' };
+      stubResolve();
+      jest
+        .spyOn(service as never, 'sendProbeRequest' as never)
+        .mockResolvedValue({ statusCode: 200, body: '' } as never);
+      await service.probeHost('handoff.example.com', { mode: 'reachability' });
+
+      // The ACME probe mints a token file in the webroot; reachability must not.
+      expect(fs.existsSync(path.join(webroot, '.well-known', 'acme-challenge'))).toBe(false);
     });
 
     it('derives the serving model from PROXY_MODE when there is no instance.json', async () => {

--- a/apps/backend/src/setup/bootstrap-dns-preflight.service.ts
+++ b/apps/backend/src/setup/bootstrap-dns-preflight.service.ts
@@ -46,7 +46,7 @@ export interface PreflightCheck {
   probeOk: boolean;
   error?: string;
   /** Which probe actually ran (absent on nothing — always set from here on). */
-  probeKind?: 'acme' | 'https-reachability';
+  probeKind?: 'acme' | 'https-reachability' | 'http-reachability';
   /** Failure classification; only populated for the reachability probe. */
   failure?: ProbeFailure;
   /** HTTP status the host answered with, when it answered at all. */
@@ -146,8 +146,7 @@ export class BootstrapDnsPreflightService {
    */
   async probeHost(host: string, opts: ProbeOptions = {}): Promise<PreflightCheck> {
     if (opts.mode === 'reachability') {
-      const model = this.resolveServingModel();
-      if (model.probeHttps) return this.httpsReachabilityProbe(host, model);
+      return this.reachabilityProbe(host, this.resolveServingModel());
     }
     return this.acmeProbe(host);
   }
@@ -226,7 +225,29 @@ export class BootstrapDnsPreflightService {
    * "something in front answered, the origin behind it did not" ones — see
    * classifyOriginError for why 502/503/504 only count when proxied.
    */
-  private async httpsReachabilityProbe(host: string, model: ServingModel): Promise<PreflightCheck> {
+  /**
+   * Reachability, on every serving model — never the ACME token echo.
+   *
+   * The echo answers "could Let's Encrypt validate this host?", which is a
+   * different and strictly harder question, and it was wrong in both
+   * directions here:
+   *
+   *  - FALSE FAILURES. Behind a Cloudflare Tunnel (Umbrel) or any proxy an
+   *    unmapped subdomain answers 404, and `fetchProbe` rejects every non-2xx
+   *    ("HTTP 404 from <host>"), so the app-catalog install gate blocked
+   *    permanently on a host that was perfectly reachable. The host cannot
+   *    answer as itself until the install creates it — chicken and egg.
+   *  - FALSE PASSES. On a direct-serving instance the echo only succeeded
+   *    because the request fell through to the PRIMARY vhost's ACME location.
+   *    It never measured the app host, and the identical probe fails once
+   *    that host has a vhost of its own (ce#584).
+   *
+   * The port still follows the serving model — `probeHttps` instances have
+   * nothing listening on 80 — but the verdict is now the same everywhere:
+   * any status that is not an origin error proves the hostname arrives here.
+   */
+  private async reachabilityProbe(host: string, model: ServingModel): Promise<PreflightCheck> {
+    const probeKind = model.probeHttps ? 'https-reachability' : 'http-reachability';
     const resolvedIps = await this.resolveA(host);
     if (resolvedIps.some((ip) => isDisallowedProbeIp(ip))) {
       return {
@@ -234,7 +255,7 @@ export class BootstrapDnsPreflightService {
         resolvedIps,
         probeOk: false,
         error: 'resolves to a private or reserved address',
-        probeKind: 'https-reachability',
+        probeKind,
         failure: 'private-ip',
       };
     }
@@ -244,13 +265,13 @@ export class BootstrapDnsPreflightService {
         resolvedIps,
         probeOk: false,
         error: 'Hostname does not resolve yet',
-        probeKind: 'https-reachability',
+        probeKind,
         failure: 'no-dns',
       };
     }
 
     try {
-      const { statusCode } = await this.fetchReachabilityProbe(host, resolvedIps[0]);
+      const { statusCode } = await this.fetchReachabilityProbe(host, resolvedIps[0], model);
       const failure = classifyOriginError(statusCode, model.proxied);
       if (failure) {
         return {
@@ -263,7 +284,7 @@ export class BootstrapDnsPreflightService {
               ? `The proxy in front of ${host} returned HTTP ${statusCode} — it could not reach an origin`
               : `The proxy in front of ${host} returned HTTP ${statusCode} — it reached this server, ` +
                 `but the backend behind it did not return a valid response`,
-          probeKind: 'https-reachability',
+          probeKind,
           failure,
         };
       }
@@ -272,15 +293,15 @@ export class BootstrapDnsPreflightService {
         resolvedIps,
         probeOk: true,
         status: statusCode,
-        probeKind: 'https-reachability',
+        probeKind,
       };
     } catch (e) {
       return {
         host,
         resolvedIps,
         probeOk: false,
-        error: e instanceof Error ? e.message : 'Unreachable over HTTPS',
-        probeKind: 'https-reachability',
+        error: e instanceof Error ? e.message : 'Unreachable',
+        probeKind,
         failure: 'no-response',
       };
     }
@@ -344,8 +365,24 @@ export class BootstrapDnsPreflightService {
   private async fetchReachabilityProbe(
     host: string,
     ip: string | undefined,
+    model: ServingModel,
   ): Promise<{ statusCode: number }> {
     if (!ip) throw new Error('No resolved address to probe');
+    // A direct-serving instance with port 80 open is probed there: it is the
+    // port nginx definitely answers on (the wildcard/default vhost), and it
+    // avoids depending on a certificate existing for a host that, by
+    // definition, does not have one yet.
+    if (!model.probeHttps) {
+      const { statusCode } = await this.sendProbeRequest({
+        host: ip,
+        port: 80,
+        path: '/',
+        method: 'GET',
+        headers: { Host: host },
+        timeout: 5000,
+      });
+      return { statusCode };
+    }
     return this.sendSecureProbeRequest({
       host: ip,
       servername: host,


### PR DESCRIPTION
Follow-up to #588 (which merged before this landed) and complementary to #587.

## Reported live

Installing Handoff on an **Umbrel** instance (CE 0.4.3) behind a **Cloudflare Tunnel** was blocked in the install dialog:

> DNS check failed for handoff.toshimoto.dev: HTTP 404 from handoff.toshimoto.dev. Resolved IPs: 172.67.207.215, 104.21.37.118.

## Root cause

That wording comes from exactly one place — `fetchProbe`, the **ACME token echo**, which rejects any non-2xx. So the app-catalog DNS gate was running the *issuance* probe rather than the *reachability* probe.

#587 improved how the reachability probe classifies origin errors, but left `probeHost` falling back to the echo whenever `model.probeHttps` is false. Umbrel writes no `bootstrap/instance.json` and sets no `PROXY_MODE`, so its serving model resolves to `'none'` and it took that branch.

Worth noting: **setting `PROXY_MODE=cloudflare-tunnel` would not have helped.** `resolveServingModel()` only accepts `'cloudflare' | 'proxy' | 'none'` and defaults anything else to `'none'` — a correctly-flagged tunnel install hit the identical wall.

## Why the echo is the wrong probe here, in both directions

- **False failures.** Behind a tunnel or any proxy, an unmapped subdomain answers 404. Confirmed externally against the reporter's domain — `handoff.toshimoto.dev` and every other unmapped host return 404 on both `:80` and `:443`, while the apex and `admin.` return 200. The gate could never pass for a host that does not exist yet, which is *every* host at install time. Chicken-and-egg.
- **False passes.** On a direct-serving instance the echo only succeeded because the request fell through to the **primary** vhost's ACME location. It never measured the app host — and the identical probe fails once that host has a vhost of its own, which is exactly what #584 found on a live droplet.

## The fix

`probeHost({ mode: 'reachability' })` always takes the reachability path.

The **port** still follows the serving model — proxied / port-80-closed instances on 443, direct instances on 80, where nginx definitely answers and no certificate need exist for a host that by definition has none yet — but the **verdict** is uniform: any status that is not an origin error proves the hostname arrives here.

New `http-reachability` probe kind, and the DNS gate words that case as the stronger result it is: no proxy in the path, so the answer came from this origin rather than merely "a live server".

The ACME echo is untouched for `run()` and `PrimarySslService`'s `extraSans` checks, which really are about issuance — #587's regression fence around that stays green.

## Verification

Backend **158 suites / 2713 tests pass**, `tsc --noEmit` clean. New tests cover the direct-serving port-80 reachability path, the Umbrel/tunnel 404 case, and that reachability mode never mints an ACME challenge file.

## Follow-up worth scoping separately

Umbrel declares no serving model at all — no `instance.json`, no `PROXY_MODE` — so CE guesses "direct" for it everywhere, not just here. That is the deferred `cloudflare-tunnel` bootstrap profile; landing it would remove this class of wrong guess rather than one instance of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019abzHPfQ6mEk8rh7bYme27
