### PR TITLE
fix(umbrel): except auth + presigned uploads from the subdomain-alias rewrite

### DIFF
--- a/apps/backend/src/domains/nginx-wildcard-parity.spec.ts
+++ b/apps/backend/src/domains/nginx-wildcard-parity.spec.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'fs';
+import * as path from 'path';
+
+/**
+ * The wildcard `*.<primary>` server block exists TWICE, hand-written, in two
+ * files that must stay in step:
+ *
+ *   - `docker/nginx/sites-available/main.conf.template` — the compose/CE stack
+ *   - `umbrel/nginx.conf.template`                      — the Umbrel package
+ *
+ * Both rewrite EVERY path into the subdomain-alias handler, so any route that
+ * must reach the backend unrewritten needs an explicit exception in BOTH. The
+ * Umbrel copy silently lacked them, which is why every Handoff upload on
+ * Umbrel 404'd: `PUT /api/storage/presigned/local` was rewritten into
+ * `/public/subdomain-alias/handoff/api/storage/presigned/local` and answered
+ * by the backend's 404 (confirmed live from a HAR — `X-Powered-By: Express`).
+ *
+ * This is a drift fence, not a rendering test: it asserts the exception list
+ * matches, so adding one to the CE template without the Umbrel one fails here.
+ */
+const REPO_ROOT = path.join(__dirname, '../../../..');
+const CE_TEMPLATE = path.join(REPO_ROOT, 'docker/nginx/sites-available/main.conf.template');
+const UMBREL_TEMPLATE = path.join(REPO_ROOT, 'umbrel/nginx.conf.template');
+
+/** Locations that must reach the backend unrewritten on an app subdomain. */
+const REQUIRED_EXCEPTIONS = [
+  // Cross-domain auth relay used by apps served on their own subdomain.
+  'location /_bffless/auth/',
+  // Presigned local-filesystem uploads AND their signed GET downloads —
+  // both controllers share the `api/storage/presigned` + `local` route.
+  'location = /api/storage/presigned/local',
+];
+
+/** The `*.<domain>` server block, from its server_name to the block's end. */
+function wildcardBlock(file: string): string {
+  const text = readFileSync(file, 'utf-8');
+  const start = text.search(/server_name\s+\*\./);
+  expect(start).toBeGreaterThan(-1);
+  // The next `server {` (or EOF) bounds this block well enough for a
+  // substring check — both files declare one wildcard block.
+  const rest = text.slice(start);
+  const next = rest.search(/\nserver\s*\{/);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+describe('wildcard subdomain block parity: CE vs Umbrel nginx templates', () => {
+  it.each(REQUIRED_EXCEPTIONS)('CE template excepts "%s" from the alias rewrite', (location) => {
+    expect(wildcardBlock(CE_TEMPLATE)).toContain(location);
+  });
+
+  it.each(REQUIRED_EXCEPTIONS)('Umbrel template excepts "%s" from the alias rewrite', (location) => {
+    expect(wildcardBlock(UMBREL_TEMPLATE)).toContain(location);
+  });
+
+  it('declares the presigned exception as an EXACT match in both, so it beats "location /"', () => {
+    for (const file of [CE_TEMPLATE, UMBREL_TEMPLATE]) {
+      const block = wildcardBlock(file);
+      expect(block).toContain('location = /api/storage/presigned/local');
+      // A prefix match would lose to nothing, but an exact match is what makes
+      // ordering irrelevant — nginx always prefers `location =`.
+      expect(block).not.toMatch(/location\s+\/api\/storage\/presigned\/local\s*\{/);
+    }
+  });
+
+  it('still rewrites everything else into the subdomain-alias handler', () => {
+    for (const file of [CE_TEMPLATE, UMBREL_TEMPLATE]) {
+      expect(wildcardBlock(file)).toContain('/public/subdomain-alias/');
+    }
+  });
+});

--- a/umbrel/nginx.conf.template
+++ b/umbrel/nginx.conf.template
@@ -195,7 +195,59 @@ server {
         set $subdomain $1;
     }
 
-    # Route all requests to backend subdomain-alias endpoint
+    # Authentication endpoints (callback, refresh, logout, session).
+    # Must be declared before the catch-all below: this block's `location /`
+    # rewrites EVERY path into the subdomain-alias handler, so without an
+    # unrewritten exception the auth relay an app on a subdomain uses would
+    # rewrite to /public/subdomain-alias/<sub>/_bffless/auth/... and 404.
+    # Mirrors the same location in docker/nginx/sites-available/main.conf.template.
+    location /_bffless/auth/ {
+        proxy_pass http://backend:3000/_bffless/auth/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+    }
+
+    # Presigned local-filesystem uploads (and their signed GET downloads —
+    # both live at this exact path) stream straight through to the backend.
+    # Same rationale as /_bffless/auth/ above: without this exception a
+    # relative presigned URL minted for an app subdomain rewrites to
+    # /public/subdomain-alias/<sub>/api/storage/presigned/local and the
+    # backend answers 404 — which is exactly what every Handoff upload on
+    # Umbrel did (ce#584 follow-up).
+    #
+    # Must be an exact match so nginx prefers it over the general
+    # "location /" below, regardless of declaration order.
+    location = /api/storage/presigned/local {
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+
+        # Extended timeouts for large transfers.
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+
+        # Stream the body to the backend incrementally instead of spooling the
+        # whole request into an nginx temp file first. proxy_request_buffering
+        # is the load-bearing directive.
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_max_temp_file_size 0;
+
+        # Above this server block's 100M default so the ceiling is the
+        # backend's signed `max`, not nginx.
+        client_max_body_size 200M;
+    }
+
+    # Route all remaining requests to backend subdomain-alias endpoint
     location / {
         rewrite ^/(.*)$ /public/subdomain-alias/$subdomain/$1 break;
 


### PR DESCRIPTION
Reported live from an Umbrel install: **every Handoff upload 404'd**, and nothing appeared in the uploads directory.

```
PUT https://handoff.toshimoto.dev/api/storage/presigned/local?key=… → 404 Not Found
X-Powered-By: Express
```

## Root cause

That `X-Powered-By: Express` is the tell — the 404 came from the **backend**, not nginx. The request arrived, at the wrong route.

Umbrel's wildcard `*.${PRIMARY_DOMAIN}` server block rewrites **every** path into the subdomain-alias handler:

```nginx
rewrite ^/(.*)$ /public/subdomain-alias/$subdomain/$1 break;
```

so the presigned PUT became `/public/subdomain-alias/handoff/api/storage/presigned/local`, which is not a route. The upload writer never ran, hence the empty uploads directory.

`docker/nginx/sites-available/main.conf.template` has carried exceptions for exactly this since the local-filesystem presigned work — its comment names this failure mode explicitly — but `umbrel/nginx.conf.template` is a **separate hand-written copy** of the same block and never received them.

## What ships

Both missing exceptions, mirroring the CE template:

- **`location = /api/storage/presigned/local`** — presigned uploads *and* their signed GET downloads; both controllers share that route (`api/storage/presigned` + `local`). Exact match, so nginx prefers it over `location /` regardless of declaration order. Streams unbuffered with extended timeouts and a 200M ceiling, so the backend's signed `max` is the real limit.
- **`location /_bffless/auth/`** — the cross-domain auth relay an app served on its own subdomain uses. Not yet observed failing (the reporter's session came from a domain-wide cookie), but structurally identical: rewritten, then 404.

## Drift fence

`nginx-wildcard-parity.spec.ts` compares the exception list across both templates, so adding one to the CE copy without the Umbrel copy fails CI. **Verified to fail against the unfixed template** (3 of 6 red), not merely to pass after the fix.

## Verification

Backend **159 suites / 2719 tests pass**, `tsc --noEmit` clean.

## Note

This was committed to #591's branch shortly after that PR merged, so it never landed — hence this separate PR against current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019abzHPfQ6mEk8rh7bYme27
