### PR TITLE
fix(nginx): apply the app-serving contract to the platform primary-domain generator

### DIFF
--- a/apps/backend/src/domains/nginx-config-presigned.spec.ts
+++ b/apps/backend/src/domains/nginx-config-presigned.spec.ts
@@ -89,6 +89,25 @@ describe('generated vhosts always expose the local presigned upload route', () =
     },
   );
 
+  // The primary-domain generator serves an app mapped to the apex — same
+  // contract, and it had none of the three until ce#584's sweep.
+  it('applies the same contract to a primary-domain mapping', async () => {
+    const primaryMapping = {
+      ...(subdomainMapping as object),
+      id: 'dom-3',
+      domain: 'toshimoto.dev',
+      domainType: 'subdomain',
+      isPrimary: true,
+      wwwBehavior: 'serve-both',
+    } as never;
+
+    const config = await buildService().generateConfig(primaryMapping, project);
+
+    expect(config).toContain('location = /api/storage/presigned/local');
+    expect(config).toContain('client_max_body_size');
+    expect(config).toContain('proxy_buffer_size 16k');
+  });
+
   it('still routes everything else into the deployment path', async () => {
     const config = await buildService().generateConfig(subdomainMapping, project);
     expect(config).toContain('/public/bffless/handoff/alias/handoff/apps/handoff/dist/');

--- a/apps/backend/src/domains/nginx-config.service.ts
+++ b/apps/backend/src/domains/nginx-config.service.ts
@@ -1235,6 +1235,9 @@ ${httpServerBlock}${httpsServerBlock}
 
     // Main location block
     const locationBlock = `
+    # nginx defaults to 1M and 413s anything larger on every proxied path.
+    # The presigned upload location below carries its own 200M ceiling.
+    client_max_body_size 100M;
 ${proxyLocations}
 
     # BFFless auth relay endpoints (login relay, session, callback, refresh, logout)
@@ -1248,6 +1251,7 @@ ${proxyLocations}
         proxy_set_header X-Forwarded-Host $host;
     }
 
+${this.presignedUploadLocation()}
     # Main location - serves static content
     location / {
         rewrite ^/(.*)$ ${internalPath}/$1 break;
@@ -1260,6 +1264,14 @@ ${proxyLocations}
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Original-URI $request_uri;
+
+        # Header buffers sized for SuperTokens' session-refresh response;
+        # nginx's 4k default returns 502 "upstream sent too big header" on a
+        # successful /api/auth/session/refresh (ce#370).
+        proxy_buffering on;
+        proxy_buffer_size 16k;
+        proxy_buffers 8 16k;
+        proxy_busy_buffers_size 32k;
 
         proxy_intercept_errors ${proxyInterceptErrors};
         ${spaErrorPage}


### PR DESCRIPTION
Third instance of the drift documented in #598, and the one #596 missed. Found while writing that issue up — filing an issue about config drift while leaving a third copy of that drift in place would have been its own kind of drift.

`generatePlatformPrimaryDomainConfig` had **none of the three**:

- no `location = /api/storage/presigned/local` → presigned uploads (and signed downloads) 404 via the catch-all rewrite
- no `client_max_body_size` → nginx's **1M default** 413s anything larger on every proxied path
- no proxy header buffer sizing → nginx's **4k default**, so a successful `/api/auth/session/refresh` returns 502 "upstream sent too big header" (**ce#370**, fixed in the CE templates, never here)

Reachable whenever an app is mapped to the **apex** on an externally-proxied install — the same `PROXY_MODE=cloudflare-tunnel` + `STORAGE_TYPE=local` shape Umbrel ships, which is what surfaced the sibling defects in #596.

Uses the shared `presignedUploadLocation()` helper #596 introduced, so this generator now emits the identical block rather than a fourth copy of it.

## Verification

Backend **160 suites / 2728 tests pass**, `tsc --noEmit` clean. `nginx-config-presigned.spec.ts` gains a primary-domain case driving the real generator; it asserts all three parts of the contract.

## Note

#596 merged while this commit was in flight, so it needed its own PR. The structural fix that would stop this recurring is #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019abzHPfQ6mEk8rh7bYme27
