### PR TITLE
fix(nginx): give every app-serving vhost the same body ceiling

### DIFF
--- a/apps/backend/src/domains/nginx-config.service.ts
+++ b/apps/backend/src/domains/nginx-config.service.ts
@@ -1444,13 +1444,12 @@ ${serverBlocks}`;
     const spaErrorPage = config.isSpa ? 'error_page 404 = @spa_fallback;' : '';
     const proxyInterceptErrors = config.isSpa ? 'on' : 'off';
 
-    // NOTE: unlike the platform-style generators this block emits no
-    // server-level client_max_body_size and no proxy header buffers. It is
-    // only ever written into sites-enabled/ of the compose CE image, whose
-    // http block (docker/nginx/nginx.conf) supplies both — 10M and 128k. That
-    // inheritance is asserted, per surface, by nginx-serving-contract.spec.ts;
-    // remove it there and this generator goes red.
-    const locationBlock = `
+    // Proxy header buffers are still inherited here: this block is only ever
+    // written into sites-enabled/ of the compose CE image, whose http block
+    // (docker/nginx/nginx.conf) supplies 128k. That inheritance is asserted
+    // per surface by nginx-serving-contract.spec.ts, which turns this
+    // generator red if the http-level value goes away.
+    const locationBlock = `${this.appServingBodyLimit()}
 ${proxyLocations}
 ${this.authRelayLocation()}
 ${this.presignedUploadLocation()}

--- a/apps/backend/src/domains/nginx-serving-contract.spec.ts
+++ b/apps/backend/src/domains/nginx-serving-contract.spec.ts
@@ -137,9 +137,19 @@ function httpLevelDirectives(file: string): string {
 const DOCKER_HTTP = () => httpLevelDirectives(path.join(REPO_ROOT, 'docker/nginx/nginx.conf'));
 const STOCK_NGINX = () => '';
 
-/** nginx's compiled-in defaults, which are wrong for every surface here. */
-const NGINX_DEFAULT_MAX_BODY = 1024 * 1024; // 1m
-const MIN_PROXY_BUFFER = 16 * 1024; // ce#370: the 4k default 502s on session refresh
+/**
+ * The one body ceiling every app-serving vhost declares.
+ *
+ * Pinned to a single value, not a floor: before ce#598 the CE-mode vhosts
+ * inherited 10M from docker/nginx/nginx.conf while the externally-proxied
+ * ones declared 100M, so the same app got a 10x different limit depending on
+ * how TLS was terminated for it. The presigned upload location keeps its own
+ * 200M — that is a per-route ceiling, not this.
+ */
+const APP_SERVING_MAX_BODY = 100 * 1024 ** 2; // 100M
+
+/** ce#370: nginx's 4k default 502s a successful session refresh. */
+const MIN_PROXY_BUFFER = 16 * 1024;
 
 // ---------------------------------------------------------------------------
 // Rendering the hand-written envsubst templates.
@@ -352,19 +362,20 @@ describe.each(SURFACES.map((surface) => [surface.name, surface] as const))(
       }
     });
 
-    it("raises client_max_body_size above nginx's 1M default", () => {
-      // Server level, or inherited from an http block shipped alongside this
-      // surface. Deliberately NOT the 200M inside the presigned location:
-      // that ceiling covers one route, while this is the floor for every
-      // other proxied path, and its absence 413'd pipeline uploads and form
-      // posts on externally-proxied installs (#596/2).
+    it('declares its own client_max_body_size rather than inheriting one', () => {
+      // Deliberately NOT the 200M inside the presigned location: that ceiling
+      // covers one route, while this is the limit for every other proxied
+      // path — notably proxy-rule POSTs, which set no ceiling of their own.
+      // Its absence 413'd externally-proxied installs at nginx's 1M (#596/2).
+      //
+      // Declared, not inherited: whether a surface has an http block of ours
+      // above it depends on how TLS is terminated for the deployment, which
+      // must not decide an app's body ceiling.
       for (const block of blocks) {
-        const scope = withoutNestedBlocks(block);
-        const value =
-          directive(scope, 'client_max_body_size') ?? directive(inherited, 'client_max_body_size');
+        const value = directive(withoutNestedBlocks(block), 'client_max_body_size');
 
         expect(value).not.toBeNull();
-        expect(parseSize(value as string)).toBeGreaterThan(NGINX_DEFAULT_MAX_BODY);
+        expect(parseSize(value as string)).toBe(APP_SERVING_MAX_BODY);
       }
     });
 

--- a/apps/backend/templates/nginx/custom-domain.conf.hbs
+++ b/apps/backend/templates/nginx/custom-domain.conf.hbs
@@ -19,6 +19,13 @@ server {
 
     server_name {{domain}};
 
+    # nginx defaults to 1M, which 413s any body larger than that on every path
+    # this vhost proxies -- proxy-rule POSTs and form posts in particular. The
+    # presigned upload location below carries its own 200M ceiling. Declared
+    # rather than inherited from the http block so an app's body ceiling does
+    # not depend on how TLS is terminated for it (ce#598).
+    client_max_body_size 100M;
+
     # Security headers are set by the NestJS backend (SecurityHeadersMiddleware)
 
 {{{blocklistRules}}}
@@ -163,6 +170,13 @@ server {
 server {
     listen {{listenPort}};
     server_name {{domain}};
+
+    # nginx defaults to 1M, which 413s any body larger than that on every path
+    # this vhost proxies -- proxy-rule POSTs and form posts in particular. The
+    # presigned upload location below carries its own 200M ceiling. Declared
+    # rather than inherited from the http block so an app's body ceiling does
+    # not depend on how TLS is terminated for it (ce#598).
+    client_max_body_size 100M;
 
     # ACME challenge for Let's Encrypt
     location /.well-known/acme-challenge/ {

--- a/apps/backend/templates/nginx/subdomain.conf.hbs
+++ b/apps/backend/templates/nginx/subdomain.conf.hbs
@@ -19,6 +19,13 @@ server {
 
     server_name {{domain}};
 
+    # nginx defaults to 1M, which 413s any body larger than that on every path
+    # this vhost proxies -- proxy-rule POSTs and form posts in particular. The
+    # presigned upload location below carries its own 200M ceiling. Declared
+    # rather than inherited from the http block so an app's body ceiling does
+    # not depend on how TLS is terminated for it (ce#598).
+    client_max_body_size 100M;
+
     # Security headers are set by the NestJS backend (SecurityHeadersMiddleware)
 
 {{{blocklistRules}}}
@@ -171,6 +178,13 @@ server {
 server {
     listen {{listenPort}};
     server_name {{domain}};
+
+    # nginx defaults to 1M, which 413s any body larger than that on every path
+    # this vhost proxies -- proxy-rule POSTs and form posts in particular. The
+    # presigned upload location below carries its own 200M ceiling. Declared
+    # rather than inherited from the http block so an app's body ceiling does
+    # not depend on how TLS is terminated for it (ce#598).
+    client_max_body_size 100M;
 
     # ACME challenge for Let's Encrypt.
     # Declared before the catch-all `location /` below, which rewrites every

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -29,10 +29,13 @@ http {
     tcp_nopush on;
     keepalive_timeout 65;
 
-    # Default max upload size for ALL server blocks (admin, wildcard, and
-    # dynamically-generated per-domain configs). Without this, per-domain
-    # server blocks fall back to nginx's built-in 1MB default. Individual
-    # server blocks may override (e.g. admin sets 100M in main.conf.template).
+    # Backstop only. Every app-serving vhost now declares its own 100M at
+    # server level (ce#598) rather than relying on this, so that an app's
+    # body ceiling is the same whether nginx terminates TLS or something in
+    # front of it does — the platform-style generators and the Umbrel
+    # templates ship no http block of ours to inherit from at all. This still
+    # catches any server block that declares nothing, which would otherwise
+    # fall back to nginx's built-in 1M.
     # For object-storage backends (S3/GCS/MinIO), presigned uploads go
     # straight to the bucket and bypass nginx entirely. Local-filesystem
     # presigned uploads do NOT bypass nginx: they PUT through the admin

--- a/docker/nginx/sites-available/main.conf.template
+++ b/docker/nginx/sites-available/main.conf.template
@@ -20,6 +20,13 @@ server {
     http2 on;
     server_name *.${PRIMARY_DOMAIN};
 
+    # nginx's http-level default (nginx.conf) is 10M. App vhosts get 100M, so
+    # an app's body ceiling doesn't depend on how TLS is terminated for it:
+    # the Umbrel wildcard and the platform-style generators already declare
+    # 100M, and this block is their compose-stack counterpart (ce#598). The
+    # presigned upload location below carries its own 200M.
+    client_max_body_size 100M;
+
     # SSL certificates (use wildcard cert — path set by entrypoint based on PROXY_MODE)
     ssl_certificate ${WILDCARD_CERT};
     ssl_certificate_key ${WILDCARD_KEY};


### PR DESCRIPTION
Stacked on #602 — merge that first. Follows from the review question on #602 about `generateCEPrimaryDomainConfig` inheriting its limit.

## The problem

An app's max request body depended on **how TLS was terminated for it**:

| Surface | Effective ceiling | Source |
| --- | --- | --- |
| `main.conf.template` wildcard | 10M | inherited |
| `subdomain.conf.hbs` (both branches) | 10M | inherited |
| `custom-domain.conf.hbs` (both branches) | 10M | inherited |
| `generateCEPrimaryDomainConfig` | 10M | inherited |
| `umbrel` wildcard | **100M** | declared |
| all three `generatePlatform*Config` | **100M** | declared (#596) |

Same app, same deployment, 10× different limit depending on whether nginx terminates TLS or Cloudflare/Traefik does.

This is the #598 shape again at lower severity. SSL termination is a legitimate per-deployment difference; it had leaked into the serving contract, which must not vary. It stayed invisible because the fence asserted only a **floor** (above nginx's 1M default) — and 10M clears that.

## What actually hit the 10M

`generateProxyLocationBlocks()` emits no `client_max_body_size` of its own — just `proxy_pass`, headers and timeouts — so proxy-rule locations inherit whatever is in scope. So the exposure was **proxy-rule POSTs and form posts on a CE-mode vhost**, 413ing above 10M.

Not affected, in both cases because they have their own ceiling:
- **Presigned uploads** — own `location =` with `client_max_body_size 200M` and `proxy_request_buffering off`, on every surface.
- **Deploy uploads** — go through the admin vhost (100M server-level, 200M presigned).

## The change

Aligned **upward to 100M**, matching what the platform generators and both Umbrel blocks already declared, so **no install has its limit lowered**. Now declared rather than inherited in all four CE surfaces:

- `docker/nginx/sites-available/main.conf.template` (wildcard vhost)
- `apps/backend/templates/nginx/subdomain.conf.hbs` (both SSL branches)
- `apps/backend/templates/nginx/custom-domain.conf.hbs` (both SSL branches)
- `generateCEPrimaryDomainConfig`, via `appServingBodyLimit()` from #602

The http-level 10M in `docker/nginx/nginx.conf` stays as a backstop for server blocks that declare nothing. Its comment is corrected — it described itself as the value per-domain configs rely on, which is no longer true.

## Fence tightened to match

`nginx-serving-contract.spec.ts` now requires each app-serving vhost to **declare** `client_max_body_size`, and **pins the value** instead of checking a floor. Inheritance is no longer accepted for this item, precisely because whether an http block of ours sits above a surface depends on the deployment.

Verified it bites, both directions:

```
COUNTERFACTUAL — tightened fence against the pre-alignment tree:
  ● main.conf.template (compose: *.<primary> wildcard) › declares its own client_max_body_size…
  ● subdomain.conf.hbs (sslEnabled)      › declares its own client_max_body_size…
  ● subdomain.conf.hbs (http-only)       › declares its own client_max_body_size…
  ● custom-domain.conf.hbs (sslEnabled)  › declares its own client_max_body_size…
  ● custom-domain.conf.hbs (http-only)   › declares its own client_max_body_size…
  ● generateCEPrimaryDomainConfig        › declares its own client_max_body_size…
  Tests: 6 failed, 47 passed

MUTATION — drop the declaration from one .hbs branch:
  ● subdomain.conf.hbs (sslEnabled) › declares its own client_max_body_size…
  Tests: 1 failed, 52 passed
```

Exactly the six CE-mode surfaces, and exactly the one mutated branch.

## Verification

- `pnpm exec jest` — 160 suites, 2775 passed / 37 skipped, **0 failed**
- `bash docker/nginx/render-main-conf.test.sh` — **ALL RENDER TESTS PASSED** (main.conf.template changed, so this matters)
- `pnpm exec tsc --noEmit` — exit 0
- ESLint: only the two `nginx-config.service.ts` prettier errors that pre-exist on `main`

## Note on proxy buffers

`generateCEPrimaryDomainConfig` still inherits `proxy_buffer_size` (128k) rather than declaring it — left as-is here, since that one is genuinely only ever written into the compose CE image, and the fence asserts the inheritance per surface. Happy to make it self-sufficient too if you'd rather nothing depend on ambient http config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
