### PR TITLE
feat(app-catalog): render registry store metadata in Admin → Apps

### DIFF
--- a/apps/backend/src/app-catalog/app-catalog.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.spec.ts
@@ -254,7 +254,11 @@ describe('AppCatalogService', () => {
           id: 'handoff',
           name: 'Handoff',
           summary: undefined,
+          description: undefined,
+          category: undefined,
           iconUrl: undefined,
+          thumbnailUrl: undefined,
+          screenshots: undefined,
           docsUrl: undefined,
           sourceUrl: undefined,
           registryVersion: '1.0.0',
@@ -262,6 +266,40 @@ describe('AppCatalogService', () => {
           installable: true,
         },
       ]);
+    });
+
+    it('passes the store-presentation fields through to the catalog entry', async () => {
+      // Admin -> Apps renders these (ce#590); they must survive the explicit
+      // field-by-field copy in buildRegistryEntry rather than be dropped.
+      const entry: AppRegistryEntry = {
+        ...HANDOFF_ENTRY,
+        summary: 'Share files with clients',
+        description: '## Handoff\n\nShare files.',
+        category: 'files',
+        iconUrl: 'https://apps.example.com/assets/handoff/icon.png',
+        thumbnailUrl: 'https://apps.example.com/assets/handoff/thumbnail.png',
+        screenshots: ['https://apps.example.com/assets/handoff/screenshots/01.png'],
+        docsUrl: 'https://example.com/docs',
+        sourceUrl: 'https://github.com/bffless/apps',
+      };
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [entry] },
+      });
+      mockDb.__queue([]);
+
+      const result = await service.listCatalog();
+
+      expect(result.data[0]).toMatchObject({
+        summary: entry.summary,
+        description: entry.description,
+        category: entry.category,
+        iconUrl: entry.iconUrl,
+        thumbnailUrl: entry.thumbnailUrl,
+        screenshots: entry.screenshots,
+        docsUrl: entry.docsUrl,
+        sourceUrl: entry.sourceUrl,
+      });
     });
 
     it('marks a registry app not-installable when an instance gate fails', async () => {

--- a/apps/backend/src/app-catalog/app-catalog.service.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.ts
@@ -54,7 +54,14 @@ export interface CatalogEntry {
   id: string;
   name: string;
   summary?: string;
+  /** Long-form markdown blurb. Registry-only — see AppRegistryEntry.description. */
+  description?: string;
+  category?: string;
   iconUrl?: string;
+  /** Wide card image for the catalog grid. Registry-only. */
+  thumbnailUrl?: string;
+  /** Absolute https URLs. Registry-only. */
+  screenshots?: string[];
   docsUrl?: string;
   sourceUrl?: string;
   /** Absent when the registry is unavailable, or this app isn't (or no longer) listed in it. */
@@ -290,7 +297,11 @@ export class AppCatalogService {
       id: entry.id,
       name: entry.name ?? entry.id,
       summary: entry.summary,
+      description: entry.description,
+      category: entry.category,
       iconUrl: entry.iconUrl,
+      thumbnailUrl: entry.thumbnailUrl,
+      screenshots: entry.screenshots,
       docsUrl: entry.docsUrl,
       sourceUrl: entry.sourceUrl,
       registryVersion: entry.version,
@@ -312,10 +323,14 @@ export class AppCatalogService {
     const manifest = row.manifest as AppManifest;
     const gates = await this.preflightService.instanceGates(manifest.requires);
 
+    // `description`/`thumbnailUrl`/`screenshots` are registry-only (the store
+    // folds them in from apps/<app>/catalog/, they never reach the bundled
+    // manifest), so a delisted app renders with just its manifest metadata.
     return {
       id: manifest.id,
       name: manifest.name,
       summary: manifest.summary,
+      category: manifest.category,
       iconUrl: manifest.iconUrl,
       docsUrl: manifest.docsUrl,
       sourceUrl: manifest.sourceUrl,

--- a/apps/backend/src/app-catalog/app-manifest.types.ts
+++ b/apps/backend/src/app-catalog/app-manifest.types.ts
@@ -41,6 +41,8 @@ export interface AppManifest {
   name: string;
   version: string;
   summary?: string;
+  /** Free-form store category (e.g. 'files'), shown as a badge in the catalog. */
+  category?: string;
   iconUrl?: string;
   docsUrl?: string;
   sourceUrl?: string;
@@ -69,7 +71,18 @@ export interface AppRegistryEntry {
   bundleUrl: string;
   sha256: string;
   summary?: string;
+  /**
+   * Long-form markdown blurb (the store's `apps/<app>/catalog/description.md`).
+   * Registry-only — it never travels in the bundled manifest, so an installed
+   * app that has dropped out of the registry renders without one.
+   */
+  description?: string;
+  category?: string;
   iconUrl?: string;
+  /** Wide (1200x630-ish) card image for the catalog grid. Registry-only. */
+  thumbnailUrl?: string;
+  /** Absolute https URLs, already ordered by the registry builder. Registry-only. */
+  screenshots?: string[];
   docsUrl?: string;
   sourceUrl?: string;
   requires?: AppManifestRequires;

--- a/apps/backend/src/app-catalog/app-manifest.util.spec.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.spec.ts
@@ -184,6 +184,70 @@ describe('validateRegistry', () => {
       expect(result.errors).toContain('apps[0].sha256: required string');
     }
   });
+
+  it('accepts and round-trips the store-presentation fields', () => {
+    const registry = {
+      schemaVersion: 1,
+      apps: [
+        {
+          ...validRegistry.apps[0],
+          description: '## Handoff\n\nShare files.',
+          category: 'files',
+          thumbnailUrl: 'https://apps.example.com/assets/handoff/thumbnail.png',
+          iconUrl: 'https://apps.example.com/assets/handoff/icon.png',
+          screenshots: [
+            'https://apps.example.com/assets/handoff/screenshots/01.png',
+            'https://apps.example.com/assets/handoff/screenshots/02.png',
+          ],
+        },
+      ],
+    };
+
+    const result = validateRegistry(registry);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.registry).toEqual(registry);
+    }
+  });
+
+  it('rejects mistyped store-presentation fields', () => {
+    const result = validateRegistry({
+      schemaVersion: 1,
+      apps: [
+        {
+          ...validRegistry.apps[0],
+          description: 42,
+          category: [],
+          thumbnailUrl: {},
+          screenshots: 'https://apps.example.com/one.png',
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toEqual(
+        expect.arrayContaining([
+          'apps[0].description: must be string',
+          'apps[0].category: must be string',
+          'apps[0].thumbnailUrl: must be string',
+          'apps[0].screenshots: must be an array of strings',
+        ]),
+      );
+    }
+  });
+
+  it('rejects a screenshots array containing a non-string', () => {
+    const result = validateRegistry({
+      schemaVersion: 1,
+      apps: [{ ...validRegistry.apps[0], screenshots: ['https://apps.example.com/one.png', 7] }],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain('apps[0].screenshots: must be an array of strings');
+    }
+  });
 });
 
 describe('manualStepApplies', () => {

--- a/apps/backend/src/app-catalog/app-manifest.util.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.ts
@@ -269,6 +269,9 @@ export function validateAppManifest(
   if (json.summary !== undefined && typeof json.summary !== 'string') {
     errors.push('summary: must be string');
   }
+  if (json.category !== undefined && typeof json.category !== 'string') {
+    errors.push('category: must be string');
+  }
   if (json.iconUrl !== undefined && typeof json.iconUrl !== 'string') {
     errors.push('iconUrl: must be string');
   }
@@ -336,6 +339,25 @@ export function validateRegistry(
       }
       if (entry.summary !== undefined && typeof entry.summary !== 'string') {
         errors.push(`${path}.summary: must be string`);
+      }
+      // Store-presentation fields (added by the registry builder from
+      // apps/<app>/catalog/). Type-checked but never required: a registry
+      // that predates them, or an app without a catalog/ dir, is still valid.
+      if (entry.description !== undefined && typeof entry.description !== 'string') {
+        errors.push(`${path}.description: must be string`);
+      }
+      if (entry.category !== undefined && typeof entry.category !== 'string') {
+        errors.push(`${path}.category: must be string`);
+      }
+      if (entry.thumbnailUrl !== undefined && typeof entry.thumbnailUrl !== 'string') {
+        errors.push(`${path}.thumbnailUrl: must be string`);
+      }
+      if (entry.screenshots !== undefined) {
+        if (!Array.isArray(entry.screenshots)) {
+          errors.push(`${path}.screenshots: must be an array of strings`);
+        } else if (entry.screenshots.some((url) => typeof url !== 'string')) {
+          errors.push(`${path}.screenshots: must be an array of strings`);
+        }
       }
       if (entry.iconUrl !== undefined && typeof entry.iconUrl !== 'string') {
         errors.push(`${path}.iconUrl: must be string`);

--- a/apps/frontend/src/components/app-catalog/AppCard.tsx
+++ b/apps/frontend/src/components/app-catalog/AppCard.tsx
@@ -12,60 +12,26 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useToast } from '@/hooks/use-toast';
-import {
-  useUpdateAppMutation,
-  type CatalogEntry,
-  type GateResult,
-} from '@/services/appCatalogApi';
+import { useUpdateAppMutation, type CatalogEntry } from '@/services/appCatalogApi';
 import { UninstallDialog } from './UninstallDialog';
 import { EjectPanel } from './EjectPanel';
-import { ExternalLink, MoreVertical, HelpCircle } from 'lucide-react';
+import { GateBlockedCta } from './GateBlockedCta';
+import { RemoteImage } from './RemoteImage';
+import { hasAppDetails } from './catalogEntry';
+import { ExternalLink, MoreVertical } from 'lucide-react';
 
 interface AppCardProps {
   entry: CatalogEntry;
   /** Opens the install wizard dialog (Task 13/14) for this app. */
   onInstall: (entry: CatalogEntry) => void;
+  /** Opens the read-only details dialog (description + screenshots). */
+  onDetails: (entry: CatalogEntry) => void;
   /**
    * Fired once `useUpdateAppMutation` returns a jobId — the parent mounts
    * `InstallDialog` in `mode="update"` with that jobId so the update run
    * reuses the same Working/Done job-progress screens as install.
    */
   onUpdateStarted: (entry: CatalogEntry, jobId: string) => void;
-}
-
-/**
- * The disabled CTA a failing instance gate produces: the gate's own message
- * IS the button label, with its remediation behind a "Why?" popover. Shared
- * by the Install and Update CTAs — the same gates block both (an update
- * re-runs `instanceGates` server-side and would fail the job), so they must
- * present the blockage identically.
- */
-function GateBlockedCta({ gate }: { gate: GateResult }) {
-  return (
-    <>
-      <Button disabled aria-label={gate.message}>
-        {gate.message}
-      </Button>
-      {(gate.remediation || gate.deepLink) && (
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button variant="ghost" size="sm" aria-label="Why?">
-              <HelpCircle className="h-4 w-4 mr-1" />
-              Why?
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent>
-            {gate.remediation && <p className="text-sm">{gate.remediation}</p>}
-            {gate.deepLink && (
-              <a href={gate.deepLink} className="text-sm text-primary underline mt-2 inline-block">
-                Fix it now
-              </a>
-            )}
-          </PopoverContent>
-        </Popover>
-      )}
-    </>
-  );
 }
 
 /**
@@ -89,11 +55,16 @@ function GateBlockedCta({ gate }: { gate: GateResult }) {
  * `EjectPanel`) that each load their own preview/payload data; Update fires
  * `useUpdateAppMutation` here and hands the job off to the shared
  * `InstallDialog` (mounted by the page) for progress.
+ *
+ * Store metadata from the registry (ce#590) rides on top: a `thumbnailUrl`
+ * banner and a `category` badge here, with the long-form description and
+ * screenshots one click away in `AppDetailsDialog`.
  */
-export function AppCard({ entry, onInstall, onUpdateStarted }: AppCardProps) {
+export function AppCard({ entry, onInstall, onDetails, onUpdateStarted }: AppCardProps) {
   const { toast } = useToast();
   const { installed } = entry;
   const failedGate = entry.gates.find((gate) => gate.status === 'fail');
+  const showDetails = hasAppDetails(entry);
 
   const [updateApp, { isLoading: isUpdating }] = useUpdateAppMutation();
   const [updatePopoverOpen, setUpdatePopoverOpen] = useState(false);
@@ -114,12 +85,53 @@ export function AppCard({ entry, onInstall, onUpdateStarted }: AppCardProps) {
     }
   };
 
+  const banner = (
+    <div className="aspect-video w-full overflow-hidden bg-muted">
+      <RemoteImage
+        src={entry.thumbnailUrl}
+        alt=""
+        className="h-full w-full object-cover"
+        fallback={
+          <div
+            aria-hidden
+            className="flex h-full w-full items-center justify-center text-4xl font-semibold text-muted-foreground/40"
+          >
+            {entry.name.slice(0, 1)}
+          </div>
+        }
+      />
+    </div>
+  );
+
   return (
-    <Card className="flex flex-col">
+    <Card className="flex flex-col overflow-hidden">
+      {/*
+        The banner is unconditional so a grid row stays even — one card with a
+        thumbnail next to one without would otherwise be twice the height. An
+        app with no `thumbnailUrl` (or whose image this instance can't reach)
+        gets a monogram plate instead. It doubles as the details affordance
+        when there IS a details view; a clickable banner that opens nothing
+        would be worse than a plain one.
+      */}
+      {showDetails ? (
+        <button
+          type="button"
+          onClick={() => onDetails(entry)}
+          aria-label={`${entry.name} details`}
+          className="block w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+        >
+          {banner}
+        </button>
+      ) : (
+        banner
+      )}
+
       <CardHeader className="flex-row items-start gap-3 space-y-0">
-        {entry.iconUrl && (
-          <img src={entry.iconUrl} alt="" className="h-10 w-10 rounded-md object-cover" />
-        )}
+        <RemoteImage
+          src={entry.iconUrl}
+          alt=""
+          className="h-10 w-10 shrink-0 rounded-md object-cover"
+        />
         <div className="min-w-0">
           <h3 className="font-semibold leading-tight truncate">{entry.name}</h3>
           {entry.summary && (
@@ -129,12 +141,28 @@ export function AppCard({ entry, onInstall, onUpdateStarted }: AppCardProps) {
       </CardHeader>
 
       <CardContent className="flex-1">
-        {installed && (
-          <Badge variant="secondary">{`Installed · v${installed.version}`}</Badge>
-        )}
+        <div className="flex flex-wrap items-center gap-2">
+          {entry.category && (
+            <Badge variant="outline" className="capitalize">
+              {entry.category}
+            </Badge>
+          )}
+          {installed && <Badge variant="secondary">{`Installed · v${installed.version}`}</Badge>}
+        </div>
       </CardContent>
 
       <CardFooter className="flex flex-wrap items-center gap-2">
+        {/*
+          Rendered first so it's the footer's tab stop before the primary CTA:
+          reading about an app should come before committing to installing it.
+          Also the only details affordance when the app has no thumbnail.
+        */}
+        {showDetails && (
+          <Button variant="ghost" size="sm" onClick={() => onDetails(entry)}>
+            Details
+          </Button>
+        )}
+
         {!installed && !failedGate && (
           <Button disabled={!entry.installable} onClick={() => onInstall(entry)}>
             Install

--- a/apps/frontend/src/components/app-catalog/AppDetailsDialog.tsx
+++ b/apps/frontend/src/components/app-catalog/AppDetailsDialog.tsx
@@ -1,0 +1,156 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { RemoteImage } from './RemoteImage';
+import { GateBlockedCta } from './GateBlockedCta';
+import type { CatalogEntry } from '@/services/appCatalogApi';
+import { ExternalLink } from 'lucide-react';
+
+interface AppDetailsDialogProps {
+  entry: CatalogEntry;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Hands off to the install wizard — the page swaps this dialog for it. */
+  onInstall: (entry: CatalogEntry) => void;
+}
+
+/**
+ * AppDetailsDialog — the read-before-you-install view for a catalog entry
+ * (ce#590). Renders the store metadata `registry.json` carries but the grid
+ * tile has no room for: the markdown `description`, the `screenshots[]`
+ * gallery, and the docs/source links, with the same Install CTA (and the same
+ * gate blocking) as the card so the operator never has to back out to act.
+ *
+ * The description is third-party markdown from whatever registry the instance
+ * points at, so it goes through `react-markdown` WITHOUT `rehype-raw` — raw
+ * HTML stays inert, and react-markdown's default URL transform already drops
+ * `javascript:` hrefs. Don't add `rehype-raw` here.
+ */
+export function AppDetailsDialog({ entry, open, onOpenChange, onInstall }: AppDetailsDialogProps) {
+  const { installed } = entry;
+  const failedGate = entry.gates.find((gate) => gate.status === 'fail');
+  const screenshots = entry.screenshots ?? [];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {/*
+        Flex column rather than the house "whole dialog scrolls" pattern: a
+        store description can run for screens, and the Install CTA must not
+        drift below the fold. Only the middle band scrolls.
+      */}
+      <DialogContent className="flex max-h-[85vh] max-w-2xl flex-col">
+        <DialogHeader>
+          <div className="flex items-start gap-3 text-left">
+            <RemoteImage
+              src={entry.iconUrl}
+              alt=""
+              className="h-12 w-12 shrink-0 rounded-md object-cover"
+            />
+            <div className="min-w-0">
+              <DialogTitle>{entry.name}</DialogTitle>
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                {entry.registryVersion && (
+                  <span className="text-xs text-muted-foreground">v{entry.registryVersion}</span>
+                )}
+                {entry.category && (
+                  <Badge variant="outline" className="capitalize">
+                    {entry.category}
+                  </Badge>
+                )}
+                {installed && <Badge variant="secondary">{`Installed · v${installed.version}`}</Badge>}
+              </div>
+            </div>
+          </div>
+          {entry.summary && (
+            <DialogDescription className="text-left pt-1">{entry.summary}</DialogDescription>
+          )}
+        </DialogHeader>
+
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto">
+          {screenshots.length > 0 && (
+            <div className="grid gap-3 sm:grid-cols-2">
+              {screenshots.map((src) => (
+                <RemoteImage
+                  key={src}
+                  src={src}
+                  alt={`${entry.name} screenshot`}
+                  className="w-full rounded-md border object-cover"
+                />
+              ))}
+            </div>
+          )}
+
+          {entry.description && (
+            <article
+              className="markdown-body prose prose-sm dark:prose-invert max-w-none
+                prose-headings:font-semibold
+                prose-a:text-primary prose-a:no-underline hover:prose-a:underline
+                prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:font-normal prose-code:before:content-none prose-code:after:content-none
+                prose-pre:bg-muted prose-pre:border prose-pre:text-foreground
+                prose-img:rounded prose-hr:border-border"
+            >
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{entry.description}</ReactMarkdown>
+            </article>
+          )}
+
+          {(entry.docsUrl || entry.sourceUrl) && (
+            <div className="flex flex-wrap gap-4 text-sm">
+              {entry.docsUrl && (
+                <a
+                  href={entry.docsUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  Documentation
+                </a>
+              )}
+              {entry.sourceUrl && (
+                <a
+                  href={entry.sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  Source code
+                </a>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+
+          {!installed && failedGate && <GateBlockedCta gate={failedGate} />}
+
+          {!installed && !failedGate && (
+            <Button disabled={!entry.installable} onClick={() => onInstall(entry)}>
+              Install
+            </Button>
+          )}
+
+          {installed?.appUrl && (
+            <Button asChild>
+              <a href={installed.appUrl} target="_blank" rel="noopener noreferrer">
+                Open
+                <ExternalLink className="h-4 w-4 ml-1" />
+              </a>
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/app-catalog/GateBlockedCta.tsx
+++ b/apps/frontend/src/components/app-catalog/GateBlockedCta.tsx
@@ -1,0 +1,39 @@
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { HelpCircle } from 'lucide-react';
+import type { GateResult } from '@/services/appCatalogApi';
+
+/**
+ * The disabled CTA a failing instance gate produces: the gate's own message
+ * IS the button label, with its remediation behind a "Why?" popover. Shared
+ * by the card's Install and Update CTAs and by the details dialog — the same
+ * gates block all of them (an update re-runs `instanceGates` server-side and
+ * would fail the job), so they must present the blockage identically.
+ */
+export function GateBlockedCta({ gate }: { gate: GateResult }) {
+  return (
+    <>
+      <Button disabled aria-label={gate.message}>
+        {gate.message}
+      </Button>
+      {(gate.remediation || gate.deepLink) && (
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="ghost" size="sm" aria-label="Why?">
+              <HelpCircle className="h-4 w-4 mr-1" />
+              Why?
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent>
+            {gate.remediation && <p className="text-sm">{gate.remediation}</p>}
+            {gate.deepLink && (
+              <a href={gate.deepLink} className="text-sm text-primary underline mt-2 inline-block">
+                Fix it now
+              </a>
+            )}
+          </PopoverContent>
+        </Popover>
+      )}
+    </>
+  );
+}

--- a/apps/frontend/src/components/app-catalog/RemoteImage.tsx
+++ b/apps/frontend/src/components/app-catalog/RemoteImage.tsx
@@ -1,0 +1,38 @@
+import { useState, type ReactNode } from 'react';
+
+interface RemoteImageProps {
+  /** Absent renders the fallback straight away — no <img> is mounted. */
+  src?: string;
+  alt: string;
+  className?: string;
+  /** Rendered when `src` is absent or the image fails to load. */
+  fallback?: ReactNode;
+}
+
+/**
+ * An `<img>` for a URL this instance may not be able to reach.
+ *
+ * Catalog imagery (icon, thumbnail, screenshots) is hosted on the registry's
+ * origin — apps.bffless.dev by default — so a self-hosted CE behind strict
+ * egress, or one pointed at a registry whose assets have moved, simply can't
+ * load it. The rule (same as `components/setup/onboarding/WelcomeStep.tsx`)
+ * is that a broken-image icon must never reach the operator: fall back to
+ * whatever the caller supplies, usually nothing at all.
+ */
+export function RemoteImage({ src, alt, className, fallback = null }: RemoteImageProps) {
+  // Keyed by URL rather than a bare boolean so a re-render with a different
+  // src (a catalog refetch after an app updates its assets) gets a fresh try.
+  const [failedSrc, setFailedSrc] = useState<string | undefined>(undefined);
+
+  if (!src || failedSrc === src) return <>{fallback}</>;
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      loading="lazy"
+      onError={() => setFailedSrc(src)}
+      className={className}
+    />
+  );
+}

--- a/apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
@@ -34,7 +34,7 @@ beforeEach(() => {
 
 describe('AppCard', () => {
   it('renders an enabled Install button when installable', () => {
-    render(<AppCard entry={baseEntry} onInstall={vi.fn()} onUpdateStarted={vi.fn()} />);
+    render(<AppCard entry={baseEntry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />);
 
     const button = screen.getByRole('button', { name: /install/i });
     expect(button).toBeEnabled();
@@ -55,7 +55,7 @@ describe('AppCard', () => {
       ],
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} onUpdateStarted={vi.fn()} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />);
 
     expect(screen.getByText('Requires bucket storage')).toBeInTheDocument();
     const button = screen.getByRole('button', { name: /requires bucket storage/i });
@@ -80,7 +80,7 @@ describe('AppCard', () => {
       },
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} onUpdateStarted={vi.fn()} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />);
 
     expect(screen.getByText('Installed · v1.2.0')).toBeInTheDocument();
     const openLink = screen.getByRole('link', { name: /open/i });
@@ -105,7 +105,7 @@ describe('AppCard', () => {
       },
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} onUpdateStarted={vi.fn()} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />);
 
     expect(screen.getByRole('button', { name: /update to v2\.0\.0/i })).toBeInTheDocument();
   });
@@ -139,7 +139,7 @@ describe('AppCard', () => {
       },
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} onUpdateStarted={vi.fn()} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />);
 
     expect(screen.queryByRole('button', { name: /update to v2\.0\.0/i })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /requires ce v0\.4\.0 or later/i })).toBeDisabled();
@@ -166,7 +166,7 @@ describe('AppCard', () => {
       },
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} onUpdateStarted={onUpdateStarted} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={onUpdateStarted} />);
 
     fireEvent.click(screen.getByRole('button', { name: /update to v2\.0\.0/i }));
 
@@ -179,6 +179,50 @@ describe('AppCard', () => {
     await vi.waitFor(() => {
       expect(onUpdateStarted).toHaveBeenCalledWith(entry, 'job-1');
     });
+  });
+
+  it('renders the registry thumbnail and category badge', () => {
+    const entry: CatalogEntry = {
+      ...baseEntry,
+      category: 'files',
+      thumbnailUrl: 'https://apps.example.com/assets/handoff/thumbnail.png',
+    };
+
+    const { container } = render(
+      <AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />,
+    );
+
+    expect(screen.getByText('files')).toBeInTheDocument();
+    expect(container.querySelector(`img[src="${entry.thumbnailUrl}"]`)).toBeInTheDocument();
+  });
+
+  it('offers no Details affordance when the entry carries no store metadata', () => {
+    // A de-listed installed app renders from its stored manifest, which never
+    // carries description/screenshots — a Details button would open nothing.
+    render(
+      <AppCard entry={baseEntry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />,
+    );
+
+    expect(screen.queryByRole('button', { name: /^details$/i })).not.toBeInTheDocument();
+  });
+
+  it('opens details from the footer button and from the thumbnail', () => {
+    const onDetails = vi.fn();
+    const entry: CatalogEntry = {
+      ...baseEntry,
+      description: '## Handoff\n\nShare files.',
+      thumbnailUrl: 'https://apps.example.com/assets/handoff/thumbnail.png',
+    };
+
+    render(
+      <AppCard entry={entry} onInstall={vi.fn()} onDetails={onDetails} onUpdateStarted={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^details$/i }));
+    expect(onDetails).toHaveBeenCalledWith(entry);
+
+    fireEvent.click(screen.getByRole('button', { name: /handoff details/i }));
+    expect(onDetails).toHaveBeenCalledTimes(2);
   });
 
   it('fires the update with prune: true when the toggle is switched on', async () => {
@@ -200,7 +244,7 @@ describe('AppCard', () => {
       },
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} onUpdateStarted={onUpdateStarted} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={onUpdateStarted} />);
 
     fireEvent.click(screen.getByRole('button', { name: /update to v2\.0\.0/i }));
     fireEvent.click(screen.getByRole('switch', { name: /reset to the app's shipped rules \(prune\)/i }));

--- a/apps/frontend/src/components/app-catalog/__tests__/AppDetailsDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/AppDetailsDialog.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { AppDetailsDialog } from '../AppDetailsDialog';
+import { hasAppDetails } from '../catalogEntry';
+import type { CatalogEntry } from '@/services/appCatalogApi';
+
+const baseEntry: CatalogEntry = {
+  id: 'handoff',
+  name: 'Handoff',
+  summary: 'Share files with clients',
+  category: 'files',
+  registryVersion: '1.0.0',
+  description: '## Highlights\n\n- **Per-folder access control**\n- Share links\n',
+  screenshots: [
+    'https://apps.example.com/assets/handoff/screenshots/01.png',
+    'https://apps.example.com/assets/handoff/screenshots/02.png',
+  ],
+  docsUrl: 'https://example.com/docs',
+  sourceUrl: 'https://github.com/bffless/apps',
+  gates: [],
+  installable: true,
+};
+
+describe('hasAppDetails', () => {
+  it('is true when there is a description or screenshots, false otherwise', () => {
+    expect(hasAppDetails(baseEntry)).toBe(true);
+    expect(hasAppDetails({ ...baseEntry, description: undefined })).toBe(true);
+    expect(hasAppDetails({ ...baseEntry, screenshots: [] })).toBe(true);
+    expect(hasAppDetails({ ...baseEntry, description: undefined, screenshots: [] })).toBe(false);
+  });
+});
+
+describe('AppDetailsDialog', () => {
+  it('renders the markdown description, screenshots, category and links', () => {
+    const { container } = render(
+      <AppDetailsDialog
+        entry={baseEntry}
+        open
+        onOpenChange={vi.fn()}
+        onInstall={vi.fn()}
+      />,
+    );
+
+    // Markdown is rendered as markup, not printed as source.
+    expect(screen.getByRole('heading', { name: 'Highlights' })).toBeInTheDocument();
+    expect(screen.getByText('Per-folder access control')).toBeInTheDocument();
+    expect(screen.queryByText(/^## Highlights/)).not.toBeInTheDocument();
+
+    expect(screen.getAllByAltText('Handoff screenshot')).toHaveLength(2);
+    expect(screen.getByText('files')).toBeInTheDocument();
+    expect(screen.getByText('v1.0.0')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /documentation/i })).toHaveAttribute(
+      'href',
+      'https://example.com/docs',
+    );
+    expect(container.querySelector('script')).toBeNull();
+  });
+
+  it('does not render raw HTML embedded in the description', () => {
+    // The description comes from whatever registry the instance points at —
+    // react-markdown must stay without rehype-raw so HTML stays inert text.
+    render(
+      <AppDetailsDialog
+        entry={{ ...baseEntry, description: '<img src="x" onerror="alert(1)">hello' }}
+        open
+        onOpenChange={vi.fn()}
+        onInstall={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByAltText('')).toBeNull();
+    expect(screen.getByText(/hello/)).toBeInTheDocument();
+  });
+
+  it('hands off to the install wizard when Install is clicked', () => {
+    const onInstall = vi.fn();
+    render(
+      <AppDetailsDialog entry={baseEntry} open onOpenChange={vi.fn()} onInstall={onInstall} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+    expect(onInstall).toHaveBeenCalledWith(baseEntry);
+  });
+
+  it('blocks Install behind a failing instance gate', () => {
+    const entry: CatalogEntry = {
+      ...baseEntry,
+      installable: false,
+      gates: [
+        {
+          id: 'storage',
+          status: 'fail',
+          message: 'Requires bucket storage',
+          remediation: 'Switch to S3/MinIO/GCS/Azure storage in Admin Settings.',
+        },
+      ],
+    };
+
+    render(<AppDetailsDialog entry={entry} open onOpenChange={vi.fn()} onInstall={vi.fn()} />);
+
+    expect(screen.queryByRole('button', { name: /^install$/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /requires bucket storage/i })).toBeDisabled();
+  });
+
+  it('shows Open instead of Install for an installed app', () => {
+    const entry: CatalogEntry = {
+      ...baseEntry,
+      installed: {
+        installedAppId: 'installed-1',
+        version: '1.0.0',
+        projectId: 'proj-1',
+        projectName: 'acme/handoff',
+        alias: 'production',
+        appUrl: 'https://handoff.example.com',
+        status: 'installed',
+        updateAvailable: false,
+        manualSteps: [],
+        manualStepsAcked: [],
+      },
+    };
+
+    render(<AppDetailsDialog entry={entry} open onOpenChange={vi.fn()} onInstall={vi.fn()} />);
+
+    expect(screen.queryByRole('button', { name: /^install$/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /open/i })).toHaveAttribute(
+      'href',
+      'https://handoff.example.com',
+    );
+    expect(screen.getByText('Installed · v1.0.0')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/app-catalog/catalogEntry.ts
+++ b/apps/frontend/src/components/app-catalog/catalogEntry.ts
@@ -1,0 +1,12 @@
+import type { CatalogEntry } from '@/services/appCatalogApi';
+
+/**
+ * True when the registry gave this app enough store metadata to be worth a
+ * details view. Shared so `AppCard` renders its "Details" affordance under
+ * exactly the same condition `AppDetailsDialog` would render content for — an
+ * app with neither a description nor screenshots (a de-listed installed app,
+ * or one published without a `catalog/` dir) gets no dead-end button.
+ */
+export function hasAppDetails(entry: CatalogEntry): boolean {
+  return Boolean(entry.description || entry.screenshots?.length);
+}

--- a/apps/frontend/src/pages/AppsPage.test.tsx
+++ b/apps/frontend/src/pages/AppsPage.test.tsx
@@ -101,6 +101,44 @@ beforeEach(() => {
   getInstallJobQueryMock.mockReset().mockImplementation(() => jobQueryResult);
 });
 
+describe('AppsPage — details dialog', () => {
+  it('opens details from a card and swaps to the install wizard on Install', async () => {
+    catalogResult = {
+      data: {
+        data: [
+          {
+            id: 'handoff',
+            name: 'Handoff',
+            summary: 'Share files with clients',
+            description: '## Highlights\n\n- Per-folder access control',
+            category: 'files',
+            screenshots: ['https://apps.example.com/assets/handoff/screenshots/01.png'],
+            gates: [],
+            installable: true,
+            registryVersion: '1.0.0',
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    };
+
+    render(<AppsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^details$/i }));
+    expect(await screen.findByRole('heading', { name: 'Highlights' })).toBeInTheDocument();
+    expect(screen.getByAltText('Handoff screenshot')).toBeInTheDocument();
+
+    // Only one modal at a time: details closes, the install wizard opens.
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: 'Highlights' })).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(/review what will change/i)).toBeInTheDocument();
+  });
+});
+
 describe('AppsPage — Done-screen ack checkbox stays live (regression)', () => {
   it('re-derives the InstallDialog entry from the current catalog query, so acking a manual step checks the box once the catalog refetches', async () => {
     const { rerender } = render(<AppsPage />);

--- a/apps/frontend/src/pages/AppsPage.tsx
+++ b/apps/frontend/src/pages/AppsPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { AppCard } from '@/components/app-catalog/AppCard';
+import { AppDetailsDialog } from '@/components/app-catalog/AppDetailsDialog';
 import { InstallDialog } from '@/components/app-catalog/InstallDialog';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -25,6 +26,7 @@ export function AppsPage() {
   // and a stale snapshot here would never pick that up (the Done screen's
   // ack checkboxes would appear permanently unchecked/disabled).
   const [installTargetSnapshot, setInstallTargetSnapshot] = useState<CatalogEntry | null>(null);
+  const [detailsTargetSnapshot, setDetailsTargetSnapshot] = useState<CatalogEntry | null>(null);
   const [updateTargetSnapshot, setUpdateTargetSnapshot] = useState<{
     entry: CatalogEntry;
     jobId: string;
@@ -34,6 +36,9 @@ export function AppsPage() {
 
   const installTarget = installTargetSnapshot
     ? (entries.find((e) => e.id === installTargetSnapshot.id) ?? installTargetSnapshot)
+    : null;
+  const detailsTarget = detailsTargetSnapshot
+    ? (entries.find((e) => e.id === detailsTargetSnapshot.id) ?? detailsTargetSnapshot)
     : null;
   const updateTarget = updateTargetSnapshot
     ? {
@@ -72,9 +77,9 @@ export function AppsPage() {
 
       {isLoading && (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          <Skeleton className="h-48 w-full" />
-          <Skeleton className="h-48 w-full" />
-          <Skeleton className="h-48 w-full" />
+          <Skeleton className="h-64 w-full" />
+          <Skeleton className="h-64 w-full" />
+          <Skeleton className="h-64 w-full" />
         </div>
       )}
 
@@ -106,12 +111,27 @@ export function AppsPage() {
               key={entry.id}
               entry={entry}
               onInstall={setInstallTargetSnapshot}
+              onDetails={setDetailsTargetSnapshot}
               onUpdateStarted={(updatedEntry, jobId) =>
                 setUpdateTargetSnapshot({ entry: updatedEntry, jobId })
               }
             />
           ))}
         </div>
+      )}
+
+      {detailsTarget && (
+        <AppDetailsDialog
+          entry={detailsTarget}
+          open={detailsTarget !== null}
+          onOpenChange={(open) => !open && setDetailsTargetSnapshot(null)}
+          // Hand off rather than stack: the details dialog closes and the
+          // install wizard takes its place, so there's only ever one modal.
+          onInstall={(entry) => {
+            setDetailsTargetSnapshot(null);
+            setInstallTargetSnapshot(entry);
+          }}
+        />
       )}
 
       {installTarget && (

--- a/apps/frontend/src/services/appCatalogApi.ts
+++ b/apps/frontend/src/services/appCatalogApi.ts
@@ -55,7 +55,17 @@ export interface CatalogEntry {
   id: string;
   name: string;
   summary?: string;
+  /**
+   * Long-form markdown blurb for the details dialog. Registry-only — an
+   * installed app that has dropped out of the registry has none.
+   */
+  description?: string;
+  category?: string;
   iconUrl?: string;
+  /** Wide card image for the catalog grid. Registry-only. */
+  thumbnailUrl?: string;
+  /** Absolute https URLs, already ordered by the registry. Registry-only. */
+  screenshots?: string[];
   docsUrl?: string;
   sourceUrl?: string;
   /** Absent when the registry is unavailable, or this app isn't (or no longer) listed in it. */


### PR DESCRIPTION
Closes #590.

`registry.json` entries have carried `description` (markdown), `category`, `thumbnailUrl`, `iconUrl` and `screenshots[]` since bffless/apps#273. They validated and cached fine on CE — but `buildRegistryEntry` copies field by field, so none of the new ones ever reached the frontend. This wires them end to end.

## Backend

- `AppRegistryEntry` gains `description`, `category`, `thumbnailUrl`, `screenshots[]`; `AppManifest` gains `category` (that's where it originates — the registry builder reads it from `bffless-app.json`, so a de-listed installed app keeps its badge).
- `validateRegistry` type-checks all four, including array-of-strings for `screenshots`. Everything stays optional, so registries that predate the fields are still valid — no `schemaVersion` bump.
- `CatalogEntry` and both catalog builders pass them through. `description`/`thumbnailUrl`/`screenshots` are registry-only (they're folded in from `apps/<app>/catalog/` and never travel in the bundled manifest), so a de-listed app renders from its manifest without them.

## Frontend

- **`AppCard`** — 16:9 thumbnail banner and a category badge. The banner is *unconditional*, falling back to a monogram plate, so a grid row can't end up half tall cards and half short ones. It doubles as the details affordance when there's a details view to open.
- **`AppDetailsDialog`** (new) — the read-before-you-install view: screenshots gallery, markdown description, docs/source links, and the same Install CTA with the same gate blocking as the card. Header and footer are pinned and only the middle band scrolls, so Install can't drift below a long description. Clicking Install hands off to the existing wizard — one modal at a time, never stacked.
- **`RemoteImage`** (new) — catalog imagery lives on the registry's origin (apps.bffless.dev by default), so a CE behind strict egress simply can't fetch it. Same rule as `WelcomeStep`: render a fallback, never a broken-image icon.
- **`GateBlockedCta`** moved out of `AppCard` into its own file so the card and the dialog present a failing gate identically.

### Security note

The description is third-party markdown from whatever registry the instance points at. It renders through `react-markdown` **without** `rehype-raw`, so raw HTML stays inert and the default URL transform drops `javascript:` hrefs. There's a test pinning that; please keep `rehype-raw` out of this path.

## Verification

- Frontend: 831/831 vitest pass (5 new specs across `AppCard`, `AppDetailsDialog`, `AppsPage`).
- Backend: 2785 pass / 37 skipped (new `validateRegistry` accept + reject cases, and a passthrough assertion that catches the field-by-field copy dropping a field).
- `tsc --noEmit` clean both apps; eslint clean on the changed files.
- Rendered the components against the live `apps.bffless.dev` handoff assets in headless Chromium and checked light, dark, and mobile. Two fixes came out of that pass: ragged grid rows when an app had no thumbnail, and the Install CTA sitting below the fold on a long description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
