### PR TITLE
fix(traffic): never enforce a half-loaded Blocklist (#607)

### DIFF
--- a/apps/backend/src/domains/edge-blocklist.service.spec.ts
+++ b/apps/backend/src/domains/edge-blocklist.service.spec.ts
@@ -76,8 +76,64 @@ describe('EdgeBlocklistService', () => {
         cb(error);
       },
     );
+    // No rules were applied before and none after, so there is nothing for a
+    // caller to regenerate — sync() reports the APPLIED delta, not the
+    // intended one (#607).
+    await expect(service.sync()).resolves.toBe(false);
+    expect(service.getServerRules('444')).toBe('');
+  });
+
+  it('reports a change when a rollback REMOVES rules that were applied', async () => {
+    await service.sync();
+    expect(service.getServerRules('444')).not.toBe('');
+
+    state = { ...state, blockSource: '(?:^/wp\\-admin|^/new)' };
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: (err: unknown) => void) => {
+      const error = new Error('nginx: configuration file test failed') as Error & { stderr: string };
+      error.stderr = 'nginx: [emerg] invalid regex';
+      cb(error);
+    });
+    // Configs still carry the old rules; they must be rewritten without them.
     await expect(service.sync()).resolves.toBe(true);
     expect(service.getServerRules('444')).toBe('');
+  });
+
+  it('retries a rolled-back pair instead of latching on the fingerprint (#607)', async () => {
+    // Regression: sync() recorded the fingerprint of the state it had just
+    // ROLLED BACK, so every later sync short-circuited on it and the edge
+    // rules stayed missing until a blocklist mutation changed the
+    // fingerprint. One transient `nginx -t` failure during an upgrade was
+    // enough to disable edge enforcement permanently.
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: (err: unknown) => void) => {
+      const error = new Error('nginx: configuration file test failed') as Error & { stderr: string };
+      error.stderr = 'nginx: [emerg] invalid regex';
+      cb(error);
+    });
+    await service.sync();
+    expect(service.getServerRules('444')).toBe('');
+
+    // Same compiled state, nginx healthy again: must re-validate and apply.
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], cb: (err: unknown, out?: unknown) => void) =>
+        cb(null, { stdout: '', stderr: '' }),
+    );
+    await expect(service.sync()).resolves.toBe(true);
+    expect(service.getServerRules('444')).toContain('^/wp\\-admin');
+  });
+
+  it('reports no change while a rolled-back pair keeps failing', async () => {
+    // Retrying is right; rewriting every nginx config every 30s is not.
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: (err: unknown) => void) => {
+      const error = new Error('nginx: configuration file test failed') as Error & { stderr: string };
+      error.stderr = 'nginx: [emerg] invalid regex';
+      cb(error);
+    });
+    await service.sync();
+    mockExecFile.mockClear();
+
+    await expect(service.sync()).resolves.toBe(false);
+    expect(mockExecFile).toHaveBeenCalled(); // re-validated…
+    expect(service.getServerRules('444')).toBe(''); // …but nothing changed.
   });
 
   it('accepts rules when only the sandbox environment fails (nginx reported syntax ok)', async () => {

--- a/apps/backend/src/domains/edge-blocklist.service.ts
+++ b/apps/backend/src/domains/edge-blocklist.service.ts
@@ -43,6 +43,14 @@ export class EdgeBlocklistService {
   private readonly logger = new Logger(EdgeBlocklistService.name);
 
   private fingerprint: string | null = null;
+  /**
+   * True when the last sync rolled at least one pair back to "no edge rules".
+   * The fingerprint then describes a state we did NOT apply, so it must not be
+   * allowed to short-circuit the next sync — otherwise one transient
+   * validation failure (an `nginx -t` during an upgrade, say) latches
+   * permanently and only a blocklist mutation can ever dislodge it (#607).
+   */
+  private degraded = false;
   private defaultSources: EdgeRuleSources = { blockSource: null, allowSource: null };
   /** Per-domain validated sources, only for domains that differ from the default. */
   private domainSources = new Map<string, EdgeRuleSources>();
@@ -66,20 +74,30 @@ export class EdgeBlocklistService {
       .sort()
       .join(';');
     const fingerprint = `${state.enabled}|${pairKey(state)}|${domainPart}`;
-    if (fingerprint === this.fingerprint) {
+    if (fingerprint === this.fingerprint && !this.degraded) {
       return false;
     }
+
+    /** Key of what is CURRENTLY applied, to tell a real change from a retry. */
+    const appliedKey = (): string =>
+      `${pairKey(this.defaultSources)}|${[...this.domainSources.entries()]
+        .map(([id, s]) => `${id}=${pairKey(s)}`)
+        .sort()
+        .join(';')}`;
+    const appliedBefore = appliedKey();
 
     // Disabled: edge rules are simply omitted everywhere.
     if (!state.enabled) {
       this.defaultSources = { blockSource: null, allowSource: null };
       this.domainSources = new Map();
       this.fingerprint = fingerprint;
+      this.degraded = false;
       return true;
     }
 
     // Validate each DISTINCT pair once — most domains share the default set.
     const validated = new Map<string, EdgeRuleSources>();
+    let rolledBack = false;
     const validatePair = async (pair: EdgeRuleSources): Promise<EdgeRuleSources> => {
       const key = pairKey(pair);
       const cached = validated.get(key);
@@ -93,9 +111,10 @@ export class EdgeBlocklistService {
         if (!valid) {
           this.logger.error(
             'Generated edge blocklist rules failed validation; omitting edge rules ' +
-              '(app-side enforcement still applies)',
+              '(app-side enforcement still applies, and the next sync will retry)',
           );
           result = { blockSource: null, allowSource: null };
+          rolledBack = true;
         }
       }
       validated.set(key, result);
@@ -109,7 +128,12 @@ export class EdgeBlocklistService {
     }
     this.domainSources = domainSources;
     this.fingerprint = fingerprint;
-    return true;
+    this.degraded = rolledBack;
+    // A rolled-back retry that produced the same (empty) rules is not a
+    // change: reporting one would rewrite every config every 30s for as long
+    // as validation keeps failing. Recovery — or any genuine state change —
+    // still reports true.
+    return !rolledBack || appliedKey() !== appliedBefore;
   }
 
   /**

--- a/apps/backend/src/domains/nginx-startup.service.ts
+++ b/apps/backend/src/domains/nginx-startup.service.ts
@@ -23,6 +23,13 @@ import { BlocklistService } from '../traffic/blocklist.service';
 const BLOCKLIST_REGEN_DEBOUNCE_MS = 1_500;
 
 /**
+ * How long startup waits for the Blocklist to load real database state before
+ * generating configs anyway. Generated configs are durable artifacts, so this
+ * is a correctness gate, not a nicety (#607).
+ */
+const BLOCKLIST_LOAD_WAIT_MS = 15_000;
+
+/**
  * Service that regenerates all nginx configs on backend startup.
  * This ensures any template changes are applied automatically without
  * requiring manual domain remapping.
@@ -57,8 +64,20 @@ export class NginxStartupService implements OnModuleInit {
     // single admin save can land as several mutations.
     this.blocklistService.onEffectiveChange(() => this.scheduleBlocklistRegen());
 
-    // Wait a bit for database connections to stabilize
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    // Gate on the Blocklist having loaded real database state rather than
+    // sleeping and hoping (#607). Every ./update.sh restarts postgres
+    // alongside the backend, and a config generated during that race used to
+    // bake in Baseline blocks without the allowlist entries that rescue them
+    // — 444'ing paths the operator had explicitly allowed until someone
+    // edited a list by hand. This also subsumes the old "wait for database
+    // connections to stabilize" sleep: a successful load IS that signal.
+    const loaded = await this.blocklistService.whenFirstLoad(BLOCKLIST_LOAD_WAIT_MS);
+    if (!loaded) {
+      this.logger.warn(
+        `Blocklist state still unloaded after ${BLOCKLIST_LOAD_WAIT_MS}ms; generating configs ` +
+          'without edge blocklist rules — the first successful refresh will regenerate them',
+      );
+    }
 
     try {
       await this.regenerateAllConfigs();
@@ -139,7 +158,9 @@ export class NginxStartupService implements OnModuleInit {
 
     // Pull (and validate) the current edge Blocklist rules before any config
     // is generated (#392). BlocklistService loaded its state during
-    // TrafficModule init, which precedes this module's.
+    // TrafficModule init, which precedes this module's; onModuleInit above
+    // additionally waits for that load to have actually reached the database,
+    // so what gets rendered here is never a half-loaded state (#607).
     await this.edgeBlocklistService.sync();
 
     // 0. Clean up orphaned config files (from previous installs or deleted mappings)

--- a/apps/backend/src/traffic/blocklist.service.spec.ts
+++ b/apps/backend/src/traffic/blocklist.service.spec.ts
@@ -82,9 +82,14 @@ describe('BlocklistService', () => {
   });
 
   describe('enforcement state (refresh + shouldBlock)', () => {
-    it('enforces the Baseline before any refresh (protected by default)', () => {
-      expect(service.shouldBlock('/wp-login.php')).toBe(true);
+    it('enforces nothing before the first successful load (#607)', () => {
+      // The Baseline alone is only half the operator's intent — the allowlist
+      // that qualifies it is database-only — so enforcing it unloaded blocks
+      // paths the operator explicitly allowed. Hold off instead.
+      expect(service.isLoaded()).toBe(false);
+      expect(service.shouldBlock('/wp-login.php')).toBe(false);
       expect(service.shouldBlock('/index.html')).toBe(false);
+      expect(service.getCompiledState().enabled).toBe(false);
     });
 
     it('after refresh with the toggle on, Baseline + list patterns block and allowlists win', async () => {
@@ -124,7 +129,12 @@ describe('BlocklistService', () => {
       expect(service.shouldBlock('/.env')).toBe(true);
     });
 
-    it('falls back to Baseline-only enforcement when the lists cannot load', async () => {
+    it('does not compile a half-loaded state when the lists cannot load (#607)', async () => {
+      // Regression: the fallback used to compile `lists = []` into a live
+      // matcher — fail-closed for Baseline blocks, fail-open for the allowlist
+      // that rescues them. On a self-hosted box that 444'd `/install.sh`
+      // (Baseline `extension('sh')`) after every ./update.sh, even though the
+      // admin had `exact:/install.sh` allowlisted.
       const failure = {
         then: (_resolve: unknown, reject: (reason: unknown) => void) =>
           reject(new Error('relation does not exist')),
@@ -132,7 +142,83 @@ describe('BlocklistService', () => {
       mockDb.orderBy.mockImplementationOnce(() => failure);
       await service.refresh();
 
+      expect(service.isLoaded()).toBe(false);
+      expect(service.shouldBlock('/install.sh')).toBe(false);
+      expect(service.shouldBlock('/.env')).toBe(false);
+      // Nothing may reach the edge either, or nginx bakes in the same asymmetry.
+      expect(service.getCompiledState().enabled).toBe(false);
+    });
+
+    it('keeps the previous allowlist when a later DB read fails (#607)', async () => {
+      mockDb.__queue([listRow()]); // listBlocklists: lists
+      mockDb.__queue([
+        entryRow({ id: 'e2', kind: 'allow', matchType: 'exact', value: '/install.sh' }),
+      ]);
+      mockDb.__queue([]); // attachments
+      mockDb.__queue([]); // domain mappings
+      await service.refresh();
+      expect(service.shouldBlock('/install.sh')).toBe(false);
       expect(service.shouldBlock('/.env')).toBe(true);
+
+      const failure = {
+        then: (_resolve: unknown, reject: (reason: unknown) => void) =>
+          reject(new Error('connection terminated')),
+      };
+      mockDb.orderBy.mockImplementationOnce(() => failure);
+      await service.refresh();
+
+      // Last good state stands — NOT recompiled to Baseline-without-allowlist.
+      expect(service.shouldBlock('/install.sh')).toBe(false);
+      expect(service.shouldBlock('/.env')).toBe(true);
+    });
+
+    it('notifies on the first successful refresh after a degraded read (#607)', async () => {
+      const listener = jest.fn();
+      service.onEffectiveChange(listener);
+
+      const failure = {
+        then: (_resolve: unknown, reject: (reason: unknown) => void) =>
+          reject(new Error('relation does not exist')),
+      };
+      mockDb.orderBy.mockImplementationOnce(() => failure);
+      await service.refresh();
+      expect(listener).not.toHaveBeenCalled();
+
+      mockDb.__queue([listRow()]);
+      mockDb.__queue([entryRow()]);
+      mockDb.__queue([]); // attachments
+      mockDb.__queue([]); // domain mappings
+      await service.refresh();
+
+      // lastFingerprint is still null here, so only the failure flag can carry
+      // the notification that startup-rendered configs need regenerating.
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(service.isLoaded()).toBe(true);
+    });
+  });
+
+  describe('first-load gate (whenFirstLoad, #607)', () => {
+    it('resolves true once a refresh has loaded real state', async () => {
+      const waiting = service.whenFirstLoad(5_000);
+
+      mockDb.__queue([]); // lists
+      mockDb.__queue([]); // domain mappings
+      await service.refresh();
+
+      await expect(waiting).resolves.toBe(true);
+      // Already-loaded callers resolve immediately.
+      await expect(service.whenFirstLoad(0)).resolves.toBe(true);
+    });
+
+    it('resolves false when the state never loads in time', async () => {
+      const failure = {
+        then: (_resolve: unknown, reject: (reason: unknown) => void) =>
+          reject(new Error('relation does not exist')),
+      };
+      mockDb.orderBy.mockImplementationOnce(() => failure);
+      await service.refresh();
+
+      await expect(service.whenFirstLoad(10)).resolves.toBe(false);
     });
   });
 

--- a/apps/backend/src/traffic/blocklist.service.ts
+++ b/apps/backend/src/traffic/blocklist.service.ts
@@ -33,6 +33,11 @@ export const BOT_PROTECTION_FLAG = 'BOT_PROTECTION_ENABLED';
  *  flips made through the generic feature-flags API and multi-replica drift). */
 const REFRESH_INTERVAL_MS = 30_000;
 
+/** Boot retry cadence while the first load is still failing (postgres warming up). */
+const BOOT_RETRY_INTERVAL_MS = 2_000;
+/** Give up on fast retries after this long and fall back to REFRESH_INTERVAL_MS. */
+const BOOT_RETRY_CEILING_MS = 60_000;
+
 export interface AttachedDomainRef {
   id: string;
   domain: string;
@@ -103,9 +108,11 @@ function normalizeHost(host: string): string {
 export class BlocklistService implements OnModuleInit {
   private readonly logger = new Logger(BlocklistService.name);
 
-  // Start protected-by-default: Baseline-only, toggle at its default. The
-  // first refresh() replaces this with the real database state; if that
-  // fails (e.g. the migration has not run yet), the Baseline still applies.
+  // A placeholder so the matcher fields are never null; it is NOT enforced
+  // until `loaded` flips (see the `enforcing` getter). Enforcing the Baseline
+  // before the lists have loaded would block `.sh`, `.env`, `/status` … while
+  // the allowlist that rescues them — a per-list, database-only property — is
+  // still missing, 444'ing paths the operator explicitly allowed (#607).
   private defaultMatcher: CompiledBlocklistMatcher = buildBlocklistMatcher(
     BASELINE_BLOCKLIST_ENTRIES,
     [],
@@ -131,10 +138,84 @@ export class BlocklistService implements OnModuleInit {
   private refreshEverFailed = false;
   private readonly changeListeners: Array<() => void> = [];
 
+  /**
+   * True once a refresh has compiled the matchers from a real database read.
+   * Until then NOTHING is enforced — app-side or at the edge (#607). The
+   * Baseline is only half of the operator's intent; its other half (the
+   * allowlist exceptions) lives exclusively in the `blocklists` tables, so a
+   * Baseline-only compile is not "degraded protection", it is protection the
+   * operator never configured, applied to paths they explicitly allowed.
+   */
+  private loaded = false;
+  /** Resolvers waiting on {@link whenFirstLoad}, drained on the first load. */
+  private loadWaiters: Array<() => void> = [];
+  /** Rate-limits the degraded-read warning to once per outage. */
+  private degradedLogged = false;
+  private bootRetryTimer: NodeJS.Timeout | null = null;
+  private bootRetryElapsedMs = 0;
+
   constructor(private readonly featureFlags: FeatureFlagsService) {}
 
   async onModuleInit(): Promise<void> {
     await this.refresh();
+    // Postgres is commonly still accepting-but-not-ready at boot (every
+    // ./update.sh restarts both). The 30s interval alone would leave a long
+    // window with no enforcement, so retry fast until the first real load.
+    if (!this.loaded) {
+      this.scheduleBootRetry();
+    }
+  }
+
+  /** True once the compiled state came from the database rather than a fallback. */
+  isLoaded(): boolean {
+    return this.loaded;
+  }
+
+  /**
+   * Resolves true once the compiled state reflects a real database read, or
+   * false if `timeoutMs` elapses first. Callers that render enforcement into
+   * DURABLE artifacts (NginxStartupService writing sites-enabled/*.conf) await
+   * this so a boot-time database race can never bake a half-loaded state into
+   * nginx (#607).
+   */
+  whenFirstLoad(timeoutMs: number): Promise<boolean> {
+    if (this.loaded) {
+      return Promise.resolve(true);
+    }
+    return new Promise<boolean>((resolve) => {
+      const timer = setTimeout(() => {
+        this.loadWaiters = this.loadWaiters.filter((waiter) => waiter !== onLoad);
+        resolve(false);
+      }, timeoutMs);
+      timer.unref?.();
+      const onLoad = () => {
+        clearTimeout(timer);
+        resolve(true);
+      };
+      this.loadWaiters.push(onLoad);
+    });
+  }
+
+  private scheduleBootRetry(): void {
+    if (this.bootRetryTimer || this.bootRetryElapsedMs >= BOOT_RETRY_CEILING_MS) {
+      return;
+    }
+    this.bootRetryTimer = setTimeout(() => {
+      this.bootRetryTimer = null;
+      this.bootRetryElapsedMs += BOOT_RETRY_INTERVAL_MS;
+      void this.refresh().then(() => {
+        if (!this.loaded) {
+          this.scheduleBootRetry();
+        }
+      });
+    }, BOOT_RETRY_INTERVAL_MS);
+    // Never hold the process open for a retry (tests, shutdown).
+    this.bootRetryTimer.unref?.();
+  }
+
+  /** The toggle AND a real loaded state — anything less enforces nothing. */
+  private get enforcing(): boolean {
+    return this.enabled && this.loaded;
   }
 
   /**
@@ -144,7 +225,7 @@ export class BlocklistService implements OnModuleInit {
    */
   getCompiledState(): CompiledBlocklistState {
     return {
-      enabled: this.enabled,
+      enabled: this.enforcing,
       blockSource: this.defaultMatcher.blockSource,
       allowSource: this.defaultMatcher.allowSource,
     };
@@ -159,7 +240,7 @@ export class BlocklistService implements OnModuleInit {
   getCompiledStateForDomain(domainMappingId: string): CompiledBlocklistState {
     const matcher = this.domainMatchers.get(domainMappingId) ?? this.defaultMatcher;
     return {
-      enabled: this.enabled,
+      enabled: this.enforcing,
       blockSource: matcher.blockSource,
       allowSource: matcher.allowSource,
     };
@@ -175,7 +256,7 @@ export class BlocklistService implements OnModuleInit {
     for (const [id, matcher] of this.domainMatchers) {
       if (matcher !== this.defaultMatcher) {
         states.set(id, {
-          enabled: this.enabled,
+          enabled: this.enforcing,
           blockSource: matcher.blockSource,
           allowSource: matcher.allowSource,
         });
@@ -202,7 +283,7 @@ export class BlocklistService implements OnModuleInit {
    * throw — a matcher bug must not take down request serving.
    */
   shouldBlock(pathname: string, host?: string | null): boolean {
-    if (!this.enabled) {
+    if (!this.enforcing) {
       return false;
     }
     try {
@@ -219,18 +300,40 @@ export class BlocklistService implements OnModuleInit {
   async refresh(): Promise<void> {
     try {
       const enabled = await this.featureFlags.isEnabled(BOT_PROTECTION_FLAG);
-      let lists: BlocklistWithEntries[] = [];
-      let domains: Array<{ id: string; domain: string }> = [];
+      let lists: BlocklistWithEntries[];
+      let domains: Array<{ id: string; domain: string }>;
       try {
         lists = await this.listBlocklists();
         domains = await db
           .select({ id: domainMappings.id, domain: domainMappings.domain })
           .from(domainMappings);
       } catch (error) {
-        // Pre-migration or transient DB failure: enforce the Baseline alone
-        // rather than dropping protection.
-        this.logger.warn(`Could not load Blocklists; enforcing Baseline only: ${String(error)}`);
+        // Pre-migration or transient DB failure. Compiling from `lists = []`
+        // here would be fail-closed for blocks and fail-OPEN for allows: the
+        // Baseline still blocks `.sh`/`.env`/`/status`, but every allowlist
+        // exception that qualifies it is missing, so the operator's explicitly
+        // allowed paths start returning 444 (#607). Abandon the refresh
+        // instead — keep the last good matchers, or enforce nothing at all if
+        // we never had any — and let the next attempt notify.
+        //
+        // Note this cannot rely on the outer catch: FeatureFlagsService
+        // swallows its own database errors, so a boot with postgres still
+        // warming up lands HERE, not there. That is why the #531/#532
+        // `refreshEverFailed` fix did not cover this path.
+        this.refreshEverFailed = true;
+        if (!this.degradedLogged) {
+          this.degradedLogged = true;
+          this.logger.warn(
+            `Could not load Blocklists; ${
+              this.loaded
+                ? 'keeping the last good compiled state'
+                : 'enforcing nothing until the first successful load'
+            }: ${String(error)}`,
+          );
+        }
+        return;
       }
+      this.degradedLogged = false;
 
       const byId = new Map(lists.map((list) => [list.id, list]));
       const defaultIds = lists.filter((list) => list.isDefault).map((list) => list.id);
@@ -295,6 +398,7 @@ export class BlocklistService implements OnModuleInit {
       this.domainMatchers = domainMatchers;
       this.hostMatchers = hostMatchers;
       this.enabled = enabled;
+      this.markLoaded();
 
       // Fingerprint the full effective state: toggle, default sources, and
       // every domain whose set differs from the default — so attachment and
@@ -307,10 +411,12 @@ export class BlocklistService implements OnModuleInit {
       const fingerprint = `${enabled}|${defaultMatcher.blockSource ?? ''}|${defaultMatcher.allowSource ?? ''}|${domainPart}`;
       // Normally the null-guard means "first refresh ever, nothing to diff
       // against, don't notify" — startup config regen already reads this
-      // state directly. But if an EARLIER refresh died in the outer catch
-      // below, the Baseline-only matcher it left behind is already live in
-      // rendered nginx configs, so this first *successful* refresh must
-      // notify even though lastFingerprint is still null (#531).
+      // state directly. But if an EARLIER refresh failed (outer catch below,
+      // #531; or the degraded-read return above, #607), configs may already
+      // have been rendered without these rules, so this first *successful*
+      // refresh must notify even though lastFingerprint is still null.
+      // Cheap when it is redundant: the edge sync fingerprint short-circuits
+      // a regeneration that would not change any file.
       const changed =
         this.refreshEverFailed ||
         (this.lastFingerprint !== null && this.lastFingerprint !== fingerprint);
@@ -323,6 +429,20 @@ export class BlocklistService implements OnModuleInit {
       // Keep the last good matchers; never let a refresh failure break serving.
       this.refreshEverFailed = true;
       this.logger.error(`Blocklist refresh failed: ${String(error)}`);
+    }
+  }
+
+  /** Flip to a real loaded state and release everyone waiting on it. */
+  private markLoaded(): void {
+    this.loaded = true;
+    if (this.bootRetryTimer) {
+      clearTimeout(this.bootRetryTimer);
+      this.bootRetryTimer = null;
+    }
+    const waiters = this.loadWaiters;
+    this.loadWaiters = [];
+    for (const waiter of waiters) {
+      waiter();
     }
   }
 


### PR DESCRIPTION
Fixes #607.

## The bug

On a self-hosted install, every `./update.sh` started 444'ing `/install.sh` — a path the admin had explicitly allowlisted as `exact:/install.sh`. The UI was fine; enforcement was wrong. Only editing a list by hand cleared it.

`/install.sh` is blocked by the **Baseline** (`extension('sh')`), and the only thing that can rescue a Baseline block is a **list allowlist** — a per-list, database-only property. So when `refresh()` hit its inner catch and compiled `lists = []`, the result was exactly *"block `.sh`, allow nothing"*. The fallback is fail-closed for blocks and fail-**open** for allows, and that second half is a self-inflicted outage.

`./update.sh` is a reliable trigger because it restarts postgres alongside the backend, so the boot refresh races a warming-up database on every upgrade.

**Why #531/#532 didn't cover this:** `FeatureFlagsService.refreshDbCache()` swallows its own database errors, so `isEnabled()` never throws. A boot against a down database lands in `refresh()`'s **inner** catch — which returned a normal-looking "successful" refresh and never set `refreshEverFailed`. The #531 flag only guards the outer catch.

## The fix

**1. Don't enforce a half-loaded state** (`blocklist.service.ts`)

The degraded read now abandons the refresh rather than compiling from `[]`. A new `loaded` flag gates enforcement — app-side (`shouldBlock`) and at the edge (the three `getCompiledState*` getters report `enabled: false`) — so the choice is *last good state* or *nothing*, never *blocks-without-their-allows*. `refreshEverFailed` is set here too, so the first successful refresh still notifies and regenerates.

A 2s boot retry (ceiling 60s) keeps the unloaded window to seconds instead of waiting out the 30s interval.

**2. Gate startup on a real load** (`nginx-startup.service.ts`)

`setTimeout(1000)` → `whenFirstLoad(15_000)`. Generated configs are durable artifacts, so this is a correctness gate. On a healthy boot it resolves **instantly** — strictly faster than the old unconditional 1s sleep — and the 15s only materializes when the database is genuinely unavailable, well inside the 300s startup-probe budget.

**3. Stop the edge fingerprint latching** (`edge-blocklist.service.ts`)

`sync()` committed the fingerprint of a state it had just rolled back, so every later sync short-circuited on it and `regenerateAllForBlocklistChange()` early-returned. One transient `nginx -t` failure — plausible mid-upgrade while the nginx image rebuilds — disabled edge enforcement *permanently*. A `degraded` flag now forces a re-validation, and `sync()` reports the **applied** delta so a persistently failing pair retries without rewriting every config every 30s.

## Trade-off worth a look

During the pre-load window nothing is enforced, where previously the Baseline was. That is deliberate — the issue calls the old behaviour "the worst of the three options" — and it is bounded by the 2s retry. A database that cannot answer these reads cannot serve public content either, so there is little left to protect. Happy to switch to holding the *previous* rendered rules instead if you'd rather not drop Baseline coverage at all; that's a bigger change, since the startup path deletes and rewrites all configs.

## On "does it self-heal?"

The issue left this open pending a live measurement. Reading the code, the ~30s interval *should* recover it: the degraded fingerprint differs from the real one, so `changed` is true and the notify → debounce → regenerate chain fires. `ScheduleModule.forRoot()` is registered, so `@Interval` does run. The one code path that could genuinely strand it is defect 3 above, and that's fixed here. This PR removes the dependency on that recovery either way — the bad state is no longer written in the first place. The measurement from the issue is still worth taking after this ships.

## Verification

- `apps/backend`: **160 suites / 2792 tests pass**, `tsc --noEmit` clean.
- New regression tests:
  - first refresh fails → `/install.sh` is **not** blocked and no edge rules are emitted (the exact reported failure)
  - a later DB failure keeps the previous allowlist instead of recompiling Baseline-only
  - a degraded read still notifies on the next successful refresh
  - `whenFirstLoad` resolves true on load / false on timeout
  - a rolled-back edge pair re-validates and applies on the next sync instead of latching
- Two existing tests encoded the old behaviour and were updated with `#607` rationale: "enforces the Baseline before any refresh" and the Baseline-only fallback. One edge test now asserts `sync()` → `false` on a first-sync rollback, since nothing was applied before or after and there is nothing to regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rPL4Mf667ZUyxFN9HmseV
