### PR TITLE
feat(app-catalog): deploy installs under the real source commit

### DIFF
--- a/apps/backend/src/app-catalog/app-bundle.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-bundle.service.spec.ts
@@ -4,7 +4,10 @@ import { BadRequestException } from '@nestjs/common';
 import { AppBundleService } from './app-bundle.service';
 import { TEST_MANIFEST } from './app-manifest.util.spec';
 
-function makeBundle(manifest: unknown = TEST_MANIFEST): { buf: Uint8Array; sha256: string } {
+function makeBundle(
+  manifest: unknown = TEST_MANIFEST,
+  extraEntries: Record<string, Uint8Array> = {},
+): { buf: Uint8Array; sha256: string } {
   const buf = zipSync({
     'bffless-app.json': strToU8(JSON.stringify(manifest)),
     'rulesets/handoff.json': strToU8(JSON.stringify({ ruleSet: { name: 'handoff' }, rules: [], schemas: [] })),
@@ -12,8 +15,15 @@ function makeBundle(manifest: unknown = TEST_MANIFEST): { buf: Uint8Array; sha25
       JSON.stringify({ ruleSet: { name: 'handoff-rss-feed' }, rules: [], schemas: [] }),
     ),
     'dist/index.html': strToU8('<!doctype html>ok'),
+    ...extraEntries,
   });
   return { buf, sha256: createHash('sha256').update(buf).digest('hex') };
+}
+
+const TEST_COMMIT = 'c01bb08a1b2c3d4e5f60718293a4b5c6d7e8f900';
+
+function withBuildStamp(stamp: string): Record<string, Uint8Array> {
+  return { '.bffless-build.json': strToU8(stamp) };
 }
 
 function fetchResponse(bytes: Uint8Array, opts: { contentLength?: number } = {}): Response {
@@ -51,6 +61,55 @@ describe('AppBundleService', () => {
       expect(loaded.sha256).toBe(sha256);
       expect(loaded.files['dist/index.html']).toBeInstanceOf(Uint8Array);
       expect(new TextDecoder().decode(loaded.files['dist/index.html'])).toBe('<!doctype html>ok');
+    });
+
+    it('exposes the source commit from the build stamp', async () => {
+      const { buf, sha256 } = makeBundle(
+        TEST_MANIFEST,
+        withBuildStamp(JSON.stringify({ commit: TEST_COMMIT })),
+      );
+
+      const loaded = await service.loadFromBuffer(buf, sha256);
+
+      expect(loaded.build).toEqual({ commit: TEST_COMMIT });
+    });
+
+    it('leaves build undefined for a bundle with no stamp', async () => {
+      const { buf, sha256 } = makeBundle();
+
+      const loaded = await service.loadFromBuffer(buf, sha256);
+
+      expect(loaded.build).toBeUndefined();
+    });
+
+    // A malformed stamp must degrade to "no provenance", never to a failed install: the stamp
+    // is cosmetic, and rejecting the bundle would take an app offline over it. Anything that is
+    // not a bare 40-hex commit is dropped rather than passed through to a deployment's SHA.
+    it.each([
+      ['not JSON', 'not json at all'],
+      ['a JSON array', '[]'],
+      ['no commit field', JSON.stringify({ builtAt: '2026-08-02' })],
+      ['a non-string commit', JSON.stringify({ commit: 12345 })],
+      ['a short commit', JSON.stringify({ commit: 'c01bb08' })],
+      ['a 64-hex sha256', JSON.stringify({ commit: 'a'.repeat(64) })],
+    ])('installs without provenance when the stamp is %s', async (_label, stamp) => {
+      const { buf, sha256 } = makeBundle(TEST_MANIFEST, withBuildStamp(stamp));
+
+      const loaded = await service.loadFromBuffer(buf, sha256);
+
+      expect(loaded.build).toBeUndefined();
+      expect(loaded.manifest).toEqual(TEST_MANIFEST);
+    });
+
+    it('normalises an uppercase commit to lowercase', async () => {
+      const { buf, sha256 } = makeBundle(
+        TEST_MANIFEST,
+        withBuildStamp(JSON.stringify({ commit: TEST_COMMIT.toUpperCase() })),
+      );
+
+      const loaded = await service.loadFromBuffer(buf, sha256);
+
+      expect(loaded.build).toEqual({ commit: TEST_COMMIT });
     });
 
     it('throws BadRequestException mentioning sha256 on mismatch, before parsing', async () => {

--- a/apps/backend/src/app-catalog/app-bundle.service.ts
+++ b/apps/backend/src/app-catalog/app-bundle.service.ts
@@ -4,12 +4,31 @@ import { createHash } from 'crypto';
 import { validateAppManifest } from './app-manifest.util';
 import type { AppManifest } from './app-manifest.types';
 
+/**
+ * Build provenance stamped into the bundle by bffless/apps' scripts/build-app-bundle.mjs
+ * (`.bffless-build.json`). Absent on bundles built before that change, and on any build whose
+ * commit could not be resolved — absence is a normal state, never an error.
+ */
+export interface BundleBuildInfo {
+  /** 40-hex commit whose tree produced this bundle. */
+  commit: string;
+}
+
 export interface LoadedBundle {
   manifest: AppManifest;
   /** entry path -> bytes; directory entries stripped */
   files: Record<string, Uint8Array>;
   sha256: string;
+  /**
+   * Source provenance, read from inside the bundle rather than from the registry entry: it
+   * travels with the bytes, so it is covered by the same sha256 the registry pins and can
+   * never attribute a bundle to a commit that did not produce it. Undefined when unstamped.
+   */
+  build?: BundleBuildInfo;
 }
+
+const BUILD_INFO_ENTRY = '.bffless-build.json';
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/i;
 
 /**
  * AppBundleService — downloads/parses an app bundle zip, verifying its
@@ -122,7 +141,12 @@ export class AppBundleService {
       );
     }
 
-    const loaded: LoadedBundle = { manifest, files, sha256: actualSha256 };
+    const loaded: LoadedBundle = {
+      manifest,
+      files,
+      sha256: actualSha256,
+      build: this.readBuildInfo(files),
+    };
     this.cache.set(actualSha256, loaded);
     if (this.cache.size > this.MAX_CACHE_ENTRIES) {
       const oldestKey = this.cache.keys().next().value;
@@ -130,6 +154,30 @@ export class AppBundleService {
     }
 
     return loaded;
+  }
+
+  /**
+   * Reads the optional build stamp. Deliberately total: a bundle whose stamp is missing,
+   * unparseable, or not a 40-hex commit still installs — it simply carries no provenance, and
+   * the caller falls back to the bundle hash. Rejecting the bundle would turn a cosmetic
+   * regression in the publisher into an outage for every install of that app.
+   */
+  private readBuildInfo(files: Record<string, Uint8Array>): BundleBuildInfo | undefined {
+    const bytes = files[BUILD_INFO_ENTRY];
+    if (!bytes) return undefined;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(new TextDecoder().decode(bytes));
+    } catch {
+      return undefined;
+    }
+
+    if (typeof parsed !== 'object' || parsed === null) return undefined;
+    const commit = (parsed as { commit?: unknown }).commit;
+    if (typeof commit !== 'string' || !COMMIT_PATTERN.test(commit)) return undefined;
+
+    return { commit: commit.toLowerCase() };
   }
 
   private unzip(buf: Uint8Array): Promise<Record<string, Uint8Array>> {

--- a/apps/backend/src/app-catalog/app-installer.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.spec.ts
@@ -103,10 +103,15 @@ function encode(s: string): Uint8Array {
   return new TextEncoder().encode(s);
 }
 
-function makeBundle(overrides: Partial<AppManifest> = {}, ruleSetJson?: unknown): LoadedBundle {
+function makeBundle(
+  overrides: Partial<AppManifest> = {},
+  ruleSetJson?: unknown,
+  build?: LoadedBundle['build'],
+): LoadedBundle {
   const manifest = { ...TEST_MANIFEST, ...overrides } as AppManifest;
   return {
     manifest,
+    build,
     files: {
       'rulesets/handoff.json': encode(
         JSON.stringify(
@@ -362,6 +367,33 @@ describe('AppInstallerService', () => {
       expect(role).toBe('admin');
       expect(file.mimetype).toBe('application/zip');
       expect(Buffer.isBuffer(file.buffer)).toBe(true);
+    });
+
+    // Provenance: a stamped bundle deploys under the commit that produced it, so the SHA in the
+    // repo browser and the deployment URL resolves to real source instead of the content hash.
+    it('deploys under the source commit when the bundle carries a build stamp', async () => {
+      const commit = 'c01bb08a1b2c3d4e5f60718293a4b5c6d7e8f900';
+      bundleService.fetchBundle.mockResolvedValue(makeBundle({}, undefined, { commit }));
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      expect(deployments.createDeploymentFromZip.mock.calls[0][1].commitSha).toBe(commit);
+    });
+
+    // Every app published before the stamp existed. Those must keep deploying exactly as they
+    // do today — same 40-char value, same storage keys, no migration.
+    it('falls back to the truncated bundle hash when the bundle is unstamped', async () => {
+      bundleService.fetchBundle.mockResolvedValue(makeBundle());
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const { commitSha } = deployments.createDeploymentFromZip.mock.calls[0][1];
+      expect(commitSha).toBe('a'.repeat(40));
+      expect(commitSha).toHaveLength(40);
     });
 
     it('uploads only the dist/ subtree, re-keyed under basePath', async () => {

--- a/apps/backend/src/app-catalog/app-installer.service.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.ts
@@ -892,7 +892,16 @@ export class AppInstallerService {
       } as Express.Multer.File,
       {
         repository: `${project.owner}/${project.name}`,
-        commitSha: bundle.sha256.slice(0, 40),
+        // The real source commit when the bundle carries one (bffless/apps#276), so the SHA in
+        // the repo browser and in the deployment URL is a commit you can actually look up —
+        // it used to be the bundle's content hash truncated to fit varchar(40), which reads as
+        // a commit in the References panel but resolves to nothing.
+        //
+        // Falls back to that truncated hash for unstamped bundles: every app published before
+        // the stamp existed, plus any build whose commit was unresolvable. Both forms are
+        // 40-hex and opaque to storage, so the fallback needs no special handling and no
+        // existing deployment moves.
+        commitSha: bundle.build?.commit ?? bundle.sha256.slice(0, 40),
         branch: 'app-catalog',
         alias,
         description: `App install: ${manifest.name} v${manifest.version}`,


### PR DESCRIPTION
Consuming half of the pair with bffless/apps#277. Closes #610.

## Problem

An install's `commitSha` is the bundle zip's sha256 truncated to 40 chars. The References panel lists it under "Commits" next to `App install: Handoff v1.0.1`, so it reads as a git commit — but `15f8496f8023…` resolves to nothing. The real commit is `c01bb08`.

## Why not just display the commit beside it

That was the original plan (persist `source_commit`/`release_tag` on `installed_apps`, render a link in the References panel). Both reasons given for keeping the content hash as the identity turned out to be wrong:

1. **"`commit_sha` is `varchar(40)` and a storage path segment."** That argues against the raw *sha256* — 64 chars. A git commit SHA is exactly 40 hex: it fits the column and `{owner}/{repo}/{commitSha}/{path}` natively.
2. **"The content hash is the identity of the bytes deployed."** It isn't. `buildDistZip` re-zips only the entries under the manifest's deployment path, re-rooted under `basePath` — so the hash in the path is of the *source bundle*, not of what is stored or served. Nothing can verify it.

Collision isn't a concern either: `createDeploymentFromZip` doesn't reject a repeated `commitSha`, and `repo-browser.service.ts` deliberately groups by it, naming coverage reports and test artifacts as the expected several-deployments-one-commit case.

So the fix is to make the SHA honest rather than annotate a dishonest one — which also drops the schema change and the UI work entirely.

## Changes

Two files.

- `app-bundle.service.ts` — parse the optional `.bffless-build.json` into `LoadedBundle.build`. Read from **inside the bundle**, not the registry entry: it travels with the bytes, so it is covered by the sha256 the registry pins and CE never has to trust the registry for it. Tolerant by design — missing, unparseable, or non-40-hex yields `undefined`, because a publisher-side regression must not become an outage for every install of that app.
- `app-installer.service.ts` — `commitSha: bundle.build?.commit ?? bundle.sha256.slice(0, 40)`.

No schema change, no migration, no UI change.

## Compatibility and sequencing

Unstamped bundles keep the truncated hash, so **every existing install and every app published before the stamp is byte-identical in behavior** — storage keys unchanged, nothing migrates.

This is therefore inert until bffless/apps#277 ships *and* an app is re-released. Safe to merge in either order.

## Verification

- `pnpm test -- src/app-catalog` — 311 pass across 12 suites (12 new: stamp present/absent, uppercase normalisation, six malformed-stamp shapes, and both installer paths).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
