### PR TITLE
fix(deployments): persist alias requiredRole/unauthorizedBehavior overrides

### DIFF
--- a/apps/backend/src/deployments/deployments.controller.spec.ts
+++ b/apps/backend/src/deployments/deployments.controller.spec.ts
@@ -481,6 +481,12 @@ describe('AliasesController', () => {
         name: 'repo',
         isPublic: true,
       }),
+      getProjectById: jest.fn().mockResolvedValue({
+        id: 'project-123',
+        owner: 'owner',
+        name: 'repo',
+        isPublic: true,
+      }),
     } as any;
 
     const module: TestingModule = await Test.createTestingModule({
@@ -560,6 +566,74 @@ describe('AliasesController', () => {
         'main',
         mockUserId,
         'admin',
+      );
+    });
+  });
+
+  describe('updateAliasVisibility', () => {
+    const mockProjectId = 'project-123';
+
+    it('forwards requiredRole to the service', async () => {
+      const dto = { requiredRole: 'admin' as const };
+
+      await controller.updateAliasVisibility(mockProjectId, 'main', dto, mockUser);
+
+      expect(mockDeploymentsService.updateAliasVisibility).toHaveBeenCalledWith(
+        mockProjectId,
+        'main',
+        undefined,
+        mockUserId,
+        'admin',
+        undefined,
+        'admin',
+      );
+    });
+
+    it('forwards unauthorizedBehavior to the service', async () => {
+      const dto = { unauthorizedBehavior: 'redirect_login' as const };
+
+      await controller.updateAliasVisibility(mockProjectId, 'main', dto, mockUser);
+
+      expect(mockDeploymentsService.updateAliasVisibility).toHaveBeenCalledWith(
+        mockProjectId,
+        'main',
+        undefined,
+        mockUserId,
+        'admin',
+        'redirect_login',
+        undefined,
+      );
+    });
+
+    it('does not coerce an omitted isPublic into an explicit null (regression: Bug 2)', async () => {
+      // Only requiredRole is being changed; isPublic and unauthorizedBehavior are
+      // absent from the request body entirely (not sent as null).
+      const dto = { requiredRole: 'viewer' as const };
+
+      await controller.updateAliasVisibility(mockProjectId, 'main', dto, mockUser);
+
+      const call = mockDeploymentsService.updateAliasVisibility.mock.calls[0];
+      // isPublic arg (index 2) must be undefined ("leave alone"), never null
+      // ("clear the override") -- that conflation is exactly Bug 2.
+      expect(call[2]).toBeUndefined();
+      // unauthorizedBehavior arg (index 5) must likewise stay undefined.
+      expect(call[5]).toBeUndefined();
+      expect(call[6]).toBe('viewer');
+    });
+
+    it('forwards an explicit null to clear an override', async () => {
+      const dto = { isPublic: null, unauthorizedBehavior: null, requiredRole: null };
+
+      await controller.updateAliasVisibility(mockProjectId, 'main', dto, mockUser);
+
+      expect(mockDeploymentsService.updateAliasVisibility).toHaveBeenCalledWith(
+        mockProjectId,
+        'main',
+        null,
+        mockUserId,
+        'admin',
+        null,
+        null,
       );
     });
   });

--- a/apps/backend/src/deployments/deployments.controller.ts
+++ b/apps/backend/src/deployments/deployments.controller.ts
@@ -736,9 +736,11 @@ export class AliasesController {
     const updated = await this.deploymentsService.updateAliasVisibility(
       projectId,
       aliasName,
-      dto.isPublic ?? null,
+      dto.isPublic,
       user.id,
       user.role || 'user',
+      dto.unauthorizedBehavior,
+      dto.requiredRole,
     );
 
     const project = await this.projectsService.getProjectById(projectId);

--- a/apps/backend/src/deployments/deployments.service.spec.ts
+++ b/apps/backend/src/deployments/deployments.service.spec.ts
@@ -568,6 +568,124 @@ describe('DeploymentsService', () => {
     });
   });
 
+  describe('updateAliasVisibility', () => {
+    const mockProjectId = 'project-id-123';
+
+    const mockAliasWithOverrides = {
+      ...mockAlias,
+      projectId: mockProjectId,
+      isPublic: false,
+      unauthorizedBehavior: null,
+      requiredRole: null,
+    };
+
+    it('persists requiredRole', async () => {
+      setupMockChain([
+        [mockAliasWithOverrides], // find existing alias
+        [{ ...mockAliasWithOverrides, requiredRole: 'admin' }], // update returning
+      ]);
+
+      await service.updateAliasVisibility(
+        mockProjectId,
+        'main',
+        undefined,
+        mockUserId,
+        'admin',
+        undefined,
+        'admin',
+      );
+
+      const setArg = mockDb.set.mock.calls[0][0];
+      expect(setArg.requiredRole).toBe('admin');
+    });
+
+    it('persists unauthorizedBehavior', async () => {
+      setupMockChain([
+        [mockAliasWithOverrides],
+        [{ ...mockAliasWithOverrides, unauthorizedBehavior: 'redirect_login' }],
+      ]);
+
+      await service.updateAliasVisibility(
+        mockProjectId,
+        'main',
+        undefined,
+        mockUserId,
+        'admin',
+        'redirect_login',
+        undefined,
+      );
+
+      const setArg = mockDb.set.mock.calls[0][0];
+      expect(setArg.unauthorizedBehavior).toBe('redirect_login');
+    });
+
+    it('leaves an existing explicit isPublic untouched when only requiredRole changes (regression: Bug 2)', async () => {
+      setupMockChain([
+        [{ ...mockAliasWithOverrides, isPublic: false }],
+        [{ ...mockAliasWithOverrides, isPublic: false, requiredRole: 'viewer' }],
+      ]);
+
+      await service.updateAliasVisibility(
+        mockProjectId,
+        'main',
+        undefined, // isPublic omitted entirely from the request
+        mockUserId,
+        'admin',
+        undefined,
+        'viewer',
+      );
+
+      const setArg = mockDb.set.mock.calls[0][0];
+      // The bug: `dto.isPublic ?? null` used to force isPublic: null onto every
+      // update, wiping an explicit Private override back to "inherit".
+      expect(setArg).not.toHaveProperty('isPublic');
+      expect(setArg).not.toHaveProperty('unauthorizedBehavior');
+      expect(setArg.requiredRole).toBe('viewer');
+    });
+
+    it('clears an override when explicitly passed null for each field', async () => {
+      setupMockChain([
+        [mockAliasWithOverrides],
+        [{ ...mockAliasWithOverrides, isPublic: null, unauthorizedBehavior: null, requiredRole: null }],
+      ]);
+
+      await service.updateAliasVisibility(
+        mockProjectId,
+        'main',
+        null,
+        mockUserId,
+        'admin',
+        null,
+        null,
+      );
+
+      const setArg = mockDb.set.mock.calls[0][0];
+      expect(setArg.isPublic).toBeNull();
+      expect(setArg.unauthorizedBehavior).toBeNull();
+      expect(setArg.requiredRole).toBeNull();
+    });
+
+    it('does not write any of the three fields when all are absent from the call', async () => {
+      setupMockChain([[mockAliasWithOverrides], [mockAliasWithOverrides]]);
+
+      await service.updateAliasVisibility(
+        mockProjectId,
+        'main',
+        undefined,
+        mockUserId,
+        'admin',
+        undefined,
+        undefined,
+      );
+
+      const setArg = mockDb.set.mock.calls[0][0];
+      expect(setArg).not.toHaveProperty('isPublic');
+      expect(setArg).not.toHaveProperty('unauthorizedBehavior');
+      expect(setArg).not.toHaveProperty('requiredRole');
+      expect(setArg).toHaveProperty('updatedAt');
+    });
+  });
+
   describe('deleteAlias', () => {
     it('should delete alias', async () => {
       setupMockChain([[mockAlias]]);

--- a/apps/backend/src/deployments/deployments.service.ts
+++ b/apps/backend/src/deployments/deployments.service.ts
@@ -1991,9 +1991,18 @@ export class DeploymentsService {
   async updateAliasVisibility(
     projectId: string,
     aliasName: string,
-    isPublic: boolean | null,
+    isPublic: boolean | null | undefined,
     userId: string,
     userRole: string,
+    unauthorizedBehavior?: 'not_found' | 'redirect_login' | null,
+    requiredRole?:
+      | 'authenticated'
+      | 'guest'
+      | 'viewer'
+      | 'contributor'
+      | 'admin'
+      | 'owner'
+      | null,
   ): Promise<typeof deploymentAliases.$inferSelect> {
     // Check project access
     await this.checkProjectAccess(projectId, userId, userRole, 'admin');
@@ -2011,13 +2020,30 @@ export class DeploymentsService {
       throw new NotFoundException(`Alias not found: ${aliasName}`);
     }
 
-    // Update visibility
+    // Build the update payload field-by-field so each of the three overrides
+    // is independent: absent (undefined) leaves the stored value untouched,
+    // explicit null clears the override (inherit from project), and a value
+    // stores that value. Using `??` here would conflate "not supplied" with
+    // "explicitly cleared" -- that conflation was the root cause of an
+    // explicit Private override silently reverting to inherit whenever only
+    // another field (e.g. requiredRole) was updated.
+    const updateData: Partial<typeof deploymentAliases.$inferInsert> = {
+      updatedAt: new Date(),
+    };
+    if (isPublic !== undefined) {
+      updateData.isPublic = isPublic;
+    }
+    if (unauthorizedBehavior !== undefined) {
+      updateData.unauthorizedBehavior = unauthorizedBehavior;
+    }
+    if (requiredRole !== undefined) {
+      updateData.requiredRole = requiredRole;
+    }
+
+    // Update visibility / access control overrides
     const [updated] = await db
       .update(deploymentAliases)
-      .set({
-        isPublic,
-        updatedAt: new Date(),
-      })
+      .set(updateData)
       .where(eq(deploymentAliases.id, existingAlias.id))
       .returning();
 


### PR DESCRIPTION
Setting a **Required Role** on an alias appears to succeed, but reopening the dialog shows "Inherit from project" again and the setting never takes effect. Found while trying to open one app in a project to `guest` while leaving the rest admin-only.

## Bug 1 — `requiredRole` and `unauthorizedBehavior` were never written

The override path is wired end to end *except* for the line that persists it:

- Columns exist — `db/schema/deployment-aliases.schema.ts:44,46`
- DTO declares and validates both — `deployments.dto.ts:670-688`
- Admin UI collects them — `UpdateAliasDialog.tsx`
- Resolver reads them — `visibility.service.ts:387-417`
- **Controller discarded them** — `deployments.controller.ts:736` called the service with only `dto.isPublic ?? null`
- **Service had no parameters for them** — `deployments.service.ts:1991` wrote only `.set({ isPublic, updatedAt })`

`grep -rn "deploymentAliases.requiredRole" apps/backend/src` returned nothing. Because the write was the only missing piece, the feature looked functional at every layer a developer would check.

## Bug 2 — an omitted `isPublic` silently cleared the visibility override

`dto.isPublic ?? null` conflated "field not supplied, leave it alone" with "explicitly null, clear the override". The frontend only sends `isPublic` when visibility actually changed, so saving a change to **only** the required role wiped an existing explicit Private override back to inherit.

That also explains the confusing UI symptom: the Access Control Overrides panel renders only when visibility is explicitly `private`, so the wipe made the entire panel vanish on reopen.

## Fix

The service now accepts all three fields and builds the update payload per field, so each override is independent:

| Request | Behaviour |
|---|---|
| field absent (`undefined`) | stored value untouched — column omitted from the SQL update |
| field explicitly `null` | override cleared, alias inherits from project |
| field has a value | value stored |

`!== undefined` per field, matching the existing pattern at `domains.service.ts:1094-1100`. The controller forwards DTO fields as-is instead of coercing with `??`.

No schema change and no migration — the columns already existed.

## Tests

192 lines added across `deployments.service.spec.ts` and `deployments.controller.spec.ts`:

- `requiredRole` persists
- `unauthorizedBehavior` persists
- **regression for Bug 2** — updating only `requiredRole` leaves an existing explicit `isPublic` untouched, asserted as `expect(setArg).not.toHaveProperty('isPublic')`
- explicit `null` clears each override
- all-absent writes none of the three

Full backend suite: 2812/2812 passing, `tsc` clean.

## Note on the design this restores

An alias override is intentionally an override in **both** directions — `resolveAccessControlForAlias` falls back to the project only when the alias has none, making the project value a default rather than a floor. That's what lets a project stay locked down while one alias is opened up. Without this fix the only way to achieve that was to lower the *project*, which drops the gate on every other alias that inherits it.

## Known follow-up, not in this PR

`UpdateAliasDialog.tsx:407` renders the Access Control Overrides panel only when visibility is explicitly `private`. An alias that *inherits* private from its project shows no panel, so you must first set Visibility to Private before a Required Role can be chosen at all. Functional but unintuitive — worth a separate UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rPL4Mf667ZUyxFN9HmseV
