### PR TITLE
fix(deployments): read back alias access-control overrides in the UI

### DIFF
--- a/apps/backend/src/deployments/deployments.dto.ts
+++ b/apps/backend/src/deployments/deployments.dto.ts
@@ -487,6 +487,27 @@ export class AliasResponseDto {
   })
   proxyRuleSetId?: string;
 
+  @ApiPropertyOptional({
+    description:
+      'Visibility override: true = force public, false = force private, null = inherit from project',
+    nullable: true,
+  })
+  isPublic?: boolean | null;
+
+  @ApiPropertyOptional({
+    description: 'Unauthorized behavior override: null = inherit from project',
+    enum: ['not_found', 'redirect_login'],
+    nullable: true,
+  })
+  unauthorizedBehavior?: 'not_found' | 'redirect_login' | null;
+
+  @ApiPropertyOptional({
+    description: 'Required role override: null = inherit from project',
+    enum: ['authenticated', 'guest', 'viewer', 'contributor', 'admin', 'owner'],
+    nullable: true,
+  })
+  requiredRole?: 'authenticated' | 'guest' | 'viewer' | 'contributor' | 'admin' | 'owner' | null;
+
   @ApiProperty()
   createdAt: Date;
 

--- a/apps/backend/src/deployments/deployments.service.spec.ts
+++ b/apps/backend/src/deployments/deployments.service.spec.ts
@@ -734,6 +734,48 @@ describe('DeploymentsService', () => {
       expect(result.data).toHaveLength(2);
       expect(result.data[0].repository).toBe(mockRepository);
     });
+
+    // Regression: bffless/ce alias access-control readback bug.
+    // The write path (#617) persists isPublic/unauthorizedBehavior/requiredRole
+    // overrides correctly, but toAliasResponse() never copied them onto the
+    // response DTO, so a listed alias always looked like it had no override.
+    it('round-trips isPublic, unauthorizedBehavior, and requiredRole overrides', async () => {
+      const aliasWithOverrides = {
+        ...mockAlias,
+        isPublic: false,
+        unauthorizedBehavior: 'redirect_login',
+        requiredRole: 'guest',
+      };
+      setupMockChain([[aliasWithOverrides]]);
+
+      const result = await service.listAliases({ repository: mockRepository }, mockUserId, 'admin');
+
+      expect(result.data[0].isPublic).toBe(false);
+      expect(result.data[0].unauthorizedBehavior).toBe('redirect_login');
+      expect(result.data[0].requiredRole).toBe('guest');
+    });
+
+    it('preserves explicit null overrides (inherit from project) rather than dropping them as undefined', async () => {
+      const aliasInheriting = {
+        ...mockAlias,
+        isPublic: null,
+        unauthorizedBehavior: null,
+        requiredRole: null,
+      };
+      setupMockChain([[aliasInheriting]]);
+
+      const result = await service.listAliases({ repository: mockRepository }, mockUserId, 'admin');
+
+      // null (inherit) must round-trip as null, not be coerced to/left as undefined -
+      // the frontend dialog relies on `?? 'inherit'` semantics that only work if the
+      // field is present and null, not absent.
+      expect(result.data[0].isPublic).toBeNull();
+      expect(result.data[0].unauthorizedBehavior).toBeNull();
+      expect(result.data[0].requiredRole).toBeNull();
+      expect('isPublic' in result.data[0]).toBe(true);
+      expect('unauthorizedBehavior' in result.data[0]).toBe(true);
+      expect('requiredRole' in result.data[0]).toBe(true);
+    });
   });
 
   describe('listDeployments', () => {

--- a/apps/backend/src/deployments/deployments.service.ts
+++ b/apps/backend/src/deployments/deployments.service.ts
@@ -1786,6 +1786,12 @@ export class DeploymentsService {
       basePath: alias.basePath ?? undefined,
       proxyRuleSetIds: ids,
       proxyRuleSetId: ids[0],
+      // Access control overrides (null = inherit from project). Preserve null as-is —
+      // do not coerce to undefined, since the frontend distinguishes "inherit" (null)
+      // from "not returned" (undefined).
+      isPublic: alias.isPublic,
+      unauthorizedBehavior: alias.unauthorizedBehavior as AliasResponseDto['unauthorizedBehavior'],
+      requiredRole: alias.requiredRole as AliasResponseDto['requiredRole'],
       createdAt: alias.createdAt,
       updatedAt: alias.updatedAt,
     };

--- a/apps/backend/src/repo-browser/repo-browser.dto.ts
+++ b/apps/backend/src/repo-browser/repo-browser.dto.ts
@@ -335,6 +335,27 @@ export class AliasDetailDto {
     type: [String],
   })
   proxyRuleSetIds?: string[];
+
+  @ApiPropertyOptional({
+    description:
+      'Visibility override: true = force public, false = force private, null = inherit from project',
+    nullable: true,
+  })
+  isPublic?: boolean | null;
+
+  @ApiPropertyOptional({
+    description: 'Unauthorized behavior override: null = inherit from project',
+    enum: ['not_found', 'redirect_login'],
+    nullable: true,
+  })
+  unauthorizedBehavior?: 'not_found' | 'redirect_login' | null;
+
+  @ApiPropertyOptional({
+    description: 'Required role override: null = inherit from project',
+    enum: ['authenticated', 'guest', 'viewer', 'contributor', 'admin', 'owner'],
+    nullable: true,
+  })
+  requiredRole?: 'authenticated' | 'guest' | 'viewer' | 'contributor' | 'admin' | 'owner' | null;
 }
 
 export class GetAliasesResponseDto {

--- a/apps/backend/src/repo-browser/repo-browser.service.spec.ts
+++ b/apps/backend/src/repo-browser/repo-browser.service.spec.ts
@@ -237,6 +237,89 @@ describe('RepoBrowserService', () => {
     });
   });
 
+  describe('getAliases', () => {
+    const mockAliasRow = {
+      id: 'alias-id-123',
+      projectId: 'project-123',
+      repository: 'owner/repo',
+      alias: 'production',
+      commitSha: 'abc123def456',
+      deploymentId: 'deployment-123',
+      isPublic: null,
+      unauthorizedBehavior: null,
+      requiredRole: null,
+      isAutoPreview: false,
+      basePath: null,
+      proxyRuleSetId: null,
+      createdAt: new Date('2025-01-01'),
+      updatedAt: new Date('2025-01-01'),
+    };
+
+    // Sets up the three sequential db.select() calls made by getAliases():
+    // 1) select aliases, 2) select matching asset (branch lookup), 3) select join-table rule set rows.
+    const mockAliasesQueryChain = (aliasRows: any[], assetRows: any[] = [], joinRows: any[] = []) => {
+      (mockDb.select as jest.Mock)
+        .mockImplementationOnce(() => ({
+          from: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnValue({
+              orderBy: jest.fn().mockResolvedValue(aliasRows),
+            }),
+          }),
+        }))
+        .mockImplementationOnce(() => ({
+          from: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnValue({
+              limit: jest.fn().mockResolvedValue(assetRows),
+            }),
+          }),
+        }))
+        .mockImplementationOnce(() => ({
+          from: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnValue({
+              orderBy: jest.fn().mockResolvedValue(joinRows),
+            }),
+          }),
+        }));
+    };
+
+    // Regression: bffless/ce alias access-control readback bug.
+    // The list-aliases endpoint backing the AliasesTab UI (getAliases -> AliasDetailDto)
+    // never included isPublic/unauthorizedBehavior/requiredRole, so the edit dialog
+    // always initialized as "Inherit from project" even when an override was stored
+    // and actively being enforced.
+    it('round-trips isPublic, unauthorizedBehavior, and requiredRole overrides', async () => {
+      mockProjectsService.getProjectByOwnerName.mockResolvedValue(mockPublicProject as any);
+      mockAliasesQueryChain([
+        {
+          ...mockAliasRow,
+          isPublic: false,
+          unauthorizedBehavior: 'redirect_login',
+          requiredRole: 'guest',
+        },
+      ]);
+
+      const result = await service.getAliases('owner', 'repo', false, 'user-123', 'admin');
+
+      expect(result.aliases[0].isPublic).toBe(false);
+      expect(result.aliases[0].unauthorizedBehavior).toBe('redirect_login');
+      expect(result.aliases[0].requiredRole).toBe('guest');
+    });
+
+    it('preserves explicit null overrides (inherit from project) rather than dropping them as undefined', async () => {
+      mockProjectsService.getProjectByOwnerName.mockResolvedValue(mockPublicProject as any);
+      mockAliasesQueryChain([{ ...mockAliasRow }]);
+
+      const result = await service.getAliases('owner', 'repo', false, 'user-123', 'admin');
+
+      expect(result.aliases[0].isPublic).toBeNull();
+      expect(result.aliases[0].unauthorizedBehavior).toBeNull();
+      expect(result.aliases[0].requiredRole).toBeNull();
+      expect('isPublic' in result.aliases[0]).toBe(true);
+      expect('unauthorizedBehavior' in result.aliases[0]).toBe(true);
+      expect('requiredRole' in result.aliases[0]).toBe(true);
+    });
+  });
+
   describe('getDeployments', () => {
     // TODO: Add integration tests with real database
     // These methods have complex database queries that are difficult to mock

--- a/apps/backend/src/repo-browser/repo-browser.service.ts
+++ b/apps/backend/src/repo-browser/repo-browser.service.ts
@@ -20,6 +20,7 @@ import {
   DeploymentItemDto,
   GetRepositoryStatsResponseDto,
   GetAliasesResponseDto,
+  AliasDetailDto,
   CreateAliasRequestDto,
   UpdateAliasRequestDto,
   AliasCreatedResponseDto,
@@ -576,6 +577,12 @@ export class RepoBrowserService {
           basePath: alias.basePath ?? undefined,
           proxyRuleSetId: alias.proxyRuleSetId ?? null,
           proxyRuleSetIds,
+          // Access control overrides (null = inherit from project). Preserve null as-is —
+          // do not coerce to undefined, since the edit dialog distinguishes "inherit"
+          // (null) from "not returned" (undefined) when initializing its form state.
+          isPublic: alias.isPublic,
+          unauthorizedBehavior: alias.unauthorizedBehavior as AliasDetailDto['unauthorizedBehavior'],
+          requiredRole: alias.requiredRole as AliasDetailDto['requiredRole'],
         };
       }),
     );

--- a/apps/frontend/src/components/repo/AliasesTab.tsx
+++ b/apps/frontend/src/components/repo/AliasesTab.tsx
@@ -5,6 +5,8 @@ import {
   useGetAliasVisibilityQuery,
   useUpdateAliasVisibilityMutation,
   type AliasDetail,
+  type UnauthorizedBehavior,
+  type RequiredRole,
 } from '@/services/repoApi';
 import { useGetProjectQuery } from '@/services/projectsApi';
 import { useGetProjectRuleSetsQuery } from '@/services/proxyRulesApi';
@@ -255,12 +257,18 @@ export function AliasesTab({ owner, repo }: AliasesTabProps) {
     commitSha: string;
     branch: string;
     proxyRuleSetIds: string[];
+    isPublic: boolean | null | undefined;
+    unauthorizedBehavior: UnauthorizedBehavior | null | undefined;
+    requiredRole: RequiredRole | null | undefined;
   }>({
     open: false,
     aliasName: '',
     commitSha: '',
     branch: '',
     proxyRuleSetIds: [],
+    isPublic: undefined,
+    unauthorizedBehavior: undefined,
+    requiredRole: undefined,
   });
   const [deleteDialogState, setDeleteDialogState] = useState<{
     open: boolean;
@@ -441,6 +449,9 @@ export function AliasesTab({ owner, repo }: AliasesTabProps) {
                     commitSha: alias.commitSha,
                     branch: alias.branch,
                     proxyRuleSetIds: ruleSetIds,
+                    isPublic: alias.isPublic,
+                    unauthorizedBehavior: alias.unauthorizedBehavior,
+                    requiredRole: alias.requiredRole,
                   })
                 }
                 onDelete={() =>
@@ -474,6 +485,9 @@ export function AliasesTab({ owner, repo }: AliasesTabProps) {
           currentCommitSha={updateDialogState.commitSha}
           currentBranch={updateDialogState.branch}
           currentProxyRuleSetIds={updateDialogState.proxyRuleSetIds}
+          currentIsPublic={updateDialogState.isPublic}
+          currentUnauthorizedBehavior={updateDialogState.unauthorizedBehavior}
+          currentRequiredRole={updateDialogState.requiredRole}
           open={updateDialogState.open}
           onOpenChange={(open) =>
             setUpdateDialogState({

--- a/apps/frontend/src/components/repo/UpdateAliasDialog.tsx
+++ b/apps/frontend/src/components/repo/UpdateAliasDialog.tsx
@@ -264,6 +264,16 @@ export function UpdateAliasDialog({
 
   const isSubmitting = isLoading || isUpdatingVisibility;
 
+  // Access-control overrides are meaningless for a public deployment, so the panel
+  // should only be hidden in that case. Gate on *effective* visibility (explicit
+  // override, or inherited from the project via visibilityInfo) rather than only
+  // an explicit "private" override — otherwise an alias that inherits private from
+  // its project shows no panel at all, making it impossible to set (or even see)
+  // a Required Role without first explicitly overriding Visibility to Private.
+  const isEffectivelyPrivate =
+    visibility === 'private' ||
+    (visibility === 'inherit' && visibilityInfo?.effectiveVisibility === 'private');
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[525px]">
@@ -403,8 +413,8 @@ export function UpdateAliasDialog({
               )}
             </div>
 
-            {/* Access Control Overrides - Only show when private */}
-            {visibility === 'private' && (
+            {/* Access Control Overrides - Only show when effectively private (explicit or inherited) */}
+            {isEffectivelyPrivate && (
               <div className="space-y-4 p-3 rounded-md bg-muted/50 border">
                 <div className="flex items-center gap-2 text-sm font-medium">
                   <Shield className="h-4 w-4" />


### PR DESCRIPTION
Follow-up to #617. That PR fixed **writing** alias access-control overrides — verified in production, a `requiredRole: guest` override now persists and is correctly enforced. But the value never displays: reopen the edit dialog or refresh the page and Required Role shows "Inherit from project" again, even while the stored override is actively gating access.

Display-only, but it makes the feature untrustworthy — you can't confirm what you set, and it looks like the save silently failed.

## Root cause — the read path drops the fields

**Two independent read paths had the same gap.** Both mappers are explicit whitelists: the DB query is `select()` so the row carries all three columns, but each response is built field-by-field and never copies them.

| Path | Consumer | Mapper |
|---|---|---|
| `AliasDetailDto` / `RepoBrowserService.getAliases` | **the AliasesTab web UI** (`useListAliasesQuery`) | `repo-browser.service.ts:577` |
| `AliasResponseDto` / `DeploymentsService.toAliasResponse` | the API-key REST surface at `/api/aliases`, used by CI/CD and the CLI | `deployments.service.ts:1779` |

**Third gap, frontend:** `AliasesTab.tsx` rendered `<UpdateAliasDialog>` without `currentIsPublic`, `currentUnauthorizedBehavior` or `currentRequiredRole`. Those props are exactly what the dialog's init effect reads (`setRequiredRole(currentRequiredRole ?? 'inherit')`), so they were always `undefined`. A grep for `currentRequiredRole` outside the dialog returned nothing.

The frontend `Alias` interface at `repoApi.ts:110-113` already declared all three with comments — the type was prepared and the wiring never completed.

## Also fixed: the overrides panel was unreachable in the common case

`UpdateAliasDialog.tsx` gated the entire Access Control Overrides section on `visibility === 'private'` — an **explicit** private override on the alias.

An alias that *inherits* private from its project showed no panel at all, so you had to first set Visibility to Private before a Required Role could even be chosen. That's the common configuration, and it's a large part of why this was so confusing to diagnose.

Now gated on **effective** visibility:

```ts
visibility === 'private' ||
(visibility === 'inherit' && visibilityInfo?.effectiveVisibility === 'private')
```

Still hidden for public deployments, where access-control overrides are meaningless.

## Preserving `null`

Both mappers copy `null` through as `null` rather than coercing to `undefined`. The distinction is load-bearing: `null` means "inherit from project" and must round-trip so the dialog initializes to "Inherit", whereas `undefined` means "the server didn't tell us" — which is precisely the bug being fixed.

## Tests

- `repo-browser.service.spec.ts` — 83 lines; the web-UI path round-trips all three fields, with `null` preserved
- `deployments.service.spec.ts` — 42 lines; same for the REST path

Backend 160 suites / 2816 tests, frontend 76 files / 831 tests, `tsc --noEmit` clean on both.

**No frontend test coverage exists for `AliasesTab` or `UpdateAliasDialog`**, so the prop wiring and the panel condition are covered by type-checking and manual verification only. Building a component-test harness for them was out of scope here, but it's the obvious gap — this bug family would have been caught immediately by one render test.

## Why three PRs for one feature

The alias override was scaffolded end to end — column, DTO, UI control, resolver — and each layer looks correct in isolation. The write silently discarded two fields (#617), the read dropped all three in two separate mappers, and the display condition hid the panel in the inherited case. Each failed independently, which is consistent with the path never having been exercised by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rPL4Mf667ZUyxFN9HmseV
