### PR TITLE
feat(app-catalog): setup notes that live on the card

### DIFF
--- a/apps/backend/drizzle/0041_chemical_spirit.sql
+++ b/apps/backend/drizzle/0041_chemical_spirit.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "installed_apps" DROP COLUMN "manual_steps_acked";

--- a/apps/backend/drizzle/meta/0041_snapshot.json
+++ b/apps/backend/drizzle/meta/0041_snapshot.json
@@ -1,0 +1,7269 @@
+{
+  "id": "5ca43944-dfdc-46c3-938d-e57040127b48",
+  "prevId": "29b3cc75-780c-4fd8-bcca-fac752c6dfe4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alias_proxy_rule_sets": {
+      "name": "alias_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alias_proxy_rule_sets_alias_ruleset_unique": {
+          "name": "alias_proxy_rule_sets_alias_ruleset_unique",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_alias_id_idx": {
+          "name": "alias_proxy_rule_sets_alias_id_idx",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_rule_set_id_idx": {
+          "name": "alias_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk": {
+          "name": "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "deployment_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_project_id_idx": {
+          "name": "api_keys_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_path": {
+          "name": "original_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_number": {
+          "name": "workflow_run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'commits'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_project_id_idx": {
+          "name": "assets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_type_idx": {
+          "name": "assets_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_path_idx": {
+          "name": "assets_project_commit_path_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_branch_idx": {
+          "name": "assets_project_branch_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_idx": {
+          "name": "assets_project_commit_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_created_at_idx": {
+          "name": "assets_project_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_committed_at_idx": {
+          "name": "assets_project_committed_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_path_idx": {
+          "name": "assets_deployment_path_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_id_idx": {
+          "name": "assets_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_size_idx": {
+          "name": "assets_deployment_size_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_uploaded_by_users_id_fk": {
+          "name": "assets_uploaded_by_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist_entries": {
+      "name": "blocklist_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prefix'"
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklist_entries_blocklist_id_idx": {
+          "name": "blocklist_entries_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocklist_entries_unique": {
+          "name": "blocklist_entries_unique",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocklist_entries_blocklist_id_blocklists_id_fk": {
+          "name": "blocklist_entries_blocklist_id_blocklists_id_fk",
+          "tableFrom": "blocklist_entries",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklists": {
+      "name": "blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklists_name_unique": {
+          "name": "blocklists_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cache_rules": {
+      "name": "cache_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_max_age": {
+          "name": "browser_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "cdn_max_age": {
+          "name": "cdn_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stale_while_revalidate": {
+          "name": "stale_while_revalidate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immutable": {
+          "name": "immutable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cacheability": {
+          "name": "cacheability",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cache_rules_project_pattern_unique": {
+          "name": "cache_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_id_idx": {
+          "name": "cache_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_priority_idx": {
+          "name": "cache_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cache_rules_project_id_projects_id_fk": {
+          "name": "cache_rules_project_id_projects_id_fk",
+          "tableFrom": "cache_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_aliases": {
+      "name": "deployment_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_preview": {
+          "name": "is_auto_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployment_aliases_project_alias_unique": {
+          "name": "deployment_aliases_project_alias_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_project_id_idx": {
+          "name": "deployment_aliases_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_alias_unique": {
+          "name": "deployment_aliases_repository_alias_unique",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_idx": {
+          "name": "deployment_aliases_repository_idx",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_commit_sha_idx": {
+          "name": "deployment_aliases_commit_sha_idx",
+          "columns": [
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_deployment_id_idx": {
+          "name": "deployment_aliases_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_aliases_project_id_projects_id_fk": {
+          "name": "deployment_aliases_project_id_projects_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_blocklists": {
+      "name": "domain_blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_blocklists_domain_blocklist_unique": {
+          "name": "domain_blocklists_domain_blocklist_unique",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_blocklists_domain_mapping_id_idx": {
+          "name": "domain_blocklists_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_blocklists_blocklist_id_idx": {
+          "name": "domain_blocklists_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_blocklists_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "domain_blocklists_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "domain_blocklists",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_blocklists_blocklist_id_blocklists_id_fk": {
+          "name": "domain_blocklists_blocklist_id_blocklists_id_fk",
+          "tableFrom": "domain_blocklists",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_mappings": {
+      "name": "domain_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_type": {
+          "name": "domain_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ssl_expires_at": {
+          "name": "ssl_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_verified": {
+          "name": "dns_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dns_verified_at": {
+          "name": "dns_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_renew_ssl": {
+          "name": "auto_renew_ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_renewed_at": {
+          "name": "ssl_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_status": {
+          "name": "ssl_renewal_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_error": {
+          "name": "ssl_renewal_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sticky_sessions_enabled": {
+          "name": "sticky_sessions_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sticky_session_duration": {
+          "name": "sticky_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 86400
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_mappings_project_id_idx": {
+          "name": "domain_mappings_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_domain_idx": {
+          "name": "domain_mappings_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_is_active_idx": {
+          "name": "domain_mappings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_mappings_project_id_projects_id_fk": {
+          "name": "domain_mappings_project_id_projects_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_mappings_created_by_users_id_fk": {
+          "name": "domain_mappings_created_by_users_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_mappings_domain_unique": {
+          "name": "domain_mappings_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_redirects": {
+      "name": "domain_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_domain": {
+          "name": "source_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_domain_id": {
+          "name": "target_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_redirects_target_domain_id_idx": {
+          "name": "domain_redirects_target_domain_id_idx",
+          "columns": [
+            {
+              "expression": "target_domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_redirects_source_domain_idx": {
+          "name": "domain_redirects_source_domain_idx",
+          "columns": [
+            {
+              "expression": "source_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_redirects_target_domain_id_domain_mappings_id_fk": {
+          "name": "domain_redirects_target_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "target_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_redirects_created_by_users_id_fk": {
+          "name": "domain_redirects_created_by_users_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_redirects_source_domain_unique": {
+          "name": "domain_redirects_source_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_rules": {
+      "name": "domain_traffic_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_key": {
+          "name": "condition_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_value": {
+          "name": "condition_value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_rules_domain_id_idx": {
+          "name": "domain_traffic_rules_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_traffic_rules_domain_id_priority_idx": {
+          "name": "domain_traffic_rules_domain_id_priority_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_rules_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_rules_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_rules",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_weights": {
+      "name": "domain_traffic_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_weights_domain_id_idx": {
+          "name": "domain_traffic_weights_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_weights_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_weights_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_weights",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_traffic_weights_domain_alias_unique": {
+          "name": "domain_traffic_weights_domain_alias_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain_id",
+            "alias"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flags_key_idx": {
+          "name": "feature_flags_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_integration_credentials": {
+      "name": "google_integration_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured": {
+          "name": "configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "google_integration_credentials_service_unique": {
+          "name": "google_integration_credentials_service_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installed_apps": {
+      "name": "installed_apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_set_ids": {
+          "name": "rule_set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "schema_ids": {
+          "name": "schema_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "bundle_sha256": {
+          "name": "bundle_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'installing'"
+        },
+        "created_resources": {
+          "name": "created_resources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "installed_by": {
+          "name": "installed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "installed_apps_project_id_idx": {
+          "name": "installed_apps_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "installed_apps_project_id_projects_id_fk": {
+          "name": "installed_apps_project_id_projects_id_fk",
+          "tableFrom": "installed_apps",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "installed_apps_installed_by_users_id_fk": {
+          "name": "installed_apps_installed_by_users_id_fk",
+          "tableFrom": "installed_apps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "installed_apps_app_project_unique": {
+          "name": "installed_apps_app_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oidc_providers_provider_id_unique": {
+          "name": "oidc_providers_provider_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rule_executions": {
+      "name": "onboarding_rule_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rule_executions_user_idx": {
+          "name": "onboarding_rule_executions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_rule_idx": {
+          "name": "onboarding_rule_executions_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_executed_at_idx": {
+          "name": "onboarding_rule_executions_executed_at_idx",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_status_idx": {
+          "name": "onboarding_rule_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rule_executions_rule_id_onboarding_rules_id_fk": {
+          "name": "onboarding_rule_executions_rule_id_onboarding_rules_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "onboarding_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "onboarding_rule_executions_user_id_users_id_fk": {
+          "name": "onboarding_rule_executions_user_id_users_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rules": {
+      "name": "onboarding_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_signup'"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rules_enabled_trigger_idx": {
+          "name": "onboarding_rules_enabled_trigger_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rules_priority_idx": {
+          "name": "onboarding_rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rules_created_by_users_id_fk": {
+          "name": "onboarding_rules_created_by_users_id_fk",
+          "tableFrom": "onboarding_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_preferences": {
+      "name": "path_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spa_mode": {
+          "name": "spa_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_path_preferences_project_id": {
+          "name": "idx_path_preferences_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_preferences_project_id_projects_id_fk": {
+          "name": "path_preferences_project_id_projects_id_fk",
+          "tableFrom": "path_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "path_preferences_project_filepath_unique": {
+          "name": "path_preferences_project_filepath_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "filepath"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_redirects": {
+      "name": "path_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'100'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "path_redirects_domain_mapping_id_idx": {
+          "name": "path_redirects_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "path_redirects_source_path_idx": {
+          "name": "path_redirects_source_path_idx",
+          "columns": [
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_redirects_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "path_redirects_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "path_redirects_created_by_users_id_fk": {
+          "name": "path_redirects_created_by_users_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_token": {
+          "name": "upload_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_token_idx": {
+          "name": "pending_uploads_token_idx",
+          "columns": [
+            {
+              "expression": "upload_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_project_idx": {
+          "name": "pending_uploads_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_project_id_projects_id_fk": {
+          "name": "pending_uploads_project_id_projects_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_uploaded_by_users_id_fk": {
+          "name": "pending_uploads_uploaded_by_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_uploads_upload_token_unique": {
+          "name": "pending_uploads_upload_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data_embeddings": {
+      "name": "pipeline_data_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_data_id": {
+          "name": "pipeline_data_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_embeddings_data_id_idx": {
+          "name": "pipeline_data_embeddings_data_id_idx",
+          "columns": [
+            {
+              "expression": "pipeline_data_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_embeddings_schema_field_idx": {
+          "name": "pipeline_data_embeddings_schema_field_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk": {
+          "name": "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_data",
+          "columnsFrom": [
+            "pipeline_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data": {
+      "name": "pipeline_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_project_id_idx": {
+          "name": "pipeline_data_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_schema_id_idx": {
+          "name": "pipeline_data_schema_id_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_created_at_idx": {
+          "name": "pipeline_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_project_id_projects_id_fk": {
+          "name": "pipeline_data_project_id_projects_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_created_by_users_id_fk": {
+          "name": "pipeline_data_created_by_users_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_execution_logs": {
+      "name": "pipeline_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_id": {
+          "name": "proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps_count": {
+          "name": "steps_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_step": {
+          "name": "error_step",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_meta": {
+          "name": "request_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_exec_logs_rule_created_idx": {
+          "name": "pipeline_exec_logs_rule_created_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_project_idx": {
+          "name": "pipeline_exec_logs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_created_idx": {
+          "name": "pipeline_exec_logs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_execution_logs_project_id_projects_id_fk": {
+          "name": "pipeline_execution_logs_project_id_projects_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schedules": {
+      "name": "pipeline_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_proxy_rule_id": {
+          "name": "target_proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schedules_project_id_idx": {
+          "name": "pipeline_schedules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_schedules_target_proxy_rule_id_idx": {
+          "name": "pipeline_schedules_target_proxy_rule_id_idx",
+          "columns": [
+            {
+              "expression": "target_proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_schedules_enabled_next_run_idx": {
+          "name": "pipeline_schedules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schedules_project_id_projects_id_fk": {
+          "name": "pipeline_schedules_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schedules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_schedules_target_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_schedules_target_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_schedules",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "target_proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schemas": {
+      "name": "pipeline_schemas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schemas_project_id_idx": {
+          "name": "pipeline_schemas_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schemas_project_id_projects_id_fk": {
+          "name": "pipeline_schemas_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schemas",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pipeline_schemas_project_name_unique": {
+          "name": "pipeline_schemas_project_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.primary_content": {
+      "name": "primary_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "www_enabled": {
+          "name": "www_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'redirect-to-www'"
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "primary_content_project_id_projects_id_fk": {
+          "name": "primary_content_project_id_projects_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "primary_content_configured_by_users_id_fk": {
+          "name": "primary_content_configured_by_users_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_default_proxy_rule_sets": {
+      "name": "project_default_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_default_proxy_rule_sets_project_ruleset_unique": {
+          "name": "project_default_proxy_rule_sets_project_ruleset_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_project_id_idx": {
+          "name": "project_default_proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_rule_set_id_idx": {
+          "name": "project_default_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_default_proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "project_default_proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite_links": {
+      "name": "project_invite_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guest'"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invite_links_project_id_idx": {
+          "name": "project_invite_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_token_idx": {
+          "name": "project_invite_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_is_active_idx": {
+          "name": "project_invite_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_links_project_id_projects_id_fk": {
+          "name": "project_invite_links_project_id_projects_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_links_created_by_users_id_fk": {
+          "name": "project_invite_links_created_by_users_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_links_token_unique": {
+          "name": "project_invite_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_group_permissions": {
+      "name": "project_group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_group_permissions_project_idx": {
+          "name": "project_group_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_permissions_group_idx": {
+          "name": "project_group_permissions_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_permissions_project_id_projects_id_fk": {
+          "name": "project_group_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_group_id_user_groups_id_fk": {
+          "name": "project_group_permissions_group_id_user_groups_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_granted_by_users_id_fk": {
+          "name": "project_group_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_group_permissions_unique": {
+          "name": "project_group_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "group_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_permissions": {
+      "name": "project_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_permissions_project_idx": {
+          "name": "project_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_permissions_user_idx": {
+          "name": "project_permissions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_permissions_project_id_projects_id_fk": {
+          "name": "project_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_user_id_users_id_fk": {
+          "name": "project_permissions_user_id_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_granted_by_users_id_fk": {
+          "name": "project_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_permissions_unique": {
+          "name": "project_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_secrets": {
+      "name": "project_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_secrets_project_name_unique": {
+          "name": "project_secrets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_secrets_project_id_idx": {
+          "name": "project_secrets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_secrets_project_id_projects_id_fk": {
+          "name": "project_secrets_project_id_projects_id_fk",
+          "tableFrom": "project_secrets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_found'"
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authenticated'"
+        },
+        "allow_public_signup": {
+          "name": "allow_public_signup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_providers": {
+          "name": "ai_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_services": {
+          "name": "ai_services",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_proxy_rule_set_id": {
+          "name": "default_proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_created_by_idx": {
+          "name": "projects_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_owner_idx": {
+          "name": "projects_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_owner_name_unique": {
+          "name": "projects_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_set_revisions": {
+      "name": "proxy_rule_set_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_set_revisions_set_created_idx": {
+          "name": "proxy_rule_set_revisions_set_created_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_set_revisions_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rule_set_revisions_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rule_set_revisions",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_sets": {
+      "name": "proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_sets_project_name_unique": {
+          "name": "proxy_rule_sets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_project_id_idx": {
+          "name": "proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_environment_idx": {
+          "name": "proxy_rule_sets_environment_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rules": {
+      "name": "proxy_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "methods": {
+          "name": "methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strip_prefix": {
+          "name": "strip_prefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "preserve_host": {
+          "name": "preserve_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forward_cookies": {
+          "name": "forward_cookies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "header_config": {
+          "name": "header_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_transform": {
+          "name": "auth_transform",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_rewrite": {
+          "name": "internal_rewrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proxy_type": {
+          "name": "proxy_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external_proxy'"
+        },
+        "email_handler_config": {
+          "name": "email_handler_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "debug_enabled": {
+          "name": "debug_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rules_rule_set_path_method_unique": {
+          "name": "proxy_rules_rule_set_path_method_unique",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_id_idx": {
+          "name": "proxy_rules_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_order_idx": {
+          "name": "proxy_rules_rule_set_order_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_proxy_type_idx": {
+          "name": "proxy_rules_proxy_type_idx",
+          "columns": [
+            {
+              "expression": "proxy_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rules_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rules_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rules",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_header_rules": {
+      "name": "response_header_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_policy": {
+          "name": "frame_policy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sameorigin'"
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_header_rules_project_pattern_unique": {
+          "name": "response_header_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_id_idx": {
+          "name": "response_header_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_priority_idx": {
+          "name": "response_header_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "response_header_rules_project_id_projects_id_fk": {
+          "name": "response_header_rules_project_id_projects_id_fk",
+          "tableFrom": "response_header_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_logs": {
+      "name": "retention_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_count": {
+          "name": "asset_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "freed_bytes": {
+          "name": "freed_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_partial": {
+          "name": "is_partial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_logs_project_id_idx": {
+          "name": "retention_logs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_rule_id_idx": {
+          "name": "retention_logs_rule_id_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_deleted_at_idx": {
+          "name": "retention_logs_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_project_deleted_at_idx": {
+          "name": "retention_logs_project_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_logs_project_id_projects_id_fk": {
+          "name": "retention_logs_project_id_projects_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retention_logs_rule_id_retention_rules_id_fk": {
+          "name": "retention_logs_rule_id_retention_rules_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "retention_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_rules": {
+      "name": "retention_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_pattern": {
+          "name": "branch_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_branches": {
+          "name": "exclude_branches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keep_with_alias": {
+          "name": "keep_with_alias",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "keep_minimum": {
+          "name": "keep_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "path_patterns": {
+          "name": "path_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_mode": {
+          "name": "path_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_summary": {
+          "name": "last_run_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_rules_project_id_idx": {
+          "name": "retention_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_next_run_idx": {
+          "name": "retention_rules_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_enabled_next_run_idx": {
+          "name": "retention_rules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_rules_project_id_projects_id_fk": {
+          "name": "retention_rules_project_id_projects_id_fk",
+          "tableFrom": "retention_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "share_links_project_id_idx": {
+          "name": "share_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_domain_mapping_id_idx": {
+          "name": "share_links_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_token_idx": {
+          "name": "share_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_is_active_idx": {
+          "name": "share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_project_id_projects_id_fk": {
+          "name": "share_links_project_id_projects_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "share_links_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_created_by_users_id_fk": {
+          "name": "share_links_created_by_users_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "share_links_token_unique": {
+          "name": "share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_challenges": {
+      "name": "ssl_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "base_domain": {
+          "name": "base_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_type": {
+          "name": "challenge_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_name": {
+          "name": "record_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_value": {
+          "name": "record_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_data": {
+          "name": "order_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authz_data": {
+          "name": "authz_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_authorization": {
+          "name": "key_authorization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_challenges_base_domain_idx": {
+          "name": "ssl_challenges_base_domain_idx",
+          "columns": [
+            {
+              "expression": "base_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_challenges_status_idx": {
+          "name": "ssl_challenges_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ssl_challenges_base_domain_unique": {
+          "name": "ssl_challenges_base_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "base_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_renewal_history": {
+      "name": "ssl_renewal_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_type": {
+          "name": "certificate_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_expires_at": {
+          "name": "new_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_renewal_history_domain_id_idx": {
+          "name": "ssl_renewal_history_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_renewal_history_created_at_idx": {
+          "name": "ssl_renewal_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssl_renewal_history_domain_id_domain_mappings_id_fk": {
+          "name": "ssl_renewal_history_domain_id_domain_mappings_id_fk",
+          "tableFrom": "ssl_renewal_history",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_settings": {
+      "name": "ssl_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_config": {
+      "name": "system_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_setup_complete": {
+          "name": "is_setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_config": {
+          "name": "storage_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_provider": {
+          "name": "email_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_config": {
+          "name": "email_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_configured": {
+          "name": "email_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "smtp_config": {
+          "name": "smtp_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_configured": {
+          "name": "smtp_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_config": {
+          "name": "cache_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwt_secret": {
+          "name": "jwt_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_salt": {
+          "name": "api_key_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_public_signups": {
+          "name": "allow_public_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "telemetry_enabled": {
+          "name": "telemetry_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "telemetry_last_sent": {
+          "name": "telemetry_last_sent",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_config": {
+          "name": "branding_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_ip_rollups": {
+      "name": "traffic_ip_rollups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_paths": {
+          "name": "sample_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "sample_user_agents": {
+          "name": "sample_user_agents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_ip_rollups_ip_unique": {
+          "name": "traffic_ip_rollups_ip_unique",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_request_count_idx": {
+          "name": "traffic_ip_rollups_request_count_idx",
+          "columns": [
+            {
+              "expression": "request_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_last_seen_idx": {
+          "name": "traffic_ip_rollups_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_requests": {
+      "name": "traffic_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_version": {
+          "name": "http_version",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referer": {
+          "name": "referer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_requests_timestamp_idx": {
+          "name": "traffic_requests_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_ip_idx": {
+          "name": "traffic_requests_ip_idx",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_status_idx": {
+          "name": "traffic_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_classification_idx": {
+          "name": "traffic_requests_classification_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_group_members": {
+      "name": "user_group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_members_group_idx": {
+          "name": "user_group_members_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_group_members_user_idx": {
+          "name": "user_group_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_group_members_group_id_user_groups_id_fk": {
+          "name": "user_group_members_group_id_user_groups_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_user_id_users_id_fk": {
+          "name": "user_group_members_user_id_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_added_by_users_id_fk": {
+          "name": "user_group_members_added_by_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_group_members_unique": {
+          "name": "user_group_members_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_groups_created_by_idx": {
+          "name": "user_groups_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_created_by_users_id_fk": {
+          "name": "user_groups_created_by_users_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_verified_at": {
+          "name": "oidc_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_invitations_email": {
+          "name": "idx_workspace_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_invitations_token": {
+          "name": "idx_workspace_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invitations_invited_by_users_id_fk": {
+          "name": "workspace_invitations_invited_by_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_accepted_user_id_users_id_fk": {
+          "name": "workspace_invitations_accepted_user_id_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitations_token_unique": {
+          "name": "workspace_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1785457155737,
       "tag": "0040_dashing_wither",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1785697701781,
+      "tag": "0041_chemical_spirit",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/app-catalog/app-catalog.controller.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.controller.spec.ts
@@ -32,7 +32,6 @@ describe('AppCatalogController routes', () => {
       uninstallPreview: jest.fn().mockResolvedValue({ dataTables: [] }),
       uninstall: jest.fn().mockResolvedValue({ removed: {}, dataTables: {}, note: '' }),
       ejectPayload: jest.fn().mockResolvedValue({ repo: 'bffless/apps' }),
-      ackManualStep: jest.fn().mockResolvedValue(['step-1']),
     } as unknown as jest.Mocked<AppCatalogService>;
     controller = new AppCatalogController(catalog);
   });
@@ -97,9 +96,7 @@ describe('AppCatalogController routes', () => {
     expect(catalog.ejectPayload).toHaveBeenCalledWith('ia-1');
   });
 
-  it('ack() delegates to catalog.ackManualStep and wraps the result as { acked }', async () => {
-    const result = await controller.ack('ia-1', { stepId: 'bucket-cors' });
-    expect(catalog.ackManualStep).toHaveBeenCalledWith('ia-1', 'bucket-cors');
-    expect(result).toEqual({ acked: ['step-1'] });
+  it('exposes no manual-step acknowledgement handler', () => {
+    expect((controller as unknown as Record<string, unknown>).ack).toBeUndefined();
   });
 });

--- a/apps/backend/src/app-catalog/app-catalog.controller.ts
+++ b/apps/backend/src/app-catalog/app-catalog.controller.ts
@@ -7,7 +7,6 @@ import { CurrentUser, type CurrentUserData } from '../auth/decorators/current-us
 import { FeatureFlagGuard, RequireFeatureFlags } from '../feature-flags/feature-flag.guard';
 import { AppCatalogService } from './app-catalog.service';
 import {
-  AckManualStepDto,
   PreflightRequestDto,
   UninstallQueryDto,
   UpdateInstalledAppDto,
@@ -85,11 +84,5 @@ export class AppCatalogController {
   @Get('installed/:id/eject')
   async eject(@Param('id') id: string) {
     return this.catalog.ejectPayload(id);
-  }
-
-  @Post('installed/:id/ack-manual-step')
-  async ack(@Param('id') id: string, @Body() body: AckManualStepDto) {
-    const acked = await this.catalog.ackManualStep(id, body.stepId);
-    return { acked };
   }
 }

--- a/apps/backend/src/app-catalog/app-catalog.dtos.ts
+++ b/apps/backend/src/app-catalog/app-catalog.dtos.ts
@@ -79,12 +79,6 @@ export class UpdateInstalledAppDto {
   prune?: boolean;
 }
 
-export class AckManualStepDto {
-  @ApiPropertyOptional({ description: 'The manual step id to mark acknowledged' })
-  @IsString()
-  stepId!: string;
-}
-
 /** `DELETE .../installed/:id?deleteData=true|false` — query strings arrive as text. */
 export class UninstallQueryDto {
   @ApiPropertyOptional({

--- a/apps/backend/src/app-catalog/app-catalog.e2e-ish.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.e2e-ish.spec.ts
@@ -125,7 +125,6 @@ const POST_UPDATE_ROW: InstalledApp = {
   schemaIds: ['sch-items', 'sch-notes'],
   bundleSha256: v2.sha256,
   manifest: v2.manifest,
-  manualStepsAcked: [],
   status: 'installed',
   createdResources: {
     projectCreated: false,

--- a/apps/backend/src/app-catalog/app-catalog.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.spec.ts
@@ -21,7 +21,7 @@ jest.mock('../db/client', () => {
 });
 
 import { ConfigService } from '@nestjs/config';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Logger, NotFoundException } from '@nestjs/common';
 import { db } from '../db/client';
 import { AppCatalogService } from './app-catalog.service';
 import type { AppManifest, AppRegistryEntry } from './app-manifest.types';
@@ -119,7 +119,7 @@ describe('AppCatalogService', () => {
     uninstallPreview: jest.Mock;
   };
   let jobs: { get: jest.Mock };
-  let certStep: { schemeFor: jest.Mock };
+  let certStep: { schemeFor: jest.Mock; plan: jest.Mock; execute: jest.Mock };
   let storageAdapter: {
     supportsPresignedUrls: jest.Mock;
     isLocalAdapter?: boolean;
@@ -155,7 +155,11 @@ describe('AppCatalogService', () => {
     // Default serving model for these tests: a certificate covers the app host,
     // so URLs are https. Scheme selection itself is covered in
     // app-cert-step.service.spec.ts.
-    certStep = { schemeFor: jest.fn().mockResolvedValue('https') };
+    certStep = {
+      schemeFor: jest.fn().mockResolvedValue('https'),
+      plan: jest.fn().mockResolvedValue({ model: 'wildcard', action: 'covered' }),
+      execute: jest.fn().mockResolvedValue({ status: 'done', detail: 'covered' }),
+    };
     storageAdapter = {
       supportsPresignedUrls: jest.fn().mockReturnValue(true),
       // Brands as local the way `resolveLocalAdapter` expects (see local.adapter.ts):
@@ -211,29 +215,6 @@ describe('AppCatalogService', () => {
       mockDb.__queue([]);
 
       await expect(service.ejectPayload('missing')).rejects.toThrow(NotFoundException);
-    });
-  });
-
-  describe('ackManualStep', () => {
-    it('appends a step id to the acked list', async () => {
-      mockDb.__queue([{ ...ROW, manualStepsAcked: ['bucket-cors'] }]);
-      mockDb.__queue([]); // update
-
-      const acked = await service.ackManualStep('ia-1', 'platform-only');
-
-      expect(acked).toEqual(expect.arrayContaining(['bucket-cors', 'platform-only']));
-      expect(mockDb.set).toHaveBeenCalledWith(
-        expect.objectContaining({ manualStepsAcked: expect.arrayContaining(['bucket-cors', 'platform-only']) }),
-      );
-    });
-
-    it('is idempotent — double-acking the same step does not duplicate it', async () => {
-      mockDb.__queue([{ ...ROW, manualStepsAcked: ['bucket-cors'] }]);
-      mockDb.__queue([]);
-
-      const acked = await service.ackManualStep('ia-1', 'bucket-cors');
-
-      expect(acked).toEqual(['bucket-cors']);
     });
   });
 
@@ -336,7 +317,6 @@ describe('AppCatalogService', () => {
         status: 'installed',
         updateAvailable: true, // 1.1.0 > 1.0.0
         manualSteps: [{ id: 'always-step', title: 'Always', body: 'always applies' }],
-        manualStepsAcked: [],
       });
     });
 
@@ -521,6 +501,88 @@ describe('AppCatalogService', () => {
         expect(handoff.installed!.appUrl).toBe('https://files.example.com');
         expect(legacy.installed!.appUrl).toBe('https://legacy.example.com');
       });
+    });
+  });
+
+  describe('installed manual steps', () => {
+    // These four cases need an appHost the service can resolve — without a
+    // domainId (ROW's default is null), buildInstalledSummary never even
+    // calls certStepService, so the cert-note tests would pass trivially
+    // without exercising anything. Give the row a domainId and queue the
+    // matching domain mapping, the same pattern the appUrl tests above use.
+    it('interpolates {projectPath} and {appHost} into the returned steps', async () => {
+      const manifest = {
+        ...MANIFEST,
+        install: {
+          ...MANIFEST.install,
+          manualSteps: [
+            {
+              id: 'grant-access',
+              title: 'Give other people access',
+              body: 'Add each person as a guest.',
+              deepLink: '/repo/{projectPath}/settings?tab=members',
+            },
+            {
+              id: 'bucket-cors',
+              title: 'Let the browser upload to your bucket',
+              body: 'Allow PUT from {appHost}.',
+            },
+          ],
+        },
+      };
+      mockDb.__queue([{ ...ROW, manifest, domainId: 'dom-1' }]);
+      mockDb.__queue([{ id: 'dom-1', domain: 'reader.example.com' }]);
+
+      const result = await service.listCatalog();
+      const steps = result.data[0].installed!.manualSteps;
+
+      expect(steps[0].deepLink).toBe('/repo/acme/site/settings?tab=members');
+      expect(steps[1].body).toBe('Allow PUT from reader.example.com.');
+    });
+
+    it('appends the cert note when the host has no certificate', async () => {
+      certStep.plan.mockResolvedValue({ model: 'direct-no-wildcard', action: 'report' });
+      certStep.execute.mockResolvedValue({
+        status: 'action-required',
+        detail: 'served over HTTP',
+        manualStep: { id: 'provision-wildcard-cert', title: 'Turn on HTTPS', body: 'Body.' },
+      });
+      mockDb.__queue([{ ...ROW, domainId: 'dom-1' }]);
+      mockDb.__queue([{ id: 'dom-1', domain: 'reader.example.com' }]);
+
+      const result = await service.listCatalog();
+
+      expect(result.data[0].installed!.manualSteps.map((s) => s.id)).toContain(
+        'provision-wildcard-cert',
+      );
+    });
+
+    it('omits the cert note when a wildcard already covers the host', async () => {
+      certStep.plan.mockResolvedValue({ model: 'wildcard', action: 'covered' });
+      certStep.execute.mockResolvedValue({ status: 'done', detail: 'covered' });
+      mockDb.__queue([{ ...ROW, domainId: 'dom-1' }]);
+      mockDb.__queue([{ id: 'dom-1', domain: 'reader.example.com' }]);
+
+      const result = await service.listCatalog();
+
+      expect(result.data[0].installed!.manualSteps.map((s) => s.id)).not.toContain(
+        'provision-wildcard-cert',
+      );
+    });
+
+    it('still lists the app when the cert lookup throws', async () => {
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+      certStep.plan.mockRejectedValue(new Error('domains service down'));
+      mockDb.__queue([{ ...ROW, domainId: 'dom-1' }]);
+      mockDb.__queue([{ id: 'dom-1', domain: 'reader.example.com' }]);
+
+      const result = await service.listCatalog();
+
+      expect(result.data[0].installed).toBeDefined();
+      expect(result.data[0].installed!.manualSteps.map((s) => s.id)).not.toContain(
+        'provision-wildcard-cert',
+      );
+      expect(warnSpy).toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/app-catalog/app-catalog.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.spec.ts
@@ -79,7 +79,6 @@ const ROW = {
   schemaIds: [] as string[],
   bundleSha256: 'a'.repeat(64),
   manifest: MANIFEST,
-  manualStepsAcked: [] as string[],
   status: 'installed' as const,
   createdResources: {},
   installedBy: 'user-1',

--- a/apps/backend/src/app-catalog/app-catalog.service.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.ts
@@ -271,21 +271,6 @@ export class AppCatalogService {
     };
   }
 
-  /** Idempotent: acking an already-acked step id is a no-op, not a duplicate entry. */
-  async ackManualStep(installedAppId: string, stepId: string): Promise<string[]> {
-    const row = await this.requireRow(installedAppId);
-    const acked = new Set(row.manualStepsAcked ?? []);
-    acked.add(stepId);
-    const updated = [...acked];
-
-    await db
-      .update(installedApps)
-      .set({ manualStepsAcked: updated, updatedAt: new Date() })
-      .where(eq(installedApps.id, row.id));
-
-    return updated;
-  }
-
   // ==================== catalog assembly helpers ====================
 
   private async buildRegistryEntry(

--- a/apps/backend/src/app-catalog/app-catalog.service.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { eq, inArray } from 'drizzle-orm';
 import { db } from '../db/client';
@@ -28,7 +28,7 @@ import {
 import { AppInstallJobsService, type InstallJob } from './app-install-jobs.service';
 import { AppCertStepService } from './app-cert-step.service';
 import { compareSemver } from './ce-version.util';
-import { manualStepApplies } from './app-manifest.util';
+import { manualStepApplies, interpolateStep, type StepPlaceholders } from './app-manifest.util';
 import type { AppManifest, AppManualStep, AppRegistryEntry } from './app-manifest.types';
 import type { PreflightRequestDto } from './app-catalog.dtos';
 
@@ -80,7 +80,6 @@ export interface CatalogEntry {
     status: InstalledAppStatus;
     updateAvailable: boolean;
     manualSteps: AppManualStep[];
-    manualStepsAcked: string[];
   };
 }
 
@@ -105,6 +104,8 @@ export interface PreflightResult {
  */
 @Injectable()
 export class AppCatalogService {
+  private readonly logger = new Logger(AppCatalogService.name);
+
   constructor(
     private readonly projectsService: ProjectsService,
     private readonly configService: ConfigService,
@@ -350,17 +351,23 @@ export class AppCatalogService {
     const updateAvailable =
       registryVersion !== undefined && compareSemver(registryVersion, row.version) > 0;
 
+    const projectPath = `${project.owner}/${project.name}`;
+    const appHost = row.domainId ? domainsById.get(row.domainId)?.domain : undefined;
+    const appUrl = await this.resolveAppUrl(row, domainsById);
+
     return {
       installedAppId: row.id,
       version: row.version,
       projectId: row.projectId,
-      projectName: `${project.owner}/${project.name}`,
+      projectName: projectPath,
       alias: row.alias,
-      appUrl: await this.resolveAppUrl(row, domainsById),
+      appUrl,
       status: row.status,
       updateAvailable,
-      manualSteps: this.applicableManualSteps(manifest),
-      manualStepsAcked: row.manualStepsAcked ?? [],
+      manualSteps: [
+        ...this.applicableManualSteps(manifest, { projectPath, appHost }),
+        ...(await this.certManualStep(appHost)),
+      ],
     };
   }
 
@@ -461,9 +468,39 @@ export class AppCatalogService {
     return `${scheme}://${ref.domain}`;
   }
 
-  private applicableManualSteps(manifest: AppManifest): AppManualStep[] {
+  private applicableManualSteps(
+    manifest: AppManifest,
+    values: StepPlaceholders,
+  ): AppManualStep[] {
     const ctx = this.instanceContext();
-    return (manifest.install.manualSteps ?? []).filter((step) => manualStepApplies(step, ctx));
+    return (manifest.install.manualSteps ?? [])
+      .filter((step) => manualStepApplies(step, ctx))
+      .map((step) => interpolateStep(step, values))
+      .filter((step): step is AppManualStep => step !== null);
+  }
+
+  /**
+   * The TLS note is synthesized during the install run and attached to the
+   * in-memory job, so it used to vanish the moment the catalog refetched
+   * (ce#584 follow-up). Re-deriving it here keeps it visible AND makes it
+   * self-healing — it disappears on its own once a wildcard covers the host.
+   *
+   * `AppCertStepService` never throws by contract; the guard is for the day
+   * that stops being true. A catalog that fails to list is worse than one
+   * missing an advisory line.
+   */
+  private async certManualStep(appHost: string | undefined): Promise<AppManualStep[]> {
+    if (!appHost) return [];
+    try {
+      const plan = await this.certStepService.plan(appHost);
+      const result = await this.certStepService.execute(plan, appHost);
+      return result.manualStep ? [result.manualStep] : [];
+    } catch (error) {
+      this.logger.warn(
+        `Could not derive the certificate note for ${appHost}: ${(error as Error).message}`,
+      );
+      return [];
+    }
   }
 
   /** Mirrors `AppInstallerService`'s private helper of the same name — small enough that

--- a/apps/backend/src/app-catalog/app-cert-step.service.ts
+++ b/apps/backend/src/app-catalog/app-cert-step.service.ts
@@ -152,13 +152,10 @@ export class AppCertStepService {
             'certificate covers it yet. The app works meanwhile; HTTPS needs a wildcard.',
           manualStep: {
             id: 'provision-wildcard-cert',
-            title: 'Provision a wildcard certificate to serve this app over HTTPS',
+            title: 'Turn on HTTPS for this app',
             body:
-              `${appHost} is reachable now, over HTTP. On this serving model a wildcard certificate ` +
-              "for *.<your domain> is what gives app subdomains HTTPS — it's the only certificate an " +
-              'app subdomain can be served with, and one wildcard covers every app you install later. ' +
-              'Provision it on the Domains page (a DNS TXT record proves ownership); the app switches ' +
-              'to HTTPS once it is issued.',
+              'Your app is live, over HTTP. Provision a wildcard certificate on the Domains ' +
+              'page and it switches to HTTPS on its own.',
             deepLink: '/domains',
             appliesWhen: 'selfHosted',
           },

--- a/apps/backend/src/app-catalog/app-installer.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.spec.ts
@@ -511,6 +511,29 @@ describe('AppInstallerService', () => {
       expect(jobs.get(jobId)!.manualSteps!.map((s) => s.id)).toEqual(['bucket-cors']);
     });
 
+    it('interpolates {projectPath} and {appHost} into the job manual steps', async () => {
+      const withToken = {
+        ...TEST_MANIFEST.install,
+        manualSteps: [
+          {
+            id: 'grant-access',
+            title: 'Give other people access',
+            body: 'Add each person as a guest.',
+            deepLink: '/repo/{projectPath}/settings?tab=members',
+          },
+        ],
+      };
+      bundleService.fetchBundle.mockResolvedValue(makeBundle({ install: withToken }));
+      queueInstallDb();
+
+      const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      expect(jobs.get(jobId)!.manualSteps![0].deepLink).toBe(
+        '/repo/acme/site/settings?tab=members',
+      );
+    });
+
     it('does not treat a CachingStorageAdapter-wrapped local adapter as bucket storage (regression: live droplet Redis cache)', async () => {
       // Shape observed live: STORAGE_ADAPTER is a CachingStorageAdapter wrapping the real
       // LocalStorageAdapter. It has no getAdapterType(), so the old `getAdapterType?.() ??
@@ -1212,6 +1235,35 @@ describe('AppInstallerService', () => {
         const deployStep = jobs.get(jobId)!.steps.find((s) => s.id === 'deploy')!;
         expect(deployStep.detail).toContain('alias "handoff"');
         expect(deployStep.detail).toContain('files.example.com');
+      });
+
+      it('interpolates {projectPath} and {appHost} into the update job manual steps', async () => {
+        const withToken = {
+          ...TEST_MANIFEST.install,
+          manualSteps: [
+            {
+              id: 'grant-access',
+              title: 'Give other people access',
+              body: 'Add each person as a guest.',
+              deepLink: '/repo/{projectPath}/settings?tab=members',
+            },
+          ],
+        };
+        bundleService.fetchBundle.mockResolvedValue(makeBundle({ install: withToken }));
+        mockDb.__queue([{ domain: 'files.example.com' }]); // lookupDomainHost
+        mockDb.__queue([]); // final record update
+
+        const { jobId } = service.startUpdate(
+          { ...installed, domainId: 'dom-1' } as never,
+          { ...ENTRY, version: '1.1.0' },
+          'user-1',
+          { prune: false },
+        );
+        await service.whenIdle();
+
+        expect(jobs.get(jobId)!.manualSteps![0].deepLink).toBe(
+          '/repo/acme/site/settings?tab=members',
+        );
       });
     });
   });

--- a/apps/backend/src/app-catalog/app-installer.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.spec.ts
@@ -177,7 +177,6 @@ const INSTALLED_ROW = {
   schemaIds: [] as string[],
   bundleSha256: 'a'.repeat(64),
   manifest: TEST_MANIFEST,
-  manualStepsAcked: [] as string[],
   status: 'installing',
   createdResources: {} as CreatedResources,
   installedBy: 'user-1',

--- a/apps/backend/src/app-catalog/app-installer.service.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.ts
@@ -26,7 +26,7 @@ import { AppBundleService, type LoadedBundle } from './app-bundle.service';
 import { AppCertStepService } from './app-cert-step.service';
 import { AppInstallJobsService, type InstallStepId } from './app-install-jobs.service';
 import { AppPreflightService, type GateResult } from './app-preflight.service';
-import { manualStepApplies } from './app-manifest.util';
+import { manualStepApplies, interpolateStep, type StepPlaceholders } from './app-manifest.util';
 import type { AppManifest, AppManualStep, AppRegistryEntry } from './app-manifest.types';
 
 export interface InstallTarget {
@@ -303,7 +303,14 @@ export class AppInstallerService {
       // ---- 9. record ----
       step = 'record';
       this.jobs.setStep(jobId, step, { status: 'running' });
-      const manualSteps = [...this.applicableManualSteps(manifest), ...certManualSteps];
+      const stepValues: StepPlaceholders = {
+        projectPath: `${project.owner}/${project.name}`,
+        appHost: appHost ?? undefined,
+      };
+      const manualSteps = [
+        ...this.applicableManualSteps(manifest, stepValues),
+        ...certManualSteps,
+      ];
       // Scheme follows the serving model, not wishful thinking: a direct+LE
       // instance with no certificate covering this host yet serves it over
       // plain HTTP, and linking to https:// there lands the operator on the
@@ -445,7 +452,10 @@ export class AppInstallerService {
         })
         .where(eq(installedApps.id, installed.id));
 
-      const manualSteps = this.applicableManualSteps(manifest);
+      const manualSteps = this.applicableManualSteps(manifest, {
+        projectPath: `${project.owner}/${project.name}`,
+        appHost: appHost ?? undefined,
+      });
       const appUrl = appHost
         ? `${await this.certStepService.schemeFor(appHost, domainRow!.sslEnabled)}://${appHost}`
         : deployment.urls?.default;
@@ -1286,9 +1296,15 @@ export class AppInstallerService {
     return Buffer.from(zipSync(entries));
   }
 
-  private applicableManualSteps(manifest: AppManifest): AppManualStep[] {
+  private applicableManualSteps(
+    manifest: AppManifest,
+    values: StepPlaceholders,
+  ): AppManualStep[] {
     const ctx = this.instanceContext();
-    return (manifest.install.manualSteps ?? []).filter((step) => manualStepApplies(step, ctx));
+    return (manifest.install.manualSteps ?? [])
+      .filter((step) => manualStepApplies(step, ctx))
+      .map((step) => interpolateStep(step, values))
+      .filter((step): step is AppManualStep => step !== null);
   }
 
   private instanceContext(): { bucketStorage: boolean; platformMode: boolean } {

--- a/apps/backend/src/app-catalog/app-manifest.util.spec.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.spec.ts
@@ -436,4 +436,20 @@ describe('interpolateStep', () => {
     expect(result!.body).toBe('But also configure locally.');
     expect(result!.body).not.toContain('{appHost}');
   });
+
+  it('drops the whole sentence, not just up to an embedded decimal point, leaving no orphan fragment', () => {
+    const result = interpolateStep(
+      {
+        id: 'x',
+        title: 'T',
+        body: 'Allow PUT from {appHost} for v1.0 clients. Nothing else.',
+      },
+      {},
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.body).toBe('Nothing else.');
+    expect(result!.body).not.toContain('0 clients');
+    expect(result!.body).not.toContain('{appHost}');
+  });
 });

--- a/apps/backend/src/app-catalog/app-manifest.util.spec.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.spec.ts
@@ -452,4 +452,41 @@ describe('interpolateStep', () => {
     expect(result!.body).not.toContain('0 clients');
     expect(result!.body).not.toContain('{appHost}');
   });
+
+  it('leaves a decimal-only body with no tokens fully unchanged', () => {
+    const result = interpolateStep({ id: 'x', title: 'T', body: 'Works fine on v1.0' }, {});
+
+    expect(result).not.toBeNull();
+    expect(result!.body).toBe('Works fine on v1.0');
+  });
+
+  it('leaves a body ending in a decimal point fully unchanged', () => {
+    const result = interpolateStep({ id: 'x', title: 'T', body: 'Ends with decimal 3.14' }, {});
+
+    expect(result).not.toBeNull();
+    expect(result!.body).toBe('Ends with decimal 3.14');
+  });
+
+  it('substitutes a resolvable token without eating the trailing decimal-bearing text', () => {
+    const result = interpolateStep(
+      { id: 'x', title: 'T', body: 'Requires {appHost} for v2.5 support' },
+      { appHost: 'x.example.com' },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.body).toBe('Requires x.example.com for v2.5 support');
+  });
+
+  it.each([
+    ['embedded decimal with no final terminator', 'Ships version v1.0 today'],
+    ['no period at all', 'No terminator here'],
+    ['single sentence', 'Just one sentence.'],
+    ['multi-sentence', 'First one. Second one. Third one.'],
+    ['ends without a terminator (dot present but unterminated)', 'See docs at v2 spec.io for details'],
+  ])('round-trips a body with no unresolvable tokens byte-identically: %s', (_label, body) => {
+    const result = interpolateStep({ id: 'x', title: 'T', body }, {});
+
+    expect(result).not.toBeNull();
+    expect(result!.body).toBe(body);
+  });
 });

--- a/apps/backend/src/app-catalog/app-manifest.util.spec.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.spec.ts
@@ -1,4 +1,9 @@
-import { validateAppManifest, validateRegistry, manualStepApplies } from './app-manifest.util';
+import {
+  validateAppManifest,
+  validateRegistry,
+  manualStepApplies,
+  interpolateStep,
+} from './app-manifest.util';
 import { APPLIES_WHEN_VALUES, type AppManualStep } from './app-manifest.types';
 
 export const TEST_MANIFEST = {
@@ -282,5 +287,66 @@ describe('manualStepApplies', () => {
     const step: AppManualStep = { ...baseStep, appliesWhen: 'selfHosted' };
     expect(manualStepApplies(step, { bucketStorage: false, platformMode: false })).toBe(true);
     expect(manualStepApplies(step, { bucketStorage: false, platformMode: true })).toBe(false);
+  });
+});
+
+describe('interpolateStep', () => {
+  const step = {
+    id: 'grant-access',
+    title: 'Give other people access',
+    body: 'Add each person as a guest on {projectPath}.',
+    deepLink: '/repo/{projectPath}/settings?tab=members',
+  };
+
+  it('expands every token across title, body and deepLink', () => {
+    const result = interpolateStep(
+      { ...step, title: 'Access for {projectPath}' },
+      { projectPath: 'acme/site', appHost: 'reader.example.com' },
+    );
+
+    expect(result.title).toBe('Access for acme/site');
+    expect(result.body).toBe('Add each person as a guest on acme/site.');
+    expect(result.deepLink).toBe('/repo/acme/site/settings?tab=members');
+  });
+
+  it('expands every occurrence of a repeated token', () => {
+    const result = interpolateStep(
+      { id: 'x', title: 't', body: 'Allow PUT from {appHost} to {appHost}.' },
+      { appHost: 'a.example.com' },
+    );
+
+    expect(result.body).toBe('Allow PUT from a.example.com to a.example.com.');
+  });
+
+  it('leaves a step with no tokens untouched', () => {
+    const plain = { id: 'x', title: 'Title', body: 'Body.', deepLink: '/domains' };
+
+    expect(interpolateStep(plain, { projectPath: 'acme/site' })).toEqual(plain);
+  });
+
+  it('drops a sentence whose token has no value rather than emitting a literal brace', () => {
+    const result = interpolateStep(
+      { id: 'x', title: 'T', body: 'First sentence. Allow PUT from {appHost}. Last sentence.' },
+      {},
+    );
+
+    expect(result.body).toBe('First sentence. Last sentence.');
+    expect(result.body).not.toContain('{appHost}');
+  });
+
+  it('omits deepLink entirely when it depends on a token with no value', () => {
+    const result = interpolateStep(
+      { id: 'x', title: 'T', body: 'B', deepLink: '/repo/{projectPath}/settings' },
+      {},
+    );
+
+    expect(result.deepLink).toBeUndefined();
+  });
+
+  it('does not mutate the input step', () => {
+    const original = { id: 'x', title: 'T', body: 'On {projectPath}.' };
+    interpolateStep(original, { projectPath: 'acme/site' });
+
+    expect(original.body).toBe('On {projectPath}.');
   });
 });

--- a/apps/backend/src/app-catalog/app-manifest.util.spec.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.spec.ts
@@ -149,6 +149,57 @@ describe('validateAppManifest', () => {
       expect(result.errors.some((e) => e.startsWith('install.alias:'))).toBe(true);
     }
   });
+
+  it('fails when a manual step body uses an unknown placeholder, naming the known ones', () => {
+    const result = validateAppManifest({
+      ...TEST_MANIFEST,
+      install: {
+        ...TEST_MANIFEST.install,
+        manualSteps: [{ id: 'x', title: 'Title', body: 'Go to {foo} now.' }],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const err = result.errors.find((e) => e.startsWith('install.manualSteps[0].body:'));
+      expect(err).toContain('unknown placeholder {foo}');
+      expect(err).toContain('projectPath, appHost');
+    }
+  });
+
+  it('fails when a manual step deepLink uses an unknown placeholder', () => {
+    const result = validateAppManifest({
+      ...TEST_MANIFEST,
+      install: {
+        ...TEST_MANIFEST.install,
+        manualSteps: [{ id: 'x', title: 'T', body: 'B', deepLink: '/repo/{owner}/settings' }],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.includes('unknown placeholder {owner}'))).toBe(true);
+    }
+  });
+
+  it('accepts the known placeholders', () => {
+    const result = validateAppManifest({
+      ...TEST_MANIFEST,
+      install: {
+        ...TEST_MANIFEST.install,
+        manualSteps: [
+          {
+            id: 'x',
+            title: 'T',
+            body: 'Allow PUT from {appHost}.',
+            deepLink: '/repo/{projectPath}/settings?tab=members',
+          },
+        ],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
 });
 
 describe('validateRegistry', () => {

--- a/apps/backend/src/app-catalog/app-manifest.util.spec.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.spec.ts
@@ -304,9 +304,10 @@ describe('interpolateStep', () => {
       { projectPath: 'acme/site', appHost: 'reader.example.com' },
     );
 
-    expect(result.title).toBe('Access for acme/site');
-    expect(result.body).toBe('Add each person as a guest on acme/site.');
-    expect(result.deepLink).toBe('/repo/acme/site/settings?tab=members');
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Access for acme/site');
+    expect(result!.body).toBe('Add each person as a guest on acme/site.');
+    expect(result!.deepLink).toBe('/repo/acme/site/settings?tab=members');
   });
 
   it('expands every occurrence of a repeated token', () => {
@@ -315,13 +316,15 @@ describe('interpolateStep', () => {
       { appHost: 'a.example.com' },
     );
 
-    expect(result.body).toBe('Allow PUT from a.example.com to a.example.com.');
+    expect(result).not.toBeNull();
+    expect(result!.body).toBe('Allow PUT from a.example.com to a.example.com.');
   });
 
   it('leaves a step with no tokens untouched', () => {
     const plain = { id: 'x', title: 'Title', body: 'Body.', deepLink: '/domains' };
 
-    expect(interpolateStep(plain, { projectPath: 'acme/site' })).toEqual(plain);
+    const result = interpolateStep(plain, { projectPath: 'acme/site' });
+    expect(result).toEqual(plain);
   });
 
   it('drops a sentence whose token has no value rather than emitting a literal brace', () => {
@@ -330,8 +333,9 @@ describe('interpolateStep', () => {
       {},
     );
 
-    expect(result.body).toBe('First sentence. Last sentence.');
-    expect(result.body).not.toContain('{appHost}');
+    expect(result).not.toBeNull();
+    expect(result!.body).toBe('First sentence. Last sentence.');
+    expect(result!.body).not.toContain('{appHost}');
   });
 
   it('omits deepLink entirely when it depends on a token with no value', () => {
@@ -340,7 +344,8 @@ describe('interpolateStep', () => {
       {},
     );
 
-    expect(result.deepLink).toBeUndefined();
+    expect(result).not.toBeNull();
+    expect(result!.deepLink).toBeUndefined();
   });
 
   it('does not mutate the input step', () => {
@@ -348,5 +353,36 @@ describe('interpolateStep', () => {
     interpolateStep(original, { projectPath: 'acme/site' });
 
     expect(original.body).toBe('On {projectPath}.');
+  });
+
+  it('returns null when title has an unresolvable token', () => {
+    const result = interpolateStep(
+      { id: 'x', title: 'Configure on {projectPath}', body: 'B' },
+      {},
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('returns a step when title tokens all resolve', () => {
+    const result = interpolateStep(
+      { id: 'x', title: 'Access for {projectPath}', body: 'B' },
+      { projectPath: 'acme/site' },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Access for acme/site');
+  });
+
+  it('survives when only body has an unresolvable token', () => {
+    const result = interpolateStep(
+      { id: 'x', title: 'Configure CORS', body: 'Allow PUT from {appHost}. But also configure locally.' },
+      {},
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Configure CORS');
+    expect(result!.body).toBe('But also configure locally.');
+    expect(result!.body).not.toContain('{appHost}');
   });
 });

--- a/apps/backend/src/app-catalog/app-manifest.util.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.ts
@@ -419,7 +419,12 @@ export function manualStepApplies(
   }
 }
 
-/** The closed set of tokens a manifest may use in a manual step. */
+/** The closed set of tokens a manifest may use in a manual step.
+ * Mirrored in `bffless/apps`'s `scripts/check-app-conventions.mjs`
+ * (`PLACEHOLDER_TOKENS`) so manifests are linted against this same list before
+ * publish. Keep in sync in that direction: removing or renaming a token here
+ * without updating that copy lets a manifest that lints clean in `bffless/apps`
+ * fail CE's install-time validation for every user who tries to install it. */
 export const PLACEHOLDER_TOKENS = ['projectPath', 'appHost'] as const;
 
 export type PlaceholderToken = (typeof PLACEHOLDER_TOKENS)[number];
@@ -434,10 +439,14 @@ const TOKEN_RE = new RegExp(`\\{(${PLACEHOLDER_TOKENS.join('|')})\\}`, 'g');
  * A sentence whose token has no value (an app installed before it had a
  * domain has no `{appHost}`) is dropped whole rather than rendered with a
  * literal brace or a hole where the host should be. Sentence = run of text up
- * to and including its terminating period + following space.
+ * to and including its terminating period + following space. A period only
+ * terminates a sentence when it's followed by whitespace or end-of-string —
+ * otherwise (e.g. the "." in "v1.0") it's treated as part of the sentence, so
+ * an embedded decimal point can't split a token-bearing sentence in two and
+ * leave an orphan fragment behind when the first half is dropped.
  */
 function expandBody(text: string, values: StepPlaceholders): string {
-  const sentences = text.match(/[^.]*\.\s*|[^.]+$/g) ?? [text];
+  const sentences = text.match(/(?:[^.]|\.(?!\s|$))*\.(?:\s+|$)|[^.]+$/g) ?? [text];
 
   return sentences
     .filter((sentence) => {

--- a/apps/backend/src/app-catalog/app-manifest.util.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.ts
@@ -407,12 +407,13 @@ export type StepPlaceholders = Partial<Record<PlaceholderToken, string>>;
 const TOKEN_RE = new RegExp(`\\{(${PLACEHOLDER_TOKENS.join('|')})\\}`, 'g');
 
 /**
+ * Expands tokens in body text, dropping sentences that contain unresolvable tokens.
  * A sentence whose token has no value (an app installed before it had a
  * domain has no `{appHost}`) is dropped whole rather than rendered with a
  * literal brace or a hole where the host should be. Sentence = run of text up
  * to and including its terminating period + following space.
  */
-function expand(text: string, values: StepPlaceholders): string {
+function expandBody(text: string, values: StepPlaceholders): string {
   const sentences = text.match(/[^.]*\.\s*|[^.]+$/g) ?? [text];
 
   return sentences
@@ -426,22 +427,37 @@ function expand(text: string, values: StepPlaceholders): string {
 }
 
 /**
+ * Checks if text can be fully expanded (all tokens have values).
+ * Used for title and deepLink which cannot be partially dropped.
+ */
+function canExpand(text: string, values: StepPlaceholders): boolean {
+  const tokens = [...text.matchAll(TOKEN_RE)].map((m) => m[1] as PlaceholderToken);
+  return tokens.every((token) => values[token] !== undefined);
+}
+
+/**
  * Expands `{projectPath}`/`{appHost}` in a manual step. A manifest cannot
  * hardcode `/repo/acme/site/settings?tab=members` — it does not know which
  * project it will be installed into — so it declares the token and CE fills
- * it in at read time. Returns a new step; never mutates the input.
+ * it in at read time. Returns a new step; never mutates the input. Returns
+ * null if the step's title has an unresolvable token — a note without a title
+ * is worse than no note.
  */
-export function interpolateStep(step: AppManualStep, values: StepPlaceholders): AppManualStep {
+export function interpolateStep(step: AppManualStep, values: StepPlaceholders): AppManualStep | null {
+  // If title has any unresolvable token, drop the entire step.
+  if (!canExpand(step.title, values)) {
+    return null;
+  }
+
   const result: AppManualStep = {
     ...step,
-    title: expand(step.title, values),
-    body: expand(step.body, values),
+    title: step.title.replace(TOKEN_RE, (_match, token: PlaceholderToken) => values[token] as string),
+    body: expandBody(step.body, values),
   };
 
   if (step.deepLink !== undefined) {
-    const tokens = [...step.deepLink.matchAll(TOKEN_RE)].map((m) => m[1] as PlaceholderToken);
     // A link to a page we can't name is worse than no link.
-    if (tokens.every((token) => values[token] !== undefined)) {
+    if (canExpand(step.deepLink, values)) {
       result.deepLink = step.deepLink.replace(
         TOKEN_RE,
         (_match, token: PlaceholderToken) => values[token] as string,

--- a/apps/backend/src/app-catalog/app-manifest.util.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.ts
@@ -395,3 +395,61 @@ export function manualStepApplies(
       return !ctx.platformMode;
   }
 }
+
+/** The closed set of tokens a manifest may use in a manual step. */
+export const PLACEHOLDER_TOKENS = ['projectPath', 'appHost'] as const;
+
+export type PlaceholderToken = (typeof PLACEHOLDER_TOKENS)[number];
+
+export type StepPlaceholders = Partial<Record<PlaceholderToken, string>>;
+
+/** Matches `{projectPath}` / `{appHost}` and nothing else — validation rejects other tokens. */
+const TOKEN_RE = new RegExp(`\\{(${PLACEHOLDER_TOKENS.join('|')})\\}`, 'g');
+
+/**
+ * A sentence whose token has no value (an app installed before it had a
+ * domain has no `{appHost}`) is dropped whole rather than rendered with a
+ * literal brace or a hole where the host should be. Sentence = run of text up
+ * to and including its terminating period + following space.
+ */
+function expand(text: string, values: StepPlaceholders): string {
+  const sentences = text.match(/[^.]*\.\s*|[^.]+$/g) ?? [text];
+
+  return sentences
+    .filter((sentence) => {
+      const tokens = [...sentence.matchAll(TOKEN_RE)].map((m) => m[1] as PlaceholderToken);
+      return tokens.every((token) => values[token] !== undefined);
+    })
+    .join('')
+    .replace(TOKEN_RE, (_match, token: PlaceholderToken) => values[token] as string)
+    .trim();
+}
+
+/**
+ * Expands `{projectPath}`/`{appHost}` in a manual step. A manifest cannot
+ * hardcode `/repo/acme/site/settings?tab=members` — it does not know which
+ * project it will be installed into — so it declares the token and CE fills
+ * it in at read time. Returns a new step; never mutates the input.
+ */
+export function interpolateStep(step: AppManualStep, values: StepPlaceholders): AppManualStep {
+  const result: AppManualStep = {
+    ...step,
+    title: expand(step.title, values),
+    body: expand(step.body, values),
+  };
+
+  if (step.deepLink !== undefined) {
+    const tokens = [...step.deepLink.matchAll(TOKEN_RE)].map((m) => m[1] as PlaceholderToken);
+    // A link to a page we can't name is worse than no link.
+    if (tokens.every((token) => values[token] !== undefined)) {
+      result.deepLink = step.deepLink.replace(
+        TOKEN_RE,
+        (_match, token: PlaceholderToken) => values[token] as string,
+      );
+    } else {
+      delete result.deepLink;
+    }
+  }
+
+  return result;
+}

--- a/apps/backend/src/app-catalog/app-manifest.util.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.ts
@@ -444,9 +444,15 @@ const TOKEN_RE = new RegExp(`\\{(${PLACEHOLDER_TOKENS.join('|')})\\}`, 'g');
  * otherwise (e.g. the "." in "v1.0") it's treated as part of the sentence, so
  * an embedded decimal point can't split a token-bearing sentence in two and
  * leave an orphan fragment behind when the first half is dropped.
+ *
+ * The fallback alternative (matching a final, unterminated run of text) must
+ * be able to match ANY remainder, including one containing a dot — otherwise
+ * `String.prototype.match` with the `g` flag silently skips text it can't
+ * match at any position, instead of erroring, and `.join('')` below no
+ * longer reconstructs the input losslessly. Use `[\s\S]+$`, not `[^.]+$`.
  */
 function expandBody(text: string, values: StepPlaceholders): string {
-  const sentences = text.match(/(?:[^.]|\.(?!\s|$))*\.(?:\s+|$)|[^.]+$/g) ?? [text];
+  const sentences = text.match(/(?:[^.]|\.(?!\s|$))*\.(?:\s+|$)|[\s\S]+$/g) ?? [text];
 
   return sentences
     .filter((sentence) => {

--- a/apps/backend/src/app-catalog/app-manifest.util.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.ts
@@ -148,6 +148,26 @@ function validateSchedules(schedules: unknown, path: string, errors: string[]): 
   });
 }
 
+/** Any `{token}` at all, so unknown ones can be named in the error. */
+const ANY_TOKEN_RE = /\{([^}]*)\}/g;
+
+function validateStepPlaceholders(
+  value: unknown,
+  fieldPath: string,
+  errors: string[],
+): void {
+  if (typeof value !== 'string') return;
+
+  for (const match of value.matchAll(ANY_TOKEN_RE)) {
+    const token = match[1];
+    if (!(PLACEHOLDER_TOKENS as readonly string[]).includes(token)) {
+      errors.push(
+        `${fieldPath}: unknown placeholder {${token}} (known: ${PLACEHOLDER_TOKENS.join(', ')})`,
+      );
+    }
+  }
+}
+
 function validateManualSteps(manualSteps: unknown, path: string, errors: string[]): void {
   if (manualSteps === undefined) return;
   if (!Array.isArray(manualSteps)) {
@@ -172,6 +192,9 @@ function validateManualSteps(manualSteps: unknown, path: string, errors: string[
     if (entry.deepLink !== undefined && typeof entry.deepLink !== 'string') {
       errors.push(`${entryPath}.deepLink: must be string`);
     }
+    validateStepPlaceholders(entry.title, `${entryPath}.title`, errors);
+    validateStepPlaceholders(entry.body, `${entryPath}.body`, errors);
+    validateStepPlaceholders(entry.deepLink, `${entryPath}.deepLink`, errors);
     if (
       entry.appliesWhen !== undefined &&
       !APPLIES_WHEN_VALUES.includes(entry.appliesWhen as (typeof APPLIES_WHEN_VALUES)[number])

--- a/apps/backend/src/db/schema/installed-apps.schema.ts
+++ b/apps/backend/src/db/schema/installed-apps.schema.ts
@@ -43,7 +43,6 @@ export const installedApps = pgTable(
     bundleSha256: varchar('bundle_sha256', { length: 64 }).notNull(),
     /** Full manifest at install time — powers eject + manual steps without refetching. */
     manifest: jsonb('manifest').notNull(),
-    manualStepsAcked: jsonb('manual_steps_acked').$type<string[]>().notNull().default([]),
     status: varchar('status', { length: 20 })
       .$type<InstalledAppStatus>()
       .notNull()

--- a/apps/frontend/src/components/app-catalog/AppCard.tsx
+++ b/apps/frontend/src/components/app-catalog/AppCard.tsx
@@ -46,11 +46,6 @@ interface AppCardProps {
  *   plus a "Why?" popover with the gate's remediation/deepLink.
  * - installed → "Installed · v{version}" badge, an "Open" link to `appUrl`,
  *   and an overflow menu (Update, Uninstall, Eject).
- *
- * An installed card also carries its app's setup notes (titles collapsed,
- * bodies expanding in place) — CE can't perform them, so they live where the
- * app lives rather than behind a one-shot dialog.
- *
  * - installed + update available → an additional primary "Update to
  *   v{registryVersion}" button that opens a confirm popover (prune toggle,
  *   default off) before firing the update — unless an instance gate fails, in
@@ -61,6 +56,10 @@ interface AppCardProps {
  * `EjectPanel`) that each load their own preview/payload data; Update fires
  * `useUpdateAppMutation` here and hands the job off to the shared
  * `InstallDialog` (mounted by the page) for progress.
+ *
+ * An installed card also carries its app's setup notes (titles collapsed,
+ * bodies expanding in place) — CE can't perform them, so they live where the
+ * app lives rather than behind a one-shot dialog.
  *
  * Store metadata from the registry (ce#590) rides on top: a `thumbnailUrl`
  * banner and a `category` badge here, with the long-form description and

--- a/apps/frontend/src/components/app-catalog/AppCard.tsx
+++ b/apps/frontend/src/components/app-catalog/AppCard.tsx
@@ -17,6 +17,7 @@ import { UninstallDialog } from './UninstallDialog';
 import { EjectPanel } from './EjectPanel';
 import { GateBlockedCta } from './GateBlockedCta';
 import { RemoteImage } from './RemoteImage';
+import { SetupNotes } from './SetupNotes';
 import { hasAppDetails } from './catalogEntry';
 import { ExternalLink, MoreVertical } from 'lucide-react';
 
@@ -45,6 +46,11 @@ interface AppCardProps {
  *   plus a "Why?" popover with the gate's remediation/deepLink.
  * - installed → "Installed · v{version}" badge, an "Open" link to `appUrl`,
  *   and an overflow menu (Update, Uninstall, Eject).
+ *
+ * An installed card also carries its app's setup notes (titles collapsed,
+ * bodies expanding in place) — CE can't perform them, so they live where the
+ * app lives rather than behind a one-shot dialog.
+ *
  * - installed + update available → an additional primary "Update to
  *   v{registryVersion}" button that opens a confirm popover (prune toggle,
  *   default off) before firing the update — unless an instance gate fails, in
@@ -140,7 +146,7 @@ export function AppCard({ entry, onInstall, onDetails, onUpdateStarted }: AppCar
         </div>
       </CardHeader>
 
-      <CardContent className="flex-1">
+      <CardContent className="flex-1 space-y-3">
         <div className="flex flex-wrap items-center gap-2">
           {entry.category && (
             <Badge variant="outline" className="capitalize">
@@ -149,6 +155,15 @@ export function AppCard({ entry, onInstall, onDetails, onUpdateStarted }: AppCar
           )}
           {installed && <Badge variant="secondary">{`Installed · v${installed.version}`}</Badge>}
         </div>
+
+        {/*
+          Titles only, collapsed. The banner above is unconditional so the grid
+          doesn't go ragged; two three-line bodies inline would reintroduce
+          exactly that unevenness, permanently. Expanding is one click, and the
+          notes are worth finding — before this they were reachable only by
+          triggering an Update.
+        */}
+        {installed && <SetupNotes steps={installed.manualSteps} />}
       </CardContent>
 
       <CardFooter className="flex flex-wrap items-center gap-2">

--- a/apps/frontend/src/components/app-catalog/InstallDialog.tsx
+++ b/apps/frontend/src/components/app-catalog/InstallDialog.tsx
@@ -10,7 +10,6 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Checkbox } from '@/components/ui/checkbox';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useToast } from '@/hooks/use-toast';
@@ -21,12 +20,12 @@ import {
   useInstallAppMutation,
   useGetInstallJobQuery,
   useUndoJobMutation,
-  useAckManualStepMutation,
   type CatalogEntry,
   type GateResult,
   type InstallStepState,
   type PreflightRequest,
 } from '@/services/appCatalogApi';
+import { SetupNotes } from './SetupNotes';
 import { useGetMyRepositoriesQuery } from '@/services/repositoriesApi';
 import {
   AlertTriangle,
@@ -143,7 +142,6 @@ export function InstallDialog({
     usePreflightAppMutation();
   const [installApp, { isLoading: isInstalling }] = useInstallAppMutation();
   const [undoJob, { isLoading: isUndoing }] = useUndoJobMutation();
-  const [ackManualStep] = useAckManualStepMutation();
 
   // Stop polling once the job reaches a terminal state. `lastJobStatus` is
   // corrected synchronously during render (not in an effect) so the very
@@ -288,15 +286,8 @@ export function InstallDialog({
     undoJob(jobId);
   };
 
-  const installedAppId = entry.installed?.installedAppId ?? job?.installedAppId;
   const manualSteps = entry.installed?.manualSteps ?? job?.manualSteps ?? [];
-  const manualStepsAcked = entry.installed?.manualStepsAcked ?? [];
   const doneAppUrl = entry.installed?.appUrl ?? job?.appUrl;
-
-  const handleAck = (stepId: string, checked: boolean) => {
-    if (!checked || !installedAppId) return;
-    ackManualStep({ id: installedAppId, stepId });
-  };
 
   const screen: 'review' | 'working' | 'done' = !jobId
     ? 'review'
@@ -538,32 +529,7 @@ export function InstallDialog({
               </Button>
             )}
 
-            {manualSteps.length > 0 && (
-              <div className="space-y-3">
-                <p className="text-sm font-medium">Finish setting up</p>
-                {manualSteps.map((step) => (
-                  <div key={step.id} className="flex items-start gap-2 rounded-md border p-2">
-                    <Checkbox
-                      id={`manual-step-${step.id}`}
-                      aria-label={step.title}
-                      checked={manualStepsAcked.includes(step.id)}
-                      onCheckedChange={(checked) => handleAck(step.id, checked === true)}
-                    />
-                    <div className="flex-1">
-                      <Label htmlFor={`manual-step-${step.id}`} className="font-medium">
-                        {step.title}
-                      </Label>
-                      <p className="text-sm text-muted-foreground">{step.body}</p>
-                      {step.deepLink && (
-                        <a href={step.deepLink} className="text-sm text-primary underline">
-                          Go
-                        </a>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
+            <SetupNotes steps={manualSteps} defaultExpanded />
 
             <DialogFooter>
               <Button onClick={() => onOpenChange(false)}>Close</Button>

--- a/apps/frontend/src/components/app-catalog/SetupNotes.tsx
+++ b/apps/frontend/src/components/app-catalog/SetupNotes.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { AppManualStep } from '@/services/appCatalogApi';
+
+interface SetupNotesProps {
+  steps: AppManualStep[];
+  /** The install dialog has room to show every body; the card does not. */
+  defaultExpanded?: boolean;
+  className?: string;
+}
+
+/**
+ * SetupNotes — the app's post-install advice, rendered identically on the
+ * install dialog's Done screen and on the installed card.
+ *
+ * These are notes, not steps: CE cannot grant a user access or write a CORS
+ * rule on someone's bucket, and it never claimed to. The list used to carry
+ * checkboxes whose only effect was to store their own checked state, which
+ * made the copy work harder to explain what the control did not do. Nothing
+ * here is stateful.
+ */
+export function SetupNotes({ steps, defaultExpanded = false, className }: SetupNotesProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(
+    () => new Set(defaultExpanded ? steps.map((step) => step.id) : []),
+  );
+
+  if (steps.length === 0) return null;
+
+  const toggle = (id: string) =>
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      <p className="text-sm font-medium">
+        Setup notes{' '}
+        <span className="font-normal text-muted-foreground">— CE can&apos;t do these for you</span>
+      </p>
+
+      <ul className="space-y-1">
+        {steps.map((step) => {
+          const isOpen = expanded.has(step.id);
+          return (
+            <li key={step.id}>
+              <button
+                type="button"
+                onClick={() => toggle(step.id)}
+                aria-expanded={isOpen}
+                className="flex w-full items-start gap-1 text-left text-sm hover:underline"
+              >
+                {isOpen ? (
+                  <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                ) : (
+                  <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                )}
+                <span>{step.title}</span>
+              </button>
+
+              {isOpen && (
+                <div className="ml-5 mt-1 space-y-1">
+                  <p className="text-sm text-muted-foreground">{step.body}</p>
+                  {step.deepLink && (
+                    <a href={step.deepLink} className="text-sm text-primary underline">
+                      Go
+                    </a>
+                  )}
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/app-catalog/SetupNotes.tsx
+++ b/apps/frontend/src/components/app-catalog/SetupNotes.tsx
@@ -63,7 +63,7 @@ export function SetupNotes({ steps, defaultExpanded = false, className }: SetupN
 
               {isOpen && (
                 <div className="ml-5 mt-1 space-y-1">
-                  <p className="text-sm text-muted-foreground">{step.body}</p>
+                  {step.body && <p className="text-sm text-muted-foreground">{step.body}</p>}
                   {step.deepLink && (
                     <a href={step.deepLink} className="text-sm text-primary underline">
                       Go

--- a/apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { AppCard } from '../AppCard';
 import type { CatalogEntry } from '@/services/appCatalogApi';
@@ -246,5 +247,78 @@ describe('AppCard', () => {
     fireEvent.click(screen.getByRole('button', { name: /confirm update/i }));
 
     expect(updateTrigger).toHaveBeenCalledWith({ id: 'installed-1', prune: true });
+  });
+
+  describe('setup notes', () => {
+    const installedWithNotes: CatalogEntry = {
+      ...baseEntry,
+      installed: {
+        installedAppId: 'installed-1',
+        version: '1.0.0',
+        projectId: 'proj-1',
+        projectName: 'acme/site',
+        alias: 'reader',
+        appUrl: 'https://reader.example.com',
+        status: 'installed',
+        updateAvailable: false,
+        manualSteps: [
+          {
+            id: 'grant-access',
+            title: 'Give other people access',
+            body: 'Rivulet is private. Add each person as a guest.',
+            deepLink: '/repo/acme/site/settings?tab=members',
+          },
+        ],
+      },
+    };
+
+    it('shows the note title on an installed card', () => {
+      render(
+        <AppCard
+          entry={installedWithNotes}
+          onInstall={vi.fn()}
+          onDetails={vi.fn()}
+          onUpdateStarted={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText('Give other people access')).toBeInTheDocument();
+      expect(screen.queryByText(/Rivulet is private/)).not.toBeInTheDocument();
+    });
+
+    it('expands the body in place', async () => {
+      render(
+        <AppCard
+          entry={installedWithNotes}
+          onInstall={vi.fn()}
+          onDetails={vi.fn()}
+          onUpdateStarted={vi.fn()}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: /give other people access/i }));
+
+      expect(screen.getByText(/Rivulet is private/)).toBeInTheDocument();
+    });
+
+    it('renders no setup notes block when the app has none', () => {
+      const entry: CatalogEntry = {
+        ...installedWithNotes,
+        installed: { ...installedWithNotes.installed!, manualSteps: [] },
+      };
+      render(
+        <AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />,
+      );
+
+      expect(screen.queryByText(/Setup notes/)).not.toBeInTheDocument();
+    });
+
+    it('renders no setup notes block when the app is not installed', () => {
+      render(
+        <AppCard entry={baseEntry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />,
+      );
+
+      expect(screen.queryByText(/Setup notes/)).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
@@ -76,7 +76,6 @@ describe('AppCard', () => {
         status: 'installed',
         updateAvailable: false,
         manualSteps: [],
-        manualStepsAcked: [],
       },
     };
 
@@ -101,7 +100,6 @@ describe('AppCard', () => {
         status: 'installed',
         updateAvailable: true,
         manualSteps: [],
-        manualStepsAcked: [],
       },
     };
 
@@ -135,7 +133,6 @@ describe('AppCard', () => {
         status: 'installed',
         updateAvailable: true,
         manualSteps: [],
-        manualStepsAcked: [],
       },
     };
 
@@ -162,7 +159,6 @@ describe('AppCard', () => {
         status: 'installed',
         updateAvailable: true,
         manualSteps: [],
-        manualStepsAcked: [],
       },
     };
 
@@ -240,7 +236,6 @@ describe('AppCard', () => {
         status: 'installed',
         updateAvailable: true,
         manualSteps: [],
-        manualStepsAcked: [],
       },
     };
 

--- a/apps/frontend/src/components/app-catalog/__tests__/AppDetailsDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/AppDetailsDialog.test.tsx
@@ -115,7 +115,6 @@ describe('AppDetailsDialog', () => {
         status: 'installed',
         updateAvailable: false,
         manualSteps: [],
-        manualStepsAcked: [],
       },
     };
 

--- a/apps/frontend/src/components/app-catalog/__tests__/EjectPanel.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/EjectPanel.test.tsx
@@ -46,7 +46,6 @@ const entry: CatalogEntry = {
     status: 'installed',
     updateAvailable: false,
     manualSteps: [],
-    manualStepsAcked: [],
   },
 };
 

--- a/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
@@ -12,7 +12,6 @@ const preflightTrigger = vi.fn();
 const resetPreflightMock = vi.fn();
 const installTrigger = vi.fn();
 const undoTrigger = vi.fn();
-const ackTrigger = vi.fn();
 const getInstallJobQueryMock = vi.fn<
   (jobId: string, options?: { pollingInterval?: number; skip?: boolean }) => { data?: InstallJob }
 >(() => jobQueryResult);
@@ -24,7 +23,6 @@ let preflightState: { data?: PreflightResponse; isLoading: boolean } = {
 let installState: { isLoading: boolean } = { isLoading: false };
 let jobQueryResult: { data?: InstallJob } = { data: undefined };
 let undoState: { isLoading: boolean } = { isLoading: false };
-let ackState: { isLoading: boolean } = { isLoading: false };
 
 vi.mock('@/services/appCatalogApi', () => ({
   usePreflightAppMutation: () => [
@@ -37,7 +35,6 @@ vi.mock('@/services/appCatalogApi', () => ({
     options?: { pollingInterval?: number; skip?: boolean },
   ) => getInstallJobQueryMock(jobId, options),
   useUndoJobMutation: () => [undoTrigger, undoState],
-  useAckManualStepMutation: () => [ackTrigger, ackState],
 }));
 
 vi.mock('@/services/repositoriesApi', () => ({
@@ -112,14 +109,12 @@ beforeEach(() => {
   resetPreflightMock.mockReset();
   installTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({ jobId: 'job-1' }) });
   undoTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({}) });
-  ackTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({ acked: [] }) });
   getInstallJobQueryMock.mockClear();
   dispatchMock.mockClear();
   preflightState = { data: makePreflight(), isLoading: false };
   installState = { isLoading: false };
   jobQueryResult = { data: undefined };
   undoState = { isLoading: false };
-  ackState = { isLoading: false };
 });
 
 describe('InstallDialog — Review screen', () => {
@@ -531,7 +526,7 @@ describe('InstallDialog — Working screen', () => {
 });
 
 describe('InstallDialog — Done screen', () => {
-  it('renders the app URL, an Open link, and the manual steps checklist, firing ack on check', async () => {
+  it('renders the app URL, an Open link, and the setup notes expanded', async () => {
     jobQueryResult = {
       data: makeJob({
         status: 'succeeded',
@@ -553,15 +548,15 @@ describe('InstallDialog — Done screen', () => {
     const openLink = await screen.findByRole('link', { name: /open/i });
     expect(openLink).toHaveAttribute('href', 'https://handoff.example.com');
 
+    // The Done screen passes `defaultExpanded`, so the body is visible
+    // without a click.
     expect(screen.getByText('Set the SIGNING_SECRET')).toBeInTheDocument();
-    const checkbox = screen.getByRole('checkbox', { name: /set the signing_secret/i });
-    expect(checkbox).not.toBeChecked();
-
-    fireEvent.click(checkbox);
-    expect(ackTrigger).toHaveBeenCalledWith({ id: 'installed-1', stepId: 'set-env' });
+    expect(
+      screen.getByText('Add SIGNING_SECRET to your environment before sharing links.'),
+    ).toBeInTheDocument();
   });
 
-  it('prefers the durable entry.installed manual-step ack state over the job', async () => {
+  it('prefers the durable entry.installed manual steps over the job’s', async () => {
     const entryWithInstall: CatalogEntry = {
       ...baseEntry,
       installed: {
@@ -574,20 +569,23 @@ describe('InstallDialog — Done screen', () => {
         status: 'installed',
         updateAvailable: false,
         manualSteps: [
-          { id: 'set-env', title: 'Set the SIGNING_SECRET', body: 'Add it before sharing links.' },
+          { id: 'installed-step', title: 'Rotate the signing secret', body: 'Do it in Settings.' },
         ],
-        manualStepsAcked: ['set-env'],
       },
     };
     jobQueryResult = {
-      data: makeJob({ status: 'succeeded', installedAppId: 'installed-1' }),
+      data: makeJob({
+        status: 'succeeded',
+        installedAppId: 'installed-1',
+        manualSteps: [{ id: 'job-step', title: 'Set the SIGNING_SECRET', body: 'From the job.' }],
+      }),
     };
 
     render(<InstallDialog entry={entryWithInstall} open onOpenChange={vi.fn()} />);
     fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
 
-    const checkbox = await screen.findByRole('checkbox', { name: /set the signing_secret/i });
-    expect(checkbox).toBeChecked();
+    expect(await screen.findByText('Rotate the signing secret')).toBeInTheDocument();
+    expect(screen.queryByText('Set the SIGNING_SECRET')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/frontend/src/components/app-catalog/__tests__/SetupNotes.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/SetupNotes.test.tsx
@@ -58,4 +58,12 @@ describe('SetupNotes', () => {
     expect(screen.getByText(/Rivulet is private/)).toBeInTheDocument();
     expect(screen.getByText('Over HTTP now.')).toBeInTheDocument();
   });
+
+  it('renders the title with no empty paragraph when body is empty', async () => {
+    const step = { id: 'empty-body', title: 'Configure something', body: '' };
+    render(<SetupNotes steps={[step]} defaultExpanded />);
+
+    expect(screen.getByText('Configure something')).toBeInTheDocument();
+    expect(document.querySelector('p.text-muted-foreground')).not.toBeInTheDocument();
+  });
 });

--- a/apps/frontend/src/components/app-catalog/__tests__/SetupNotes.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/SetupNotes.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import { SetupNotes } from '../SetupNotes';
+
+const STEPS = [
+  {
+    id: 'grant-access',
+    title: 'Give other people access',
+    body: 'Rivulet is private. Add each person as a guest.',
+    deepLink: '/repo/acme/site/settings?tab=members',
+  },
+  { id: 'provision-wildcard-cert', title: 'Turn on HTTPS for this app', body: 'Over HTTP now.' },
+];
+
+describe('SetupNotes', () => {
+  it('renders nothing when there are no steps', () => {
+    const { container } = render(<SetupNotes steps={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows titles collapsed, bodies hidden', () => {
+    render(<SetupNotes steps={STEPS} />);
+
+    expect(screen.getByText('Give other people access')).toBeInTheDocument();
+    expect(screen.getByText('Turn on HTTPS for this app')).toBeInTheDocument();
+    expect(screen.queryByText(/Rivulet is private/)).not.toBeInTheDocument();
+  });
+
+  it('says CE cannot do these for you', () => {
+    render(<SetupNotes steps={STEPS} />);
+    expect(screen.getByText(/can't do these for you/i)).toBeInTheDocument();
+  });
+
+  it('expands one body on click without expanding the others', async () => {
+    render(<SetupNotes steps={STEPS} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /give other people access/i }));
+
+    expect(screen.getByText(/Rivulet is private/)).toBeInTheDocument();
+    expect(screen.queryByText('Over HTTP now.')).not.toBeInTheDocument();
+  });
+
+  it('renders the deep link once expanded', async () => {
+    render(<SetupNotes steps={STEPS} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /give other people access/i }));
+
+    expect(screen.getByRole('link', { name: /manage members|go/i })).toHaveAttribute(
+      'href',
+      '/repo/acme/site/settings?tab=members',
+    );
+  });
+
+  it('shows every body from the start when defaultExpanded', () => {
+    render(<SetupNotes steps={STEPS} defaultExpanded />);
+
+    expect(screen.getByText(/Rivulet is private/)).toBeInTheDocument();
+    expect(screen.getByText('Over HTTP now.')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/app-catalog/__tests__/UninstallDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/UninstallDialog.test.tsx
@@ -43,7 +43,6 @@ const entry: CatalogEntry = {
     status: 'installed',
     updateAvailable: false,
     manualSteps: [],
-    manualStepsAcked: [],
   },
 };
 

--- a/apps/frontend/src/pages/AppsPage.test.tsx
+++ b/apps/frontend/src/pages/AppsPage.test.tsx
@@ -1,17 +1,21 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { AppsPage } from './AppsPage';
-import type { CatalogEntry, CatalogListResult, InstallJob } from '@/services/appCatalogApi';
+import type {
+  AppManualStep,
+  CatalogEntry,
+  CatalogListResult,
+  InstallJob,
+} from '@/services/appCatalogApi';
 
 // --- appCatalogApi -----------------------------------------------------
 // `catalogResult` is reassigned between renders to simulate the RTK Query
 // cache refreshing after a mutation invalidates the `AppCatalog` tag (e.g.
-// ackManualStep). Because it's read fresh on every call, re-rendering
-// AppsPage after reassigning it is equivalent to a real refetch.
+// updateApp). Because it's read fresh on every call, re-rendering AppsPage
+// after reassigning it is equivalent to a real refetch.
 let catalogResult: { data?: CatalogListResult; isLoading: boolean; isError: boolean };
 const refetchMock = vi.fn();
 const updateTrigger = vi.fn();
-const ackTrigger = vi.fn();
 const getInstallJobQueryMock = vi.fn<
   (jobId: string, options?: { pollingInterval?: number; skip?: boolean }) => { data?: InstallJob }
 >();
@@ -30,7 +34,6 @@ vi.mock('@/services/appCatalogApi', () => ({
     options?: { pollingInterval?: number; skip?: boolean },
   ) => getInstallJobQueryMock(jobId, options),
   useUndoJobMutation: () => [vi.fn(), { isLoading: false }],
-  useAckManualStepMutation: () => [ackTrigger, { isLoading: false }],
 }));
 
 vi.mock('@/services/apiKeysApi', () => ({
@@ -53,7 +56,7 @@ vi.mock('@/store/hooks', () => ({
   useAppDispatch: () => vi.fn(),
 }));
 
-function makeEntry(manualStepsAcked: string[]): CatalogEntry {
+function makeEntry(manualSteps: AppManualStep[]): CatalogEntry {
   return {
     id: 'handoff',
     name: 'Handoff',
@@ -70,13 +73,16 @@ function makeEntry(manualStepsAcked: string[]): CatalogEntry {
       appUrl: 'https://handoff.example.com',
       status: 'installed',
       updateAvailable: true,
-      manualSteps: [
-        { id: 'bucket-cors', title: 'Configure bucket CORS', body: 'Allow PUT from your app origin.' },
-      ],
-      manualStepsAcked,
+      manualSteps,
     },
   };
 }
+
+const BUCKET_CORS_STEP: AppManualStep = {
+  id: 'bucket-cors',
+  title: 'Configure bucket CORS',
+  body: 'Allow PUT from your app origin.',
+};
 
 function makeJob(): InstallJob {
   return {
@@ -93,10 +99,13 @@ function makeJob(): InstallJob {
 }
 
 beforeEach(() => {
-  catalogResult = { data: { data: [makeEntry([])] }, isLoading: false, isError: false };
+  catalogResult = {
+    data: { data: [makeEntry([BUCKET_CORS_STEP])] },
+    isLoading: false,
+    isError: false,
+  };
   refetchMock.mockReset();
   updateTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({ jobId: 'job-1' }) });
-  ackTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({ acked: ['bucket-cors'] }) });
   jobQueryResult = { data: makeJob() };
   getInstallJobQueryMock.mockReset().mockImplementation(() => jobQueryResult);
 });
@@ -139,32 +148,41 @@ describe('AppsPage — details dialog', () => {
   });
 });
 
-describe('AppsPage — Done-screen ack checkbox stays live (regression)', () => {
-  it('re-derives the InstallDialog entry from the current catalog query, so acking a manual step checks the box once the catalog refetches', async () => {
+describe('AppsPage — Done-screen setup notes stay live (regression)', () => {
+  it('re-derives the InstallDialog entry from the current catalog query, so a changed manual-steps list shows up once the catalog refetches', async () => {
     const { rerender } = render(<AppsPage />);
 
     // Open the update dialog straight onto the Done screen (job already succeeded).
     fireEvent.click(screen.getByRole('button', { name: /update to v2\.0\.0/i }));
     fireEvent.click(screen.getByRole('button', { name: /confirm update/i }));
 
-    const checkbox = await screen.findByRole('checkbox', { name: /configure bucket cors/i });
-    expect(checkbox).not.toBeChecked();
+    expect(await screen.findByText('Configure bucket CORS')).toBeInTheDocument();
+    expect(screen.queryByText('Rotate the signing secret')).not.toBeInTheDocument();
 
-    fireEvent.click(checkbox);
-    expect(ackTrigger).toHaveBeenCalledWith({ id: 'installed-1', stepId: 'bucket-cors' });
-
-    // Simulate the server ack completing and ackManualStep's `invalidatesTags`
-    // causing `useGetAppCatalogQuery` to refetch with the updated entry, then
-    // force AppsPage to re-render against that new query result (mirroring
-    // the re-render RTK Query itself triggers on a real cache update). If
-    // AppsPage were still holding a point-in-time snapshot of `entry` (the
-    // bug), this new catalog data would never reach InstallDialog and the
-    // checkbox would stay unchecked forever.
-    catalogResult = { data: { data: [makeEntry(['bucket-cors'])] }, isLoading: false, isError: false };
+    // Simulate the update finishing server-side (e.g. a manual step's manifest
+    // definition changed) and `updateApp`'s `invalidatesTags` causing
+    // `useGetAppCatalogQuery` to refetch with a different manual-steps list,
+    // then force AppsPage to re-render against that new query result
+    // (mirroring the re-render RTK Query itself triggers on a real cache
+    // update). If AppsPage were still holding a point-in-time snapshot of
+    // `entry` (the bug), this new catalog data would never reach
+    // InstallDialog and the stale step would stay on screen forever.
+    catalogResult = {
+      data: {
+        data: [
+          makeEntry([
+            { id: 'rotate-secret', title: 'Rotate the signing secret', body: 'Do it in Settings.' },
+          ]),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    };
     rerender(<AppsPage />);
 
     await waitFor(() => {
-      expect(screen.getByRole('checkbox', { name: /configure bucket cors/i })).toBeChecked();
+      expect(screen.getByText('Rotate the signing secret')).toBeInTheDocument();
     });
+    expect(screen.queryByText('Configure bucket CORS')).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/pages/AppsPage.test.tsx
+++ b/apps/frontend/src/pages/AppsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { vi } from 'vitest';
 import { AppsPage } from './AppsPage';
 import type {
@@ -156,8 +156,14 @@ describe('AppsPage — Done-screen setup notes stay live (regression)', () => {
     fireEvent.click(screen.getByRole('button', { name: /update to v2\.0\.0/i }));
     fireEvent.click(screen.getByRole('button', { name: /confirm update/i }));
 
-    expect(await screen.findByText('Configure bucket CORS')).toBeInTheDocument();
-    expect(screen.queryByText('Rotate the signing secret')).not.toBeInTheDocument();
+    // The installed card behind the dialog now carries its own SetupNotes
+    // block too (this task), so once the dialog reaches the Done screen the
+    // same note title exists twice in the DOM (card + dialog) — scope to the
+    // dialog to keep asserting on what this regression test actually cares
+    // about: the Done screen's live-derived content.
+    const dialog = await screen.findByRole('dialog', { name: /handoff updated/i });
+    expect(within(dialog).getByText('Configure bucket CORS')).toBeInTheDocument();
+    expect(within(dialog).queryByText('Rotate the signing secret')).not.toBeInTheDocument();
 
     // Simulate the update finishing server-side (e.g. a manual step's manifest
     // definition changed) and `updateApp`'s `invalidatesTags` causing
@@ -181,8 +187,8 @@ describe('AppsPage — Done-screen setup notes stay live (regression)', () => {
     rerender(<AppsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Rotate the signing secret')).toBeInTheDocument();
+      expect(within(dialog).getByText('Rotate the signing secret')).toBeInTheDocument();
     });
-    expect(screen.queryByText('Configure bucket CORS')).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('Configure bucket CORS')).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/pages/AppsPage.tsx
+++ b/apps/frontend/src/pages/AppsPage.tsx
@@ -22,9 +22,9 @@ export function AppsPage() {
   // key and as a fallback if the app disappears from the catalog while the
   // dialog is open. The dialog is actually handed the LIVE entry (derived
   // below from the current `data`), not this snapshot: server-side mutations
-  // like ackManualStep invalidate the `AppCatalog` tag and refetch `data`,
-  // and a stale snapshot here would never pick that up (the Done screen's
-  // ack checkboxes would appear permanently unchecked/disabled).
+  // like updateApp invalidate the `AppCatalog` tag and refetch `data`, and a
+  // stale snapshot here would never pick that up (the Done screen's setup
+  // notes would appear stuck on the pre-update list).
   const [installTargetSnapshot, setInstallTargetSnapshot] = useState<CatalogEntry | null>(null);
   const [detailsTargetSnapshot, setDetailsTargetSnapshot] = useState<CatalogEntry | null>(null);
   const [updateTargetSnapshot, setUpdateTargetSnapshot] = useState<{

--- a/apps/frontend/src/services/appCatalogApi.ts
+++ b/apps/frontend/src/services/appCatalogApi.ts
@@ -7,7 +7,7 @@ import { api } from './api';
  * `app-preflight.service.ts`, `app-installer.service.ts`, and
  * `app-install-jobs.service.ts` for the source of truth.
  *
- * `preflightApp`/`installApp`/`getInstallJob`/`undoJob`/`ackManualStep` back
+ * `preflightApp`/`installApp`/`getInstallJob`/`undoJob` back
  * the 1-click install wizard dialog (Tasks 13–14 wire them up); this task
  * only wires `getAppCatalog` (catalog page) and the simpler one-shot actions
  * (`updateApp`, `uninstallApp`, `getEjectPayload`) directly into `AppCard`.
@@ -84,7 +84,6 @@ export interface CatalogEntry {
     status: InstalledAppStatus;
     updateAvailable: boolean;
     manualSteps: AppManualStep[];
-    manualStepsAcked: string[];
   };
 }
 
@@ -260,15 +259,6 @@ export const appCatalogApi = api.injectEndpoints({
     getEjectPayload: builder.query<EjectPayload, string>({
       query: (id) => `/api/admin/apps/installed/${id}/eject`,
     }),
-
-    ackManualStep: builder.mutation<{ acked: string[] }, { id: string; stepId: string }>({
-      query: ({ id, stepId }) => ({
-        url: `/api/admin/apps/installed/${id}/ack-manual-step`,
-        method: 'POST',
-        body: { stepId },
-      }),
-      invalidatesTags: ['AppCatalog', 'InstalledApp'],
-    }),
   }),
 });
 
@@ -284,5 +274,4 @@ export const {
   useUninstallAppMutation,
   useGetEjectPayloadQuery,
   useLazyGetEjectPayloadQuery,
-  useAckManualStepMutation,
 } = appCatalogApi;

--- a/docs/superpowers/plans/2026-08-02-app-setup-notes.md
+++ b/docs/superpowers/plans/2026-08-02-app-setup-notes.md
@@ -1,0 +1,1428 @@
+# App Setup Notes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn an app manifest's `install.manualSteps` from a one-shot checklist of unreadable paragraphs into short, deep-linked notes that live permanently on the installed app's card.
+
+**Architecture:** Three independent moves. The backend loses the acknowledgement mechanism entirely (endpoint, DTO, service method, DB column) and gains two things: `{projectPath}`/`{appHost}` placeholder interpolation so a manifest can link into the dashboard it doesn't know the shape of, and a live re-derivation of the synthesized TLS note so it survives past the install dialog. The frontend extracts one `SetupNotes` component rendered in two places — collapsed on the installed card (its permanent home) and expanded on the install dialog's Done screen. A separate repo, `bffless/apps`, carries the rewritten manifest copy and a lint rule that keeps future copy short.
+
+**Tech Stack:** NestJS + Drizzle + Jest (CE backend), React 18 + RTK Query + Vitest + Testing Library (CE frontend), plain ESM + `node:test` (apps repo scripts).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-02-app-setup-notes-design.md`.
+- **Copy rule:** a note's title is the action; its body is at most **220 characters**. A note that needs a conditional to decide whether it applies to the reader belongs in the app's README, not the manifest.
+- **Placeholders are a closed set:** `{projectPath}` and `{appHost}`. Any other `{token}` is a manifest validation error.
+- The `manualSteps` manifest key keeps its name — renaming it would break `schemaVersion: 1` for manifests already published to the registry.
+- Two repos, two PRs: `/home/rico/bffless/repos/ce/.claude/worktrees/app-setup-notes` (branch `spec/app-setup-notes`) and `/home/rico/bffless/repos/apps` (needs its own branch, Task 7).
+- CE backend tests: `cd apps/backend && npx jest <path>`. CE frontend tests: `cd apps/frontend && npx vitest run <path>`.
+- Never run `pnpm db:generate` — it is interactive. Task 4 hands the command to the operator and stops.
+
+---
+
+### Task 1: Placeholder interpolation
+
+The pure function every later backend task depends on. Expands `{projectPath}` and `{appHost}` in a manual step's `title`, `body` and `deepLink`.
+
+**Files:**
+- Modify: `apps/backend/src/app-catalog/app-manifest.util.ts` (append at end of file)
+- Test: `apps/backend/src/app-catalog/app-manifest.util.spec.ts` (append at end of file)
+
+**Interfaces:**
+- Consumes: `AppManualStep` from `./app-manifest.types` (already imported at the top of the util).
+- Produces:
+  ```ts
+  export interface StepPlaceholders {
+    projectPath?: string;
+    appHost?: string;
+  }
+  export function interpolateStep(step: AppManualStep, values: StepPlaceholders): AppManualStep
+  export const PLACEHOLDER_TOKENS: readonly string[]  // ['projectPath', 'appHost']
+  ```
+  Tasks 2, 3 and 5 call `interpolateStep`. Task 6 uses `PLACEHOLDER_TOKENS` for validation.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/backend/src/app-catalog/app-manifest.util.spec.ts`:
+
+```ts
+describe('interpolateStep', () => {
+  const step = {
+    id: 'grant-access',
+    title: 'Give other people access',
+    body: 'Add each person as a guest on {projectPath}.',
+    deepLink: '/repo/{projectPath}/settings?tab=members',
+  };
+
+  it('expands every token across title, body and deepLink', () => {
+    const result = interpolateStep(
+      { ...step, title: 'Access for {projectPath}' },
+      { projectPath: 'acme/site', appHost: 'reader.example.com' },
+    );
+
+    expect(result.title).toBe('Access for acme/site');
+    expect(result.body).toBe('Add each person as a guest on acme/site.');
+    expect(result.deepLink).toBe('/repo/acme/site/settings?tab=members');
+  });
+
+  it('expands every occurrence of a repeated token', () => {
+    const result = interpolateStep(
+      { id: 'x', title: 't', body: 'Allow PUT from {appHost} to {appHost}.' },
+      { appHost: 'a.example.com' },
+    );
+
+    expect(result.body).toBe('Allow PUT from a.example.com to a.example.com.');
+  });
+
+  it('leaves a step with no tokens untouched', () => {
+    const plain = { id: 'x', title: 'Title', body: 'Body.', deepLink: '/domains' };
+
+    expect(interpolateStep(plain, { projectPath: 'acme/site' })).toEqual(plain);
+  });
+
+  it('drops a sentence whose token has no value rather than emitting a literal brace', () => {
+    const result = interpolateStep(
+      { id: 'x', title: 'T', body: 'First sentence. Allow PUT from {appHost}. Last sentence.' },
+      {},
+    );
+
+    expect(result.body).toBe('First sentence. Last sentence.');
+    expect(result.body).not.toContain('{appHost}');
+  });
+
+  it('omits deepLink entirely when it depends on a token with no value', () => {
+    const result = interpolateStep(
+      { id: 'x', title: 'T', body: 'B', deepLink: '/repo/{projectPath}/settings' },
+      {},
+    );
+
+    expect(result.deepLink).toBeUndefined();
+  });
+
+  it('does not mutate the input step', () => {
+    const original = { id: 'x', title: 'T', body: 'On {projectPath}.' };
+    interpolateStep(original, { projectPath: 'acme/site' });
+
+    expect(original.body).toBe('On {projectPath}.');
+  });
+});
+```
+
+Add `interpolateStep` to the existing import at the top of the spec file, which currently reads:
+
+```ts
+import { validateAppManifest, validateRegistry, manualStepApplies } from './app-manifest.util';
+```
+
+so that it becomes:
+
+```ts
+import {
+  validateAppManifest,
+  validateRegistry,
+  manualStepApplies,
+  interpolateStep,
+} from './app-manifest.util';
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/backend && npx jest src/app-catalog/app-manifest.util.spec.ts -t interpolateStep`
+Expected: FAIL — TypeScript cannot resolve `interpolateStep` from `./app-manifest.util`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `apps/backend/src/app-catalog/app-manifest.util.ts`:
+
+```ts
+/** The closed set of tokens a manifest may use in a manual step. */
+export const PLACEHOLDER_TOKENS = ['projectPath', 'appHost'] as const;
+
+export type PlaceholderToken = (typeof PLACEHOLDER_TOKENS)[number];
+
+export type StepPlaceholders = Partial<Record<PlaceholderToken, string>>;
+
+/** Matches `{projectPath}` / `{appHost}` and nothing else — validation rejects other tokens. */
+const TOKEN_RE = new RegExp(`\\{(${PLACEHOLDER_TOKENS.join('|')})\\}`, 'g');
+
+/**
+ * A sentence whose token has no value (an app installed before it had a
+ * domain has no `{appHost}`) is dropped whole rather than rendered with a
+ * literal brace or a hole where the host should be. Sentence = run of text up
+ * to and including its terminating period + following space.
+ */
+function expand(text: string, values: StepPlaceholders): string {
+  const sentences = text.match(/[^.]*\.\s*|[^.]+$/g) ?? [text];
+
+  return sentences
+    .filter((sentence) => {
+      const tokens = [...sentence.matchAll(TOKEN_RE)].map((m) => m[1] as PlaceholderToken);
+      return tokens.every((token) => values[token] !== undefined);
+    })
+    .join('')
+    .replace(TOKEN_RE, (_match, token: PlaceholderToken) => values[token] as string)
+    .trim();
+}
+
+/**
+ * Expands `{projectPath}`/`{appHost}` in a manual step. A manifest cannot
+ * hardcode `/repo/acme/site/settings?tab=members` — it does not know which
+ * project it will be installed into — so it declares the token and CE fills
+ * it in at read time. Returns a new step; never mutates the input.
+ */
+export function interpolateStep(step: AppManualStep, values: StepPlaceholders): AppManualStep {
+  const result: AppManualStep = {
+    ...step,
+    title: expand(step.title, values),
+    body: expand(step.body, values),
+  };
+
+  if (step.deepLink !== undefined) {
+    const tokens = [...step.deepLink.matchAll(TOKEN_RE)].map((m) => m[1] as PlaceholderToken);
+    // A link to a page we can't name is worse than no link.
+    if (tokens.every((token) => values[token] !== undefined)) {
+      result.deepLink = step.deepLink.replace(
+        TOKEN_RE,
+        (_match, token: PlaceholderToken) => values[token] as string,
+      );
+    } else {
+      delete result.deepLink;
+    }
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/backend && npx jest src/app-catalog/app-manifest.util.spec.ts`
+Expected: PASS — the six new `interpolateStep` cases plus every pre-existing case in the file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/app-catalog/app-manifest.util.ts apps/backend/src/app-catalog/app-manifest.util.spec.ts
+git commit -m "feat(app-catalog): interpolate {projectPath}/{appHost} in manual steps"
+```
+
+---
+
+### Task 2: Reject unknown placeholder tokens at validation
+
+A typo like `{projectpath}` must fail the manifest rather than ship a literal brace to a user.
+
+**Files:**
+- Modify: `apps/backend/src/app-catalog/app-manifest.util.ts` (inside `validateManualSteps`, which starts at line 151)
+- Test: `apps/backend/src/app-catalog/app-manifest.util.spec.ts`
+
+**Interfaces:**
+- Consumes: `PLACEHOLDER_TOKENS` from Task 1.
+- Produces: no new exports. `validateAppManifest` gains errors of the form `install.manualSteps[0].body: unknown placeholder {foo} (known: projectPath, appHost)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the existing top-level `describe` that holds the other `validateAppManifest` cases in `apps/backend/src/app-catalog/app-manifest.util.spec.ts`. Model the fixture on the neighbouring test at line 97 (`'fails when a manualSteps entry has an appliesWhen outside the closed enum…'`) — reuse whatever base-manifest helper that test uses:
+
+```ts
+it('fails when a manual step body uses an unknown placeholder, naming the known ones', () => {
+  const result = validateAppManifest({
+    ...baseManifest,
+    install: {
+      ...baseManifest.install,
+      manualSteps: [{ id: 'x', title: 'Title', body: 'Go to {foo} now.' }],
+    },
+  });
+
+  const err = result.errors.find((e) => e.startsWith('install.manualSteps[0].body:'));
+  expect(err).toContain('unknown placeholder {foo}');
+  expect(err).toContain('projectPath, appHost');
+});
+
+it('fails when a manual step deepLink uses an unknown placeholder', () => {
+  const result = validateAppManifest({
+    ...baseManifest,
+    install: {
+      ...baseManifest.install,
+      manualSteps: [{ id: 'x', title: 'T', body: 'B', deepLink: '/repo/{owner}/settings' }],
+    },
+  });
+
+  expect(result.errors.some((e) => e.includes('unknown placeholder {owner}'))).toBe(true);
+});
+
+it('accepts the known placeholders', () => {
+  const result = validateAppManifest({
+    ...baseManifest,
+    install: {
+      ...baseManifest.install,
+      manualSteps: [
+        {
+          id: 'x',
+          title: 'T',
+          body: 'Allow PUT from {appHost}.',
+          deepLink: '/repo/{projectPath}/settings?tab=members',
+        },
+      ],
+    },
+  });
+
+  expect(result.errors.filter((e) => e.includes('placeholder'))).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/backend && npx jest src/app-catalog/app-manifest.util.spec.ts -t placeholder`
+Expected: FAIL — the first two cases find no matching error (`err` is `undefined`), because nothing checks tokens yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/backend/src/app-catalog/app-manifest.util.ts`, add this helper directly above `validateManualSteps` (line 151):
+
+```ts
+/** Any `{token}` at all, so unknown ones can be named in the error. */
+const ANY_TOKEN_RE = /\{([^}]*)\}/g;
+
+function validateStepPlaceholders(
+  value: unknown,
+  fieldPath: string,
+  errors: string[],
+): void {
+  if (typeof value !== 'string') return;
+
+  for (const match of value.matchAll(ANY_TOKEN_RE)) {
+    const token = match[1];
+    if (!(PLACEHOLDER_TOKENS as readonly string[]).includes(token)) {
+      errors.push(
+        `${fieldPath}: unknown placeholder {${token}} (known: ${PLACEHOLDER_TOKENS.join(', ')})`,
+      );
+    }
+  }
+}
+```
+
+Then, inside `validateManualSteps`'s `manualSteps.forEach((entry, i) => { … })` body, after the existing `title`/`body`/`deepLink` type checks and before the `appliesWhen` check, add:
+
+```ts
+    validateStepPlaceholders(entry.title, `${entryPath}.title`, errors);
+    validateStepPlaceholders(entry.body, `${entryPath}.body`, errors);
+    validateStepPlaceholders(entry.deepLink, `${entryPath}.deepLink`, errors);
+```
+
+`PLACEHOLDER_TOKENS` is declared later in the file than `validateManualSteps`, which is fine — `const` at module scope is initialised before `validateAppManifest` is ever called.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/backend && npx jest src/app-catalog/app-manifest.util.spec.ts`
+Expected: PASS — all cases, including the pre-existing ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/app-catalog/app-manifest.util.ts apps/backend/src/app-catalog/app-manifest.util.spec.ts
+git commit -m "feat(app-catalog): reject unknown manual-step placeholders at validation"
+```
+
+---
+
+### Task 3: Interpolate + re-derive the cert note when listing installed apps
+
+`buildInstalledSummary` currently returns manifest steps verbatim. It should return them interpolated, with the synthesized TLS note appended when the host still has no certificate.
+
+**Files:**
+- Modify: `apps/backend/src/app-catalog/app-catalog.service.ts` (`buildInstalledSummary` ~line 340-365, `applicableManualSteps` ~line 464-467, `resolveAppUrl` ~line 455)
+- Test: `apps/backend/src/app-catalog/app-catalog.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `interpolateStep` (Task 1); `AppCertStepService.plan(appHost): Promise<CertPlan>` and `.execute(plan, appHost): Promise<AppCertStepResult>` (`app-cert-step.service.ts`), where `AppCertStepResult.manualStep?: AppManualStep`. `AppCertStepService` is already injected as `this.certStepService`.
+- Produces: `CatalogEntry['installed'].manualSteps` now contains interpolated steps plus, when applicable, the cert note. `applicableManualSteps` gains a second parameter:
+  ```ts
+  private applicableManualSteps(manifest: AppManifest, values: StepPlaceholders): AppManualStep[]
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/backend/src/app-catalog/app-catalog.service.spec.ts` already builds a service with mocked collaborators and a `ROW` fixture whose `manifest` carries `manualSteps` (see line 43 and line 338). Follow that file's existing setup exactly — the mocks, `mockDb.__queue`, and the `ROW`/project fixtures are already there. Append:
+
+```ts
+describe('installed manual steps', () => {
+  it('interpolates {projectPath} and {appHost} into the returned steps', async () => {
+    // Fixture project resolves to acme/site; fixture domain resolves to reader.example.com.
+    const manifest = {
+      ...MANIFEST,
+      install: {
+        ...MANIFEST.install,
+        manualSteps: [
+          {
+            id: 'grant-access',
+            title: 'Give other people access',
+            body: 'Add each person as a guest.',
+            deepLink: '/repo/{projectPath}/settings?tab=members',
+          },
+          {
+            id: 'bucket-cors',
+            title: 'Let the browser upload to your bucket',
+            body: 'Allow PUT from {appHost}.',
+          },
+        ],
+      },
+    };
+    mockDb.__queue([{ ...ROW, manifest }]);
+
+    const result = await service.listCatalog();
+    const steps = result.data[0].installed!.manualSteps;
+
+    expect(steps[0].deepLink).toBe('/repo/acme/site/settings?tab=members');
+    expect(steps[1].body).toBe('Allow PUT from reader.example.com.');
+  });
+
+  it('appends the cert note when the host has no certificate', async () => {
+    certStepService.plan.mockResolvedValue({ model: 'direct-no-wildcard', action: 'report' });
+    certStepService.execute.mockResolvedValue({
+      status: 'action-required',
+      detail: 'served over HTTP',
+      manualStep: { id: 'provision-wildcard-cert', title: 'Turn on HTTPS', body: 'Body.' },
+    });
+    mockDb.__queue([ROW]);
+
+    const result = await service.listCatalog();
+
+    expect(result.data[0].installed!.manualSteps.map((s) => s.id)).toContain(
+      'provision-wildcard-cert',
+    );
+  });
+
+  it('omits the cert note when a wildcard already covers the host', async () => {
+    certStepService.plan.mockResolvedValue({ model: 'wildcard', action: 'covered' });
+    certStepService.execute.mockResolvedValue({ status: 'done', detail: 'covered' });
+    mockDb.__queue([ROW]);
+
+    const result = await service.listCatalog();
+
+    expect(result.data[0].installed!.manualSteps.map((s) => s.id)).not.toContain(
+      'provision-wildcard-cert',
+    );
+  });
+
+  it('still lists the app when the cert lookup throws', async () => {
+    certStepService.plan.mockRejectedValue(new Error('domains service down'));
+    mockDb.__queue([ROW]);
+
+    const result = await service.listCatalog();
+
+    expect(result.data[0].installed).toBeDefined();
+    expect(result.data[0].installed!.manualSteps.map((s) => s.id)).not.toContain(
+      'provision-wildcard-cert',
+    );
+  });
+});
+```
+
+If the existing `certStepService` mock in this file has no `plan`/`execute` jest functions, add them to that mock object: `plan: jest.fn().mockResolvedValue({ model: 'wildcard', action: 'covered' })` and `execute: jest.fn().mockResolvedValue({ status: 'done', detail: 'covered' })`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/backend && npx jest src/app-catalog/app-catalog.service.spec.ts -t "installed manual steps"`
+Expected: FAIL — the first case returns the literal `/repo/{projectPath}/settings?tab=members`; the second finds no `provision-wildcard-cert`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/backend/src/app-catalog/app-catalog.service.ts`:
+
+Add `interpolateStep` and the `StepPlaceholders` type to the existing import from `./app-manifest.util` (currently `import { manualStepApplies } from './app-manifest.util';` at line 31):
+
+```ts
+import { manualStepApplies, interpolateStep, type StepPlaceholders } from './app-manifest.util';
+```
+
+Replace `applicableManualSteps` (line 464-467) with:
+
+```ts
+  private applicableManualSteps(
+    manifest: AppManifest,
+    values: StepPlaceholders,
+  ): AppManualStep[] {
+    const ctx = this.instanceContext();
+    return (manifest.install.manualSteps ?? [])
+      .filter((step) => manualStepApplies(step, ctx))
+      .map((step) => interpolateStep(step, values));
+  }
+```
+
+Add this private helper next to it:
+
+```ts
+  /**
+   * The TLS note is synthesized during the install run and attached to the
+   * in-memory job, so it used to vanish the moment the catalog refetched
+   * (ce#584 follow-up). Re-deriving it here keeps it visible AND makes it
+   * self-healing — it disappears on its own once a wildcard covers the host.
+   *
+   * `AppCertStepService` never throws by contract; the guard is for the day
+   * that stops being true. A catalog that fails to list is worse than one
+   * missing an advisory line.
+   */
+  private async certManualStep(appHost: string | undefined): Promise<AppManualStep[]> {
+    if (!appHost) return [];
+    try {
+      const plan = await this.certStepService.plan(appHost);
+      const result = await this.certStepService.execute(plan, appHost);
+      return result.manualStep ? [result.manualStep] : [];
+    } catch (error) {
+      this.logger.warn(
+        `Could not derive the certificate note for ${appHost}: ${(error as Error).message}`,
+      );
+      return [];
+    }
+  }
+```
+
+If `AppCatalogService` has no `logger` property yet, add one alongside the constructor: `private readonly logger = new Logger(AppCatalogService.name);` and add `Logger` to the `@nestjs/common` import.
+
+Rewrite `buildInstalledSummary` (line 340-365) so the host is resolved once and reused:
+
+```ts
+  private async buildInstalledSummary(
+    row: InstalledApp,
+    registryVersion: string | undefined,
+    domainsById: Map<string, DomainRef>,
+  ): Promise<NonNullable<CatalogEntry['installed']>> {
+    const manifest = row.manifest as AppManifest;
+    const project = await this.projectsService.getProjectById(row.projectId);
+    const updateAvailable =
+      registryVersion !== undefined && compareSemver(registryVersion, row.version) > 0;
+
+    const projectPath = `${project.owner}/${project.name}`;
+    const appHost = row.domainId ? domainsById.get(row.domainId)?.domain : undefined;
+    const appUrl = await this.resolveAppUrl(row, domainsById);
+
+    return {
+      installedAppId: row.id,
+      version: row.version,
+      projectId: row.projectId,
+      projectName: projectPath,
+      alias: row.alias,
+      appUrl,
+      status: row.status,
+      updateAvailable,
+      manualSteps: [
+        ...this.applicableManualSteps(manifest, { projectPath, appHost }),
+        ...(await this.certManualStep(appHost)),
+      ],
+    };
+  }
+```
+
+Note `manualStepsAcked` is deliberately gone from the returned object — Task 4 removes the rest of that mechanism, and leaving it here would keep the column alive.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/backend && npx jest src/app-catalog/app-catalog.service.spec.ts`
+Expected: PASS for the four new cases. Pre-existing cases at lines 219-231 assert on `manualStepsAcked` and will now fail — **delete those two cases**, since Task 4 removes the feature they cover. Any other case asserting `manualStepsAcked` in the returned summary: delete the assertion line, keep the case.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/app-catalog/app-catalog.service.ts apps/backend/src/app-catalog/app-catalog.service.spec.ts
+git commit -m "feat(app-catalog): interpolate manual steps and re-derive the cert note on read"
+```
+
+---
+
+### Task 4: Delete the acknowledgement mechanism
+
+Endpoint, DTO, service method, and the DB column. The tick recorded a string only the checkbox read; with the checkbox gone in Task 6, the state has no consumer.
+
+**Files:**
+- Modify: `apps/backend/src/app-catalog/app-catalog.controller.ts` (delete the `ack` handler at lines 90-93 and the `AckManualStepDto` import on line 1-20)
+- Modify: `apps/backend/src/app-catalog/app-catalog.dtos.ts` (delete `AckManualStepDto`, lines 82-86)
+- Modify: `apps/backend/src/app-catalog/app-catalog.service.ts` (delete `ackManualStep`, line 274 and its doc comment; delete `manualStepsAcked` from the `CatalogEntry['installed']` interface at line 83)
+- Modify: `apps/backend/src/db/schema/installed-apps.schema.ts:46` (delete the `manualStepsAcked` column)
+- Test: `apps/backend/src/app-catalog/app-catalog.controller.spec.ts`, `apps/backend/src/app-catalog/app-catalog.e2e-ish.spec.ts:128`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `POST /api/admin/apps/installed/:id/ack-manual-step` no longer exists. `CatalogEntry['installed']` no longer has `manualStepsAcked` — Task 6 relies on this.
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/backend/src/app-catalog/app-catalog.controller.spec.ts`, following that file's existing controller-construction pattern, add:
+
+```ts
+it('exposes no manual-step acknowledgement handler', () => {
+  expect((controller as unknown as Record<string, unknown>).ack).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/backend && npx jest src/app-catalog/app-catalog.controller.spec.ts -t acknowledgement`
+Expected: FAIL — `controller.ack` is still a function.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Delete, in order:
+
+1. `apps/backend/src/app-catalog/app-catalog.controller.ts` — the whole handler:
+   ```ts
+   @Post('installed/:id/ack-manual-step')
+   async ack(@Param('id') id: string, @Body() body: AckManualStepDto) {
+     const acked = await this.catalog.ackManualStep(id, body.stepId);
+     return { acked };
+   }
+   ```
+   and `AckManualStepDto` from the `./app-catalog.dtos` import list. If `Body` is now unused in the file, drop it from the `@nestjs/common` import too.
+
+2. `apps/backend/src/app-catalog/app-catalog.dtos.ts` — the `AckManualStepDto` class (lines 82-86). If `IsString` is now unused, drop it from the `class-validator` import.
+
+3. `apps/backend/src/app-catalog/app-catalog.service.ts` — the `ackManualStep` method (line 274) with its `/** Idempotent: … */` comment, and the `manualStepsAcked: string[];` line from the `installed` block of the `CatalogEntry` interface (line 83). If `installedApps` is no longer used in an `update()` anywhere in this file, leave the import alone — `requireRow` still selects from it.
+
+4. `apps/backend/src/db/schema/installed-apps.schema.ts` — delete line 46:
+   ```ts
+   manualStepsAcked: jsonb('manual_steps_acked').$type<string[]>().notNull().default([]),
+   ```
+
+5. `apps/backend/src/app-catalog/app-catalog.e2e-ish.spec.ts:128` — delete the `manualStepsAcked: [],` line from the fixture row.
+
+6. `apps/backend/src/app-catalog/app-installer.service.spec.ts:180` — delete the `manualStepsAcked: [] as string[],` line from the fixture row.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/backend && npx jest src/app-catalog`
+Expected: PASS across the whole app-catalog suite. Then confirm nothing references the removed names:
+
+Run: `cd apps/backend && grep -rn "manualStepsAcked\|ackManualStep\|AckManualStepDto\|manual_steps_acked" src/`
+Expected: no output.
+
+- [ ] **Step 5: Generate the migration (operator, not agent)**
+
+The column drop needs a Drizzle migration, and `db:generate` is interactive — **stop here and hand this to the operator**:
+
+```bash
+cd repos/ce/apps/backend && pnpm db:generate
+```
+
+Expect a prompt showing a dropped column on `installed_apps`; a name like `drop-manual-steps-acked` is right. When they report the generated filename, review the SQL (it should be a single `ALTER TABLE "installed_apps" DROP COLUMN "manual_steps_acked";`) and include it in the commit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/backend/src/app-catalog apps/backend/src/db/schema/installed-apps.schema.ts apps/backend/drizzle
+git commit -m "refactor(app-catalog): drop the manual-step acknowledgement mechanism
+
+The tick appended a string to installed_apps.manual_steps_acked, and the only
+consumer of that column was the checkbox's own checked state. Nothing gated on
+it. Setup notes are read, not completed."
+```
+
+---
+
+### Task 5: Interpolate manual steps in the installer
+
+The install job's own copy of the notes needs the same expansion, or the Done screen shows literal braces during the run.
+
+**Files:**
+- Modify: `apps/backend/src/app-catalog/app-installer.service.ts` (`applicableManualSteps` ~line 1289-1292, call site ~line 306, second call site ~line 448)
+- Test: `apps/backend/src/app-catalog/app-installer.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `interpolateStep`, `StepPlaceholders` (Task 1).
+- Produces: `InstallJob.manualSteps` entries are interpolated. No signature change visible outside the service.
+
+- [ ] **Step 1: Write the failing test**
+
+The spec file already drives a full install run and asserts on `jobs.get(jobId)!.manualSteps` (see lines 512 and 543). Following that same setup, add:
+
+```ts
+it('interpolates {projectPath} and {appHost} into the job manual steps', async () => {
+  // MANIFEST_WITH_STEPS mirrors the fixture used at line 69, with a token added.
+  const manifest = {
+    ...MANIFEST,
+    install: {
+      ...MANIFEST.install,
+      manualSteps: [
+        {
+          id: 'grant-access',
+          title: 'Give other people access',
+          body: 'Add each person as a guest.',
+          deepLink: '/repo/{projectPath}/settings?tab=members',
+        },
+      ],
+    },
+  };
+
+  const jobId = await runInstall({ manifest });
+
+  expect(jobs.get(jobId)!.manualSteps![0].deepLink).toBe(
+    '/repo/acme/site/settings?tab=members',
+  );
+});
+```
+
+Use whatever helper the neighbouring tests use to drive a run and to override the bundle's manifest — do not invent a new harness.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/backend && npx jest src/app-catalog/app-installer.service.spec.ts -t interpolates`
+Expected: FAIL — `deepLink` is still `/repo/{projectPath}/settings?tab=members`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/backend/src/app-catalog/app-installer.service.ts`:
+
+Extend the import on line 29:
+
+```ts
+import { manualStepApplies, interpolateStep, type StepPlaceholders } from './app-manifest.util';
+```
+
+Replace `applicableManualSteps` (line 1289-1292):
+
+```ts
+  private applicableManualSteps(
+    manifest: AppManifest,
+    values: StepPlaceholders,
+  ): AppManualStep[] {
+    const ctx = this.instanceContext();
+    return (manifest.install.manualSteps ?? [])
+      .filter((step) => manualStepApplies(step, ctx))
+      .map((step) => interpolateStep(step, values));
+  }
+```
+
+At the install call site (line 306), the run already has `project` and `appHost` in scope:
+
+```ts
+      const stepValues: StepPlaceholders = {
+        projectPath: `${project.owner}/${project.name}`,
+        appHost: appHost ?? undefined,
+      };
+      const manualSteps = [
+        ...this.applicableManualSteps(manifest, stepValues),
+        ...certManualSteps,
+      ];
+```
+
+At the update call site (line 448), pass the same shape, using whatever project/host variables that scope already holds:
+
+```ts
+      const manualSteps = this.applicableManualSteps(manifest, {
+        projectPath: `${project.owner}/${project.name}`,
+        appHost: appHost ?? undefined,
+      });
+```
+
+If either scope lacks `project`, load it the way the surrounding code already does (`await this.projectsService.getProjectById(row.projectId)`) rather than threading a new parameter through.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/backend && npx jest src/app-catalog/app-installer.service.spec.ts`
+Expected: PASS — the new case and the two pre-existing `manualSteps` cases at lines 512 and 543.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/app-catalog/app-installer.service.ts apps/backend/src/app-catalog/app-installer.service.spec.ts
+git commit -m "feat(app-catalog): interpolate manual steps in the installer job"
+```
+
+---
+
+### Task 6: `SetupNotes` component + install dialog
+
+One component, two consumers. This task builds it and wires the first consumer; Task 7 wires the card.
+
+**Files:**
+- Create: `apps/frontend/src/components/app-catalog/SetupNotes.tsx`
+- Create: `apps/frontend/src/components/app-catalog/__tests__/SetupNotes.test.tsx`
+- Modify: `apps/frontend/src/components/app-catalog/InstallDialog.tsx` (lines 292-299 and 541-566)
+- Modify: `apps/frontend/src/services/appCatalogApi.ts` (lines 10, 87, 264-271, 287)
+- Modify: `apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx`
+
+**Interfaces:**
+- Consumes: `AppManualStep` from `@/services/appCatalogApi`.
+- Produces:
+  ```tsx
+  export function SetupNotes(props: {
+    steps: AppManualStep[];
+    defaultExpanded?: boolean;  // default false
+    className?: string;
+  }): JSX.Element | null
+  ```
+  Returns `null` when `steps` is empty. Task 7 renders it with `defaultExpanded` omitted.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/frontend/src/components/app-catalog/__tests__/SetupNotes.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import { SetupNotes } from '../SetupNotes';
+
+const STEPS = [
+  {
+    id: 'grant-access',
+    title: 'Give other people access',
+    body: 'Rivulet is private. Add each person as a guest.',
+    deepLink: '/repo/acme/site/settings?tab=members',
+  },
+  { id: 'provision-wildcard-cert', title: 'Turn on HTTPS for this app', body: 'Over HTTP now.' },
+];
+
+describe('SetupNotes', () => {
+  it('renders nothing when there are no steps', () => {
+    const { container } = render(<SetupNotes steps={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows titles collapsed, bodies hidden', () => {
+    render(<SetupNotes steps={STEPS} />);
+
+    expect(screen.getByText('Give other people access')).toBeInTheDocument();
+    expect(screen.getByText('Turn on HTTPS for this app')).toBeInTheDocument();
+    expect(screen.queryByText(/Rivulet is private/)).not.toBeInTheDocument();
+  });
+
+  it('says CE cannot do these for you', () => {
+    render(<SetupNotes steps={STEPS} />);
+    expect(screen.getByText(/can't do these for you/i)).toBeInTheDocument();
+  });
+
+  it('expands one body on click without expanding the others', async () => {
+    render(<SetupNotes steps={STEPS} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /give other people access/i }));
+
+    expect(screen.getByText(/Rivulet is private/)).toBeInTheDocument();
+    expect(screen.queryByText('Over HTTP now.')).not.toBeInTheDocument();
+  });
+
+  it('renders the deep link once expanded', async () => {
+    render(<SetupNotes steps={STEPS} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /give other people access/i }));
+
+    expect(screen.getByRole('link', { name: /manage members|go/i })).toHaveAttribute(
+      'href',
+      '/repo/acme/site/settings?tab=members',
+    );
+  });
+
+  it('shows every body from the start when defaultExpanded', () => {
+    render(<SetupNotes steps={STEPS} defaultExpanded />);
+
+    expect(screen.getByText(/Rivulet is private/)).toBeInTheDocument();
+    expect(screen.getByText('Over HTTP now.')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/frontend && npx vitest run src/components/app-catalog/__tests__/SetupNotes.test.tsx`
+Expected: FAIL — cannot resolve `../SetupNotes`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/frontend/src/components/app-catalog/SetupNotes.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { AppManualStep } from '@/services/appCatalogApi';
+
+interface SetupNotesProps {
+  steps: AppManualStep[];
+  /** The install dialog has room to show every body; the card does not. */
+  defaultExpanded?: boolean;
+  className?: string;
+}
+
+/**
+ * SetupNotes — the app's post-install advice, rendered identically on the
+ * install dialog's Done screen and on the installed card.
+ *
+ * These are notes, not steps: CE cannot grant a user access or write a CORS
+ * rule on someone's bucket, and it never claimed to. The list used to carry
+ * checkboxes whose only effect was to store their own checked state, which
+ * made the copy work harder to explain what the control did not do. Nothing
+ * here is stateful.
+ */
+export function SetupNotes({ steps, defaultExpanded = false, className }: SetupNotesProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(
+    () => new Set(defaultExpanded ? steps.map((step) => step.id) : []),
+  );
+
+  if (steps.length === 0) return null;
+
+  const toggle = (id: string) =>
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      <p className="text-sm font-medium">
+        Setup notes{' '}
+        <span className="font-normal text-muted-foreground">— CE can&apos;t do these for you</span>
+      </p>
+
+      <ul className="space-y-1">
+        {steps.map((step) => {
+          const isOpen = expanded.has(step.id);
+          return (
+            <li key={step.id}>
+              <button
+                type="button"
+                onClick={() => toggle(step.id)}
+                aria-expanded={isOpen}
+                className="flex w-full items-start gap-1 text-left text-sm hover:underline"
+              >
+                {isOpen ? (
+                  <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                ) : (
+                  <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                )}
+                <span>{step.title}</span>
+              </button>
+
+              {isOpen && (
+                <div className="ml-5 mt-1 space-y-1">
+                  <p className="text-sm text-muted-foreground">{step.body}</p>
+                  {step.deepLink && (
+                    <a href={step.deepLink} className="text-sm text-primary underline">
+                      Go
+                    </a>
+                  )}
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/frontend && npx vitest run src/components/app-catalog/__tests__/SetupNotes.test.tsx`
+Expected: PASS, all six cases.
+
+- [ ] **Step 5: Wire the install dialog and drop the ack client**
+
+In `apps/frontend/src/services/appCatalogApi.ts`:
+
+- Delete the `ackManualStep` mutation (lines 264-271) and `useAckManualStepMutation` from the export list (line 287).
+- Delete `manualStepsAcked: string[];` from the `installed` block (line 87).
+- In the file's header comment (line 10), drop `/ackManualStep` from the sentence listing the wizard-backing endpoints.
+
+In `apps/frontend/src/components/app-catalog/InstallDialog.tsx`:
+
+- Delete `useAckManualStepMutation` from the import block and its `const [ackManualStep] = useAckManualStepMutation();` call.
+- Replace lines 292-299 with:
+  ```tsx
+  const manualSteps = entry.installed?.manualSteps ?? job?.manualSteps ?? [];
+  ```
+  (deleting `manualStepsAcked` and the whole `handleAck` function).
+- Replace the entire `{manualSteps.length > 0 && ( … )}` block (lines 541-566) with:
+  ```tsx
+  <SetupNotes steps={manualSteps} defaultExpanded />
+  ```
+- Add `import { SetupNotes } from './SetupNotes';` and remove the now-unused `Checkbox` import if nothing else in the file uses it.
+
+In `apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx`, replace any case asserting checkbox/ack behaviour with:
+
+```tsx
+it('renders the setup notes expanded on the done screen', async () => {
+  // …existing harness that drives the dialog to a succeeded job…
+  expect(screen.getByText(/Setup notes/)).toBeInTheDocument();
+  expect(screen.getByText(/Rivulet is private/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 6: Run the frontend suite**
+
+Run: `cd apps/frontend && npx vitest run src/components/app-catalog src/pages/AppsPage.test.tsx`
+Expected: PASS. Then confirm the client is clean:
+
+Run: `cd apps/frontend && grep -rn "manualStepsAcked\|ackManualStep\|AckManualStep" src/`
+Expected: no output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/frontend/src/components/app-catalog apps/frontend/src/services/appCatalogApi.ts
+git commit -m "feat(app-catalog): SetupNotes component, replacing the Done-screen checklist"
+```
+
+---
+
+### Task 7: Setup notes on the installed card
+
+The permanent home. Collapsed by default so a 3-up grid stays even.
+
+**Files:**
+- Modify: `apps/frontend/src/components/app-catalog/AppCard.tsx` (CardContent block, lines 131-135)
+- Modify: `apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `SetupNotes` (Task 6); `CatalogEntry['installed'].manualSteps` (Task 3).
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx`, following the file's existing `baseEntry` fixture and render helper (it already has an installed-entry fixture — see the `manualSteps` reference in it), add:
+
+```tsx
+describe('setup notes', () => {
+  const installedWithNotes = {
+    ...baseEntry,
+    installed: {
+      installedAppId: 'installed-1',
+      version: '1.0.0',
+      projectId: 'proj-1',
+      projectName: 'acme/site',
+      alias: 'reader',
+      appUrl: 'https://reader.example.com',
+      status: 'installed' as const,
+      updateAvailable: false,
+      manualSteps: [
+        {
+          id: 'grant-access',
+          title: 'Give other people access',
+          body: 'Rivulet is private. Add each person as a guest.',
+          deepLink: '/repo/acme/site/settings?tab=members',
+        },
+      ],
+    },
+  };
+
+  it('shows the note title on an installed card', () => {
+    render(<AppCard entry={installedWithNotes} {...noopHandlers} />);
+
+    expect(screen.getByText('Give other people access')).toBeInTheDocument();
+    expect(screen.queryByText(/Rivulet is private/)).not.toBeInTheDocument();
+  });
+
+  it('expands the body in place', async () => {
+    render(<AppCard entry={installedWithNotes} {...noopHandlers} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /give other people access/i }));
+
+    expect(screen.getByText(/Rivulet is private/)).toBeInTheDocument();
+  });
+
+  it('renders no setup notes block when the app has none', () => {
+    const entry = {
+      ...installedWithNotes,
+      installed: { ...installedWithNotes.installed, manualSteps: [] },
+    };
+    render(<AppCard entry={entry} {...noopHandlers} />);
+
+    expect(screen.queryByText(/Setup notes/)).not.toBeInTheDocument();
+  });
+
+  it('renders no setup notes block when the app is not installed', () => {
+    render(<AppCard entry={baseEntry} {...noopHandlers} />);
+
+    expect(screen.queryByText(/Setup notes/)).not.toBeInTheDocument();
+  });
+});
+```
+
+`noopHandlers` stands for the `onInstall`/`onDetails`/`onUpdateStarted` props the existing tests already pass — use whatever that file already does.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/frontend && npx vitest run src/components/app-catalog/__tests__/AppCard.test.tsx -t "setup notes"`
+Expected: FAIL — no note title on the card.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/frontend/src/components/app-catalog/AppCard.tsx`, add the import:
+
+```tsx
+import { SetupNotes } from './SetupNotes';
+```
+
+and replace the `CardContent` block (lines 131-135) with:
+
+```tsx
+      <CardContent className="flex-1 space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          {entry.category && (
+            <Badge variant="outline" className="capitalize">
+              {entry.category}
+            </Badge>
+          )}
+          {installed && <Badge variant="secondary">{`Installed · v${installed.version}`}</Badge>}
+        </div>
+
+        {/*
+          Titles only, collapsed. The banner above is unconditional so the grid
+          doesn't go ragged; two three-line bodies inline would reintroduce
+          exactly that unevenness, permanently. Expanding is one click, and the
+          notes are worth finding — before this they were reachable only by
+          triggering an Update.
+        */}
+        {installed && <SetupNotes steps={installed.manualSteps} />}
+      </CardContent>
+```
+
+Add the doc block to the component's header comment, under the existing `- installed →` bullet:
+
+```
+ * An installed card also carries its app's setup notes (titles collapsed,
+ * bodies expanding in place) — CE can't perform them, so they live where the
+ * app lives rather than behind a one-shot dialog.
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/frontend && npx vitest run src/components/app-catalog src/pages/AppsPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/frontend/src/components/app-catalog/AppCard.tsx apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
+git commit -m "feat(app-catalog): show setup notes on the installed app card"
+```
+
+---
+
+### Task 8: Full CE verification
+
+**Files:** none.
+
+**Interfaces:**
+- Consumes: Tasks 1-7.
+- Produces: a green CE branch ready for a PR.
+
+- [ ] **Step 1: Run the backend app-catalog suite**
+
+Run: `cd apps/backend && npx jest src/app-catalog`
+Expected: PASS, no skipped suites.
+
+- [ ] **Step 2: Run the frontend suite**
+
+Run: `cd apps/frontend && npx vitest run`
+Expected: PASS. Note: `pnpm lint` fails on `main` with pre-existing problems in this repo — check that your files add none, don't try to reach zero.
+
+- [ ] **Step 3: Typecheck both apps**
+
+Run: `cd apps/backend && npx tsc --noEmit` then `cd ../frontend && npx tsc --noEmit`
+Expected: no errors. A dangling reference to `manualStepsAcked` or `useAckManualStepMutation` surfaces here if the greps in Tasks 4 and 6 missed anything.
+
+- [ ] **Step 4: Confirm the mechanism is fully gone**
+
+Run: `git grep -n "manualStepsAcked\|ackManualStep\|manual_steps_acked" -- apps/ | grep -v drizzle/`
+Expected: no output. (The generated migration under `drizzle/` legitimately names the dropped column.)
+
+- [ ] **Step 5: Push and open the PR**
+
+```bash
+git push -u origin spec/app-setup-notes
+gh pr create --title "feat(app-catalog): setup notes that live on the card" --body-file - <<'EOF'
+Implements docs/superpowers/specs/2026-08-02-app-setup-notes-design.md.
+
+An app manifest's `install.manualSteps` rendered as a one-shot checklist on the
+install dialog's Done screen, in bodies of 200-570 characters, behind
+checkboxes whose only effect was to store their own checked state.
+
+- Notes now live on the installed app's card — titles visible, bodies expanding
+  in place. Before this they were reachable only by triggering an Update.
+- The acknowledgement mechanism is gone: endpoint, DTO, service method, and the
+  `manual_steps_acked` column. Nothing gated on it.
+- Manifests can deep-link into the dashboard via `{projectPath}`/`{appHost}`,
+  interpolated at read time; unknown tokens fail manifest validation.
+- The synthesized TLS note is re-derived on read, fixing it vanishing once the
+  catalog refetched, and it now disappears on its own once a wildcard exists.
+
+Copy rewrites for the shipped manifests are in a companion bffless/apps PR.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_018rPL4Mf667ZUyxFN9HmseV
+EOF
+```
+
+**Ask the operator before pushing** — this repo's rule is to confirm before anything leaves the machine.
+
+---
+
+### Task 9: Rewrite the shipped manifest copy (`bffless/apps`)
+
+Different repo. Branch it first: `cd /home/rico/bffless/repos/apps && git checkout -b fix/setup-notes-copy origin/main`.
+
+**Files:**
+- Modify: `apps/reader/bffless-app.json` (the `install.manualSteps` array, lines 44-57)
+- Modify: `apps/handoff/bffless-app.json` (the `install.manualSteps` array)
+- Modify: `apps/reader/bffless/README.md`
+- Modify: `apps/handoff/bffless/README.md`
+- Modify: `scripts/check-app-conventions.mjs`
+- Create: `scripts/check-app-conventions.test.mjs`
+
+**Interfaces:**
+- Consumes: the 220-character rule and the `{projectPath}`/`{appHost}` token set from Global Constraints.
+- Produces:
+  ```js
+  export function checkManualSteps(manifest, manifestRel)  // → string[] of errors
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/check-app-conventions.test.mjs`, modelled on `scripts/build-registry.test.mjs`:
+
+```js
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { checkManualSteps } from './check-app-conventions.mjs'
+
+const REL = 'apps/demo/bffless-app.json'
+
+function manifestWith(steps) {
+  return { install: { manualSteps: steps } }
+}
+
+test('accepts a short note', () => {
+  const errors = checkManualSteps(
+    manifestWith([{ id: 'a', title: 'Do the thing', body: 'Short and plain.' }]),
+    REL,
+  )
+  assert.deepEqual(errors, [])
+})
+
+test('rejects a body over 220 characters', () => {
+  const errors = checkManualSteps(
+    manifestWith([{ id: 'a', title: 'T', body: 'x'.repeat(221) }]),
+    REL,
+  )
+  assert.equal(errors.length, 1)
+  assert.match(errors[0], /install\.manualSteps\[0\]\.body/)
+  assert.match(errors[0], /221 characters/)
+  assert.match(errors[0], /220/)
+})
+
+test('rejects an unknown placeholder', () => {
+  const errors = checkManualSteps(
+    manifestWith([{ id: 'a', title: 'T', body: 'Go to {foo}.' }]),
+    REL,
+  )
+  assert.equal(errors.length, 1)
+  assert.match(errors[0], /unknown placeholder \{foo\}/)
+})
+
+test('accepts the known placeholders', () => {
+  const errors = checkManualSteps(
+    manifestWith([
+      {
+        id: 'a',
+        title: 'T',
+        body: 'Allow PUT from {appHost}.',
+        deepLink: '/repo/{projectPath}/settings?tab=members',
+      },
+    ]),
+    REL,
+  )
+  assert.deepEqual(errors, [])
+})
+
+test('accepts a manifest with no manual steps', () => {
+  assert.deepEqual(checkManualSteps({ install: {} }, REL), [])
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/rico/bffless/repos/apps && node --test scripts/check-app-conventions.test.mjs`
+Expected: FAIL — `checkManualSteps` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `scripts/check-app-conventions.mjs`, add near the other module-scope constants:
+
+```js
+// Mirrors PLACEHOLDER_TOKENS in the CE repo's app-manifest.util.ts.
+const PLACEHOLDER_TOKENS = ['projectPath', 'appHost']
+// A note's body is at most three short lines in the install dialog's width.
+const MAX_BODY_CHARS = 220
+```
+
+and export the checker:
+
+```js
+/**
+ * A setup note is read, not completed: title is the action, body is at most
+ * three short lines. A note that needs a conditional to decide whether it
+ * applies to the reader belongs in the app's README instead.
+ */
+export function checkManualSteps(manifest, manifestRel) {
+  const steps = manifest?.install?.manualSteps
+  if (!Array.isArray(steps)) return []
+
+  const errors = []
+
+  steps.forEach((step, i) => {
+    const at = `${manifestRel}: install.manualSteps[${i}]`
+
+    if (typeof step?.body === 'string' && step.body.length > MAX_BODY_CHARS) {
+      errors.push(
+        `${at}.body: ${step.body.length} characters, max ${MAX_BODY_CHARS} — ` +
+          `shorten it, or move the detail to the app README`,
+      )
+    }
+
+    for (const field of ['title', 'body', 'deepLink']) {
+      const value = step?.[field]
+      if (typeof value !== 'string') continue
+      for (const match of value.matchAll(/\{([^}]*)\}/g)) {
+        if (!PLACEHOLDER_TOKENS.includes(match[1])) {
+          errors.push(
+            `${at}.${field}: unknown placeholder {${match[1]}} ` +
+              `(known: ${PLACEHOLDER_TOKENS.join(', ')})`,
+          )
+        }
+      }
+    }
+  })
+
+  return errors
+}
+```
+
+Then call it from `checkManifest`, just before its final `return errors`:
+
+```js
+  errors.push(...checkManualSteps(manifest, manifestRel))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/rico/bffless/repos/apps && node --test scripts/check-app-conventions.test.mjs`
+Expected: PASS, five cases.
+
+- [ ] **Step 5: Rewrite the manifests**
+
+In `apps/reader/bffless-app.json`, replace the whole `manualSteps` array (lines 44-57) with:
+
+```json
+    "manualSteps": [
+      {
+        "id": "grant-access",
+        "title": "Give other people access",
+        "body": "Rivulet is private — only signed-in users with access to this project can read feeds. Add each person as a guest. Just you? Nothing to do here.",
+        "deepLink": "/repo/{projectPath}/settings?tab=members",
+        "appliesWhen": "always"
+      }
+    ]
+```
+
+In `apps/handoff/bffless-app.json`, replace its `manualSteps` array with:
+
+```json
+    "manualSteps": [
+      {
+        "id": "bucket-cors",
+        "title": "Let the browser upload to your bucket",
+        "body": "Uploads go straight from the browser to your storage bucket, so the bucket needs a CORS rule allowing PUT and Content-Type from {appHost}. CE can't set this for you — do it in your cloud console.",
+        "appliesWhen": "bucketStorage"
+      }
+    ]
+```
+
+Both `embed-headers` (reader) and `iframe-headers` (handoff) are deleted — they only matter to a project that already applies a cross-origin-isolation policy, which a reader has to parse the whole paragraph to discover doesn't describe them.
+
+- [ ] **Step 6: Move the cut notes into the READMEs**
+
+Append to `apps/reader/bffless/README.md`:
+
+```markdown
+## Posts won't render inline
+
+Rivulet shows a Handoff markdown post's body inline by iframing the Handoff
+viewer's chromeless `?embed=1` mode. If this project applies a
+cross-origin-isolation policy (COOP/COEP) somewhere else — another app using
+`SharedArrayBuffer`, say — that iframe is blocked.
+
+Fix: add a response-header rule matching the reader's files (`apps/reader/**`)
+with `Cross-Origin-Opener-Policy: unsafe-none` and
+`Cross-Origin-Embedder-Policy: unsafe-none`, at a priority below the isolating
+rule, and make sure the Handoff instance allows the reader's origin to frame
+it. A fresh project with no isolation policy needs none of this.
+```
+
+Append to `apps/handoff/bffless/README.md`:
+
+```markdown
+## Sites or embeds won't render in an iframe
+
+Handoff renders user-uploaded Sites (served with no COEP) in an iframe, and
+exposes a chromeless `?embed=1` viewer that other apps iframe to show a post
+inline. If this project applies a cross-origin-isolation policy (COOP/COEP)
+somewhere else, both are blocked.
+
+Fix: add a response-header rule matching Handoff's files (`apps/handoff/**`)
+with `Cross-Origin-Opener-Policy: unsafe-none` and
+`Cross-Origin-Embedder-Policy: unsafe-none`, at a priority below the isolating
+rule. A fresh project with no isolation policy needs none of this.
+```
+
+- [ ] **Step 7: Verify the conventions check passes**
+
+Run: `cd /home/rico/bffless/repos/apps && pnpm apps:check`
+Expected: `All N app(s) satisfy the per-app pipelines convention.` Both rewritten bodies are under 220 characters (148 and 196).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/reader/bffless-app.json apps/handoff/bffless-app.json apps/reader/bffless/README.md apps/handoff/bffless/README.md scripts/check-app-conventions.mjs scripts/check-app-conventions.test.mjs
+git commit -m "fix(apps): rewrite setup notes short, deep-linked, and README-bound
+
+Bodies were 201-571 characters of prose that buried the action inside a
+conditional. Each note now states what's true, what to do, and when to skip, in
+under 220 characters — enforced by apps:check. The two COOP/COEP notes move to
+their app READMEs: they only matter to a project that already applies an
+isolation policy, which a reader had to parse the whole paragraph to rule out."
+```
+
+**Do not push or open this PR without asking** — in `bffless/apps` a merge is a live rule and manifest deploy.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Copy rule → Task 9 (enforced by Task 9's lint rule, 220 chars). Four manifest rewrites and two cuts → Task 9 Steps 5-6. CE's synthesized cert note rewrite → **gap found**: the spec rewrites `app-cert-step.service.ts:153`'s body but no task did it. Folded into Task 3, below. Placeholders → Tasks 1, 2, 3, 5, and mirrored in Task 9. Ack removal → Task 4 (backend + column) and Task 6 (client). `SetupNotes` → Task 6. Card → Task 7. Install dialog → Task 6. Cert re-derive → Task 3. Error handling for a throwing cert lookup → Task 3, Step 1 case 4. Testing section → covered across Tasks 1-3, 6, 7, 9.
+
+**Placeholder scan.** No TBDs. Every code step carries the actual code. The three places that say "follow the file's existing pattern" (Task 3's mock setup, Task 5's run helper, Task 7's `noopHandlers`) point at named, existing fixtures rather than deferring a decision.
+
+**Type consistency.** `interpolateStep(step, values)` and `StepPlaceholders` are used identically in Tasks 3 and 5. `applicableManualSteps(manifest, values)` has the same two-parameter shape in both services. `SetupNotes` takes `steps`/`defaultExpanded`/`className` in Tasks 6 and 7 alike. `checkManualSteps(manifest, manifestRel)` matches its call site.
+
+**Gap fix — add to Task 3 as a sixth step:**
+
+- [ ] **Step 6 (Task 3): Rewrite CE's synthesized cert note**
+
+In `apps/backend/src/app-catalog/app-cert-step.service.ts`, replace the `manualStep` object at line 153 with:
+
+```ts
+          manualStep: {
+            id: 'provision-wildcard-cert',
+            title: 'Turn on HTTPS for this app',
+            body:
+              'Your app is live, over HTTP. Provision a wildcard certificate on the Domains ' +
+              'page and it switches to HTTPS on its own.',
+            deepLink: '/domains',
+            appliesWhen: 'selfHosted',
+          },
+```
+
+The id, `deepLink` and `appliesWhen` are unchanged; only the copy shortens (from ~380 characters to 128). Then run `cd apps/backend && npx jest src/app-catalog/app-cert-step.service.spec.ts` — the case at line 153-156 asserts the body contains "wildcard", which the new copy still does. Commit with Task 3's other changes.

--- a/docs/superpowers/specs/2026-08-02-app-setup-notes-design.md
+++ b/docs/superpowers/specs/2026-08-02-app-setup-notes-design.md
@@ -1,0 +1,235 @@
+# App setup notes — readable copy, and a home on the card
+
+**Date:** 2026-08-02
+**Status:** design approved, plan pending
+**Repos:** `bffless/ce` (backend + frontend), `bffless/apps` (manifests + READMEs)
+
+## Problem
+
+An app manifest's `install.manualSteps` renders as a checklist on the install
+dialog's Done screen. Two things are wrong with it.
+
+**The copy is unreadable.** Rivulet's two steps are 447 and 571 characters of
+unbroken prose in a `sm:max-w-lg` dialog; Handoff's are 201 and 542. Each one
+buries its action inside a conditional ("if this project applies a
+cross-origin-isolation policy elsewhere…"), so a reader has to parse the whole
+paragraph before learning it doesn't apply to them.
+
+**The list is one-shot.** It renders only on the Done screen
+(`InstallDialog.tsx:541-566`). Closing unmounts the dialog, and an installed
+app's card has no Install button, so the only way back is to trigger an
+Update. The advice you were given at install time is unreachable exactly when
+you go looking for it.
+
+A third fact shapes both fixes: **the checkboxes do nothing.** Ticking one
+appends a string to `installed_apps.manual_steps_acked`, and the only consumer
+of that column is the checkbox's own `checked` state. Nothing gates on it, no
+install fails without it, and the acked state is invisible everywhere else.
+The copy is dense partly because it is straining to carry meaning the control
+doesn't.
+
+## Approach
+
+Stop calling them steps you complete and start treating them as **notes you
+read**: short, plain, linked to the place in the dashboard where the work
+actually happens, and permanently visible on the installed app's card.
+
+Three consequences:
+
+1. Rewrite the copy against a stated rule, and delete the notes that don't
+   apply to almost anyone.
+2. Delete the ack mechanism entirely — with no ticks, there is no state to
+   persist, no endpoint, and no column.
+3. Put the notes on the card, not behind a modal.
+
+## 1. Copy
+
+### Rule (to be documented alongside the manifest schema)
+
+A note's **title is the action**. Its **body is at most three short lines**:
+what is true, what to do, when to skip. A note that needs a conditional to
+decide whether it applies to the reader is not a note — it is a troubleshooting
+entry, and it belongs in the app's README. Every note that has a destination in
+the admin UI carries a `deepLink`.
+
+### Rewrites
+
+| Step | Before | After |
+| --- | --- | --- |
+| `reader/grant-access` | 447 ch | **Give other people access** — "Rivulet is private — only signed-in users with access to this project can read feeds. Add each person as a guest. Just you? Nothing to do here." → `/repo/{projectPath}/settings?tab=members` |
+| `reader/embed-headers` | 571 ch | **Cut.** Moves to the Rivulet README as "Posts won't render inline". |
+| `handoff/bucket-cors` | 201 ch | **Let the browser upload to your bucket** — "Uploads go straight from the browser to your storage bucket, so the bucket needs a CORS rule allowing `PUT` and `Content-Type` from `{appHost}`. CE can't set this for you — do it in your cloud console." → docs link |
+| `handoff/iframe-headers` | 542 ch | **Cut.** Moves to the Handoff README (same COOP/COEP note). |
+
+CE synthesizes one note of its own, and it breaks the same rule, so it is
+rewritten here too — `AppCertStepService` (`app-cert-step.service.ts:153`, id
+`provision-wildcard-cert`, currently five lines):
+
+> **Turn on HTTPS for this app** — "Your app is live, over HTTP. Provision a
+> wildcard certificate and it switches to HTTPS on its own." → `/domains`
+> (deep link unchanged)
+
+### Placeholders
+
+A manifest cannot hardcode `/repo/acme/site/settings?tab=members` — it does not
+know the project it will be installed into. The backend interpolates a **closed
+set** of placeholders into `title`, `body` and `deepLink` when it builds the
+note list:
+
+| Token | Expands to |
+| --- | --- |
+| `{projectPath}` | `owner/name` of the installed project |
+| `{appHost}` | the app's host, e.g. `reader.example.com` |
+
+`app-manifest.util.ts` rejects any other `{token}` at validation time, so a typo
+fails the manifest rather than shipping a literal brace to a user.
+
+The `manualSteps` manifest key keeps its name. Renaming it would break
+`schemaVersion: 1` for manifests already published to the registry; the change
+here is how CE presents them, not what an app declares.
+
+## 2. Removing the ack mechanism
+
+Deleted:
+
+- `POST /api/admin/apps/installed/:id/ack-manual-step`
+  (`app-catalog.controller.ts:90`)
+- `AckManualStepDto` (`app-catalog.dtos.ts:82`)
+- `AppCatalogService.ackManualStep` (`app-catalog.service.ts:274`)
+- `manualStepsAcked` from `CatalogEntry['installed']`
+  (`app-catalog.service.ts:83`)
+- `useAckManualStepMutation` and its RTK Query endpoint (`appCatalogApi.ts`)
+- the `manual_steps_acked` column
+  (`db/schema/installed-apps.schema.ts:46`)
+
+The column drop needs a generated Drizzle migration. `pnpm db:generate` is
+interactive and must be run by the operator, not the agent:
+
+```bash
+cd repos/ce/apps/backend && pnpm db:generate
+```
+
+Kept: the `manualSteps` manifest key, and `appliesWhen` filtering via
+`manualStepApplies` (`app-manifest.util.ts:381`).
+
+## 3. Surfacing the notes
+
+### `SetupNotes.tsx` (new)
+
+One component, rendering a heading ("Setup notes"), the line "CE can't do
+these for you", and one entry per note: title, body, deep link. A
+`defaultExpanded` prop controls whether bodies start open.
+
+### On the installed card (`AppCard.tsx`)
+
+The permanent home. An installed card grows a Setup notes block between its
+badges and its footer, listing each note's **title only**, as a disclosure
+button; clicking one expands its body and deep link in place.
+
+```
+┌─ Rivulet ────────────────────────┐
+│  [banner image]                  │
+│  Rivulet                         │
+│  A quiet, multi-user RSS reader  │
+│  [reading] [Installed · v1.0.0]  │
+│                                  │
+│  Setup notes — CE can't do       │
+│  these for you                   │
+│   › Give other people access     │
+│   › Turn on HTTPS for this app   │
+│                                  │
+│  Details    Open ↗         ⋮     │
+└──────────────────────────────────┘
+```
+
+Titles-only-by-default is deliberate: the catalog is a 3-up grid, and the
+banner is already unconditional so that one card with a thumbnail isn't twice
+the height of its neighbour (`AppCard.tsx:104-112`). Two three-line bodies
+inline would reintroduce exactly that unevenness, permanently. Collapsed, every
+installed card differs by at most a line or two.
+
+The block renders only when the app has notes. No badge, no count, no ⋮ menu
+item — the notes are on the card, so a modal to reach them would be a second
+door to the same room.
+
+### On the install dialog (`InstallDialog.tsx`)
+
+The Done screen's inline block (`:541-566`) is replaced by `<SetupNotes
+defaultExpanded />` — same content, bodies open, because the dialog has the
+room and this is the moment the notes are most relevant.
+
+### Cert note on read (`app-catalog.service.ts`)
+
+`buildInstalledSummary` appends the cert note by calling
+`certStepService.execute(await certStepService.plan(host))` and taking
+`result.manualStep` when present. The host is already resolved there for
+`resolveAppUrl`, so this adds no new lookup path.
+
+This fixes an existing gap: the cert note is synthesized during the install run
+and attached to the **in-memory** job (`app-installer.service.ts:306`), while
+the Done screen prefers `entry.installed?.manualSteps ?? job?.manualSteps`
+(`InstallDialog.tsx:292`). Once the catalog query refetches, the manifest-only
+list wins and the HTTPS advice vanishes. Re-deriving on read also makes it
+self-healing: the note disappears on its own once a wildcard covers the host.
+
+## Data flow
+
+```
+manifest.install.manualSteps
+        │
+        ├─ manualStepApplies(step, {bucketStorage, platformMode})   filter
+        │
+        ├─ interpolate({projectPath, appHost})                      expand
+        │
+        └─ + certStepService step, when the host has no cert
+                │
+                ├─→ CatalogEntry.installed.manualSteps → AppCard → SetupNotes
+                └─→ InstallJob.manualSteps → InstallDialog → SetupNotes
+```
+
+Both paths converge on the same component. No state is written at any point.
+
+## Error handling
+
+- **Cert lookup fails while listing the catalog.** `AppCertStepService` never
+  throws by contract (every `execute` branch degrades). If `plan` throws
+  anyway, `buildInstalledSummary` catches and omits the note — a catalog that
+  fails to list is worse than one missing an advisory line.
+- **A note references a placeholder CE can't resolve** (no domain yet, so no
+  `{appHost}`). Substitute the alias URL if there is one, otherwise leave the
+  sentence out rather than emitting an empty gap. Validation guarantees the
+  token itself is known; only its value can be absent.
+- **Stale acked ids.** None — the column is gone.
+
+## Testing
+
+Backend:
+
+- `interpolateStep` expands both tokens across title/body/deepLink; leaves
+  text with no tokens untouched.
+- `validateAppManifest` rejects an unknown `{token}`, naming it.
+- `buildInstalledSummary` appends the cert note when the plan is
+  `direct-no-wildcard`, and omits it when a wildcard exists.
+- The ack route is gone: a request to it 404s.
+
+Frontend:
+
+- `SetupNotes` renders titles collapsed, expands one body on click, and
+  renders the deep link as a link.
+- `AppCard` shows the block only when installed and only when notes exist.
+- `InstallDialog`'s Done screen renders notes expanded.
+- No component references `manualStepsAcked`.
+
+Manifests (`bffless/apps`): both rewritten manifests pass `validateAppManifest`
+(the repo's manifest test), and every remaining note's body is ≤ 220
+characters — the measurable stand-in for "three short lines" at the dialog's
+width.
+
+## Out of scope
+
+- Verifying notes rather than describing them (CE checking member counts, or
+  probing bucket CORS). Discussed and deferred: it is a per-note check to write
+  and test, and it changes the notes from advice into status. Worth revisiting
+  once the notes themselves are readable.
+- Any change to `appliesWhen`'s enum, including a `crossOriginIsolated` value
+  that would let the cut COOP/COEP notes return as conditional ones.


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-08-02-app-setup-notes-design.md`.

An app manifest's `install.manualSteps` rendered as a one-shot checklist on the install dialog's Done screen, in bodies of 200-570 characters, behind checkboxes whose only effect was to store their own checked state.

Three things were wrong, and this fixes all three.

**The notes were unreachable.** They rendered only on the Done screen; closing the dialog lost them, and an installed card has no Install button, so the only way back was triggering an Update. Notes now live on the installed app's card — titles visible, bodies expanding in place, collapsed by default so a 3-up grid stays even.

**The checkboxes did nothing.** Ticking one appended a string to `installed_apps.manual_steps_acked`, and the only consumer of that column was the checkbox's own `checked` state. Nothing gated on it; no install failed without it. The whole mechanism is gone: endpoint, DTO, service method, RTK Query hook, and the column (migration `0041_chemical_spirit.sql`). CE can't grant someone access or write a CORS rule on their bucket, and the UI no longer implies otherwise.

**Manifests couldn't link anywhere.** A manifest doesn't know which project it will be installed into, so it can't hardcode `/repo/acme/site/settings?tab=members`. Notes now declare `{projectPath}` / `{appHost}` and CE expands them at read time; unknown tokens fail manifest validation, naming the known set.

Also fixes a pre-existing gap: the synthesized TLS note was attached to the **in-memory** install job, so it vanished as soon as the catalog refetched. It's re-derived on read now, which also makes it self-healing — it disappears on its own once a wildcard certificate covers the host.

## Notes for review

- `interpolateStep` returns `AppManualStep | null`. Sentence-dropping applies to bodies only; a note whose *title* has an unresolvable token is dropped entirely, on the same reasoning the deepLink branch already used — a note we can't title is worse than a blank row.
- `applicableManualSteps` is deliberately duplicated across `AppCatalogService` and `AppInstallerService` rather than extracted. Two call sites didn't justify the cross-module coupling.
- The copy rewrites for the shipped manifests are in a companion PR on `bffless/apps`.

## Verification

Backend 351/351 (`src/app-catalog`), frontend 841/841 (77 files), `tsc --noEmit` clean on both apps, and no dangling references to the removed mechanism outside the generated migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rPL4Mf667ZUyxFN9HmseV


## ⚠️ Destructive migration — read before deploying

`drizzle/0041_chemical_spirit.sql` drops `installed_apps.manual_steps_acked`. Drizzle has no down-migration, and the ORM emits explicit column lists, so **rolling the backend image back below this release against an already-migrated database makes every `installed_apps` query fail** (`column "manual_steps_acked" does not exist`) — the app catalog 500s until the column is restored by hand.

Forward deployment is safe and correctly sequenced: every read of the column was removed in `f71cad3`, before the migration landed in `c22509d`, and the self-hosted entrypoint migrates before starting the single backend container, so there is no rolling window where old code meets the new schema.

Frontend/backend skew is benign in both directions — an old SPA against the new backend reads the absent field through `?? []` and its ack POST simply 404s; a new SPA against an old backend gets an extra field it ignores.

The acknowledgement data itself is not recoverable after the drop. That is intended — nothing read it — but it is one-way.
