### PR TITLE
fix: serve fresh bytes on same-SHA republish via presigned uploads

### DIFF
--- a/apps/backend/src/deployments/deployments.service.spec.ts
+++ b/apps/backend/src/deployments/deployments.service.spec.ts
@@ -928,4 +928,93 @@ describe('DeploymentsService', () => {
       expect(result.message).toBe('Commit deleted successfully');
     });
   });
+
+  describe('createAssetsFromManifest', () => {
+    // Same-SHA republish (issue #623): presigned PUTs bypass
+    // CachingStorageAdapter.upload(), so finalize must evict the content
+    // cache and must not keep the previous publish's contentHash.
+    const manifestParams = {
+      projectId: mockProjectId,
+      repository: mockRepository,
+      commitSha: mockCommitSha,
+      branch: 'main',
+      files: [
+        {
+          path: 'registry.json',
+          size: 6393,
+          contentType: 'application/json',
+          storageKey: `${mockRepository}/commits/${mockCommitSha}/registry.json`,
+        },
+      ],
+      userId: mockUserId,
+    };
+
+    const existingManifestAsset = {
+      ...mockAsset,
+      fileName: 'registry.json',
+      publicPath: 'registry.json',
+      storageKey: manifestParams.files[0].storageKey,
+      size: 3441,
+      contentHash: 'stale-hash-from-first-publish',
+    };
+
+    it('invalidates the content cache for each uploaded storage key', async () => {
+      const invalidateKey = jest.fn().mockResolvedValue(undefined);
+      (mockStorageAdapter as any).invalidateKey = invalidateKey;
+
+      setupMockChain([
+        [existingManifestAsset], // existing asset lookup
+        [{ ...existingManifestAsset, size: 6393, contentHash: null }], // update returning
+      ]);
+
+      await service.createAssetsFromManifest(manifestParams);
+
+      expect(invalidateKey).toHaveBeenCalledWith(manifestParams.files[0].storageKey);
+    });
+
+    it('invalidates via getUnderlyingAdapter when wrapped (DynamicStorageAdapter shape)', async () => {
+      const invalidateKey = jest.fn().mockResolvedValue(undefined);
+      (mockStorageAdapter as any).getUnderlyingAdapter = jest
+        .fn()
+        .mockReturnValue({ invalidateKey });
+
+      setupMockChain([
+        [existingManifestAsset],
+        [{ ...existingManifestAsset, size: 6393, contentHash: null }],
+      ]);
+
+      await service.createAssetsFromManifest(manifestParams);
+
+      expect(invalidateKey).toHaveBeenCalledWith(manifestParams.files[0].storageKey);
+    });
+
+    it('clears the stale contentHash when updating an existing asset', async () => {
+      setupMockChain([
+        [existingManifestAsset],
+        [{ ...existingManifestAsset, size: 6393, contentHash: null }],
+      ]);
+
+      await service.createAssetsFromManifest(manifestParams);
+
+      expect(mockDb.set).toHaveBeenCalledWith(
+        expect.objectContaining({ contentHash: null, size: 6393 }),
+      );
+    });
+
+    it('does not fail the deployment when cache invalidation throws', async () => {
+      (mockStorageAdapter as any).invalidateKey = jest
+        .fn()
+        .mockRejectedValue(new Error('cache backend down'));
+
+      setupMockChain([
+        [existingManifestAsset],
+        [{ ...existingManifestAsset, size: 6393, contentHash: null }],
+      ]);
+
+      const result = await service.createAssetsFromManifest(manifestParams);
+
+      expect(result.fileCount).toBe(1);
+      expect(result.failed).toHaveLength(0);
+    });
+  });
 });

--- a/apps/backend/src/deployments/deployments.service.ts
+++ b/apps/backend/src/deployments/deployments.service.ts
@@ -1808,6 +1808,28 @@ export class DeploymentsService {
   }
 
   /**
+   * Evict a key from the app-level content cache.
+   *
+   * The injected adapter is typically DynamicStorageAdapter wrapping a
+   * CachingStorageAdapter; only the latter exposes invalidateKey, so unwrap
+   * via getUnderlyingAdapter when needed (same pattern as
+   * LocalPresignedUploadController.invalidateCache). Failures are logged,
+   * not thrown — a stale cache entry must not fail the deployment itself.
+   */
+  private async invalidateCachedKey(storageKey: string): Promise<void> {
+    const adapter = this.storageAdapter as unknown as {
+      invalidateKey?: (key: string) => Promise<void>;
+      getUnderlyingAdapter?: () => { invalidateKey?: (key: string) => Promise<void> };
+    };
+    const target = adapter.invalidateKey ? adapter : adapter.getUnderlyingAdapter?.();
+    try {
+      await target?.invalidateKey?.(storageKey);
+    } catch (err) {
+      this.logger.warn(`Cache invalidation failed for ${storageKey}: ${(err as Error).message}`);
+    }
+  }
+
+  /**
    * Create asset records from a file manifest (for presigned URL uploads)
    * This method creates database records without handling file content - files are
    * already uploaded directly to storage via presigned URLs.
@@ -1864,6 +1886,12 @@ export class DeploymentsService {
         const publicPath = this.normalizePublicPath(file.path);
         const fileName = file.path.split('/').pop() || file.path;
 
+        // Presigned PUTs write straight to the backing store, bypassing
+        // CachingStorageAdapter.upload(), so on a same-SHA republish the
+        // content cache still holds the previous publish's bytes for this
+        // key (issue #623). Evict it before the new record goes live.
+        await this.invalidateCachedKey(file.storageKey);
+
         // Check if asset already exists (upsert logic for re-runs)
         const [existingAsset] = await db
           .select()
@@ -1879,7 +1907,10 @@ export class DeploymentsService {
 
         let newAsset: Asset;
         if (existingAsset) {
-          // Update existing asset
+          // Update existing asset. The manifest carries no hash and the
+          // server never saw the bytes, so a stale contentHash from an
+          // earlier publish must not survive — it feeds the ETag, and a
+          // stale ETag makes CDN/browser revalidation 304 old content.
           const [updated] = await db
             .update(assets)
             .set({
@@ -1888,6 +1919,7 @@ export class DeploymentsService {
               storageKey: file.storageKey,
               mimeType: file.contentType,
               size: file.size,
+              contentHash: null,
               branch: params.branch,
               uploadedBy: params.userId,
               deploymentId,


### PR DESCRIPTION
Fixes #623.

## Root cause

The write side was never broken. Verified live: a signed URL straight to GCS for `bffless/apps/commits/cb98ed4a…/registry-staging/registry.json` returned the second publish's 6393-byte content while the backend served the first publish's 3441 bytes for the same commit. Two coupled read-side defects in the presigned finalize path:

1. **Content cache never evicted.** Presigned PUTs write directly to the bucket, bypassing `CachingStorageAdapter.upload()` (which is what normally evicts `cache:<storageKey>`). `finalize-upload` → `createAssetsFromManifest` updated the records but never touched the cache, so `serveFile` → `downloadWithCacheInfo` kept returning the old bytes. `MemoryCacheAdapter` uses `updateAgeOnGet: true`, so any regularly-read file never expires — stale indefinitely, not just until TTL. This also explains the issue's symptom shape: *new* files (no warm cache entry) served fine; *replaced* files didn't.
2. **`contentHash` never updated on upsert.** The serve path builds the ETag from `asset.contentHash ?? md5(buffer)`, so the ETag stayed the first publish's hash forever ("same ETag, new size" in the issue) and poisoned CDN/browser `If-None-Match` revalidation even after an eviction.

The zip/multipart paths are unaffected — they upload through the adapter, which invalidates.

## Fix

In `createAssetsFromManifest`, per file:

- Evict the file's cache key via a new `invalidateCachedKey()` helper that unwraps `DynamicStorageAdapter` → `CachingStorageAdapter.invalidateKey` (same pattern as `LocalPresignedUploadController.invalidateCache`); failures log a warning instead of failing the deployment.
- Set `contentHash: null` on the update branch — the manifest carries no hash and the server never saw the bytes, so the ETag falls back to md5 of the actually-served buffer (matching how the insert branch has always behaved).

## Testing

- 4 new tests (written failing first): eviction with the adapter exposing `invalidateKey` directly and through `getUnderlyingAdapter()`, `contentHash` cleared on update, and invalidation failure not failing the deployment.
- Full backend suite: 160/160 suites, 2887 passed. `tsc --noEmit` clean. Lint delta zero (remaining errors pre-exist on main).

## Noted, out of scope

`DynamicStorageAdapter.downloadWithCacheInfo(key)` drops its `ttlHint` argument, so cache-rule TTL hints never reach the cache layer on dynamically-configured instances. Separate small fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q2Nr6vxU7asVFXbmxQKUy
