### PR TITLE
feat(onboarding): ?onboarding=1 developer override to replay the modal

### DIFF
--- a/apps/frontend/src/pages/HomePage.test.tsx
+++ b/apps/frontend/src/pages/HomePage.test.tsx
@@ -47,21 +47,25 @@ vi.mock('@/hooks/useBranding', () => ({
   useBranding: () => ({ authLogoUrl: '/logo.svg', siteName: 'BFFLESS' }),
 }));
 
+const mockDispatch = vi.fn();
+
 vi.mock('react-redux', async () => {
   const actual = await vi.importActual<typeof import('react-redux')>('react-redux');
   return {
     ...actual,
     useSelector: () => ({ hasCompletedOnboarding: true }),
+    useDispatch: () => mockDispatch,
   };
 });
 
 vi.mock('@/components/setup/onboarding/OnboardingModal', () => ({
-  OnboardingModal: () => null,
+  OnboardingModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="onboarding-modal" /> : null,
 }));
 
-function renderHomePage() {
+function renderHomePage(initialEntries: string[] = ['/']) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <HomePage />
     </MemoryRouter>,
   );
@@ -223,5 +227,44 @@ describe('HomePage — Repositories card gating (#517)', () => {
     renderHomePage();
 
     expect(screen.getByText('Repositories')).toBeInTheDocument();
+  });
+});
+
+describe('HomePage — ?onboarding=1 developer override', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockGetSession.mockReturnValue({
+      data: { user: { email: 'admin@example.com', role: 'admin' } },
+    });
+    mockGetSetupStatus.mockReturnValue({ data: { isSetupComplete: true }, isLoading: false });
+    mockGetWildcardStatus.mockReturnValue({ data: undefined });
+    mockGetPrimarySslStatus.mockReturnValue({ data: undefined });
+    // Established workspace: repos exist, so the normal auto-show guard
+    // (hasNoRepos) can never pass — only the override can open the modal.
+    mockGetMyRepositories.mockReturnValue({ data: { total: 3 } });
+  });
+
+  it('force-opens the modal past the completed flag and repo-count guards, resetting the wizard', () => {
+    renderHomePage(['/?onboarding=1']);
+
+    expect(screen.getByTestId('onboarding-modal')).toBeInTheDocument();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'setup/resetOnboarding' }),
+    );
+  });
+
+  it('does not open the modal without the param (completed flag set, repos exist)', () => {
+    renderHomePage();
+
+    expect(screen.queryByTestId('onboarding-modal')).not.toBeInTheDocument();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('ignores other values of the param (e.g. ?onboarding=0)', () => {
+    renderHomePage(['/?onboarding=0']);
+
+    expect(screen.queryByTestId('onboarding-modal')).not.toBeInTheDocument();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Link, Navigate } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { Link, Navigate, useSearchParams } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
 import { useGetSessionQuery } from '@/services/authApi';
 import { useGetSetupStatusQuery } from '@/services/setupApi';
 import { useGetWildcardCertificateStatusQuery } from '@/services/domainsApi';
@@ -8,6 +8,7 @@ import { useGetPrimarySslStatusQuery } from '@/services/primarySslApi';
 import { useFeatureFlags } from '@/services/featureFlagsApi';
 import { useGetMyRepositoriesQuery } from '@/services/repositoriesApi';
 import { RootState } from '@/store';
+import { resetOnboarding } from '@/store/slices/setupSlice';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -30,6 +31,8 @@ export function HomePage() {
   const { authLogoUrl, siteName } = useBranding();
   const { hasCompletedOnboarding } = useSelector((state: RootState) => state.setup.onboarding);
   const [showOnboarding, setShowOnboarding] = useState(false);
+  const dispatch = useDispatch();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   // Feature flags and wildcard SSL status for banner
   const { isEnabled, isReady: flagsReady } = useFeatureFlags();
@@ -108,6 +111,21 @@ export function HomePage() {
     localStorage.setItem(expiryDismissKey, 'true');
     setIsExpiryBannerDismissed(true);
   };
+
+  // Developer override: ?onboarding=1 replays the onboarding modal regardless
+  // of the completed flag and repo-count guards below (an established
+  // workspace can never satisfy hasNoRepos, so this is the only way to see
+  // the modal there). Resets the wizard to step 1 and consumes the param so a
+  // refresh doesn't re-trigger it; the reset also clears the localStorage
+  // completed flag, which skip/complete inside the modal writes back.
+  useEffect(() => {
+    if (searchParams.get('onboarding') !== '1') return;
+    dispatch(resetOnboarding());
+    setShowOnboarding(true);
+    const next = new URLSearchParams(searchParams);
+    next.delete('onboarding');
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams, dispatch]);
 
   // Show onboarding modal if user hasn't completed onboarding
   // Only show for admin/user roles since they can create repos (the modal guides through repo creation)


### PR DESCRIPTION
## Summary

The onboarding modal is gated on the per-browser `hasCompletedOnboarding` flag **plus** a zero-repo guard (added in #503), so on an established workspace clearing the localStorage flag no longer re-triggers it — there was no way to see the modal (including the new app-install callout from #593) without deleting all repos or patching the guard locally.

This adds a developer/testing override: visiting the home page with **`?onboarding=1`**:

- dispatches the existing `resetOnboarding` action (wizard back to step 1, created-project/API-key state and localStorage flag cleared)
- force-opens the modal, bypassing both the completed-flag and repo-count guards
- consumes the param with a `replace` navigation so a refresh doesn't re-trigger it

Skipping or completing the replayed modal writes the completed flag back, exactly like a real first run. Other param values (e.g. `?onboarding=0`) are ignored.

The apps callout inside the modal keeps its own gating (admin + `ENABLE_APP_CATALOG`) — the override only controls modal visibility.

## Testing

- 3 new tests in `HomePage.test.tsx`: override opens the modal past both guards and dispatches `setup/resetOnboarding`; no param → no modal; non-`1` values ignored
- All 17 HomePage tests pass; frontend `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)