### PR TITLE
fix: list only file records in the Uploads tab

### DIFF
--- a/apps/backend/src/pipelines/pipeline-data.controller.ts
+++ b/apps/backend/src/pipelines/pipeline-data.controller.ts
@@ -51,7 +51,7 @@ export class PipelineDataController {
   @ApiQuery({ name: 'createdBefore', required: false, type: String, description: 'ISO date for createdAt <= filter' })
   @ApiQuery({ name: 'updatedAfter', required: false, type: String, description: 'ISO date for updatedAt >= filter' })
   @ApiQuery({ name: 'updatedBefore', required: false, type: String, description: 'ISO date for updatedAt <= filter' })
-  @ApiQuery({ name: 'filters', required: false, type: String, description: 'JSON string of field filters: {"fieldName":{"op":"eq","value":"xxx"}}' })
+  @ApiQuery({ name: 'filters', required: false, type: String, description: 'JSON string of field filters: {"fieldName":{"op":"eq","value":"xxx"}}. Ops: eq, ne, gt, lt, gte, lte, like, exists (value "true"/"false" — filters on the field being present rather than its value)' })
   @ApiQuery({ name: 'sortBy', required: false, type: String, description: 'Field to sort by (createdAt, updatedAt, or data field name)' })
   @ApiQuery({ name: 'sortOrder', required: false, enum: ['asc', 'desc'], description: 'Sort order' })
   @ApiResponse({ status: 200, description: 'Paginated data records', type: PaginatedDataResponseDto })

--- a/apps/backend/src/pipelines/pipeline-data.service.filters.spec.ts
+++ b/apps/backend/src/pipelines/pipeline-data.service.filters.spec.ts
@@ -1,0 +1,66 @@
+jest.mock('../db/client', () => {
+  const queued: unknown[] = [];
+  const methods = ['select', 'from', 'where', 'orderBy', 'limit', 'offset'];
+  const chainable: Record<string, unknown> = {};
+  for (const method of methods) chainable[method] = jest.fn(() => chainable);
+  chainable.then = (resolve: (v: unknown) => unknown, reject: (r: unknown) => unknown) =>
+    Promise.resolve(queued.length > 0 ? queued.shift() : []).then(resolve, reject);
+  chainable.__queue = (result: unknown) => queued.push(result);
+  chainable.__reset = () => {
+    queued.length = 0;
+    for (const method of methods) (chainable[method] as jest.Mock).mockClear();
+  };
+  return { db: chainable };
+});
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { db } from '../db/client';
+import { PipelineDataService } from './pipeline-data.service';
+import { PermissionsService } from '../permissions/permissions.service';
+
+const mockDb = db as unknown as Record<string, jest.Mock> & {
+  __queue: (r: unknown) => void;
+  __reset: () => void;
+};
+
+/**
+ * The admin data listing supports JSONB field filters. `exists` is the one op
+ * that asks about presence rather than value — it is what the Uploads tab uses
+ * to show only records that actually reference a stored file, in schemas that
+ * mix file rows with non-file rows (e.g. a folder tree stored in one schema).
+ */
+describe('PipelineDataService field filters', () => {
+  const service = new PipelineDataService({
+    requireProjectAccess: jest.fn(),
+  } as unknown as PermissionsService);
+
+  beforeEach(() => mockDb.__reset());
+
+  /** Run a filtered list and return the rendered SQL of the count query's WHERE. */
+  async function whereSqlFor(
+    filters: Record<string, { op: string; value: string }>,
+  ): Promise<string> {
+    mockDb.__queue([{ id: 'schema-1', projectId: 'proj-1', fields: [] }]); // schema lookup
+    mockDb.__queue([{ count: 0 }]); // count query
+    mockDb.__queue([]); // records query
+    await service.getBySchemaId('schema-1', 1, 20, 'user-1', 'user', { filters }, null);
+    // call 0 is the schema lookup; call 1 is the filtered count query
+    return new PgDialect().sqlToQuery(mockDb.where.mock.calls[1][0]).sql.toLowerCase();
+  }
+
+  it('exists: keeps only rows where the field is present', async () => {
+    const sql = await whereSqlFor({ storage_path: { op: 'exists', value: 'true' } });
+    expect(sql).toContain("->>'storage_path' is not null");
+  });
+
+  it('exists with value "false": keeps only rows missing the field', async () => {
+    const sql = await whereSqlFor({ storage_path: { op: 'exists', value: 'false' } });
+    expect(sql).toContain("->>'storage_path' is null");
+    expect(sql).not.toContain('is not null');
+  });
+
+  it('leaves unknown ops out of the query rather than failing the request', async () => {
+    const sql = await whereSqlFor({ storage_path: { op: 'wat', value: 'x' } });
+    expect(sql).not.toContain('storage_path');
+  });
+});

--- a/apps/backend/src/pipelines/pipeline-data.service.ts
+++ b/apps/backend/src/pipelines/pipeline-data.service.ts
@@ -125,6 +125,15 @@ export class PipelineDataService {
             case 'like':
               conditions.push(sql`${fieldPath} ILIKE ${`%${value}%`}`);
               break;
+            case 'exists':
+              // Presence rather than value: `->>` yields NULL both when the key is
+              // absent and when its value is JSON null, which is exactly what
+              // "this record has no such field" means for a heterogeneous schema
+              // (e.g. file rows and folder rows sharing one schema).
+              conditions.push(
+                value === 'false' ? sql`${fieldPath} IS NULL` : sql`${fieldPath} IS NOT NULL`,
+              );
+              break;
           }
         }
       }

--- a/apps/frontend/src/components/data/DataFilters.tsx
+++ b/apps/frontend/src/components/data/DataFilters.tsx
@@ -87,6 +87,7 @@ function formatOperator(op: FieldFilter['op']): string {
     gte: '>=',
     lte: '<=',
     like: 'contains',
+    exists: 'has value',
   };
   return labels[op];
 }

--- a/apps/frontend/src/pages/UploadDetailPage.test.tsx
+++ b/apps/frontend/src/pages/UploadDetailPage.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { UploadDetailPage } from './UploadDetailPage';
+import type { PipelineSchemaWithCount } from '@/services/pipelineSchemasApi';
+
+// Captures the args the page passes to the data query, so the test can assert
+// on the filter it asks the API for (the fix for uploads listing folder rows).
+const dataQueryArgs = vi.fn();
+let schemaResult: { data?: PipelineSchemaWithCount; isLoading: boolean };
+let dataResult: {
+  data?: { records: unknown[]; total: number; page: number; pageSize: number; totalPages: number };
+  isLoading: boolean;
+};
+
+vi.mock('@/services/pipelineSchemasApi', () => ({
+  useGetSchemaQuery: () => schemaResult,
+  useGetSchemaDataQuery: (args: unknown, options: unknown) => {
+    dataQueryArgs(args, options);
+    return dataResult;
+  },
+  useDeleteRecordMutation: () => [vi.fn(), { isLoading: false }],
+}));
+
+vi.mock('@/hooks/useProjectRole', () => ({
+  useProjectRole: () => ({ canEdit: true }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function makeSchema(fieldNames: string[], recordCount: number): PipelineSchemaWithCount {
+  return {
+    id: 'schema-1',
+    name: 'handoff_nodes',
+    projectId: 'proj-1',
+    fields: fieldNames.map((name) => ({ name, type: 'string', required: false })),
+    recordCount,
+  } as unknown as PipelineSchemaWithCount;
+}
+
+function fileRecord() {
+  return {
+    id: 'rec-1',
+    createdAt: '2026-08-04T06:14:42.000Z',
+    data: {
+      original_name: 'shot.png',
+      storage_path: 'bffless/handoff/uploads/content/uuid-shot.png',
+      content_type: 'image/png',
+      size: 232200,
+      url: '/api/uploads/content/uuid-shot.png',
+    },
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/repo/bffless/handoff/uploads/schema-1']}>
+      <Routes>
+        <Route path="/repo/:owner/:repo/uploads/:schemaId" element={<UploadDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  dataQueryArgs.mockClear();
+  schemaResult = { data: makeSchema(['storage_path', 'content_type', 'url'], 3), isLoading: false };
+  dataResult = {
+    data: { records: [fileRecord()], total: 1, page: 1, pageSize: 20, totalPages: 1 },
+    isLoading: false,
+  };
+});
+
+describe('UploadDetailPage', () => {
+  it('asks only for records that reference a stored file', () => {
+    renderPage();
+    expect(dataQueryArgs).toHaveBeenCalled();
+    const [args] = dataQueryArgs.mock.calls[dataQueryArgs.mock.calls.length - 1];
+    expect(args.filters).toEqual({ storage_path: { op: 'exists', value: 'true' } });
+  });
+
+  it('reports the records held back so they are not silently dropped', () => {
+    renderPage();
+    // schema has 3 records, 1 of which is a file → 2 folder/metadata rows
+    expect(screen.getByText(/1 uploaded file/)).toBeInTheDocument();
+    expect(screen.getByText(/2 records without a file \(not shown\)/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /view in data/i })).toHaveAttribute(
+      'href',
+      '/repo/bffless/handoff/data/schema-1',
+    );
+  });
+
+  it('does not mention held-back records when every row is a file', () => {
+    schemaResult = { data: makeSchema(['storage_path', 'url'], 1), isLoading: false };
+    renderPage();
+    expect(screen.queryByText(/without a file/)).not.toBeInTheDocument();
+  });
+
+  it('sends no file filter for a schema that has no storage_path field', () => {
+    schemaResult = { data: makeSchema(['name', 'body'], 2), isLoading: false };
+    renderPage();
+    const [args] = dataQueryArgs.mock.calls[dataQueryArgs.mock.calls.length - 1];
+    expect(args.filters).toBeUndefined();
+  });
+
+  it('waits for the schema before querying records', () => {
+    schemaResult = { data: undefined, isLoading: true };
+    renderPage();
+    const [, options] = dataQueryArgs.mock.calls[dataQueryArgs.mock.calls.length - 1];
+    expect(options.skip).toBe(true);
+  });
+});

--- a/apps/frontend/src/pages/UploadDetailPage.tsx
+++ b/apps/frontend/src/pages/UploadDetailPage.tsx
@@ -42,6 +42,15 @@ function getPreviewUrl(storagePath: string): string {
 }
 
 /**
+ * Every record written by an upload handler carries `storage_path` — it is what
+ * makes a record an uploaded file rather than an arbitrary row. A schema is free
+ * to hold both (an app modelling a file tree stores its folders as rows in the
+ * same schema), so this view lists only the rows that reference stored bytes;
+ * the rest are shown as a count with a pointer to the Data tab.
+ */
+const FILE_MARKER_FIELD = 'storage_path';
+
+/**
  * UploadDetailPage - Shows uploaded files for a specific upload schema.
  * Route: /repo/:owner/:repo/uploads/:schemaId
  */
@@ -80,7 +89,12 @@ export function UploadDetailPage() {
 
   useDocumentTitle(schema ? [schema.name, 'Uploads', `${owner}/${repo}`] : null);
 
-  // Fetch uploaded files (pipeline data records)
+  // Only records that actually reference stored bytes belong in an uploads list.
+  const hasFileMarker = schema?.fields?.some((f) => f.name === FILE_MARKER_FIELD) ?? false;
+
+  // Fetch uploaded files (pipeline data records). Waits for the schema so the
+  // file filter is known up front — otherwise the first render would briefly
+  // list non-file records.
   const {
     data: filesData,
     isLoading: isLoadingFiles,
@@ -92,10 +106,13 @@ export function UploadDetailPage() {
       search: debouncedSearch || undefined,
       createdAfter: dateFrom ? new Date(dateFrom).toISOString() : undefined,
       createdBefore: dateTo ? new Date(dateTo + 'T23:59:59').toISOString() : undefined,
+      filters: hasFileMarker
+        ? { [FILE_MARKER_FIELD]: { op: 'exists' as const, value: 'true' } }
+        : undefined,
       sortBy: 'createdAt',
       sortOrder: 'desc',
     },
-    { skip: !schemaId },
+    { skip: !schemaId || !schema },
   );
 
   const [deleteRecord, { isLoading: isDeleting }] = useDeleteRecordMutation();
@@ -138,6 +155,15 @@ export function UploadDetailPage() {
   const isLoading = isLoadingSchema || isLoadingFiles;
   const files = filesData?.records || [];
   const totalPages = filesData?.totalPages || 1;
+
+  // Records held back by the file filter. Only meaningful against an unfiltered
+  // list — schema.recordCount is the whole schema, so a search or date range
+  // would make the subtraction lie.
+  const isUnfiltered = !debouncedSearch && !dateFrom && !dateTo;
+  const nonFileCount =
+    hasFileMarker && isUnfiltered && schema && filesData
+      ? Math.max(0, schema.recordCount - filesData.total)
+      : 0;
 
   const formatFileSize = (bytes: unknown): string => {
     const size = Number(bytes);
@@ -187,6 +213,18 @@ export function UploadDetailPage() {
             <CardTitle>{schema?.name || 'Upload Schema'}</CardTitle>
             <CardDescription>
               {filesData?.total || 0} uploaded file{(filesData?.total || 0) !== 1 ? 's' : ''}
+              {nonFileCount > 0 && (
+                <>
+                  {' · '}
+                  {nonFileCount} record{nonFileCount !== 1 ? 's' : ''} without a file (not shown){' '}
+                  <Link
+                    to={`/repo/${owner}/${repo}/data/${schemaId}`}
+                    className="underline underline-offset-2 hover:text-foreground"
+                  >
+                    view in Data
+                  </Link>
+                </>
+              )}
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/apps/frontend/src/pages/UploadsListPage.tsx
+++ b/apps/frontend/src/pages/UploadsListPage.tsx
@@ -230,8 +230,11 @@ function SchemaCard({
             <div>
               <h3 className="font-medium">{schema.name}</h3>
               <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                {/* recordCount counts every row in the schema, and a schema may
+                    hold non-file rows too — so this is a record count, not a
+                    file count. The detail view reports the file total. */}
                 <span>
-                  {schema.recordCount} file{schema.recordCount !== 1 ? 's' : ''}
+                  {schema.recordCount} record{schema.recordCount !== 1 ? 's' : ''}
                 </span>
               </div>
             </div>

--- a/apps/frontend/src/services/pipelineSchemasApi.ts
+++ b/apps/frontend/src/services/pipelineSchemasApi.ts
@@ -112,7 +112,8 @@ export interface GenerateUploadSchemaResponse {
 }
 
 export interface FieldFilter {
-  op: 'eq' | 'ne' | 'gt' | 'lt' | 'gte' | 'lte' | 'like';
+  /** `exists` filters on presence of the field, with value 'true' | 'false'. */
+  op: 'eq' | 'ne' | 'gt' | 'lt' | 'gte' | 'lte' | 'like' | 'exists';
   value: string;
 }
 


### PR DESCRIPTION
## Problem

The Uploads tab treats **every record in the selected schema as an uploaded file**.

An app is free to store non-file rows in the same schema. `bffless/handoff` models its file tree as a single `handoff_nodes` schema: `nodeType: "folder"` rows (parent/owner/display-name, no bytes) alongside `nodeType: "file"` rows written by `register_upload`. In the Uploads tab the folder rows show up as a literal **"file"** with `—` for type and size — because the label falls back to `data.original_name || data.filename || 'file'`, and folders have neither.

Three consequences:

- the header count is wrong ("3 uploaded files" for 1 file + 2 folders)
- the rows are meaningless — no preview, no type, no size
- the delete button on those rows deletes the folder node, orphaning its children

## Fix

A record written by an upload handler always carries `storage_path` (see `UploadRecordService.createUploadRecords`) — that is what makes it a file rather than an arbitrary row.

- **Backend** — add an `exists` field-filter op to the data listing: `data->>'field' IS NOT NULL` (or `IS NULL` with value `"false"`). Presence rather than value, which is what a heterogeneous schema needs; `->>` yields NULL both for an absent key and a JSON null, which is exactly "this record has no such field".
- **Uploads detail view** — when the schema declares `storage_path`, list only rows that have it, so both the rows and the count are files. The query waits for the schema so there is no unfiltered flash on first render. Held-back records are reported rather than silently dropped: `1 uploaded file · 2 records without a file (not shown) · view in Data`, linking to the Data tab. The note is suppressed while a search or date filter is active, since `recordCount` covers the whole schema and the subtraction would lie.
- **Uploads list** — schema cards said "N files" from `recordCount`; now "N records", since that counts every row.

Schemas whose rows are all files (anything from Generate Upload Schema) are unaffected.

## Verification

- `npx jest src/pipelines` → 30 suites / 325 tests pass, including new `pipeline-data.service.filters.spec.ts` (3 tests, asserts on the rendered SQL via `PgDialect`)
- `npx vitest run src/pages/UploadDetailPage.test.tsx` → 5 tests pass (filter sent, held-back count + Data link, no filter for a schema without `storage_path`, query skipped until the schema loads)
- Both new specs confirmed **red** against the unfixed code and green after
- `tsc --noEmit` clean on backend and frontend; eslint clean on the changed frontend files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
