### PR TITLE
fix: count files, not rows, on the Uploads schema cards

### DIFF
--- a/apps/frontend/src/pages/UploadsListPage.test.tsx
+++ b/apps/frontend/src/pages/UploadsListPage.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { UploadsListPage } from './UploadsListPage';
+import type { PipelineSchemaWithCount } from '@/services/pipelineSchemasApi';
+
+const dataQueryArgs = vi.fn();
+let schemas: PipelineSchemaWithCount[];
+let fileTotals: Record<string, number | undefined>;
+
+vi.mock('@/services/pipelineSchemasApi', () => ({
+  useGetProjectSchemasQuery: () => ({ data: { schemas }, isLoading: false, error: undefined }),
+  useGetSchemaDataQuery: (args: { schemaId: string }) => {
+    dataQueryArgs(args);
+    const total = fileTotals[args.schemaId];
+    return { data: total === undefined ? undefined : { records: [], total }, isLoading: false };
+  },
+  // Rendered by the page's "Generate Upload Schema" modal, unused by these specs.
+  useGenerateUploadSchemaMutation: () => [vi.fn(), { isLoading: false }],
+}));
+
+vi.mock('@/services/proxyRulesApi', () => ({
+  useGetProjectRuleSetsQuery: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/services/projectsApi', () => ({
+  useGetProjectQuery: () => ({ data: { id: 'proj-1' }, isLoading: false }),
+}));
+
+vi.mock('@/hooks/useProjectRole', () => ({
+  useProjectRole: () => ({ canEdit: true }),
+}));
+
+function uploadSchema(name: string, recordCount: number): PipelineSchemaWithCount {
+  return {
+    id: `${name}-id`,
+    name,
+    projectId: 'proj-1',
+    recordCount,
+    fields: ['storage_path', 'content_type', 'url'].map((f) => ({
+      name: f,
+      type: 'string',
+      required: true,
+    })),
+  } as unknown as PipelineSchemaWithCount;
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/repo/bffless/handoff/uploads']}>
+      <Routes>
+        <Route path="/repo/:owner/:repo/uploads" element={<UploadsListPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  dataQueryArgs.mockClear();
+  schemas = [uploadSchema('handoff_nodes', 3)];
+  fileTotals = { 'handoff_nodes-id': 1 };
+});
+
+describe('UploadsListPage schema cards', () => {
+  it('counts files with the same filter the detail view uses', () => {
+    renderPage();
+    expect(dataQueryArgs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        schemaId: 'handoff_nodes-id',
+        filters: { storage_path: { op: 'exists', value: 'true' } },
+      }),
+    );
+  });
+
+  it('shows the file count, not the row count, and accounts for the difference', () => {
+    renderPage();
+    // 3 rows in the schema, 1 of them a file → 2 folder/metadata rows
+    expect(screen.getByText('1 file · 2 non-file records')).toBeInTheDocument();
+    expect(screen.queryByText(/3 records/)).not.toBeInTheDocument();
+  });
+
+  it('says nothing about non-file records when every row is a file', () => {
+    schemas = [uploadSchema('product_images', 4)];
+    fileTotals = { 'product_images-id': 4 };
+    renderPage();
+    expect(screen.getByText('4 files')).toBeInTheDocument();
+  });
+
+  it('shows a placeholder rather than a wrong count while the total loads', () => {
+    fileTotals = {};
+    renderPage();
+    // The row count would be a lie for a mixed schema, so it is never shown —
+    // not even as a stand-in that would then flicker to the real number.
+    expect(screen.queryByText(/\d+ (file|record)/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/pages/UploadsListPage.tsx
+++ b/apps/frontend/src/pages/UploadsListPage.tsx
@@ -11,7 +11,11 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Upload, Zap, FileImage, ArrowRight } from 'lucide-react';
-import { useGetProjectSchemasQuery, PipelineSchemaWithCount } from '@/services/pipelineSchemasApi';
+import {
+  useGetProjectSchemasQuery,
+  useGetSchemaDataQuery,
+  PipelineSchemaWithCount,
+} from '@/services/pipelineSchemasApi';
 import { useGetProjectQuery } from '@/services/projectsApi';
 import { useProjectRole } from '@/hooks/useProjectRole';
 import { GenerateUploadModal } from '@/components/uploads/GenerateUploadModal';
@@ -216,6 +220,21 @@ function SchemaCard({
   schema: PipelineSchemaWithCount;
   onClick: () => void;
 }) {
+  // `recordCount` counts every row in the schema, so for a schema that also
+  // holds non-file rows it overstates the uploads (a file tree stored as one
+  // schema counts its folders). Ask for the same file-only total the detail
+  // view shows, so the two pages can't disagree; pageSize 1 because only the
+  // total is wanted.
+  const { data: fileData } = useGetSchemaDataQuery({
+    schemaId: schema.id,
+    page: 1,
+    pageSize: 1,
+    filters: { storage_path: { op: 'exists', value: 'true' } },
+  });
+
+  const fileCount = fileData?.total;
+  const nonFileCount = fileCount === undefined ? 0 : Math.max(0, schema.recordCount - fileCount);
+
   return (
     <Card
       className="cursor-pointer hover:bg-muted/50 transition-colors"
@@ -230,12 +249,14 @@ function SchemaCard({
             <div>
               <h3 className="font-medium">{schema.name}</h3>
               <div className="flex items-center gap-3 text-sm text-muted-foreground">
-                {/* recordCount counts every row in the schema, and a schema may
-                    hold non-file rows too — so this is a record count, not a
-                    file count. The detail view reports the file total. */}
-                <span>
-                  {schema.recordCount} record{schema.recordCount !== 1 ? 's' : ''}
-                </span>
+                {fileCount === undefined ? (
+                  <Skeleton className="h-4 w-16" />
+                ) : (
+                  <span>
+                    {fileCount} file{fileCount !== 1 ? 's' : ''}
+                    {nonFileCount > 0 && ` · ${nonFileCount} non-file record${nonFileCount !== 1 ? 's' : ''}`}
+                  </span>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
Follow-up to #628, reported from the live UI.

#628 fixed the Uploads **detail** view to list only records that reference stored bytes. The schema cards on the parent Uploads page still showed `recordCount` — every row in the schema — so the two pages disagreed for a schema that holds non-file rows:

| | before | after |
|---|---|---|
| Uploads card | `3 records` | `1 file · 2 non-file records` |
| Uploads detail | `1 uploaded file · 2 records without a file` | unchanged |

`handoff_nodes` is the live example: one schema holding a whole file tree, so its folder rows counted as uploads on the card.

## Change

`SchemaCard` now asks for the same file-only total the detail view uses — `filters: { storage_path: { op: 'exists', value: 'true' } }`, `pageSize: 1` since only `total` is wanted — so the card and the detail view cannot drift. The remainder is named rather than dropped (`· 2 non-file records`), and while the count is in flight the card renders a skeleton instead of the row count, which would only flicker to a different number.

One small query per upload-schema card, on a page that typically shows one or two.

## Verification

- `npx vitest run src/pages/UploadsListPage.test.tsx src/pages/UploadDetailPage.test.tsx` → 9 tests pass (4 new: the filter sent, file-vs-row count, no remainder when every row is a file, no stand-in count while loading)
- `tsc --noEmit` clean; eslint clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
