### PR TITLE
feat: warn when an upload schema doesn't match what upload handlers write

### DIFF
--- a/apps/backend/src/mcp/tools/proxy-rules.tools.spec.ts
+++ b/apps/backend/src/mcp/tools/proxy-rules.tools.spec.ts
@@ -23,7 +23,7 @@ describe('proxy-rule-set MCP tools source passthrough', () => {
       { id: 'rs-1', projectId: 'p1', name: 'managed', source },
       { id: 'rs-2', projectId: 'p1', name: 'manual', source: null },
     ]);
-    const tools = new ProxyRulesTools({ listByProject } as any, {} as any, {} as any);
+    const tools = new ProxyRulesTools({ listByProject } as any, {} as any, {} as any, {} as any);
 
     const raw = await tools.listRuleSets({ projectId: 'p1' }, {} as any, request);
     const parsed = JSON.parse(raw);
@@ -37,12 +37,67 @@ describe('proxy-rule-set MCP tools source passthrough', () => {
     const getById = jest
       .fn()
       .mockResolvedValue({ id: 'rs-1', projectId: 'p1', name: 'managed', source, rules: [] });
-    const tools = new ProxyRulesTools({ getById } as any, {} as any, {} as any);
+    const tools = new ProxyRulesTools({ getById } as any, {} as any, {} as any, {} as any);
 
     const raw = await tools.getRuleSet({ id: 'rs-1' }, {} as any, request);
     const parsed = JSON.parse(raw);
 
     expect(getById).toHaveBeenCalledWith('rs-1', null);
     expect(parsed.source).toEqual(source);
+  });
+});
+
+/**
+ * An agent authoring an upload pipeline never sees the admin UI, so the tool
+ * result is the only channel that can tell it the schema it just wired up
+ * doesn't declare what upload handlers write (bffless/ce#630).
+ */
+describe('proxy-rule MCP tools upload-schema warnings', () => {
+  const request = { user: { id: 'u1', apiKeyProjectId: null } } as any;
+  const authService = { getUserById: jest.fn().mockResolvedValue({ id: 'u1', role: 'admin' }) };
+  const pipelineConfig = {
+    steps: [{ name: 'upload', handlerType: 'register_upload', config: { schemaId: 's1' } }],
+  };
+
+  const toolsWith = (warnings: string[], create = jest.fn()) => {
+    const rulesService = {
+      create: create.mockResolvedValue({ id: 'r1', pipelineConfig }),
+      update: jest.fn().mockResolvedValue({ id: 'r1', pipelineConfig }),
+    };
+    const lint = { lintPipelineConfig: jest.fn().mockResolvedValue(warnings) };
+    return {
+      tools: new ProxyRulesTools({} as any, rulesService as any, authService as any, lint as any),
+      lint,
+    };
+  };
+
+  it('attaches warnings to create_proxy_rule', async () => {
+    const { tools, lint } = toolsWith(['Upload schema "uploads": does not declare storage_path.']);
+
+    const parsed = JSON.parse(await tools.createRule({ ruleSetId: 'rs-1' }, {} as any, request));
+
+    expect(lint.lintPipelineConfig).toHaveBeenCalledWith(pipelineConfig);
+    expect(parsed.uploadSchemaWarnings).toEqual([
+      'Upload schema "uploads": does not declare storage_path.',
+    ]);
+    expect(parsed.id).toBe('r1');
+  });
+
+  it('attaches warnings to update_proxy_rule', async () => {
+    const { tools } = toolsWith(['Upload schema "uploads": does not declare size.']);
+
+    const parsed = JSON.parse(
+      await tools.updateRule({ id: 'r1', description: 'x' }, {} as any, request),
+    );
+
+    expect(parsed.uploadSchemaWarnings).toHaveLength(1);
+  });
+
+  it('omits the key entirely when the schema matches', async () => {
+    const { tools } = toolsWith([]);
+
+    const parsed = JSON.parse(await tools.createRule({ ruleSetId: 'rs-1' }, {} as any, request));
+
+    expect(parsed).not.toHaveProperty('uploadSchemaWarnings');
   });
 });

--- a/apps/backend/src/mcp/tools/proxy-rules.tools.ts
+++ b/apps/backend/src/mcp/tools/proxy-rules.tools.ts
@@ -6,6 +6,7 @@ import { ProxyRuleSetsService } from '../../proxy-rules/proxy-rule-sets.service'
 import { ProxyRulesService } from '../../proxy-rules/proxy-rules.service';
 import { AuthService } from '../../auth/auth.service';
 import { getUserContext } from '../helpers/user-context.helper';
+import { UploadSchemaLintService } from '../../pipelines/upload-schema-lint.service';
 
 const pipelineStepSchema = z.object({
   id: z.string().describe('Unique step ID'),
@@ -101,7 +102,23 @@ export class ProxyRulesTools {
     private readonly proxyRuleSetsService: ProxyRuleSetsService,
     private readonly proxyRulesService: ProxyRulesService,
     private readonly authService: AuthService,
+    private readonly uploadSchemaLint: UploadSchemaLintService,
   ) {}
+
+  /**
+   * Attach upload-schema warnings to a rule result (bffless/ce#630).
+   *
+   * An agent authoring a pipeline never sees the admin UI, so this tool result
+   * is the only place it can learn that the schema it just wired up doesn't
+   * declare what upload handlers write. Advisory: the rule is already saved,
+   * and the key is omitted entirely when there is nothing to say.
+   */
+  private async withUploadSchemaWarnings<T extends { pipelineConfig?: unknown }>(
+    result: T,
+  ): Promise<T | (T & { uploadSchemaWarnings: string[] })> {
+    const warnings = await this.uploadSchemaLint.lintPipelineConfig(result?.pipelineConfig);
+    return warnings.length > 0 ? { ...result, uploadSchemaWarnings: warnings } : result;
+  }
 
   // =====================
   // Rule Set Tools
@@ -299,7 +316,7 @@ export class ProxyRulesTools {
       user.role,
       user.apiKeyProjectId,
     );
-    return JSON.stringify(result);
+    return JSON.stringify(await this.withUploadSchemaWarnings(result));
   }
 
   @Tool({
@@ -372,7 +389,7 @@ export class ProxyRulesTools {
       user.role,
       user.apiKeyProjectId,
     );
-    return JSON.stringify(result);
+    return JSON.stringify(await this.withUploadSchemaWarnings(result));
   }
 
   @Tool({

--- a/apps/backend/src/pipelines/handlers/file-upload.handler.ts
+++ b/apps/backend/src/pipelines/handlers/file-upload.handler.ts
@@ -228,6 +228,7 @@ export class FileUploadHandler implements StepHandler<FileUploadHandlerConfig> {
       publicPath: keyParts.publicPath,
       contentHash,
       extraData,
+      schemaFields: schema.fields,
     });
 
     return { success: true, output };

--- a/apps/backend/src/pipelines/handlers/register-upload.handler.ts
+++ b/apps/backend/src/pipelines/handlers/register-upload.handler.ts
@@ -247,6 +247,7 @@ export class RegisterUploadHandler
       publicPath: keyParts.publicPath,
       contentHash: metadata.etag ?? null,
       extraData,
+      schemaFields: schema.fields,
     });
 
     return { success: true, output };

--- a/apps/backend/src/pipelines/pipelines.module.ts
+++ b/apps/backend/src/pipelines/pipelines.module.ts
@@ -8,6 +8,7 @@ import { ChatSchemaGeneratorService } from './chat-schema-generator.service';
 import { UploadSchemaGeneratorService } from './upload-schema-generator.service';
 import { SchemaGeneratorRevisionsService } from './schema-generator-revisions.service';
 import { UploadRecordService } from './upload-record.service';
+import { UploadSchemaLintService } from './upload-schema-lint.service';
 import {
   PipelineExecutionService,
   StepHandlerRegistry,
@@ -109,6 +110,8 @@ import {
     SchemaGeneratorRevisionsService,
     // Shared upload bookkeeping (used by file_upload + register_upload handlers)
     UploadRecordService,
+    // Advisory upload-schema check for rule authoring paths (sync, MCP)
+    UploadSchemaLintService,
     // Execution engine
     PipelineExecutionService,
     StepHandlerRegistry,
@@ -178,6 +181,7 @@ import {
     SkillsService,
     AIToolPluginService,
     UploadSchemaGeneratorService,
+    UploadSchemaLintService,
     PipelineExecutionLogService,
   ],
 })

--- a/apps/backend/src/pipelines/upload-record.service.ts
+++ b/apps/backend/src/pipelines/upload-record.service.ts
@@ -8,6 +8,12 @@ import { PipelineContext } from './execution/pipeline-context.interface';
 import { ExpressionEvaluator } from './execution/expression-evaluator';
 import { PipelineDataService } from './pipeline-data.service';
 import { ConfigurationError } from './errors';
+import {
+  DeclaredField,
+  describeUploadSchemaGap,
+  diffUploadSchema,
+  hasUploadSchemaGap,
+} from './upload-schema-contract';
 
 /**
  * Parts of a computed upload storage key.
@@ -48,6 +54,9 @@ export interface UploadRecordOutput {
 @Injectable()
 export class UploadRecordService {
   private readonly logger = new Logger(UploadRecordService.name);
+
+  /** `${schemaId}:${version}` already warned about — see {@link warnOnSchemaGap}. */
+  private readonly warnedSchemaGaps = new Set<string>();
 
   constructor(
     private readonly dataService: PipelineDataService,
@@ -244,8 +253,16 @@ export class UploadRecordService {
     contentHash?: string | null;
     /** Already-evaluated extra fields to merge into the pipeline_data record */
     extraData?: Record<string, unknown>;
+    /**
+     * The target schema's declared fields, when the caller has them. Used only
+     * to warn about a schema that doesn't describe what is being written —
+     * never to change what is written.
+     */
+    schemaFields?: DeclaredField[];
   }): Promise<UploadRecordOutput> {
     const { context } = params;
+
+    this.warnOnSchemaGap(params);
 
     const data: Record<string, unknown> = {
       filename: params.storedFilename,
@@ -298,6 +315,37 @@ export class UploadRecordService {
       size: params.size,
       original_name: params.originalName,
     };
+  }
+
+  /**
+   * Last-resort backstop for a schema that doesn't describe its own upload
+   * records — the authoring-time lint is where an author should hear about
+   * this, so this only catches schemas edited after the rule was written.
+   *
+   * Deliberately never throws: the record is written correctly either way, and
+   * failing an upload over a metadata declaration would lose someone's file.
+   * Logged once per (schema, version) so a busy upload endpoint doesn't flood
+   * the log with the same line.
+   */
+  private warnOnSchemaGap(params: {
+    schemaId: string;
+    schemaVersion: number;
+    extraData?: Record<string, unknown>;
+    schemaFields?: DeclaredField[];
+  }): void {
+    if (!params.schemaFields) return;
+
+    const seenKey = `${params.schemaId}:${params.schemaVersion}`;
+    if (this.warnedSchemaGaps.has(seenKey)) return;
+
+    const gap = diffUploadSchema(params.schemaFields, Object.keys(params.extraData ?? {}));
+    if (!hasUploadSchemaGap(gap)) return;
+
+    this.warnedSchemaGaps.add(seenKey);
+    this.logger.warn(
+      describeUploadSchemaGap(`${params.schemaId}`, gap) ??
+        `Upload schema ${params.schemaId} does not match the upload record shape`,
+    );
   }
 
   /**

--- a/apps/backend/src/pipelines/upload-schema-contract.spec.ts
+++ b/apps/backend/src/pipelines/upload-schema-contract.spec.ts
@@ -1,0 +1,102 @@
+import {
+  UPLOAD_RECORD_FIELDS,
+  diffUploadSchema,
+  hasUploadSchemaGap,
+  describeUploadSchemaGap,
+  DeclaredField,
+} from './upload-schema-contract';
+
+/** The canonical shape, as `generate_upload_schema` produces it. */
+const canonical = (): DeclaredField[] => UPLOAD_RECORD_FIELDS.map((f) => ({ ...f }));
+
+describe('diffUploadSchema', () => {
+  it('reports no gap for the schema the generator creates', () => {
+    const gap = diffUploadSchema(canonical());
+    expect(hasUploadSchemaGap(gap)).toBe(false);
+  });
+
+  it('ignores fields the schema declares beyond the contract', () => {
+    // An app is free to add its own columns — handoff stores a whole node tree
+    // alongside the file metadata.
+    const gap = diffUploadSchema([
+      ...canonical(),
+      { name: 'nodeType', type: 'string', required: true },
+      { name: 'parentId', type: 'string', required: true },
+    ]);
+    expect(hasUploadSchemaGap(gap)).toBe(false);
+  });
+
+  it('names every contract field an AI-authored schema left out', () => {
+    const gap = diffUploadSchema([
+      { name: 'name', type: 'string', required: true },
+      { name: 'path', type: 'string', required: true },
+      { name: 'mime', type: 'string', required: true },
+    ]);
+    expect(gap.missing).toEqual([
+      'filename',
+      'storage_path',
+      'content_type',
+      'size',
+      'url',
+      'sub_dir',
+      'original_name',
+    ]);
+  });
+
+  it('treats configured extraFields as part of the expected shape', () => {
+    const gap = diffUploadSchema(canonical(), ['nodeType', 'parentId']);
+    expect(gap.missing).toEqual(['nodeType', 'parentId']);
+  });
+
+  it('accepts text where the contract says string', () => {
+    // A long storage path in a `text` column is fine — the value round-trips.
+    const declared = canonical().map((f) =>
+      f.name === 'storage_path' ? { ...f, type: 'text' as const } : f,
+    );
+    expect(hasUploadSchemaGap(diffUploadSchema(declared))).toBe(false);
+  });
+
+  it('flags a type that cannot hold what the handler writes', () => {
+    const declared = canonical().map((f) =>
+      f.name === 'size' ? { ...f, type: 'string' as const } : f,
+    );
+    const gap = diffUploadSchema(declared);
+    expect(gap.typeMismatches).toEqual([{ name: 'size', expected: 'number', declared: 'string' }]);
+  });
+
+  it('treats a schema with no fields as missing everything', () => {
+    expect(diffUploadSchema([]).missing).toHaveLength(UPLOAD_RECORD_FIELDS.length);
+    expect(diffUploadSchema(undefined).missing).toHaveLength(UPLOAD_RECORD_FIELDS.length);
+  });
+
+  it('does not care whether the schema marks the fields required', () => {
+    // The write path never enforces `required`, so demanding it would be a
+    // warning the author cannot act on meaningfully.
+    const declared = canonical().map((f) => ({ ...f, required: false }));
+    expect(hasUploadSchemaGap(diffUploadSchema(declared))).toBe(false);
+  });
+});
+
+describe('describeUploadSchemaGap', () => {
+  it('returns null when the schema matches', () => {
+    expect(describeUploadSchemaGap('uploads', diffUploadSchema(canonical()))).toBeNull();
+  });
+
+  it('says what actually breaks, not just what differs', () => {
+    const message = describeUploadSchemaGap('uploads', diffUploadSchema([]))!;
+    expect(message).toContain('Upload schema "uploads"');
+    expect(message).toContain('storage_path');
+    // The author needs to know the upload still succeeds, or the warning reads
+    // as a failure they must fix before shipping.
+    expect(message).toContain('still upload');
+    expect(message).toMatch(/searchable|Uploads tab/);
+  });
+
+  it('describes a type mismatch in both directions', () => {
+    const declared = canonical().map((f) =>
+      f.name === 'size' ? { ...f, type: 'string' as const } : f,
+    );
+    const message = describeUploadSchemaGap('uploads', diffUploadSchema(declared))!;
+    expect(message).toContain('declares size as string but uploads write number');
+  });
+});

--- a/apps/backend/src/pipelines/upload-schema-contract.ts
+++ b/apps/backend/src/pipelines/upload-schema-contract.ts
@@ -1,0 +1,157 @@
+import { SchemaField, SchemaFieldType } from '../db/schema';
+
+/**
+ * The record shape every upload handler writes.
+ *
+ * `UploadRecordService.createUploadRecords` sets exactly these keys (plus any
+ * configured `extraFields`) on the pipeline_data record, whatever the target
+ * schema happens to declare — the write is not driven by the schema. So this
+ * list is the real contract, and a schema that does not declare it is
+ * describing something its own data isn't.
+ *
+ * Kept here rather than inline in the generator so the thing that CREATES an
+ * upload schema and the thing that WRITES upload records cannot drift apart.
+ */
+export const UPLOAD_RECORD_FIELDS: readonly SchemaField[] = [
+  { name: 'filename', type: 'string', required: true },
+  { name: 'storage_path', type: 'string', required: true },
+  { name: 'content_type', type: 'string', required: true },
+  { name: 'size', type: 'number', required: true },
+  { name: 'url', type: 'string', required: true },
+  { name: 'sub_dir', type: 'string', required: true },
+  { name: 'original_name', type: 'string', required: true },
+];
+
+/**
+ * Handler types whose `config.schemaId` names a schema that upload records are
+ * written into. `presigned_upload` is deliberately absent: it is the prepare
+ * half of the direct-to-bucket flow and writes no record (it has no schemaId).
+ */
+export const UPLOAD_RECORD_HANDLER_TYPES = ['file_upload_handler', 'register_upload'] as const;
+
+/** A field definition as declared by a schema — DB rows and payload entries both fit. */
+export interface DeclaredField {
+  name: string;
+  type: SchemaFieldType;
+  required?: boolean;
+}
+
+export interface UploadSchemaGap {
+  /** Contract fields the schema does not declare at all. */
+  missing: string[];
+  /** Contract fields declared with a type that can't hold what the handler writes. */
+  typeMismatches: { name: string; expected: SchemaFieldType; declared: SchemaFieldType }[];
+}
+
+/**
+ * Types that can carry an upload field's value without lying about it. `size`
+ * is a number; everything else is a string, and `text` is just as good a home
+ * for a string as `string` is (a long storage path in a `text` field is fine).
+ */
+function isCompatible(expected: SchemaFieldType, declared: SchemaFieldType): boolean {
+  if (expected === declared) return true;
+  if (expected === 'string') return declared === 'text';
+  return false;
+}
+
+/**
+ * Compare what a schema declares against what upload handlers write.
+ *
+ * `extraFieldNames` are the handler's configured `extraFields` — an app is free
+ * to add its own columns (handoff stores `nodeType`, `parentId`, … alongside
+ * the file metadata), so those count as declared-on-purpose and a schema that
+ * omits them is reported the same way as one missing a contract field.
+ */
+export function diffUploadSchema(
+  declared: DeclaredField[] | undefined | null,
+  extraFieldNames: string[] = [],
+): UploadSchemaGap {
+  const byName = new Map((declared ?? []).map((f) => [f.name, f]));
+  const gap: UploadSchemaGap = { missing: [], typeMismatches: [] };
+
+  for (const field of UPLOAD_RECORD_FIELDS) {
+    const match = byName.get(field.name);
+    if (!match) {
+      gap.missing.push(field.name);
+    } else if (!isCompatible(field.type, match.type)) {
+      gap.typeMismatches.push({ name: field.name, expected: field.type, declared: match.type });
+    }
+  }
+
+  for (const name of extraFieldNames) {
+    if (!byName.has(name)) gap.missing.push(name);
+  }
+
+  return gap;
+}
+
+/** An upload step's reference to the schema its records land in. */
+export interface UploadStepRef {
+  stepName: string;
+  schemaId: string;
+  extraFieldNames: string[];
+}
+
+/**
+ * Find the steps of a pipeline config that write upload records.
+ *
+ * Reads defensively: this runs on save/sync paths where the config is whatever
+ * an author (or an agent) just sent, and a lint that throws on a malformed
+ * pipeline would turn an advisory into an outage.
+ */
+export function collectUploadStepRefs(pipelineConfig: unknown): UploadStepRef[] {
+  const steps = (pipelineConfig as { steps?: unknown } | null | undefined)?.steps;
+  if (!Array.isArray(steps)) return [];
+
+  const refs: UploadStepRef[] = [];
+  for (const step of steps) {
+    if (!step || typeof step !== 'object') continue;
+    const { handlerType, config, name } = step as {
+      handlerType?: unknown;
+      config?: unknown;
+      name?: unknown;
+    };
+    if (!UPLOAD_RECORD_HANDLER_TYPES.includes(handlerType as never)) continue;
+
+    const schemaId = (config as { schemaId?: unknown } | undefined)?.schemaId;
+    if (typeof schemaId !== 'string' || schemaId.length === 0) continue;
+
+    const extraFields = (config as { extraFields?: unknown }).extraFields;
+    refs.push({
+      stepName: typeof name === 'string' ? name : String(handlerType),
+      schemaId,
+      extraFieldNames:
+        extraFields && typeof extraFields === 'object' ? Object.keys(extraFields) : [],
+    });
+  }
+  return refs;
+}
+
+export function hasUploadSchemaGap(gap: UploadSchemaGap): boolean {
+  return gap.missing.length > 0 || gap.typeMismatches.length > 0;
+}
+
+/**
+ * One human-readable line describing the gap, or null when the schema matches.
+ * Says what breaks, not just what differs — an author who sees only "missing
+ * storage_path" has no reason to care, since the upload itself still succeeds.
+ */
+export function describeUploadSchemaGap(schemaName: string, gap: UploadSchemaGap): string | null {
+  if (!hasUploadSchemaGap(gap)) return null;
+
+  const parts: string[] = [];
+  if (gap.missing.length > 0) {
+    parts.push(`does not declare ${gap.missing.join(', ')}`);
+  }
+  for (const mismatch of gap.typeMismatches) {
+    parts.push(
+      `declares ${mismatch.name} as ${mismatch.declared} but uploads write ${mismatch.expected}`,
+    );
+  }
+
+  return (
+    `Upload schema "${schemaName}": ${parts.join('; ')}. ` +
+    `Files will still upload, but undeclared fields are not searchable and the schema ` +
+    `will not be recognised as an upload schema in the Uploads tab.`
+  );
+}

--- a/apps/backend/src/pipelines/upload-schema-generator.service.ts
+++ b/apps/backend/src/pipelines/upload-schema-generator.service.ts
@@ -11,6 +11,7 @@ import type { PipelineConfig, PipelineStepConfig } from '../db/schema/proxy-rule
 import type { ProxyRuleSet } from '../db/schema/proxy-rule-sets.schema';
 import type { ValidatorConfig } from './types';
 import { SchemaGeneratorRevisionsService } from './schema-generator-revisions.service';
+import { UPLOAD_RECORD_FIELDS } from './upload-schema-contract';
 import { eq, and } from 'drizzle-orm';
 
 /**
@@ -65,16 +66,9 @@ export class UploadSchemaGeneratorService {
       throw new ConflictException(`A schema with name "${dto.name}" already exists`);
     }
 
-    // Define upload metadata schema fields
-    const fields: SchemaField[] = [
-      { name: 'filename', type: 'string', required: true },
-      { name: 'storage_path', type: 'string', required: true },
-      { name: 'content_type', type: 'string', required: true },
-      { name: 'size', type: 'number', required: true },
-      { name: 'url', type: 'string', required: true },
-      { name: 'sub_dir', type: 'string', required: true },
-      { name: 'original_name', type: 'string', required: true },
-    ];
+    // The record shape upload handlers write — shared with the writer so the
+    // generated schema and the actual records cannot drift apart.
+    const fields: SchemaField[] = UPLOAD_RECORD_FIELDS.map((f) => ({ ...f }));
 
     // Create the schema
     const [schema] = await db

--- a/apps/backend/src/pipelines/upload-schema-lint.service.spec.ts
+++ b/apps/backend/src/pipelines/upload-schema-lint.service.spec.ts
@@ -1,0 +1,104 @@
+import { UploadSchemaLintService } from './upload-schema-lint.service';
+import { PipelineSchemasService } from './pipeline-schemas.service';
+import { UPLOAD_RECORD_FIELDS } from './upload-schema-contract';
+
+const CANONICAL = UPLOAD_RECORD_FIELDS.map((f) => ({ ...f }));
+
+function buildService(schemas: Record<string, { name: string; fields: unknown[] }>) {
+  const getById = jest.fn(async (id: string) => (schemas[id] ? { id, ...schemas[id] } : null));
+  const service = new UploadSchemaLintService({
+    getById,
+  } as unknown as PipelineSchemasService);
+  return { service, getById };
+}
+
+const uploadStep = (schemaId: string, extraFields?: Record<string, string>) => ({
+  name: 'upload',
+  handlerType: 'register_upload',
+  config: { schemaId, subDir: 'content', ...(extraFields ? { extraFields } : {}) },
+});
+
+describe('UploadSchemaLintService', () => {
+  it('is silent for a schema that matches the upload record shape', async () => {
+    const { service } = buildService({ s1: { name: 'uploads', fields: CANONICAL } });
+    const warnings = await service.lintPipelineConfig({ steps: [uploadStep('s1')] });
+    expect(warnings).toEqual([]);
+  });
+
+  it('warns, naming the schema and the fields it left out', async () => {
+    const { service } = buildService({
+      s1: { name: 'my_files', fields: [{ name: 'path', type: 'string', required: true }] },
+    });
+    const [warning, ...rest] = await service.lintPipelineConfig({ steps: [uploadStep('s1')] });
+    expect(rest).toEqual([]);
+    expect(warning).toContain('my_files');
+    expect(warning).toContain('storage_path');
+  });
+
+  it('counts configured extraFields as part of the expected shape', async () => {
+    const { service } = buildService({ s1: { name: 'nodes', fields: CANONICAL } });
+    const [warning] = await service.lintPipelineConfig({
+      steps: [uploadStep('s1', { nodeType: "'file'", parentId: 'request.body.parentId' })],
+    });
+    expect(warning).toContain('nodeType');
+    expect(warning).toContain('parentId');
+  });
+
+  it('checks the proxied upload handler too, not just the presigned one', async () => {
+    const { service } = buildService({ s1: { name: 'uploads', fields: [] } });
+    const warnings = await service.lintPipelineConfig({
+      steps: [{ name: 'up', handlerType: 'file_upload_handler', config: { schemaId: 's1' } }],
+    });
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('ignores steps that write no upload record', async () => {
+    const { service, getById } = buildService({});
+    const warnings = await service.lintPipelineConfig({
+      steps: [
+        // prepare half of the direct-to-bucket flow — writes nothing
+        { name: 'prepare', handlerType: 'presigned_upload', config: { subDir: 'content' } },
+        { name: 'save', handlerType: 'data_create', config: { schemaId: 's1' } },
+        { name: 'out', handlerType: 'response_handler', config: {} },
+      ],
+    });
+    expect(warnings).toEqual([]);
+    expect(getById).not.toHaveBeenCalled();
+  });
+
+  it('reports a schema once even when several steps target it', async () => {
+    const { service } = buildService({ s1: { name: 'uploads', fields: [] } });
+    const warnings = await service.lintPipelineConfig({
+      steps: [uploadStep('s1'), { ...uploadStep('s1'), name: 'upload2' }],
+    });
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('stays quiet about a schema it cannot resolve — the handler reports that itself', async () => {
+    const { service } = buildService({});
+    const warnings = await service.lintPipelineConfig({ steps: [uploadStep('missing')] });
+    expect(warnings).toEqual([]);
+  });
+
+  it('tolerates malformed pipeline configs rather than throwing at save time', async () => {
+    const { service } = buildService({});
+    await expect(service.lintPipelineConfig(undefined)).resolves.toEqual([]);
+    await expect(service.lintPipelineConfig({})).resolves.toEqual([]);
+    await expect(service.lintPipelineConfig({ steps: 'nope' })).resolves.toEqual([]);
+    await expect(
+      service.lintPipelineConfig({ steps: [null, { handlerType: 'register_upload' }] }),
+    ).resolves.toEqual([]);
+  });
+
+  it('lints against caller-supplied fields when the schema is not saved yet', async () => {
+    // The rules-as-code sync path knows the fields a bundled schema WILL have,
+    // before anything is written (and under dryRun, nothing ever is).
+    const { service, getById } = buildService({});
+    const warnings = service.lintWithFields({ steps: [uploadStep('src-1')] }, (schemaId) =>
+      schemaId === 'src-1' ? { name: 'uploads', fields: [] } : undefined,
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('uploads');
+    expect(getById).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/pipelines/upload-schema-lint.service.ts
+++ b/apps/backend/src/pipelines/upload-schema-lint.service.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common';
+import { PipelineSchemasService } from './pipeline-schemas.service';
+import {
+  DeclaredField,
+  collectUploadStepRefs,
+  describeUploadSchemaGap,
+  diffUploadSchema,
+} from './upload-schema-contract';
+
+/** What a schema looks like to the lint — a name to report and fields to check. */
+export interface LintableSchema {
+  name: string;
+  fields: DeclaredField[];
+}
+
+/**
+ * Advisory check run where upload pipelines are authored: does the schema a
+ * step writes into actually declare what upload handlers write?
+ *
+ * Nothing here blocks a save. A mismatch is not a broken pipeline — files still
+ * upload and the record is still written correctly — it just means the schema
+ * describes something its own data isn't, and the fields it omits are invisible
+ * to search and to the Uploads tab. Authors (and agents, via MCP tool output)
+ * get told at the moment they can cheaply fix it.
+ */
+@Injectable()
+export class UploadSchemaLintService {
+  constructor(private readonly schemasService: PipelineSchemasService) {}
+
+  /**
+   * Lint a saved pipeline config, resolving each referenced schema from the DB.
+   * Used by the rule create/update paths, where schema ids are real.
+   */
+  async lintPipelineConfig(pipelineConfig: unknown): Promise<string[]> {
+    const refs = collectUploadStepRefs(pipelineConfig);
+    if (refs.length === 0) return [];
+
+    const resolved = new Map<string, LintableSchema | undefined>();
+    for (const ref of refs) {
+      if (resolved.has(ref.schemaId)) continue;
+      const schema = await this.schemasService.getById(ref.schemaId);
+      resolved.set(ref.schemaId, schema ? { name: schema.name, fields: schema.fields } : undefined);
+    }
+
+    return this.lintWithFields(pipelineConfig, (schemaId) => resolved.get(schemaId));
+  }
+
+  /**
+   * Lint against schemas the caller already knows. The rules-as-code sync path
+   * needs this: a bundled schema may not exist yet (and under `dryRun` never
+   * will), but its fields are right there in the payload.
+   */
+  lintWithFields(
+    pipelineConfig: unknown,
+    resolve: (schemaId: string) => LintableSchema | undefined,
+  ): string[] {
+    const warnings: string[] = [];
+    const reported = new Set<string>();
+
+    for (const ref of collectUploadStepRefs(pipelineConfig)) {
+      if (reported.has(ref.schemaId)) continue;
+
+      // An unresolvable schema is not this lint's business — the handler raises
+      // SchemaNotFoundError at run time, and duplicating it here as a warning
+      // would just add noise to a save that already has a real error path.
+      const schema = resolve(ref.schemaId);
+      if (!schema) continue;
+
+      const message = describeUploadSchemaGap(
+        schema.name,
+        diffUploadSchema(schema.fields, ref.extraFieldNames),
+      );
+      if (message) {
+        reported.add(ref.schemaId);
+        warnings.push(message);
+      }
+    }
+
+    return warnings;
+  }
+}

--- a/apps/backend/src/proxy-rules/export-cli-equivalence.spec.ts
+++ b/apps/backend/src/proxy-rules/export-cli-equivalence.spec.ts
@@ -27,6 +27,7 @@ import { ProxyRulesService } from './proxy-rules.service';
 import { PermissionsService } from '../permissions/permissions.service';
 import { NginxRegenerationService } from '../domains/nginx-regeneration.service';
 import { PipelineSchemasService } from '../pipelines/pipeline-schemas.service';
+import { UploadSchemaLintService } from '../pipelines/upload-schema-lint.service';
 import { ProxyRuleSetRevisionsService } from './proxy-rule-set-revisions.service';
 import {
   RULE_KEY_ORDER as BACKEND_RULE_KEY_ORDER,
@@ -402,6 +403,11 @@ describe('server export ↔ CLI canonicalizer equivalence (#448 drift guard)', (
           // present only to satisfy ProxyRuleSetsService's constructor.
           provide: ProxyRuleSetRevisionsService,
           useValue: { capture: jest.fn(), captureIfUnrevisioned: jest.fn() },
+        },
+        {
+          // Likewise unused here — the upload-schema lint runs on sync, not export.
+          provide: UploadSchemaLintService,
+          useValue: { lintWithFields: jest.fn().mockReturnValue([]) },
         },
       ],
     }).compile();

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
@@ -5,6 +5,7 @@ import { ProxyRulesService } from './proxy-rules.service';
 import { PermissionsService } from '../permissions/permissions.service';
 import { NginxRegenerationService } from '../domains/nginx-regeneration.service';
 import { PipelineSchemasService } from '../pipelines/pipeline-schemas.service';
+import { UploadSchemaLintService } from '../pipelines/upload-schema-lint.service';
 import {
   ProxyRuleSetRevisionsService,
   computeRevisionHash,
@@ -189,6 +190,7 @@ describe('ProxyRuleSetsService', () => {
         { provide: NginxRegenerationService, useValue: mockNginxRegenerationService },
         { provide: PipelineSchemasService, useValue: mockPipelineSchemasService },
         { provide: ProxyRuleSetRevisionsService, useValue: mockProxyRuleSetRevisionsService },
+        UploadSchemaLintService,
       ],
     }).compile();
 
@@ -1525,6 +1527,112 @@ describe('ProxyRuleSetsService', () => {
         },
       ]);
       expect(result.created).toEqual([{ pathPattern: '/api/comments', method: 'GET' }]);
+    });
+
+    /**
+     * bffless/ce#630 — a rules-as-code author (often an agent) gets no signal
+     * today that the schema their upload step writes into doesn't declare what
+     * upload handlers actually write. Warning-level: the push still succeeds.
+     */
+    describe('upload schema lint', () => {
+      const uploadRule = (schemaId: string, extraFields?: Record<string, string>) => ({
+        pathPattern: '/api/uploads',
+        method: 'POST',
+        pipelineConfig: {
+          name: 'upload',
+          steps: [
+            {
+              name: 'save',
+              handlerType: 'register_upload',
+              config: { schemaId, subDir: 'content', ...(extraFields ? { extraFields } : {}) },
+            },
+          ],
+        },
+      });
+
+      const canonicalFields = [
+        { name: 'filename', type: 'string', required: true },
+        { name: 'storage_path', type: 'string', required: true },
+        { name: 'content_type', type: 'string', required: true },
+        { name: 'size', type: 'number', required: true },
+        { name: 'url', type: 'string', required: true },
+        { name: 'sub_dir', type: 'string', required: true },
+        { name: 'original_name', type: 'string', required: true },
+      ];
+
+      it('warns about a bundled upload schema that omits contract fields', async () => {
+        mockDb.__setResults([[mockProject], []]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([]);
+
+        const result = await sync(
+          syncDto({
+            rules: [uploadRule('src-uploads')],
+            schemas: [
+              { id: 'src-uploads', name: 'my_files', fields: [{ name: 'path', type: 'string' }] },
+            ],
+            options: { dryRun: true },
+          }),
+        );
+
+        expect(result.warnings).toHaveLength(1);
+        expect(result.warnings[0]).toContain('my_files');
+        expect(result.warnings[0]).toContain('storage_path');
+        // Advisory only — the push is still a normal, successful plan.
+        expect(result.created).toEqual([{ pathPattern: '/api/uploads', method: 'POST' }]);
+      });
+
+      it('stays silent when the bundled schema matches the upload record shape', async () => {
+        mockDb.__setResults([[mockProject], []]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([]);
+
+        const result = await sync(
+          syncDto({
+            rules: [uploadRule('src-uploads')],
+            schemas: [{ id: 'src-uploads', name: 'uploads', fields: canonicalFields }],
+            options: { dryRun: true },
+          }),
+        );
+
+        expect(result.warnings).toEqual([]);
+      });
+
+      it('counts the step extraFields as part of the expected shape', async () => {
+        mockDb.__setResults([[mockProject], []]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([]);
+
+        const result = await sync(
+          syncDto({
+            rules: [uploadRule('src-uploads', { nodeType: "'file'" })],
+            schemas: [{ id: 'src-uploads', name: 'nodes', fields: canonicalFields }],
+            options: { dryRun: true },
+          }),
+        );
+
+        expect(result.warnings[0]).toContain('nodeType');
+      });
+
+      it('falls back to the live schema when the rule references one not in the payload', async () => {
+        mockDb.__setResults([[mockProject], []]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([
+          { id: 'live-uploads', projectId: 'project-1', name: 'legacy_files', fields: [] },
+        ]);
+
+        const result = await sync(
+          syncDto({ rules: [uploadRule('live-uploads')], options: { dryRun: true } }),
+        );
+
+        expect(result.warnings[0]).toContain('legacy_files');
+      });
+
+      it('does not query schemas at all for a rule set with no upload steps', async () => {
+        mockDb.__setResults([[mockProject], []]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([]);
+
+        const result = await sync(syncDto({ options: { dryRun: true } }));
+
+        expect(result.warnings).toEqual([]);
+        expect(mockPipelineSchemasService.getByProjectId).not.toHaveBeenCalled();
+      });
     });
 
     describe('revision capture', () => {

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
@@ -21,6 +21,8 @@ import {
 import { PermissionsService } from '../permissions/permissions.service';
 import { NginxRegenerationService } from '../domains/nginx-regeneration.service';
 import { PipelineSchemasService } from '../pipelines/pipeline-schemas.service';
+import { LintableSchema, UploadSchemaLintService } from '../pipelines/upload-schema-lint.service';
+import { collectUploadStepRefs } from '../pipelines/upload-schema-contract';
 import {
   ProxyRuleSetRevisionsService,
   computeRevisionHash,
@@ -92,6 +94,8 @@ export class ProxyRuleSetsService {
     @Inject(forwardRef(() => PipelineSchemasService))
     private readonly pipelineSchemasService: PipelineSchemasService,
     private readonly proxyRuleSetRevisionsService: ProxyRuleSetRevisionsService,
+    @Inject(forwardRef(() => UploadSchemaLintService))
+    private readonly uploadSchemaLint: UploadSchemaLintService,
   ) {}
 
   /**
@@ -727,6 +731,62 @@ export class ProxyRuleSetsService {
   }
 
   /**
+   * Warn when a rule's upload step targets a schema that doesn't declare the
+   * fields upload handlers write (bffless/ce#630).
+   *
+   * Warning-level only, matching the schema-mismatch policy above: files still
+   * upload and the record is still correct, so a hard failure would break
+   * pushes for a metadata declaration. `--strict-schemas` deliberately does NOT
+   * cover this — that flag means "live schema drift", and extending it would
+   * fail CI for anyone whose upload schema was always partial.
+   *
+   * Schema fields come from the payload bundle when present (the shape the
+   * schema WILL have, including under `dryRun` where nothing is written), and
+   * from the project's live schemas otherwise. Payload entries are indexed
+   * under both their source id and their remapped target id, because `dryRun`
+   * creates have no target id to remap to.
+   */
+  private async lintUploadSchemas(
+    projectId: string,
+    rules: SyncRuleInput[],
+    payloadSchemas: { id: string; name: string; fields: ComparableSchemaField[] }[] | undefined,
+    idMap: Map<string, string>,
+    apiKeyProjectId?: string | null,
+  ): Promise<string[]> {
+    const referenced = rules.flatMap((rule) => collectUploadStepRefs(rule.pipelineConfig));
+    if (referenced.length === 0) return [];
+
+    const byId = new Map<string, LintableSchema>();
+    for (const schema of payloadSchemas ?? []) {
+      const entry: LintableSchema = { name: schema.name.trim(), fields: schema.fields };
+      byId.set(schema.id, entry);
+      const targetId = idMap.get(schema.id);
+      if (targetId) byId.set(targetId, entry);
+    }
+
+    if (referenced.some((ref) => !byId.has(ref.schemaId))) {
+      const live = await this.pipelineSchemasService.getByProjectId(projectId, apiKeyProjectId);
+      for (const schema of live) {
+        if (!byId.has(schema.id)) byId.set(schema.id, { name: schema.name, fields: schema.fields });
+      }
+    }
+
+    const warnings: string[] = [];
+    const seen = new Set<string>();
+    for (const rule of rules) {
+      for (const warning of this.uploadSchemaLint.lintWithFields(rule.pipelineConfig, (id) =>
+        byId.get(id),
+      )) {
+        // Two rules sharing one bad schema is one problem, not two.
+        if (seen.has(warning)) continue;
+        seen.add(warning);
+        warnings.push(warning);
+      }
+    }
+    return warnings;
+  }
+
+  /**
    * Resolve bundled schema definitions against the target project by NAME —
    * the non-interactive counterpart of importRuleSet's resolution block, for
    * the sync path (Task 6/7 of the Phase 1 plan). No `ImportSchemaResolutionDto`
@@ -958,6 +1018,19 @@ export class ProxyRuleSetsService {
     // with an empty idMap the rules still alias the request DTO, so downstream
     // code must not mutate them in place.
     const incomingRules = idMap.size > 0 ? remapSchemaIds(dtoRules, idMap) : dtoRules;
+
+    // Advisory: an upload step whose target schema doesn't declare what upload
+    // handlers write. Runs on the remapped rules so ids match the target
+    // project, and before any writing so `dryRun` reports it too.
+    warnings.push(
+      ...(await this.lintUploadSchemas(
+        projectId,
+        incomingRules,
+        dto.schemas,
+        idMap,
+        apiKeyProjectId,
+      )),
+    );
 
     const existing = await this.findByName(projectId, name);
     const setCreated = !existing;


### PR DESCRIPTION
Closes #630.

## Problem

"Upload schema" was a convention with no enforcement and no marker. `UploadRecordService.createUploadRecords` always writes the same seven keys — `filename`, `storage_path`, `content_type`, `size`, `url`, `sub_dir`, `original_name` — plus any `extraFields`, **whatever the target schema declares**, and nothing compared the two:

- both upload handlers load the schema (for ownership and `version`) but never look at `schema.fields`
- `PipelineDataService.create` inserts the blob as-is — no required-field check, no unknown-key stripping
- `rules push --strict-schemas` compares yaml against the *live* schema of the same name; it has no concept of an upload schema
- `storage_path` appears zero times across `bffless/skills`

So a hand-written or AI-generated schema declaring `{ name, path, mime }` produced **no error anywhere**. Uploads kept working, but the schema described something its own data wasn't — and the undeclared fields are invisible to search (`getBySchemaId` only scans *declared* string/text fields) and to the Uploads tab (#628's file filter never engages).

## Change

**One source of truth** — `upload-schema-contract.ts` holds the field list plus `diffUploadSchema()`. `upload-schema-generator.service.ts` (which *creates* upload schemas) and `UploadRecordService` (which *fills* them) now share it instead of restating the list, so they cannot drift.

**Author-time lint**, via `UploadSchemaLintService`:
- **rules-as-code** — the sync response's existing `warnings[]` channel, which `push.ts` already prints. No CLI change; `--dry-run` reports it too. Bundled schemas are linted from the payload (the shape they *will* have), live schemas by id otherwise.
- **MCP** — `create_proxy_rule` / `update_proxy_rule` return `uploadSchemaWarnings`. This is the piece that actually addresses the AI case: an agent never sees the admin UI, but it does read tool output and correct itself. The key is omitted entirely when there's nothing to say.

**Runtime backstop** — `createUploadRecords` logs once per `(schemaId, schemaVersion)`, catching schemas edited after the rule was authored.

The message says what breaks, not just what differs — an author who reads "missing storage_path" has no reason to care, since the upload still succeeds.

## Deliberately not in scope

- **Failing** on mismatch, including under `--strict-schemas`. That flag means "live schema drift is an error"; widening it would fail CI for anyone whose upload schema was always partial. A metadata declaration should never cost someone their upload.
- **Auto-repairing** the schema — a request path silently mutating user config, and it would flap against the next `rules push`.
- **A `kind: 'upload'` column** so the UI stops guessing from field names. Needs a migration plus generator/yaml/CLI/UI changes, and only pays off once this lint exists.
- **A rule-editor banner** in the admin UI — follow-up now that the warnings exist server-side.

Type compatibility is deliberately loose where it can be: `text` satisfies a `string` field (the value round-trips), and `required` is not checked at all, since the write path never enforces it and the author couldn't act on it.

## Verification

- `npx jest src/pipelines src/proxy-rules src/mcp` → 49 suites / 690 tests pass
- New: `upload-schema-contract.spec.ts` (11), `upload-schema-lint.service.spec.ts` (9), 5 sync-path specs in `proxy-rule-sets.service.spec.ts`, 3 MCP specs. The lint specs were confirmed red before the service existed.
- `tsc --noEmit` clean; eslint clean on every file touched (the pre-existing prettier errors in `proxy-rule-sets.service.ts` and `proxy-rules.tools.ts` are all outside the changed hunks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
