### PR TITLE
AI settings clarity: name the cards, preset the COOP/COEP recipe, link out from manual steps

### DIFF
--- a/apps/backend/src/app-catalog/app-manifest.types.ts
+++ b/apps/backend/src/app-catalog/app-manifest.types.ts
@@ -13,11 +13,19 @@ export const APPLIES_WHEN_VALUES: readonly AppliesWhen[] = [
   'selfHosted',
 ];
 
+/** An off-CE destination where a credential is obtained (e.g. a provider's
+ *  token page). Rendered beside `deepLink`, which goes into the admin panel. */
+export interface AppManualStepExternalLink {
+  label: string;
+  url: string;
+}
+
 export interface AppManualStep {
   id: string;
   title: string;
   body: string;
   deepLink?: string;
+  externalLink?: AppManualStepExternalLink;
   appliesWhen?: AppliesWhen;
 }
 

--- a/apps/backend/src/app-catalog/app-manifest.util.spec.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.spec.ts
@@ -200,6 +200,114 @@ describe('validateAppManifest', () => {
 
     expect(result.ok).toBe(true);
   });
+
+  it('accepts a manual step with an external link', () => {
+    const result = validateAppManifest({
+      ...TEST_MANIFEST,
+      install: {
+        ...TEST_MANIFEST.install,
+        manualSteps: [
+          {
+            id: 'add-hf-token',
+            title: 'Optional: HF_TOKEN for speaker diarization',
+            body: 'Create a secret named HF_TOKEN.',
+            externalLink: {
+              label: 'Get a Hugging Face token',
+              url: 'https://huggingface.co/settings/tokens',
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects an external link missing a label', () => {
+    const result = validateAppManifest({
+      ...TEST_MANIFEST,
+      install: {
+        ...TEST_MANIFEST.install,
+        manualSteps: [
+          {
+            id: 'a',
+            title: 'T',
+            body: 'B',
+            externalLink: { url: 'https://example.com' },
+          },
+        ],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain(
+        'install.manualSteps[0].externalLink.label: required string',
+      );
+    }
+  });
+
+  it('rejects a non-https external link', () => {
+    const result = validateAppManifest({
+      ...TEST_MANIFEST,
+      install: {
+        ...TEST_MANIFEST.install,
+        manualSteps: [
+          {
+            id: 'a',
+            title: 'T',
+            body: 'B',
+            externalLink: { label: 'Docs', url: 'http://example.com' },
+          },
+        ],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain(
+        'install.manualSteps[0].externalLink.url: must be an https:// URL',
+      );
+    }
+  });
+
+  it('rejects an external link that is not an object', () => {
+    const result = validateAppManifest({
+      ...TEST_MANIFEST,
+      install: {
+        ...TEST_MANIFEST.install,
+        manualSteps: [
+          { id: 'a', title: 'T', body: 'B', externalLink: 'https://example.com' },
+        ],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain('install.manualSteps[0].externalLink: must be an object');
+    }
+  });
+
+  it('does not apply placeholder validation to an external link url', () => {
+    // externalLink is a literal external URL, not a templated admin path, so
+    // a brace in it is a plain character and must not be read as a token.
+    const result = validateAppManifest({
+      ...TEST_MANIFEST,
+      install: {
+        ...TEST_MANIFEST.install,
+        manualSteps: [
+          {
+            id: 'a',
+            title: 'T',
+            body: 'B',
+            externalLink: { label: 'Docs', url: 'https://example.com/a{b}c' },
+          },
+        ],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
 });
 
 describe('validateRegistry', () => {

--- a/apps/backend/src/app-catalog/app-manifest.util.ts
+++ b/apps/backend/src/app-catalog/app-manifest.util.ts
@@ -192,6 +192,20 @@ function validateManualSteps(manualSteps: unknown, path: string, errors: string[
     if (entry.deepLink !== undefined && typeof entry.deepLink !== 'string') {
       errors.push(`${entryPath}.deepLink: must be string`);
     }
+    if (entry.externalLink !== undefined) {
+      if (!isPlainObject(entry.externalLink)) {
+        errors.push(`${entryPath}.externalLink: must be an object`);
+      } else {
+        if (!isNonEmptyString(entry.externalLink.label)) {
+          errors.push(`${entryPath}.externalLink.label: required string`);
+        }
+        if (!isNonEmptyString(entry.externalLink.url)) {
+          errors.push(`${entryPath}.externalLink.url: required string`);
+        } else if (!entry.externalLink.url.startsWith('https://')) {
+          errors.push(`${entryPath}.externalLink.url: must be an https:// URL`);
+        }
+      }
+    }
     validateStepPlaceholders(entry.title, `${entryPath}.title`, errors);
     validateStepPlaceholders(entry.body, `${entryPath}.body`, errors);
     validateStepPlaceholders(entry.deepLink, `${entryPath}.deepLink`, errors);

--- a/apps/backend/src/pipelines/ai-plugins/plugins/rag-search.plugin.ts
+++ b/apps/backend/src/pipelines/ai-plugins/plugins/rag-search.plugin.ts
@@ -103,7 +103,7 @@ export class RagSearchPlugin implements AIToolPlugin {
     id: 'rag-search',
     name: 'AI Data Tools',
     description:
-      'Give the AI tools to search and query your pipeline data. Supports semantic search (vector embeddings) and exact data lookups. Vector search requires Replicate in AI Services.',
+      'Give the AI tools to search and query your pipeline data. Supports semantic search (vector embeddings) and exact data lookups. Vector search requires a Replicate token (Settings → AI → Replicate).',
     category: 'information',
     icon: 'database',
     pipelineOptionsSchema: z.object({

--- a/apps/backend/src/pipelines/chat-schema-generator.service.ts
+++ b/apps/backend/src/pipelines/chat-schema-generator.service.ts
@@ -61,7 +61,7 @@ export class ChatSchemaGeneratorService {
       throw new ConflictException(
         dto.provider
           ? `AI provider '${dto.provider}' is not configured for this project`
-          : 'No AI provider is configured for this project. Configure AI settings in Project Settings first.',
+          : 'No AI provider is configured for this project. Add an LLM provider in Settings → AI.',
       );
     }
 

--- a/apps/backend/src/pipelines/handlers/replicate.handler.ts
+++ b/apps/backend/src/pipelines/handlers/replicate.handler.ts
@@ -73,7 +73,7 @@ export class ReplicateHandler implements StepHandler<ReplicateHandlerConfig> {
         success: false,
         error: {
           code: 'REPLICATE_NOT_CONFIGURED',
-          message: 'Replicate API token is not configured. Add it in Settings > AI > AI Services.',
+          message: 'Replicate API token is not configured. Add it in Settings > AI > Replicate.',
         },
       };
     }

--- a/apps/backend/src/pipelines/handlers/replicate.handler.ts
+++ b/apps/backend/src/pipelines/handlers/replicate.handler.ts
@@ -73,7 +73,7 @@ export class ReplicateHandler implements StepHandler<ReplicateHandlerConfig> {
         success: false,
         error: {
           code: 'REPLICATE_NOT_CONFIGURED',
-          message: 'Replicate API token is not configured. Add it in Settings > AI > Replicate.',
+          message: 'Replicate API token is not configured. Add it in Settings → AI → Replicate.',
         },
       };
     }

--- a/apps/frontend/src/components/app-catalog/SetupNotes.tsx
+++ b/apps/frontend/src/components/app-catalog/SetupNotes.tsx
@@ -64,10 +64,24 @@ export function SetupNotes({ steps, defaultExpanded = false, className }: SetupN
               {isOpen && (
                 <div className="ml-5 mt-1 space-y-1">
                   {step.body && <p className="text-sm text-muted-foreground">{step.body}</p>}
-                  {step.deepLink && (
-                    <a href={step.deepLink} className="text-sm text-primary underline">
-                      Go
-                    </a>
+                  {(step.deepLink || step.externalLink) && (
+                    <div className="flex items-center gap-3">
+                      {step.deepLink && (
+                        <a href={step.deepLink} className="text-sm text-primary underline">
+                          Go
+                        </a>
+                      )}
+                      {step.externalLink && (
+                        <a
+                          href={step.externalLink.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-sm text-primary underline"
+                        >
+                          {step.externalLink.label}
+                        </a>
+                      )}
+                    </div>
                   )}
                 </div>
               )}

--- a/apps/frontend/src/components/app-catalog/__tests__/SetupNotes.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/SetupNotes.test.tsx
@@ -11,6 +11,16 @@ const STEPS = [
     deepLink: '/repo/acme/site/settings?tab=members',
   },
   { id: 'provision-wildcard-cert', title: 'Turn on HTTPS for this app', body: 'Over HTTP now.' },
+  {
+    id: 'add-hf-token',
+    title: 'Optional: HF_TOKEN for speaker diarization',
+    body: 'Create a secret named HF_TOKEN.',
+    deepLink: '/repo/acme/site/settings?tab=ai',
+    externalLink: {
+      label: 'Get a Hugging Face token',
+      url: 'https://huggingface.co/settings/tokens',
+    },
+  },
 ];
 
 describe('SetupNotes', () => {
@@ -65,5 +75,49 @@ describe('SetupNotes', () => {
 
     expect(screen.getByText('Configure something')).toBeInTheDocument();
     expect(document.querySelector('p.text-muted-foreground')).not.toBeInTheDocument();
+  });
+
+  it('renders the external link once expanded', async () => {
+    render(<SetupNotes steps={STEPS} />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /HF_TOKEN for speaker diarization/i }),
+    );
+
+    expect(screen.getByRole('link', { name: 'Get a Hugging Face token' })).toHaveAttribute(
+      'href',
+      'https://huggingface.co/settings/tokens',
+    );
+  });
+
+  it('opens the external link in a new tab safely', async () => {
+    render(<SetupNotes steps={STEPS} />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /HF_TOKEN for speaker diarization/i }),
+    );
+    const link = screen.getByRole('link', { name: 'Get a Hugging Face token' });
+
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders both the deep link and the external link side by side', async () => {
+    render(<SetupNotes steps={STEPS} />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /HF_TOKEN for speaker diarization/i }),
+    );
+
+    expect(screen.getByRole('link', { name: 'Go' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Get a Hugging Face token' })).toBeInTheDocument();
+  });
+
+  it('renders no external link for a step without one', async () => {
+    render(<SetupNotes steps={STEPS} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /give other people access/i }));
+
+    expect(screen.queryByRole('link', { name: /hugging face/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
+++ b/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
@@ -214,7 +214,7 @@ function ProjectAIServicesSection({ project }: { project: Project }) {
               <span className="text-muted-foreground">Replicate not connected</span>
             </div>
             <p className="text-sm text-muted-foreground">
-              Connect Replicate to enable transcription, image generation, and vector-search steps.
+              Connect Replicate to enable transcription, image generation, and embeddings.
             </p>
             <Button onClick={() => setShowAddDialog(true)}>
               <Plus className="h-4 w-4 mr-2" />
@@ -235,9 +235,11 @@ function ProjectAIServicesSection({ project }: { project: Project }) {
       }}>
         <DialogContent className="sm:max-w-[450px]">
           <DialogHeader>
-            <DialogTitle>{hasReplicate ? 'Replace Replicate token' : 'Add Replicate'}</DialogTitle>
+            <DialogTitle>{hasReplicate ? 'Replace Replicate token' : 'Connect Replicate'}</DialogTitle>
             <DialogDescription>
-              Add your Replicate API token to enable ML model pipelines.
+              {hasReplicate
+                ? 'Replace the stored Replicate API token.'
+                : 'Add your Replicate API token to enable ML model pipelines.'}
             </DialogDescription>
           </DialogHeader>
 
@@ -309,10 +311,10 @@ function ProjectAIServicesSection({ project }: { project: Project }) {
               {isAdding ? (
                 <>
                   <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Adding...
+                  {hasReplicate ? 'Saving...' : 'Connecting...'}
                 </>
               ) : (
-                hasReplicate ? 'Save token' : 'Add Replicate'
+                hasReplicate ? 'Save token' : 'Connect Replicate'
               )}
             </Button>
           </DialogFooter>

--- a/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
+++ b/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
@@ -150,18 +150,23 @@ function ProjectAIServicesSection({ project }: { project: Project }) {
           <div>
             <CardTitle className="flex items-center gap-2">
               <Zap className="h-5 w-5" />
-              AI Services
+              Replicate
             </CardTitle>
             <CardDescription>
-              Configure external ML services for pipeline steps.
+              Your Replicate API token. Powers ML model steps: transcription, image generation,
+              and embeddings.
             </CardDescription>
           </div>
-          {!hasReplicate && (
-            <Button onClick={() => setShowAddDialog(true)}>
-              <Plus className="h-4 w-4 mr-2" />
-              Add Service
-            </Button>
-          )}
+          <Button onClick={() => setShowAddDialog(true)}>
+            {hasReplicate ? (
+              'Replace token'
+            ) : (
+              <>
+                <Plus className="h-4 w-4 mr-2" />
+                Connect Replicate
+              </>
+            )}
+          </Button>
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -181,7 +186,6 @@ function ProjectAIServicesSection({ project }: { project: Project }) {
                         <p className="text-sm text-muted-foreground">
                           Token: <span className="font-mono text-xs">{svc.apiToken}</span>
                         </p>
-                        <p className="text-xs text-muted-foreground mt-1">{meta.description}</p>
                       </div>
                     </div>
                     <Button
@@ -207,14 +211,14 @@ function ProjectAIServicesSection({ project }: { project: Project }) {
           <div className="space-y-3">
             <div className="flex items-center text-sm">
               <AlertTriangle className="h-4 w-4 text-yellow-500 mr-2" />
-              <span className="text-muted-foreground">No AI services configured</span>
+              <span className="text-muted-foreground">Replicate not connected</span>
             </div>
             <p className="text-sm text-muted-foreground">
-              Add an AI service to enable Replicate ML model pipelines.
+              Connect Replicate to enable transcription, image generation, and vector-search steps.
             </p>
             <Button onClick={() => setShowAddDialog(true)}>
               <Plus className="h-4 w-4 mr-2" />
-              Add Service
+              Connect Replicate
             </Button>
           </div>
         )}
@@ -231,7 +235,7 @@ function ProjectAIServicesSection({ project }: { project: Project }) {
       }}>
         <DialogContent className="sm:max-w-[450px]">
           <DialogHeader>
-            <DialogTitle>Add Replicate</DialogTitle>
+            <DialogTitle>{hasReplicate ? 'Replace Replicate token' : 'Add Replicate'}</DialogTitle>
             <DialogDescription>
               Add your Replicate API token to enable ML model pipelines.
             </DialogDescription>
@@ -308,7 +312,7 @@ function ProjectAIServicesSection({ project }: { project: Project }) {
                   Adding...
                 </>
               ) : (
-                'Add Replicate'
+                hasReplicate ? 'Save token' : 'Add Replicate'
               )}
             </Button>
           </DialogFooter>
@@ -637,9 +641,9 @@ function AddProviderDialog({
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
-          <DialogTitle>Add AI Provider</DialogTitle>
+          <DialogTitle>Add LLM Provider</DialogTitle>
           <DialogDescription>
-            Configure a new AI provider for this project's chat pipelines.
+            Choose a provider and paste its API key.
           </DialogDescription>
         </DialogHeader>
 
@@ -921,10 +925,11 @@ export function ProjectAISettingsTab({ project }: ProjectAISettingsTabProps) {
             <div>
               <CardTitle className="flex items-center gap-2">
                 <Bot className="h-5 w-5" />
-                AI Settings
+                LLM Providers
               </CardTitle>
               <CardDescription>
-                Configure AI providers for chat pipelines in this project.
+                API keys for OpenAI, Anthropic, and Google. Used by any AI step in your pipelines
+                — chat and one-off text generation.
               </CardDescription>
             </div>
             {availableToAdd.length > 0 && (
@@ -961,10 +966,11 @@ export function ProjectAISettingsTab({ project }: ProjectAISettingsTabProps) {
             <div className="space-y-3">
               <div className="flex items-center text-sm">
                 <AlertTriangle className="h-4 w-4 text-yellow-500 mr-2" />
-                <span className="text-muted-foreground">No AI providers configured</span>
+                <span className="text-muted-foreground">No LLM providers connected</span>
               </div>
               <p className="text-sm text-muted-foreground">
-                Add an AI provider to enable chat pipelines and AI-powered features for this project.
+                Add a provider — Anthropic, OpenAI, or Google — to enable AI steps in this
+                project's pipelines.
               </p>
               <Button onClick={() => setShowAddDialog(true)}>
                 <Plus className="h-4 w-4 mr-2" />

--- a/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
+++ b/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
@@ -902,7 +902,7 @@ export function ProjectAISettingsTab({ project }: ProjectAISettingsTabProps) {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Bot className="h-5 w-5" />
-            AI Settings
+            LLM Providers
           </CardTitle>
         </CardHeader>
         <CardContent>

--- a/apps/frontend/src/components/project/ProjectResponseHeaderRulesTab.tsx
+++ b/apps/frontend/src/components/project/ProjectResponseHeaderRulesTab.tsx
@@ -67,20 +67,42 @@ const defaultRuleForm: CreateResponseHeaderRuleDto = {
   description: '',
 };
 
-const presets = [
+export interface HeaderRulePreset {
+  name: string;
+  pathPattern: string;
+  framePolicy: 'allow' | 'deny' | 'sameorigin';
+  allowedOrigins: string[];
+  description: string;
+  customHeaders?: { name: string; value: string }[];
+}
+
+// eslint-disable-next-line react-refresh/only-export-components -- exported for unit testing (see __tests__/responseHeaderPresets.test.ts)
+export const presets: HeaderRulePreset[] = [
   {
     name: 'Embed Widget',
     pathPattern: 'embed/**',
-    framePolicy: 'allow' as const,
+    framePolicy: 'allow',
     allowedOrigins: [],
     description: 'Allow iframe embedding of widget pages (add allowed origins below)',
   },
   {
     name: 'Block Framing',
     pathPattern: '**',
-    framePolicy: 'deny' as const,
+    framePolicy: 'deny',
     allowedOrigins: [],
     description: 'Prevent all iframe embedding',
+  },
+  {
+    name: 'Cross-Origin Isolation',
+    pathPattern: '**',
+    framePolicy: 'sameorigin',
+    allowedOrigins: [],
+    description:
+      'Enable SharedArrayBuffer for multithreaded WebAssembly (in-browser video export)',
+    customHeaders: [
+      { name: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+      { name: 'Cross-Origin-Embedder-Policy', value: 'credentialless' },
+    ],
   },
 ];
 
@@ -149,7 +171,7 @@ export function ProjectResponseHeaderRulesTab({ project }: ProjectResponseHeader
     setShowRuleDialog(true);
   };
 
-  const applyPreset = (preset: (typeof presets)[0]) => {
+  const applyPreset = (preset: HeaderRulePreset) => {
     setRuleForm({
       ...defaultRuleForm,
       pathPattern: preset.pathPattern,
@@ -159,7 +181,7 @@ export function ProjectResponseHeaderRulesTab({ project }: ProjectResponseHeader
       description: preset.description,
     });
     setOriginsText(preset.allowedOrigins.join('\n'));
-    setCustomHeaderRows([]);
+    setCustomHeaderRows(preset.customHeaders ? [...preset.customHeaders] : []);
   };
 
   const handleEditRule = (rule: ResponseHeaderRule) => {

--- a/apps/frontend/src/components/project/ProjectResponseHeaderRulesTab.tsx
+++ b/apps/frontend/src/components/project/ProjectResponseHeaderRulesTab.tsx
@@ -98,7 +98,9 @@ export const presets: HeaderRulePreset[] = [
     framePolicy: 'sameorigin',
     allowedOrigins: [],
     description:
-      'Enable SharedArrayBuffer for multithreaded WebAssembly (in-browser video export)',
+      'Enable SharedArrayBuffer for multithreaded WebAssembly (in-browser video export). ' +
+      'Applies project-wide: adds a frame-ancestors CSP and may block cross-origin ' +
+      'subresources that lack a CORP header.',
     customHeaders: [
       { name: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
       { name: 'Cross-Origin-Embedder-Policy', value: 'credentialless' },

--- a/apps/frontend/src/components/project/__tests__/responseHeaderPresets.test.ts
+++ b/apps/frontend/src/components/project/__tests__/responseHeaderPresets.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { presets } from '../ProjectResponseHeaderRulesTab';
+
+describe('response header presets', () => {
+  it('offers a Cross-Origin Isolation preset', () => {
+    const names = presets.map((p) => p.name);
+    expect(names).toContain('Cross-Origin Isolation');
+  });
+
+  it('sets both cross-origin isolation headers to the values SharedArrayBuffer requires', () => {
+    const preset = presets.find((p) => p.name === 'Cross-Origin Isolation');
+
+    expect(preset?.customHeaders).toEqual([
+      { name: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+      { name: 'Cross-Origin-Embedder-Policy', value: 'credentialless' },
+    ]);
+  });
+
+  it('applies project-wide, carrying no app-specific path', () => {
+    const preset = presets.find((p) => p.name === 'Cross-Origin Isolation');
+
+    // A generic control offered to every project cannot assume an app's
+    // basePath, so the pattern is '**' and the field stays editable.
+    expect(preset?.pathPattern).toBe('**');
+  });
+
+  it('leaves framing behaviour alone', () => {
+    const preset = presets.find((p) => p.name === 'Cross-Origin Isolation');
+
+    // 'sameorigin' is the existing default (nginx already emits
+    // X-Frame-Options: SAMEORIGIN), so enabling isolation must not
+    // silently change who may frame the content.
+    expect(preset?.framePolicy).toBe('sameorigin');
+  });
+
+  it('leaves the existing presets carrying no custom headers', () => {
+    const blockFraming = presets.find((p) => p.name === 'Block Framing');
+
+    expect(blockFraming?.customHeaders).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/services/appCatalogApi.ts
+++ b/apps/frontend/src/services/appCatalogApi.ts
@@ -41,11 +41,17 @@ export type AppliesWhen =
   | 'platformMode'
   | 'selfHosted';
 
+export interface AppManualStepExternalLink {
+  label: string;
+  url: string;
+}
+
 export interface AppManualStep {
   id: string;
   title: string;
   body: string;
   deepLink?: string;
+  externalLink?: AppManualStepExternalLink;
   appliesWhen?: AppliesWhen;
 }
 

--- a/apps/frontend/src/services/appCatalogApi.ts
+++ b/apps/frontend/src/services/appCatalogApi.ts
@@ -41,6 +41,7 @@ export type AppliesWhen =
   | 'platformMode'
   | 'selfHosted';
 
+// Mirrors AppManualStepExternalLink in apps/backend/src/app-catalog/app-manifest.types.ts — keep both in sync.
 export interface AppManualStepExternalLink {
   label: string;
   url: string;


### PR DESCRIPTION
Three onboarding fixes found while installing an app on a fresh instance.

## Name the AI cards

`AI Settings` and `AI Services` sat adjacent on one tab with near-identical names and unrelated contents, and neither said what it held.

- **`AI Services` is Replicate and only Replicate** — `AIServiceType` is a single-member union, and the dialog inside was already titled "Add Replicate". The generic framing hid the one thing the card does. Now **Replicate**.
- **`AI Settings` holds the Anthropic key but never said so**, and its "chat pipelines" subtitle was narrower than the truth: those keys feed `ai_handler` in both `chat` and `completion` mode, so someone debugging a completion-mode step had no reason to look there. Now **LLM Providers**.

Also makes a configured Replicate token replaceable — the header button used to vanish once a token existed, so rotating one meant remove-then-add. `addOrUpdateService` already upserts, so reopening the dialog is enough. And fixes the loading-skeleton title, which flashed the old name on every load, plus three backend strings that named the retired card.

## Cross-Origin Isolation preset

Enabling `SharedArrayBuffer` (needed for multithreaded `ffmpeg.wasm`) meant hand-typing two header names and two values an operator cannot guess. The Response Headers dialog already had a preset row; it just could not carry custom headers, because `applyPreset` hardcoded an empty row list.

The pattern is `**` deliberately: this is a generic control offered to every project, so it cannot assume any app's `basePath`. The description names the consequence — the rule is project-wide and `COEP: credentialless` can break cross-origin subresources lacking CORP — and the path field stays editable.

## `externalLink` on app manual steps

A manual step could link *into* the admin panel via `deepLink`, but had no way to send an operator *out* to where a credential is obtained, and step bodies render as plain text so a URL in one is unclickable.

Optional and additive: validation checks known fields and never rejects unknown ones, so a manifest carrying `externalLink` still installs on an older CE, which simply does not render it. No `ceMin` bump. `interpolateStep` spreads, so the field survives both delivery paths and is correctly not interpolated — an external URL is literal.

## Verification

- Frontend 871 passing (was 862), backend 2939 passed / 37 skipped / 0 failed, both typechecks clean.
- `pnpm lint` at 58 problems — identical to main's pre-existing baseline.
- The built bundle contains the new strings and zero occurrences of `AI Settings` / `AI Services` / `Add Service`.

**Not verified here:** on-screen rendering, since this was built without a running CE stack. Worth clicking the new preset and eyeballing the renamed cards after deploy — the preset's data layer is unit-tested, but the click-through is not.

Unblocks a companion PR in `bffless/apps` that quotes the new card names, the preset name, and this manifest field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
