### PR TITLE
feat(ui): name the AI settings cards LLM Providers and Replicate

### DIFF
--- a/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
+++ b/apps/frontend/src/components/project/ProjectAISettingsTab.tsx
@@ -65,12 +65,11 @@ import { ProjectAIPluginsSection } from './ProjectAIPluginsSection';
 import { ProjectSecretsSection } from './ProjectSecretsSection';
 
 // AI Service display config
-const SERVICE_CONFIG: Record<string, { name: string; color: string; bgColor: string; description: string }> = {
+const SERVICE_CONFIG: Record<string, { name: string; color: string; bgColor: string }> = {
   replicate: {
     name: 'Replicate',
     color: 'text-indigo-600',
     bgColor: 'bg-indigo-50',
-    description: 'Run ML models (CLIP embeddings, image generation, transcription, etc.)',
   },
 };
 
@@ -173,7 +172,7 @@ function ProjectAIServicesSection({ project }: { project: Project }) {
         {configuredServices.length > 0 ? (
           <div className="space-y-3">
             {configuredServices.map((svc) => {
-              const meta = SERVICE_CONFIG[svc.service] || { name: svc.service, color: 'text-gray-600', bgColor: 'bg-gray-50', description: '' };
+              const meta = SERVICE_CONFIG[svc.service] || { name: svc.service, color: 'text-gray-600', bgColor: 'bg-gray-50' };
               return (
                 <div key={svc.service} className="border rounded-lg p-4">
                   <div className="flex items-start justify-between">


### PR DESCRIPTION
## Why this PR exists

**#637 shipped this work but cannot be released.** Its squash subject was
`AI settings clarity: name the cards, preset the COOP/COEP recipe, link out from manual steps (#637)` —
not a conventional commit. Release Please ran against it, succeeded, and produced no release PR,
because it had nothing it recognised. The last release is still `v0.4.18`, cut before that merge.

That matters beyond the changelog: `main-release.yml` triggers only on a `v*` tag, tags come from
release-please, so **no tag means no image and no deploy**. The renamed cards, the Cross-Origin
Isolation preset and the `externalLink` manifest field are all sitting on `main` undeployed.

This PR carries the conventional subject that lets release-please cut that release. Its title is
the changelog line for the work in #637; the diff is small because the feature already landed.

## The actual diff

The one deferred cleanup from #637's review: `SERVICE_CONFIG.replicate.description` and the
empty-string fallback in the `SERVICE_CONFIG[svc.service] || {...}` expression are now dead. Their
only consumer was the per-service description row, deleted in #637 once the card's own subtitle
said the same thing. Only `name`, `color` and `bgColor` are read.

## What the resulting release contains

- `AI Settings` → **LLM Providers**, `AI Services` → **Replicate**, plus a `Replace token` button
  so a rotated Replicate token no longer needs remove-then-add
- A **Cross-Origin Isolation** response-header preset — COOP/COEP in one click
- `externalLink` on app manual steps, so a step can link out to where a credential is obtained

## Verification

Frontend 871 passing, typecheck clean, `pnpm lint` at 58 problems — identical to main's
pre-existing baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
