### PR TITLE
feat: scope AI skills source to the pipeline step

### DIFF
--- a/apps/backend/src/pipelines/execution/step-handler.interface.ts
+++ b/apps/backend/src/pipelines/execution/step-handler.interface.ts
@@ -436,6 +436,25 @@ export interface AIHandlerConfig extends BaseHandlerConfig {
      * Each name should match a skill's `name` field in its frontmatter.
      */
     enabled?: string[];
+
+    /**
+     * Directory within the deployment holding the `SKILL.md` files, e.g.
+     * `apps/studio/dist/bffless/skills`. Falls back to the project-wide
+     * `settings.skillsPath` (default `.bffless/skills`) when omitted.
+     *
+     * Note a deployment can never contain a *nested* dot-directory — the zip
+     * importer drops any entry containing `/.` — so an app served under a
+     * base path must publish its skills to a non-hidden directory and name it
+     * here.
+     */
+    path?: string;
+
+    /**
+     * Deployment alias to load skills from, e.g. a dedicated `skills` alias.
+     * Falls back to the project-wide `settings.skillsAlias`, and finally to
+     * the deployment serving the request.
+     */
+    alias?: string;
   };
 
   /**

--- a/apps/backend/src/pipelines/handlers/ai.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/ai.handler.spec.ts
@@ -31,16 +31,20 @@ export function createHandler(overrides: Partial<Record<string, unknown>> = {}) 
     getSkillsPath: jest.fn().mockResolvedValue('skills'),
     ...((overrides.projectAISettingsService as object) || {}),
   };
+  const skillsService = {
+    listSkills: jest.fn().mockResolvedValue([]),
+    ...((overrides.skillsService as object) || {}),
+  };
   const handler = new AIHandler(
     registry as never,
     new ExpressionEvaluator(),
     projectAISettingsService as never,
     {} as never, // PipelineDataService
     {} as never, // PipelineSchemasService
-    { listSkills: jest.fn().mockResolvedValue([]) } as never, // SkillsService
+    skillsService as never, // SkillsService
     {} as never, // AIToolPluginService
   );
-  return { handler, projectAISettingsService };
+  return { handler, projectAISettingsService, skillsService };
 }
 
 describe('AIHandler.validateConfig — attachments', () => {
@@ -225,5 +229,90 @@ describe('AIHandler.execute — completion attachments', () => {
       image: 'https://x.test/a.png?token=secret123',
     });
     expect(typeof userMessage.content[1].image).toBe('string');
+  });
+});
+
+describe('AIHandler.execute — step-scoped skills source', () => {
+  beforeEach(() => {
+    (generateText as jest.Mock).mockReset().mockResolvedValue({
+      text: 'ok',
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      finishReason: 'stop',
+      steps: [],
+    });
+  });
+
+  function deploymentContext(): PipelineContext {
+    return {
+      ...createContext({ prep: { prompt: 'draft a thumbnail' } }),
+      deployment: { owner: 'bffless', repo: 'studio', commitSha: 'sha-serving' },
+    } as PipelineContext;
+  }
+
+  it("loads skills from the step's own path instead of the project setting", async () => {
+    const { handler, skillsService } = createHandler();
+
+    await handler.execute(
+      deploymentContext(),
+      completionStep({
+        messageField: 'steps.prep.prompt',
+        skills: {
+          mode: 'selected',
+          enabled: ['image-prompts'],
+          path: 'apps/studio/dist/bffless/skills',
+        },
+      }),
+    );
+
+    expect(skillsService.listSkills).toHaveBeenCalledWith(
+      'bffless',
+      'studio',
+      'sha-serving',
+      'apps/studio/dist/bffless/skills',
+    );
+  });
+
+  it('falls back to the project skills path when the step declares none', async () => {
+    const { handler, skillsService } = createHandler();
+
+    await handler.execute(
+      deploymentContext(),
+      completionStep({
+        messageField: 'steps.prep.prompt',
+        skills: { mode: 'selected', enabled: ['image-prompts'] },
+      }),
+    );
+
+    expect(skillsService.listSkills).toHaveBeenCalledWith(
+      'bffless',
+      'studio',
+      'sha-serving',
+      'skills',
+    );
+  });
+
+  it("resolves the commit SHA from the step's own skills alias", async () => {
+    const { handler, projectAISettingsService, skillsService } = createHandler();
+    projectAISettingsService.resolveSkillsCommitSha.mockResolvedValue('sha-from-alias');
+
+    await handler.execute(
+      deploymentContext(),
+      completionStep({
+        messageField: 'steps.prep.prompt',
+        skills: { mode: 'selected', enabled: ['image-prompts'], alias: 'skills-only' },
+      }),
+    );
+
+    expect(projectAISettingsService.resolveSkillsCommitSha).toHaveBeenCalledWith(
+      'proj-1',
+      'sha-serving',
+      'skills-only',
+    );
+    expect(skillsService.listSkills).toHaveBeenCalledWith(
+      'bffless',
+      'studio',
+      'sha-from-alias',
+      'skills',
+    );
   });
 });

--- a/apps/backend/src/pipelines/handlers/ai.handler.ts
+++ b/apps/backend/src/pipelines/handlers/ai.handler.ts
@@ -326,14 +326,19 @@ export class AIHandler implements StepHandler<AIHandlerConfig> {
 
     if (config.skills?.mode !== 'none' && context.deployment) {
       const { owner, repo } = context.deployment;
-      // Use the project's configured skills alias if set; otherwise load skills
-      // from the deployment serving this request.
+      // Source resolution is step-first: this step's own alias/path win, then
+      // the project-wide settings, then the deployment serving this request.
+      // Keeping it per-step is what lets two AI steps in one project load
+      // skills from different deployments or directories.
       const commitSha =
         (await this.projectAISettingsService.resolveSkillsCommitSha(
           context.projectId,
           context.deployment.commitSha,
+          config.skills?.alias,
         )) ?? context.deployment.commitSha;
-      const skillsPath = await this.projectAISettingsService.getSkillsPath(context.projectId);
+      const skillsPath =
+        config.skills?.path?.trim() ||
+        (await this.projectAISettingsService.getSkillsPath(context.projectId));
       this.logger.debug(
         `Skills source for project ${context.projectId}: ${commitSha?.substring(0, 8)} (path: ${skillsPath})`,
       );

--- a/apps/backend/src/projects/project-ai-settings.service.ts
+++ b/apps/backend/src/projects/project-ai-settings.service.ts
@@ -756,15 +756,19 @@ export class ProjectAISettingsService {
 
   /**
    * Resolve the commit SHA that skills should be loaded from for a project.
-   * If a skills alias is configured and resolves to a deployment, that SHA is
-   * returned; otherwise the provided fallback (e.g. the serving deployment's
-   * SHA at runtime) is returned.
+   * If a skills alias resolves to a deployment, that SHA is returned; otherwise
+   * the provided fallback (e.g. the serving deployment's SHA at runtime).
+   *
+   * `aliasOverride` is the alias declared on an individual pipeline step, which
+   * wins over the project-wide setting so two AI steps in one project can load
+   * skills from different deployments.
    */
   async resolveSkillsCommitSha(
     projectId: string,
     fallbackCommitSha?: string,
+    aliasOverride?: string,
   ): Promise<string | undefined> {
-    const alias = await this.getSkillsAlias(projectId);
+    const alias = aliasOverride?.trim() || (await this.getSkillsAlias(projectId));
     if (alias) {
       const [record] = await db
         .select({ commitSha: deploymentAliases.commitSha })

--- a/apps/backend/src/projects/projects.controller.spec.ts
+++ b/apps/backend/src/projects/projects.controller.spec.ts
@@ -15,4 +15,70 @@ describe('ProjectsController', () => {
       expect(guardNames).toEqual(expect.arrayContaining(['ApiKeyGuard', 'RolesGuard']));
     });
   });
+
+  // The skills picker in the pipeline editor lists what a *step's* path resolves
+  // to. Without these overrides it would answer from the project-wide setting,
+  // so an author typing a per-step path would see a stale (usually empty) list
+  // with no clue why — the same silent miss that made this bug hard to spot.
+  describe('listSkills source overrides', () => {
+    function createController(overrides: Record<string, unknown> = {}) {
+      const skillsService = { listSkills: jest.fn().mockResolvedValue([]) };
+      const aiSettingsService = {
+        resolveSkillsCommitSha: jest.fn().mockResolvedValue('sha-project'),
+        getSkillsPath: jest.fn().mockResolvedValue('.bffless/skills'),
+        ...overrides,
+      };
+      const projectsService = {
+        getProjectById: jest.fn().mockResolvedValue({ owner: 'bffless', name: 'studio' }),
+      };
+      const controller = new ProjectsController(
+        projectsService as never,
+        aiSettingsService as never,
+        {} as never,
+        skillsService as never,
+        {} as never,
+        {} as never,
+        {} as never,
+      );
+      return { controller, skillsService, aiSettingsService };
+    }
+
+    it('lists from the requested path instead of the project setting', async () => {
+      const { controller, skillsService } = createController();
+
+      await controller.listSkills('proj-1', undefined, 'apps/studio/dist/bffless/skills');
+
+      expect(skillsService.listSkills).toHaveBeenCalledWith(
+        'bffless',
+        'studio',
+        'sha-project',
+        'apps/studio/dist/bffless/skills',
+      );
+    });
+
+    it('resolves the commit SHA from the requested alias', async () => {
+      const { controller, aiSettingsService } = createController();
+
+      await controller.listSkills('proj-1', undefined, undefined, 'skills-only');
+
+      expect(aiSettingsService.resolveSkillsCommitSha).toHaveBeenCalledWith(
+        'proj-1',
+        undefined,
+        'skills-only',
+      );
+    });
+
+    it('falls back to the project path when no override is given', async () => {
+      const { controller, skillsService } = createController();
+
+      await controller.listSkills('proj-1');
+
+      expect(skillsService.listSkills).toHaveBeenCalledWith(
+        'bffless',
+        'studio',
+        'sha-project',
+        '.bffless/skills',
+      );
+    });
+  });
 });

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -194,6 +194,8 @@ export class ProjectsController {
   async listSkills(
     @Param('id') projectId: string,
     @Query('commitSha') commitSha?: string,
+    @Query('path') path?: string,
+    @Query('alias') alias?: string,
     @CurrentUser('id') userId?: string,
   ): Promise<{ skills: SkillSummary[] }> {
     const project = await this.projectsService.getProjectById(projectId);
@@ -201,9 +203,14 @@ export class ProjectsController {
       throw new NotFoundException('Project not found');
     }
 
+    // `?path` and `?alias` let the pipeline editor preview what a single step's
+    // source resolves to, before that step is saved. Both fall back to the
+    // project-wide settings when absent, which is what a project-level skills
+    // picker (and every pre-existing caller) gets.
+    //
     // Resolve commitSha in priority order:
     //   1. explicit ?commitSha query param
-    //   2. the project's configured skills alias (settings.skillsAlias)
+    //   2. ?alias, else the project's skills alias (settings.skillsAlias)
     //   3. the 'production' alias
     //   4. the most recent deployment
     // Steps 3-4 are sensible defaults for when no skills alias is configured;
@@ -211,7 +218,11 @@ export class ProjectsController {
     // 'production' (e.g. 'studio').
     let sha = commitSha;
     if (!sha) {
-      sha = await this.aiSettingsService.resolveSkillsCommitSha(projectId);
+      sha = await this.aiSettingsService.resolveSkillsCommitSha(
+        projectId,
+        undefined,
+        alias,
+      );
     }
     if (!sha) {
       try {
@@ -236,7 +247,8 @@ export class ProjectsController {
       return { skills: [] };
     }
 
-    const skillsPath = await this.aiSettingsService.getSkillsPath(projectId);
+    const skillsPath =
+      path?.trim() || (await this.aiSettingsService.getSkillsPath(projectId));
     const skills = await this.skillsService.listSkills(
       project.owner,
       project.name,

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
@@ -253,6 +253,72 @@ describe('ProxyRulesController', () => {
         expect.anything(),
       );
     });
+
+    // "Test" must load skills from the same deployment production would, or a
+    // rule that works in the editor breaks live (and vice versa).
+    describe('skills deployment context', () => {
+      const aiStepRule = (skills: Record<string, unknown>) =>
+        createMockPipelineRule({
+          pipelineConfig: {
+            name: 'Test Pipeline',
+            steps: [
+              { id: 'draft', handlerType: 'ai_handler', config: { skills }, isEnabled: true },
+            ],
+          },
+        });
+
+      beforeEach(() => {
+        mockProjectsService.getProjectById.mockResolvedValue({
+          owner: 'bffless',
+          name: 'studio',
+        } as never);
+        mockDeploymentsService.resolveAlias.mockResolvedValue('sha-1' as never);
+      });
+
+      it("resolves the step's own skills alias instead of production", async () => {
+        mockProxyRulesService.getRuleById.mockResolvedValue(
+          aiStepRule({ mode: 'selected', enabled: ['image-prompts'], alias: 'studio' }),
+        );
+
+        await controller.testPipelineRule('rule-1', {}, mockUser, { file: undefined } as any);
+
+        expect(mockDeploymentsService.resolveAlias).toHaveBeenCalledWith(
+          'bffless/studio',
+          'studio',
+        );
+      });
+
+      it('still falls back to production when no step declares an alias', async () => {
+        mockProxyRulesService.getRuleById.mockResolvedValue(
+          aiStepRule({ mode: 'selected', enabled: ['image-prompts'] }),
+        );
+
+        await controller.testPipelineRule('rule-1', {}, mockUser, { file: undefined } as any);
+
+        expect(mockDeploymentsService.resolveAlias).toHaveBeenCalledWith(
+          'bffless/studio',
+          'production',
+        );
+      });
+
+      it('lets an explicitly requested alias win over the step config', async () => {
+        mockProxyRulesService.getRuleById.mockResolvedValue(
+          aiStepRule({ mode: 'selected', enabled: ['image-prompts'], alias: 'studio' }),
+        );
+
+        await controller.testPipelineRule(
+          'rule-1',
+          { deploymentAlias: 'staging' },
+          mockUser,
+          { file: undefined } as any,
+        );
+
+        expect(mockDeploymentsService.resolveAlias).toHaveBeenCalledWith(
+          'bffless/studio',
+          'staging',
+        );
+      });
+    });
   });
 
   describe('user role fallback', () => {

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.ts
@@ -297,18 +297,30 @@ export class ProxyRulesController {
     let deployment: { owner: string; repo: string; commitSha: string; alias?: string } | undefined;
 
     // Check if skills are configured in any step
-    const hasSkillsConfig = (pipelineConfig.steps || []).some(
+    const skillsSteps = (pipelineConfig.steps || []).filter(
       (step) => step.config?.skills && (step.config.skills as any).mode !== 'none',
     );
+    const hasSkillsConfig = skillsSteps.length > 0;
+
+    // A step may name the alias its skills live on. Honour it here so "Test"
+    // reads from the same deployment the live request would — otherwise a rule
+    // that passes in the editor can still find no skills in production.
+    const stepSkillsAlias = skillsSteps
+      .map((step) => (step.config?.skills as any)?.alias)
+      .find((alias): alias is string => typeof alias === 'string' && alias.trim() !== '')
+      ?.trim();
 
     // Check if any step requires deployment context (file uploads need owner/repo for storage keys)
     const needsDeploymentContext = (pipelineConfig.steps || []).some(
       (step) => step.handlerType === 'file_upload_handler' || step.handlerType === 'file_serve_handler',
     );
 
-    // Use provided alias, or fallback to "production" if skills or deployment context are needed
+    // Explicit request wins, then a step's own skills alias, then "production"
+    // when skills or deployment context are needed at all.
     const aliasToResolve =
-      dto.deploymentAlias || (hasSkillsConfig || needsDeploymentContext ? 'production' : undefined);
+      dto.deploymentAlias ||
+      stepSkillsAlias ||
+      (hasSkillsConfig || needsDeploymentContext ? 'production' : undefined);
 
     if (aliasToResolve) {
       const project = await this.projectsService.getProjectById(ruleSet.projectId);

--- a/apps/frontend/src/components/pipelines/handlers/SkillsConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/SkillsConfig.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const listSkillsQuery = vi.fn();
+const setSkillsPath = vi.fn();
+const setSkillsAlias = vi.fn();
+
+vi.mock('@/services/projectsApi', () => ({
+  useListProjectSkillsQuery: (args: unknown) => {
+    listSkillsQuery(args);
+    return { data: { skills: [{ name: 'image-prompts', description: 'thumbnails' }] }, isLoading: false };
+  },
+  useGetProjectSkillsPathQuery: () => ({ data: { skillsPath: '.bffless/skills' } }),
+  useSetProjectSkillsPathMutation: () => [setSkillsPath, { isLoading: false }],
+  useGetProjectByIdQuery: () => ({ data: { owner: 'bffless', name: 'studio' } }),
+  useGetProjectSkillsAliasQuery: () => ({ data: { skillsAlias: null } }),
+  useSetProjectSkillsAliasMutation: () => [setSkillsAlias],
+}));
+
+vi.mock('@/services/repoApi', () => ({
+  useListAliasesQuery: () => ({ data: { aliases: [{ name: 'studio' }, { name: 'production' }] } }),
+}));
+
+const { SkillsConfig } = await import('./SkillsConfig');
+
+describe('SkillsConfig — step-scoped source', () => {
+  beforeEach(() => {
+    listSkillsQuery.mockClear();
+    setSkillsPath.mockClear();
+    setSkillsAlias.mockClear();
+  });
+
+  it('edits the path into the step config rather than the project setting', async () => {
+    const onChange = vi.fn();
+    render(
+      <SkillsConfig config={{ mode: 'selected', enabled: [] }} onChange={onChange} projectId="proj-1" />,
+    );
+
+    await userEvent.type(screen.getByPlaceholderText('.bffless/skills'), 'x');
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ path: 'x' }));
+    // The old separate Save button wrote a project-wide setting that silently
+    // reconfigured every other AI step in the project.
+    expect(setSkillsPath).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+  });
+
+  it("lists skills from the step's own path and alias", () => {
+    render(
+      <SkillsConfig
+        config={{ mode: 'selected', enabled: [], path: 'apps/studio/dist/bffless/skills', alias: 'studio' }}
+        onChange={vi.fn()}
+        projectId="proj-1"
+      />,
+    );
+
+    expect(listSkillsQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'proj-1',
+        path: 'apps/studio/dist/bffless/skills',
+        alias: 'studio',
+      }),
+    );
+  });
+
+  it('shows the project default as the placeholder when the step sets no path', () => {
+    render(
+      <SkillsConfig config={{ mode: 'selected', enabled: [] }} onChange={vi.fn()} projectId="proj-1" />,
+    );
+
+    expect(screen.getByPlaceholderText('.bffless/skills')).toHaveValue('');
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/SkillsConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/SkillsConfig.tsx
@@ -1,16 +1,12 @@
-import { useState, useEffect } from 'react';
 import {
   useListProjectSkillsQuery,
   useGetProjectSkillsPathQuery,
-  useSetProjectSkillsPathMutation,
-  useGetProjectByIdQuery,
   useGetProjectSkillsAliasQuery,
-  useSetProjectSkillsAliasMutation,
+  useGetProjectByIdQuery,
 } from '@/services/projectsApi';
 import { useListAliasesQuery } from '@/services/repoApi';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
 import {
   Select,
   SelectContent,
@@ -21,11 +17,17 @@ import {
 import { Checkbox } from '@/components/ui/checkbox';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Info, Check } from 'lucide-react';
+import { Info } from 'lucide-react';
 
 export interface SkillsConfigValue {
   mode: 'none' | 'all' | 'selected';
   enabled?: string[];
+  /** Directory in the deployment holding SKILL.md files. Inherits the
+   *  project-wide default when empty. */
+  path?: string;
+  /** Deployment alias to load skills from. Inherits the project-wide default,
+   *  then the deployment serving the request, when empty. */
+  alias?: string;
 }
 
 interface SkillsConfigProps {
@@ -34,47 +36,33 @@ interface SkillsConfigProps {
   projectId: string;
 }
 
+const AUTO = '__auto__';
+
 export function SkillsConfig({ config, onChange, projectId }: SkillsConfigProps) {
-  const { data, isLoading } = useListProjectSkillsQuery({ projectId });
-  const { data: pathData } = useGetProjectSkillsPathQuery({ projectId });
-  const [setSkillsPath, { isLoading: isSaving }] = useSetProjectSkillsPathMutation();
-  const [localPath, setLocalPath] = useState('');
-  const [saved, setSaved] = useState(false);
+  // Both source controls live on the step and save with the rule. The project
+  // settings below are read-only here — they only supply the inherited default
+  // shown when a step leaves a field blank.
+  const { data: projectPathData } = useGetProjectSkillsPathQuery({ projectId });
+  const { data: projectAliasData } = useGetProjectSkillsAliasQuery({ projectId });
+  const projectPath = projectPathData?.skillsPath || '.bffless/skills';
+  const projectAlias = projectAliasData?.skillsAlias || null;
+
+  const { data, isLoading } = useListProjectSkillsQuery({
+    projectId,
+    path: config.path?.trim() || undefined,
+    alias: config.alias?.trim() || undefined,
+  });
   const skills = data?.skills ?? [];
 
-  // Skills alias: which deployment alias to load skills from
   const { data: project } = useGetProjectByIdQuery(projectId);
   const { data: aliasesData } = useListAliasesQuery(
     { owner: project?.owner ?? '', repo: project?.name ?? '' },
     { skip: !project?.owner || !project?.name },
   );
-  const { data: aliasData } = useGetProjectSkillsAliasQuery({ projectId });
-  const [setSkillsAlias] = useSetProjectSkillsAliasMutation();
   const aliases = aliasesData?.aliases ?? [];
-  const AUTO = '__auto__';
-  const selectedAlias = aliasData?.skillsAlias || AUTO;
 
-  const handleAliasChange = async (value: string) => {
-    await setSkillsAlias({
-      projectId,
-      skillsAlias: value === AUTO ? null : value,
-    });
-  };
-
-  useEffect(() => {
-    if (pathData?.skillsPath) {
-      setLocalPath(pathData.skillsPath);
-    }
-  }, [pathData?.skillsPath]);
-
-  const handleSavePath = async () => {
-    if (!localPath.trim()) return;
-    await setSkillsPath({ projectId, skillsPath: localPath.trim() });
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
-  };
-
-  const isDirty = pathData?.skillsPath !== localPath;
+  const effectivePath = config.path?.trim() || projectPath;
+  const noSkillsFound = config.mode === 'selected' && !isLoading && skills.length === 0;
 
   return (
     <div className="space-y-4">
@@ -105,12 +93,21 @@ export function SkillsConfig({ config, onChange, projectId }: SkillsConfigProps)
       {config.mode !== 'none' && (
         <div className="space-y-2">
           <Label>Skills Source (Alias)</Label>
-          <Select value={selectedAlias} onValueChange={handleAliasChange}>
+          <Select
+            value={config.alias || AUTO}
+            onValueChange={(v) =>
+              onChange({ ...config, alias: v === AUTO ? undefined : v })
+            }
+          >
             <SelectTrigger>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={AUTO}>Auto (serving deployment)</SelectItem>
+              <SelectItem value={AUTO}>
+                {projectAlias
+                  ? `Inherit project default (${projectAlias})`
+                  : 'Auto (serving deployment)'}
+              </SelectItem>
               {aliases.map((a) => (
                 <SelectItem key={a.name} value={a.name}>
                   {a.name}
@@ -119,9 +116,9 @@ export function SkillsConfig({ config, onChange, projectId }: SkillsConfigProps)
             </SelectContent>
           </Select>
           <p className="text-xs text-muted-foreground">
-            Which deployment alias to load <code className="bg-muted px-1 rounded">SKILL.md</code> files
-            from. <strong>Auto</strong> uses whichever deployment serves the request at runtime; pick a
-            specific alias to always load skills from there (e.g. a dedicated skills deployment).
+            Which deployment alias this step loads{' '}
+            <code className="bg-muted px-1 rounded">SKILL.md</code> files from. Saved with the
+            rule, so each AI step can use its own.
           </p>
         </div>
       )}
@@ -129,25 +126,19 @@ export function SkillsConfig({ config, onChange, projectId }: SkillsConfigProps)
       {config.mode !== 'none' && (
         <div className="space-y-2">
           <Label>Skills Path</Label>
-          <div className="flex gap-2">
-            <Input
-              value={localPath}
-              onChange={(e) => { setLocalPath(e.target.value); setSaved(false); }}
-              placeholder=".bffless/skills"
-              className="font-mono text-sm"
-            />
-            <Button
-              size="sm"
-              variant={saved ? 'default' : 'outline'}
-              onClick={handleSavePath}
-              disabled={!isDirty || isSaving}
-            >
-              {saved ? <Check className="h-4 w-4" /> : 'Save'}
-            </Button>
-          </div>
+          <Input
+            value={config.path ?? ''}
+            onChange={(e) => onChange({ ...config, path: e.target.value || undefined })}
+            placeholder={projectPath}
+            className="font-mono text-sm"
+          />
           <p className="text-xs text-muted-foreground">
-            Path within the deployment where <code className="bg-muted px-1 rounded">SKILL.md</code> files
-            are located. Useful for monorepos where skills aren't at the root.
+            Path within the deployment where{' '}
+            <code className="bg-muted px-1 rounded">SKILL.md</code> files live. Leave blank to
+            inherit the project default (
+            <code className="bg-muted px-1 rounded">{projectPath}</code>). An app served under a
+            base path publishes skills to a non-hidden directory — e.g.{' '}
+            <code className="bg-muted px-1 rounded">apps/studio/dist/bffless/skills</code>.
           </p>
         </div>
       )}
@@ -157,12 +148,16 @@ export function SkillsConfig({ config, onChange, projectId }: SkillsConfigProps)
           <Label>Enabled Skills</Label>
           {isLoading ? (
             <Skeleton className="h-20" />
-          ) : skills.length === 0 ? (
-            <Alert>
+          ) : noSkillsFound ? (
+            // Loud on purpose: an unresolvable path used to fail silently at
+            // runtime, with the model inventing a skill it never loaded.
+            <Alert variant="destructive">
               <Info className="h-4 w-4" />
               <AlertDescription>
-                No skills found. Add <code className="bg-muted px-1 rounded">SKILL.md</code> files
-                to <code className="bg-muted px-1 rounded">{localPath || '.bffless/skills/'}</code> in your deployment.
+                No <code className="bg-muted px-1 rounded">SKILL.md</code> files found under{' '}
+                <code className="bg-muted px-1 rounded">{effectivePath}</code>
+                {config.alias ? ` on alias "${config.alias}"` : ''}. This step will run with no
+                skills loaded — check the path against your deployment's files.
               </AlertDescription>
             </Alert>
           ) : (

--- a/apps/frontend/src/services/projectsApi.ts
+++ b/apps/frontend/src/services/projectsApi.ts
@@ -469,12 +469,20 @@ export const projectsApi = api.injectEndpoints({
     // Skills endpoint
     listProjectSkills: builder.query<
       { skills: SkillSummary[] },
-      { projectId: string; commitSha?: string }
+      { projectId: string; commitSha?: string; path?: string; alias?: string }
     >({
-      query: ({ projectId, commitSha }) => ({
-        url: `/api/projects/${projectId}/ai/skills`,
-        params: commitSha ? { commitSha } : undefined,
-      }),
+      // `path`/`alias` preview what a single pipeline step's source resolves to;
+      // omitting them falls back to the project-wide settings server-side.
+      query: ({ projectId, commitSha, path, alias }) => {
+        const params: Record<string, string> = {};
+        if (commitSha) params.commitSha = commitSha;
+        if (path) params.path = path;
+        if (alias) params.alias = alias;
+        return {
+          url: `/api/projects/${projectId}/ai/skills`,
+          params: Object.keys(params).length ? params : undefined,
+        };
+      },
       providesTags: (_result, _error, { projectId }) => [
         { type: 'ProjectAI' as const, id: `${projectId}-skills` },
       ],


### PR DESCRIPTION
## The bug

The **Skills Path** and **Skills Source** controls render inside a pipeline's AI step, but they were never part of the rule. Each had its own `Save` button writing a *project-wide* setting (`projects.settings.skillsPath` / `skillsAlias`).

Three consequences:

1. **Two AI steps in one project shared one path and one alias** — last save wins, silently reconfiguring the other step.
2. **The value never travelled in the rule**, so a rule set exported as code or installed from the app catalog could not carry its own skills location. Studio ships a `point-skills-path` manual step purely to work around this.
3. **The default `.bffless/skills` can never match an app served under a base path** — `deployments.service.ts` drops any zip entry containing `/.`, so such apps must publish skills to a non-hidden directory (Studio uses `apps/studio/dist/bffless/skills`).

The failure was silent: `listSkills` returned nothing, no `load_skill` tool was injected, and the model invented a skill it had never read.

## The change

`skills` on an `ai_handler` step gains optional `path` and `alias`. Resolution is **step-first, falling back to the project settings** — existing rules behave exactly as before, so there is no migration and no behaviour change for live projects.

- `step-handler.interface.ts` — `skills.path` / `skills.alias` on the step config
- `ai.handler.ts` — step value wins over the project setting
- `project-ai-settings.service.ts` — `resolveSkillsCommitSha` takes an alias override
- `projects.controller.ts` — `GET :id/ai/skills` accepts `?path` / `?alias` so the picker previews a *step's* source instead of answering from the project setting
- `proxy-rules.controller.ts` — rule test-runs honour the step's alias, so "Test" reads from the deployment production would
- `SkillsConfig.tsx` — both controls save with the rule; the separate Save button is gone, the project value becomes the inherited placeholder, and an unresolvable path now shows a destructive alert instead of failing silently

No CLI change needed — `PipelineStepManifestSchema.config` is already `z.record(z.unknown())`, so rules-as-code round-trips the new fields.

## Verification

- backend: 2948 passed, 37 skipped, 163 suites
- frontend: 874 passed, 82 files
- `tsc --noEmit` clean on both apps

New tests cover step-over-project precedence, the project fallback, alias-driven SHA resolution, the `?path`/`?alias` query overrides, and the test-run alias — each written failing first.

## Follow-up (not in this PR)

`docs-public` `docs/features/ai-pipelines.md:317` says the skills path lives in *Settings → AI → Skills Path*. That was already wrong and is now more so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147JaquQw1asQbLWJuC8GYx
