### PR TITLE
fix: resolve Replicate file inputs held in arrays

### DIFF
--- a/apps/backend/src/pipelines/handlers/replicate.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/replicate.handler.spec.ts
@@ -1,0 +1,156 @@
+import { ReplicateHandler } from './replicate.handler';
+import { ExpressionEvaluator } from '../execution/expression-evaluator';
+import { PipelineContext } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+
+/**
+ * Image models take their reference images as an *array* of URIs
+ * (`google/nano-banana-2`'s `image_input`, for one). Storage paths inside such
+ * an array have to be resolved the same way a bare string input is, or the raw
+ * path reaches Replicate and the prediction fails.
+ */
+function createHandler(download: Buffer = Buffer.from('png-bytes')) {
+  const registry = { register: jest.fn() };
+  const projectAISettingsService = {
+    getServiceConfig: jest.fn().mockResolvedValue({ apiToken: 'r8-test' }),
+  };
+  const storageAdapter = { download: jest.fn().mockResolvedValue(download) };
+  const handler = new ReplicateHandler(
+    registry as never,
+    new ExpressionEvaluator(),
+    projectAISettingsService as never,
+    storageAdapter as never,
+  );
+  return { handler, storageAdapter };
+}
+
+/**
+ * The expression evaluator has no array literal syntax, so a rule supplies an
+ * array input by referencing a prior step's output (`steps.prep.images`) — a
+ * `function_handler` that returns the list. That's the shape real rules use, so
+ * it's the shape these tests exercise.
+ */
+function createContext(images: unknown = []): PipelineContext {
+  return {
+    request: { body: {} } as never,
+    stepOutputs: { prep: { images } },
+    projectId: 'proj-1',
+    pipelineId: 'pipe-1',
+    deployment: { owner: 'bffless', repo: 'studio', commitSha: 'sha-1' },
+    metadata: { path: '/x', method: 'POST', headers: {}, query: {}, body: {} },
+  } as PipelineContext;
+}
+
+function step(input: Record<string, unknown>): PipelineStep {
+  return {
+    id: 'generate',
+    name: 'generate',
+    handlerType: 'replicate',
+    config: {
+      model: 'google/nano-banana-2',
+      // Pin the version so execute() doesn't make a lookup request first.
+      version: 'google/nano-banana-2:abc123',
+      input,
+    },
+  } as PipelineStep;
+}
+
+/** The `input` object actually POSTed to Replicate's predictions endpoint. */
+function sentInput(): Record<string, unknown> {
+  const call = (global.fetch as jest.Mock).mock.calls.find(([url]) =>
+    String(url).endsWith('/predictions'),
+  );
+  return JSON.parse(call[1].body).input;
+}
+
+describe('ReplicateHandler — file inputs', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'pred-1', status: 'succeeded', output: 'https://out.test/i.png' }),
+    }) as never;
+  });
+
+  it('resolves a storage path held in an array input', async () => {
+    const { handler, storageAdapter } = createHandler();
+
+    await handler.execute(
+      createContext(['bffless/studio/uploads/thumbnails/face.png']),
+      step({ prompt: "'a thumbnail'", image_input: 'steps.prep.images' }),
+    );
+
+    expect(storageAdapter.download).toHaveBeenCalledWith(
+      'bffless/studio/uploads/thumbnails/face.png',
+    );
+    expect(sentInput().image_input).toEqual([
+      `data:image/png;base64,${Buffer.from('png-bytes').toString('base64')}`,
+    ]);
+  });
+
+  it('resolves an /api/uploads serve path held in an array input', async () => {
+    const { handler, storageAdapter } = createHandler();
+
+    await handler.execute(
+      createContext(['/api/uploads/thumbnails/face.png']),
+      step({ prompt: "'x'", image_input: 'steps.prep.images' }),
+    );
+
+    expect(storageAdapter.download).toHaveBeenCalledWith(
+      'bffless/studio/uploads/thumbnails/face.png',
+    );
+  });
+
+  it('leaves plain https entries in an array untouched', async () => {
+    const { handler, storageAdapter } = createHandler();
+
+    await handler.execute(
+      createContext(['https://cdn.test/face.png']),
+      step({ prompt: "'x'", image_input: 'steps.prep.images' }),
+    );
+
+    expect(storageAdapter.download).not.toHaveBeenCalled();
+    expect(sentInput().image_input).toEqual(['https://cdn.test/face.png']);
+  });
+
+  it('passes an empty array through unchanged', async () => {
+    const { handler } = createHandler();
+
+    await handler.execute(
+      createContext([]),
+      step({ prompt: "'x'", image_input: 'steps.prep.images' }),
+    );
+
+    expect(sentInput().image_input).toEqual([]);
+  });
+
+  it('resolves only the storage entries in a mixed array, in order', async () => {
+    const { handler } = createHandler();
+
+    await handler.execute(
+      createContext([
+        'https://cdn.test/a.png',
+        'bffless/studio/uploads/thumbnails/face.png',
+      ]),
+      step({ prompt: "'x'", image_input: 'steps.prep.images' }),
+    );
+
+    expect(sentInput().image_input).toEqual([
+      'https://cdn.test/a.png',
+      `data:image/png;base64,${Buffer.from('png-bytes').toString('base64')}`,
+    ]);
+  });
+
+  it('still resolves a bare string input (regression)', async () => {
+    const { handler, storageAdapter } = createHandler();
+
+    await handler.execute(
+      createContext(),
+      step({ prompt: "'x'", image: "'bffless/studio/uploads/thumbnails/face.png'" }),
+    );
+
+    expect(storageAdapter.download).toHaveBeenCalledWith(
+      'bffless/studio/uploads/thumbnails/face.png',
+    );
+    expect(sentInput().image).toMatch(/^data:image\/png;base64,/);
+  });
+});

--- a/apps/backend/src/pipelines/handlers/replicate.handler.ts
+++ b/apps/backend/src/pipelines/handlers/replicate.handler.ts
@@ -211,32 +211,54 @@ export class ReplicateHandler implements StepHandler<ReplicateHandlerConfig> {
     apiToken: string,
   ): Promise<void> {
     for (const [key, value] of Object.entries(input)) {
-      if (typeof value !== 'string') continue;
-
-      // Skip if already a URL (http/https) or data URI
-      if (value.startsWith('http://') || value.startsWith('https://') || value.startsWith('data:')) {
+      // Image models take reference images as an array of URIs (e.g.
+      // google/nano-banana-2's `image_input`), so resolve element-wise too —
+      // otherwise a storage path inside the array reaches Replicate raw.
+      if (Array.isArray(value)) {
+        input[key] = await Promise.all(
+          value.map((entry) => this.resolveFileValue(entry, context, apiToken)),
+        );
         continue;
       }
 
-      let storagePath: string | null = null;
-
-      // Pattern 1: Storage path (contains "uploads/" with owner/repo prefix)
-      if (value.includes('/uploads/') && value.includes('/')) {
-        storagePath = value;
-      }
-
-      // Pattern 2: Internal API URL like "/api/uploads/sub_dir/uuid-file.png"
-      if (!storagePath && value.startsWith('/api/uploads/')) {
-        storagePath = this.resolveApiUrlToStoragePath(value, context);
-      }
-
-      if (!storagePath) continue;
-
-      const resolved = await this.resolveStorageFile(storagePath, context, apiToken);
-      if (resolved) {
-        input[key] = resolved;
-      }
+      input[key] = await this.resolveFileValue(value, context, apiToken);
     }
+  }
+
+  /**
+   * Resolve one input value: a storage path or internal `/api/uploads/...` URL
+   * becomes a data URI or Replicate Files URL; anything else is returned as-is.
+   */
+  private async resolveFileValue(
+    value: unknown,
+    context: PipelineContext,
+    apiToken: string,
+  ): Promise<unknown> {
+    if (typeof value !== 'string') return value;
+
+    // Skip if already a URL (http/https) or data URI
+    if (value.startsWith('http://') || value.startsWith('https://') || value.startsWith('data:')) {
+      return value;
+    }
+
+    let storagePath: string | null = null;
+
+    // Pattern 1: Internal API URL like "/api/uploads/sub_dir/uuid-file.png".
+    // Checked FIRST because it also contains "/uploads/" — matching the bare
+    // storage-path pattern below would hand storage the un-prefixed API URL.
+    if (value.startsWith('/api/uploads/')) {
+      storagePath = this.resolveApiUrlToStoragePath(value, context);
+    }
+
+    // Pattern 2: Storage path (contains "uploads/" with owner/repo prefix)
+    if (!storagePath && value.includes('/uploads/') && value.includes('/')) {
+      storagePath = value;
+    }
+
+    if (!storagePath) return value;
+
+    const resolved = await this.resolveStorageFile(storagePath, context, apiToken);
+    return resolved ?? value;
   }
 
   /**


### PR DESCRIPTION
## The bug

`ReplicateHandler.resolveFileInputs` auto-resolves a storage path (or internal `/api/uploads/...` URL) into a data URI or Replicate Files URL — but only for **string** input values:

```ts
if (typeof value !== 'string') continue;
```

Image models take their reference images as an **array** of URIs. `google/nano-banana-2` declares:

```json
"image_input": { "type": "array", "items": {"type":"string","format":"uri"},
                 "default": [], "description": "Input images to transform or use as reference (supports up to 14 images)" }
```

So a storage path inside that array was skipped and passed to Replicate verbatim, and the prediction failed. Only single-file string inputs ever worked.

## The change

Resolution is now element-wise for array values, so an array can mix already-public URLs with storage paths and each is handled independently. Non-string entries and empty arrays pass through untouched.

### Latent bug fixed alongside

The two path patterns were tested in the wrong order, making **Pattern 2 unreachable**:

```ts
// before
if (value.includes('/uploads/') && value.includes('/')) storagePath = value;      // claims it
if (!storagePath && value.startsWith('/api/uploads/')) storagePath = resolve(...) // never runs
```

`/api/uploads/thumbnails/face.png` contains `/uploads/`, so the bare storage-path branch always won and handed the storage adapter an un-prefixed path — despite the function's own doc comment advertising the `/api/uploads/` pattern as supported. The more specific pattern is now checked first. A test covers it.

## Why this matters beyond one model

Any multi-image Replicate model becomes usable from a pipeline without the app having to mint public URLs itself. That matters for give-away apps in particular: CE reads the bytes and uploads them to Replicate, so it works on **every** storage backend, including local-filesystem installs where presigned GET is unavailable.

## Verification

- backend: 2945 passed, 37 skipped, 164 suites
- `tsc --noEmit` clean

New `replicate.handler.spec.ts` (the handler had none) covers array storage paths, array `/api/uploads` paths, https pass-through, empty arrays, mixed arrays preserving order, and a bare-string regression — each written failing first.

Note for rule authors: the expression evaluator has no array-literal syntax, so an array input is supplied by referencing a prior step's output (`image_input: steps.prep.images`) rather than an inline literal. The tests exercise that shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147JaquQw1asQbLWJuC8GYx
