### PR TITLE
fix: stop large app installs OOM-killing the backend

### DIFF
--- a/apps/backend/src/app-catalog/app-bundle.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-bundle.service.spec.ts
@@ -179,6 +179,37 @@ describe('AppBundleService', () => {
       expect(second.manifest).toEqual(TEST_MANIFEST);
     });
 
+    // The cache used to be bounded by entry count alone (3 entries), so three big apps could
+    // pin ~190MB of decompressed bundles in a 384MB container. Retaining a bundle must never
+    // cost more than the byte budget, however few entries that is.
+    it('does not retain a bundle larger than the cache byte budget', async () => {
+      // ~12MB of incompressible payload, over the 8MB budget for a single cached bundle.
+      const big = new Uint8Array(12 * 1024 * 1024);
+      for (let i = 0; i < big.length; i++) big[i] = i % 251;
+      const { buf, sha256 } = makeBundle(TEST_MANIFEST, { 'dist/big.wasm': big });
+      fetchSpy.mockResolvedValue(fetchResponse(buf));
+
+      const first = await service.fetchBundle('https://example.com/big.zip', sha256);
+      const second = await service.fetchBundle('https://example.com/big.zip', sha256);
+
+      // Correct content both times — it just gets re-fetched instead of pinned in memory.
+      expect(first.manifest).toEqual(TEST_MANIFEST);
+      expect(second.manifest).toEqual(TEST_MANIFEST);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    // Small bundles are the common case and must still be cached, so preflight-then-install
+    // does not download twice.
+    it('still caches bundles that fit the byte budget', async () => {
+      const { buf, sha256 } = makeBundle();
+      fetchSpy.mockResolvedValue(fetchResponse(buf));
+
+      await service.fetchBundle('https://example.com/handoff.zip', sha256);
+      await service.fetchBundle('https://example.com/handoff.zip', sha256);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('throws on sha mismatch', async () => {
       const { buf } = makeBundle();
       fetchSpy.mockResolvedValue(fetchResponse(buf));

--- a/apps/backend/src/app-catalog/app-bundle.service.ts
+++ b/apps/backend/src/app-catalog/app-bundle.service.ts
@@ -40,7 +40,50 @@ export class AppBundleService {
   private readonly MAX_BUNDLE_BYTES = 200 * 1024 * 1024;
   private readonly DOWNLOAD_TIMEOUT_MS = 30_000;
   private readonly MAX_CACHE_ENTRIES = 3;
+  /**
+   * Byte ceiling for what the cache may retain, in total and per bundle.
+   *
+   * The cache exists so preflight-then-install downloads once; it is a latency optimisation,
+   * never a correctness requirement. Bounding it by entry count alone let three large apps
+   * pin ~190MB of decompressed bundles inside a 384MB container, which is most of the budget
+   * the install itself needs. A bundle over this size simply isn't cached — it gets
+   * re-downloaded, which is strictly better than an OOM kill.
+   */
+  private readonly MAX_CACHE_BYTES = 8 * 1024 * 1024;
   private readonly cache = new Map<string, LoadedBundle>();
+
+  /** Decompressed size of a bundle's entries — what retaining it actually costs. */
+  private bundleBytes(files: Record<string, Uint8Array>): number {
+    let total = 0;
+    for (const bytes of Object.values(files)) total += bytes.byteLength;
+    return total;
+  }
+
+  /**
+   * Cache a bundle if it is small enough to be worth the memory, evicting least-recently-used
+   * entries until both the byte and entry ceilings hold. A bundle bigger than the whole
+   * budget is never cached rather than evicting everything else to make room for it.
+   */
+  private retain(loaded: LoadedBundle): void {
+    const bytes = this.bundleBytes(loaded.files);
+    if (bytes > this.MAX_CACHE_BYTES) return;
+
+    this.cache.set(loaded.sha256, loaded);
+
+    let total = 0;
+    for (const entry of this.cache.values()) total += this.bundleBytes(entry.files);
+
+    while (
+      this.cache.size > 0 &&
+      (total > this.MAX_CACHE_BYTES || this.cache.size > this.MAX_CACHE_ENTRIES)
+    ) {
+      const oldestKey = this.cache.keys().next().value as string | undefined;
+      if (oldestKey === undefined || oldestKey === loaded.sha256) break;
+      const evicted = this.cache.get(oldestKey);
+      this.cache.delete(oldestKey);
+      if (evicted) total -= this.bundleBytes(evicted.files);
+    }
+  }
 
   async fetchBundle(url: string, expectedSha256: string): Promise<LoadedBundle> {
     if (expectedSha256) {
@@ -147,11 +190,7 @@ export class AppBundleService {
       sha256: actualSha256,
       build: this.readBuildInfo(files),
     };
-    this.cache.set(actualSha256, loaded);
-    if (this.cache.size > this.MAX_CACHE_ENTRIES) {
-      const oldestKey = this.cache.keys().next().value;
-      if (oldestKey !== undefined) this.cache.delete(oldestKey);
-    }
+    this.retain(loaded);
 
     return loaded;
   }

--- a/apps/backend/src/app-catalog/app-catalog.e2e-ish.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.e2e-ish.spec.ts
@@ -148,7 +148,7 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
   let certStep: { plan: jest.Mock; execute: jest.Mock };
   let ruleSets: { syncRuleSet: jest.Mock; delete: jest.Mock };
   let deployments: {
-    createDeploymentFromZip: jest.Mock;
+    createDeploymentFromFiles: jest.Mock;
     deleteDeployment: jest.Mock;
     deleteAlias: jest.Mock;
   };
@@ -185,7 +185,7 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
     certStep = { plan: jest.fn(), execute: jest.fn() }; // unused: the fixture manifest declares no domain
     ruleSets = { syncRuleSet: jest.fn(), delete: jest.fn().mockResolvedValue(undefined) };
     deployments = {
-      createDeploymentFromZip: jest.fn().mockResolvedValue(deployResponse()),
+      createDeploymentFromFiles: jest.fn().mockResolvedValue(deployResponse()),
       deleteDeployment: jest.fn().mockResolvedValue(undefined),
       deleteAlias: jest.fn().mockResolvedValue(undefined),
     };
@@ -300,11 +300,12 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
     expect(finalUpdate.createdResources.ruleSetIds).toEqual(['rs-a', 'rs-b']);
     expect(finalUpdate.createdResources.schemaIdsCreated).toEqual(['sch-items', 'sch-notes']);
 
-    // Real zip built from real bundle bytes: only dist/, re-keyed under basePath.
-    const { unzipSync } = jest.requireActual('fflate') as typeof import('fflate');
-    const zippedFile = deployments.createDeploymentFromZip.mock.calls[0][0] as { buffer: Buffer };
-    const entries = Object.keys(unzipSync(new Uint8Array(zippedFile.buffer))).sort();
-    expect(entries).toEqual(['apps/fixture-app/dist/index.html']);
+    // Real bundle bytes handed over directly: only dist/, re-keyed under basePath.
+    const deployed = deployments.createDeploymentFromFiles.mock.calls[0][0] as Record<
+      string,
+      Uint8Array
+    >;
+    expect(Object.keys(deployed).sort()).toEqual(['apps/fixture-app/dist/index.html']);
   });
 
   it('updates to v2 from real bundle bytes: same alias redeployed, prune false, version bumped', async () => {
@@ -351,7 +352,7 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
         dryRun: false,
         setCreated: false,
       });
-    deployments.createDeploymentFromZip.mockResolvedValue(deployResponse({ deploymentId: 'dep-fixture-2' }));
+    deployments.createDeploymentFromFiles.mockResolvedValue(deployResponse({ deploymentId: 'dep-fixture-2' }));
     mockDb.__queue([]); // final record update — startUpdate takes the row directly, no db read
 
     const { jobId } = service.startUpdate(installedAfterV1, ENTRY_V2, 'user-1', { prune: false });
@@ -378,8 +379,8 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
     expect(ruleSets.syncRuleSet.mock.calls[1][1].options).toEqual(updateOptions);
 
     // Same alias redeployed — not a new one.
-    const [zippedFile, deployDto] = deployments.createDeploymentFromZip.mock.calls[0] as [
-      { buffer: Buffer },
+    const [deployed, deployDto] = deployments.createDeploymentFromFiles.mock.calls[0] as [
+      Record<string, Uint8Array>,
       { alias: string },
     ];
     expect(deployDto.alias).toBe('fixture-app');
@@ -396,10 +397,11 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
     expect(finalUpdate.bundleSha256).toBe(v2.sha256);
     expect(finalUpdate.deploymentId).toBe('dep-fixture-2');
 
-    // Real v2 zip: dist/ changed — index.html content differs and assets/app.js is new.
-    const { unzipSync } = jest.requireActual('fflate') as typeof import('fflate');
-    const entries = Object.keys(unzipSync(new Uint8Array(zippedFile.buffer))).sort();
-    expect(entries).toEqual(['apps/fixture-app/dist/assets/app.js', 'apps/fixture-app/dist/index.html']);
+    // Real v2 bundle: dist/ changed — index.html content differs and assets/app.js is new.
+    expect(Object.keys(deployed).sort()).toEqual([
+      'apps/fixture-app/dist/assets/app.js',
+      'apps/fixture-app/dist/index.html',
+    ]);
   });
 
   describe('uninstall (post v1-install, v2-update state)', () => {

--- a/apps/backend/src/app-catalog/app-installer.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.spec.ts
@@ -195,7 +195,7 @@ describe('AppInstallerService', () => {
   let certStep: { plan: jest.Mock; execute: jest.Mock; schemeFor: jest.Mock };
   let ruleSets: { syncRuleSet: jest.Mock; delete: jest.Mock };
   let deployments: {
-    createDeploymentFromZip: jest.Mock;
+    createDeploymentFromFiles: jest.Mock;
     deleteDeployment: jest.Mock;
     deleteAlias: jest.Mock;
   };
@@ -242,7 +242,7 @@ describe('AppInstallerService', () => {
       delete: jest.fn().mockResolvedValue(undefined),
     };
     deployments = {
-      createDeploymentFromZip: jest.fn().mockResolvedValue(deployResponse()),
+      createDeploymentFromFiles: jest.fn().mockResolvedValue(deployResponse()),
       deleteDeployment: jest.fn().mockResolvedValue(undefined),
       deleteAlias: jest.fn().mockResolvedValue(undefined),
     };
@@ -328,9 +328,9 @@ describe('AppInstallerService', () => {
 
       expect(ruleSets.syncRuleSet).toHaveBeenCalledTimes(2);
       expect(ruleSets.syncRuleSet.mock.invocationCallOrder[1]).toBeLessThan(
-        deployments.createDeploymentFromZip.mock.invocationCallOrder[0],
+        deployments.createDeploymentFromFiles.mock.invocationCallOrder[0],
       );
-      expect(deployments.createDeploymentFromZip.mock.invocationCallOrder[0]).toBeLessThan(
+      expect(deployments.createDeploymentFromFiles.mock.invocationCallOrder[0]).toBeLessThan(
         domains.create.mock.invocationCallOrder[0],
       );
     });
@@ -357,7 +357,7 @@ describe('AppInstallerService', () => {
       service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
       await service.whenIdle();
 
-      const [file, dto, userId, role] = deployments.createDeploymentFromZip.mock.calls[0];
+      const [entries, dto, userId, role] = deployments.createDeploymentFromFiles.mock.calls[0];
       expect(dto.proxyRuleSetNames).toEqual(['handoff']);
       expect(dto.repository).toBe('acme/site');
       expect(dto.alias).toBe('handoff');
@@ -367,8 +367,7 @@ describe('AppInstallerService', () => {
       expect(dto.source).toBe('manual');
       expect(userId).toBe('user-1');
       expect(role).toBe('admin');
-      expect(file.mimetype).toBe('application/zip');
-      expect(Buffer.isBuffer(file.buffer)).toBe(true);
+      expect(Object.values(entries).every((v) => v instanceof Uint8Array)).toBe(true);
     });
 
     // Provenance: a stamped bundle deploys under the commit that produced it, so the SHA in the
@@ -381,7 +380,7 @@ describe('AppInstallerService', () => {
       service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
       await service.whenIdle();
 
-      expect(deployments.createDeploymentFromZip.mock.calls[0][1].commitSha).toBe(commit);
+      expect(deployments.createDeploymentFromFiles.mock.calls[0][1].commitSha).toBe(commit);
     });
 
     // Every app published before the stamp existed. Those must keep deploying exactly as they
@@ -393,7 +392,7 @@ describe('AppInstallerService', () => {
       service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
       await service.whenIdle();
 
-      const { commitSha } = deployments.createDeploymentFromZip.mock.calls[0][1];
+      const { commitSha } = deployments.createDeploymentFromFiles.mock.calls[0][1];
       expect(commitSha).toBe('a'.repeat(40));
       expect(commitSha).toHaveLength(40);
     });
@@ -404,10 +403,25 @@ describe('AppInstallerService', () => {
       service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
       await service.whenIdle();
 
-      const { unzipSync } = jest.requireActual('fflate') as typeof import('fflate');
-      const file = deployments.createDeploymentFromZip.mock.calls[0][0];
-      const entries = Object.keys(unzipSync(new Uint8Array(file.buffer))).sort();
+      const entries = Object.keys(deployments.createDeploymentFromFiles.mock.calls[0][0]).sort();
       expect(entries).toEqual(['apps/handoff/dist/assets/app.js', 'apps/handoff/dist/index.html']);
+    });
+
+    // The deploy step used to re-zip the bundle it had just decompressed, only for the
+    // deployment service to unzip it again — two extra full copies of the payload. Studio's
+    // 63MB bundle made that the difference between installing and an OOM kill, so the
+    // entries must be handed over by reference, never re-encoded.
+    it('hands the bundle bytes to the deployment without re-zipping them', async () => {
+      queueInstallDb();
+
+      service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
+      await service.whenIdle();
+
+      const bundle = await bundleService.fetchBundle.mock.results[0].value;
+      const entries = deployments.createDeploymentFromFiles.mock.calls[0][0];
+
+      // Same underlying Uint8Array objects — no copy was made.
+      expect(entries['apps/handoff/dist/index.html']).toBe(bundle.files['dist/index.html']);
     });
 
     it('creates the app domain with SSL and the manifest visibility flags', async () => {
@@ -824,7 +838,7 @@ describe('AppInstallerService', () => {
 
   describe('deploy verification', () => {
     it('fails the step when the returned aliases do not include the app alias', async () => {
-      deployments.createDeploymentFromZip.mockResolvedValue(deployResponse({ aliases: [] }));
+      deployments.createDeploymentFromFiles.mockResolvedValue(deployResponse({ aliases: [] }));
       queueInstallDb();
 
       const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
@@ -858,7 +872,7 @@ describe('AppInstallerService', () => {
       // Nothing deployed yet at that point.
       expect(afterSync.deploymentId).toBeNull();
       expect(mockDb.set.mock.invocationCallOrder[0]).toBeLessThan(
-        deployments.createDeploymentFromZip.mock.invocationCallOrder[0],
+        deployments.createDeploymentFromFiles.mock.invocationCallOrder[0],
       );
     });
 
@@ -877,7 +891,7 @@ describe('AppInstallerService', () => {
           }),
         )
         .mockResolvedValueOnce(syncResponse({ ruleSetId: 'rs-2' }));
-      deployments.createDeploymentFromZip.mockResolvedValue(deployResponse({ aliases: [] }));
+      deployments.createDeploymentFromFiles.mockResolvedValue(deployResponse({ aliases: [] }));
       queueInstallDb();
 
       service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
@@ -911,7 +925,7 @@ describe('AppInstallerService', () => {
     });
 
     it('stamps installedAppId on a failed job once a row exists, so it can still be undone by jobId', async () => {
-      deployments.createDeploymentFromZip.mockResolvedValue(deployResponse({ aliases: [] }));
+      deployments.createDeploymentFromFiles.mockResolvedValue(deployResponse({ aliases: [] }));
       queueInstallDb();
 
       const { jobId } = service.startInstall(ENTRY, { projectId: 'proj-1' }, 'user-1');
@@ -936,7 +950,7 @@ describe('AppInstallerService', () => {
     });
 
     it('persists a failed update run too', async () => {
-      deployments.createDeploymentFromZip.mockResolvedValue(deployResponse({ aliases: [] }));
+      deployments.createDeploymentFromFiles.mockResolvedValue(deployResponse({ aliases: [] }));
 
       service.startUpdate(
         { ...INSTALLED_ROW, status: 'installed', createdResources: {} } as never,
@@ -1145,7 +1159,7 @@ describe('AppInstallerService', () => {
       expect(job.error).toMatch(/below the required minimum 0\.4\.0/);
       expect(bundleService.fetchBundle).not.toHaveBeenCalled();
       expect(ruleSets.syncRuleSet).not.toHaveBeenCalled();
-      expect(deployments.createDeploymentFromZip).not.toHaveBeenCalled();
+      expect(deployments.createDeploymentFromFiles).not.toHaveBeenCalled();
     });
 
     it('leaves the healthy installed row untouched when a gate refuses the update', async () => {
@@ -1174,7 +1188,7 @@ describe('AppInstallerService', () => {
         prune: true,
         conflictPolicy: 'preserve',
       });
-      expect(deployments.createDeploymentFromZip.mock.calls[0][1].alias).toBe('handoff');
+      expect(deployments.createDeploymentFromFiles.mock.calls[0][1].alias).toBe('handoff');
     });
 
     // Silently KEEPING a local edit is no better than silently discarding one:

--- a/apps/backend/src/app-catalog/app-installer.service.ts
+++ b/apps/backend/src/app-catalog/app-installer.service.ts
@@ -3,7 +3,6 @@ import { ConfigService } from '@nestjs/config';
 import { plainToInstance } from 'class-transformer';
 import { validateSync, type ValidationError } from 'class-validator';
 import { and, eq } from 'drizzle-orm';
-import { zipSync } from 'fflate';
 import { db } from '../db/client';
 import {
   deploymentAliases,
@@ -932,16 +931,12 @@ export class AppInstallerService {
     project: ProjectRef,
     userId: string,
   ) {
-    const zipped = this.buildDistZip(bundle, manifest);
+    const distEntries = this.buildDistEntries(bundle, manifest);
     const alias = manifest.install.alias;
     const attachNames = ruleSets.filter((r) => r.attach).map((r) => r.name);
 
-    const response = await this.deploymentsService.createDeploymentFromZip(
-      {
-        buffer: zipped,
-        originalname: `${manifest.id}-bundle.zip`,
-        mimetype: 'application/zip',
-      } as Express.Multer.File,
+    const response = await this.deploymentsService.createDeploymentFromFiles(
+      distEntries,
       {
         repository: `${project.owner}/${project.name}`,
         // The real source commit when the bundle carries one (bffless/apps#276), so the SHA in
@@ -1319,7 +1314,18 @@ export class AppInstallerService {
    * re-keyed under `basePath` (e.g. `dist/index.html` →
    * `apps/handoff/dist/index.html`) so the alias's basePath resolves.
    */
-  private buildDistZip(bundle: LoadedBundle, manifest: AppManifest): Buffer {
+  /**
+   * Select the bundle's deployable subtree and re-key it under the manifest's basePath.
+   *
+   * Returns the bundle's own byte arrays BY REFERENCE — this used to zip them into a Buffer
+   * that `createDeploymentFromZip` immediately unzipped again, which cost two extra full
+   * copies of the payload and OOM-killed the backend on large bundles (Studio ships two
+   * ~31MB wasm blobs). Nothing here may copy or mutate the bytes.
+   */
+  private buildDistEntries(
+    bundle: LoadedBundle,
+    manifest: AppManifest,
+  ): Record<string, Uint8Array> {
     const prefix = `${manifest.install.deployment.path.replace(/\/+$/, '')}/`;
     const base = manifest.install.deployment.basePath.replace(/^\/+/, '').replace(/\/+$/, '');
 
@@ -1335,7 +1341,7 @@ export class AppInstallerService {
       throw new Error(`Bundle has no files under ${manifest.install.deployment.path}/ to deploy`);
     }
 
-    return Buffer.from(zipSync(entries));
+    return entries;
   }
 
   private applicableManualSteps(

--- a/apps/backend/src/deployments/deployments.service.spec.ts
+++ b/apps/backend/src/deployments/deployments.service.spec.ts
@@ -277,6 +277,68 @@ describe('DeploymentsService', () => {
     });
   });
 
+  // The app installer deploys entries it already holds decompressed, instead of re-zipping
+  // them for createDeploymentFromZip to unzip again (two extra full copies of the payload,
+  // which OOM-killed the backend on large app bundles).
+  describe('createDeploymentFromFiles', () => {
+    const dto = {
+      repository: mockRepository,
+      commitSha: mockCommitSha,
+      branch: 'app-catalog',
+    } as any;
+
+    it('uploads each entry without requiring a zip', async () => {
+      setupMockChain([[], [mockAsset], [], []]);
+
+      const result = await service.createDeploymentFromFiles(
+        {
+          'index.html': new TextEncoder().encode('<!doctype html>hi'),
+          'assets/app.js': new TextEncoder().encode('console.log(1)'),
+        },
+        dto,
+        mockUserId,
+        'admin',
+      );
+
+      expect(mockStorageAdapter.upload).toHaveBeenCalledTimes(2);
+      expect(result.deploymentId).toBeDefined();
+    });
+
+    // The per-file Buffer is now a zero-copy VIEW over the entry's ArrayBuffer. Built with the
+    // one-arg Buffer.from it would copy (32MB per large asset); built carelessly with the
+    // three-arg form it would read the WHOLE backing buffer instead of this entry's slice.
+    // fflate hands back views into shared buffers, so this is a real failure mode.
+    it('uploads exactly the entry bytes when entries are views into a shared buffer', async () => {
+      setupMockChain([[], [mockAsset], [], []]);
+
+      // One backing buffer, two entries at non-zero offsets — as fflate produces.
+      const backing = new Uint8Array([...Array(64).keys()]);
+      const entry = backing.subarray(10, 20);
+
+      await service.createDeploymentFromFiles({ 'a.bin': entry }, dto, mockUserId, 'admin');
+
+      const uploaded = mockStorageAdapter.upload.mock.calls[0][0] as Buffer;
+      expect(uploaded.length).toBe(10);
+      expect(Array.from(uploaded)).toEqual([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
+      // Same backing memory — proves no duplicate allocation was made. Copying here is what
+      // cost ~32MB of peak RSS per large asset.
+      expect(uploaded.buffer).toBe(entry.buffer);
+    });
+
+    it('enforces project write access the same as the zip path', async () => {
+      mockPermissionsService.getUserProjectRole.mockResolvedValue('viewer');
+
+      await expect(
+        service.createDeploymentFromFiles(
+          { 'index.html': new TextEncoder().encode('x') },
+          dto,
+          mockUserId,
+          'user',
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
   describe('getDeployment', () => {
     it('should return deployment details', async () => {
       // Phase 3H.7: Now returns { asset, project } objects from leftJoin

--- a/apps/backend/src/deployments/deployments.service.ts
+++ b/apps/backend/src/deployments/deployments.service.ts
@@ -188,17 +188,7 @@ export class DeploymentsService {
     userId: string,
     userRole?: string,
   ): Promise<CreateDeploymentResponseDto> {
-    // Parse repository string to get owner and name
-    const [owner, name] = dto.repository.split('/');
-    if (!owner || !name) {
-      throw new BadRequestException('Invalid repository format. Expected "owner/repo"');
-    }
-
-    // Find or create project
-    const project = await this.projectsService.findOrCreateProject(owner, name, userId);
-
-    // Phase 3H.6: Check project access with proper permission system
-    await this.checkProjectAccess(project.id, userId, userRole, 'contributor');
+    const project = await this.resolveDeploymentProject(dto.repository, userId, userRole);
 
     if (!file) {
       throw new BadRequestException('No zip file provided');
@@ -214,6 +204,67 @@ export class DeploymentsService {
       throw new BadRequestException('File must be a zip archive');
     }
 
+    let unzipped: Record<string, Uint8Array>;
+    try {
+      // Parse zip with fflate (async, non-blocking - better CPU performance)
+      unzipped = await new Promise<Record<string, Uint8Array>>((resolve, reject) => {
+        unzip(new Uint8Array(file.buffer), (err, result) => {
+          if (err) reject(new BadRequestException(`Failed to parse zip: ${err.message}`));
+          else resolve(result);
+        });
+      });
+    } catch (error) {
+      if (error instanceof BadRequestException) throw error;
+      throw new BadRequestException(`Failed to process zip file: ${error.message}`);
+    }
+
+    return this.deployEntries(unzipped, project, dto, userId);
+  }
+
+  /**
+   * Deploy an already-decompressed set of entries (entry path -> bytes).
+   *
+   * The app installer already holds the bundle's files in memory, so routing it through
+   * `createDeploymentFromZip` meant re-zipping them only for this service to immediately
+   * unzip them again — two extra full copies of the payload. On a 63MB app bundle in a
+   * 384MB container that was the difference between installing and being OOM-killed
+   * (exit 137), so the installer hands its entries straight to this method instead.
+   *
+   * Entries are borrowed: never mutated, never retained past the call.
+   */
+  async createDeploymentFromFiles(
+    entries: Record<string, Uint8Array>,
+    dto: CreateDeploymentZipDto,
+    userId: string,
+    userRole?: string,
+  ): Promise<CreateDeploymentResponseDto> {
+    const project = await this.resolveDeploymentProject(dto.repository, userId, userRole);
+    return this.deployEntries(entries, project, dto, userId);
+  }
+
+  /** Resolve (creating if needed) the project a deployment targets, enforcing write access. */
+  private async resolveDeploymentProject(repository: string, userId: string, userRole?: string) {
+    // Parse repository string to get owner and name
+    const [owner, name] = repository.split('/');
+    if (!owner || !name) {
+      throw new BadRequestException('Invalid repository format. Expected "owner/repo"');
+    }
+
+    // Find or create project
+    const project = await this.projectsService.findOrCreateProject(owner, name, userId);
+
+    // Phase 3H.6: Check project access with proper permission system
+    await this.checkProjectAccess(project.id, userId, userRole, 'contributor');
+
+    return project;
+  }
+
+  private async deployEntries(
+    unzipped: Record<string, Uint8Array>,
+    project: { id: string },
+    dto: CreateDeploymentZipDto,
+    userId: string,
+  ): Promise<CreateDeploymentResponseDto> {
     const deploymentId = uuidv4();
     const uploadedAssets: (typeof assets.$inferSelect)[] = [];
     const failed: { file: string; error: string }[] = [];
@@ -238,14 +289,6 @@ export class DeploymentsService {
     });
 
     try {
-      // Parse zip with fflate (async, non-blocking - better CPU performance)
-      const unzipped = await new Promise<Record<string, Uint8Array>>((resolve, reject) => {
-        unzip(new Uint8Array(file.buffer), (err, result) => {
-          if (err) reject(new BadRequestException(`Failed to parse zip: ${err.message}`));
-          else resolve(result);
-        });
-      });
-
       // Process each file in the zip
       for (const [entryPath, contentArray] of Object.entries(unzipped)) {
         // Skip directories (fflate marks them with trailing /)
@@ -277,8 +320,14 @@ export class DeploymentsService {
         }
 
         try {
-          // Convert Uint8Array to Buffer
-          const content = Buffer.from(contentArray);
+          // View the entry's bytes as a Buffer WITHOUT copying them. `Buffer.from(uint8array)`
+          // allocates a duplicate, which on a 32MB asset is 32MB of avoidable peak RSS; the
+          // three-arg form wraps the existing ArrayBuffer instead. Read-only from here on.
+          const content = Buffer.from(
+            contentArray.buffer,
+            contentArray.byteOffset,
+            contentArray.byteLength,
+          );
           const fileSize = content.length;
 
           // Check total size limit

--- a/apps/backend/src/storage/gcs.adapter.spec.ts
+++ b/apps/backend/src/storage/gcs.adapter.spec.ts
@@ -150,6 +150,25 @@ describe('GcsStorageAdapter', () => {
       );
     });
 
+    // Without an explicit chunkSize the resumable upload treats the whole payload as one
+    // chunk and keeps it in its retry cache, roughly doubling peak RSS per file. On a 63MB
+    // app bundle in a 384MB container that is the difference between installing and being
+    // OOM-killed (exit 137). Bounding the chunk bounds the retry cache.
+    it('bounds the resumable upload chunk size so large files do not double peak memory', async () => {
+      await adapter.upload(Buffer.alloc(32 * 1024 * 1024), 'big/file.wasm');
+
+      const opts = mockFile.save.mock.calls[0][1];
+      expect(opts.chunkSize).toBe(8 * 1024 * 1024);
+    });
+
+    // GCS requires resumable chunk sizes to be a multiple of 256 KiB.
+    it('uses a chunk size GCS accepts (multiple of 256KiB)', async () => {
+      await adapter.upload(Buffer.from('test'), 'small/file.txt');
+
+      const { chunkSize } = mockFile.save.mock.calls[0][1];
+      expect(chunkSize % (256 * 1024)).toBe(0);
+    });
+
     it('should reject path traversal', async () => {
       await expect(adapter.upload(Buffer.from('test'), '../etc/passwd')).rejects.toThrow(
         'path traversal detected',

--- a/apps/backend/src/storage/gcs.adapter.ts
+++ b/apps/backend/src/storage/gcs.adapter.ts
@@ -17,6 +17,9 @@ import { GcsStorageConfig, validateGcsConfig } from './gcs.config';
  */
 @Injectable()
 export class GcsStorageAdapter implements IStorageAdapter {
+  /** Resumable-upload chunk size. Must be a multiple of 256KiB — GCS rejects anything else. */
+  static readonly UPLOAD_CHUNK_BYTES = 8 * 1024 * 1024;
+
   private readonly logger = new Logger(GcsStorageAdapter.name);
   private readonly storage: Storage;
   private readonly bucket: Bucket;
@@ -85,6 +88,12 @@ export class GcsStorageAdapter implements IStorageAdapter {
     try {
       await blob.save(file, {
         contentType,
+        // Bound the resumable upload's retry cache. Left unset, the whole payload is treated
+        // as a single chunk and held in memory alongside the Buffer we already have, which
+        // measured ~40MB of extra peak RSS for one 32MB asset — enough to OOM-kill a 384MB
+        // backend container mid-deploy. An 8MB chunk holds that to ~17MB. Must stay a
+        // multiple of 256KiB: GCS rejects resumable chunk sizes that are not.
+        chunkSize: GcsStorageAdapter.UPLOAD_CHUNK_BYTES,
         metadata: {
           metadata: this.normalizeMetadata(metadata),
         },


### PR DESCRIPTION
## What broke

Installing **Studio** from the app catalog kills the backend on `bffless.dev`:

```
LOG [GcsStorageAdapter] Uploaded file to GCS: .../assets/ffmpeg-core-CgUfceKH.wasm
assethost-backend exited with code 137 (restarting)
```

Exit 137 is a SIGKILL from the cgroup OOM killer — not a storage error. Everything after is fallout: nginx 502s while Nest reboots, then `GET /api/admin/apps/jobs/<id>` returns **404** because the install job is in-memory and died with the process, so the UI hangs on "deploying".

It installs fine on `sahp.app` (same CE version, **local** storage). Handoff and Rivulet install fine everywhere — they're small.

## Root cause

The deploy step held roughly **five full copies** of the bundle, and Studio is the first app big enough to expose it (63MB dist, two ffmpeg wasm blobs at 30.7MB and 31.2MB):

1. `AppBundleService.unzip` → `bundle.files`, fully decompressed, *retained* by a cache bounded by entry count (3), not bytes
2. `buildDistZip` → `zipSync(entries)` then `Buffer.from(...)` — a second copy
3. `createDeploymentFromZip` → unzips the whole thing **again**
4. per file: `Buffer.from(contentArray)`
5. `storageAdapter.upload(content, …)`

Replaying that chain against the real Studio dist, peak RSS was **346.5MB** from a process with only a 51MB baseline — against the backend's **384MB** container limit. The jump lands exactly on the file the log died at:

```
3. unzipped again (2nd full copy)      rss=284.5MB
   ffmpeg-core-CgUfceKH.wasm   30.7MB  rss=315.3MB
   ffmpeg-core-CtEvOXHf.wasm   31.2MB  rss=346.5MB
```

### Why GCS and not local

Marginal RSS for uploading one 32MB file, each measured in a clean process against the real library:

| sink | marginal RSS |
|---|---|
| local `fs.writeFile(buffer)` | **0.0MB** |
| GCS `blob.save(buffer)`, default | **40.0MB** |
| GCS `resumable: false` | 27.5MB |
| GCS `chunkSize: 8MB` | **17.3MB** |

Local writes the Buffer it already has straight to disk. GCS's resumable upload keeps the entire write as one chunk in `writeBuffers` plus a retry cache, because `chunkSize` is never set. Headroom was 37.5MB and GCS needed 37.1MB — bucket storage is exactly what tipped it. **This is not GCS-specific**: S3, MinIO and Azure would tip it the same way.

## The fix

- **Deploy entries directly.** `createDeploymentFromFiles(entries, …)` takes an already-decompressed entry map; `createDeploymentFromZip` unzips and delegates to the same core. The installer's `buildDistZip` becomes `buildDistEntries`, re-keying by reference. Removes steps 2 and 3 entirely.
- **Zero-copy per-file Buffer.** The three-arg `Buffer.from(ab, byteOffset, byteLength)` views the entry instead of duplicating it.
- **Byte-bounded bundle cache.** A bundle over the budget isn't cached — re-downloading is strictly better than an OOM kill. Small bundles still cache, so preflight-then-install still downloads once.
- **Bounded GCS chunk size** (8MB, a multiple of 256KiB as GCS requires).

## Result

Peak RSS for the same install, same measurement harness:

| | peak RSS |
|---|---|
| before | 346.5MB (+ ~40MB GCS = over the 384MB cap) |
| after | **146.8MB** (+ ~17MB GCS) |

The two wasm files now add ~0.2MB between them instead of +62MB.

## Tests

- `deployments.service.spec.ts` — `createDeploymentFromFiles` uploads without a zip, enforces the same write access as the zip path, and uploads exactly the entry's bytes when entries are views into a shared buffer (fflate hands back such views) while sharing their backing memory, which pins the zero-copy property.
- `app-bundle.service.spec.ts` — an oversized bundle is not retained; a small one still is.
- `gcs.adapter.spec.ts` — `chunkSize` is set and is a valid multiple of 256KiB.
- `app-installer.service.spec.ts` / `app-catalog.e2e-ish.spec.ts` — assert the bundle bytes are handed over by reference, never re-encoded.

Each new test was confirmed to fail against the unfixed code. Full backend suite: **165 suites, 2974 passed, 0 failed**. `tsc --noEmit` clean; no new lint errors (the 20 pre-existing prettier errors in these files are unchanged).

## Follow-up, not in this PR

`AppBundleService.MAX_BUNDLE_BYTES` is 200MB against a 384MB container, so the guard meant to protect this path still can't. Worth lowering, or replacing with a decompressed-size check that fails with a clean 400 instead of a container kill — but that gates real installs, so it's a deliberate policy call rather than a drive-by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
