### PR TITLE
feat: preview the app catalog on the admin home page

### DIFF
--- a/apps/frontend/src/components/app-catalog/AppCatalogGrid.tsx
+++ b/apps/frontend/src/components/app-catalog/AppCatalogGrid.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { AppCard } from './AppCard';
+import { AppDetailsDialog } from './AppDetailsDialog';
+import { InstallDialog } from './InstallDialog';
+import type { CatalogEntry } from '@/services/appCatalogApi';
+
+interface AppCatalogGridProps {
+  /**
+   * The apps to render. Pass the LIVE list from `useGetAppCatalogQuery` on
+   * every render (sliced is fine) — the dialogs below re-resolve their target
+   * out of it, so a stale array would freeze their contents.
+   */
+  entries: CatalogEntry[];
+  /** Grid classes, so a host page can choose its own column count. */
+  className?: string;
+}
+
+/**
+ * AppCatalogGrid — the app-catalog tiles plus the three dialogs their CTAs
+ * open (details, install wizard, update progress). Shared by the full `/apps`
+ * page and the featured strip on the admin home page so both get identical
+ * install/update/details behavior; each host page owns its own heading and
+ * loading/empty/error chrome.
+ */
+export function AppCatalogGrid({
+  entries,
+  className = 'grid gap-4 md:grid-cols-2 lg:grid-cols-3',
+}: AppCatalogGridProps) {
+  // These hold the entry captured at open time — used only as an id lookup
+  // key and as a fallback if the app disappears from the catalog while the
+  // dialog is open. The dialog is actually handed the LIVE entry (derived
+  // below from the current `entries`), not this snapshot: server-side
+  // mutations like updateApp invalidate the `AppCatalog` tag and refetch the
+  // catalog, and a stale snapshot here would never pick that up (the Done
+  // screen's setup notes would appear stuck on the pre-update list).
+  const [installTargetSnapshot, setInstallTargetSnapshot] = useState<CatalogEntry | null>(null);
+  const [detailsTargetSnapshot, setDetailsTargetSnapshot] = useState<CatalogEntry | null>(null);
+  const [updateTargetSnapshot, setUpdateTargetSnapshot] = useState<{
+    entry: CatalogEntry;
+    jobId: string;
+  } | null>(null);
+
+  const installTarget = installTargetSnapshot
+    ? (entries.find((e) => e.id === installTargetSnapshot.id) ?? installTargetSnapshot)
+    : null;
+  const detailsTarget = detailsTargetSnapshot
+    ? (entries.find((e) => e.id === detailsTargetSnapshot.id) ?? detailsTargetSnapshot)
+    : null;
+  const updateTarget = updateTargetSnapshot
+    ? {
+        entry:
+          entries.find((e) => e.id === updateTargetSnapshot.entry.id) ??
+          updateTargetSnapshot.entry,
+        jobId: updateTargetSnapshot.jobId,
+      }
+    : null;
+
+  return (
+    <>
+      <div className={className}>
+        {entries.map((entry) => (
+          <AppCard
+            key={entry.id}
+            entry={entry}
+            onInstall={setInstallTargetSnapshot}
+            onDetails={setDetailsTargetSnapshot}
+            onUpdateStarted={(updatedEntry, jobId) =>
+              setUpdateTargetSnapshot({ entry: updatedEntry, jobId })
+            }
+          />
+        ))}
+      </div>
+
+      {detailsTarget && (
+        <AppDetailsDialog
+          entry={detailsTarget}
+          open={detailsTarget !== null}
+          onOpenChange={(open) => !open && setDetailsTargetSnapshot(null)}
+          // Hand off rather than stack: the details dialog closes and the
+          // install wizard takes its place, so there's only ever one modal.
+          onInstall={(entry) => {
+            setDetailsTargetSnapshot(null);
+            setInstallTargetSnapshot(entry);
+          }}
+        />
+      )}
+
+      {installTarget && (
+        <InstallDialog
+          entry={installTarget}
+          open={installTarget !== null}
+          onOpenChange={(open) => !open && setInstallTargetSnapshot(null)}
+        />
+      )}
+
+      {updateTarget && (
+        <InstallDialog
+          entry={updateTarget.entry}
+          open={updateTarget !== null}
+          onOpenChange={(open) => !open && setUpdateTargetSnapshot(null)}
+          mode="update"
+          initialJobId={updateTarget.jobId}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/frontend/src/pages/AppsPage.tsx
+++ b/apps/frontend/src/pages/AppsPage.tsx
@@ -1,53 +1,23 @@
 import { useState } from 'react';
-import { AppCard } from '@/components/app-catalog/AppCard';
-import { AppDetailsDialog } from '@/components/app-catalog/AppDetailsDialog';
-import { InstallDialog } from '@/components/app-catalog/InstallDialog';
+import { AppCatalogGrid } from '@/components/app-catalog/AppCatalogGrid';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useGetAppCatalogQuery, type CatalogEntry } from '@/services/appCatalogApi';
+import { useGetAppCatalogQuery } from '@/services/appCatalogApi';
 import { AlertTriangle, LayoutGrid, X } from 'lucide-react';
 
 /**
  * AppsPage — the app catalog admin page (Task 12 of the app-catalog spec).
  * Lists every app the registry knows about, each rendered as an `AppCard`
- * with its own install/manage CTA. Registry fetch failures don't block the
- * page — already-installed apps still render (`registryError` becomes a
- * dismissable notice instead of an error state).
+ * (via the shared `AppCatalogGrid`) with its own install/manage CTA. Registry
+ * fetch failures don't block the page — already-installed apps still render
+ * (`registryError` becomes a dismissable notice instead of an error state).
  */
 export function AppsPage() {
   const { data, isLoading, isError, refetch } = useGetAppCatalogQuery();
   const [registryNoticeDismissed, setRegistryNoticeDismissed] = useState(false);
-  // These hold the entry captured at open time — used only as an id lookup
-  // key and as a fallback if the app disappears from the catalog while the
-  // dialog is open. The dialog is actually handed the LIVE entry (derived
-  // below from the current `data`), not this snapshot: server-side mutations
-  // like updateApp invalidate the `AppCatalog` tag and refetch `data`, and a
-  // stale snapshot here would never pick that up (the Done screen's setup
-  // notes would appear stuck on the pre-update list).
-  const [installTargetSnapshot, setInstallTargetSnapshot] = useState<CatalogEntry | null>(null);
-  const [detailsTargetSnapshot, setDetailsTargetSnapshot] = useState<CatalogEntry | null>(null);
-  const [updateTargetSnapshot, setUpdateTargetSnapshot] = useState<{
-    entry: CatalogEntry;
-    jobId: string;
-  } | null>(null);
 
   const entries = data?.data ?? [];
-
-  const installTarget = installTargetSnapshot
-    ? (entries.find((e) => e.id === installTargetSnapshot.id) ?? installTargetSnapshot)
-    : null;
-  const detailsTarget = detailsTargetSnapshot
-    ? (entries.find((e) => e.id === detailsTargetSnapshot.id) ?? detailsTargetSnapshot)
-    : null;
-  const updateTarget = updateTargetSnapshot
-    ? {
-        entry:
-          entries.find((e) => e.id === updateTargetSnapshot.entry.id) ??
-          updateTargetSnapshot.entry,
-        jobId: updateTargetSnapshot.jobId,
-      }
-    : null;
 
   return (
     <div className="container mx-auto py-8">
@@ -104,53 +74,7 @@ export function AppsPage() {
         </div>
       )}
 
-      {!isLoading && entries.length > 0 && (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {entries.map((entry) => (
-            <AppCard
-              key={entry.id}
-              entry={entry}
-              onInstall={setInstallTargetSnapshot}
-              onDetails={setDetailsTargetSnapshot}
-              onUpdateStarted={(updatedEntry, jobId) =>
-                setUpdateTargetSnapshot({ entry: updatedEntry, jobId })
-              }
-            />
-          ))}
-        </div>
-      )}
-
-      {detailsTarget && (
-        <AppDetailsDialog
-          entry={detailsTarget}
-          open={detailsTarget !== null}
-          onOpenChange={(open) => !open && setDetailsTargetSnapshot(null)}
-          // Hand off rather than stack: the details dialog closes and the
-          // install wizard takes its place, so there's only ever one modal.
-          onInstall={(entry) => {
-            setDetailsTargetSnapshot(null);
-            setInstallTargetSnapshot(entry);
-          }}
-        />
-      )}
-
-      {installTarget && (
-        <InstallDialog
-          entry={installTarget}
-          open={installTarget !== null}
-          onOpenChange={(open) => !open && setInstallTargetSnapshot(null)}
-        />
-      )}
-
-      {updateTarget && (
-        <InstallDialog
-          entry={updateTarget.entry}
-          open={updateTarget !== null}
-          onOpenChange={(open) => !open && setUpdateTargetSnapshot(null)}
-          mode="update"
-          initialJobId={updateTarget.jobId}
-        />
-      )}
+      {!isLoading && entries.length > 0 && <AppCatalogGrid entries={entries} />}
     </div>
   );
 }

--- a/apps/frontend/src/pages/HomePage.test.tsx
+++ b/apps/frontend/src/pages/HomePage.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { HomePage } from './HomePage';
 import type { WildcardCertificateStatus } from '@/services/domainsApi';
@@ -12,6 +12,7 @@ const mockGetSetupStatus = vi.fn();
 const mockGetWildcardStatus = vi.fn();
 const mockGetMyRepositories = vi.fn();
 const mockGetPrimarySslStatus = vi.fn();
+const mockGetAppCatalog = vi.fn();
 
 vi.mock('@/services/authApi', () => ({
   useGetSessionQuery: () => mockGetSession(),
@@ -29,14 +30,38 @@ vi.mock('@/services/primarySslApi', () => ({
   useGetPrimarySslStatusQuery: () => mockGetPrimarySslStatus(),
 }));
 
+// Flipped per-test by the featured-apps suite; every other suite leaves the
+// app catalog off, which is also what a CE instance without the flag sees.
+let mockAppCatalogFlag = false;
+
 vi.mock('@/services/featureFlagsApi', () => ({
   useFeatureFlags: () => ({
     isReady: true,
     isEnabled: (flag: string) =>
       flag === 'ENABLE_WILDCARD_SSL_BANNER' ||
       flag === 'ENABLE_WILDCARD_SSL' ||
-      flag === 'ENABLE_PRIMARY_SSL_MANAGEMENT',
+      flag === 'ENABLE_PRIMARY_SSL_MANAGEMENT' ||
+      (flag === 'ENABLE_APP_CATALOG' && mockAppCatalogFlag),
   }),
+}));
+
+// Honors `skip` so the tests exercise HomePage's own gating (admin + flag)
+// rather than just the presence of data.
+vi.mock('@/services/appCatalogApi', () => ({
+  useGetAppCatalogQuery: (_arg: undefined, options?: { skip?: boolean }) =>
+    options?.skip ? {} : (mockGetAppCatalog() ?? {}),
+}));
+
+// The grid itself (cards, install/details dialogs) is covered by
+// AppsPage.test.tsx; here only the strip's gating and slicing matter.
+vi.mock('@/components/app-catalog/AppCatalogGrid', () => ({
+  AppCatalogGrid: ({ entries }: { entries: Array<{ id: string; name: string }> }) => (
+    <div data-testid="app-catalog-grid">
+      {entries.map((entry) => (
+        <span key={entry.id}>{entry.name}</span>
+      ))}
+    </div>
+  ),
 }));
 
 vi.mock('@/services/repositoriesApi', () => ({
@@ -266,5 +291,72 @@ describe('HomePage — ?onboarding=1 developer override', () => {
 
     expect(screen.queryByTestId('onboarding-modal')).not.toBeInTheDocument();
     expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('HomePage — featured apps strip', () => {
+  const catalog = (names: string[]) => ({
+    data: { data: names.map((name) => ({ id: name.toLowerCase(), name })) },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockAppCatalogFlag = true;
+    mockGetSession.mockReturnValue({
+      data: { user: { email: 'admin@example.com', role: 'admin' } },
+    });
+    mockGetSetupStatus.mockReturnValue({ data: { isSetupComplete: true }, isLoading: false });
+    mockGetWildcardStatus.mockReturnValue({ data: undefined });
+    mockGetPrimarySslStatus.mockReturnValue({ data: undefined });
+    mockGetMyRepositories.mockReturnValue({ data: { total: 1 } });
+    mockGetAppCatalog.mockReturnValue(catalog(['Handoff', 'Rivulet', 'Studio']));
+  });
+
+  afterEach(() => {
+    mockAppCatalogFlag = false;
+  });
+
+  it('shows the catalog apps with a link through to the full page', () => {
+    renderHomePage();
+
+    const grid = screen.getByTestId('app-catalog-grid');
+    expect(within(grid).getByText('Handoff')).toBeInTheDocument();
+    expect(within(grid).getByText('Rivulet')).toBeInTheDocument();
+    expect(within(grid).getByText('Studio')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View all apps' })).toHaveAttribute('href', '/apps');
+  });
+
+  it('previews only the first three apps', () => {
+    mockGetAppCatalog.mockReturnValue(catalog(['Handoff', 'Rivulet', 'Studio', 'Fourth']));
+    renderHomePage();
+
+    const grid = screen.getByTestId('app-catalog-grid');
+    expect(within(grid).getByText('Studio')).toBeInTheDocument();
+    expect(within(grid).queryByText('Fourth')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the catalog is empty (no loading/empty chrome on the home page)', () => {
+    mockGetAppCatalog.mockReturnValue({ data: { data: [] } });
+    renderHomePage();
+
+    expect(screen.queryByTestId('app-catalog-grid')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'View all apps' })).not.toBeInTheDocument();
+  });
+
+  it('skips the catalog query entirely when ENABLE_APP_CATALOG is off', () => {
+    mockAppCatalogFlag = false;
+    renderHomePage();
+
+    expect(mockGetAppCatalog).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('app-catalog-grid')).not.toBeInTheDocument();
+  });
+
+  it('skips the catalog query for non-admins (the endpoint is admin-only)', () => {
+    mockGetSession.mockReturnValue({ data: { user: { email: 'u@example.com', role: 'user' } } });
+    renderHomePage();
+
+    expect(mockGetAppCatalog).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('app-catalog-grid')).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -7,6 +7,8 @@ import { useGetWildcardCertificateStatusQuery } from '@/services/domainsApi';
 import { useGetPrimarySslStatusQuery } from '@/services/primarySslApi';
 import { useFeatureFlags } from '@/services/featureFlagsApi';
 import { useGetMyRepositoriesQuery } from '@/services/repositoriesApi';
+import { useGetAppCatalogQuery } from '@/services/appCatalogApi';
+import { AppCatalogGrid } from '@/components/app-catalog/AppCatalogGrid';
 import { RootState } from '@/store';
 import { resetOnboarding } from '@/store/slices/setupSlice';
 import { Button } from '@/components/ui/button';
@@ -23,6 +25,9 @@ import { useBranding } from '@/hooks/useBranding';
  * Shows onboarding modal for first-time users
  */
 const SSL_BANNER_DISMISSED_KEY = 'ssl-setup-banner-dismissed';
+
+/** How many catalog apps the home page previews before "View all apps". */
+const FEATURED_APP_COUNT = 3;
 
 export function HomePage() {
   const { data: setupStatus, isLoading: isSetupLoading } = useGetSetupStatusQuery();
@@ -92,6 +97,18 @@ export function HomePage() {
   const { data: myRepos } = useGetMyRepositoriesQuery(undefined, { skip: !user });
   const canCreateRepos = user?.role === 'admin' || user?.role === 'user';
   const showRepositoriesCard = canCreateRepos || (myRepos?.total ?? 0) > 0;
+
+  // Featured apps strip. The catalog endpoint is admin-only and behind the
+  // ENABLE_APP_CATALOG flag (it 401s/403s otherwise), so the query is skipped
+  // under exactly the conditions that gate the "Apps" button below. The strip
+  // shows the first few apps as a shortcut into /apps — it deliberately has
+  // no loading/empty/error chrome of its own; a catalog that can't be reached
+  // just doesn't render here, and /apps stays the place that explains why.
+  const isAppCatalogEnabled = isEnabled('ENABLE_APP_CATALOG');
+  const { data: appCatalog } = useGetAppCatalogQuery(undefined, {
+    skip: !flagsReady || !isAppCatalogEnabled || user?.role !== 'admin',
+  });
+  const featuredApps = (appCatalog?.data ?? []).slice(0, FEATURED_APP_COUNT);
 
   const missingWildcard = certStatus?.exists === false;
   const showExpiryBanner = wildcardExpiring && !isExpiryBannerDismissed;
@@ -233,10 +250,10 @@ export function HomePage() {
         )}
 
         {/* Navigation Cards */}
-        <div className={`grid gap-4 ${user?.role === 'admin' ? 'md:grid-cols-2 lg:grid-cols-4' : showRepositoriesCard ? 'md:grid-cols-3' : 'md:grid-cols-2'}`}>
+        <div className={`grid gap-4 ${user?.role === 'admin' ? 'md:grid-cols-3 lg:grid-cols-5' : showRepositoriesCard ? 'md:grid-cols-3' : 'md:grid-cols-2'}`}>
           {showRepositoriesCard && (
             <Link to="/repo" className="group block">
-              <div className="bg-white dark:bg-card border border-[#3a3a3a]/10 dark:border-border rounded-lg p-6 hover:border-[#d96459]/50 hover:shadow-md transition-all duration-200">
+              <div className="h-full bg-white dark:bg-card border border-[#3a3a3a]/10 dark:border-border rounded-lg p-6 hover:border-[#d96459]/50 hover:shadow-md transition-all duration-200">
                 <div className="flex items-start justify-between">
                   <FolderGit2 className="h-8 w-8 text-[#d96459]" />
                   <ArrowRight className="h-5 w-5 text-[#4a4a4a]/30 group-hover:text-[#d96459] group-hover:translate-x-1 transition-all" />
@@ -253,7 +270,7 @@ export function HomePage() {
 
           {user?.role === 'admin' && (
             <Link to="/users" className="group block">
-              <div className="bg-white dark:bg-card border border-[#3a3a3a]/10 dark:border-border rounded-lg p-6 hover:border-[#d96459]/50 hover:shadow-md transition-all duration-200">
+              <div className="h-full bg-white dark:bg-card border border-[#3a3a3a]/10 dark:border-border rounded-lg p-6 hover:border-[#d96459]/50 hover:shadow-md transition-all duration-200">
                 <div className="flex items-start justify-between">
                   <UserCog className="h-8 w-8 text-[#d96459]" />
                   <ArrowRight className="h-5 w-5 text-[#4a4a4a]/30 group-hover:text-[#d96459] group-hover:translate-x-1 transition-all" />
@@ -270,7 +287,7 @@ export function HomePage() {
 
           {user?.role === 'admin' && (
             <Link to="/groups" className="group block">
-              <div className="bg-white dark:bg-card border border-[#3a3a3a]/10 dark:border-border rounded-lg p-6 hover:border-[#d96459]/50 hover:shadow-md transition-all duration-200">
+              <div className="h-full bg-white dark:bg-card border border-[#3a3a3a]/10 dark:border-border rounded-lg p-6 hover:border-[#d96459]/50 hover:shadow-md transition-all duration-200">
                 <div className="flex items-start justify-between">
                   <Users className="h-8 w-8 text-[#d96459]" />
                   <ArrowRight className="h-5 w-5 text-[#4a4a4a]/30 group-hover:text-[#d96459] group-hover:translate-x-1 transition-all" />
@@ -286,7 +303,7 @@ export function HomePage() {
           )}
 
           <Link to="/settings?tab=sites" className="group block">
-            <div className="bg-white dark:bg-card border border-[#3a3a3a]/10 dark:border-border rounded-lg p-6 hover:border-[#d96459]/50 hover:shadow-md transition-all duration-200">
+            <div className="h-full bg-white dark:bg-card border border-[#3a3a3a]/10 dark:border-border rounded-lg p-6 hover:border-[#d96459]/50 hover:shadow-md transition-all duration-200">
               <div className="flex items-start justify-between">
                 <Globe className="h-8 w-8 text-[#d96459]" />
                 <ArrowRight className="h-5 w-5 text-[#4a4a4a]/30 group-hover:text-[#d96459] group-hover:translate-x-1 transition-all" />
@@ -301,7 +318,7 @@ export function HomePage() {
           </Link>
 
           <Link to="/settings" className="group block">
-            <div className="bg-white dark:bg-card border border-[#3a3a3a]/10 dark:border-border rounded-lg p-6 hover:border-[#d96459]/50 hover:shadow-md transition-all duration-200">
+            <div className="h-full bg-white dark:bg-card border border-[#3a3a3a]/10 dark:border-border rounded-lg p-6 hover:border-[#d96459]/50 hover:shadow-md transition-all duration-200">
               <div className="flex items-start justify-between">
                 <Settings className="h-8 w-8 text-[#d96459]" />
                 <ArrowRight className="h-5 w-5 text-[#4a4a4a]/30 group-hover:text-[#d96459] group-hover:translate-x-1 transition-all" />
@@ -315,6 +332,29 @@ export function HomePage() {
             </div>
           </Link>
         </div>
+
+        {/* Featured Apps */}
+        {featuredApps.length > 0 && (
+          <div>
+            <div className="flex items-baseline justify-between gap-4 mb-4">
+              <div>
+                <h2 className="text-lg font-semibold text-[#3a3a3a] dark:text-foreground">
+                  Apps
+                </h2>
+                <p className="text-sm text-[#4a4a4a] dark:text-muted-foreground mt-1">
+                  1-click install apps built on top of BFFless
+                </p>
+              </div>
+              <Link
+                to="/apps"
+                className="shrink-0 text-sm font-medium text-[#d96459] hover:underline"
+              >
+                View all apps
+              </Link>
+            </div>
+            <AppCatalogGrid entries={featuredApps} className="grid gap-4 md:grid-cols-3" />
+          </div>
+        )}
 
         {/* Admin Section */}
         {user?.role === 'admin' && (


### PR DESCRIPTION
Two home-page changes from live feedback on `admin.sahp.app`:

1. **The first 3 catalog apps now appear on the home page**, between the navigation cards and the Admin box — an "Apps" heading, the `/apps` subtitle, and a "View all apps" link through to the full page. These are the real `AppCard`s, so Details / Install / Update / Open all work exactly as they do on `/apps`.
2. **The admin nav cards fit 5 to a row** (`lg:grid-cols-4` → `lg:grid-cols-5`, `md:grid-cols-2` → `md:grid-cols-3`), so all five land on one row instead of 4 + 1.

### How

The tiles plus the three dialogs their CTAs open (details, install wizard, update progress) move out of `AppsPage` into a shared `AppCatalogGrid`, so the home page gets identical behavior rather than a second copy of the wiring — `AppsPage` loses ~85 lines and keeps only its own chrome.

The two surfaces differ deliberately in what they say when there's nothing to show: `/apps` owns the loading skeletons, the empty state and the registry-error notice; the home-page strip has none of that and simply doesn't render when the catalog is empty or unreachable. The catalog query is skipped unless the viewer is an admin and `ENABLE_APP_CATALOG` is on — the same gating as the existing Apps button, and what the admin-only endpoint requires.

Going five-across exposed that the nav cards were only ever even by luck (their descriptions wrap to different line counts), so the card bodies take `h-full`.

### Verification

- `tsc --noEmit` clean; eslint clean on the touched files.
- Full frontend unit suite: **884 tests / 83 files passed**, including 5 new `HomePage` tests — slices to 3, links to `/apps`, renders nothing when the catalog is empty, and skips the query both when the flag is off and for non-admins.
- Rendered the new layout in headless Chromium at 1440px and 900px (Tailwind-compiled harness of the exact markup): five even cards in one row at `lg`, 3 + 2 at `md`, apps strip sitting between the cards and the Admin box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
