### PR TITLE
fix(frontend): scroll install dialog when preflight results overflow

### DIFF
--- a/apps/frontend/src/components/app-catalog/InstallDialog.tsx
+++ b/apps/frontend/src/components/app-catalog/InstallDialog.tsx
@@ -303,7 +303,11 @@ export function InstallDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+      {/* The review screen grows with the number of preflight gates and synced
+          rule sets, and DialogContent is vertically centred with no height cap
+          of its own, so tall results pushed the title off the top of the
+          viewport with no way to scroll. Cap and scroll instead. */}
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>
             {screen === 'done'


### PR DESCRIPTION
## Problem

The app **Install** modal can grow taller than the viewport, and there's no way to scroll it. `DialogContent` is `fixed top-[50%] translate-y-[-50%]` with no height cap and no overflow handling (`components/ui/dialog.tsx:41`), so once the review screen exceeds the window it expands in *both* directions from the centre: the dialog title is clipped off the top edge and the trailing rule-sync results are unreachable.

The review screen grows with content — project fields, then one card per preflight gate, then a line per synced rule set — so this shows up on any app with several gates, on ordinary laptop viewports.

![Install modal clipped at the top with no scrollbar](https://handoff.bffless.dev/r/78a4ae95-a483-4451-bb51-e11ed2540152/screenshot-2026-08-06-at-10-42-27-pm.png?token=04318eb1-1773-40c9-81cc-7c39d34dd3ab)

## Fix

```diff
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
```

This is the established convention in this codebase, not a new approach — 13 dialogs already append `max-h-[Nvh] overflow-y-auto` to `DialogContent`. The closest precedent is `setup/onboarding/OnboardingModal.tsx:116`, which uses the byte-identical `max-h-[90vh] overflow-y-auto sm:max-w-lg` and already carries a comment describing this same failure mode. Others: `CreateDeploymentDialog.tsx:260`, `RecordEditorDialog.tsx:246`, `EditDomainDialog.tsx:230`.

There is no `flex flex-col` + `flex-1 overflow-y-auto` sticky-header pattern anywhere in this frontend, so this doesn't invent one — the whole panel scrolls, header and footer included, exactly like the other 13 call sites.

The cap sits on the single shared `DialogContent`, so it covers all three screens (`review`, `working`, `done`) and both `DialogFooter`s.

## Verification

- `tsc --noEmit` (frontend) — exit 0
- `vitest run src/components/app-catalog` — 7 files, 79 tests, all passing (includes `InstallDialog.test.tsx`)

Not verified in a live browser — that needs the full stack plus a catalog entry with enough gates to overflow.

## Follow-up (not in this PR)

Two siblings have the same latent bug and would take the identical one-liner, but are out of scope here since only the install modal was reported:

- `app-catalog/EjectPanel.tsx:80` — `className="sm:max-w-lg"`, uncapped
- `app-catalog/UninstallDialog.tsx:85` — bare `<DialogContent>`, uncapped

(`AppDetailsDialog.tsx:50` is already fine — it uses the `flex max-h-[85vh] flex-col` variant.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
