### PR TITLE
fix: pin SuperTokens core to 12.0.10 and survive role-claim merge failure in signin

### DIFF
--- a/apps/backend/src/auth/auth.controller.spec.ts
+++ b/apps/backend/src/auth/auth.controller.spec.ts
@@ -26,6 +26,22 @@ jest.mock('supertokens-node/recipe/emailverification', () => ({
   },
 }));
 
+jest.mock('supertokens-node/recipe/emailpassword', () => ({
+  __esModule: true,
+  default: {
+    signIn: jest.fn(),
+  },
+}));
+
+jest.mock('supertokens-node/recipe/session', () => ({
+  __esModule: true,
+  default: {
+    createNewSession: jest.fn(),
+  },
+}));
+
+import EmailPassword from 'supertokens-node/recipe/emailpassword';
+import Session from 'supertokens-node/recipe/session';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { SetupService } from '../setup/setup.service';
@@ -148,6 +164,61 @@ describe('AuthController.getSession (project-membership gate, Phase B)', () => {
 
     expect(result.user).toEqual({ id: dbUser.id, email: dbUser.email, role: dbUser.role });
     expect(permissions.getUserProjectRole).toHaveBeenCalledWith(SESSION_USER_ID, 'proj-1');
+  });
+
+  describe('signIn (post-session resilience)', () => {
+    const signInMock = EmailPassword.signIn as jest.Mock;
+    const createNewSessionMock = Session.createNewSession as jest.Mock;
+
+    const makeSession = (mergeImpl: () => Promise<void>) => ({
+      getUserId: () => SESSION_USER_ID,
+      getHandle: () => SESSION_HANDLE,
+      mergeIntoAccessTokenPayload: jest.fn(mergeImpl),
+    });
+
+    const signInReq = () => ({ headers: { host: 'admin.bffless.app' } }) as unknown as Request;
+
+    beforeEach(() => {
+      // ENABLE_EMAIL_PASSWORD must be on; REQUIRE_PROJECT_MEMBERSHIP stays off.
+      featureFlags.isEnabled.mockImplementation(async (flag: string) => flag === 'ENABLE_EMAIL_PASSWORD');
+      authService.getUserByEmail.mockResolvedValue(dbUser as never);
+      signInMock.mockResolvedValue({
+        status: 'OK',
+        recipeUserId: { getAsString: () => SESSION_USER_ID },
+      });
+    });
+
+    it('adds the role to the access token payload on the happy path', async () => {
+      const session = makeSession(() => Promise.resolve());
+      createNewSessionMock.mockResolvedValue(session);
+
+      const result: any = await controller.signIn(
+        { email: dbUser.email, password: 'pw' } as never,
+        signInReq(),
+        {} as never,
+      );
+
+      expect(result.message).toBe('Signed in successfully');
+      expect(session.mergeIntoAccessTokenPayload).toHaveBeenCalledWith({ role: dbUser.role });
+    });
+
+    it('still reports success when the role-claim merge fails after the session was created', async () => {
+      // Once createNewSession has run, the session cookies are already attached
+      // to the response — the user IS signed in. A failure while decorating the
+      // access token (e.g. the SuperTokens core erroring on /recipe/session/
+      // regenerate) must not convert a successful login into a 401.
+      const session = makeSession(() => Promise.reject(new Error('core regenerate blew up')));
+      createNewSessionMock.mockResolvedValue(session);
+
+      const result: any = await controller.signIn(
+        { email: dbUser.email, password: 'pw' } as never,
+        signInReq(),
+        {} as never,
+      );
+
+      expect(result.message).toBe('Signed in successfully');
+      expect(result.user).toEqual({ id: dbUser.id, email: dbUser.email, role: dbUser.role });
+    });
   });
 
   it('uses the SuperTokens session userId for the membership check (works even if DB user is missing)', async () => {

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -559,10 +559,23 @@ export class AuthController {
       }
 
       // Add role to JWT access token payload for external validation
-      // This allows Control Plane to validate admin access without database lookup
-      await session.mergeIntoAccessTokenPayload({
-        role: user.role,
-      });
+      // This allows Control Plane to validate admin access without database lookup.
+      // Non-fatal: by this point the session cookies are already attached to the
+      // response — the user IS signed in. If the SuperTokens core fails here
+      // (e.g. /recipe/session/regenerate erroring), failing the whole signin
+      // would report "Login failed" for a login that succeeded, while the client
+      // keeps the valid session cookies. CE's own guards read roles from the
+      // database; the claim only degrades external JWT validation.
+      try {
+        await session.mergeIntoAccessTokenPayload({
+          role: user.role,
+        });
+      } catch (mergeError) {
+        this.logger.error(
+          '[Signin] Failed to add role claim to access token (session is still valid, continuing):',
+          mergeError,
+        );
+      }
 
       // Process project invite link if present
       if (body.projectInviteToken) {

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -93,7 +93,12 @@ services:
       - assethost-network
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    # Pinned: an unpinned (latest) tag let core 12.1.0 slip in, whose in-place
+    # upgrade migration misses two session_info columns (prev_refresh_token_hash_2,
+    # refresh_token_rotated_at) and breaks session refresh/regenerate with 500s
+    # (signin reports "Failed to sign in" even though the session is created).
+    # Bump deliberately after verifying the upgrade migration on an existing DB.
+    image: registry.supertokens.io/supertokens/supertokens-postgresql:12.0.10
     container_name: assethost-supertokens
     profiles:
       - supertokens # Only starts with --profile supertokens (CE local mode)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,7 +52,12 @@ services:
       retries: 5
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    # Pinned: an unpinned (latest) tag let core 12.1.0 slip in, whose in-place
+    # upgrade migration misses two session_info columns (prev_refresh_token_hash_2,
+    # refresh_token_rotated_at) and breaks session refresh/regenerate with 500s
+    # (signin reports "Failed to sign in" even though the session is created).
+    # Bump deliberately after verifying the upgrade migration on an existing DB.
+    image: registry.supertokens.io/supertokens/supertokens-postgresql:12.0.10
     container_name: assethost-supertokens-dev
     profiles:
       - supertokens                    # Only starts with --profile supertokens (CE local mode)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,12 @@ services:
       - assethost-network
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    # Pinned: an unpinned (latest) tag let core 12.1.0 slip in, whose in-place
+    # upgrade migration misses two session_info columns (prev_refresh_token_hash_2,
+    # refresh_token_rotated_at) and breaks session refresh/regenerate with 500s
+    # (signin reports "Failed to sign in" even though the session is created).
+    # Bump deliberately after verifying the upgrade migration on an existing DB.
+    image: registry.supertokens.io/supertokens/supertokens-postgresql:12.0.10
     container_name: assethost-supertokens
     profiles:
       - supertokens # Only starts with --profile supertokens (CE local mode)


### PR DESCRIPTION
## Problem

Admin logins started showing a **"Login failed / Failed to sign in"** toast even though the login succeeded (dashboard loads, session works). Session refresh (`POST /api/auth/session/refresh`) also returns 500, so sessions die at access-token expiry (~1h) and force a re-login.

## Root cause

The compose files pulled the SuperTokens core **unpinned** (`registry.supertokens.io/supertokens/supertokens-postgresql`, no tag). A redeploy re-pulled the image and picked up **core 12.1.0** (released 2026-08-12), whose **in-place upgrade migration is broken**: it creates the new 12.x tables but misses two new `session_info` columns (`prev_refresh_token_hash_2`, `refresh_token_rotated_at`). Every `/recipe/session/refresh` and `/recipe/session/regenerate` call then fails:

```
PSQLException: ERROR: column sess.prev_refresh_token_hash_2 does not exist
```

Fresh 12.1.0 databases get the columns — only upgraded databases are affected.

In CE's signin, the failure surfaced through `session.mergeIntoAccessTokenPayload({ role })`, which runs **after** `Session.createNewSession` has already attached session cookies to the response. The catch-all converted that into a 401 "Failed to sign in" — for a login that succeeded, with the client keeping valid cookies.

Verified by local reproduction with supertokens-node 17.1.5 against cores 9.0 → 12.1.0: only the 11.x → 12.1.0 in-place upgrade fails; fresh DBs all pass.

## Changes

1. **Pin the core image to `12.0.10`** in `docker-compose.yml`, `docker-compose.dev.yml`, `docker-compose.build.yml`. Verified: 11.x → 12.0.10 upgrade migration is good, and 12.0.10 also **cleanly heals a database already damaged by 12.1.0** (downgrade boots, refresh/regenerate work again — no manual schema repair needed).
2. **Make the role-claim merge non-fatal in signin** (`auth.controller.ts`): once the session exists, a failure while decorating the access token is logged and signin returns success. CE guards read roles from the DB; the JWT role claim only serves external validation. Regression test added (red before the fix, green after; all 110 auth tests + typecheck pass).

## Deploying to an affected instance

Just the normal update: pull the release, `docker compose up -d supertokens`. The pinned 12.0.10 replaces the broken 12.1.0 and sessions work again immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
