### PR TITLE
feat: run swap setup during onboarding and bless docker-compose.override.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -535,8 +535,17 @@ SSL_CERT_PATH=/etc/nginx/ssl
 # backend container at >= 1.5-2 GB memory (or a
 # swap-backed droplet); below that the pre-flight check refuses jobs with
 # "insufficient memory" and apps fall back to client-side processing.
-# The stock docker-compose mem_limit (384M) is below the threshold on
-# purpose - raise it to enable the capability.
+# The stock docker-compose backend limit (384M) is below the threshold on
+# purpose. To raise it WITHOUT editing docker-compose.yml (which would break
+# `git pull` updates), create a git-ignored docker-compose.override.yml:
+#   services:
+#     backend:
+#       deploy:
+#         resources:
+#           limits:
+#             memory: 1536M
+# then `docker compose up -d backend`. For swap: sudo ./scripts/setup-swap.sh
+# (idempotent; setup.sh runs it automatically on low-RAM hosts).
 #
 # Opt-in switch (default off). The admin-UI toggle overrides this.
 # FFMPEG_HANDLER_ENABLED=true

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,8 @@ apps/frontend/storybook-static/
 
 # Impeccable tooling cache
 **/.impeccable/
+
+# Local compose customizations (e.g. raising the backend memory limit for
+# server video ops) — the supported override seam; never edit docker-compose.yml
+# on a deployed instance or `git pull` updates will conflict.
+docker-compose.override.yml

--- a/setup.sh
+++ b/setup.sh
@@ -305,6 +305,28 @@ install_openssl() {
     print_success "OpenSSL installed successfully"
 }
 
+setup_swap_if_needed() {
+    # Low-RAM hosts want a swapfile as an OOM buffer (heavy app installs,
+    # optional server video ops). scripts/setup-swap.sh is idempotent and
+    # exits untouched on hosts with >= 4 GB RAM or existing swap, so calling
+    # it unconditionally here is safe. Opt out with SKIP_SWAP_SETUP=1.
+    if [ -n "${SKIP_SWAP_SETUP:-}" ]; then
+        return 0
+    fi
+    if [ ! -f "scripts/setup-swap.sh" ]; then
+        return 0
+    fi
+    if [ "$(id -u)" -ne 0 ]; then
+        # Swap needs root; setup itself may not. A hint beats a hard failure.
+        print_info "Skipping swap check (not root). Low-RAM hosts can add swap later: sudo ./scripts/setup-swap.sh"
+        return 0
+    fi
+    print_info "Checking swap configuration..."
+    if ! bash scripts/setup-swap.sh; then
+        print_warning "Swap setup did not complete (see above); continuing without it."
+    fi
+}
+
 # Detect OS type
 detect_os() {
     if [ -f /etc/os-release ]; then
@@ -513,6 +535,8 @@ check_prerequisites() {
             exit 1
         fi
     fi
+
+    setup_swap_if_needed
 
     echo ""
     print_success "All prerequisites met!"


### PR DESCRIPTION
## Summary

Closes the manual-steps gap found while enabling server video ops on a live 2 GB droplet (follow-up to #654/#656):

- **`setup.sh` now runs `scripts/setup-swap.sh` at the end of the prerequisites check** — covering both the interactive and web-bootstrap flows. The script was already idempotent and RAM-aware (no-ops on ≥ 4 GB hosts or existing swap; shipped with the DO one-click image but never wired into the normal install path). Not-root prints a hint instead of failing; `SKIP_SWAP_SETUP=1` opts out.
- **`docker-compose.override.yml` is now git-ignored** and documented as *the* supported way to customize compose (e.g. raising the backend memory limit for server video ops) without breaking `git pull` updates on deployed instances.
- **`.env.example`** replaces the vague "raise it" in the server-video-ops section with the exact override snippet + the swap script pointer.

## Testing

- `bash -n setup.sh` clean; `scripts/setup-swap.test.sh` all cases pass
- Field-verified: the override-file + swap approach is exactly what enabled server video ops on bffless.dev (2 GB droplet) — clean `git status` (untracked override only), encode CPU peaks ~75% with the API responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TMhm1VqRhMysfLNtXUXtd

