### PR TITLE
ci: generate herdr-style release notes from conventional commits

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -212,6 +212,13 @@ jobs:
           # Get the current release body
           CURRENT_BODY=$(gh release view "$VERSION" --json body -q '.body')
 
+          # The release-notes job (release-please.yml) writes the Docker block
+          # itself; only append when it is missing (manual tag builds).
+          if printf '%s' "$CURRENT_BODY" | grep -q '^## Docker Images'; then
+            echo "Release notes already list Docker images, skipping"
+            exit 0
+          fi
+
           # Append Docker image info
           DOCKER_INFO="
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,30 @@
+name: PR Title
+
+# PRs are squash-merged with the PR title as the commit subject, and release
+# notes / CHANGELOG entries are generated from those subjects
+# (scripts/release-notes.mjs). This gate keeps titles conventional so every
+# change lands in the right section (feat → Added, fix → Fixed, ...).
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/release-notes.mjs
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate conventional PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: node scripts/release-notes.mjs check --subject "$TITLE"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,73 @@ jobs:
           echo "Release created: ${{ steps.release.outputs.tag_name }}"
           echo "Version: ${{ steps.release.outputs.version }}"
 
+  # Rewrite the release body (and the CHANGELOG.md entry) from conventional
+  # commits in herdr style — Added / Fixed / Performance sections, (#PR, thanks
+  # @user) refs, no commit hashes. See scripts/release-notes.mjs.
+  release-notes:
+    name: Polish release notes
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ needs.release-please.outputs.tag_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Resolve previous stable tag
+        id: prev
+        run: |
+          set -euo pipefail
+          git fetch --tags --force origin
+          # Nearest v* tag reachable from the parent of the release commit
+          # (excludes preview-* and the CLI's bffless-v* tags).
+          PREV="$(git describe --tags --match 'v[0-9]*' --abbrev=0 "${TAG}^" 2>/dev/null || true)"
+          if [ -z "$PREV" ]; then
+            echo "No previous stable tag found; using root commit"
+            PREV="$(git rev-list --max-parents=0 HEAD | tail -1)"
+          fi
+          echo "previous=$PREV" >> "$GITHUB_OUTPUT"
+          echo "date=$(git log -1 --format=%cs "$TAG")" >> "$GITHUB_OUTPUT"
+          echo "Range: $PREV..$TAG"
+
+      - name: Collect PR authors
+        run: node scripts/release-notes.mjs authors --range "${{ steps.prev.outputs.previous }}..$TAG" > authors.json
+
+      - name: Rewrite GitHub release body
+        run: |
+          set -euo pipefail
+          node scripts/release-notes.mjs stable --tag "$TAG" --previous "${{ steps.prev.outputs.previous }}" --authors authors.json > RELEASE_NOTES.md
+          cat RELEASE_NOTES.md
+          gh release edit "$TAG" --notes-file RELEASE_NOTES.md
+
+      - name: Rewrite CHANGELOG.md entry
+        run: |
+          set -euo pipefail
+          node scripts/release-notes.mjs changelog --tag "$TAG" --previous "${{ steps.prev.outputs.previous }}" --date "${{ steps.prev.outputs.date }}" --authors authors.json
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "CHANGELOG.md unchanged"; exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "chore(changelog): polish $TAG notes"
+          # main may have moved while we ran — rebase once and retry.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then exit 0; fi
+            git fetch origin main && git rebase origin/main
+          done
+          echo "::warning::Could not push CHANGELOG.md polish for $TAG"
+
   build-docker:
     name: Build Docker Images
     needs: release-please

--- a/.github/workflows/shell-checks.yml
+++ b/.github/workflows/shell-checks.yml
@@ -42,3 +42,10 @@ jobs:
           bash scripts/compose-profiles.test.sh
           bash scripts/lifecycle.test.sh
           bash marketplace/digitalocean/files/first-login.test.sh
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Script unit tests (node)
+        run: node --test scripts/release-notes.test.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,34 +316,17 @@ pnpm test:e2e -- tests/upload.spec.ts
 
 ### CI/CD Workflows
 
-The repository uses two GitHub Actions workflows:
-
-**1. `main-release.yml`** - Triggered on push to main
-- Type checking (frontend + backend)
-- Testing with coverage upload
-- Docker image build and push to GHCR
-- Deployment to production (DigitalOcean)
-- Automatic versioning and GitHub release creation
-- Docker images tagged with: `latest`, `vX.Y.Z`, `main-<sha>`
-
-**2. `pr-tests.yml`** - Triggered on pull requests
-- Type checking (frontend + backend)
-- Testing with coverage upload
-- Frontend build preview (for PRs targeting main)
+- **`pr-tests.yml`** — type check, tests + coverage, frontend build preview on PRs. **`pr-title.yml`** gates conventional PR titles (they become the squash commit subjects the release notes are generated from).
+- **`release-please.yml`** — keeps the `chore(main): release X` PR open; merging it tags `vX.Y.Z`, then `main-release.yml` builds `latest` + `vX.Y.Z` images and the `release-notes` job rewrites the release body / `CHANGELOG.md` entry via `scripts/release-notes.mjs`.
 
 ### Releases
 
-Releases are created automatically on successful deploy to main:
-- Version is auto-incremented (patch by default)
-- Can trigger manual minor/major bumps via workflow dispatch
-- Docker images are tagged with semantic version
-- GitHub Release is created with auto-generated changelog
-- `package.json` version is kept in sync
+Releases are batched: merge PRs freely, cut a stable release by merging the release-please PR. Notes are generated from conventional commit subjects — never hand-edit `CHANGELOG.md` or the release body. See `CONTRIBUTING.md` → *Releases*.
 
 ```bash
 # Pull specific version
-docker pull ghcr.io/bffless/ce-frontend:v0.1.5
-docker pull ghcr.io/bffless/ce-backend:v0.1.5
+docker pull ghcr.io/bffless/ce-frontend:v0.4.28
+docker pull ghcr.io/bffless/ce-backend:v0.4.28
 ```
 
 ### Docker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,18 +28,42 @@ Thank you for your interest in contributing! This document provides guidelines a
 - Write meaningful variable and function names
 - Add comments for complex logic
 
-## Commit Messages
+## Commit Messages and PR Titles
 
-Use clear and descriptive commit messages:
+PRs are squash-merged and **the PR title becomes the commit subject on `main`**.
+Release notes and `CHANGELOG.md` are generated from those subjects, so titles
+must follow [Conventional Commits](https://www.conventionalcommits.org/) — a CI
+check (`PR Title`) enforces it:
 
 ```
-feat: add user authentication
-fix: resolve asset upload bug
-docs: update API documentation
-refactor: simplify storage adapter interface
-test: add tests for asset deletion
-chore: update dependencies
+feat(cli): add login command          → Added
+fix: resolve asset upload bug         → Fixed
+perf: cache nginx config lookups      → Performance
+feat!: drop Node 18 support           → Breaking (and Added)
+docs / ci / test / refactor / chore   → Maintenance (collapsed in release notes)
 ```
+
+Write the description as the line you would want to read in the release notes:
+what changed for the user, not how. Scopes are optional; when present they are
+kept as a prefix (`cli: add login command`). Do not repeat the PR number — GitHub
+appends `(#N)` on squash.
+
+## Releases
+
+Releases are **batched**, not cut on every merge:
+
+- [release-please](https://github.com/googleapis/release-please) keeps a
+  `chore(main): release X.Y.Z` PR open that accumulates everything merged since
+  the last release. **Merging that PR cuts the stable release**: it tags `vX.Y.Z`,
+  builds the `latest` images, and `scripts/release-notes.mjs` rewrites the
+  release body and the `CHANGELOG.md` entry into Added / Fixed / Performance
+  sections with `(#PR, thanks @contributor)` references.
+- Versions bump from commit types (`fix` → patch, `feat` → minor while pre-1.0
+  is configured as patch). To force a specific version, add a
+  `Release-As: X.Y.Z` footer to a commit on `main`.
+
+Nothing in the release notes is hand-written — if a line reads badly, fix the
+PR title before merging.
 
 ## Pull Request Process
 
@@ -64,4 +88,3 @@ Feel free to open an issue for questions or clarifications.
 ## Code of Conduct
 
 Be respectful and constructive in all interactions.
-

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,10 +21,10 @@
     }
   },
   "changelog-sections": [
-    { "type": "feat", "section": "Features" },
-    { "type": "fix", "section": "Bug Fixes" },
-    { "type": "perf", "section": "Performance Improvements" },
-    { "type": "revert", "section": "Reverts" },
+    { "type": "feat", "section": "Added" },
+    { "type": "fix", "section": "Fixed" },
+    { "type": "perf", "section": "Performance" },
+    { "type": "revert", "section": "Reverted" },
     { "type": "docs", "section": "Documentation", "hidden": true },
     { "type": "style", "section": "Styles", "hidden": true },
     { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,494 @@
+#!/usr/bin/env node
+// release-notes.mjs — generate human-readable release notes from conventional commits.
+//
+// CE squash-merges PRs with conventional titles (`type(scope)!: description (#N)`),
+// so the git history of `main` is the changelog. This script turns a commit range
+// into Keep-a-Changelog style sections (Breaking / Added / Fixed / Performance /
+// Reverted / Maintenance / Other) with `(#N, thanks @user)` references and no
+// commit hashes. It is the single source for three consumers:
+//
+//   stable     GitHub release body for a vX.Y.Z release
+//   preview    GitHub pre-release body for a preview build
+//   changelog  rewrite the release-please entry for a version in CHANGELOG.md
+//   authors    collect PR author + association for a range (needs `gh`)
+//   check      validate a PR title / commit subject is conventional (CI gate)
+//
+// Zero dependencies (Node >= 20). Tests: node --test scripts/release-notes.test.mjs
+//
+// Usage:
+//   node scripts/release-notes.mjs stable    --tag v0.5.0 --previous v0.4.28 [--repo bffless/ce] [--authors authors.json]
+//   node scripts/release-notes.mjs preview   --commit <sha> --previous <sha|tag> --base-version v0.4.28 --build-id 2026-08-15-abcdef123456 [--repo ...]
+//   node scripts/release-notes.mjs changelog --tag v0.5.0 --previous v0.4.28 --date 2026-08-20 [--file CHANGELOG.md] [--authors authors.json]
+//   node scripts/release-notes.mjs authors   --range v0.4.28..v0.5.0 [--repo bffless/ce]
+//   node scripts/release-notes.mjs check     --subject "feat(cli): add login (#12)"   # exit 1 if not conventional
+//
+// All subcommands print to stdout except `changelog`, which rewrites --file in place.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export const DEFAULT_REPO = 'bffless/ce';
+export const DEFAULT_BRANCH = 'main';
+export const INSTALL_URL = 'https://bffless.dev/install.sh';
+
+const TYPE_SECTIONS = {
+  feat: 'Added',
+  fix: 'Fixed',
+  perf: 'Performance',
+  revert: 'Reverted',
+  docs: 'Maintenance',
+  ci: 'Maintenance',
+  test: 'Maintenance',
+  refactor: 'Maintenance',
+  chore: 'Maintenance',
+  build: 'Maintenance',
+  style: 'Maintenance',
+};
+
+export const SECTION_ORDER = [
+  'Breaking',
+  'Added',
+  'Fixed',
+  'Performance',
+  'Reverted',
+  'Maintenance',
+  'Other',
+];
+
+/** Association values GitHub reports for people who maintain the repo (no "thanks"). */
+const MAINTAINER_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+
+const HIDDEN_SUBJECT_PATTERNS = [
+  /^chore(\([^)]*\))?: release\b/i, // release-please: "chore(main): release 0.4.28" / "chore: release main"
+  /^chore\(changelog\):/i, // our own CHANGELOG polish commits
+  /^Merge (branch|pull request|remote-tracking branch)\b/, // merge commits
+];
+
+const CONVENTIONAL_RE = /^(?<type>[a-z]+)(?:\((?<scope>[^)]*)\))?(?<bang>!)?:\s+(?<desc>.+)$/s;
+const TRAILING_PR_RE = /\s*\(#(?<pr>\d+)\)\s*$/;
+
+/**
+ * Parse a commit subject (and optional body) into its conventional parts.
+ * @returns {{type: string|null, scope: string|null, breaking: boolean, description: string, pr: number|null, section: string, hidden: boolean}}
+ */
+export function parseSubject(subject, body = '') {
+  const raw = subject.trim();
+  const hidden = HIDDEN_SUBJECT_PATTERNS.some((re) => re.test(raw));
+
+  let pr = null;
+  let text = raw;
+  const prMatch = TRAILING_PR_RE.exec(text);
+  if (prMatch) {
+    pr = Number(prMatch.groups.pr);
+    text = text.slice(0, prMatch.index).trim();
+  }
+
+  const breakingFooter = /(^|\n)BREAKING[ -]CHANGE:/.test(body);
+  const m = CONVENTIONAL_RE.exec(text);
+  if (!m || !(m.groups.type in TYPE_SECTIONS)) {
+    return {
+      type: null,
+      scope: null,
+      breaking: breakingFooter,
+      description: text,
+      pr,
+      section: 'Other',
+      hidden,
+    };
+  }
+  const type = m.groups.type;
+  return {
+    type,
+    scope: m.groups.scope?.trim() || null,
+    breaking: Boolean(m.groups.bang) || breakingFooter,
+    description: m.groups.desc.trim(),
+    pr,
+    section: TYPE_SECTIONS[type],
+    hidden,
+  };
+}
+
+function capitalize(s) {
+  return s.length ? s[0].toUpperCase() + s.slice(1) : s;
+}
+
+function prRef(pr, { repo, linkPrs }) {
+  return linkPrs ? `[#${pr}](https://github.com/${repo}/pull/${pr})` : `#${pr}`;
+}
+
+/**
+ * Render one bullet: "scope: Description (#N, thanks @user)".
+ */
+export function renderLine(parsed, { authors = {}, repo = DEFAULT_REPO, linkPrs = false } = {}) {
+  const text = parsed.scope
+    ? `${parsed.scope}: ${parsed.description}`
+    : capitalize(parsed.description);
+  if (parsed.pr == null) return text;
+  const meta = [prRef(parsed.pr, { repo, linkPrs })];
+  const who = authors[parsed.pr] ?? authors[String(parsed.pr)];
+  if (who?.author && !MAINTAINER_ASSOCIATIONS.has(String(who.association ?? '').toUpperCase())) {
+    meta.push(`thanks @${who.author}`);
+  }
+  return `${text} (${meta.join(', ')})`;
+}
+
+/**
+ * Group commits into an ordered Map<section, string[]> of rendered bullets.
+ * Breaking changes appear both under "Breaking" and their natural section.
+ * Empty sections are omitted; hidden commits are dropped.
+ */
+export function groupCommits(commits, opts = {}) {
+  const buckets = new Map(SECTION_ORDER.map((s) => [s, []]));
+  for (const c of commits) {
+    const parsed = parseSubject(c.subject, c.body ?? '');
+    if (parsed.hidden) continue;
+    const line = renderLine(parsed, opts);
+    if (parsed.breaking) buckets.get('Breaking').push(line);
+    buckets.get(parsed.section).push(line);
+  }
+  return new Map([...buckets].filter(([, lines]) => lines.length > 0));
+}
+
+/**
+ * Render grouped sections as markdown. With `collapseMaintenance`, the
+ * Maintenance section is wrapped in a <details> block so it stays out of the way.
+ */
+export function renderSections(groups, { collapseMaintenance = false } = {}) {
+  const parts = [];
+  for (const [section, lines] of groups) {
+    const bullets = lines.map((l) => `- ${l}`).join('\n');
+    if (section === 'Maintenance' && collapseMaintenance) {
+      parts.push(`<details>\n<summary>Maintenance</summary>\n\n${bullets}\n\n</details>\n`);
+    } else {
+      parts.push(`### ${section}\n${bullets}\n`);
+    }
+  }
+  return parts.join('\n');
+}
+
+function compareUrl(repo, from, to) {
+  return `https://github.com/${repo}/compare/${from}...${to}`;
+}
+
+function dockerBlock(repo, tag) {
+  return [
+    '## Docker Images',
+    '',
+    '```bash',
+    `docker pull ghcr.io/${repo}-frontend:${tag}`,
+    `docker pull ghcr.io/${repo}-backend:${tag}`,
+    '```',
+    '',
+  ].join('\n');
+}
+
+/** Stable release body. */
+export function renderStable({ tag, previous, repo = DEFAULT_REPO, commits, authors = {} }) {
+  const groups = groupCommits(commits, { authors, repo });
+  const body = groups.size
+    ? renderSections(groups, { collapseMaintenance: true })
+    : '_No user-facing changes in this release._\n';
+  const install = [
+    '## Install / Update',
+    '',
+    '```bash',
+    `# New install`,
+    `sh -c "$(curl -fsSL ${INSTALL_URL})"`,
+    `# Existing install`,
+    './update.sh',
+    '```',
+    '',
+  ].join('\n');
+  const footer = previous ? `**Full changelog**: ${compareUrl(repo, previous, tag)}\n` : '';
+  return [body, dockerBlock(repo, tag), install, footer].filter(Boolean).join('\n');
+}
+
+/** Preview (pre-release) body. */
+export function renderPreview({
+  commit,
+  previous,
+  baseVersion,
+  buildId,
+  repo = DEFAULT_REPO,
+  branch = DEFAULT_BRANCH,
+  commits,
+  authors = {},
+}) {
+  const shortSha = commit.slice(0, 12);
+  const header = [
+    `Preview build ${buildId}`,
+    '',
+    `Built from \`${shortSha}\` on \`${branch}\`.`,
+    `Base stable: ${baseVersion}`,
+    `Compare: ${compareUrl(repo, previous, commit)}`,
+    '',
+  ].join('\n');
+  const groups = groupCommits(commits, { authors, repo });
+  const body = groups.size
+    ? renderSections(groups, { collapseMaintenance: false })
+    : `### Changed\n- Rebuilt preview from the current ${branch} branch.\n`;
+  const previewTag = `preview-${buildId}`;
+  const channel = [
+    '## Docker Images',
+    '',
+    '```bash',
+    `docker pull ghcr.io/${repo}-frontend:${previewTag}`,
+    `docker pull ghcr.io/${repo}-backend:${previewTag}`,
+    '```',
+    '',
+    `The moving \`:preview\` tag also points at this build. Opt a self-hosted install into the preview channel with \`CHANNEL=preview\` on install or \`./update.sh --channel preview\`.`,
+    '',
+  ].join('\n');
+  return [header, body, channel].join('\n');
+}
+
+/** CHANGELOG.md entry for a version, in release-please's header format. */
+export function renderChangelogEntry({
+  tag,
+  previous,
+  date,
+  repo = DEFAULT_REPO,
+  commits,
+  authors = {},
+}) {
+  const version = tag.replace(/^v/, '');
+  const link = previous
+    ? compareUrl(repo, previous, tag)
+    : `https://github.com/${repo}/releases/tag/${tag}`;
+  const header = `## [${version}](${link}) (${date})\n`;
+  const groups = groupCommits(commits, { authors, repo, linkPrs: true });
+  const body = groups.size
+    ? renderSections(groups, { collapseMaintenance: false })
+    : '_No user-facing changes in this release._\n';
+  return `${header}\n${body}`;
+}
+
+/**
+ * Replace the `## [version]` block in a CHANGELOG with `entry` (which must start
+ * with its own `## [version]` header and end with a newline). If the version is
+ * absent, insert before the first `## [` entry. Idempotent.
+ */
+export function replaceChangelogEntry(changelog, tag, entry) {
+  const version = tag.replace(/^v/, '');
+  const lines = changelog.split('\n');
+  const isEntryHeader = (l) => /^## \[/.test(l);
+  const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const start = lines.findIndex((l) => new RegExp(`^## \\[${escaped}\\]`).test(l));
+  const entryLines = entry.replace(/\n+$/, '').split('\n');
+
+  if (start === -1) {
+    const first = lines.findIndex(isEntryHeader);
+    const at = first === -1 ? lines.length : first;
+    const before = lines.slice(0, at);
+    while (before.length && before[before.length - 1] === '') before.pop();
+    const after = lines.slice(at);
+    return [...before, '', ...entryLines, '', ...after].join('\n');
+  }
+
+  let end = start + 1;
+  while (end < lines.length && !isEntryHeader(lines[end])) end++;
+  const before = lines.slice(0, start);
+  const after = lines.slice(end);
+  const out = [...before, ...entryLines];
+  if (after.length) out.push('', ...after);
+  else out.push('');
+  return out.join('\n');
+}
+
+/**
+ * Is this subject a conventional commit we know how to render? Used as the PR
+ * title gate so squash commits (whose subject is the PR title) stay parseable.
+ */
+export function isConventional(subject) {
+  return parseSubject(subject).type !== null;
+}
+
+/** Unique, sorted PR numbers referenced by a commit list. */
+export function extractPrNumbers(commits) {
+  const set = new Set();
+  for (const c of commits) {
+    const p = parseSubject(c.subject, c.body ?? '');
+    if (p.pr != null) set.add(p.pr);
+  }
+  return [...set].sort((a, b) => a - b);
+}
+
+// ---------------------------------------------------------------------------
+// git / gh plumbing
+// ---------------------------------------------------------------------------
+
+const FIELD_SEP = '\x00';
+const RECORD_SEP = '\x1e';
+
+/** Parse `git log --format=%H%x00%s%x00%b%x1e` output. */
+export function parseGitLog(raw) {
+  return raw
+    .split(RECORD_SEP)
+    .map((r) => r.replace(/^\n/, ''))
+    .filter((r) => r.trim().length)
+    .map((r) => {
+      const [sha, subject, body = ''] = r.split(FIELD_SEP);
+      return { sha: sha.trim(), subject: (subject ?? '').trim(), body: body.trim() };
+    });
+}
+
+export function readCommits(range) {
+  // git expands %x00 / %x1e itself — argv strings must not contain NUL bytes.
+  const raw = execFileSync('git', ['log', '--no-merges', '--format=%H%x00%s%x00%b%x1e', range], {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return parseGitLog(raw);
+}
+
+/** Look up PR author + association via `gh api`. Failures degrade to "unknown". */
+export function fetchAuthors(prs, repo = DEFAULT_REPO) {
+  const out = {};
+  for (const pr of prs) {
+    try {
+      const json = execFileSync(
+        'gh',
+        [
+          'api',
+          `repos/${repo}/pulls/${pr}`,
+          '--jq',
+          '{author: .user.login, association: .author_association}',
+        ],
+        {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        },
+      );
+      out[pr] = JSON.parse(json);
+    } catch {
+      // PR may not exist (e.g. squash from a fork mirror) — leave it out
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const [cmd, ...rest] = argv;
+  const opts = {};
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+    const next = rest[i + 1];
+    if (next === undefined || next.startsWith('--')) opts[key] = true;
+    else {
+      opts[key] = next;
+      i++;
+    }
+  }
+  return { cmd, opts };
+}
+
+function need(opts, ...keys) {
+  for (const k of keys) {
+    if (opts[k] === undefined || opts[k] === true) {
+      console.error(`missing --${k.replace(/[A-Z]/g, (c) => '-' + c.toLowerCase())}`);
+      process.exit(2);
+    }
+  }
+}
+
+function loadAuthors(path) {
+  if (!path) return {};
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const { cmd, opts } = parseArgs(argv);
+  const repo = opts.repo ?? DEFAULT_REPO;
+  switch (cmd) {
+    case 'stable': {
+      need(opts, 'tag', 'previous');
+      const commits = readCommits(`${opts.previous}..${opts.tag}`);
+      process.stdout.write(
+        renderStable({
+          tag: opts.tag,
+          previous: opts.previous,
+          repo,
+          commits,
+          authors: loadAuthors(opts.authors),
+        }),
+      );
+      return 0;
+    }
+    case 'preview': {
+      need(opts, 'commit', 'previous', 'baseVersion', 'buildId');
+      const commits = readCommits(`${opts.previous}..${opts.commit}`);
+      process.stdout.write(
+        renderPreview({
+          commit: opts.commit,
+          previous: opts.previous,
+          baseVersion: opts.baseVersion,
+          buildId: opts.buildId,
+          repo,
+          branch: opts.branch ?? DEFAULT_BRANCH,
+          commits,
+          authors: loadAuthors(opts.authors),
+        }),
+      );
+      return 0;
+    }
+    case 'changelog': {
+      need(opts, 'tag', 'previous', 'date');
+      const file = opts.file ?? 'CHANGELOG.md';
+      const commits = readCommits(`${opts.previous}..${opts.tag}`);
+      const entry = renderChangelogEntry({
+        tag: opts.tag,
+        previous: opts.previous,
+        date: opts.date,
+        repo,
+        commits,
+        authors: loadAuthors(opts.authors),
+      });
+      const current = readFileSync(file, 'utf8');
+      const next = replaceChangelogEntry(current, opts.tag, entry);
+      if (next !== current) writeFileSync(file, next);
+      console.error(
+        next === current ? `${file}: already up to date` : `${file}: rewrote entry for ${opts.tag}`,
+      );
+      return 0;
+    }
+    case 'authors': {
+      need(opts, 'range');
+      const commits = readCommits(opts.range);
+      process.stdout.write(
+        JSON.stringify(fetchAuthors(extractPrNumbers(commits), repo), null, 2) + '\n',
+      );
+      return 0;
+    }
+    case 'check': {
+      need(opts, 'subject');
+      if (isConventional(opts.subject)) {
+        console.log(`ok: ${opts.subject}`);
+        return 0;
+      }
+      const types = Object.keys(TYPE_SECTIONS).join('|');
+      console.error(
+        `Not a conventional title: "${opts.subject}"\n` +
+          `Expected: <type>(<optional scope>)<optional !>: <description>\n` +
+          `Types: ${types}\n` +
+          `Examples: "feat(cli): add login command", "fix: survive empty token", "feat!: drop node 18"`,
+      );
+      return 1;
+    }
+    default:
+      console.error(
+        'usage: release-notes.mjs <stable|preview|changelog|authors|check> [--options]',
+      );
+      return 2;
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exit(main());
+}

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -1,0 +1,255 @@
+// Tests for scripts/release-notes.mjs — run with: node --test scripts/release-notes.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseSubject,
+  groupCommits,
+  renderSections,
+  renderStable,
+  renderPreview,
+  renderChangelogEntry,
+  replaceChangelogEntry,
+  extractPrNumbers,
+  parseGitLog,
+  isConventional,
+} from './release-notes.mjs';
+
+const REPO = 'bffless/ce';
+
+test('parseSubject: type, scope, pr, breaking marker', () => {
+  const p = parseSubject('feat(cli)!: add login command (#123)');
+  assert.equal(p.type, 'feat');
+  assert.equal(p.scope, 'cli');
+  assert.equal(p.breaking, true);
+  assert.equal(p.description, 'add login command');
+  assert.equal(p.pr, 123);
+  assert.equal(p.section, 'Added');
+});
+
+test('parseSubject: maps types to sections', () => {
+  assert.equal(parseSubject('fix: x').section, 'Fixed');
+  assert.equal(parseSubject('perf: x').section, 'Performance');
+  assert.equal(parseSubject('revert: x').section, 'Reverted');
+  for (const t of ['docs', 'ci', 'test', 'refactor', 'chore', 'build', 'style']) {
+    assert.equal(parseSubject(`${t}: x`).section, 'Maintenance', t);
+  }
+});
+
+test('parseSubject: non-conventional subject lands in Other, no type', () => {
+  const p = parseSubject('AI settings clarity: name the cards (#637)');
+  assert.equal(p.type, null);
+  assert.equal(p.section, 'Other');
+  assert.equal(p.pr, 637);
+  assert.equal(p.description, 'AI settings clarity: name the cards');
+});
+
+test('parseSubject: hidden subjects', () => {
+  assert.equal(parseSubject('chore(main): release 0.4.28 (#661)').hidden, true);
+  assert.equal(parseSubject('chore: release main (#661)').hidden, true);
+  assert.equal(parseSubject('chore(changelog): polish v0.4.28 notes').hidden, true);
+  assert.equal(parseSubject("Merge branch 'main' into foo").hidden, true);
+  assert.equal(parseSubject('Merge pull request #1 from x/y').hidden, true);
+  assert.equal(parseSubject('chore: bump deps (#5)').hidden, false);
+});
+
+test('parseSubject: BREAKING CHANGE footer marks breaking', () => {
+  const p = parseSubject(
+    'feat: drop node 18 (#9)',
+    'Some body\n\nBREAKING CHANGE: node 20 required',
+  );
+  assert.equal(p.breaking, true);
+});
+
+test('groupCommits: orders sections, capitalizes, keeps scope, adds thanks', () => {
+  const commits = [
+    { subject: 'chore: tidy ci (#3)', body: '' },
+    { subject: 'fix(cli): handle empty token (#2)', body: '' },
+    { subject: 'feat!: new auth flow (#1)', body: '' },
+    { subject: 'feat: add thing (#4)', body: '' },
+    { subject: 'chore(main): release 0.1.0 (#5)', body: '' },
+  ];
+  const authors = {
+    2: { author: 'alice', association: 'CONTRIBUTOR' },
+    4: { author: 'toshimoto821', association: 'OWNER' },
+  };
+  const groups = groupCommits(commits, { authors });
+  assert.deepEqual([...groups.keys()], ['Breaking', 'Added', 'Fixed', 'Maintenance']);
+  assert.deepEqual(groups.get('Breaking'), ['New auth flow (#1)']);
+  assert.deepEqual(groups.get('Added'), ['New auth flow (#1)', 'Add thing (#4)']);
+  assert.deepEqual(groups.get('Fixed'), ['cli: handle empty token (#2, thanks @alice)']);
+  assert.deepEqual(groups.get('Maintenance'), ['Tidy ci (#3)']);
+});
+
+test('groupCommits: description without pr number renders bare', () => {
+  const groups = groupCommits([{ subject: 'fix: no pr here', body: '' }], {});
+  assert.deepEqual(groups.get('Fixed'), ['No pr here']);
+});
+
+test('groupCommits: pr link mode renders markdown links', () => {
+  const groups = groupCommits([{ subject: 'fix: thing (#7)', body: '' }], {
+    repo: REPO,
+    linkPrs: true,
+  });
+  assert.deepEqual(groups.get('Fixed'), ['Thing ([#7](https://github.com/bffless/ce/pull/7))']);
+});
+
+test('renderSections: collapses Maintenance into details when asked', () => {
+  const groups = new Map([
+    ['Added', ['A (#1)']],
+    ['Maintenance', ['M (#2)']],
+  ]);
+  const out = renderSections(groups, { collapseMaintenance: true });
+  assert.match(out, /### Added\n- A \(#1\)\n/);
+  assert.match(out, /<details>\n<summary>Maintenance<\/summary>\n\n- M \(#2\)\n\n<\/details>/);
+  assert.doesNotMatch(out, /### Maintenance/);
+  const inline = renderSections(groups, { collapseMaintenance: false });
+  assert.match(inline, /### Maintenance\n- M \(#2\)/);
+});
+
+test('renderStable: sections + docker + install + compare', () => {
+  const commits = [
+    { subject: 'feat: add thing (#4)', body: '' },
+    { subject: 'ci: bump action (#6)', body: '' },
+  ];
+  const out = renderStable({
+    tag: 'v0.5.0',
+    previous: 'v0.4.28',
+    repo: REPO,
+    commits,
+    authors: {},
+  });
+  assert.match(out, /^### Added\n- Add thing \(#4\)\n/);
+  assert.match(out, /<summary>Maintenance<\/summary>/);
+  assert.match(
+    out,
+    /## Docker Images\n\n```bash\ndocker pull ghcr\.io\/bffless\/ce-frontend:v0\.5\.0\ndocker pull ghcr\.io\/bffless\/ce-backend:v0\.5\.0\n```/,
+  );
+  assert.match(out, /## Install \/ Update/);
+  assert.match(out, /https:\/\/bffless\.dev\/install\.sh/);
+  assert.match(
+    out,
+    /\*\*Full changelog\*\*: https:\/\/github\.com\/bffless\/ce\/compare\/v0\.4\.28\.\.\.v0\.5\.0/,
+  );
+});
+
+test('renderStable: empty range says so instead of empty body', () => {
+  const out = renderStable({
+    tag: 'v0.5.0',
+    previous: 'v0.4.28',
+    repo: REPO,
+    commits: [],
+    authors: {},
+  });
+  assert.match(out, /No user-facing changes/);
+});
+
+test('renderPreview: header, sections, fallback and docker block', () => {
+  const base = {
+    commit: 'd78e3d3b51266a1ff80ae6858b894e782aac3e9f',
+    previous: 'v0.4.28',
+    baseVersion: 'v0.4.28',
+    buildId: '2026-08-15-d78e3d3b5126',
+    repo: REPO,
+  };
+  const out = renderPreview({
+    ...base,
+    commits: [
+      { subject: 'fix: keep status visible (#2239)', body: '' },
+      { subject: 'docs: refine blog post', body: '' },
+    ],
+  });
+  assert.match(
+    out,
+    /^Preview build 2026-08-15-d78e3d3b5126\n\nBuilt from `d78e3d3b5126` on `main`\.\nBase stable: v0\.4\.28\nCompare: https:\/\/github\.com\/bffless\/ce\/compare\/v0\.4\.28\.\.\.d78e3d3b51266a1ff80ae6858b894e782aac3e9f\n/,
+  );
+  assert.match(out, /### Fixed\n- Keep status visible \(#2239\)\n/);
+  assert.match(out, /### Maintenance\n- Refine blog post\n/);
+  assert.match(out, /docker pull ghcr\.io\/bffless\/ce-backend:preview-2026-08-15-d78e3d3b5126/);
+  assert.match(out, /:preview/);
+  const empty = renderPreview({ ...base, commits: [] });
+  assert.match(empty, /### Changed\n- Rebuilt preview from the current main branch\./);
+});
+
+test('renderChangelogEntry: release-please compatible header, linked PRs, no docker footer', () => {
+  const out = renderChangelogEntry({
+    tag: 'v0.5.0',
+    previous: 'v0.4.28',
+    date: '2026-08-20',
+    repo: REPO,
+    commits: [{ subject: 'feat: add thing (#4)', body: '' }],
+    authors: {},
+  });
+  assert.match(
+    out,
+    /^## \[0\.5\.0\]\(https:\/\/github\.com\/bffless\/ce\/compare\/v0\.4\.28\.\.\.v0\.5\.0\) \(2026-08-20\)\n\n### Added\n- Add thing \(\[#4\]\(https:\/\/github\.com\/bffless\/ce\/pull\/4\)\)\n/,
+  );
+  assert.doesNotMatch(out, /Docker/);
+});
+
+const CHANGELOG = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.4.28](https://github.com/bffless/ce/compare/v0.4.27...v0.4.28) (2026-08-13)
+
+
+### Features
+
+* run swap setup ([#660](https://github.com/bffless/ce/issues/660)) ([428f982](https://github.com/bffless/ce/commit/428f982))
+
+## [0.4.27](https://github.com/bffless/ce/compare/v0.4.26...v0.4.27) (2026-08-13)
+
+
+### Bug Fixes
+
+* pin SuperTokens ([#658](https://github.com/bffless/ce/issues/658)) ([6f15dec](https://github.com/bffless/ce/commit/6f15dec))
+`;
+
+test('replaceChangelogEntry: replaces only the matching block and is idempotent', () => {
+  const entry =
+    '## [0.4.28](https://github.com/bffless/ce/compare/v0.4.27...v0.4.28) (2026-08-13)\n\n### Added\n- Run swap setup ([#660](https://github.com/bffless/ce/pull/660))\n';
+  const once = replaceChangelogEntry(CHANGELOG, 'v0.4.28', entry);
+  assert.match(once, /### Added\n- Run swap setup/);
+  assert.doesNotMatch(once, /### Features/);
+  assert.match(once, /## \[0\.4\.27\][\s\S]*### Bug Fixes/); // untouched
+  assert.equal(replaceChangelogEntry(once, 'v0.4.28', entry), once);
+  // exactly one blank line between blocks
+  assert.match(once, /pull\/660\)\)\n\n## \[0\.4\.27\]/);
+});
+
+test('replaceChangelogEntry: inserts before first entry when the version is missing', () => {
+  const entry =
+    '## [0.5.0](https://github.com/bffless/ce/compare/v0.4.28...v0.5.0) (2026-08-20)\n\n### Added\n- New (#1)\n';
+  const out = replaceChangelogEntry(CHANGELOG, 'v0.5.0', entry);
+  assert.match(out, /documented in this file\.\n\n## \[0\.5\.0\][\s\S]*\n\n## \[0\.4\.28\]/);
+});
+
+test('extractPrNumbers: unique, sorted', () => {
+  assert.deepEqual(
+    extractPrNumbers([
+      { subject: 'a (#5)', body: '' },
+      { subject: 'b (#2)', body: '' },
+      { subject: 'c (#5)', body: '' },
+      { subject: 'd', body: '' },
+    ]),
+    [2, 5],
+  );
+});
+
+test('parseGitLog: splits NUL/RS separated records', () => {
+  const raw = 'abc\x00feat: a (#1)\x00body a\x1e' + 'def\x00fix: b\x00\x1e';
+  assert.deepEqual(parseGitLog(raw), [
+    { sha: 'abc', subject: 'feat: a (#1)', body: 'body a' },
+    { sha: 'def', subject: 'fix: b', body: '' },
+  ]);
+});
+
+test('isConventional: PR title gate', () => {
+  assert.equal(isConventional('feat(cli): add login command'), true);
+  assert.equal(isConventional('fix!: drop node 18 (#9)'), true);
+  assert.equal(isConventional('chore(main): release 0.5.0'), true);
+  assert.equal(isConventional('Feat: capitalised type'), false);
+  assert.equal(isConventional('AI settings clarity: name the cards'), false);
+  assert.equal(isConventional('update readme'), false);
+  assert.equal(isConventional('feat:missing space'), false);
+});


### PR DESCRIPTION
## Why

CE releases have been cut on every merged `feat`/`fix` with raw conventional-commit notes (hashes, "Miscellaneous" noise). We want the [herdr](https://github.com/herdrdev/herdr/releases) pattern: batched stable releases with a clean Keep-a-Changelog body, and preview builds in between — **without hand-writing notes**.

This PR is part 1 (notes + batching); preview builds follow in a stacked PR.

## What

- **`scripts/release-notes.mjs`** — zero-dependency Node script (+ `node --test` suite, 18 tests, wired into `shell-checks.yml`) that turns a commit range into `### Added / Fixed / Performance / Breaking` sections with `(#PR, thanks @user)` refs and no hashes. Subcommands: `stable`, `preview`, `changelog`, `authors`, `check`.
- **`release-please.yml`** — new `release-notes` job: after a release is created it rewrites the GitHub release body (`gh release edit`) and the `CHANGELOG.md` entry for that version, pushing one `chore(changelog): polish vX notes` commit to `main` (GITHUB_TOKEN pushes don't retrigger workflows).
- **`main-release.yml`** — the "Docker Images" append is now idempotent (the generator writes that block itself).
- **`pr-title.yml`** — PR titles must be conventional (they become the squash subjects the notes are generated from).
- **`release-please-config.json`** — sections renamed to Added / Fixed / Performance / Reverted.
- **`CONTRIBUTING.md` / `CLAUDE.md`** — document titles-as-changelog and the batched release process.

## Batching

No code needed: just leave the `chore(main): release X` PR open and merge it when a release is worth cutting.

## Sample output (`stable --tag v0.4.28 --previous v0.4.20`)

```
### Added
- Run swap setup during onboarding and bless docker-compose.override.yml (#660)
- Server video ops become an opt-in admin setting (#656)
- Server-side video ops via ffmpeg pipeline handler (#654)
- pipelines: include chunk metadata in vector search results (#652)
- Preview the app catalog on the admin home page (#646)
- Preserve local rule edits when updating an installed app (#643)

### Fixed
- Pin SuperTokens core to 12.0.10 and survive role-claim merge failure in signin (#658)
- frontend: scroll install dialog when preflight results overflow (#649)
- Stop large app installs OOM-killing the backend (#645)

## Docker Images
...
**Full changelog**: https://github.com/bffless/ce/compare/v0.4.20...v0.4.28
```

## Verification

- `node --test scripts/release-notes.test.mjs` → 18/18
- Dry-runs against real history for `stable`, `preview`, and `changelog` (idempotent on second run)
- The `release-notes` job is exercised by the next stable release — check `gh release view vX` and the `chore(changelog)` commit on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
