### PR TITLE
feat: preview builds on every merge and stable/preview release channels

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -7,9 +7,18 @@ on:
   workflow_call:
     inputs:
       tag:
-        description: 'Tag to build'
+        description: 'Image tag to publish (vX.Y.Z, or preview-<build-id>)'
         required: true
         type: string
+      ref:
+        description: 'Git ref to build (defaults to the tag)'
+        required: false
+        type: string
+      channel:
+        description: "stable (default: also tags :latest, runs the full test suite) or preview (tags :preview, type-check + build only)"
+        required: false
+        type: string
+        default: 'stable'
   workflow_dispatch:
     inputs:
       tag:
@@ -18,7 +27,7 @@ on:
         type: string
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.tag || github.ref }}
   cancel-in-progress: false
 
 env:
@@ -38,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ inputs.ref || inputs.tag || github.ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -80,15 +89,18 @@ jobs:
           path: apps/frontend/dist
           api-url: ${{ vars.ASSET_HOST_URL }}
           api-key: ${{ secrets.ASSET_HOST_KEY }}
-          alias: production
-          description: 'Frontend build for ${{ github.ref_name }}@${{ github.sha }}'
+          alias: ${{ inputs.channel == 'preview' && 'preview' || 'production' }}
+          description: 'Frontend build for ${{ inputs.tag || github.ref_name }}@${{ github.sha }}'
           summary-title: Frontend Build
 
+      # Preview builds skip the suite: PR CI already ran it on the same commits,
+      # and a preview should land minutes after the merge.
       - name: Run tests with coverage
+        if: inputs.channel != 'preview'
         run: pnpm test
 
       - name: Upload backend coverage
-        if: hashFiles('apps/backend/coverage') != ''
+        if: inputs.channel != 'preview' && hashFiles('apps/backend/coverage') != ''
         continue-on-error: true
         uses: bffless/upload-artifact@v1
         with:
@@ -100,7 +112,7 @@ jobs:
           summary: 'false'
 
       - name: Upload frontend coverage
-        if: hashFiles('apps/frontend/coverage') != ''
+        if: inputs.channel != 'preview' && hashFiles('apps/frontend/coverage') != ''
         continue-on-error: true
         uses: bffless/upload-artifact@v1
         with:
@@ -120,7 +132,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ inputs.ref || inputs.tag || github.ref }}
 
       - name: Get version from tag
         id: version
@@ -151,7 +163,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-frontend
           tags: |
-            type=raw,value=latest
+            type=raw,value=${{ inputs.channel == 'preview' && 'preview' || 'latest' }}
             type=raw,value=${{ steps.version.outputs.version }}
             type=sha,prefix=main-
 
@@ -161,7 +173,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-backend
           tags: |
-            type=raw,value=latest
+            type=raw,value=${{ inputs.channel == 'preview' && 'preview' || 'latest' }}
             type=raw,value=${{ steps.version.outputs.version }}
             type=sha,prefix=main-
 
@@ -191,12 +203,13 @@ jobs:
           path: apps/frontend/dist
           api-url: ${{ vars.ASSET_HOST_URL }}
           api-key: ${{ secrets.ASSET_HOST_KEY }}
-          alias: production
+          alias: ${{ inputs.channel == 'preview' && 'preview' || 'production' }}
           tags: ${{ steps.version.outputs.version }}
           description: 'Frontend build for release ${{ steps.version.outputs.version }}'
           summary: 'false'
 
       - name: Update release with Docker image info
+        if: inputs.channel != 'preview'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,221 @@
+name: Preview Build
+
+# Every merge to main publishes a preview: ghcr images tagged
+# preview-<YYYY-MM-DD>-<sha12> (+ the moving :preview tag) and a GitHub
+# pre-release whose notes are generated from the conventional commits since
+# the previous preview (scripts/release-notes.mjs). Stable releases are cut
+# separately by merging the release-please PR (see CONTRIBUTING.md → Releases).
+#
+# Self-hosted installs opt in with `CHANNEL=preview` at install time or
+# `./update.sh --channel preview`.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'Optional main commit SHA to publish (defaults to HEAD)'
+        required: false
+        type: string
+
+# A newer push supersedes an in-flight preview; its commits are covered by the
+# next preview's notes (the range starts at the last *published* preview).
+concurrency:
+  group: preview
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  KEEP_PREVIEWS: 30
+
+jobs:
+  preflight:
+    name: Plan preview
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.plan.outputs.should_publish }}
+      commit: ${{ steps.plan.outputs.commit }}
+      short_sha: ${{ steps.plan.outputs.short_sha }}
+      build_id: ${{ steps.plan.outputs.build_id }}
+      tag: ${{ steps.plan.outputs.tag }}
+      base_version: ${{ steps.plan.outputs.base_version }}
+      previous: ${{ steps.plan.outputs.previous }}
+      cli_changed: ${{ steps.plan.outputs.cli_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Select preview commit
+        id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --tags --force origin
+          requested="${{ github.event.inputs.commit || '' }}"
+          if [ -n "$requested" ]; then
+            commit="$(git rev-parse "${requested}^{commit}")"
+            if ! git merge-base --is-ancestor "$commit" origin/main; then
+              echo "::error::requested commit $commit is not reachable from origin/main"
+              exit 1
+            fi
+          else
+            commit="$(git rev-parse origin/main)"
+          fi
+          subject="$(git log -1 --format=%s "$commit")"
+          # The release merge is built as vX.Y.Z by release-please.yml, and
+          # changelog polish commits carry no code — neither needs a preview.
+          case "$subject" in
+            "chore(main): release"*|"chore: release"*|"chore(changelog):"*)
+              echo "Skipping preview for: $subject"
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+          if [ -n "$(git tag --points-at "$commit" 'preview-*')" ]; then
+            echo "A preview already exists for $commit; skipping."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git checkout -q --detach "$commit"
+          short_sha="$(git rev-parse --short=12 HEAD)"
+          day="$(git show -s --format=%cs HEAD)"
+          build_id="$day-$short_sha"
+          base_version="v$(node -p "require('./package.json').version")"
+          # Range base for the notes: newest previous preview tag on main, else
+          # the newest stable tag.
+          previous="$(git tag --list 'preview-*' --sort=-creatordate --merged "$commit^" 2>/dev/null | head -1)"
+          if [ -z "$previous" ]; then
+            previous="$(git describe --tags --match 'v[0-9]*' --abbrev=0 "$commit^" 2>/dev/null || true)"
+          fi
+          if [ -z "$previous" ]; then
+            previous="$(git rev-list --max-parents=0 "$commit" | tail -1)"
+          fi
+          if git diff --quiet "$previous" "$commit" -- packages/cli; then
+            cli_changed=false
+          else
+            cli_changed=true
+          fi
+          {
+            echo "should_publish=true"
+            echo "commit=$commit"
+            echo "short_sha=$short_sha"
+            echo "build_id=$build_id"
+            echo "tag=preview-$build_id"
+            echo "base_version=$base_version"
+            echo "previous=$previous"
+            echo "cli_changed=$cli_changed"
+          } >> "$GITHUB_OUTPUT"
+          echo "Preview preview-$build_id from $commit (base $base_version, notes since $previous, cli_changed=$cli_changed)"
+
+  build:
+    name: Build preview images
+    needs: preflight
+    if: needs.preflight.outputs.should_publish == 'true'
+    uses: ./.github/workflows/main-release.yml
+    with:
+      tag: ${{ needs.preflight.outputs.tag }}
+      ref: ${{ needs.preflight.outputs.commit }}
+      channel: preview
+    secrets: inherit
+
+  publish:
+    name: Publish pre-release
+    needs: [preflight, build]
+    if: needs.preflight.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ needs.preflight.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.commit }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate notes
+        run: |
+          set -euo pipefail
+          git fetch --tags --force origin
+          node scripts/release-notes.mjs authors --range "${{ needs.preflight.outputs.previous }}..${{ needs.preflight.outputs.commit }}" > authors.json
+          node scripts/release-notes.mjs preview \
+            --commit "${{ needs.preflight.outputs.commit }}" \
+            --previous "${{ needs.preflight.outputs.previous }}" \
+            --base-version "${{ needs.preflight.outputs.base_version }}" \
+            --build-id "${{ needs.preflight.outputs.build_id }}" \
+            --authors authors.json > PREVIEW_NOTES.md
+          cat PREVIEW_NOTES.md
+
+      - name: Create preview pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.preflight.outputs.tag }}
+          name: Preview build ${{ needs.preflight.outputs.build_id }}
+          body_path: PREVIEW_NOTES.md
+          prerelease: true
+          make_latest: false
+          target_commitish: ${{ needs.preflight.outputs.commit }}
+
+      - name: Prune old preview pre-releases
+        run: |
+          set -euo pipefail
+          gh release list --repo "$GITHUB_REPOSITORY" --limit 200 --json tagName,isPrerelease,createdAt \
+            | node -e '
+              const rs = JSON.parse(require("fs").readFileSync(0, "utf8"))
+                .filter((r) => r.isPrerelease && String(r.tagName).startsWith("preview-"))
+                .sort((a, b) => String(b.createdAt).localeCompare(String(a.createdAt)));
+              for (const r of rs.slice(Number(process.env.KEEP_PREVIEWS))) console.log(r.tagName);
+            ' > old-previews.txt
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            echo "Deleting $tag"
+            gh release delete "$tag" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag || echo "::warning::could not delete $tag"
+          done < old-previews.txt
+
+      - name: Summary
+        run: |
+          {
+            echo "## Preview build ${{ needs.preflight.outputs.build_id }}"
+            echo ""
+            echo "- Release: https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG}"
+            echo "- Images: \`ghcr.io/${GITHUB_REPOSITORY}-backend:${TAG}\`, \`ghcr.io/${GITHUB_REPOSITORY}-frontend:${TAG}\` (also \`:preview\`)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish-cli-next:
+    name: Publish CLI as bffless@next
+    needs: [preflight, build]
+    if: needs.preflight.outputs.should_publish == 'true' && needs.preflight.outputs.cli_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.commit }}
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+      - run: pnpm install --frozen-lockfile
+      - name: Version as prerelease
+        working-directory: packages/cli
+        run: |
+          set -euo pipefail
+          base="$(node -p "require('./package.json').version")"
+          day="$(echo "${{ needs.preflight.outputs.build_id }}" | cut -d- -f1-3 | tr -d -)"
+          version="${base}-next.${day}.g${{ needs.preflight.outputs.short_sha }}"  # g-prefix: keeps an all-digit sha a valid semver identifier
+          npm version "$version" --no-git-tag-version
+          echo "Publishing bffless@$version (dist-tag next)"
+      - run: pnpm --filter ./packages/cli publish --tag next --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/shell-checks.yml
+++ b/.github/workflows/shell-checks.yml
@@ -25,8 +25,9 @@ jobs:
         run: |
           shellcheck \
             restart.sh update.sh logs.sh status.sh backup.sh \
-            scripts/setup-swap.sh scripts/compose-profiles.sh \
+            scripts/setup-swap.sh scripts/compose-profiles.sh scripts/channel.sh \
             scripts/setup-swap.test.sh scripts/compose-profiles.test.sh scripts/lifecycle.test.sh \
+            scripts/channel.test.sh \
             marketplace/digitalocean/scripts/010-prep.sh \
             marketplace/digitalocean/scripts/020-docker.sh \
             marketplace/digitalocean/scripts/030-bffless.sh \
@@ -41,6 +42,7 @@ jobs:
           bash scripts/setup-swap.test.sh
           bash scripts/compose-profiles.test.sh
           bash scripts/lifecycle.test.sh
+          bash scripts/channel.test.sh
           bash marketplace/digitalocean/files/first-login.test.sh
 
       - uses: actions/setup-node@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,11 +317,14 @@ pnpm test:e2e -- tests/upload.spec.ts
 ### CI/CD Workflows
 
 - **`pr-tests.yml`** — type check, tests + coverage, frontend build preview on PRs. **`pr-title.yml`** gates conventional PR titles (they become the squash commit subjects the release notes are generated from).
+- **`preview.yml`** — every push to `main` publishes a preview pre-release (`preview-YYYY-MM-DD-<sha>`) with `ghcr.io/bffless/ce-{frontend,backend}:preview` images (built through `main-release.yml` with `channel: preview`), and `bffless@next` on npm when `packages/cli` changed.
 - **`release-please.yml`** — keeps the `chore(main): release X` PR open; merging it tags `vX.Y.Z`, then `main-release.yml` builds `latest` + `vX.Y.Z` images and the `release-notes` job rewrites the release body / `CHANGELOG.md` entry via `scripts/release-notes.mjs`.
 
 ### Releases
 
-Releases are batched: merge PRs freely, cut a stable release by merging the release-please PR. Notes are generated from conventional commit subjects — never hand-edit `CHANGELOG.md` or the release body. See `CONTRIBUTING.md` → *Releases*.
+Releases are batched: merge PRs freely (each merge = a preview build), cut a stable release by merging the release-please PR. Notes are generated from conventional commit subjects — never hand-edit `CHANGELOG.md` or the release body. See `CONTRIBUTING.md` → *Releases*.
+
+Self-hosted installs follow a **release channel** (`scripts/channel.sh`, persisted as `BFFLESS_CHANNEL` in `.env`): `stable` pins the git tree to the newest `vX.Y.Z` tag + `:latest` images; `preview` tracks `main` + `:preview` images. `install.sh` (`CHANNEL=…`) and `update.sh --channel …` manage it.
 
 ```bash
 # Pull specific version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,9 @@ appends `(#N)` on squash.
 
 Releases are **batched**, not cut on every merge:
 
+- Merging to `main` publishes a **preview build** (a pre-release tagged
+  `preview-YYYY-MM-DD-<sha>` with `ghcr.io/bffless/ce-*:preview` images) — see
+  the README's _Release channels_ section.
 - [release-please](https://github.com/googleapis/release-please) keeps a
   `chore(main): release X.Y.Z` PR open that accumulates everything merged since
   the last release. **Merging that PR cuts the stable release**: it tags `vX.Y.Z`,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BFFless
 
+[![Stable](https://img.shields.io/github/v/release/bffless/ce?label=stable&color=2ea44f)](https://github.com/bffless/ce/releases/latest)
+[![Preview](https://img.shields.io/github/v/release/bffless/ce?include_prereleases&filter=preview-*&label=preview&color=blue)](https://github.com/bffless/ce/releases?q=preview&expanded=false)
 [![Main Release](https://github.com/bffless/ce/actions/workflows/main-release.yml/badge.svg)](https://github.com/bffless/ce/actions/workflows/main-release.yml)
 [![PR Tests](https://github.com/bffless/ce/actions/workflows/pr-tests.yml/badge.svg)](https://github.com/bffless/ce/actions/workflows/pr-tests.yml)
 
@@ -66,7 +68,7 @@ to re-run.
 | `./start.sh` | Start services (profile-aware; `--all`, `--minimal`) |
 | `./stop.sh` | Stop services (`--volumes` also deletes data — careful) |
 | `./restart.sh` | `stop.sh` + `start.sh`; flags pass through to `start.sh` |
-| `./update.sh` | Upgrade: `git pull --ff-only` → pull images → restart. Aborts on a dirty tree |
+| `./update.sh` | Upgrade to what your release channel tracks → pull images → restart. Aborts on a dirty tree. `--channel stable\|preview` switches channel |
 | `./logs.sh [service]` | Follow logs for all services, or one (`backend`, `nginx`, ...) |
 | `./status.sh` | Versions (with restart-pending warning), services, RAM/swap/disk, domain, SSL expiry, health check |
 | `./backup.sh` | `backups/bffless-backup-<ts>.tar.gz`: database dump + assets + config. Contains secrets — store securely |
@@ -77,6 +79,27 @@ out containers:
 ```bash
 sudo ./scripts/setup-swap.sh   # idempotent; no-ops on hosts with >= 4 GB RAM
 ```
+
+### Release channels
+
+| Channel | What you run | When it moves |
+| --- | --- | --- |
+| **stable** (default) | The newest [`vX.Y.Z` release](https://github.com/bffless/ce/releases/latest): git tree pinned to that tag, images `ghcr.io/bffless/ce-*:latest` | When a release is cut (batched, roughly weekly) |
+| **preview** | `main`: git tree on `main`, images `ghcr.io/bffless/ce-*:preview` | On every merge — each one is a [pre-release](https://github.com/bffless/ce/releases?q=preview&expanded=false) with generated notes |
+
+```bash
+# New install on the preview channel
+CHANNEL=preview sh -c "$(curl -fsSL https://bffless.dev/install.sh)"
+
+# Switch an existing install (persisted in .env, then followed by ./update.sh)
+./update.sh --channel preview
+./update.sh --channel stable
+```
+
+Preview images are exactly what the next stable release will contain, built minutes
+after each merge — useful for testing a fix before it ships. Every preview
+pre-release lists the changes since the previous one and pins its image tag
+(`preview-YYYY-MM-DD-<sha>`) if you need to reproduce a build.
 
 ## Technology Stack
 

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,10 @@
 # Or with custom installation directory:
 #   INSTALL_DIR=/opt/bffless sh -c "$(curl -fsSL https://...)"
 #
-# Or specify a branch/tag:
+# Release channel (default: stable — the newest vX.Y.Z tag + :latest images):
+#   CHANNEL=preview sh -c "$(curl -fsSL https://...)"   # main + :preview images
+#
+# Or pin an explicit branch/tag (overrides the channel's ref):
 #   BRANCH=v1.0.0 sh -c "$(curl -fsSL https://...)"
 #
 # For the old terminal-based onboarding wizard instead of the web bootstrap:
@@ -32,7 +35,11 @@ set -e
 
 # Repository configuration
 REPO_URL="${REPO_URL:-https://github.com/bffless/ce.git}"
-BRANCH="${BRANCH:-main}"
+# Release channel: stable (default) or preview. Persisted to .env after setup;
+# ./update.sh follows it from then on (see scripts/channel.sh).
+CHANNEL="${CHANNEL:-stable}"
+# BRANCH: explicit override; otherwise resolved from the channel in main().
+BRANCH="${BRANCH:-}"
 
 # Installation directory (default: current directory)
 INSTALL_DIR="${INSTALL_DIR:-./ce}"
@@ -102,6 +109,26 @@ print_info() {
 # Check if a command exists
 command_exists() {
     command -v "$1" >/dev/null 2>&1
+}
+
+# Newest stable release tag (vX.Y.Z) on the remote — the stable channel pins
+# the checkout to it so compose files / scripts match the :latest images.
+# Mirrors channel_latest_stable_tag in scripts/channel.sh (not cloned yet here).
+latest_stable_tag() {
+    git ls-remote --tags --refs "$REPO_URL" 'refs/tags/v[0-9]*' 2>/dev/null \
+        | sed -nE 's#^[0-9a-f]+[[:space:]]+refs/tags/(v[0-9]+\.[0-9]+\.[0-9]+)$#\1#p' \
+        | sort -t. -k1.2,1n -k2,2n -k3,3n \
+        | tail -1
+}
+
+# Record the release channel in .env (after setup.sh has created it) so
+# docker compose pulls the matching images and ./update.sh keeps following it.
+persist_channel() {
+    if [ -f ".env" ] && [ -f "scripts/channel.sh" ]; then
+        # shellcheck disable=SC1091
+        . ./scripts/channel.sh
+        channel_write "$CHANNEL" .env
+    fi
 }
 
 # Best-effort public IP detection, for the "open https://<ip>" fallback in
@@ -193,6 +220,29 @@ main() {
         exit 1
     fi
 
+    case "$CHANNEL" in
+        stable|preview) ;;
+        *)
+            print_error "Unknown CHANNEL '$CHANNEL' (stable|preview)."
+            exit 1
+            ;;
+    esac
+
+    # Resolve what to check out: an explicit BRANCH wins; otherwise the
+    # channel decides — stable pins the newest release tag, preview tracks main.
+    if [ -z "$BRANCH" ]; then
+        if [ "$CHANNEL" = "preview" ]; then
+            BRANCH="main"
+        else
+            BRANCH="$(latest_stable_tag)"
+            if [ -z "$BRANCH" ]; then
+                print_warning "Could not resolve the latest release tag; falling back to main."
+                BRANCH="main"
+            fi
+        fi
+    fi
+    print_info "Channel: $CHANNEL (checkout: $BRANCH)"
+
     # Check if installation directory exists
     if [ -d "$INSTALL_DIR" ]; then
         print_warning "Directory $INSTALL_DIR already exists."
@@ -203,9 +253,14 @@ main() {
             [yY][eE][sS]|[yY])
                 print_info "Updating existing installation..."
                 cd "$INSTALL_DIR"
-                git fetch origin
-                git checkout "$BRANCH"
-                git pull origin "$BRANCH"
+                git fetch --tags origin
+                if git show-ref -q --verify "refs/remotes/origin/$BRANCH"; then
+                    git checkout "$BRANCH"
+                    git pull --ff-only origin "$BRANCH"
+                else
+                    # A tag (stable channel): detached checkout, nothing to pull
+                    git checkout --detach "$BRANCH"
+                fi
                 ;;
             *)
                 print_info "Installation cancelled."
@@ -269,6 +324,7 @@ main() {
         print_info "Running setup script (interactive)..."
         echo ""
         BFFLESS_INSTALL_DIR="$ABSOLUTE_INSTALL_DIR" ./setup.sh "$@"
+        persist_channel
         return 0
     fi
 
@@ -285,6 +341,7 @@ main() {
             print_error "Bootstrap setup failed (exit $bootstrap_exit). Not starting the stack."
             exit "$bootstrap_exit"
         fi
+        persist_channel
 
         if [ ! -f "start.sh" ]; then
             print_error "Start script not found at start.sh"
@@ -306,6 +363,7 @@ main() {
     print_info "Running setup script..."
     echo ""
     BFFLESS_INSTALL_DIR="$ABSOLUTE_INSTALL_DIR" ./setup.sh "$@"
+    persist_channel
 }
 
 # Run main function

--- a/marketplace/digitalocean/files/first-login.sh
+++ b/marketplace/digitalocean/files/first-login.sh
@@ -77,8 +77,14 @@ if [ "$answer" != "setup" ]; then
 fi
 
 # ---- Terminal fallback: Coolify-style interactive setup. --------------------
-echo "Self-updating first (safe to skip on network failure)..."
-timeout 120 git pull --ff-only || echo -e "${YELLOW}⚠ git pull failed — continuing with the current version${NC}"
+echo "Self-updating to the newest stable release first (safe to skip on network failure)..."
+# shellcheck disable=SC1091
+source scripts/channel.sh
+if timeout 120 git fetch --tags origin; then
+    git checkout -q --detach "$(channel_ref stable origin)" || echo -e "${YELLOW}⚠ checkout failed — continuing with the current version${NC}"
+else
+    echo -e "${YELLOW}⚠ git fetch failed — continuing with the current version${NC}"
+fi
 timeout 600 docker compose --profile postgres --profile minio --profile redis --profile supertokens pull || echo -e "${YELLOW}⚠ image pull failed — continuing with cached images${NC}"
 
 # Interactive setup.sh will ask before overwriting the bootstrap .env — answer

--- a/marketplace/digitalocean/files/var/lib/cloud/scripts/per-instance/002-bffless-first-boot
+++ b/marketplace/digitalocean/files/var/lib/cloud/scripts/per-instance/002-bffless-first-boot
@@ -12,8 +12,16 @@ for _ in $(seq 1 60); do
     sleep 2
 done
 
-# Best-effort self-update: the image is a warm cache, never a pinned release.
-timeout 120 git pull --ff-only || echo "git pull failed/timed out — continuing with baked tree"
+# Best-effort self-update to the newest stable release: the image is a warm
+# cache, never a pinned release. The tree is pinned to the release tag so
+# compose files / scripts match the :latest images (stable channel).
+# shellcheck disable=SC1091
+source scripts/channel.sh
+if timeout 120 git fetch --tags origin; then
+    git checkout -q --detach "$(channel_ref stable origin)" || echo "checkout failed — continuing with baked tree"
+else
+    echo "git fetch failed/timed out — continuing with baked tree"
+fi
 timeout 600 docker compose --profile postgres --profile minio --profile redis --profile supertokens pull || echo "compose pull failed/timed out — continuing with cached images"
 
 # Generates per-droplet secrets + ONBOARDING_TOKEN, writes .env, exits 0.

--- a/marketplace/digitalocean/scripts/030-bffless.sh
+++ b/marketplace/digitalocean/scripts/030-bffless.sh
@@ -9,6 +9,11 @@ MARKETPLACE_DIR="$INSTALL_DIR/marketplace/digitalocean"
 
 git clone https://github.com/bffless/ce.git "$INSTALL_DIR"
 cd "$INSTALL_DIR"
+# Stable channel: bake the newest release tag, not main (droplets re-pin at
+# first boot; main can be ahead of the :latest images between releases).
+# shellcheck disable=SC1091
+source scripts/channel.sh
+git checkout --detach "$(channel_ref stable origin)"
 
 # Pre-pull every profile's images so a droplet's first boot only fetches deltas.
 docker compose --profile postgres --profile minio --profile redis --profile supertokens pull

--- a/scripts/channel.sh
+++ b/scripts/channel.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# Shared helper: release-channel handling for self-hosted installs.
+# POSIX sh — sourced by install.sh, update.sh and status.sh.
+#
+#   stable  (default)  git tree pinned to the newest vX.Y.Z tag, images :latest
+#   preview            git tree on main, images :preview (rebuilt on every merge)
+#
+# The choice is persisted in .env as BFFLESS_CHANNEL; the preview channel also
+# sets BACKEND_TAG / FRONTEND_TAG so docker-compose.yml resolves :preview.
+# Tests: bash scripts/channel.test.sh
+
+CHANNEL_DEFAULT="stable"
+CHANNEL_MAIN_BRANCH="${CHANNEL_MAIN_BRANCH:-main}"
+
+channel_valid() {
+    case "$1" in
+        stable|preview) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Channel recorded in an .env file (default ./.env); "stable" when unset/invalid.
+channel_read() {
+    _env_file="${1:-.env}"
+    _ch=""
+    if [ -f "$_env_file" ]; then
+        _ch=$(sed -nE 's/^BFFLESS_CHANNEL=["'"'"']?([A-Za-z]+).*$/\1/p' "$_env_file" | tail -1)
+    fi
+    if channel_valid "$_ch"; then
+        echo "$_ch"
+    else
+        echo "$CHANNEL_DEFAULT"
+    fi
+}
+
+# Persist a channel to an .env file (default ./.env). Replaces any existing
+# BFFLESS_CHANNEL / BACKEND_TAG / FRONTEND_TAG lines. stable drops the *_TAG
+# keys so docker-compose.yml falls back to :latest.
+channel_write() {
+    _ch="$1"
+    _env_file="${2:-.env}"
+    if ! channel_valid "$_ch"; then
+        echo "channel_write: invalid channel '$_ch' (stable|preview)" >&2
+        return 1
+    fi
+    [ -f "$_env_file" ] || : > "$_env_file"
+    _tmp="${_env_file}.channel.tmp"
+    grep -vE '^(BFFLESS_CHANNEL|BACKEND_TAG|FRONTEND_TAG)=|^# Release channel \(' "$_env_file" > "$_tmp" || true
+    # Ensure the file ends with a newline before appending.
+    if [ -s "$_tmp" ] && [ "$(tail -c1 "$_tmp" | od -An -c | tr -d ' ')" != '\n' ]; then
+        echo "" >> "$_tmp"
+    fi
+    {
+        echo "# Release channel (stable | preview) - managed by install.sh / update.sh --channel"
+        echo "BFFLESS_CHANNEL=$_ch"
+        if [ "$_ch" = "preview" ]; then
+            echo "BACKEND_TAG=preview"
+            echo "FRONTEND_TAG=preview"
+        fi
+    } >> "$_tmp"
+    mv "$_tmp" "$_env_file"
+}
+
+# Newest stable tag (vX.Y.Z, no pre-release suffix) on a remote (name or URL).
+# Prints nothing when the remote has no stable tags or cannot be reached.
+channel_latest_stable_tag() {
+    _remote="${1:-origin}"
+    git ls-remote --tags --refs "$_remote" 'refs/tags/v[0-9]*' 2>/dev/null \
+        | sed -nE 's#^[0-9a-f]+[[:space:]]+refs/tags/(v[0-9]+\.[0-9]+\.[0-9]+)$#\1#p' \
+        | sort -t. -k1.2,1n -k2,2n -k3,3n \
+        | tail -1
+}
+
+# Git ref a channel should track on a remote: preview → main;
+# stable → newest vX.Y.Z tag, or main when the remote has no stable tag yet.
+channel_ref() {
+    _ch="$1"
+    _remote="${2:-origin}"
+    if [ "$_ch" = "preview" ]; then
+        echo "$CHANNEL_MAIN_BRANCH"
+        return 0
+    fi
+    _tag=$(channel_latest_stable_tag "$_remote")
+    echo "${_tag:-$CHANNEL_MAIN_BRANCH}"
+}
+
+# preview-YYYY-MM-DD-<sha> tag pointing exactly at HEAD, if any.
+channel_head_preview_tag() {
+    git tag --points-at HEAD 'preview-*' 2>/dev/null | head -1
+}

--- a/scripts/channel.test.sh
+++ b/scripts/channel.test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Unit tests for scripts/channel.sh. Run: bash scripts/channel.test.sh
+# No network: the "remote" is a local bare repo with tags.
+set -u
+FAILURES=0
+LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/channel.sh"
+
+ok()   { echo "ok: $1"; }
+fail() { echo "FAIL: $1"; FAILURES=$((FAILURES+1)); }
+assert_eq() { # got want label
+    if [ "$1" = "$2" ]; then ok "$3"; else fail "$3 (got '$1', want '$2')"; fi
+}
+assert_grep() { # file pattern label
+    if grep -qE "$2" "$1"; then ok "$3"; else fail "$3 (no /$2/ in $1)"; fi
+}
+assert_no_grep() { # file pattern label
+    if ! grep -qE "$2" "$1"; then ok "$3"; else fail "$3 (unexpected /$2/ in $1)"; fi
+}
+
+SB=$(mktemp -d)
+trap 'rm -rf "$SB"' EXIT
+cd "$SB" || exit 1
+# shellcheck disable=SC1090
+. "$LIB"
+
+echo "— channel_read —"
+assert_eq "$(channel_read /nonexistent)" "stable" "missing .env → stable"
+printf 'FOO=bar\n' > a.env
+assert_eq "$(channel_read a.env)" "stable" "no key → stable"
+printf 'BFFLESS_CHANNEL=preview\n' > a.env
+assert_eq "$(channel_read a.env)" "preview" "preview read back"
+printf 'BFFLESS_CHANNEL="preview"\n' > a.env
+assert_eq "$(channel_read a.env)" "preview" "quoted value read back"
+printf 'BFFLESS_CHANNEL=nightly\n' > a.env
+assert_eq "$(channel_read a.env)" "stable" "invalid value → stable"
+
+echo "— channel_write —"
+printf 'ENABLE_MINIO=true' > b.env   # no trailing newline on purpose
+channel_write preview b.env
+assert_grep b.env '^ENABLE_MINIO=true$' "existing keys preserved"
+assert_grep b.env '^BFFLESS_CHANNEL=preview$' "channel written"
+assert_grep b.env '^BACKEND_TAG=preview$' "backend tag written"
+assert_grep b.env '^FRONTEND_TAG=preview$' "frontend tag written"
+channel_write preview b.env
+assert_eq "$(grep -c '^BFFLESS_CHANNEL=' b.env)" "1" "rewrite is idempotent (one channel line)"
+assert_eq "$(grep -c '^# Release channel' b.env)" "1" "rewrite is idempotent (one comment line)"
+channel_write stable b.env
+assert_grep b.env '^BFFLESS_CHANNEL=stable$' "switch back to stable"
+assert_no_grep b.env '^(BACKEND|FRONTEND)_TAG=' "stable drops image tag overrides"
+assert_grep b.env '^ENABLE_MINIO=true$' "other keys still intact after switch"
+assert_eq "$(channel_read b.env)" "stable" "read after write round-trips"
+channel_write bogus b.env 2>/dev/null; rc=$?
+assert_eq "$rc" "1" "invalid channel rejected"
+channel_write preview c.env
+assert_grep c.env '^BFFLESS_CHANNEL=preview$' "creates .env when missing"
+
+echo "— channel_latest_stable_tag / channel_ref —"
+git init -q src && (
+    cd src || exit 1; git config user.email t@t && git config user.name t
+    git commit -q --allow-empty -m init
+    git tag v0.4.9; git tag v0.4.10; git tag v0.4.28; git tag bffless-v0.3.1
+    git tag preview-2026-08-15-abcdef123456; git tag v0.5.0-rc.1
+)
+git clone -q --bare src remote.git
+assert_eq "$(channel_latest_stable_tag "$SB/remote.git")" "v0.4.28" "newest stable tag (numeric sort, ignores cli/preview/rc tags)"
+assert_eq "$(channel_ref stable "$SB/remote.git")" "v0.4.28" "stable ref = newest tag"
+assert_eq "$(channel_ref preview "$SB/remote.git")" "main" "preview ref = main"
+git init -q --bare empty.git
+assert_eq "$(channel_latest_stable_tag "$SB/empty.git")" "" "no tags → empty"
+assert_eq "$(channel_ref stable "$SB/empty.git")" "main" "stable with no tags falls back to main"
+assert_eq "$(channel_ref stable "$SB/does-not-exist.git")" "main" "unreachable remote falls back to main"
+
+echo "— channel_head_preview_tag —"
+(
+    cd src || exit 1
+    assert_eq "$(channel_head_preview_tag)" "preview-2026-08-15-abcdef123456" "preview tag at HEAD"
+    git commit -q --allow-empty -m next
+    assert_eq "$(channel_head_preview_tag)" "" "no preview tag at new HEAD"
+    exit "$FAILURES"
+); FAILURES=$((FAILURES+$?))
+
+if [ "$FAILURES" -eq 0 ]; then
+    echo 'ALL CHANNEL TESTS PASSED'
+else
+    echo "$FAILURES FAILURES"
+    exit 1
+fi

--- a/scripts/lifecycle.test.sh
+++ b/scripts/lifecycle.test.sh
@@ -26,6 +26,7 @@ make_sandbox() {
         [ -f "$REPO_ROOT/$f" ] && cp "$REPO_ROOT/$f" "$SB/app/"
     done
     cp "$REPO_ROOT/scripts/compose-profiles.sh" "$SB/app/scripts/" 2>/dev/null || true
+    cp "$REPO_ROOT/scripts/channel.sh" "$SB/app/scripts/" 2>/dev/null || true
     # Default docker stub: log argv, succeed. Cases overwrite for richer behavior.
     cat > "$SB/bin/docker" <<'STUB'
 #!/bin/bash
@@ -113,6 +114,86 @@ echo "— update.sh: clean tree pulls with detected profiles and restarts —"
         "profile-aware image pull (minio on, redis off)"
     assert_contains "calls.log" "restart" "restart.sh invoked"
     assert_contains "$DOCKER_LOG" "docker image prune -f" "superseded images pruned after restart"
+    cd / && rm -rf "$SB"
+    exit "$FAILURES"
+); FAILURES=$((FAILURES+$?))
+
+echo "— update.sh: stable channel pins the tree to the newest release tag —"
+(
+    make_sandbox
+    FAILURES=0
+    cd "$SB/app" || exit 1
+    printf '{\n  "version": "0.0.1"\n}\n' > package.json
+    # shellcheck disable=SC2016  # $CALLS_LOG must expand at stub run time
+    printf '#!/bin/bash\necho "restart $*" >> "$CALLS_LOG"\n' > restart.sh && chmod +x restart.sh
+    export CALLS_LOG="$SB/calls.log"
+    git init -q -b main && git config user.email t@t && git config user.name t
+    git add -A && git commit -qm init
+    git clone -q --bare . "$SB/origin.git"
+    git remote add origin "$SB/origin.git"
+    # Origin: v0.0.2 tagged, then main moves ahead (unreleased work)
+    git clone -q "$SB/origin.git" "$SB/dev" && (
+        cd "$SB/dev" && git config user.email t@t && git config user.name t
+        printf '{\n  "version": "0.0.2"\n}\n' > package.json && git commit -qam "release 0.0.2"
+        git tag v0.0.2
+        echo ahead > ahead.txt && git add ahead.txt && git commit -qm "feat: unreleased"
+        git push -q origin main --tags
+    )
+    git fetch -q origin && git branch -q --set-upstream-to=origin/main
+    PATH="$SB/bin:$PATH" ./update.sh > "$SB/update.out" 2>&1; rc=$?
+    assert_exit 0 "$rc" "stable update exits 0"
+    assert_contains "$SB/update.out" "channel: stable" "channel reported"
+    tag_at_head=$(git tag --points-at HEAD)
+    if [ "$tag_at_head" = "v0.0.2" ]; then echo "ok: tree pinned to v0.0.2"; else echo "FAIL: tree at '$tag_at_head', want v0.0.2"; FAILURES=$((FAILURES+1)); fi
+    if [ ! -e ahead.txt ]; then echo "ok: unreleased main commit not checked out"; else echo "FAIL: main was checked out"; FAILURES=$((FAILURES+1)); fi
+    assert_contains "$DOCKER_LOG" "pull" "images pulled"
+    assert_contains "$CALLS_LOG" "restart" "restart.sh invoked"
+    # Second run: already pinned, still succeeds
+    PATH="$SB/bin:$PATH" ./update.sh > "$SB/update2.out" 2>&1; rc=$?
+    assert_exit 0 "$rc" "re-running stable update is a no-op success"
+    assert_contains "$SB/update2.out" "Already at v0.0.2" "reports already at tag"
+    cd / && rm -rf "$SB"
+    exit "$FAILURES"
+); FAILURES=$((FAILURES+$?))
+
+echo "— update.sh: --channel preview switches .env and tracks main; invalid channel rejected —"
+(
+    make_sandbox
+    FAILURES=0
+    cd "$SB/app" || exit 1
+    printf '{\n  "version": "0.0.1"\n}\n' > package.json
+    printf 'ENABLE_MINIO=true\n' > .env
+    printf '.env\n' > .gitignore   # like the real repo: .env is untracked
+    # shellcheck disable=SC2016  # $CALLS_LOG must expand at stub run time
+    printf '#!/bin/bash\necho "restart $*" >> "$CALLS_LOG"\n' > restart.sh && chmod +x restart.sh
+    export CALLS_LOG="$SB/calls.log"
+    git init -q -b main && git config user.email t@t && git config user.name t
+    git add -A && git commit -qm init
+    git clone -q --bare . "$SB/origin.git"
+    git remote add origin "$SB/origin.git"
+    git clone -q "$SB/origin.git" "$SB/dev" && (
+        cd "$SB/dev" && git config user.email t@t && git config user.name t
+        git tag v0.0.1
+        echo ahead > ahead.txt && git add ahead.txt && git commit -qm "feat: unreleased"
+        git push -q origin main --tags
+    )
+    git fetch -q origin && git branch -q --set-upstream-to=origin/main
+    PATH="$SB/bin:$PATH" ./update.sh --channel bogus > "$SB/bogus.out" 2>&1; rc=$?
+    assert_exit 1 "$rc" "unknown channel exits 1"
+    assert_not_contains "$DOCKER_LOG" "pull" "no pull on invalid channel"
+    PATH="$SB/bin:$PATH" ./update.sh --channel preview > "$SB/update.out" 2>&1; rc=$?
+    assert_exit 0 "$rc" "preview update exits 0"
+    assert_contains "$SB/update.out" "Switching channel: stable → preview" "switch announced"
+    assert_contains .env "BFFLESS_CHANNEL=preview" "channel persisted in .env"
+    assert_contains .env "BACKEND_TAG=preview" "backend image tag override written"
+    assert_contains .env "ENABLE_MINIO=true" "existing .env keys kept"
+    if [ -e ahead.txt ]; then echo "ok: preview tracks main (unreleased commit present)"; else echo "FAIL: main not checked out"; FAILURES=$((FAILURES+1)); fi
+    assert_contains "$DOCKER_LOG" "docker compose --profile postgres --profile minio --profile supertokens pull" "profiles still detected after switch"
+    # Switch back to stable → tree returns to v0.0.1, tag overrides removed
+    PATH="$SB/bin:$PATH" ./update.sh --channel stable > "$SB/back.out" 2>&1; rc=$?
+    assert_exit 0 "$rc" "switch back to stable exits 0"
+    assert_not_contains .env "BACKEND_TAG=" "stable removes image tag override"
+    if [ ! -e ahead.txt ]; then echo "ok: stable re-pins to v0.0.1"; else echo "FAIL: still on main"; FAILURES=$((FAILURES+1)); fi
     cd / && rm -rf "$SB"
     exit "$FAILURES"
 ); FAILURES=$((FAILURES+$?))

--- a/status.sh
+++ b/status.sh
@@ -26,9 +26,13 @@ section() {
 }
 
 section "Version"
+# shellcheck disable=SC1091
+source scripts/channel.sh
 PKG_VERSION=$(sed -nE 's/.*"version": *"([^"]+)".*/\1/p' package.json | head -1)
 GIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-echo "Checked-out repo:  v${PKG_VERSION} (${GIT_SHA})"
+PREVIEW_TAG=$(channel_head_preview_tag)
+echo "Checked-out repo:  v${PKG_VERSION} (${GIT_SHA})${PREVIEW_TAG:+ [${PREVIEW_TAG}]}"
+echo "Release channel:   $(channel_read .env)  (switch with ./update.sh --channel stable|preview)"
 
 restart_pending=false
 for svc in backend frontend; do

--- a/update.sh
+++ b/update.sh
@@ -7,28 +7,52 @@ RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+# shellcheck disable=SC1091
+source scripts/channel.sh
+
+usage() {
     cat <<'EOF'
-Usage: ./update.sh
+Usage: ./update.sh [--channel stable|preview]
 
 Updates this BFFless install:
   1. Aborts if the git tree has local changes (commit or stash them first)
-  2. git pull --ff-only
+  2. Moves the git tree to what the release channel tracks:
+       stable  (default)  newest vX.Y.Z tag, images :latest
+       preview            main branch, images :preview (rebuilt on every merge)
   3. docker compose pull (only the profiles this install has enabled)
   4. ./restart.sh — start.sh rebuilds the local nginx image from the pulled tree
   5. docker image prune -f — reclaims disk from superseded (dangling) images
+
+  --channel <name>  Switch this install to another channel (persisted in .env),
+                    then update. Without it the channel recorded in .env is used.
 EOF
-    exit 0
+}
+
+NEW_CHANNEL=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --help|-h) usage; exit 0 ;;
+        --channel) NEW_CHANNEL="${2:-}"; shift ;;
+        --channel=*) NEW_CHANNEL="${1#--channel=}" ;;
+        *) echo -e "${RED}✗ Unknown argument: $1${NC}"; usage; exit 1 ;;
+    esac
+    shift
+done
+if [ -n "$NEW_CHANNEL" ] && ! channel_valid "$NEW_CHANNEL"; then
+    echo -e "${RED}✗ Unknown channel '$NEW_CHANNEL' (stable|preview)${NC}"
+    exit 1
 fi
 
 current_version() {
-    local pkg_version sha
+    local pkg_version sha preview_tag
     pkg_version=$(sed -nE 's/.*"version": *"([^"]+)".*/\1/p' package.json | head -1)
     sha=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-    echo "v${pkg_version} (${sha})"
+    preview_tag=$(channel_head_preview_tag)
+    echo "v${pkg_version} (${sha})${preview_tag:+ [${preview_tag}]}"
 }
 
-echo -e "Current version: ${GREEN}$(current_version)${NC}"
+CHANNEL=$(channel_read .env)
+echo -e "Current version: ${GREEN}$(current_version)${NC} — channel: ${CHANNEL}"
 
 if [ -n "$(git status --porcelain)" ]; then
     echo -e "${RED}✗ Local changes detected in $(pwd) — update.sh only fast-forwards a clean tree.${NC}"
@@ -37,8 +61,33 @@ if [ -n "$(git status --porcelain)" ]; then
     exit 1
 fi
 
-echo "Pulling latest code..."
-git pull --ff-only
+if [ -n "$NEW_CHANNEL" ] && [ "$NEW_CHANNEL" != "$CHANNEL" ]; then
+    echo "Switching channel: ${CHANNEL} → ${NEW_CHANNEL}"
+    channel_write "$NEW_CHANNEL" .env
+    CHANNEL="$NEW_CHANNEL"
+fi
+
+echo "Pulling latest code (${CHANNEL} channel)..."
+git fetch --tags origin
+TARGET=$(channel_ref "$CHANNEL" origin)
+if [ "$CHANNEL" = "stable" ] && [ "$TARGET" != "$CHANNEL_MAIN_BRANCH" ]; then
+    # Stable: pin the tree to the newest release tag so scripts / compose files
+    # match the :latest images (main can be ahead between releases).
+    if [ "$(git rev-parse HEAD)" != "$(git rev-parse "${TARGET}^{commit}")" ]; then
+        echo "Checking out ${TARGET}..."
+        git checkout -q --detach "$TARGET"
+    else
+        echo "Already at ${TARGET}."
+    fi
+else
+    # Preview (or a repo with no release tags yet): track main.
+    if [ "$(git symbolic-ref -q --short HEAD 2>/dev/null)" != "$CHANNEL_MAIN_BRANCH" ] \
+        && git show-ref -q --verify "refs/remotes/origin/$CHANNEL_MAIN_BRANCH"; then
+        echo "Checking out ${CHANNEL_MAIN_BRANCH}..."
+        git checkout -q -B "$CHANNEL_MAIN_BRANCH" "origin/$CHANNEL_MAIN_BRANCH"
+    fi
+    git pull --ff-only
+fi
 
 if [ -f .env ]; then
     set -a


### PR DESCRIPTION
> Base: `main` (#663 merged; rebased on top of it).

## Why

Part 2 of the herdr-style release pattern. With stable releases now batched (#663), `main` runs ahead of the last release for days — so (a) there must be a testable build of every merge, and (b) installs that clone `main` but pull `:latest` images would drift. This PR adds **preview builds** and a **release channel** for self-hosted installs.

## What

**Preview builds — `.github/workflows/preview.yml`** (every push to `main`, or manual dispatch with a commit)
- `preflight` picks the commit, skips release/changelog-polish merges and already-previewed commits, computes `preview-<YYYY-MM-DD>-<sha12>`, the notes range (previous preview tag → else newest stable tag), and whether `packages/cli` changed.
- `build` reuses `main-release.yml` with new `ref` / `channel` inputs: preview tags images `:preview` + `:preview-<id>` (never `:latest`), skips the test suite (PR CI ran it), uploads the frontend under the `preview` alias.
- `publish` generates notes with `scripts/release-notes.mjs preview` (Built from / Base stable / Compare / Added-Fixed-Maintenance) → `softprops/action-gh-release` pre-release → prunes `preview-*` beyond the newest 30 (`--cleanup-tag`).
- `publish-cli-next` publishes `bffless@<ver>-next.<date>.g<sha>` under the `next` dist-tag when the CLI changed.
- `concurrency: preview, cancel-in-progress: true` — a newer push supersedes an in-flight preview; its commits show up in the next preview's notes.

**Release channels — `scripts/channel.sh`** (POSIX sh, `channel.test.sh` + lifecycle tests)
| channel | git tree | images |
|---|---|---|
| `stable` (default) | pinned to the newest `vX.Y.Z` tag | `:latest` |
| `preview` | `main` | `:preview` |

- `install.sh`: `CHANNEL=stable|preview` (persisted as `BFFLESS_CHANNEL` in `.env` after setup); stable resolves the newest tag via `git ls-remote`, explicit `BRANCH=` still wins.
- `update.sh`: follows the recorded channel (stable → `git checkout --detach <newest tag>`, preview → `main` + `pull --ff-only`); `--channel <name>` switches and rewrites `.env` (`BACKEND_TAG`/`FRONTEND_TAG=preview` or removed). Existing installs with no `BFFLESS_CHANNEL` are treated as stable and get pinned to the newest tag on their next update.
- `status.sh` shows the channel and any `preview-*` tag at HEAD.
- DO marketplace image build / first-boot / first-login pin the newest stable tag instead of `git pull` on `main` (same drift).
- README: `stable` / `preview` shields badges + a *Release channels* section; CONTRIBUTING / CLAUDE.md updated.

## Verification

- `bash scripts/channel.test.sh`, `bash scripts/lifecycle.test.sh` (new cases: stable pins to newest tag even when main is ahead; `--channel preview` switches `.env` + tracks main; back to stable re-pins; invalid channel rejected), `bash marketplace/…/first-login.test.sh`, `node --test scripts/release-notes.test.mjs` — all green; shellcheck clean on the CI list.
- `install.sh`'s `latest_stable_tag` resolves `v0.4.28` against the real remote under `dash`.
- Live: after merge, the merge commit itself is skipped (release/changelog only) — the **next** merged PR should produce `Preview build …` + `ghcr.io/bffless/ce-backend:preview`. Then on a scratch box: `CHANNEL=preview sh -c "$(curl -fsSL https://bffless.dev/install.sh)"` and `./update.sh --channel stable`.

## Follow-ups (not in this PR)
- GHCR pruning of old `preview-*` images (blocked on the multi-arch-safe cleanup — see `cleanup-images.yml` header).
- docs-public: upgrade / channel docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)