### PR TITLE
fix(pipelines): evaluate templates in a single pass so substituted data is never re-evaluated

### DIFF
--- a/apps/backend/src/pipelines/execution/expression-evaluator.template.spec.ts
+++ b/apps/backend/src/pipelines/execution/expression-evaluator.template.spec.ts
@@ -1,0 +1,69 @@
+import { ExpressionEvaluator } from './expression-evaluator';
+import { PipelineContext } from './pipeline-context.interface';
+
+/**
+ * evaluateTemplate: substituted values must be terminal — data pulled in by
+ * one placeholder is never re-scanned as template syntax (bffless/ce#431).
+ */
+describe('ExpressionEvaluator.evaluateTemplate', () => {
+  const evaluator = new ExpressionEvaluator();
+
+  const context = {
+    user: { id: 'user-123' },
+    stepOutputs: {
+      gate: {
+        node: { id: 'n1', name: '{{user.id}}' },
+        name: '{{user.id}}',
+        obj: { a: 1 },
+        raw: 'raw{{{steps.gate.obj}}}',
+      },
+    },
+  } as unknown as PipelineContext;
+
+  it('substitutes {{expr}} with the string value', () => {
+    expect(evaluator.evaluateTemplate('hello {{user.id}}!', context)).toBe('hello user-123!');
+  });
+
+  it('substitutes {{{expr}}} objects as JSON', () => {
+    expect(evaluator.evaluateTemplate('{"node": {{{steps.gate.node}}}}', context)).toBe(
+      '{"node": {"id":"n1","name":"{{user.id}}"}}',
+    );
+  });
+
+  it('renders null/undefined as "null" for triple and "" for double braces', () => {
+    expect(evaluator.evaluateTemplate('{{{steps.gate.missing}}}', context)).toBe('null');
+    expect(evaluator.evaluateTemplate('[{{steps.gate.missing}}]', context)).toBe('[]');
+  });
+
+  it('does not re-evaluate {{ }} sequences contained in a {{{ }}} value', () => {
+    // #431: the folder name is data, not template source
+    const out = evaluator.evaluateTemplate('{"node": {{{steps.gate.node}}}}', context);
+    expect(JSON.parse(out).node.name).toBe('{{user.id}}');
+    expect(out).not.toContain('user-123');
+  });
+
+  it('does not re-evaluate {{ }} sequences contained in a {{ }} value', () => {
+    expect(evaluator.evaluateTemplate('name={{steps.gate.name}}', context)).toBe(
+      'name={{user.id}}',
+    );
+  });
+
+  it('does not re-evaluate {{{ }}} sequences contained in a substituted value', () => {
+    expect(evaluator.evaluateTemplate('{{steps.gate.raw}}', context)).toBe(
+      'raw{{{steps.gate.obj}}}',
+    );
+    expect(evaluator.evaluateTemplate('{{{steps.gate.raw}}}', context)).toBe(
+      'raw{{{steps.gate.obj}}}',
+    );
+  });
+
+  it('handles mixed triple and double placeholders in one template', () => {
+    expect(
+      evaluator.evaluateTemplate('{"user":"{{user.id}}","obj":{{{steps.gate.obj}}}}', context),
+    ).toBe('{"user":"user-123","obj":{"a":1}}');
+  });
+
+  it('leaves text without placeholders untouched', () => {
+    expect(evaluator.evaluateTemplate('plain {text} } {{', context)).toBe('plain {text} } {{');
+  });
+});

--- a/apps/backend/src/pipelines/execution/expression-evaluator.ts
+++ b/apps/backend/src/pipelines/execution/expression-evaluator.ts
@@ -216,31 +216,32 @@ export class ExpressionEvaluator {
       return String(template ?? '');
     }
 
-    // First, handle triple braces {{{expr}}} for raw JSON output
-    let result = template.replace(/\{\{\{(.+?)\}\}\}/g, (_, expression) => {
-      const value = this.evaluateExpression(expression.trim(), context, stepName);
-      if (value === null || value === undefined) {
-        return 'null';
-      }
-      // For triple braces, output raw (no HTML escaping)
-      if (typeof value === 'object') {
-        return JSON.stringify(value);
-      }
-      // Primitives: output as-is without JSON quotes
-      return String(value);
-    });
-
-    // Then, handle double braces {{expr}} for string interpolation
-    result = result.replace(/\{\{(.+?)\}\}/g, (_, expression) => {
-      const value = this.evaluateExpression(expression.trim(), context, stepName);
-      if (value === null || value === undefined) {
-        return '';
-      }
-      // For double braces, convert to string (objects become [object Object])
-      return String(value);
-    });
-
-    return result;
+    // Single tokenizing pass: {{{expr}}} (raw/JSON) and {{expr}} (string) are
+    // matched in one scan of the ORIGINAL template, so a substituted value is
+    // terminal and can never be re-interpreted as template syntax (#431).
+    return template.replace(
+      /\{\{\{(.+?)\}\}\}|\{\{(.+?)\}\}/g,
+      (_, tripleExpr: string | undefined, doubleExpr: string | undefined) => {
+        if (tripleExpr !== undefined) {
+          const value = this.evaluateExpression(tripleExpr.trim(), context, stepName);
+          if (value === null || value === undefined) {
+            return 'null';
+          }
+          // Triple braces: raw output (no HTML escaping); objects as JSON
+          if (typeof value === 'object') {
+            return JSON.stringify(value);
+          }
+          // Primitives: output as-is without JSON quotes
+          return String(value);
+        }
+        const value = this.evaluateExpression((doubleExpr as string).trim(), context, stepName);
+        if (value === null || value === undefined) {
+          return '';
+        }
+        // Double braces: convert to string (objects become [object Object])
+        return String(value);
+      },
+    );
   }
 
   /**


### PR DESCRIPTION
Closes #431

## Problem
`ExpressionEvaluator.evaluateTemplate` substituted in two sequential regex passes — `{{{expr}}}` first, then `{{expr}}` over the **already-substituted output**. Any `{{...}}` sequence inside a value the first pass pulled from data (e.g. a folder named `{{user.id}}`) was evaluated as a live template expression, letting one record inject other `steps.*`/`user.*`/`request.*` data into response bodies or corrupt the serialized JSON. Confirmed live via Handoff's `GET /api/resolve/*`.

## Fix
Single tokenizing pass: one alternation regex `/\{\{\{(.+?)\}\}\}|\{\{(.+?)\}\}/g` over the original template, so every substituted value is terminal and never re-scanned. Triple/double semantics (JSON for objects, `null` vs `''` for missing, no escaping change) are preserved.

## Tests
New `expression-evaluator.template.spec.ts` (8 cases) — 3 failed before the fix (`{{ }}` inside a `{{{ }}}` value, `{{{ }}}` inside a substituted value), all pass after. `src/pipelines` suite 444/444, `tsc --noEmit` clean. Repo-wide grep confirms this is the only brace-template implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
