### PR TITLE
chore(agents): publish issue-triage summaries to Handoff

### DIFF
--- a/.claude/agents/issue-triage.md
+++ b/.claude/agents/issue-triage.md
@@ -1,6 +1,6 @@
 ---
 name: issue-triage
-description: Categorizes and prioritizes open issues in the bffless/ce GitHub repository. Use when asked to triage, label, or prioritize CE issues, or for a summary of what's open grouped by priority.
+description: Categorizes and prioritizes open issues in the bffless/ce GitHub repository, and publishes its summary report to Handoff. Use when asked to triage, label, or prioritize CE issues, or for a summary of what's open grouped by priority.
 model: sonnet
 effort: high
 tools: Bash, Read, Grep, Glob, WebFetch
@@ -42,12 +42,92 @@ comment explaining your reasoning and asking for clarification, and skip the lab
 - Always state which repository and issue number you are acting on before changing anything.
 - Never close, reopen, or merge anything. Never push commits. Your job is limited to
   categorization, prioritization, labeling, and cross-referencing comments.
-- Not every label exists yet. `bffless/ce` currently has `bug`, `enhancement`,
-  `documentation`, `question`, `duplicate`, `good first issue`, `help wanted`,
-  `ready-for-agent`, `bots`. The `chore` and `P0`–`P3` labels do not exist — if one is
-  missing, report that rather than creating it, unless explicitly told to create labels.
+- Every label you apply exists in `bffless/ce`: the five categories (`bug`,
+  `enhancement`, `documentation`, `question`, `chore`) and the four priorities
+  (`P0-critical`, `P1-high`, `P2-medium`, `P3-low`), alongside `duplicate`,
+  `good first issue`, `help wanted`, `ready-for-agent`, `bots`. If some other label
+  you want is missing, report that rather than creating it, unless explicitly told
+  to create labels.
 
 ## Reporting
 
 When asked for a summary, group issues by category and priority, and lead with
 anything P0/P1. Return a compact report, not a transcript of every command you ran.
+
+Then publish that same report to Handoff (below) and include its link in what you
+return, so the summary outlives the session.
+
+## Publishing the report to Handoff
+
+Reports go to the `triage` folder of the Handoff deployment at
+<https://handoff.bffless.dev/tree/triage>. Handoff has no app server — `/api/*` is a
+BFFless proxy rule set — so this is plain `curl`. The `bffless-apps:handoff-api`
+skill is the full reference; the sequence below is the verified minimum.
+
+Markdown is the right format: the Handoff viewer renders `text/markdown` files with
+a "View source" toggle, so upload the report as a `.md` **File**. Do not register it
+as a Site (that is for HTML bundles).
+
+### 1. Resolve the API key
+
+Handoff authenticates with a BFFless API key in an `X-API-Key` header, sourced in
+this order:
+
+1. `$BFFLESS_API_KEY`, if set.
+2. `npx bffless auth token --api-url https://admin.bffless.dev`
+
+**Run the CLI command on its own first.** On failure it writes to stderr and prints
+nothing to stdout, so `$(...)` substitutes an empty string and the request silently
+degrades to `X-API-Key: ` instead of erroring. Only embed it once it exits 0 and
+prints a key. If neither source yields one, skip the upload, say so, and tell the
+user to run `npx bffless login`.
+
+### 2. Write the report
+
+You have no `Write` tool — use a Bash heredoc:
+
+```bash
+cat > /tmp/triage-report.md <<'EOF'
+# CE issue triage — <date>
+...
+EOF
+```
+
+Name the file `ce-triage-<UTC timestamp>.md`, e.g.
+`ce-triage-$(date -u +%Y-%m-%dT%H%MZ).md`. **Names must be unique within the folder** —
+an in-folder collision is rejected at prepare time, so a fixed name breaks the second
+run of the day rather than overwriting.
+
+### 3. Upload (prepare → PUT → register)
+
+Resolve the `triage` folder id by listing the root and matching on name, rather than
+hardcoding it:
+
+```bash
+curl -s -H "X-API-Key: $K" "https://handoff.bffless.dev/api/nodes"
+```
+
+Then, with `$K` as the key, `$F` as the filename and `$TRIAGE` as that folder id:
+
+```bash
+curl -s -X POST "https://handoff.bffless.dev/api/uploads/prepare" -H "X-API-Key: $K" -H "Content-Type: application/json" -d "{\"filename\":\"$F\",\"contentType\":\"text/markdown\",\"path\":\"triage/$F\",\"parentId\":\"$TRIAGE\"}"
+curl -s -X PUT "<uploadUrl from prepare>" -H "Content-Type: text/markdown" --data-binary "@/tmp/triage-report.md"
+curl -s -X POST "https://handoff.bffless.dev/api/nodes" -H "X-API-Key: $K" -H "Content-Type: application/json" -d "{\"storageKey\":\"<storageKey from prepare>\",\"originalName\":\"$F\",\"parentId\":\"$TRIAGE\",\"displayName\":\"$F\",\"createdMs\":$(date +%s%3N)}"
+```
+
+- `path` is required and is the **verbatim content sub-path** — the folder path plus
+  the filename (`triage/<filename>`). Omitting it fails with `400 MISSING_KEY`.
+- `parentId` on *prepare* is what makes a name collision fail before any bytes are
+  minted. Send it, and keep it consistent with `path`.
+- Pass prepare's `storageKey` to register **unchanged**.
+- The PUT is a presigned bucket URL — **do not** send the API key on it.
+
+The report is then readable at `https://handoff.bffless.dev/blob/triage/<filename>`.
+Report that URL back.
+
+### Limits
+
+- Publish into `triage` only. Never create folders, change grants or sharing modes,
+  or delete existing nodes there — the folder's audience is somebody else's decision.
+- A failed upload is not a failed triage. If Handoff is unreachable or the key is
+  missing, still return the report in-session and note that publishing failed.


### PR DESCRIPTION
The `issue-triage` agent's report only existed in the session that produced it — close the terminal and the triage was gone. This publishes it to the `triage` folder of the Handoff deployment at <https://handoff.bffless.dev/tree/triage> and returns the link, so a triage pass leaves something behind.

## Shape of the change

One file, `.claude/agents/issue-triage.md` — a new **Publishing the report to Handoff** section plus the line in *Reporting* that sends it there.

**Markdown, registered as a File.** `apps/handoff/src/lib/preview.ts` → `previewFor()` returns `'markdown'` for `text/markdown` and gives it a View-source toggle, so a `.md` renders natively in the viewer. Registering as a Site would be the wrong shape — that path is for HTML bundles, and a `text/html` File registered through `/api/nodes` falls through to "Preview unavailable".

**Timestamped filenames** (`ce-triage-<UTC>.md`). Handoff rejects an in-folder name collision at prepare time, so a fixed name would break the second run of a day rather than overwrite.

**Folder id resolved at runtime** by listing the root and matching on name, not hardcoded — it survives a rebuild of the deployment.

**Write scope is deliberately narrow.** The agent may add files to `triage` and nothing else: no folder creation, no grant or sharing-mode changes, no deleting existing nodes. Who that folder is shared with stays a human decision.

**A failed upload is not a failed triage.** If Handoff is unreachable or no API key resolves, the agent still returns the report in-session and says publishing failed.

The auth section documents the trap that actually bites here: `npx bffless auth token` writes errors to stderr and nothing to stdout, so `$(...)` substitutes an empty string and the request silently degrades to `X-API-Key: ` instead of erroring. It says to run the command standalone first and only embed it once it exits 0.

## Labels

The old hard-limit bullet said `chore` and `P0`–`P3` don't exist, which made the priority half of this agent a no-op it had to report around. Those five labels have now been created in the repo, so that bullet is refreshed to match.

## Verification

Ran the agent headlessly against the real tracker (`claude -p ... --agent issue-triage`, the same invocation shape `pr-review.yml` uses), scoped to report-only so the test wouldn't mutate issues. Exit 0.

| Check | Result |
|---|---|
| Node created in `triage` | `ce-triage-2026-08-16T1920Z.md` · `text/markdown` · 5757 bytes |
| Viewer route | `/blob/triage/ce-triage-2026-08-16T1920Z.md` → 200 |
| Content | Real report — headline P1s, category × priority tables, cluster analysis |
| Issues mutated | **0** — nothing in the repo updated during the run |

The upload sequence itself (prepare → PUT → register, then delete) was also exercised standalone against the live deployment before the instructions were written, so the documented calls are transcribed from working ones rather than from the skill's examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
