### PR TITLE
chore(agents): ce-implement is pre-authorised to commit/push/PR on its own branch

### DIFF
--- a/.claude/agents/ce-implement.md
+++ b/.claude/agents/ce-implement.md
@@ -117,9 +117,48 @@ do not skip, weaken, or `.skip` a test to get green.
    review request. Do not stop to ask. (Approval is still required for anything
    outside that — see Hard limits.)
 2. Commit with a conventional message, `git push -u origin <branch>`, then
-   `gh pr create --title "<conventional title>" --body-file - <<'EOF' … EOF` with:
-   `Closes #<n>`, what changed and why, compatibility notes (which checklist surfaces
-   were touched and how they stay safe), and how it was verified.
+   `gh pr create --title "<conventional title>" --body-file - <<'EOF' … EOF`.
+
+   **Write the PR for a reader who has not read the issue and will not read the diff.**
+   Lead with the outcome, not with file paths. The maintainer decides whether to merge
+   from the body alone; the reviewer agent reads the diff. Use exactly this structure:
+
+   ```
+   Closes #<n>
+
+   ## Summary
+   2–4 plain-language sentences: the problem a user/operator had, what this PR does
+   about it, and what they will notice afterwards. No file paths here.
+
+   ## Behaviour changes
+   What is different for a user, operator, API client, or stored rule set — as
+   before → after bullets. Say "None — internal refactor only" if that is true.
+   Anything additive vs. breaking is called out explicitly here.
+
+   ## Why
+   The motivation, in one short paragraph: what was wrong / missing, and why this
+   approach (link the issue discussion or ADR if one shaped it).
+
+   ## What changed
+   Grouped by area (backend / frontend / CLI / docs / tests), one line per group,
+   naming the key files. Keep it short — this is a map, not a changelog.
+
+   ## Compatibility
+   Which checklist surfaces (migrations, API/CLI contract, env vars, nginx generation,
+   storage layout, pipeline semantics) are touched and how they stay safe. If none:
+   one line saying so.
+
+   ## Verification
+   The commands run and their real results (counts, not "passed").
+
+   ## Out of scope / follow-ups
+   Adjacent problems noticed but deliberately not fixed here.
+   ```
+
+   Rules of thumb: the **Summary** should make sense to someone who only reads that
+   section; **Behaviour changes** must never be hidden inside Compatibility or What
+   changed; one PR title says one thing — if you need "and" in it, the summary should
+   explain why the two belong together.
 3. **Do not run `ce-pr-review` yourself.** Opening or pushing to the PR triggers
    `.github/workflows/pr-review.yml`, which runs that agent in CI and posts its report
    as a "🤖 Automated CE review" comment. Wait for it rather than duplicating it:

--- a/.claude/agents/ce-implement.md
+++ b/.claude/agents/ce-implement.md
@@ -111,11 +111,12 @@ do not skip, weaken, or `.skip` a test to get green.
 
 ## Step 6 — hand off
 
-1. **Stop before committing.** Show the user `git status` + a summary of the diff and
-   the proposed commit message / PR title, and ask for approval (CLAUDE.md: always ask
-   before committing). When running unattended (`$CI` set, or the user has explicitly
-   pre-authorised commits for this run), you may proceed.
-2. On approval: commit with a conventional message, `git push -u origin <branch>`, then
+1. **You are pre-authorised to commit, push, and open the PR on your own branch.**
+   This is the one standing exception to CLAUDE.md's "ask before committing": the
+   branch is yours, nothing reaches `main` without a human merging, and the PR *is* the
+   review request. Do not stop to ask. (Approval is still required for anything
+   outside that — see Hard limits.)
+2. Commit with a conventional message, `git push -u origin <branch>`, then
    `gh pr create --title "<conventional title>" --body-file - <<'EOF' … EOF` with:
    `Closes #<n>`, what changed and why, compatibility notes (which checklist surfaces
    were touched and how they stay safe), and how it was verified.
@@ -124,7 +125,7 @@ do not skip, weaken, or `.skip` a test to get green.
    as a "🤖 Automated CE review" comment. Wait for it rather than duplicating it:
    `gh pr checks <n> --watch` (the job is *Agent review*), then read the comment with
    `gh pr view <n> --comments`. Include its verdict in your report. If it finds real
-   problems, fix them in the same worktree and push again (with approval) — that
+   problems, fix them in the same worktree and push again — that
    re-triggers the review; do not argue with a correct finding. Run the agent locally
    only if CI skipped it (fork PR, or the agent isn't on the base commit yet) or the
    user asks.
@@ -140,12 +141,13 @@ Return a compact report, not a transcript:
 2. **Housekeeping** — main synced? (yes / skipped, why); worktrees removed; worktrees kept and why.
 3. **Change** — worktree path, branch, files touched, compatibility surfaces and how they're kept safe.
 4. **Verification** — the commands run and their real results.
-5. **Status** — awaiting commit approval / PR #n opened / review verdict / merged & cleaned up.
+5. **Status** — PR #n opened / CI review verdict / merged & cleaned up.
 6. **Follow-ups** — adjacent issues noticed, migration commands the user must run, anything blocked.
 
 ## Hard limits
 
-- Never commit or push without approval unless explicitly pre-authorised for the run.
+- Commit/push/PR only on your own `<type>/<n>-<slug>` branch. Never commit to `main`
+  or to a branch you didn't create in this run.
 - Never `git checkout`, `git switch`, `git stash`, `git reset --hard`, or `git merge` in
   the shared checkout. `git pull --ff-only` on a clean `main` is the only mutation allowed there.
 - Never force-push a shared branch. `--force-with-lease` on your own PR branch only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,7 +408,7 @@ Three agents form the issue → PR loop; each is procedure + guardrails, not sol
 | Agent | Role |
 | --- | --- |
 | `issue-triage` | Labels/prioritises open issues; marks fully-specified ones `ready-for-agent`. |
-| `ce-implement` | Picks up an issue: syncs `main`, GCs merged worktrees (`.claude/scripts/worktree-gc.sh`), works in `.claude/worktrees/<name>`, verifies, opens a PR, then hands off to review. Stops for commit approval. |
+| `ce-implement` | Picks up an issue: syncs `main`, GCs merged worktrees (`.claude/scripts/worktree-gc.sh`), works in `.claude/worktrees/<name>`, verifies, pushes and opens a PR on its own branch (pre-authorised), then waits for the CI review. |
 | `ce-pr-review` | Read-only review of a CE PR against `.claude/ce-pr-review-checklist.md` (backwards-compat first). |
 
 Implementer and reviewer share the same checklist file — grow it there, not in the agent bodies.


### PR DESCRIPTION
Follow-up to #674 (the first commit missed that merge). Two changes to the `ce-implement` agent:

**1. Pre-authorised to commit/push/PR on its own branch.** It no longer stops for commit approval: the human gate is merge, not commit, and the stop stalled unattended `/loop` runs. Hard limits tightened to compensate — it may only commit to the `<type>/<n>-<slug>` branch it created this run; everything else (no force-push shared, no merge/deploy/close) unchanged. `CLAUDE.md` Subagents row updated to match.

**2. Outcome-first PR descriptions.** A fixed body structure — Summary → Behaviour changes → Why → What changed → Compatibility → Verification → Follow-ups — written for a maintainer who hasn't read the issue and won't read the diff. Prompted by #675, whose body opened with file paths and buried the actual behaviour changes inside the compatibility paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
