### PR TITLE
fix(pipelines): merge data_update fields in SQL so concurrent field-disjoint updates compose

### DIFF
--- a/apps/backend/src/pipelines/handlers/data-update.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/data-update.handler.spec.ts
@@ -13,9 +13,10 @@ jest.mock('../../db/client', () => {
   return { db: chainable };
 });
 
+import { SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import { db } from '../../db/client';
-import { DataUpdateHandler } from './data-update.handler';
+import { DataUpdateHandler, buildDataMergeExpression } from './data-update.handler';
 import { ExpressionEvaluator } from '../execution/expression-evaluator';
 import { PipelineSchemasService } from '../pipeline-schemas.service';
 import { PipelineContext } from '../execution/pipeline-context.interface';
@@ -193,8 +194,9 @@ describe('DataUpdateHandler schema type coercion (ce#562)', () => {
     );
 
     expect(result.success).toBe(true);
-    const setArg = mockDb.set.mock.calls[0][0] as { data: Record<string, unknown> };
-    expect(setArg.data.updatedMs).toBe(1704067200000);
+    const setArg = mockDb.set.mock.calls[0][0] as { data: SQL };
+    const { params } = new PgDialect().sqlToQuery(setArg.data);
+    expect(params).toContain(JSON.stringify({ updatedMs: 1704067200000 }));
   });
 
   it('returns VALIDATION_ERROR for a non-coercible value instead of writing it', async () => {
@@ -236,5 +238,90 @@ describe('DataUpdateHandler ne operator is null-safe', () => {
     expect(sql.toLowerCase()).toContain('is distinct from');
     expect(sql).not.toContain('!=');
     expect(params).toEqual(expect.arrayContaining(['false']));
+  });
+});
+
+describe('DataUpdateHandler merges in SQL, not from the earlier read (ce#432)', () => {
+  beforeEach(() => mockDb.__reset());
+
+  const dialect = new PgDialect();
+  const setDataSql = (callIndex: number) =>
+    dialect.sqlToQuery((mockDb.set.mock.calls[callIndex][0] as { data: SQL }).data);
+
+  it('writes `data || <updates>::jsonb` instead of a whole-blob replacement', async () => {
+    const { handler } = buildHandler();
+    mockDb.__queue([{ id: 'n1', data: { mode: 'inheriting', grantsJson: '[]', title: 'Docs' } }]);
+    mockDb.__queue([{ id: 'n1', data: { mode: 'restricted', grantsJson: '[]', title: 'Docs' } }]);
+
+    const result = await handler.execute(
+      context({}),
+      step({ schemaId: 'schema-1', recordId: 'n1', fields: { mode: 'restricted' } }),
+    );
+
+    expect(result.success).toBe(true);
+    const { sql, params } = setDataSql(0);
+    expect(sql).toMatch(/"pipeline_data"\."data" \|\| \$1::jsonb/);
+    // Only the fields this step sets travel to the database — never the stale
+    // copy of the other fields we read a moment ago.
+    expect(params).toEqual([JSON.stringify({ mode: 'restricted' })]);
+    expect(JSON.stringify(params)).not.toContain('grantsJson');
+    expect(JSON.stringify(params)).not.toContain('Docs');
+  });
+
+  it('two concurrent field-disjoint updates each send only their own field', async () => {
+    // Reproduces the Handoff race: PATCH /api/node (mode) and POST /api/grants/revoke
+    // (grantsJson) fired via Promise.all against the same record. Both handlers read
+    // the same pre-update row; neither write may carry the other\'s field.
+    const { handler } = buildHandler();
+    const original = { id: 'n1', data: { mode: 'inheriting', grantsJson: '[]' } };
+    mockDb.__queue([original]); // select for update A
+    mockDb.__queue([original]); // select for update B (stale, same as A)
+    mockDb.__queue([{ id: 'n1', data: { mode: 'restricted', grantsJson: '[]' } }]);
+    mockDb.__queue([{ id: 'n1', data: { mode: 'restricted', grantsJson: '[{"u":"x"}]' } }]);
+
+    const [a, b] = await Promise.all([
+      handler.execute(
+        context({}),
+        step({ schemaId: 'schema-1', recordId: 'n1', fields: { mode: 'restricted' } }),
+      ),
+      handler.execute(
+        context({}),
+        step({ schemaId: 'schema-1', recordId: 'n1', fields: { grantsJson: '[{"u":"x"}]' } }),
+      ),
+    ]);
+
+    expect(a.success).toBe(true);
+    expect(b.success).toBe(true);
+    expect(mockDb.set).toHaveBeenCalledTimes(2);
+    const paramSets = [setDataSql(0).params, setDataSql(1).params].map((p) => JSON.parse(String(p[0])));
+    expect(paramSets).toEqual(
+      expect.arrayContaining([{ mode: 'restricted' }, { grantsJson: '[{"u":"x"}]' }]),
+    );
+    // Neither write mentions the field it did not set, so `||` in Postgres composes
+    // them regardless of commit order.
+    for (const p of paramSets) {
+      expect(Object.keys(p)).toHaveLength(1);
+    }
+  });
+
+  it('removes keys whose evaluated value is undefined (matches the old spread + JSON semantics)', () => {
+    const { sql, params } = dialect.sqlToQuery(
+      buildDataMergeExpression({ keep: 1, gone: undefined }),
+    );
+    expect(sql).toBe('("pipeline_data"."data" - $1::text) || $2::jsonb');
+    expect(params).toEqual(['gone', JSON.stringify({ keep: 1 })]);
+  });
+
+  it('emits a bare `data - key` when every update is undefined', () => {
+    const { sql, params } = dialect.sqlToQuery(buildDataMergeExpression({ gone: undefined }));
+    expect(sql).toBe('("pipeline_data"."data" - $1::text)');
+    expect(params).toEqual(['gone']);
+  });
+
+  it('serialises nested objects and nulls into the jsonb payload', () => {
+    const { params } = dialect.sqlToQuery(
+      buildDataMergeExpression({ meta: { a: [1, 2] }, cleared: null }),
+    );
+    expect(params).toEqual([JSON.stringify({ meta: { a: [1, 2] }, cleared: null })]);
   });
 });

--- a/apps/backend/src/pipelines/handlers/data-update.handler.ts
+++ b/apps/backend/src/pipelines/handlers/data-update.handler.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, sql, SQL } from 'drizzle-orm';
 import { StepHandler, DataUpdateHandlerConfig } from '../execution/step-handler.interface';
 import { StepHandlerRegistry } from '../execution/step-handler.registry';
 import { ExpressionEvaluator } from '../execution/expression-evaluator';
@@ -140,16 +140,17 @@ export class DataUpdateHandler implements StepHandler<DataUpdateHandlerConfig> {
       };
     }
 
-    // Update each matching record
+    // Update each matching record. The merge happens in SQL (`jsonb ||`) rather
+    // than as a JS spread over the row we read above, so two concurrent updates
+    // touching different fields of the same record compose instead of the later
+    // writer clobbering the earlier one with a stale whole-blob write (ce#432).
+    const mergeExpression = buildDataMergeExpression(updates);
     const updatedRecords: Array<Record<string, unknown>> = [];
     for (const record of existingRecords) {
-      const existingData = record.data as Record<string, unknown>;
-      const newData = { ...existingData, ...updates };
-
       const [updated] = await db
         .update(pipelineData)
         .set({
-          data: newData,
+          data: mergeExpression,
           updatedAt: new Date(),
         })
         .where(eq(pipelineData.id, record.id))
@@ -184,4 +185,34 @@ export class DataUpdateHandler implements StepHandler<DataUpdateHandlerConfig> {
       },
     };
   }
+}
+
+/**
+ * Build the SQL expression that merges `updates` into the stored `data` blob.
+ *
+ * `jsonb || jsonb` is a shallow merge — the same semantics as the JS spread it
+ * replaces — but evaluated against the row's *current* value at write time, so
+ * it never depends on an earlier read. Fields whose evaluated value is
+ * `undefined` are removed from the record (a JS spread followed by JSON
+ * serialisation dropped them too), which `jsonb - key` reproduces.
+ */
+export function buildDataMergeExpression(updates: Record<string, unknown>): SQL {
+  const toSet: Record<string, unknown> = {};
+  const toRemove: string[] = [];
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) {
+      toRemove.push(key);
+    } else {
+      toSet[key] = value;
+    }
+  }
+
+  let expression: SQL = sql`${pipelineData.data}`;
+  for (const key of toRemove) {
+    expression = sql`(${expression} - ${key}::text)`;
+  }
+  if (Object.keys(toSet).length > 0) {
+    expression = sql`${expression} || ${JSON.stringify(toSet)}::jsonb`;
+  }
+  return expression;
 }


### PR DESCRIPTION
Closes #432

## Summary
Two `data_update` steps that changed *different* fields of the same record at the same time could silently lose one of the writes: each read the whole record, merged its own fields in JavaScript, and wrote the entire blob back, so the later writer overwrote the earlier one's committed field with its stale copy. This PR moves the merge into Postgres (`data || <updates>::jsonb`), so each write only carries the fields that step actually sets and the database composes them regardless of commit order. Users will notice nothing on single writers; concurrent field-disjoint updates (two pipelines, a schedule plus a user, a browser `Promise.all`) now both persist.

## Behaviour changes
- Before: concurrent `data_update`s on disjoint fields of one record → last writer wins, other field silently reverted. After: both fields persist.
- Single-writer semantics are unchanged: shallow merge of the given fields over the existing record, `updatedAt` bumped, the merged record returned as step output.
- A field whose expression evaluates to `undefined` is still removed from the record (previously via spread + JSON serialisation dropping the key; now via `data - 'key'`), so stored rule sets keep behaving as before.
- Additive / non-breaking; no API, CLI, or config shape changes.

## Why
Real occurrence on Handoff (j5s.dev, 2026-07-07): `PATCH /api/node` (`mode`) and `POST /api/grants/revoke` (`grantsJson`) fired together; both returned 200 but `mode` was reverted. The app sequenced the calls as a mitigation (bffless/apps#194), but the race is reachable from any two concurrent pipelines on any schema. `jsonb ||` is the minimal change the issue proposes: identical single-writer semantics, no dependence on the earlier read, no locking.

## What changed
- backend: `apps/backend/src/pipelines/handlers/data-update.handler.ts` — replaces the JS spread with an exported `buildDataMergeExpression()` that emits `("data" - 'k')… || $json::jsonb` and passes it to `.set({ data })`.
- tests: `apps/backend/src/pipelines/handlers/data-update.handler.spec.ts` — new `ce#432` block (SQL shape, concurrent field-disjoint pair sends only its own field, undefined-key removal, nested/null payloads); the existing coercion test now asserts on the SQL param instead of a plain object.

## Compatibility
- Pipeline semantics (live customer data): the stored-rule-set behaviour is intentionally identical for every non-racing case (shallow merge, undefined removes key, null stored as null); only the racing case changes, from data loss to correct composition. Not opt-in because the old behaviour was never a feature.
- No migrations, env vars, nginx generation, storage layout, CLI/API contract, or upload endpoint touched.

## Verification
- `pnpm --filter backend exec tsc --noEmit` — clean
- `pnpm --filter frontend exec tsc --noEmit` — clean
- `cd apps/backend && pnpm test -- data-update.handler` — 1 suite, 13 tests passed (8 existing + 5 new)
- `cd apps/backend && pnpm test -- src/pipelines` — 44 suites, 467 tests passed

## Out of scope / follow-ups
- Read-then-write still happens for record *selection* (filters / recordId) — a record deleted between the select and the update simply updates 0 rows, as before.
- `data_upsert_many` / other handlers that write whole blobs were not audited here; if they have the same read-modify-write shape a similar fix could follow.
- No local DB on this VPS, so the `jsonb ||` / `- text` SQL was verified via Drizzle's dialect output, not against a live Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
