### PR TITLE
fix(ffmpeg): probe the Worker at /health — Cloud Run's front door intercepts /healthz

### DIFF
--- a/apps/backend/src/pipelines/__tests__/integration/ffmpeg.remote.spec.ts
+++ b/apps/backend/src/pipelines/__tests__/integration/ffmpeg.remote.spec.ts
@@ -61,10 +61,10 @@ async function waitForHealth(base: string, deadlineMs = 15_000): Promise<void> {
   let last = 'never answered';
   while (Date.now() < until) {
     try {
-      const res = await fetch(`${base}/healthz`);
+      const res = await fetch(`${base}/health`);
       const body = (await res.json()) as { ok?: boolean; ffmpeg?: string | null };
       if (res.ok && body.ok) return;
-      last = `healthz ${res.status} ${JSON.stringify(body)}`;
+      last = `health ${res.status} ${JSON.stringify(body)}`;
     } catch (error) {
       last = error instanceof Error ? error.message : String(error);
     }

--- a/apps/backend/src/pipelines/ffmpeg/executor/remote/id-token.ts
+++ b/apps/backend/src/pipelines/ffmpeg/executor/remote/id-token.ts
@@ -52,7 +52,7 @@ function flatten(headers: Record<string, string> | Headers): Record<string, stri
  * Mints `Authorization: Bearer <Google ID token>` for the Worker.
  *
  * The audience is the URL's **origin** (Cloud Run signs tokens for the service
- * URL, not per-path), so `/jobs` and `/healthz` share one client. The client is
+ * URL, not per-path), so `/jobs` and `/health` share one client. The client is
  * created lazily — a CE instance that never runs a remote job never touches ADC —
  * and cached per audience because `IdTokenClient` refreshes its own token ~5 min
  * before expiry; caching the *token* here would fight it.

--- a/apps/backend/src/pipelines/ffmpeg/executor/remote/worker-client.spec.ts
+++ b/apps/backend/src/pipelines/ffmpeg/executor/remote/worker-client.spec.ts
@@ -110,7 +110,7 @@ it('a 200 with a non-worker body is a transport error (never a silent success)',
   ).rejects.toBeInstanceOf(WorkerTransportError);
 });
 
-it('health() GETs /healthz with auth', async () => {
+it('health() GETs /health (not /healthz — Cloud Run intercepts that path) with auth', async () => {
   const fetchImpl = jest.fn().mockResolvedValue(
     json(200, {
       ok: true,
@@ -123,7 +123,7 @@ it('health() GETs /healthz with auth', async () => {
   await expect(
     new WorkerClient('https://w', auth, fetchImpl as never, noSleep).health(),
   ).resolves.toMatchObject({ ok: true, version: '0.4.31' });
-  expect(fetchImpl.mock.calls[0][0]).toBe('https://w/healthz');
+  expect(fetchImpl.mock.calls[0][0]).toBe('https://w/health');
 });
 
 describe('the default job transport', () => {

--- a/apps/backend/src/pipelines/ffmpeg/executor/remote/worker-client.ts
+++ b/apps/backend/src/pipelines/ffmpeg/executor/remote/worker-client.ts
@@ -1,5 +1,5 @@
 /**
- * The HTTP half of the remote executor: POST /jobs, GET /healthz, and the one
+ * The HTTP half of the remote executor: POST /jobs, GET /health, and the one
  * retry policy CE is allowed to have.
  *
  * A remote ffmpeg job is NOT idempotent (it re-encodes and re-uploads), so this
@@ -143,7 +143,10 @@ export class WorkerClient {
 
   /** Liveness + version, for readiness and the settings "Test connection" button. Never retried. */
   async health(opts: { signal?: AbortSignal; timeoutMs?: number } = {}): Promise<WorkerHealth> {
-    const url = `${this.baseUrl}/healthz`;
+    // `/health`, NOT `/healthz`: on Cloud Run's *.run.app domain Google's front door
+    // intercepts the literal `/healthz` with an HTML 404 before the request reaches the
+    // service, so a `/healthz` probe would report every Cloud Run worker as unreachable.
+    const url = `${this.baseUrl}/health`;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? HEALTH_TIMEOUT_MS);
     const onAbort = () => controller.abort();
@@ -156,23 +159,20 @@ export class WorkerClient {
       });
       if (!res.ok) {
         throw new WorkerTransportError(
-          `worker healthz responded ${res.status}: ${await errorBody(res)}`,
+          `worker health responded ${res.status}: ${await errorBody(res)}`,
           res.status,
           RETRYABLE_STATUSES.has(res.status),
         );
       }
       const body = (await res.json()) as WorkerHealth;
       if (typeof body?.ok !== 'boolean' || typeof body?.version !== 'string') {
-        throw new WorkerTransportError(
-          'worker healthz response was not a WorkerHealth',
-          res.status,
-        );
+        throw new WorkerTransportError('worker health response was not a WorkerHealth', res.status);
       }
       return body;
     } catch (error) {
       if (error instanceof WorkerTransportError) throw error;
       const message = error instanceof Error ? error.message : String(error);
-      throw new WorkerTransportError(`healthz request to ${url} failed: ${message}`);
+      throw new WorkerTransportError(`health request to ${url} failed: ${message}`);
     } finally {
       clearTimeout(timer);
       opts.signal?.removeEventListener('abort', onAbort);

--- a/docs/superpowers/specs/2026-08-17-ffmpeg-remote-executor-design.md
+++ b/docs/superpowers/specs/2026-08-17-ffmpeg-remote-executor-design.md
@@ -138,7 +138,7 @@ Non-zero exit → `200` with `ok:false`, `exitCode`, `stderrTail`, `code` ∈
 CE maps `INPUT_FETCH_FAILED` → `FILE_NOT_FOUND`, upload/size failures → `FFMPEG_FAILED`
 with the worker message. Transport-level non-2xx / unreachable → `FFMPEG_EXECUTOR_UNAVAILABLE`.
 
-`GET /healthz` → `{ ok, version, ffmpeg, ops:["ffmpeg","ffprobe"], uptimeS }`.
+`GET /health` → `{ ok, version, ffmpeg, ops:["ffmpeg","ffprobe"], uptimeS }` (**as built:** the path is `/health`, with `/healthz` served only as an alias — Google's front door on `*.run.app` intercepts the literal `/healthz` with an HTML 404 before IAM, so it cannot be the readiness probe).
 
 ### 1.4 Worker (`workers/ffmpeg/`)
 

--- a/workers/ffmpeg/README.md
+++ b/workers/ffmpeg/README.md
@@ -60,15 +60,17 @@ exited non-zero. Response (always `200` — the _request_ succeeded even when th
 (caller disconnected — CE never sees it, its request is gone). One job at a time per
 process: a second concurrent `POST /jobs` gets `503 {"code":"BUSY"}`.
 
-`GET /healthz` → `{ ok, version, ffmpeg, ops:["ffmpeg","ffprobe"], uptimeS }`, `503` when
-the ffmpeg binary is missing.
+`GET /health` → `{ ok, version, ffmpeg, ops:["ffmpeg","ffprobe"], uptimeS }`, `503` when
+the ffmpeg binary is missing. `/healthz` is served as an alias, but CE probes `/health`:
+on Cloud Run's `*.run.app` domain Google's front door intercepts the literal `/healthz`
+(HTML 404 before IAM ever sees the request), so it cannot be the readiness path.
 
 ## Env
 
 | Var                     | Default       | Meaning                                                      |
 | ----------------------- | ------------- | ------------------------------------------------------------ |
 | `PORT`                  | `8080`        | Listen port                                                  |
-| `WORKER_VERSION`        | `dev`         | Reported in `/healthz` and `worker.version` (CE's version)   |
+| `WORKER_VERSION`        | `dev`         | Reported in `/health` and `worker.version` (CE's version)   |
 | `WORKER_ALLOW_HTTP`     | unset         | `1` allows plain-`http:` signed URLs (private networks only) |
 | `WORKER_SCRATCH_DIR`    | `os.tmpdir()` | Per-job scratch parent; each job dir is wiped in `finally`   |
 | `WORKER_MAX_BODY_BYTES` | `1048576`     | Envelope size cap (`413` beyond)                             |

--- a/workers/ffmpeg/server.mjs
+++ b/workers/ffmpeg/server.mjs
@@ -1,6 +1,6 @@
 /**
  * HTTP surface of the BFFless ffmpeg Worker: `POST /jobs` (one envelope in, one
- * WorkerResponse out) and `GET /healthz`. Everything interesting lives in job.mjs —
+ * WorkerResponse out) and `GET /health` (alias `/healthz`). Everything interesting lives in job.mjs —
  * this file is routing, body limits, the one-job-at-a-time fuse and the disconnect →
  * cancel rule.
  *
@@ -66,7 +66,10 @@ export function createServer({
     req.on('error', () => {});
     res.on('error', () => {});
     const url = new URL(req.url, 'http://worker');
-    if (req.method === 'GET' && url.pathname === '/healthz') {
+    // `/health` is the path CE probes. `/healthz` is kept as an alias for local docker/k8s
+    // conventions, but on Cloud Run's *.run.app domain Google's front door intercepts the
+    // literal `/healthz` (HTML 404 before IAM), so it must never be the only route.
+    if (req.method === 'GET' && (url.pathname === '/health' || url.pathname === '/healthz')) {
       sendJson(res, ffmpeg ? 200 : 503, {
         ok: Boolean(ffmpeg),
         version,

--- a/workers/ffmpeg/test/server.test.mjs
+++ b/workers/ffmpeg/test/server.test.mjs
@@ -52,10 +52,10 @@ const post = (url, body, init = {}) =>
     ...init,
   });
 
-test('GET /healthz reports the worker version, ffmpeg and ops', async () => {
+test('GET /health reports the worker version, ffmpeg and ops', async () => {
   const wk = await boot({ ffmpeg: 'ffmpeg version 6.1.2', runJob: async () => result() });
   try {
-    const res = await fetch(`${wk.url}/healthz`);
+    const res = await fetch(`${wk.url}/health`);
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.equal(body.ok, true);
@@ -63,6 +63,19 @@ test('GET /healthz reports the worker version, ffmpeg and ops', async () => {
     assert.equal(body.ffmpeg, 'ffmpeg version 6.1.2');
     assert.deepEqual(body.ops, ['ffmpeg', 'ffprobe']);
     assert.equal(typeof body.uptimeS, 'number');
+  } finally {
+    await wk.stop();
+  }
+});
+
+test('GET /healthz is served as an alias of /health (same body)', async () => {
+  const wk = await boot({ ffmpeg: 'ffmpeg version 6.1.2', runJob: async () => result() });
+  try {
+    const [a, b] = await Promise.all([fetch(`${wk.url}/health`), fetch(`${wk.url}/healthz`)]);
+    assert.equal(a.status, 200);
+    assert.equal(b.status, 200);
+    const [ja, jb] = await Promise.all([a.json(), b.json()]);
+    assert.deepEqual({ ...ja, uptimeS: 0 }, { ...jb, uptimeS: 0 });
   } finally {
     await wk.stop();
   }


### PR DESCRIPTION
## Summary

Follow-up to #684 (Remote executor). On Cloud Run's `*.run.app` domain, Google's front door answers the literal path **`/healthz`** with an HTML 404 *before* IAM ever sees the request — verified against a deployed private service today: `/healthz` → 404 (no `server` header), while `/`, `/health`, `/healthz/`, `/jobs` → 403 from IAM. `RemoteFfmpegExecutor.ready()` polled exactly `GET {url}/healthz`, so every Cloud Run worker would have reported `remote.ready:false` → `FFMPEG_EXECUTOR_UNAVAILABLE`. The MinIO integration suite never saw it because it hits the Worker directly.

## Change

- CE `WorkerClient.health()` probes **`/health`** (comment explains why not `/healthz`).
- Worker `server.mjs` serves **`/health`** and keeps **`/healthz` as an alias** (docker/k8s conventions).
- Tests updated + a new Worker test that both paths return the same body; README, spec §1.3 as-built note.

Should merge **before** the release PR (#679) so `ce-ffmpeg-worker:0.4.31` / `:latest` work on the reference deployment out of the box.

## Test plan

- [x] `node --test workers/ffmpeg/test/*.test.mjs` 32/32
- [x] backend `tsc --noEmit`, `jest --testPathPattern 'remote/'` 48/48, eslint clean on touched files
- [x] Real MinIO ↔ Worker integration suite (`FFMPEG_IT_MINIO_ENDPOINT=…`) 7/7 through the new health path
- [ ] After merge/preview build: re-point the Cloud Run service to the new image and confirm CE's probe reports `remote.ready:true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKMmceop9SRzsLxnE6omSF
