### PR TITLE
feat(ffmpeg): admin-editable executor settings — Local/Remote, encrypted SA key, test connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -576,6 +576,10 @@ SSL_CERT_PATH=/etc/nginx/ssl
 # Azure) - not local-FS. Cloud Run is the reference deployment; see docs
 # "Server Video Ops → Remote executor" and workers/ffmpeg/README.md.
 # Which executor runs a step unless the step says otherwise: local | remote
+# These four (FFMPEG_EXECUTOR, FFMPEG_REMOTE_URL, FFMPEG_REMOTE_AUTH, FFMPEG_REMOTE_SA_KEY_JSON)
+# can instead be set in Admin Settings → Features → Server video ops → Executor. When an env
+# var is set it WINS over the admin value and the UI shows that field as env-managed.
+# FFMPEG_REMOTE_MAX_INFLIGHT / FFMPEG_WORKER_MIN_VERSION / FFMPEG_MAX_OUTPUT_BYTES are env-only.
 # FFMPEG_EXECUTOR=local
 # Worker base URL (https). Setting this enables the remote executor.
 # FFMPEG_REMOTE_URL=https://bffless-ffmpeg-xxxx-uc.a.run.app

--- a/apps/backend/drizzle/0043_swift_namorita.sql
+++ b/apps/backend/drizzle/0043_swift_namorita.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "ffmpeg_executor_settings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"local_enabled" boolean DEFAULT true NOT NULL,
+	"remote_enabled" boolean DEFAULT false NOT NULL,
+	"remote_url" text,
+	"remote_auth" varchar(32) DEFAULT 'google_id_token' NOT NULL,
+	"sa_key_encrypted" text,
+	"default_executor" varchar(16) DEFAULT 'local' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"updated_by_user_id" uuid
+);

--- a/apps/backend/drizzle/meta/0043_snapshot.json
+++ b/apps/backend/drizzle/meta/0043_snapshot.json
@@ -1,0 +1,7355 @@
+{
+  "id": "ab6822dd-0448-4b39-8fa0-445687ff358f",
+  "prevId": "62f45680-4910-4a11-9a18-07c1032a1849",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alias_proxy_rule_sets": {
+      "name": "alias_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alias_proxy_rule_sets_alias_ruleset_unique": {
+          "name": "alias_proxy_rule_sets_alias_ruleset_unique",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_alias_id_idx": {
+          "name": "alias_proxy_rule_sets_alias_id_idx",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_rule_set_id_idx": {
+          "name": "alias_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk": {
+          "name": "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "deployment_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_project_id_idx": {
+          "name": "api_keys_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_path": {
+          "name": "original_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_number": {
+          "name": "workflow_run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'commits'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_project_id_idx": {
+          "name": "assets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_type_idx": {
+          "name": "assets_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_path_idx": {
+          "name": "assets_project_commit_path_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_branch_idx": {
+          "name": "assets_project_branch_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_idx": {
+          "name": "assets_project_commit_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_created_at_idx": {
+          "name": "assets_project_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_committed_at_idx": {
+          "name": "assets_project_committed_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_path_idx": {
+          "name": "assets_deployment_path_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_id_idx": {
+          "name": "assets_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_size_idx": {
+          "name": "assets_deployment_size_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_uploaded_by_users_id_fk": {
+          "name": "assets_uploaded_by_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist_entries": {
+      "name": "blocklist_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prefix'"
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklist_entries_blocklist_id_idx": {
+          "name": "blocklist_entries_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocklist_entries_unique": {
+          "name": "blocklist_entries_unique",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocklist_entries_blocklist_id_blocklists_id_fk": {
+          "name": "blocklist_entries_blocklist_id_blocklists_id_fk",
+          "tableFrom": "blocklist_entries",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklists": {
+      "name": "blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklists_name_unique": {
+          "name": "blocklists_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cache_rules": {
+      "name": "cache_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_max_age": {
+          "name": "browser_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "cdn_max_age": {
+          "name": "cdn_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stale_while_revalidate": {
+          "name": "stale_while_revalidate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immutable": {
+          "name": "immutable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cacheability": {
+          "name": "cacheability",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cache_rules_project_pattern_unique": {
+          "name": "cache_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_id_idx": {
+          "name": "cache_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_priority_idx": {
+          "name": "cache_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cache_rules_project_id_projects_id_fk": {
+          "name": "cache_rules_project_id_projects_id_fk",
+          "tableFrom": "cache_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_aliases": {
+      "name": "deployment_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_preview": {
+          "name": "is_auto_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployment_aliases_project_alias_unique": {
+          "name": "deployment_aliases_project_alias_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_project_id_idx": {
+          "name": "deployment_aliases_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_alias_unique": {
+          "name": "deployment_aliases_repository_alias_unique",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_idx": {
+          "name": "deployment_aliases_repository_idx",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_commit_sha_idx": {
+          "name": "deployment_aliases_commit_sha_idx",
+          "columns": [
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_deployment_id_idx": {
+          "name": "deployment_aliases_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_aliases_project_id_projects_id_fk": {
+          "name": "deployment_aliases_project_id_projects_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_blocklists": {
+      "name": "domain_blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_blocklists_domain_blocklist_unique": {
+          "name": "domain_blocklists_domain_blocklist_unique",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_blocklists_domain_mapping_id_idx": {
+          "name": "domain_blocklists_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_blocklists_blocklist_id_idx": {
+          "name": "domain_blocklists_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_blocklists_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "domain_blocklists_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "domain_blocklists",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_blocklists_blocklist_id_blocklists_id_fk": {
+          "name": "domain_blocklists_blocklist_id_blocklists_id_fk",
+          "tableFrom": "domain_blocklists",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_mappings": {
+      "name": "domain_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_type": {
+          "name": "domain_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ssl_expires_at": {
+          "name": "ssl_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_verified": {
+          "name": "dns_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dns_verified_at": {
+          "name": "dns_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_renew_ssl": {
+          "name": "auto_renew_ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_renewed_at": {
+          "name": "ssl_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_status": {
+          "name": "ssl_renewal_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_error": {
+          "name": "ssl_renewal_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sticky_sessions_enabled": {
+          "name": "sticky_sessions_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sticky_session_duration": {
+          "name": "sticky_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 86400
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_mappings_project_id_idx": {
+          "name": "domain_mappings_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_domain_idx": {
+          "name": "domain_mappings_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_is_active_idx": {
+          "name": "domain_mappings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_mappings_project_id_projects_id_fk": {
+          "name": "domain_mappings_project_id_projects_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_mappings_created_by_users_id_fk": {
+          "name": "domain_mappings_created_by_users_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_mappings_domain_unique": {
+          "name": "domain_mappings_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_redirects": {
+      "name": "domain_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_domain": {
+          "name": "source_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_domain_id": {
+          "name": "target_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_redirects_target_domain_id_idx": {
+          "name": "domain_redirects_target_domain_id_idx",
+          "columns": [
+            {
+              "expression": "target_domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_redirects_source_domain_idx": {
+          "name": "domain_redirects_source_domain_idx",
+          "columns": [
+            {
+              "expression": "source_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_redirects_target_domain_id_domain_mappings_id_fk": {
+          "name": "domain_redirects_target_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "target_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_redirects_created_by_users_id_fk": {
+          "name": "domain_redirects_created_by_users_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_redirects_source_domain_unique": {
+          "name": "domain_redirects_source_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_rules": {
+      "name": "domain_traffic_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_key": {
+          "name": "condition_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_value": {
+          "name": "condition_value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_rules_domain_id_idx": {
+          "name": "domain_traffic_rules_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_traffic_rules_domain_id_priority_idx": {
+          "name": "domain_traffic_rules_domain_id_priority_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_rules_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_rules_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_rules",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_weights": {
+      "name": "domain_traffic_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_weights_domain_id_idx": {
+          "name": "domain_traffic_weights_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_weights_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_weights_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_weights",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_traffic_weights_domain_alias_unique": {
+          "name": "domain_traffic_weights_domain_alias_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain_id",
+            "alias"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flags_key_idx": {
+          "name": "feature_flags_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ffmpeg_executor_settings": {
+      "name": "ffmpeg_executor_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "local_enabled": {
+          "name": "local_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "remote_enabled": {
+          "name": "remote_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_auth": {
+          "name": "remote_auth",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google_id_token'"
+        },
+        "sa_key_encrypted": {
+          "name": "sa_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_executor": {
+          "name": "default_executor",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_integration_credentials": {
+      "name": "google_integration_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured": {
+          "name": "configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "google_integration_credentials_service_unique": {
+          "name": "google_integration_credentials_service_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installed_apps": {
+      "name": "installed_apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_set_ids": {
+          "name": "rule_set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "schema_ids": {
+          "name": "schema_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "bundle_sha256": {
+          "name": "bundle_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'installing'"
+        },
+        "created_resources": {
+          "name": "created_resources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "installed_by": {
+          "name": "installed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "installed_apps_project_id_idx": {
+          "name": "installed_apps_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "installed_apps_project_id_projects_id_fk": {
+          "name": "installed_apps_project_id_projects_id_fk",
+          "tableFrom": "installed_apps",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "installed_apps_installed_by_users_id_fk": {
+          "name": "installed_apps_installed_by_users_id_fk",
+          "tableFrom": "installed_apps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "installed_apps_app_project_unique": {
+          "name": "installed_apps_app_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oidc_providers_provider_id_unique": {
+          "name": "oidc_providers_provider_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rule_executions": {
+      "name": "onboarding_rule_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rule_executions_user_idx": {
+          "name": "onboarding_rule_executions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_rule_idx": {
+          "name": "onboarding_rule_executions_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_executed_at_idx": {
+          "name": "onboarding_rule_executions_executed_at_idx",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_status_idx": {
+          "name": "onboarding_rule_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rule_executions_rule_id_onboarding_rules_id_fk": {
+          "name": "onboarding_rule_executions_rule_id_onboarding_rules_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "onboarding_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "onboarding_rule_executions_user_id_users_id_fk": {
+          "name": "onboarding_rule_executions_user_id_users_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rules": {
+      "name": "onboarding_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_signup'"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rules_enabled_trigger_idx": {
+          "name": "onboarding_rules_enabled_trigger_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rules_priority_idx": {
+          "name": "onboarding_rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rules_created_by_users_id_fk": {
+          "name": "onboarding_rules_created_by_users_id_fk",
+          "tableFrom": "onboarding_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_preferences": {
+      "name": "path_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spa_mode": {
+          "name": "spa_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_path_preferences_project_id": {
+          "name": "idx_path_preferences_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_preferences_project_id_projects_id_fk": {
+          "name": "path_preferences_project_id_projects_id_fk",
+          "tableFrom": "path_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "path_preferences_project_filepath_unique": {
+          "name": "path_preferences_project_filepath_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "filepath"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_redirects": {
+      "name": "path_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'100'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "path_redirects_domain_mapping_id_idx": {
+          "name": "path_redirects_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "path_redirects_source_path_idx": {
+          "name": "path_redirects_source_path_idx",
+          "columns": [
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_redirects_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "path_redirects_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "path_redirects_created_by_users_id_fk": {
+          "name": "path_redirects_created_by_users_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_token": {
+          "name": "upload_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_token_idx": {
+          "name": "pending_uploads_token_idx",
+          "columns": [
+            {
+              "expression": "upload_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_project_idx": {
+          "name": "pending_uploads_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_project_id_projects_id_fk": {
+          "name": "pending_uploads_project_id_projects_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_uploaded_by_users_id_fk": {
+          "name": "pending_uploads_uploaded_by_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_uploads_upload_token_unique": {
+          "name": "pending_uploads_upload_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data_embeddings": {
+      "name": "pipeline_data_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_data_id": {
+          "name": "pipeline_data_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_embeddings_data_id_idx": {
+          "name": "pipeline_data_embeddings_data_id_idx",
+          "columns": [
+            {
+              "expression": "pipeline_data_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_embeddings_schema_field_idx": {
+          "name": "pipeline_data_embeddings_schema_field_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk": {
+          "name": "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_data",
+          "columnsFrom": [
+            "pipeline_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data": {
+      "name": "pipeline_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_project_id_idx": {
+          "name": "pipeline_data_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_schema_id_idx": {
+          "name": "pipeline_data_schema_id_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_created_at_idx": {
+          "name": "pipeline_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_project_id_projects_id_fk": {
+          "name": "pipeline_data_project_id_projects_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_created_by_users_id_fk": {
+          "name": "pipeline_data_created_by_users_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_execution_logs": {
+      "name": "pipeline_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_id": {
+          "name": "proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps_count": {
+          "name": "steps_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_step": {
+          "name": "error_step",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_meta": {
+          "name": "request_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_exec_logs_rule_created_idx": {
+          "name": "pipeline_exec_logs_rule_created_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_project_idx": {
+          "name": "pipeline_exec_logs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_created_idx": {
+          "name": "pipeline_exec_logs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_execution_logs_project_id_projects_id_fk": {
+          "name": "pipeline_execution_logs_project_id_projects_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schedules": {
+      "name": "pipeline_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_proxy_rule_id": {
+          "name": "target_proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schedules_project_id_idx": {
+          "name": "pipeline_schedules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_schedules_target_proxy_rule_id_idx": {
+          "name": "pipeline_schedules_target_proxy_rule_id_idx",
+          "columns": [
+            {
+              "expression": "target_proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_schedules_enabled_next_run_idx": {
+          "name": "pipeline_schedules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schedules_project_id_projects_id_fk": {
+          "name": "pipeline_schedules_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schedules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_schedules_target_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_schedules_target_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_schedules",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "target_proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schemas": {
+      "name": "pipeline_schemas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schemas_project_id_idx": {
+          "name": "pipeline_schemas_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schemas_project_id_projects_id_fk": {
+          "name": "pipeline_schemas_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schemas",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pipeline_schemas_project_name_unique": {
+          "name": "pipeline_schemas_project_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.primary_content": {
+      "name": "primary_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "www_enabled": {
+          "name": "www_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'redirect-to-www'"
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "primary_content_project_id_projects_id_fk": {
+          "name": "primary_content_project_id_projects_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "primary_content_configured_by_users_id_fk": {
+          "name": "primary_content_configured_by_users_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_default_proxy_rule_sets": {
+      "name": "project_default_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_default_proxy_rule_sets_project_ruleset_unique": {
+          "name": "project_default_proxy_rule_sets_project_ruleset_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_project_id_idx": {
+          "name": "project_default_proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_rule_set_id_idx": {
+          "name": "project_default_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_default_proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "project_default_proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite_links": {
+      "name": "project_invite_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guest'"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invite_links_project_id_idx": {
+          "name": "project_invite_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_token_idx": {
+          "name": "project_invite_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_is_active_idx": {
+          "name": "project_invite_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_links_project_id_projects_id_fk": {
+          "name": "project_invite_links_project_id_projects_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_links_created_by_users_id_fk": {
+          "name": "project_invite_links_created_by_users_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_links_token_unique": {
+          "name": "project_invite_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_group_permissions": {
+      "name": "project_group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_group_permissions_project_idx": {
+          "name": "project_group_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_permissions_group_idx": {
+          "name": "project_group_permissions_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_permissions_project_id_projects_id_fk": {
+          "name": "project_group_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_group_id_user_groups_id_fk": {
+          "name": "project_group_permissions_group_id_user_groups_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_granted_by_users_id_fk": {
+          "name": "project_group_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_group_permissions_unique": {
+          "name": "project_group_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "group_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_permissions": {
+      "name": "project_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_permissions_project_idx": {
+          "name": "project_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_permissions_user_idx": {
+          "name": "project_permissions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_permissions_project_id_projects_id_fk": {
+          "name": "project_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_user_id_users_id_fk": {
+          "name": "project_permissions_user_id_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_granted_by_users_id_fk": {
+          "name": "project_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_permissions_unique": {
+          "name": "project_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_secrets": {
+      "name": "project_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_secrets_project_name_unique": {
+          "name": "project_secrets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_secrets_project_id_idx": {
+          "name": "project_secrets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_secrets_project_id_projects_id_fk": {
+          "name": "project_secrets_project_id_projects_id_fk",
+          "tableFrom": "project_secrets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_found'"
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authenticated'"
+        },
+        "allow_public_signup": {
+          "name": "allow_public_signup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_providers": {
+          "name": "ai_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_services": {
+          "name": "ai_services",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_proxy_rule_set_id": {
+          "name": "default_proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_created_by_idx": {
+          "name": "projects_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_owner_idx": {
+          "name": "projects_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_owner_name_unique": {
+          "name": "projects_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_set_revisions": {
+      "name": "proxy_rule_set_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_set_revisions_set_created_idx": {
+          "name": "proxy_rule_set_revisions_set_created_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_set_revisions_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rule_set_revisions_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rule_set_revisions",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_sets": {
+      "name": "proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_sets_project_name_unique": {
+          "name": "proxy_rule_sets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_project_id_idx": {
+          "name": "proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_environment_idx": {
+          "name": "proxy_rule_sets_environment_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rules": {
+      "name": "proxy_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "methods": {
+          "name": "methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strip_prefix": {
+          "name": "strip_prefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "preserve_host": {
+          "name": "preserve_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forward_cookies": {
+          "name": "forward_cookies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "header_config": {
+          "name": "header_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_transform": {
+          "name": "auth_transform",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_rewrite": {
+          "name": "internal_rewrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proxy_type": {
+          "name": "proxy_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external_proxy'"
+        },
+        "email_handler_config": {
+          "name": "email_handler_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "debug_enabled": {
+          "name": "debug_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rules_rule_set_path_method_unique": {
+          "name": "proxy_rules_rule_set_path_method_unique",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_id_idx": {
+          "name": "proxy_rules_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_order_idx": {
+          "name": "proxy_rules_rule_set_order_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_proxy_type_idx": {
+          "name": "proxy_rules_proxy_type_idx",
+          "columns": [
+            {
+              "expression": "proxy_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rules_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rules_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rules",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_header_rules": {
+      "name": "response_header_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_policy": {
+          "name": "frame_policy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sameorigin'"
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_header_rules_project_pattern_unique": {
+          "name": "response_header_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_id_idx": {
+          "name": "response_header_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_priority_idx": {
+          "name": "response_header_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "response_header_rules_project_id_projects_id_fk": {
+          "name": "response_header_rules_project_id_projects_id_fk",
+          "tableFrom": "response_header_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_logs": {
+      "name": "retention_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_count": {
+          "name": "asset_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "freed_bytes": {
+          "name": "freed_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_partial": {
+          "name": "is_partial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_logs_project_id_idx": {
+          "name": "retention_logs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_rule_id_idx": {
+          "name": "retention_logs_rule_id_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_deleted_at_idx": {
+          "name": "retention_logs_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_project_deleted_at_idx": {
+          "name": "retention_logs_project_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_logs_project_id_projects_id_fk": {
+          "name": "retention_logs_project_id_projects_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retention_logs_rule_id_retention_rules_id_fk": {
+          "name": "retention_logs_rule_id_retention_rules_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "retention_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_rules": {
+      "name": "retention_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_pattern": {
+          "name": "branch_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_branches": {
+          "name": "exclude_branches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keep_with_alias": {
+          "name": "keep_with_alias",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "keep_minimum": {
+          "name": "keep_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "path_patterns": {
+          "name": "path_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_mode": {
+          "name": "path_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_summary": {
+          "name": "last_run_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_rules_project_id_idx": {
+          "name": "retention_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_next_run_idx": {
+          "name": "retention_rules_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_enabled_next_run_idx": {
+          "name": "retention_rules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_rules_project_id_projects_id_fk": {
+          "name": "retention_rules_project_id_projects_id_fk",
+          "tableFrom": "retention_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "share_links_project_id_idx": {
+          "name": "share_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_domain_mapping_id_idx": {
+          "name": "share_links_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_token_idx": {
+          "name": "share_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_is_active_idx": {
+          "name": "share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_project_id_projects_id_fk": {
+          "name": "share_links_project_id_projects_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "share_links_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_created_by_users_id_fk": {
+          "name": "share_links_created_by_users_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "share_links_token_unique": {
+          "name": "share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_challenges": {
+      "name": "ssl_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "base_domain": {
+          "name": "base_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_type": {
+          "name": "challenge_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_name": {
+          "name": "record_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_value": {
+          "name": "record_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_data": {
+          "name": "order_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authz_data": {
+          "name": "authz_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_authorization": {
+          "name": "key_authorization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_challenges_base_domain_idx": {
+          "name": "ssl_challenges_base_domain_idx",
+          "columns": [
+            {
+              "expression": "base_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_challenges_status_idx": {
+          "name": "ssl_challenges_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ssl_challenges_base_domain_unique": {
+          "name": "ssl_challenges_base_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "base_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_renewal_history": {
+      "name": "ssl_renewal_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_type": {
+          "name": "certificate_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_expires_at": {
+          "name": "new_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_renewal_history_domain_id_idx": {
+          "name": "ssl_renewal_history_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_renewal_history_created_at_idx": {
+          "name": "ssl_renewal_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssl_renewal_history_domain_id_domain_mappings_id_fk": {
+          "name": "ssl_renewal_history_domain_id_domain_mappings_id_fk",
+          "tableFrom": "ssl_renewal_history",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_settings": {
+      "name": "ssl_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_config": {
+      "name": "system_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_setup_complete": {
+          "name": "is_setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_config": {
+          "name": "storage_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_provider": {
+          "name": "email_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_config": {
+          "name": "email_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_configured": {
+          "name": "email_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "smtp_config": {
+          "name": "smtp_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_configured": {
+          "name": "smtp_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_config": {
+          "name": "cache_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwt_secret": {
+          "name": "jwt_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_salt": {
+          "name": "api_key_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_public_signups": {
+          "name": "allow_public_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "telemetry_enabled": {
+          "name": "telemetry_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "telemetry_last_sent": {
+          "name": "telemetry_last_sent",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_config": {
+          "name": "branding_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_ip_rollups": {
+      "name": "traffic_ip_rollups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_paths": {
+          "name": "sample_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "sample_user_agents": {
+          "name": "sample_user_agents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_ip_rollups_ip_unique": {
+          "name": "traffic_ip_rollups_ip_unique",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_request_count_idx": {
+          "name": "traffic_ip_rollups_request_count_idx",
+          "columns": [
+            {
+              "expression": "request_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_last_seen_idx": {
+          "name": "traffic_ip_rollups_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_requests": {
+      "name": "traffic_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_version": {
+          "name": "http_version",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referer": {
+          "name": "referer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_requests_timestamp_idx": {
+          "name": "traffic_requests_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_ip_idx": {
+          "name": "traffic_requests_ip_idx",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_status_idx": {
+          "name": "traffic_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_classification_idx": {
+          "name": "traffic_requests_classification_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_group_members": {
+      "name": "user_group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_members_group_idx": {
+          "name": "user_group_members_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_group_members_user_idx": {
+          "name": "user_group_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_group_members_group_id_user_groups_id_fk": {
+          "name": "user_group_members_group_id_user_groups_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_user_id_users_id_fk": {
+          "name": "user_group_members_user_id_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_added_by_users_id_fk": {
+          "name": "user_group_members_added_by_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_group_members_unique": {
+          "name": "user_group_members_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_groups_created_by_idx": {
+          "name": "user_groups_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_created_by_users_id_fk": {
+          "name": "user_groups_created_by_users_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_verified_at": {
+          "name": "oidc_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_invitations_email": {
+          "name": "idx_workspace_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_invitations_token": {
+          "name": "idx_workspace_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invitations_invited_by_users_id_fk": {
+          "name": "workspace_invitations_invited_by_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_accepted_user_id_users_id_fk": {
+          "name": "workspace_invitations_accepted_user_id_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitations_token_unique": {
+          "name": "workspace_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1785844449680,
       "tag": "0042_nifty_captain_universe",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1787008710122,
+      "tag": "0043_swift_namorita",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema/ffmpeg-executor-settings.schema.ts
+++ b/apps/backend/src/db/schema/ffmpeg-executor-settings.schema.ts
@@ -1,0 +1,41 @@
+import { pgTable, uuid, boolean, varchar, text, timestamp } from 'drizzle-orm/pg-core';
+
+/**
+ * Instance-level configuration of the ffmpeg executors (Local server / Remote
+ * Worker) edited in Admin Settings → Features → Server video ops → Executor.
+ * Exactly one row (the service upserts; there is no natural key beyond "the
+ * instance"). Env vars override individual fields — FFMPEG_EXECUTOR,
+ * FFMPEG_REMOTE_URL, FFMPEG_REMOTE_AUTH, FFMPEG_REMOTE_SA_KEY_JSON — see
+ * `pipelines/ffmpeg/ffmpeg-executor-settings.service.ts` (`resolved()`).
+ *
+ * The service-account key is AES-256-GCM encrypted with common/crypto/aes-gcm.ts
+ * (same wire format as oidc_providers.config_encrypted) and is WRITE-ONLY: the
+ * API reports only whether one is stored.
+ *
+ * Spec: docs/superpowers/specs/2026-08-17-ffmpeg-remote-executor-design.md §1.5.
+ */
+export const ffmpegExecutorSettings = pgTable('ffmpeg_executor_settings', {
+  id: uuid('id').primaryKey().defaultRandom(),
+
+  // Local executor: ffmpeg spawned by this backend. Only meaningful when the
+  // binaries are present; off lets an admin force Remote on a box that has ffmpeg.
+  localEnabled: boolean('local_enabled').default(true).notNull(),
+
+  // Remote executor: a Worker CE calls over HTTPS (Cloud Run is the reference).
+  remoteEnabled: boolean('remote_enabled').default(false).notNull(),
+  remoteUrl: text('remote_url'),
+  // 'google_id_token' | 'none'
+  remoteAuth: varchar('remote_auth', { length: 32 }).default('google_id_token').notNull(),
+  // encryptString(<service-account JSON>) or null (= use ADC / no key)
+  saKeyEncrypted: text('sa_key_encrypted'),
+
+  // 'local' | 'remote' — which executor a step runs on unless it names one.
+  defaultExecutor: varchar('default_executor', { length: 16 }).default('local').notNull(),
+
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  updatedByUserId: uuid('updated_by_user_id'),
+});
+
+export type FfmpegExecutorSettingsRow = typeof ffmpegExecutorSettings.$inferSelect;
+export type NewFfmpegExecutorSettingsRow = typeof ffmpegExecutorSettings.$inferInsert;

--- a/apps/backend/src/db/schema/index.ts
+++ b/apps/backend/src/db/schema/index.ts
@@ -25,6 +25,7 @@ export * from './domain-traffic-weights.schema';
 export * from './domain-traffic-rules.schema';
 export * from './path-preferences.schema';
 export * from './feature-flags.schema';
+export * from './ffmpeg-executor-settings.schema';
 export * from './workspace-invitations.schema';
 export * from './retention-rules.schema';
 export * from './cache-rules.schema';

--- a/apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-config.providers.ts
+++ b/apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-config.providers.ts
@@ -1,0 +1,30 @@
+import { Provider } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import { FfmpegExecutorSettingsService } from '../ffmpeg-executor-settings.service';
+import { FFMPEG_CONFIG, FFMPEG_REMOTE_DEPS } from './ffmpeg-config.tokens';
+
+/**
+ * The effective-config providers, shared by PipelinesModule and the wiring spec
+ * so there is one definition to get right.
+ *
+ * Resolved LAZILY through ModuleRef on purpose: the settings service holds an
+ * @Optional() RemoteFfmpegExecutor (for Test connection) and the executor reads
+ * its config from FFMPEG_REMOTE_DEPS, so `inject: [FfmpegExecutorSettingsService]`
+ * would close a cycle Nest cannot instantiate — the module graph never finishes
+ * compiling. Nothing calls these closures during construction, so deferring the
+ * lookup to first use breaks the cycle without changing behaviour.
+ */
+export const FFMPEG_CONFIG_PROVIDERS: Provider[] = [
+  {
+    provide: FFMPEG_CONFIG,
+    useFactory: (ref: ModuleRef) => () => ref.get(FfmpegExecutorSettingsService).resolved(),
+    inject: [ModuleRef],
+  },
+  {
+    provide: FFMPEG_REMOTE_DEPS,
+    useFactory: (ref: ModuleRef) => ({
+      env: () => ref.get(FfmpegExecutorSettingsService).resolved(),
+    }),
+    inject: [ModuleRef],
+  },
+];

--- a/apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-config.tokens.ts
+++ b/apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-config.tokens.ts
@@ -1,0 +1,15 @@
+import type { FfmpegEnvConfig } from '../ffmpeg-env';
+
+/**
+ * DI tokens through which the executors receive the EFFECTIVE ffmpeg config —
+ * env merged over the admin-saved DB row (FfmpegExecutorSettingsService.resolved()).
+ * Both are @Optional() at the injection sites and default to plain readFfmpegEnv(),
+ * so unit tests and older wiring keep working unchanged.
+ */
+export const FFMPEG_CONFIG = Symbol('FFMPEG_CONFIG');
+export type FfmpegConfigResolver = () => FfmpegEnvConfig;
+
+export const FFMPEG_REMOTE_DEPS = Symbol('FFMPEG_REMOTE_DEPS');
+export interface FfmpegRemoteDeps {
+  env?: FfmpegConfigResolver;
+}

--- a/apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-executor.selector.spec.ts
+++ b/apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-executor.selector.spec.ts
@@ -3,7 +3,7 @@
  * which one a step gets, and the additive capability payload. Literal
  * collaborators cast `as never`, per the repo's handler-spec pattern.
  */
-import { readFfmpegEnv } from '../ffmpeg-env';
+import { readFfmpegEnv, type FfmpegEnvConfig } from '../ffmpeg-env';
 import { FfmpegExecutorSelector } from './ffmpeg-executor.selector';
 
 function make(
@@ -12,6 +12,8 @@ function make(
     localAvailable?: boolean;
     flag?: boolean;
     remoteReady?: { ok: boolean; reason?: string; version?: string };
+    /** Overrides on the RESOLVED config — what FfmpegExecutorSettingsService.resolved() would hand back. */
+    cfg?: Partial<FfmpegEnvConfig>;
   } = {},
 ) {
   const local = {
@@ -33,7 +35,7 @@ function make(
     getOps: async () => ['probe', 'extract_audio', 'slice', 'concat'],
     isFlagOn: async () => o.flag ?? true,
   };
-  const env = readFfmpegEnv(envOver);
+  const env = { ...readFfmpegEnv(envOver), ...(o.cfg ?? {}) };
   return {
     selector: new FfmpegExecutorSelector(
       local as never,
@@ -107,4 +109,26 @@ it('probe(): server = flag && any ready; additive executors/defaultExecutor/remo
       { localAvailable: false, remoteReady: { ok: false, reason: 'nope' } },
     ).selector.probe(),
   ).resolves.toMatchObject({ server: false, remote: { ready: false, reason: 'nope' } });
+});
+
+it('enabled(): localEnabled=false hides local even with binaries; remoteEnabled=false hides remote even with a URL', () => {
+  expect(make({}, { cfg: { localEnabled: false } }).selector.enabled()).toEqual([]);
+  expect(
+    make(
+      {},
+      { cfg: { remoteEnabled: false, remoteUrl: 'https://w.example.com' } },
+    ).selector.enabled(),
+  ).toEqual(['local']);
+  expect(
+    make(
+      {},
+      { cfg: { localEnabled: false, remoteEnabled: true, remoteUrl: 'https://w.example.com' } },
+    ).selector.enabled(),
+  ).toEqual(['remote']);
+});
+
+it("pick('remote') when remote is switched off says so without pointing only at the env var", async () => {
+  const { selector } = make({}, { cfg: { remoteEnabled: false } });
+  await expect(selector.pick('remote')).rejects.toThrow(/not enabled on this instance/);
+  await expect(selector.pick('remote')).rejects.toThrow(/Admin Settings/);
 });

--- a/apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-executor.selector.ts
+++ b/apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-executor.selector.ts
@@ -81,7 +81,7 @@ export class FfmpegExecutorSelector {
       throw new FfmpegExecutorUnavailableError(
         name === 'remote'
           ? "ffmpeg_handler: executor 'remote' is not enabled on this instance (enable it in Admin Settings → Features → Server video ops, or set FFMPEG_REMOTE_URL)"
-          : "ffmpeg_handler: executor 'local' is not enabled on this instance (ffmpeg is not installed)",
+          : "ffmpeg_handler: executor 'local' is not enabled on this instance (needs ffmpeg installed and Local switched on in Admin Settings → Features → Server video ops)",
       );
     }
     const executor: FfmpegExecutor = name === 'local' ? this.local : this.remote;

--- a/apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-executor.selector.ts
+++ b/apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-executor.selector.ts
@@ -1,8 +1,9 @@
-import { Injectable, Optional } from '@nestjs/common';
+import { Inject, Injectable, Optional } from '@nestjs/common';
 import { FFMPEG_OPS, FfmpegCapabilityService } from '../ffmpeg-capability.service';
-import { readFfmpegEnv, type FfmpegEnvConfig } from '../ffmpeg-env';
+import { readFfmpegEnv } from '../ffmpeg-env';
 import { FfmpegExecutorUnavailableError } from '../ffmpeg-errors';
 import type { FfmpegExecutor, FfmpegExecutorName } from './ffmpeg-executor.interface';
+import { FFMPEG_CONFIG, type FfmpegConfigResolver } from './ffmpeg-config.tokens';
 import { LocalFfmpegExecutor } from './local-ffmpeg.executor';
 import { RemoteFfmpegExecutor } from './remote/remote-ffmpeg.executor';
 
@@ -44,14 +45,15 @@ export class FfmpegExecutorSelector {
     private readonly local: LocalFfmpegExecutor,
     private readonly remote: RemoteFfmpegExecutor,
     private readonly capability: FfmpegCapabilityService,
-    @Optional() private readonly env: () => FfmpegEnvConfig = readFfmpegEnv,
+    @Optional() @Inject(FFMPEG_CONFIG) private readonly env: FfmpegConfigResolver = readFfmpegEnv,
   ) {}
 
-  /** Executors an operator has enabled: local iff ffmpeg binaries are present; remote iff FFMPEG_REMOTE_URL is set. */
+  /** Executors an operator has enabled: local iff binaries present AND localEnabled; remote iff remoteEnabled AND a Worker URL. */
   enabled(): FfmpegExecutorName[] {
+    const cfg = this.env();
     const names: FfmpegExecutorName[] = [];
-    if (this.capability.isAvailable()) names.push('local');
-    if (this.env().remoteUrl) names.push('remote');
+    if (this.capability.isAvailable() && cfg.localEnabled) names.push('local');
+    if (cfg.remoteEnabled && cfg.remoteUrl) names.push('remote');
     return names;
   }
 
@@ -78,7 +80,7 @@ export class FfmpegExecutorSelector {
     if (!this.enabled().includes(name)) {
       throw new FfmpegExecutorUnavailableError(
         name === 'remote'
-          ? "ffmpeg_handler: executor 'remote' is not enabled on this instance (set FFMPEG_REMOTE_URL)"
+          ? "ffmpeg_handler: executor 'remote' is not enabled on this instance (enable it in Admin Settings → Features → Server video ops, or set FFMPEG_REMOTE_URL)"
           : "ffmpeg_handler: executor 'local' is not enabled on this instance (ffmpeg is not installed)",
       );
     }

--- a/apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.spec.ts
+++ b/apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.spec.ts
@@ -7,7 +7,7 @@ import {
   RemoteFfmpegExecutor,
   semverLt,
 } from './remote-ffmpeg.executor';
-import { readFfmpegEnv } from '../../ffmpeg-env';
+import { readFfmpegEnv, type FfmpegEnvConfig } from '../../ffmpeg-env';
 import { IdTokenMinter, NoAuth } from './id-token';
 import { WorkerClient, WorkerTransportError } from './worker-client';
 
@@ -57,15 +57,22 @@ function make(envOver: Record<string, string> = {}, storageOver: Record<string, 
     ...storageOver,
   };
   let now = 1_000_000;
+  // Every config the executor built a client for — how the tests below see which
+  // URL/auth a call actually used (the fake client itself is shared).
+  const seenEnvs: FfmpegEnvConfig[] = [];
   const executor = new RemoteFfmpegExecutor(storage as never, {
     env: () => env,
-    clientFactory: () => client as never,
+    clientFactory: (cfg) => {
+      seenEnvs.push(cfg);
+      return client as never;
+    },
     now: () => now,
   });
   return {
     executor,
     client,
     storage,
+    seenEnvs,
     tick: (ms: number) => {
       now += ms;
     },
@@ -149,6 +156,18 @@ describe('ready()', () => {
     tick(2_000);
     await executor.ready();
     expect(client.health).toHaveBeenCalledTimes(2);
+  });
+  it('ready({fresh:true}) bypasses the readiness cache and ready({env}) evaluates a candidate config', async () => {
+    const { executor, client, seenEnvs } = make();
+    await executor.ready();
+    await executor.ready();
+    expect(client.health).toHaveBeenCalledTimes(1); // cached
+    await executor.ready({ fresh: true });
+    expect(client.health).toHaveBeenCalledTimes(2);
+    const candidate = readFfmpegEnv({ FFMPEG_REMOTE_URL: 'https://other.example.com' });
+    const r = await executor.ready({ env: candidate });
+    expect(r).toEqual({ ok: true, version: '0.4.31' });
+    expect(seenEnvs.map((e) => e.remoteUrl)).toContain('https://other.example.com');
   });
   it('unreachable worker and too-old worker are not ready', async () => {
     const a = make();
@@ -334,5 +353,22 @@ describe('the default client factory', () => {
     expect(
       authOf(buildWorkerClient(env({ FFMPEG_REMOTE_AUTH: 'google_id_token' }))),
     ).toBeInstanceOf(IdTokenMinter);
+  });
+});
+
+describe('testConnection()', () => {
+  it('hits the Worker at the override URL, uncached — and never memoises the draft client', async () => {
+    const { executor, client, seenEnvs } = make();
+    await executor.testConnection({ remoteUrl: 'https://draft.example.com' });
+    expect(seenEnvs.map((e) => e.remoteUrl)).toContain('https://draft.example.com');
+    expect(client.health).toHaveBeenCalledTimes(1);
+    // No overrides → back to the live config, not the draft's client.
+    await executor.testConnection();
+    expect(seenEnvs[seenEnvs.length - 1].remoteUrl).toBe('https://w');
+  });
+  it('refuses without a Worker URL', async () => {
+    await expect(make({ FFMPEG_REMOTE_URL: '' }).executor.testConnection()).rejects.toMatchObject({
+      code: 'FFMPEG_EXECUTOR_UNAVAILABLE',
+    });
   });
 });

--- a/apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.spec.ts
+++ b/apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.spec.ts
@@ -169,6 +169,27 @@ describe('ready()', () => {
     expect(r).toEqual({ ok: true, version: '0.4.31' });
     expect(seenEnvs.map((e) => e.remoteUrl)).toContain('https://other.example.com');
   });
+  it('a candidate/fresh check builds its own client and never evicts the live memoised one', async () => {
+    const { executor, seenEnvs, tick } = make();
+    await executor.ready();
+    expect(seenEnvs).toHaveLength(1); // the live client
+    await executor.ready({ fresh: true });
+    await executor.ready({
+      env: readFfmpegEnv({ FFMPEG_REMOTE_URL: 'https://other.example.com' }),
+    });
+    // Each draft got its OWN client — the last one for a different worker entirely.
+    expect(seenEnvs.map((e) => e.remoteUrl)).toEqual([
+      'https://w',
+      'https://w',
+      'https://other.example.com',
+    ]);
+    // Live path again once the 60 s cache expires: the memo must still hold the
+    // original client (a rebuild here would mean the draft evicted it).
+    tick(61_000);
+    const before = seenEnvs.length;
+    await executor.ready();
+    expect(seenEnvs).toHaveLength(before);
+  });
   it('unreachable worker and too-old worker are not ready', async () => {
     const a = make();
     a.client.health.mockRejectedValue(new WorkerTransportError('ECONNREFUSED'));

--- a/apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.ts
+++ b/apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { LOCAL_PRESIGN_PATH } from '../../../../storage/local.adapter';
 import { STORAGE_ADAPTER, type IStorageAdapter } from '../../../../storage/storage.interface';
 import { readFfmpegEnv, type FfmpegEnvConfig } from '../../ffmpeg-env';
+import { FFMPEG_REMOTE_DEPS } from '../ffmpeg-config.tokens';
 import {
   FfmpegBusyError,
   FfmpegExecutorUnavailableError,
@@ -106,8 +107,9 @@ export class RemoteFfmpegExecutor implements FfmpegExecutor {
 
   constructor(
     @Inject(STORAGE_ADAPTER) private readonly storageAdapter: IStorageAdapter,
-    // Test seams only — @Optional() so Nest never tries to resolve a provider for it.
-    @Optional() deps: Deps = {},
+    // The effective config (+ test seams). @Optional() so a hand-built executor
+    // and any wiring without the token keep the plain readFfmpegEnv() default.
+    @Optional() @Inject(FFMPEG_REMOTE_DEPS) deps: Deps = {},
   ) {
     this.env = deps.env ?? (() => readFfmpegEnv());
     this.clientFactory = deps.clientFactory ?? buildWorkerClient;

--- a/apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.ts
+++ b/apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.ts
@@ -121,9 +121,21 @@ export class RemoteFfmpegExecutor implements FfmpegExecutor {
     return 0;
   }
 
-  async ready(): Promise<FfmpegExecutorReadiness> {
-    const env = this.env();
-    if (!env.remoteUrl) return { ok: false, reason: 'FFMPEG_REMOTE_URL is not set' };
+  /**
+   * `fresh` skips (and does not poison) the shared 60 s cache and `env` judges a
+   * CANDIDATE config — both are what the settings "Test connection" button needs
+   * to report on an unsaved draft without disturbing the live readiness answer.
+   */
+  async ready(
+    opts: { fresh?: boolean; env?: FfmpegEnvConfig } = {},
+  ): Promise<FfmpegExecutorReadiness> {
+    const env = opts.env ?? this.env();
+    if (!env.remoteUrl)
+      return {
+        ok: false,
+        reason:
+          'no Worker URL configured (Admin Settings → Server video ops → Executor, or FFMPEG_REMOTE_URL)',
+      };
     let url: URL;
     try {
       url = new URL(env.remoteUrl);
@@ -134,7 +146,7 @@ export class RemoteFfmpegExecutor implements FfmpegExecutor {
       return { ok: false, reason: 'remote auth google_id_token requires an https worker URL' };
     }
 
-    const entry = this.cacheEntry(env);
+    const entry = opts.fresh || opts.env ? this.freshEntry(env) : this.cacheEntry(env);
     entry.storage ??= await this.probeStorage();
     if (!entry.storage.ok) return entry.storage;
 
@@ -159,11 +171,15 @@ export class RemoteFfmpegExecutor implements FfmpegExecutor {
     return { ok: true, version: health.version };
   }
 
-  /** Uncached liveness check for the settings "Test connection" button. */
-  async testConnection(): Promise<WorkerHealth> {
-    const env = this.env();
-    if (!env.remoteUrl) throw new FfmpegExecutorUnavailableError('FFMPEG_REMOTE_URL is not set');
-    return this.clientFor(env).health();
+  /** Uncached liveness check for the settings "Test connection" button; `overrides` = the unsaved form draft. */
+  async testConnection(
+    overrides: Partial<Pick<FfmpegEnvConfig, 'remoteUrl' | 'remoteAuth' | 'remoteSaKeyJson'>> = {},
+  ): Promise<WorkerHealth> {
+    const env: FfmpegEnvConfig = { ...this.env(), ...overrides };
+    if (!env.remoteUrl) throw new FfmpegExecutorUnavailableError('no Worker URL configured');
+    // Never memoise a draft's client over the live one — a draft may carry a different key.
+    const client = Object.keys(overrides).length ? this.clientFactory(env) : this.clientFor(env);
+    return client.health();
   }
 
   async run(job: FfmpegJob, opts: { signal: AbortSignal }): Promise<FfmpegJobResult> {
@@ -332,6 +348,11 @@ export class RemoteFfmpegExecutor implements FfmpegExecutor {
       const message = error instanceof Error ? error.message : String(error);
       return { ok: false, reason: `worker unreachable: ${message}` };
     }
+  }
+
+  /** An entry nobody else sees — for Test connection and candidate configs. */
+  private freshEntry(env: FfmpegEnvConfig): CacheEntry {
+    return { key: this.identity(env), at: this.now() };
   }
 
   /** One cache entry per worker identity; a config change invalidates it immediately. */

--- a/apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.ts
+++ b/apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.ts
@@ -158,7 +158,7 @@ export class RemoteFfmpegExecutor implements FfmpegExecutor {
       }
     }
 
-    entry.health ??= await this.probeHealth(env);
+    entry.health ??= await this.probeHealth(env, { throwaway: Boolean(opts.fresh || opts.env) });
     if (!entry.health.ok) return { ok: false, reason: entry.health.reason };
     const health = entry.health.health;
     if (!health.ok) return { ok: false, reason: 'worker reports not ok' };
@@ -184,7 +184,7 @@ export class RemoteFfmpegExecutor implements FfmpegExecutor {
 
   async run(job: FfmpegJob, opts: { signal: AbortSignal }): Promise<FfmpegJobResult> {
     const env = this.env();
-    if (!env.remoteUrl) throw new FfmpegExecutorUnavailableError('FFMPEG_REMOTE_URL is not set');
+    if (!env.remoteUrl) throw new FfmpegExecutorUnavailableError('no Worker URL configured');
     // ready() normally catches this; guard here too so a caller that skipped it
     // gets the typed error instead of a TypeError on an absent optional method.
     if (typeof this.storageAdapter.getPresignedUploadUrl !== 'function') {
@@ -341,9 +341,18 @@ export class RemoteFfmpegExecutor implements FfmpegExecutor {
     return { ok: true };
   }
 
-  private async probeHealth(env: FfmpegEnvConfig): Promise<NonNullable<CacheEntry['health']>> {
+  /**
+   * `throwaway` = a Test-connection / candidate check: build a one-off client so a
+   * draft config cannot evict the live memoised WorkerClient (and the ID token it
+   * has already minted) out from under running jobs.
+   */
+  private async probeHealth(
+    env: FfmpegEnvConfig,
+    opts: { throwaway?: boolean } = {},
+  ): Promise<NonNullable<CacheEntry['health']>> {
     try {
-      return { ok: true, health: await this.clientFor(env).health() };
+      const client = opts.throwaway ? this.clientFactory(env) : this.clientFor(env);
+      return { ok: true, health: await client.health() };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return { ok: false, reason: `worker unreachable: ${message}` };

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-env.spec.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-env.spec.ts
@@ -73,4 +73,13 @@ describe('remote executor env', () => {
       }),
     ).toMatchObject({ executor: 'local', remoteAuth: 'google_id_token', remoteUrl: null });
   });
+  it('localEnabled is always true from env; remoteEnabled mirrors whether FFMPEG_REMOTE_URL is set', () => {
+    const off = readFfmpegEnv({});
+    expect(off.localEnabled).toBe(true);
+    expect(off.remoteEnabled).toBe(false);
+    const on = readFfmpegEnv({ FFMPEG_REMOTE_URL: 'https://w.example.com/' });
+    expect(on.remoteEnabled).toBe(true);
+    expect(on.remoteUrl).toBe('https://w.example.com');
+    expect(readFfmpegEnv({ FFMPEG_REMOTE_URL: '' }).remoteEnabled).toBe(false);
+  });
 });

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-env.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-env.ts
@@ -20,6 +20,10 @@ export interface FfmpegEnvConfig {
   /** Ceiling for a single storage call (metadata, download, upload). */
   ioMaxSeconds: number;
   scratchDir: string;
+  /** Operator switch for the Local executor (DB-backed; env has no knob → always true here). */
+  localEnabled: boolean;
+  /** Operator switch for the Remote executor. From env alone: on iff FFMPEG_REMOTE_URL is set. */
+  remoteEnabled: boolean;
   /** Which executor runs a step unless the step says otherwise. */
   executor: FfmpegExecutorSetting;
   /** Worker base URL (https), trimmed and trailing-slash-stripped. Setting this enables the remote executor. */
@@ -53,6 +57,7 @@ function str(raw: string | undefined): string | null {
 
 export function readFfmpegEnv(env: NodeJS.ProcessEnv = process.env): FfmpegEnvConfig {
   const maxSeconds = num(env.FFMPEG_MAX_SECONDS, 1800);
+  const remoteUrl = str(env.FFMPEG_REMOTE_URL);
   return {
     memoryMb: num(env.FFMPEG_MEMORY_MB, 1024),
     threads: num(env.FFMPEG_THREADS, Math.max(1, os.cpus().length - 1)),
@@ -65,7 +70,9 @@ export function readFfmpegEnv(env: NodeJS.ProcessEnv = process.env): FfmpegEnvCo
         ? env.FFMPEG_SCRATCH_DIR
         : path.join(os.tmpdir(), 'bffless-ffmpeg'),
     executor: env.FFMPEG_EXECUTOR === 'remote' ? 'remote' : 'local',
-    remoteUrl: str(env.FFMPEG_REMOTE_URL),
+    localEnabled: true,
+    remoteEnabled: remoteUrl !== null,
+    remoteUrl,
     remoteAuth: env.FFMPEG_REMOTE_AUTH === 'none' ? 'none' : 'google_id_token',
     remoteSaKeyJson: str(env.FFMPEG_REMOTE_SA_KEY_JSON),
     remoteMaxInflight: num(env.FFMPEG_REMOTE_MAX_INFLIGHT, 8),

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.controller.spec.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.controller.spec.ts
@@ -1,0 +1,37 @@
+import { FfmpegExecutorSettingsController } from './ffmpeg-executor-settings.controller';
+
+describe('FfmpegExecutorSettingsController', () => {
+  const service = {
+    getStatus: jest.fn(async () => ({ hasSaKey: false })),
+    update: jest.fn(async () => ({ hasSaKey: true })),
+    testConnection: jest.fn(async () => ({ ok: true })),
+  };
+  const controller = new FfmpegExecutorSettingsController(service as never);
+
+  it('GET returns status', async () => {
+    await expect(controller.getStatus()).resolves.toEqual({ hasSaKey: false });
+  });
+
+  it('PUT forwards the body + user id and returns the new status', async () => {
+    const body = {
+      remoteEnabled: true,
+      remoteUrl: 'https://w.example.com',
+      saKeyJson: '{"type":"service_account"}',
+    };
+    await expect(controller.update(body, { id: 'u1' })).resolves.toEqual({ hasSaKey: true });
+    expect(service.update).toHaveBeenCalledWith(body, 'u1');
+  });
+
+  it('POST /test forwards the draft', async () => {
+    await controller.test({ remoteUrl: 'https://draft.example.com' });
+    expect(service.testConnection).toHaveBeenCalledWith({ remoteUrl: 'https://draft.example.com' });
+  });
+
+  it('is admin-only on every route (guard + Roles metadata)', () => {
+    const roles = (m: string) =>
+      Reflect.getMetadata('roles', (FfmpegExecutorSettingsController.prototype as any)[m]);
+    expect(roles('getStatus')).toEqual(['admin']);
+    expect(roles('update')).toEqual(['admin']);
+    expect(roles('test')).toEqual(['admin']);
+  });
+});

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.controller.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.controller.ts
@@ -1,0 +1,56 @@
+import { Body, Controller, Get, Post, Put, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiKeyGuard } from '../../auth/api-key.guard';
+import { RolesGuard } from '../../auth/roles.guard';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import {
+  FfmpegExecutorSettingsService,
+  type FfmpegExecutorTestDraft,
+  type UpdateFfmpegExecutorInput,
+} from './ffmpeg-executor-settings.service';
+
+/**
+ * Admin Settings → Features → Server video ops → Executor. Admin-only; the
+ * service-account key is write-only (never in a response). Lives in
+ * PipelinesModule (not SettingsModule) because it depends on the executor
+ * services and SettingsModule must not import PipelinesModule.
+ */
+@ApiTags('settings')
+@Controller('api/settings/ffmpeg-executor')
+@UseGuards(ApiKeyGuard, RolesGuard)
+export class FfmpegExecutorSettingsController {
+  constructor(private readonly settings: FfmpegExecutorSettingsService) {}
+
+  @Get()
+  @Roles('admin')
+  @ApiOperation({
+    summary: 'ffmpeg executor settings (Local / Remote) — the SA key is never returned',
+  })
+  @ApiResponse({ status: 200 })
+  getStatus() {
+    return this.settings.getStatus();
+  }
+
+  @Put()
+  @Roles('admin')
+  @ApiOperation({
+    summary:
+      'Update ffmpeg executor settings (partial; saKeyJson: string=replace, null=clear, absent=keep)',
+  })
+  @ApiResponse({ status: 200 })
+  @ApiResponse({ status: 400, description: 'Invalid combination (see message)' })
+  update(@Body() body: UpdateFfmpegExecutorInput, @CurrentUser() user: { id: string }) {
+    return this.settings.update(body, user?.id);
+  }
+
+  @Post('test')
+  @Roles('admin')
+  @ApiOperation({
+    summary: 'Test the Worker connection for the saved settings or an unsaved draft',
+  })
+  @ApiResponse({ status: 200 })
+  test(@Body() body: FfmpegExecutorTestDraft = {}) {
+    return this.settings.testConnection(body ?? {});
+  }
+}

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts
@@ -517,16 +517,39 @@ describe('FfmpegExecutorSettingsService', () => {
       expect(res.worker).toBeUndefined();
     });
 
-    it('a malformed draft key is rejected before anything can quote it back', async () => {
+    it('a malformed draft key fails through the same channel, without quoting the key back', async () => {
       mockSelect([]);
       const { service, remote } = makeWithRemote();
       await service.reload();
       const secret = '{"type":"service_account","private_key":"-----BEGIN PRIVATE KEY-----abc';
-      await expect(service.testConnection({ saKeyJson: secret })).rejects.toBeInstanceOf(
-        BadRequestException,
-      );
-      await expect(service.testConnection({ saKeyJson: secret })).rejects.not.toThrow(/BEGIN/);
+      const res = await service.testConnection({ saKeyJson: secret });
+      expect(res.ok).toBe(false);
+      expect(res.error).toBe('Service-account key must be valid JSON.');
+      expect(res.readiness).toEqual({
+        ok: false,
+        reason: 'Service-account key must be valid JSON.',
+      });
+      expect(res.latencyMs).toBeNull();
+      expect(res.credential).toBe('sa_key');
+      expect(JSON.stringify(res)).not.toContain('BEGIN PRIVATE KEY');
+      expect(JSON.stringify(res)).not.toContain(secret.slice(0, 30));
       expect(remote.testConnection).not.toHaveBeenCalled();
+      expect(remote.ready).not.toHaveBeenCalled();
+    });
+
+    it('credential=sa_key when a key is stored in the DB, and the key never reaches the result', async () => {
+      mockSelect([
+        row({
+          remoteEnabled: true,
+          remoteUrl: 'https://w.example.com',
+          saKeyEncrypted: encryptString(SA_KEY),
+        }),
+      ]);
+      const { service } = makeWithRemote();
+      await service.reload();
+      const res = await service.testConnection();
+      expect(res.credential).toBe('sa_key');
+      expect(JSON.stringify(res)).not.toContain('gserviceaccount');
     });
 
     it('without a wired remote executor it fails loudly instead of reporting a healthy worker', async () => {

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ServiceUnavailableException } from '@nestjs/common';
 
 jest.mock('../../db/client', () => ({
   db: {
@@ -61,15 +61,22 @@ function make(
     localAvailable?: boolean;
   } = {},
 ) {
-  const storage = {
-    getUrl: async () => 'https://bucket.example.com/x?sig=1',
-    ...(o.presign === false
-      ? {}
+  // `presign: false` = the local-filesystem adapter, which DOES sign — its URLs
+  // just point at CE's own route, so a Worker cannot use them. resolveLocalAdapter()
+  // keys off the `isLocalAdapter` marker (storage/local.adapter.ts), not the shape.
+  const storage =
+    o.presign === false
+      ? {
+          isLocalAdapter: true,
+          getUrl: async () => '/api/storage/local/x',
+          supportsPresignedUrls: () => true,
+          getPresignedUploadUrl: async () => '/api/storage/presigned/local?key=x',
+        }
       : {
+          getUrl: async () => 'https://bucket.example.com/x?sig=1',
           supportsPresignedUrls: () => true,
           getPresignedUploadUrl: async () => 'https://bucket.example.com/x?put=1',
-        }),
-  };
+        };
   const capability = {
     isAvailable: () => o.localAvailable ?? true,
     getVersion: () => ((o.localAvailable ?? true) ? 'ffmpeg version 6.1.1' : null),
@@ -234,11 +241,16 @@ describe('FfmpegExecutorSettingsService', () => {
 
     it("saKeySource is 'env' when FFMPEG_REMOTE_SA_KEY_JSON is set, storagePresignable false on local-FS", async () => {
       mockSelect([]);
-      const { service } = make({ env: { FFMPEG_REMOTE_SA_KEY_JSON: SA_KEY }, presign: false });
+      const { service, storage } = make({
+        env: { FFMPEG_REMOTE_SA_KEY_JSON: SA_KEY },
+        presign: false,
+      });
       await service.reload();
       const status = await service.getStatus();
       expect(status.hasSaKey).toBe(true);
       expect(status.saKeySource).toBe('env');
+      // The local adapter advertises presigning; being LOCAL is what disqualifies it.
+      expect(storage.supportsPresignedUrls?.()).toBe(true);
       expect(status.storagePresignable).toBe(false);
     });
   });
@@ -362,6 +374,62 @@ describe('FfmpegExecutorSettingsService', () => {
       await expect(
         pinned.service.update({ remoteUrl: 'https://other.example.com' }),
       ).rejects.toBeInstanceOf(BadRequestException);
+
+      const pinnedAuth = make({ env: { FFMPEG_REMOTE_AUTH: 'none' } });
+      await pinnedAuth.service.reload();
+      await expect(pinnedAuth.service.update({ remoteAuth: 'none' })).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+
+      const pinnedKey = make({ env: { FFMPEG_REMOTE_SA_KEY_JSON: SA_KEY } });
+      await pinnedKey.service.reload();
+      await expect(pinnedKey.service.update({ saKeyJson: SA_KEY })).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+
+      const pinnedDefault = make({ env: { FFMPEG_EXECUTOR: 'local' } });
+      await pinnedDefault.service.reload();
+      await expect(
+        pinnedDefault.service.update({ defaultExecutor: 'local' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it("saKeyJson '' clears the stored key (a blanked UI field is not a JSON error)", async () => {
+      mockSelect([row({ saKeyEncrypted: encryptString(SA_KEY) })]);
+      const { set } = mockWrite();
+      const { service } = make();
+      await service.reload();
+
+      await service.update({ saKeyJson: '   ' });
+      expect(set.mock.calls[0][0].saKeyEncrypted).toBeNull();
+      expect(service.resolved().remoteSaKeyJson).toBeNull();
+    });
+
+    it('refuses to save while the row could not be loaded — never merges onto defaults', async () => {
+      mockSelectThrows(new Error('relation "ffmpeg_executor_settings" does not exist'));
+      const { set, values } = mockWrite();
+      const { service } = make();
+      await service.reload();
+
+      await expect(service.update({ localEnabled: true })).rejects.toBeInstanceOf(
+        ServiceUnavailableException,
+      );
+      expect(values).not.toHaveBeenCalled();
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it('a non-Remote save is not blocked by local-FS storage when FFMPEG_REMOTE_URL pins Remote on', async () => {
+      mockSelect([row({ localEnabled: true })]);
+      const { set } = mockWrite();
+      const localFs = make({
+        presign: false,
+        env: { FFMPEG_REMOTE_URL: 'https://env.example.com' },
+      });
+      await localFs.service.reload();
+
+      const status = await localFs.service.update({ localEnabled: true });
+      expect(set).toHaveBeenCalledTimes(1);
+      expect(status.storagePresignable).toBe(false);
     });
   });
 });

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, ServiceUnavailableException } from '@nestjs/common';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 
 jest.mock('../../db/client', () => ({
   db: {
@@ -59,6 +63,8 @@ function make(
     env?: NodeJS.ProcessEnv;
     presign?: boolean;
     localAvailable?: boolean;
+    /** The RemoteFfmpegExecutor stand-in — only testConnection() needs one. */
+    remote?: unknown;
   } = {},
 ) {
   // `presign: false` = the local-filesystem adapter, which DOES sign — its URLs
@@ -85,6 +91,7 @@ function make(
     storage as never,
     capability as never,
     () => o.env ?? {},
+    o.remote as never,
   );
   return { service, storage, capability };
 }
@@ -430,6 +437,103 @@ describe('FfmpegExecutorSettingsService', () => {
       const status = await localFs.service.update({ localEnabled: true });
       expect(set).toHaveBeenCalledTimes(1);
       expect(status.storagePresignable).toBe(false);
+    });
+  });
+
+  describe('testConnection()', () => {
+    const HEALTH = {
+      ok: true,
+      version: '0.4.31',
+      ffmpeg: 'ffmpeg version 6.1.1',
+      ops: ['probe', 'extract_audio', 'slice', 'concat'],
+      uptimeS: 12,
+    };
+    function makeWithRemote(
+      o: {
+        health?: () => Promise<unknown>;
+        readiness?: { ok: boolean; reason?: string };
+        env?: NodeJS.ProcessEnv;
+      } = {},
+    ) {
+      const remote = {
+        testConnection: jest.fn(async (_overrides?: Record<string, unknown>) =>
+          o.health ? o.health() : HEALTH,
+        ),
+        ready: jest.fn(
+          async (_opts?: Record<string, unknown>) => o.readiness ?? { ok: true, version: '0.4.31' },
+        ),
+      };
+      const { service } = make({ env: o.env, remote });
+      return { service, remote };
+    }
+
+    it('returns worker health + latency + readiness; credential=adc when no key stored', async () => {
+      mockSelect([row({ remoteEnabled: true, remoteUrl: 'https://w.example.com' })]);
+      const { service, remote } = makeWithRemote();
+      await service.reload();
+      const res = await service.testConnection();
+      expect(res.ok).toBe(true);
+      expect(res.worker?.version).toBe('0.4.31');
+      expect(res.worker?.ops).toContain('slice');
+      expect(typeof res.latencyMs).toBe('number');
+      expect(res.readiness).toEqual({ ok: true });
+      expect(res.credential).toBe('adc');
+      expect(remote.ready).toHaveBeenCalledWith(expect.objectContaining({ fresh: true }));
+    });
+
+    it('draft overrides reach the executor; env-managed fields cannot be overridden; credential reflects the draft key', async () => {
+      mockSelect([]);
+      const { service, remote } = makeWithRemote({ env: { FFMPEG_REMOTE_AUTH: 'none' } });
+      await service.reload();
+      const res = await service.testConnection({
+        remoteUrl: 'https://draft.example.com',
+        remoteAuth: 'google_id_token',
+        saKeyJson: SA_KEY,
+      });
+      expect(remote.testConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          remoteUrl: 'https://draft.example.com',
+          remoteSaKeyJson: SA_KEY,
+        }),
+      );
+      expect(remote.testConnection.mock.calls[0][0]).not.toHaveProperty('remoteAuth'); // pinned by env
+      expect(res.credential).toBe('none'); // effective auth is env's 'none'
+    });
+
+    it('unreachable worker → ok:false with error, latency null, readiness reason passed through', async () => {
+      mockSelect([row({ remoteEnabled: true, remoteUrl: 'https://w.example.com' })]);
+      const { service } = makeWithRemote({
+        health: async () => {
+          throw new Error('worker unreachable: connect ECONNREFUSED');
+        },
+        readiness: { ok: false, reason: 'worker unreachable: connect ECONNREFUSED' },
+      });
+      await service.reload();
+      const res = await service.testConnection();
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/ECONNREFUSED/);
+      expect(res.latencyMs).toBeNull();
+      expect(res.readiness.reason).toMatch(/ECONNREFUSED/);
+      expect(res.worker).toBeUndefined();
+    });
+
+    it('a malformed draft key is rejected before anything can quote it back', async () => {
+      mockSelect([]);
+      const { service, remote } = makeWithRemote();
+      await service.reload();
+      const secret = '{"type":"service_account","private_key":"-----BEGIN PRIVATE KEY-----abc';
+      await expect(service.testConnection({ saKeyJson: secret })).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      await expect(service.testConnection({ saKeyJson: secret })).rejects.not.toThrow(/BEGIN/);
+      expect(remote.testConnection).not.toHaveBeenCalled();
+    });
+
+    it('without a wired remote executor it fails loudly instead of reporting a healthy worker', async () => {
+      mockSelect([]);
+      const { service } = make();
+      await service.reload();
+      await expect(service.testConnection()).rejects.toBeInstanceOf(InternalServerErrorException);
     });
   });
 });

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts
@@ -49,12 +49,18 @@ let table: Record<string, unknown>[] = [];
 function mockSelect(rows: unknown[]) {
   table = rows as Record<string, unknown>[];
   db.select.mockReturnValue({
-    from: jest.fn().mockReturnValue({ limit: jest.fn().mockImplementation(async () => table) }),
+    from: jest.fn().mockReturnValue({
+      orderBy: jest.fn().mockReturnValue({
+        limit: jest.fn().mockImplementation(async () => table),
+      }),
+    }),
   });
 }
 function mockSelectThrows(err: Error) {
   db.select.mockReturnValue({
-    from: jest.fn().mockReturnValue({ limit: jest.fn().mockRejectedValue(err) }),
+    from: jest.fn().mockReturnValue({
+      orderBy: jest.fn().mockReturnValue({ limit: jest.fn().mockRejectedValue(err) }),
+    }),
   });
 }
 
@@ -533,6 +539,24 @@ describe('FfmpegExecutorSettingsService', () => {
       expect(res.credential).toBe('sa_key');
       expect(JSON.stringify(res)).not.toContain('BEGIN PRIVATE KEY');
       expect(JSON.stringify(res)).not.toContain(secret.slice(0, 30));
+      expect(remote.testConnection).not.toHaveBeenCalled();
+      expect(remote.ready).not.toHaveBeenCalled();
+    });
+
+    it('a malformed env-pinned key fails through the same channel, without quoting the key back, and never calls the executor', async () => {
+      mockSelect([]);
+      const { service, remote } = makeWithRemote({
+        env: { FFMPEG_REMOTE_SA_KEY_JSON: '{not json -----BEGIN PRIVATE KEY-----' },
+      });
+      await service.reload();
+      const res = await service.testConnection();
+      expect(res.ok).toBe(false);
+      expect(res.error).toBe('Service-account key must be valid JSON.');
+      expect(res.readiness).toEqual({
+        ok: false,
+        reason: 'Service-account key must be valid JSON.',
+      });
+      expect(JSON.stringify(res)).not.toContain('BEGIN PRIVATE KEY');
       expect(remote.testConnection).not.toHaveBeenCalled();
       expect(remote.ready).not.toHaveBeenCalled();
     });

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts
@@ -1,0 +1,367 @@
+import { BadRequestException } from '@nestjs/common';
+
+jest.mock('../../db/client', () => ({
+  db: {
+    select: jest.fn(),
+    insert: jest.fn(),
+    update: jest.fn(),
+  },
+}));
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { db } = require('../../db/client');
+
+import { FfmpegExecutorSettingsService } from './ffmpeg-executor-settings.service';
+import { encryptString, __resetKeyForTests } from '../../common/crypto/aes-gcm';
+
+const TEST_KEY = Buffer.alloc(32, 7).toString('base64');
+const SA_KEY = JSON.stringify({
+  type: 'service_account',
+  client_email: 'x@p.iam.gserviceaccount.com',
+});
+
+/** A row as Drizzle would return it. */
+function row(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'row-1',
+    localEnabled: true,
+    remoteEnabled: false,
+    remoteUrl: null,
+    remoteAuth: 'google_id_token',
+    saKeyEncrypted: null,
+    defaultExecutor: 'local',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    updatedByUserId: null,
+    ...over,
+  };
+}
+
+/**
+ * Stand-in for the single-row table: `select` reads it, the `update`/`insert`
+ * mocks write to it, so a `reload()` after a save sees what was persisted.
+ */
+let table: Record<string, unknown>[] = [];
+
+function mockSelect(rows: unknown[]) {
+  table = rows as Record<string, unknown>[];
+  db.select.mockReturnValue({
+    from: jest.fn().mockReturnValue({ limit: jest.fn().mockImplementation(async () => table) }),
+  });
+}
+function mockSelectThrows(err: Error) {
+  db.select.mockReturnValue({
+    from: jest.fn().mockReturnValue({ limit: jest.fn().mockRejectedValue(err) }),
+  });
+}
+
+function make(
+  o: {
+    env?: NodeJS.ProcessEnv;
+    presign?: boolean;
+    localAvailable?: boolean;
+  } = {},
+) {
+  const storage = {
+    getUrl: async () => 'https://bucket.example.com/x?sig=1',
+    ...(o.presign === false
+      ? {}
+      : {
+          supportsPresignedUrls: () => true,
+          getPresignedUploadUrl: async () => 'https://bucket.example.com/x?put=1',
+        }),
+  };
+  const capability = {
+    isAvailable: () => o.localAvailable ?? true,
+    getVersion: () => ((o.localAvailable ?? true) ? 'ffmpeg version 6.1.1' : null),
+  };
+  const service = new FfmpegExecutorSettingsService(
+    storage as never,
+    capability as never,
+    () => o.env ?? {},
+  );
+  return { service, storage, capability };
+}
+
+describe('FfmpegExecutorSettingsService', () => {
+  let originalKey: string | undefined;
+  beforeEach(() => {
+    originalKey = process.env.ENCRYPTION_KEY;
+    process.env.ENCRYPTION_KEY = TEST_KEY;
+    __resetKeyForTests();
+    jest.clearAllMocks();
+  });
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = originalKey;
+    __resetKeyForTests();
+  });
+
+  describe('resolved()', () => {
+    it('with no row behaves exactly like readFfmpegEnv (Plan 1 semantics)', async () => {
+      mockSelect([]);
+      const { service } = make({ env: { FFMPEG_REMOTE_URL: 'https://w.example.com' } });
+      await service.reload();
+      const cfg = service.resolved();
+      expect(cfg.localEnabled).toBe(true);
+      expect(cfg.remoteEnabled).toBe(true);
+      expect(cfg.remoteUrl).toBe('https://w.example.com');
+      expect(cfg.executor).toBe('local');
+    });
+
+    it('DB row fills fields env leaves unset; the SA key is decrypted into memory', async () => {
+      mockSelect([
+        row({
+          localEnabled: false,
+          remoteEnabled: true,
+          remoteUrl: 'https://db.example.com/',
+          remoteAuth: 'none',
+          saKeyEncrypted: encryptString(SA_KEY),
+          defaultExecutor: 'remote',
+        }),
+      ]);
+      const { service } = make();
+      await service.reload();
+      const cfg = service.resolved();
+      expect(cfg.localEnabled).toBe(false);
+      expect(cfg.remoteEnabled).toBe(true);
+      expect(cfg.remoteUrl).toBe('https://db.example.com'); // trailing slash stripped like env
+      expect(cfg.remoteAuth).toBe('none');
+      expect(cfg.remoteSaKeyJson).toBe(SA_KEY);
+      expect(cfg.executor).toBe('remote');
+    });
+
+    it('env wins per field, and FFMPEG_REMOTE_URL forces remoteEnabled', async () => {
+      mockSelect([
+        row({
+          remoteEnabled: false,
+          remoteUrl: 'https://db.example.com',
+          remoteAuth: 'none',
+          defaultExecutor: 'remote',
+          saKeyEncrypted: encryptString(SA_KEY),
+        }),
+      ]);
+      const { service } = make({
+        env: {
+          FFMPEG_EXECUTOR: 'local',
+          FFMPEG_REMOTE_URL: 'https://env.example.com',
+          FFMPEG_REMOTE_AUTH: 'google_id_token',
+          FFMPEG_REMOTE_SA_KEY_JSON: '{"type":"service_account","env":true}',
+        },
+      });
+      await service.reload();
+      const cfg = service.resolved();
+      expect(cfg.executor).toBe('local');
+      expect(cfg.remoteEnabled).toBe(true);
+      expect(cfg.remoteUrl).toBe('https://env.example.com');
+      expect(cfg.remoteAuth).toBe('google_id_token');
+      expect(cfg.remoteSaKeyJson).toBe('{"type":"service_account","env":true}');
+      expect(service.envManaged()).toEqual({
+        defaultExecutor: true,
+        remoteUrl: true,
+        remoteAuth: true,
+        saKey: true,
+      });
+    });
+
+    it("'' env values count as unset (compose passthrough)", async () => {
+      mockSelect([
+        row({
+          remoteEnabled: true,
+          remoteUrl: 'https://db.example.com',
+          defaultExecutor: 'remote',
+        }),
+      ]);
+      const { service } = make({
+        env: {
+          FFMPEG_EXECUTOR: '',
+          FFMPEG_REMOTE_URL: '',
+          FFMPEG_REMOTE_AUTH: '',
+          FFMPEG_REMOTE_SA_KEY_JSON: '',
+        },
+      });
+      await service.reload();
+      expect(service.resolved().remoteUrl).toBe('https://db.example.com');
+      expect(service.envManaged()).toEqual({
+        defaultExecutor: false,
+        remoteUrl: false,
+        remoteAuth: false,
+        saKey: false,
+      });
+    });
+
+    it('a missing table (pre-migration boot) is tolerated: env-only, no throw', async () => {
+      mockSelectThrows(new Error('relation "ffmpeg_executor_settings" does not exist'));
+      const { service } = make();
+      await expect(service.reload()).resolves.toBeUndefined();
+      expect(service.resolved().localEnabled).toBe(true);
+    });
+
+    it('an undecryptable key is treated as absent (does not poison the config)', async () => {
+      mockSelect([row({ saKeyEncrypted: 'not-a-ciphertext' })]);
+      const { service } = make();
+      await service.reload();
+      expect(service.resolved().remoteSaKeyJson).toBeNull();
+    });
+  });
+
+  describe('getStatus()', () => {
+    it('never includes the key; reports source + envManaged + storagePresignable', async () => {
+      mockSelect([
+        row({
+          remoteEnabled: true,
+          remoteUrl: 'https://db.example.com',
+          saKeyEncrypted: encryptString(SA_KEY),
+        }),
+      ]);
+      const { service } = make();
+      await service.reload();
+      const status = await service.getStatus();
+      expect(JSON.stringify(status)).not.toContain('service_account');
+      expect(status).toEqual({
+        localAvailable: true,
+        localVersion: 'ffmpeg version 6.1.1',
+        localEnabled: true,
+        remoteEnabled: true,
+        remoteUrl: 'https://db.example.com',
+        remoteAuth: 'google_id_token',
+        hasSaKey: true,
+        saKeySource: 'db',
+        defaultExecutor: 'local',
+        storagePresignable: true,
+        envManaged: { defaultExecutor: false, remoteUrl: false, remoteAuth: false, saKey: false },
+      });
+    });
+
+    it("saKeySource is 'env' when FFMPEG_REMOTE_SA_KEY_JSON is set, storagePresignable false on local-FS", async () => {
+      mockSelect([]);
+      const { service } = make({ env: { FFMPEG_REMOTE_SA_KEY_JSON: SA_KEY }, presign: false });
+      await service.reload();
+      const status = await service.getStatus();
+      expect(status.hasSaKey).toBe(true);
+      expect(status.saKeySource).toBe('env');
+      expect(status.storagePresignable).toBe(false);
+    });
+  });
+
+  describe('update()', () => {
+    function mockWrite() {
+      const set = jest.fn().mockImplementation((patch: Record<string, unknown>) => ({
+        where: jest.fn().mockImplementation(async () => {
+          table = [{ ...table[0], ...patch }];
+        }),
+      }));
+      db.update.mockReturnValue({ set });
+      const values = jest.fn().mockImplementation(async (vals: Record<string, unknown>) => {
+        table = [{ ...row(), ...vals }];
+      });
+      db.insert.mockReturnValue({ values });
+      return { set, values };
+    }
+
+    it('inserts when no row exists, encrypts the key, refreshes the cache and returns status', async () => {
+      mockSelect([]);
+      const { values } = mockWrite();
+      const { service } = make();
+      await service.reload();
+      // After the write, reload() re-reads: return the row the write produced.
+      const status = await service
+        .update(
+          {
+            remoteEnabled: true,
+            remoteUrl: 'https://w.example.com/',
+            remoteAuth: 'google_id_token',
+            defaultExecutor: 'remote',
+            saKeyJson: SA_KEY,
+          },
+          'user-1',
+        )
+        .catch((e) => {
+          throw e;
+        });
+      expect(values).toHaveBeenCalledTimes(1);
+      const inserted = values.mock.calls[0][0];
+      expect(inserted.remoteUrl).toBe('https://w.example.com');
+      expect(inserted.saKeyEncrypted).not.toContain('service_account');
+      expect(inserted.updatedByUserId).toBe('user-1');
+      expect(status.hasSaKey).toBe(true);
+      expect(status.defaultExecutor).toBe('remote');
+      expect(service.resolved().remoteSaKeyJson).toBe(SA_KEY);
+    });
+
+    it('updates the existing row; saKeyJson undefined keeps the stored key, null clears it', async () => {
+      const stored = encryptString(SA_KEY);
+      mockSelect([
+        row({ remoteEnabled: true, remoteUrl: 'https://w.example.com', saKeyEncrypted: stored }),
+      ]);
+      const { set } = mockWrite();
+      const { service } = make();
+      await service.reload();
+
+      await service.update({ remoteAuth: 'none' });
+      expect(set.mock.calls[0][0]).not.toHaveProperty('saKeyEncrypted');
+      expect(service.resolved().remoteSaKeyJson).toBe(SA_KEY);
+
+      await service.update({ saKeyJson: null });
+      expect(set.mock.calls[1][0].saKeyEncrypted).toBeNull();
+      expect(service.resolved().remoteSaKeyJson).toBeNull();
+    });
+
+    it('rejects: remote on without URL / bad URL / http with google_id_token / non-service-account key / default not enabled', async () => {
+      mockSelect([]);
+      mockWrite();
+      const { service } = make();
+      await service.reload();
+      await expect(service.update({ remoteEnabled: true, remoteUrl: null })).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      await expect(
+        service.update({ remoteEnabled: true, remoteUrl: 'not a url' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      await expect(
+        service.update({
+          remoteEnabled: true,
+          remoteUrl: 'http://w.example.com',
+          remoteAuth: 'google_id_token',
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      await expect(
+        service.update({ saKeyJson: '{"type":"authorized_user"}' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      await expect(service.update({ saKeyJson: '{not json' })).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      await expect(service.update({ defaultExecutor: 'remote' })).rejects.toBeInstanceOf(
+        BadRequestException,
+      ); // remote not enabled
+      await expect(service.update({ localEnabled: false })).rejects.toBeInstanceOf(
+        BadRequestException,
+      ); // default 'local' would not be enabled
+    });
+
+    it('http URL is fine with auth none; refuses Remote on non-presignable storage; refuses editing env-managed fields', async () => {
+      mockSelect([]);
+      mockWrite();
+      const ok = make();
+      await ok.service.reload();
+      await expect(
+        ok.service.update({
+          remoteEnabled: true,
+          remoteUrl: 'http://ffmpeg-worker:8080',
+          remoteAuth: 'none',
+        }),
+      ).resolves.toBeDefined();
+
+      const localFs = make({ presign: false });
+      await localFs.service.reload();
+      await expect(
+        localFs.service.update({ remoteEnabled: true, remoteUrl: 'https://w.example.com' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      const pinned = make({ env: { FFMPEG_REMOTE_URL: 'https://env.example.com' } });
+      await pinned.service.reload();
+      await expect(
+        pinned.service.update({ remoteUrl: 'https://other.example.com' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+});

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts
@@ -391,20 +391,28 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
     if (draft.saKeyJson !== undefined && !managed.saKey)
       overrides.remoteSaKeyJson = draft.saKeyJson === null ? null : draft.saKeyJson.trim();
 
+    const effective: FfmpegEnvConfig = { ...this.resolved(), ...overrides };
+    const credential: FfmpegExecutorTestResult['credential'] =
+      effective.remoteAuth === 'none' ? 'none' : effective.remoteSaKeyJson ? 'sa_key' : 'adc';
+
     // Parse a draft key HERE: deeper down it is JSON.parse'd inside the token
     // minter, and V8's SyntaxError quotes the offending input — which would put
-    // service-account bytes into the response. Same message `update()` uses.
+    // service-account bytes into the response. Reported through the button's one
+    // error channel, with `update()`'s wording.
     if (typeof overrides.remoteSaKeyJson === 'string' && overrides.remoteSaKeyJson !== '') {
       try {
         JSON.parse(overrides.remoteSaKeyJson);
       } catch {
-        throw new BadRequestException('Service-account key must be valid JSON.');
+        const reason = 'Service-account key must be valid JSON.';
+        return {
+          ok: false,
+          latencyMs: null,
+          error: reason,
+          readiness: { ok: false, reason },
+          credential,
+        };
       }
     }
-
-    const effective: FfmpegEnvConfig = { ...this.resolved(), ...overrides };
-    const credential: FfmpegExecutorTestResult['credential'] =
-      effective.remoteAuth === 'none' ? 'none' : effective.remoteSaKeyJson ? 'sa_key' : 'adc';
 
     let worker: FfmpegExecutorTestResult['worker'];
     let error: string | undefined;

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts
@@ -15,6 +15,7 @@ import { decryptString, encryptString } from '../../common/crypto/aes-gcm';
 import { resolveLocalAdapter } from '../../storage/local.adapter';
 import { IStorageAdapter, STORAGE_ADAPTER } from '../../storage/storage.interface';
 import { FfmpegCapabilityService } from './ffmpeg-capability.service';
+import { RemoteFfmpegExecutor } from './executor/remote/remote-ffmpeg.executor';
 import {
   readFfmpegEnv,
   type FfmpegEnvConfig,
@@ -53,6 +54,23 @@ export interface UpdateFfmpegExecutorInput {
   defaultExecutor?: FfmpegExecutorSetting;
   /** undefined = keep the stored key; null (or '', a blanked UI field) = clear it; string = replace it. */
   saKeyJson?: string | null;
+}
+
+/** The unsaved admin form a "Test connection" is run against. */
+export interface FfmpegExecutorTestDraft {
+  remoteUrl?: string | null;
+  remoteAuth?: FfmpegRemoteAuth;
+  saKeyJson?: string | null;
+}
+
+/** What the admin UI shows after a "Test connection". The SA key is never part of it. */
+export interface FfmpegExecutorTestResult {
+  ok: boolean;
+  latencyMs: number | null;
+  worker?: { version: string; ffmpeg: string | null; ops: string[]; uptimeS: number };
+  error?: string;
+  readiness: { ok: boolean; reason?: string };
+  credential: 'sa_key' | 'adc' | 'none';
 }
 
 /** The decrypted, in-memory shape of the DB row. */
@@ -104,6 +122,8 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
     private readonly capability: FfmpegCapabilityService,
     /** Test seam: the process env to read. */
     @Optional() private readonly processEnv: () => NodeJS.ProcessEnv = () => process.env,
+    /** @Optional() so a hand-built service (and Plan 1's specs) need not supply one. */
+    @Optional() private readonly remote?: RemoteFfmpegExecutor,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -350,6 +370,68 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
     await this.persist(next, input.saKeyJson !== undefined, userId);
     await this.reload();
     return this.getStatus();
+  }
+
+  /**
+   * Uncached "Test connection" for the admin UI. `draft` is the unsaved form; env-managed
+   * fields are ignored (env wins). Reports both the raw /healthz answer and what the
+   * selector's readiness check says about the same config, so the UI can show
+   * "reachable but not usable" (e.g. version too old, storage not presignable).
+   */
+  async testConnection(draft: FfmpegExecutorTestDraft = {}): Promise<FfmpegExecutorTestResult> {
+    if (!this.remote) throw new InternalServerErrorException('Remote executor is not wired.');
+    const managed = this.envManaged();
+    const overrides: Partial<
+      Pick<FfmpegEnvConfig, 'remoteUrl' | 'remoteAuth' | 'remoteSaKeyJson'>
+    > = {};
+    if (draft.remoteUrl !== undefined && !managed.remoteUrl)
+      overrides.remoteUrl = normaliseUrl(draft.remoteUrl);
+    if (draft.remoteAuth !== undefined && !managed.remoteAuth)
+      overrides.remoteAuth = draft.remoteAuth;
+    if (draft.saKeyJson !== undefined && !managed.saKey)
+      overrides.remoteSaKeyJson = draft.saKeyJson === null ? null : draft.saKeyJson.trim();
+
+    // Parse a draft key HERE: deeper down it is JSON.parse'd inside the token
+    // minter, and V8's SyntaxError quotes the offending input — which would put
+    // service-account bytes into the response. Same message `update()` uses.
+    if (typeof overrides.remoteSaKeyJson === 'string' && overrides.remoteSaKeyJson !== '') {
+      try {
+        JSON.parse(overrides.remoteSaKeyJson);
+      } catch {
+        throw new BadRequestException('Service-account key must be valid JSON.');
+      }
+    }
+
+    const effective: FfmpegEnvConfig = { ...this.resolved(), ...overrides };
+    const credential: FfmpegExecutorTestResult['credential'] =
+      effective.remoteAuth === 'none' ? 'none' : effective.remoteSaKeyJson ? 'sa_key' : 'adc';
+
+    let worker: FfmpegExecutorTestResult['worker'];
+    let error: string | undefined;
+    let latencyMs: number | null = null;
+    const t0 = Date.now();
+    try {
+      const health = await this.remote.testConnection(overrides);
+      latencyMs = Date.now() - t0;
+      worker = {
+        version: health.version,
+        ffmpeg: health.ffmpeg,
+        ops: health.ops,
+        uptimeS: health.uptimeS,
+      };
+      if (!health.ok) error = 'worker reports not ok (no ffmpeg binary?)';
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+    const readiness = await this.remote.ready({ fresh: true, env: effective });
+    return {
+      ok: !error && readiness.ok,
+      latencyMs,
+      ...(worker ? { worker } : {}),
+      ...(error ? { error } : {}),
+      readiness: { ok: readiness.ok, ...(readiness.reason ? { reason: readiness.reason } : {}) },
+      credential,
+    };
   }
 
   private async persist(next: CachedSettings, keyChanged: boolean, userId?: string): Promise<void> {

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts
@@ -6,11 +6,13 @@ import {
   Logger,
   OnModuleInit,
   Optional,
+  ServiceUnavailableException,
 } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
 import { db } from '../../db/client';
 import { ffmpegExecutorSettings, type FfmpegExecutorSettingsRow } from '../../db/schema';
 import { decryptString, encryptString } from '../../common/crypto/aes-gcm';
+import { resolveLocalAdapter } from '../../storage/local.adapter';
 import { IStorageAdapter, STORAGE_ADAPTER } from '../../storage/storage.interface';
 import { FfmpegCapabilityService } from './ffmpeg-capability.service';
 import {
@@ -49,7 +51,7 @@ export interface UpdateFfmpegExecutorInput {
   remoteUrl?: string | null;
   remoteAuth?: FfmpegRemoteAuth;
   defaultExecutor?: FfmpegExecutorSetting;
-  /** undefined = keep the stored key; null = clear it; string = replace it. */
+  /** undefined = keep the stored key; null (or '', a blanked UI field) = clear it; string = replace it. */
   saKeyJson?: string | null;
 }
 
@@ -88,6 +90,13 @@ function normaliseUrl(raw: string | null | undefined): string | null {
 export class FfmpegExecutorSettingsService implements OnModuleInit {
   private readonly logger = new Logger(FfmpegExecutorSettingsService.name);
   private cached: CachedSettings | null = null;
+  /**
+   * Why this exists: a failed load also leaves `cached === null`, which is
+   * indistinguishable from "no row yet". Merging a partial update onto the
+   * DEFAULTS in that state would silently overwrite a real row's URL/auth/
+   * default with defaults, so `update()` refuses while the state is 'error'.
+   */
+  private loadState: 'ok' | 'empty' | 'error' = 'empty';
   private warnedMissing = false;
 
   constructor(
@@ -117,9 +126,11 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
         });
       }
       this.cached = null;
+      this.loadState = 'error';
       return;
     }
     this.cached = row ? this.decode(row) : null;
+    this.loadState = row ? 'ok' : 'empty';
   }
 
   private decode(row: FfmpegExecutorSettingsRow): CachedSettings {
@@ -134,10 +145,12 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
         });
       }
     }
+    // Invariant: remoteEnabled ⇒ a URL. A row without one cannot run remote work.
+    const remoteUrl = normaliseUrl(row.remoteUrl);
     return {
       localEnabled: row.localEnabled,
-      remoteEnabled: row.remoteEnabled,
-      remoteUrl: normaliseUrl(row.remoteUrl),
+      remoteEnabled: row.remoteEnabled && remoteUrl !== null,
+      remoteUrl,
       remoteAuth: row.remoteAuth === 'none' ? 'none' : 'google_id_token',
       saKeyJson,
       defaultExecutor: row.defaultExecutor === 'remote' ? 'remote' : 'local',
@@ -156,8 +169,12 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
 
   /** The effective config: env over the cached DB row. Synchronous by design (executors call it per job). */
   resolved(): FfmpegEnvConfig {
+    return this.resolveWith(this.cached);
+  }
+
+  /** env over `row` — the cached row for `resolved()`, a candidate row when validating a save. */
+  private resolveWith(row: CachedSettings | null): FfmpegEnvConfig {
     const env = readFfmpegEnv(this.processEnv());
-    const row = this.cached;
     if (!row) return env;
     const managed = this.envManaged();
     const remoteUrl = managed.remoteUrl ? env.remoteUrl : row.remoteUrl;
@@ -172,10 +189,20 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
     };
   }
 
+  /**
+   * Can a Worker fetch inputs / PUT outputs straight from storage?
+   *
+   * `supportsPresignedUrls()` alone is NOT enough: the local-filesystem adapter
+   * also signs, but its URLs point at CE's own `/api/storage/presigned/local`
+   * route (relative, and served only on the app's own domains), which a remote
+   * Worker cannot use. So local is excluded explicitly — the same call
+   * `deployments.controller.ts` makes for the same reason.
+   */
   private storagePresignable(): boolean {
     return (
-      typeof this.storageAdapter.getPresignedUploadUrl === 'function' &&
-      this.storageAdapter.supportsPresignedUrls?.() === true
+      resolveLocalAdapter(this.storageAdapter) === null &&
+      this.storageAdapter.supportsPresignedUrls?.() === true &&
+      typeof this.storageAdapter.getPresignedUploadUrl === 'function'
     );
   }
 
@@ -202,6 +229,13 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
    * `saKeyJson`: undefined keeps the stored key, null clears it, a string replaces it.
    */
   async update(input: UpdateFfmpegExecutorInput, userId?: string): Promise<FfmpegExecutorStatus> {
+    if (this.loadState === 'error') {
+      await this.reload();
+      if (this.loadState === 'error') {
+        throw new ServiceUnavailableException('Executor settings could not be loaded; try again');
+      }
+    }
+
     const managed = this.envManaged();
     if (input.remoteUrl !== undefined && managed.remoteUrl) {
       throw new BadRequestException('Worker URL is managed by FFMPEG_REMOTE_URL on this instance.');
@@ -253,6 +287,10 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
     }
     if (typeof next.saKeyJson === 'string') {
       next.saKeyJson = next.saKeyJson.trim();
+    }
+    // A blanked-out UI field means "remove the key", not "here is invalid JSON".
+    if (next.saKeyJson === '') next.saKeyJson = null;
+    if (typeof next.saKeyJson === 'string') {
       let parsed: unknown;
       try {
         parsed = JSON.parse(next.saKeyJson);
@@ -272,7 +310,7 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
 
     // Validate the EFFECTIVE config (env pins applied) so a save can never leave the
     // instance in a state the selector would refuse.
-    const effective = this.effectiveOf(next);
+    const effective = this.resolveWith(next);
     if (effective.remoteEnabled) {
       if (!effective.remoteUrl)
         throw new BadRequestException('Remote executor needs a Worker URL.');
@@ -287,7 +325,12 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
           'Worker URL must be https:// when auth is Google ID token (use auth "none" only on a private network).',
         );
       }
-      if (!this.storagePresignable()) {
+      // Only when THIS save turns Remote on: an env-pinned FFMPEG_REMOTE_URL on
+      // local-FS storage must not make every unrelated save (e.g. toggling
+      // localEnabled) fail. `storagePresignable` is reported in status either way.
+      const turningRemoteOn =
+        input.remoteEnabled === true || (next.remoteEnabled && !current.remoteEnabled);
+      if (turningRemoteOn && !this.storagePresignable()) {
         throw new BadRequestException(
           'Remote executor needs bucket storage (S3, GCS, MinIO or Azure) — the Worker fetches inputs and uploads outputs via signed URLs, which local filesystem storage cannot provide.',
         );
@@ -309,17 +352,6 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
     return this.getStatus();
   }
 
-  /** `resolved()` for a candidate row instead of the cached one. */
-  private effectiveOf(row: CachedSettings): FfmpegEnvConfig {
-    const saved = this.cached;
-    this.cached = row;
-    try {
-      return this.resolved();
-    } finally {
-      this.cached = saved;
-    }
-  }
-
   private async persist(next: CachedSettings, keyChanged: boolean, userId?: string): Promise<void> {
     const base = {
       localEnabled: next.localEnabled,
@@ -330,21 +362,24 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
       updatedAt: new Date(),
       updatedByUserId: userId ?? null,
     };
-    const keyPatch = keyChanged
-      ? { saKeyEncrypted: next.saKeyJson === null ? null : encryptString(next.saKeyJson) }
-      : {};
+    // undefined = the key was not part of this save, so the stored one is preserved.
+    const encrypted = keyChanged
+      ? next.saKeyJson === null
+        ? null
+        : encryptString(next.saKeyJson)
+      : undefined;
     try {
       const existing = (await db.select().from(ffmpegExecutorSettings).limit(1))[0];
       if (existing) {
         await db
           .update(ffmpegExecutorSettings)
-          .set({ ...base, ...keyPatch })
+          .set({ ...base, ...(encrypted !== undefined ? { saKeyEncrypted: encrypted } : {}) })
           .where(eq(ffmpegExecutorSettings.id, existing.id));
       } else {
-        await db.insert(ffmpegExecutorSettings).values({
-          ...base,
-          saKeyEncrypted: next.saKeyJson === null ? null : encryptString(next.saKeyJson),
-        });
+        // Insert: there is no stored key to preserve, so "not provided" = none.
+        await db
+          .insert(ffmpegExecutorSettings)
+          .values({ ...base, saKeyEncrypted: encrypted ?? null });
       }
     } catch (error) {
       this.logger.error({

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts
@@ -382,7 +382,7 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
 
   /**
    * Uncached "Test connection" for the admin UI. `draft` is the unsaved form; env-managed
-   * fields are ignored (env wins). Reports both the raw /healthz answer and what the
+   * fields are ignored (env wins). Reports both the raw /health answer and what the
    * selector's readiness check says about the same config, so the UI can show
    * "reachable but not usable" (e.g. version too old, storage not presignable).
    */

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts
@@ -135,7 +135,15 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
   async reload(): Promise<void> {
     let row: FfmpegExecutorSettingsRow | undefined;
     try {
-      const rows = await db.select().from(ffmpegExecutorSettings).limit(1);
+      // .orderBy(createdAt): with exactly one row this is a no-op, but it makes
+      // "the first row" deterministic instead of whatever order Postgres happens
+      // to return — matters if a stray second row ever exists (e.g. a race on
+      // first insert) so reload() and persist() always agree on the same row.
+      const rows = await db
+        .select()
+        .from(ffmpegExecutorSettings)
+        .orderBy(ffmpegExecutorSettings.createdAt)
+        .limit(1);
       row = rows[0];
     } catch (error) {
       if (!this.warnedMissing) {
@@ -395,13 +403,16 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
     const credential: FfmpegExecutorTestResult['credential'] =
       effective.remoteAuth === 'none' ? 'none' : effective.remoteSaKeyJson ? 'sa_key' : 'adc';
 
-    // Parse a draft key HERE: deeper down it is JSON.parse'd inside the token
-    // minter, and V8's SyntaxError quotes the offending input — which would put
-    // service-account bytes into the response. Reported through the button's one
-    // error channel, with `update()`'s wording.
-    if (typeof overrides.remoteSaKeyJson === 'string' && overrides.remoteSaKeyJson !== '') {
+    // Validate the EFFECTIVE key — a pasted draft key OR an env-pinned
+    // FFMPEG_REMOTE_SA_KEY_JSON, whichever `effective` ends up with — not just
+    // the draft's. Deeper down the key is JSON.parse'd inside the token minter,
+    // and V8's SyntaxError quotes the offending input, which would put
+    // service-account bytes (draft- or env-sourced) into the response. Caught
+    // here instead, through the button's one error channel, with `update()`'s
+    // wording, before the executor is ever called.
+    if (effective.remoteAuth === 'google_id_token' && effective.remoteSaKeyJson) {
       try {
-        JSON.parse(overrides.remoteSaKeyJson);
+        JSON.parse(effective.remoteSaKeyJson);
       } catch {
         const reason = 'Service-account key must be valid JSON.';
         return {
@@ -452,14 +463,24 @@ export class FfmpegExecutorSettingsService implements OnModuleInit {
       updatedAt: new Date(),
       updatedByUserId: userId ?? null,
     };
-    // undefined = the key was not part of this save, so the stored one is preserved.
-    const encrypted = keyChanged
-      ? next.saKeyJson === null
-        ? null
-        : encryptString(next.saKeyJson)
-      : undefined;
     try {
-      const existing = (await db.select().from(ffmpegExecutorSettings).limit(1))[0];
+      // undefined = the key was not part of this save, so the stored one is
+      // preserved. Computed INSIDE the try: encryptString() throws on a bad/
+      // missing ENCRYPTION_KEY, and that failure must surface through the same
+      // shaped InternalServerErrorException as every other persist failure,
+      // not as a raw crypto error.
+      const encrypted = keyChanged
+        ? next.saKeyJson === null
+          ? null
+          : encryptString(next.saKeyJson)
+        : undefined;
+      const existing = (
+        await db
+          .select()
+          .from(ffmpegExecutorSettings)
+          .orderBy(ffmpegExecutorSettings.createdAt)
+          .limit(1)
+      )[0];
       if (existing) {
         await db
           .update(ffmpegExecutorSettings)

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts
@@ -1,0 +1,357 @@
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  OnModuleInit,
+  Optional,
+} from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import { db } from '../../db/client';
+import { ffmpegExecutorSettings, type FfmpegExecutorSettingsRow } from '../../db/schema';
+import { decryptString, encryptString } from '../../common/crypto/aes-gcm';
+import { IStorageAdapter, STORAGE_ADAPTER } from '../../storage/storage.interface';
+import { FfmpegCapabilityService } from './ffmpeg-capability.service';
+import {
+  readFfmpegEnv,
+  type FfmpegEnvConfig,
+  type FfmpegExecutorSetting,
+  type FfmpegRemoteAuth,
+} from './ffmpeg-env';
+
+export interface FfmpegExecutorEnvManaged {
+  defaultExecutor: boolean;
+  remoteUrl: boolean;
+  remoteAuth: boolean;
+  saKey: boolean;
+}
+
+/** What the admin UI renders. The service-account key itself is NEVER part of this. */
+export interface FfmpegExecutorStatus {
+  localAvailable: boolean;
+  localVersion: string | null;
+  localEnabled: boolean;
+  remoteEnabled: boolean;
+  remoteUrl: string | null;
+  remoteAuth: FfmpegRemoteAuth;
+  hasSaKey: boolean;
+  saKeySource: 'db' | 'env' | null;
+  defaultExecutor: FfmpegExecutorSetting;
+  /** false on the local-FS adapter: a Worker cannot fetch CE-relative URLs (D3), so Remote cannot be enabled. */
+  storagePresignable: boolean;
+  envManaged: FfmpegExecutorEnvManaged;
+}
+
+export interface UpdateFfmpegExecutorInput {
+  localEnabled?: boolean;
+  remoteEnabled?: boolean;
+  remoteUrl?: string | null;
+  remoteAuth?: FfmpegRemoteAuth;
+  defaultExecutor?: FfmpegExecutorSetting;
+  /** undefined = keep the stored key; null = clear it; string = replace it. */
+  saKeyJson?: string | null;
+}
+
+/** The decrypted, in-memory shape of the DB row. */
+interface CachedSettings {
+  localEnabled: boolean;
+  remoteEnabled: boolean;
+  remoteUrl: string | null;
+  remoteAuth: FfmpegRemoteAuth;
+  saKeyJson: string | null;
+  defaultExecutor: FfmpegExecutorSetting;
+}
+
+/** '' counts as unset — compose passthrough materialises unconfigured vars as ''. */
+function envSet(env: NodeJS.ProcessEnv, key: string): boolean {
+  return (env[key] ?? '').trim() !== '';
+}
+
+/** Same normalisation `ffmpeg-env.ts` applies to FFMPEG_REMOTE_URL. */
+function normaliseUrl(raw: string | null | undefined): string | null {
+  if (raw === undefined || raw === null) return null;
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  return trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
+}
+
+/**
+ * Admin-editable executor configuration (spec §1.5). One DB row, decrypted into
+ * memory at boot and after every save so the executors can read it SYNCHRONOUSLY
+ * through `resolved()` — the same `FfmpegEnvConfig` shape `readFfmpegEnv()` returns,
+ * with env winning over the DB per field (FFMPEG_EXECUTOR, FFMPEG_REMOTE_URL,
+ * FFMPEG_REMOTE_AUTH, FFMPEG_REMOTE_SA_KEY_JSON). CE runs one backend process per
+ * instance, so an in-process cache refreshed on write is sufficient.
+ */
+@Injectable()
+export class FfmpegExecutorSettingsService implements OnModuleInit {
+  private readonly logger = new Logger(FfmpegExecutorSettingsService.name);
+  private cached: CachedSettings | null = null;
+  private warnedMissing = false;
+
+  constructor(
+    @Inject(STORAGE_ADAPTER) private readonly storageAdapter: IStorageAdapter,
+    private readonly capability: FfmpegCapabilityService,
+    /** Test seam: the process env to read. */
+    @Optional() private readonly processEnv: () => NodeJS.ProcessEnv = () => process.env,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    if (process.env.NODE_ENV === 'test') return;
+    await this.reload();
+  }
+
+  /** DB → cache. A missing table (instance not yet migrated) or a DB error leaves the cache empty = env-only. */
+  async reload(): Promise<void> {
+    let row: FfmpegExecutorSettingsRow | undefined;
+    try {
+      const rows = await db.select().from(ffmpegExecutorSettings).limit(1);
+      row = rows[0];
+    } catch (error) {
+      if (!this.warnedMissing) {
+        this.warnedMissing = true;
+        this.logger.warn({
+          event: 'ffmpeg_executor_settings_unavailable',
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      this.cached = null;
+      return;
+    }
+    this.cached = row ? this.decode(row) : null;
+  }
+
+  private decode(row: FfmpegExecutorSettingsRow): CachedSettings {
+    let saKeyJson: string | null = null;
+    if (row.saKeyEncrypted) {
+      try {
+        saKeyJson = decryptString(row.saKeyEncrypted);
+      } catch (error) {
+        this.logger.error({
+          event: 'ffmpeg_executor_sa_key_undecryptable',
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    return {
+      localEnabled: row.localEnabled,
+      remoteEnabled: row.remoteEnabled,
+      remoteUrl: normaliseUrl(row.remoteUrl),
+      remoteAuth: row.remoteAuth === 'none' ? 'none' : 'google_id_token',
+      saKeyJson,
+      defaultExecutor: row.defaultExecutor === 'remote' ? 'remote' : 'local',
+    };
+  }
+
+  envManaged(): FfmpegExecutorEnvManaged {
+    const env = this.processEnv();
+    return {
+      defaultExecutor: envSet(env, 'FFMPEG_EXECUTOR'),
+      remoteUrl: envSet(env, 'FFMPEG_REMOTE_URL'),
+      remoteAuth: envSet(env, 'FFMPEG_REMOTE_AUTH'),
+      saKey: envSet(env, 'FFMPEG_REMOTE_SA_KEY_JSON'),
+    };
+  }
+
+  /** The effective config: env over the cached DB row. Synchronous by design (executors call it per job). */
+  resolved(): FfmpegEnvConfig {
+    const env = readFfmpegEnv(this.processEnv());
+    const row = this.cached;
+    if (!row) return env;
+    const managed = this.envManaged();
+    const remoteUrl = managed.remoteUrl ? env.remoteUrl : row.remoteUrl;
+    return {
+      ...env,
+      localEnabled: row.localEnabled,
+      remoteEnabled: managed.remoteUrl ? true : row.remoteEnabled,
+      remoteUrl,
+      remoteAuth: managed.remoteAuth ? env.remoteAuth : row.remoteAuth,
+      remoteSaKeyJson: managed.saKey ? env.remoteSaKeyJson : row.saKeyJson,
+      executor: managed.defaultExecutor ? env.executor : row.defaultExecutor,
+    };
+  }
+
+  private storagePresignable(): boolean {
+    return (
+      typeof this.storageAdapter.getPresignedUploadUrl === 'function' &&
+      this.storageAdapter.supportsPresignedUrls?.() === true
+    );
+  }
+
+  async getStatus(): Promise<FfmpegExecutorStatus> {
+    const cfg = this.resolved();
+    const managed = this.envManaged();
+    return {
+      localAvailable: this.capability.isAvailable(),
+      localVersion: this.capability.getVersion(),
+      localEnabled: cfg.localEnabled,
+      remoteEnabled: cfg.remoteEnabled,
+      remoteUrl: cfg.remoteUrl,
+      remoteAuth: cfg.remoteAuth,
+      hasSaKey: cfg.remoteSaKeyJson !== null,
+      saKeySource: cfg.remoteSaKeyJson === null ? null : managed.saKey ? 'env' : 'db',
+      defaultExecutor: cfg.executor,
+      storagePresignable: this.storagePresignable(),
+      envManaged: managed,
+    };
+  }
+
+  /**
+   * Validate → upsert → reload → status. Partial: only the provided fields change.
+   * `saKeyJson`: undefined keeps the stored key, null clears it, a string replaces it.
+   */
+  async update(input: UpdateFfmpegExecutorInput, userId?: string): Promise<FfmpegExecutorStatus> {
+    const managed = this.envManaged();
+    if (input.remoteUrl !== undefined && managed.remoteUrl) {
+      throw new BadRequestException('Worker URL is managed by FFMPEG_REMOTE_URL on this instance.');
+    }
+    if (input.remoteAuth !== undefined && managed.remoteAuth) {
+      throw new BadRequestException('Auth mode is managed by FFMPEG_REMOTE_AUTH on this instance.');
+    }
+    if (input.saKeyJson !== undefined && managed.saKey) {
+      throw new BadRequestException(
+        'The service-account key is managed by FFMPEG_REMOTE_SA_KEY_JSON on this instance.',
+      );
+    }
+    if (input.defaultExecutor !== undefined && managed.defaultExecutor) {
+      throw new BadRequestException(
+        'The default executor is managed by FFMPEG_EXECUTOR on this instance.',
+      );
+    }
+
+    const current: CachedSettings = this.cached ?? {
+      localEnabled: true,
+      remoteEnabled: false,
+      remoteUrl: null,
+      remoteAuth: 'google_id_token',
+      saKeyJson: null,
+      defaultExecutor: 'local',
+    };
+    const next: CachedSettings = {
+      localEnabled: input.localEnabled ?? current.localEnabled,
+      remoteEnabled: input.remoteEnabled ?? current.remoteEnabled,
+      remoteUrl: input.remoteUrl === undefined ? current.remoteUrl : normaliseUrl(input.remoteUrl),
+      remoteAuth: input.remoteAuth ?? current.remoteAuth,
+      saKeyJson: input.saKeyJson === undefined ? current.saKeyJson : input.saKeyJson,
+      defaultExecutor: input.defaultExecutor ?? current.defaultExecutor,
+    };
+
+    if (
+      input.remoteAuth !== undefined &&
+      input.remoteAuth !== 'google_id_token' &&
+      input.remoteAuth !== 'none'
+    ) {
+      throw new BadRequestException("Auth mode must be 'google_id_token' or 'none'.");
+    }
+    if (
+      input.defaultExecutor !== undefined &&
+      input.defaultExecutor !== 'local' &&
+      input.defaultExecutor !== 'remote'
+    ) {
+      throw new BadRequestException("Default executor must be 'local' or 'remote'.");
+    }
+    if (typeof next.saKeyJson === 'string') {
+      next.saKeyJson = next.saKeyJson.trim();
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(next.saKeyJson);
+      } catch {
+        throw new BadRequestException('Service-account key must be valid JSON.');
+      }
+      if (
+        !parsed ||
+        typeof parsed !== 'object' ||
+        (parsed as { type?: unknown }).type !== 'service_account'
+      ) {
+        throw new BadRequestException(
+          'Service-account key must be a Google service-account JSON key ("type": "service_account").',
+        );
+      }
+    }
+
+    // Validate the EFFECTIVE config (env pins applied) so a save can never leave the
+    // instance in a state the selector would refuse.
+    const effective = this.effectiveOf(next);
+    if (effective.remoteEnabled) {
+      if (!effective.remoteUrl)
+        throw new BadRequestException('Remote executor needs a Worker URL.');
+      let url: URL;
+      try {
+        url = new URL(effective.remoteUrl);
+      } catch {
+        throw new BadRequestException(`Worker URL is not a valid URL: ${effective.remoteUrl}`);
+      }
+      if (effective.remoteAuth !== 'none' && url.protocol !== 'https:') {
+        throw new BadRequestException(
+          'Worker URL must be https:// when auth is Google ID token (use auth "none" only on a private network).',
+        );
+      }
+      if (!this.storagePresignable()) {
+        throw new BadRequestException(
+          'Remote executor needs bucket storage (S3, GCS, MinIO or Azure) — the Worker fetches inputs and uploads outputs via signed URLs, which local filesystem storage cannot provide.',
+        );
+      }
+    }
+    const enabled: FfmpegExecutorSetting[] = [];
+    if (this.capability.isAvailable() && effective.localEnabled) enabled.push('local');
+    if (effective.remoteEnabled && effective.remoteUrl) enabled.push('remote');
+    if (!enabled.includes(effective.executor)) {
+      throw new BadRequestException(
+        enabled.length === 0
+          ? 'At least one executor must be enabled (Local needs ffmpeg installed on this server; Remote needs a Worker URL).'
+          : `Default executor '${effective.executor}' is not enabled — pick one of: ${enabled.join(', ')}.`,
+      );
+    }
+
+    await this.persist(next, input.saKeyJson !== undefined, userId);
+    await this.reload();
+    return this.getStatus();
+  }
+
+  /** `resolved()` for a candidate row instead of the cached one. */
+  private effectiveOf(row: CachedSettings): FfmpegEnvConfig {
+    const saved = this.cached;
+    this.cached = row;
+    try {
+      return this.resolved();
+    } finally {
+      this.cached = saved;
+    }
+  }
+
+  private async persist(next: CachedSettings, keyChanged: boolean, userId?: string): Promise<void> {
+    const base = {
+      localEnabled: next.localEnabled,
+      remoteEnabled: next.remoteEnabled,
+      remoteUrl: next.remoteUrl,
+      remoteAuth: next.remoteAuth,
+      defaultExecutor: next.defaultExecutor,
+      updatedAt: new Date(),
+      updatedByUserId: userId ?? null,
+    };
+    const keyPatch = keyChanged
+      ? { saKeyEncrypted: next.saKeyJson === null ? null : encryptString(next.saKeyJson) }
+      : {};
+    try {
+      const existing = (await db.select().from(ffmpegExecutorSettings).limit(1))[0];
+      if (existing) {
+        await db
+          .update(ffmpegExecutorSettings)
+          .set({ ...base, ...keyPatch })
+          .where(eq(ffmpegExecutorSettings.id, existing.id));
+      } else {
+        await db.insert(ffmpegExecutorSettings).values({
+          ...base,
+          saKeyEncrypted: next.saKeyJson === null ? null : encryptString(next.saKeyJson),
+        });
+      }
+    } catch (error) {
+      this.logger.error({
+        event: 'ffmpeg_executor_settings_persist_failed',
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new InternalServerErrorException('Failed to save executor settings.');
+    }
+  }
+}

--- a/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-wiring.spec.ts
+++ b/apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-wiring.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * The module graph itself: the settings service holds an @Optional() remote
+ * executor while the executor's config comes from a provider that needs the
+ * settings service. Wired eagerly (`inject: [FfmpegExecutorSettingsService]`)
+ * that is a cycle Nest never finishes compiling — this spec is the fence.
+ */
+jest.mock('../../db/client', () => ({
+  db: { select: jest.fn(), insert: jest.fn(), update: jest.fn() },
+}));
+
+import { Test } from '@nestjs/testing';
+import { STORAGE_ADAPTER } from '../../storage/storage.interface';
+import { FfmpegCapabilityService } from './ffmpeg-capability.service';
+import { FfmpegExecutorSettingsService } from './ffmpeg-executor-settings.service';
+import { FFMPEG_CONFIG_PROVIDERS } from './executor/ffmpeg-config.providers';
+import { FFMPEG_CONFIG, type FfmpegConfigResolver } from './executor/ffmpeg-config.tokens';
+import { FfmpegExecutorSelector } from './executor/ffmpeg-executor.selector';
+import { LocalFfmpegExecutor } from './executor/local-ffmpeg.executor';
+import { RemoteFfmpegExecutor } from './executor/remote/remote-ffmpeg.executor';
+
+const storage = {
+  getUrl: async () => 'https://bucket.example.com/x?sig=1',
+  supportsPresignedUrls: () => true,
+  getPresignedUploadUrl: async () => 'https://bucket.example.com/x?put=1',
+};
+const capability = {
+  isAvailable: () => true,
+  getVersion: () => 'ffmpeg version 6.1.1',
+  isEnabled: async () => true,
+  isFlagOn: async () => true,
+  getOps: async () => [],
+};
+
+it('compiles the ffmpeg provider graph and resolves the effective config lazily', async () => {
+  const moduleRef = await Test.createTestingModule({
+    providers: [
+      { provide: STORAGE_ADAPTER, useValue: storage },
+      { provide: FfmpegCapabilityService, useValue: capability },
+      { provide: LocalFfmpegExecutor, useValue: { name: 'local' } },
+      RemoteFfmpegExecutor,
+      FfmpegExecutorSelector,
+      FfmpegExecutorSettingsService,
+      ...FFMPEG_CONFIG_PROVIDERS,
+    ],
+  }).compile();
+
+  const settings = moduleRef.get(FfmpegExecutorSettingsService);
+  const remote = moduleRef.get(RemoteFfmpegExecutor);
+  // The @Optional() back-edge is real, not silently dropped.
+  expect((settings as unknown as { remote?: unknown }).remote).toBe(remote);
+  // Both executors read the SAME resolved config the settings service serves.
+  expect(moduleRef.get<FfmpegConfigResolver>(FFMPEG_CONFIG)()).toEqual(settings.resolved());
+  expect((remote as unknown as { env: FfmpegConfigResolver }).env()).toEqual(settings.resolved());
+  expect(moduleRef.get(FfmpegExecutorSelector).enabled()).toEqual(['local']);
+}, 10_000);

--- a/apps/backend/src/pipelines/pipelines.module.ts
+++ b/apps/backend/src/pipelines/pipelines.module.ts
@@ -61,6 +61,7 @@ import { LocalFfmpegExecutor } from './ffmpeg/executor/local-ffmpeg.executor';
 import { RemoteFfmpegExecutor } from './ffmpeg/executor/remote/remote-ffmpeg.executor';
 import { FfmpegExecutorSelector } from './ffmpeg/executor/ffmpeg-executor.selector';
 import { FfmpegExecutorSettingsService } from './ffmpeg/ffmpeg-executor-settings.service';
+import { FfmpegExecutorSettingsController } from './ffmpeg/ffmpeg-executor-settings.controller';
 import { FFMPEG_CONFIG_PROVIDERS } from './ffmpeg/executor/ffmpeg-config.providers';
 import { FeedParserService } from './feed-parser.service';
 import { IntegrationsModule } from '../integrations/integrations.module';
@@ -109,6 +110,7 @@ import {
     PipelineSchemasController,
     PipelineDataController,
     AIPluginsController,
+    FfmpegExecutorSettingsController,
   ],
   providers: [
     // Core services

--- a/apps/backend/src/pipelines/pipelines.module.ts
+++ b/apps/backend/src/pipelines/pipelines.module.ts
@@ -60,6 +60,8 @@ import { FfmpegScratchService } from './ffmpeg/ffmpeg-scratch.service';
 import { LocalFfmpegExecutor } from './ffmpeg/executor/local-ffmpeg.executor';
 import { RemoteFfmpegExecutor } from './ffmpeg/executor/remote/remote-ffmpeg.executor';
 import { FfmpegExecutorSelector } from './ffmpeg/executor/ffmpeg-executor.selector';
+import { FfmpegExecutorSettingsService } from './ffmpeg/ffmpeg-executor-settings.service';
+import { FFMPEG_CONFIG, FFMPEG_REMOTE_DEPS } from './ffmpeg/executor/ffmpeg-config.tokens';
 import { FeedParserService } from './feed-parser.service';
 import { IntegrationsModule } from '../integrations/integrations.module';
 // Embeddings service
@@ -175,6 +177,21 @@ import {
     LocalFfmpegExecutor,
     RemoteFfmpegExecutor,
     FfmpegExecutorSelector,
+    // Admin-editable executor config; the two tokens below hand the EFFECTIVE
+    // config (env over the saved row) to the selector and the remote executor.
+    FfmpegExecutorSettingsService,
+    {
+      provide: FFMPEG_CONFIG,
+      useFactory: (settings: FfmpegExecutorSettingsService) => () => settings.resolved(),
+      inject: [FfmpegExecutorSettingsService],
+    },
+    {
+      provide: FFMPEG_REMOTE_DEPS,
+      useFactory: (settings: FfmpegExecutorSettingsService) => ({
+        env: () => settings.resolved(),
+      }),
+      inject: [FfmpegExecutorSettingsService],
+    },
     // Validators (auto-register on construction)
     AuthRequiredValidator,
     RateLimitValidator,
@@ -200,6 +217,7 @@ import {
     UploadSchemaGeneratorService,
     UploadSchemaLintService,
     PipelineExecutionLogService,
+    FfmpegExecutorSettingsService,
   ],
 })
 export class PipelinesModule {}

--- a/apps/backend/src/pipelines/pipelines.module.ts
+++ b/apps/backend/src/pipelines/pipelines.module.ts
@@ -61,7 +61,7 @@ import { LocalFfmpegExecutor } from './ffmpeg/executor/local-ffmpeg.executor';
 import { RemoteFfmpegExecutor } from './ffmpeg/executor/remote/remote-ffmpeg.executor';
 import { FfmpegExecutorSelector } from './ffmpeg/executor/ffmpeg-executor.selector';
 import { FfmpegExecutorSettingsService } from './ffmpeg/ffmpeg-executor-settings.service';
-import { FFMPEG_CONFIG, FFMPEG_REMOTE_DEPS } from './ffmpeg/executor/ffmpeg-config.tokens';
+import { FFMPEG_CONFIG_PROVIDERS } from './ffmpeg/executor/ffmpeg-config.providers';
 import { FeedParserService } from './feed-parser.service';
 import { IntegrationsModule } from '../integrations/integrations.module';
 // Embeddings service
@@ -177,21 +177,10 @@ import {
     LocalFfmpegExecutor,
     RemoteFfmpegExecutor,
     FfmpegExecutorSelector,
-    // Admin-editable executor config; the two tokens below hand the EFFECTIVE
+    // Admin-editable executor config; FFMPEG_CONFIG_PROVIDERS hands the EFFECTIVE
     // config (env over the saved row) to the selector and the remote executor.
     FfmpegExecutorSettingsService,
-    {
-      provide: FFMPEG_CONFIG,
-      useFactory: (settings: FfmpegExecutorSettingsService) => () => settings.resolved(),
-      inject: [FfmpegExecutorSettingsService],
-    },
-    {
-      provide: FFMPEG_REMOTE_DEPS,
-      useFactory: (settings: FfmpegExecutorSettingsService) => ({
-        env: () => settings.resolved(),
-      }),
-      inject: [FfmpegExecutorSettingsService],
-    },
+    ...FFMPEG_CONFIG_PROVIDERS,
     // Validators (auto-register on construction)
     AuthRequiredValidator,
     RateLimitValidator,

--- a/apps/frontend/src/components/settings/FeatureToggles.tsx
+++ b/apps/frontend/src/components/settings/FeatureToggles.tsx
@@ -2,6 +2,7 @@
 // Each entry is a DB-backed feature flag (Database > env > default) rendered as a
 // toggle row. Deliberately a registry, not an enumeration of all flags — flags
 // appear here only when an operator-facing toggle is intentional.
+import type { ComponentType } from 'react';
 import {
   useGetFeatureFlagQuery,
   useSetFeatureFlagMutation,
@@ -13,6 +14,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Clapperboard, ToggleRight, type LucideIcon } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { FfmpegExecutorSettings } from './FfmpegExecutorSettings';
 
 type FeatureToggle = {
   flagKey: string;
@@ -21,6 +23,8 @@ type FeatureToggle = {
   description: string; // row description under the label
   enabledToast: { title: string; description: string };
   disabledToast: { title: string; description: string };
+  /** Optional configuration panel rendered under the toggle row. */
+  Panel?: ComponentType;
 };
 
 const FEATURE_TOGGLES: FeatureToggle[] = [
@@ -41,6 +45,7 @@ const FEATURE_TOGGLES: FeatureToggle[] = [
       title: 'Server video ops disabled',
       description: 'Apps fall back to in-browser processing.',
     },
+    Panel: FfmpegExecutorSettings,
   },
 ];
 
@@ -110,7 +115,10 @@ export function FeatureToggles() {
       </CardHeader>
       <CardContent className="space-y-4">
         {FEATURE_TOGGLES.map((toggle) => (
-          <FeatureToggleRow key={toggle.flagKey} toggle={toggle} />
+          <div key={toggle.flagKey} className="space-y-3">
+            <FeatureToggleRow toggle={toggle} />
+            {toggle.Panel && <toggle.Panel />}
+          </div>
         ))}
       </CardContent>
     </Card>

--- a/apps/frontend/src/components/settings/FfmpegExecutorSettings.test.tsx
+++ b/apps/frontend/src/components/settings/FfmpegExecutorSettings.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { FfmpegExecutorSettings } from './FfmpegExecutorSettings';
+
+const update = vi.fn(() => ({ unwrap: () => Promise.resolve({}) }));
+const testConnection = vi.fn(() => ({
+  unwrap: () =>
+    Promise.resolve({
+      ok: true,
+      latencyMs: 42,
+      worker: { version: '0.4.31', ffmpeg: 'ffmpeg version 6.1.1', ops: ['probe', 'slice'], uptimeS: 3 },
+      readiness: { ok: true },
+      credential: 'adc',
+    }),
+}));
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let status: any;
+
+vi.mock('@/services/settingsApi', () => ({
+  useGetFfmpegExecutorSettingsQuery: () => ({ data: status, isLoading: false, error: undefined }),
+  useUpdateFfmpegExecutorSettingsMutation: () => [update, { isLoading: false }],
+  useTestFfmpegExecutorConnectionMutation: () => [testConnection, { isLoading: false }],
+}));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+beforeEach(() => {
+  update.mockClear();
+  testConnection.mockClear();
+  status = {
+    localAvailable: true,
+    localVersion: 'ffmpeg version 6.1.1',
+    localEnabled: true,
+    remoteEnabled: false,
+    remoteUrl: null,
+    remoteAuth: 'google_id_token',
+    hasSaKey: false,
+    saKeySource: null,
+    defaultExecutor: 'local',
+    storagePresignable: true,
+    envManaged: { defaultExecutor: false, remoteUrl: false, remoteAuth: false, saKey: false },
+  };
+});
+
+describe('FfmpegExecutorSettings', () => {
+  it('shows the local version and disables the remote radio until Remote has a URL', () => {
+    render(<FfmpegExecutorSettings />);
+    expect(screen.getByText(/ffmpeg version 6\.1\.1/)).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /remote/i })).toBeDisabled();
+  });
+
+  it('shows the red banner for auth none', () => {
+    status.remoteEnabled = true;
+    status.remoteUrl = 'http://ffmpeg-worker:8080';
+    status.remoteAuth = 'none';
+    render(<FfmpegExecutorSettings />);
+    expect(screen.getByText(/No authentication/)).toBeInTheDocument();
+  });
+
+  it('env-managed URL is read-only with a badge', () => {
+    status.remoteEnabled = true;
+    status.remoteUrl = 'https://env.example.com';
+    status.envManaged.remoteUrl = true;
+    render(<FfmpegExecutorSettings />);
+    expect(screen.getByLabelText(/Worker URL/)).toBeDisabled();
+    expect(screen.getByText(/Managed by FFMPEG_REMOTE_URL/)).toBeInTheDocument();
+  });
+
+  it('Test connection sends the draft and renders version, ops, latency and the ADC note', async () => {
+    status.remoteEnabled = true;
+    render(<FfmpegExecutorSettings />);
+    fireEvent.change(screen.getByLabelText(/Worker URL/), {
+      target: { value: 'https://draft.example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Test connection/ }));
+    await waitFor(() =>
+      expect(testConnection).toHaveBeenCalledWith(
+        expect.objectContaining({ remoteUrl: 'https://draft.example.com' }),
+      ),
+    );
+    expect(await screen.findByText(/0\.4\.31/)).toBeInTheDocument();
+    expect(screen.getByText(/42 ms/)).toBeInTheDocument();
+    // "Application Default Credentials" also appears in the empty-key helper text,
+    // so assert on the credential note's own wording.
+    expect(screen.getByText(/Using Application Default Credentials/)).toBeInTheDocument();
+  });
+
+  it('Save sends only changed fields; a pasted key is sent as saKeyJson; stored key offers Replace/Remove', async () => {
+    render(<FfmpegExecutorSettings />);
+    fireEvent.click(screen.getByRole('switch', { name: /Remote/ }));
+    fireEvent.change(screen.getByLabelText(/Worker URL/), { target: { value: 'https://w.example.com' } });
+    fireEvent.change(screen.getByLabelText(/Service-account key/), {
+      target: { value: '{"type":"service_account"}' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Save/ }));
+    await waitFor(() =>
+      expect(update).toHaveBeenCalledWith({
+        remoteEnabled: true,
+        remoteUrl: 'https://w.example.com',
+        saKeyJson: '{"type":"service_account"}',
+      }),
+    );
+
+    status.hasSaKey = true;
+    status.saKeySource = 'db';
+    status.remoteEnabled = true;
+    status.remoteUrl = 'https://w.example.com';
+    render(<FfmpegExecutorSettings />);
+    expect(screen.getByText(/Key stored/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Replace key/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Remove key/ })).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/settings/FfmpegExecutorSettings.test.tsx
+++ b/apps/frontend/src/components/settings/FfmpegExecutorSettings.test.tsx
@@ -127,6 +127,19 @@ describe('FfmpegExecutorSettings', () => {
     await waitFor(() => expect(update).toHaveBeenCalledWith({ saKeyJson: null }));
   });
 
+  it('Remove key reaches Test connection: sends saKeyJson: null', async () => {
+    status.hasSaKey = true;
+    status.saKeySource = 'db';
+    status.remoteEnabled = true;
+    status.remoteUrl = 'https://w.example.com';
+    render(<FfmpegExecutorSettings />);
+    fireEvent.click(screen.getByRole('button', { name: /Remove key/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Test connection/ }));
+    await waitFor(() =>
+      expect(testConnection).toHaveBeenCalledWith(expect.objectContaining({ saKeyJson: null })),
+    );
+  });
+
   it('local-filesystem storage makes Remote unavailable', () => {
     status.storagePresignable = false;
     render(<FfmpegExecutorSettings />);
@@ -157,6 +170,17 @@ describe('FfmpegExecutorSettings', () => {
     await waitFor(() =>
       expect(update).toHaveBeenCalledWith({ remoteEnabled: false, defaultExecutor: 'local' }),
     );
+  });
+
+  it('an env-pinned default executor never auto-moves', async () => {
+    status.envManaged.defaultExecutor = true;
+    status.defaultExecutor = 'remote';
+    status.remoteEnabled = true;
+    status.remoteUrl = 'https://w.example.com';
+    render(<FfmpegExecutorSettings />);
+    fireEvent.click(screen.getByRole('switch', { name: /Remote/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Save/ }));
+    await waitFor(() => expect(update).toHaveBeenCalledWith({ remoteEnabled: false }));
   });
 
   it('a draft edit clears a stale test result', async () => {

--- a/apps/frontend/src/components/settings/FfmpegExecutorSettings.test.tsx
+++ b/apps/frontend/src/components/settings/FfmpegExecutorSettings.test.tsx
@@ -63,6 +63,9 @@ describe('FfmpegExecutorSettings', () => {
     render(<FfmpegExecutorSettings />);
     expect(screen.getByLabelText(/Worker URL/)).toBeDisabled();
     expect(screen.getByText(/Managed by FFMPEG_REMOTE_URL/)).toBeInTheDocument();
+    // The backend forces remoteEnabled on when FFMPEG_REMOTE_URL is set, so the
+    // switch must be read-only rather than a toggle that snaps back.
+    expect(screen.getByRole('switch', { name: /Remote/ })).toBeDisabled();
   });
 
   it('Test connection sends the draft and renders version, ops, latency and the ADC note', async () => {
@@ -84,7 +87,7 @@ describe('FfmpegExecutorSettings', () => {
     expect(screen.getByText(/Using Application Default Credentials/)).toBeInTheDocument();
   });
 
-  it('Save sends only changed fields; a pasted key is sent as saKeyJson; stored key offers Replace/Remove', async () => {
+  it('Save sends only the changed fields, with a pasted key as saKeyJson', async () => {
     render(<FfmpegExecutorSettings />);
     fireEvent.click(screen.getByRole('switch', { name: /Remote/ }));
     fireEvent.change(screen.getByLabelText(/Worker URL/), { target: { value: 'https://w.example.com' } });
@@ -99,7 +102,9 @@ describe('FfmpegExecutorSettings', () => {
         saKeyJson: '{"type":"service_account"}',
       }),
     );
+  });
 
+  it('a stored key offers Replace/Remove instead of a textarea', () => {
     status.hasSaKey = true;
     status.saKeySource = 'db';
     status.remoteEnabled = true;
@@ -108,5 +113,59 @@ describe('FfmpegExecutorSettings', () => {
     expect(screen.getByText(/Key stored/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Replace key/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Remove key/ })).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/service_account/)).not.toBeInTheDocument();
+  });
+
+  it('Remove key sends saKeyJson: null and nothing else', async () => {
+    status.hasSaKey = true;
+    status.saKeySource = 'db';
+    status.remoteEnabled = true;
+    status.remoteUrl = 'https://w.example.com';
+    render(<FfmpegExecutorSettings />);
+    fireEvent.click(screen.getByRole('button', { name: /Remove key/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Save/ }));
+    await waitFor(() => expect(update).toHaveBeenCalledWith({ saKeyJson: null }));
+  });
+
+  it('local-filesystem storage makes Remote unavailable', () => {
+    status.storagePresignable = false;
+    render(<FfmpegExecutorSettings />);
+    expect(screen.getByRole('switch', { name: /Remote/ })).toBeDisabled();
+    expect(screen.getByText(/Needs bucket storage/)).toBeInTheDocument();
+  });
+
+  it('an env-managed service-account key is a badge, not an editable field', () => {
+    status.remoteEnabled = true;
+    status.remoteUrl = 'https://w.example.com';
+    status.hasSaKey = true;
+    status.saKeySource = 'env';
+    status.envManaged.saKey = true;
+    render(<FfmpegExecutorSettings />);
+    expect(screen.getByText(/Managed by FFMPEG_REMOTE_SA_KEY_JSON/)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/service_account/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Replace key/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Remove key/ })).not.toBeInTheDocument();
+  });
+
+  it('moves the default off an executor the draft just disabled', async () => {
+    status.remoteEnabled = true;
+    status.remoteUrl = 'https://w.example.com';
+    status.defaultExecutor = 'remote';
+    render(<FfmpegExecutorSettings />);
+    fireEvent.click(screen.getByRole('switch', { name: /Remote/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Save/ }));
+    await waitFor(() =>
+      expect(update).toHaveBeenCalledWith({ remoteEnabled: false, defaultExecutor: 'local' }),
+    );
+  });
+
+  it('a draft edit clears a stale test result', async () => {
+    status.remoteEnabled = true;
+    status.remoteUrl = 'https://w.example.com';
+    render(<FfmpegExecutorSettings />);
+    fireEvent.click(screen.getByRole('button', { name: /Test connection/ }));
+    expect(await screen.findByText(/0\.4\.31/)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/Worker URL/), { target: { value: 'https://other.example.com' } });
+    expect(screen.queryByText(/0\.4\.31/)).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/settings/FfmpegExecutorSettings.tsx
+++ b/apps/frontend/src/components/settings/FfmpegExecutorSettings.tsx
@@ -69,8 +69,12 @@ function diff(s: FfmpegExecutorStatus, d: Draft): UpdateFfmpegExecutorDto {
  * clearing the Worker URL) would otherwise leave a default the server rejects
  * with a 400 on save. Moves to the other executor when that one is selectable;
  * if neither is, leave it and let the server's message surface in the toast.
+ * An env-pinned default (FFMPEG_EXECUTOR) is never moved — the radio group is
+ * disabled and the server ignores the field, so auto-moving it here would
+ * just produce a phantom defaultExecutor change in the diff.
  */
-function withSelectableDefault(d: Draft, localAvailable: boolean): Draft {
+function withSelectableDefault(d: Draft, localAvailable: boolean, defaultPinned: boolean): Draft {
+  if (defaultPinned) return d;
   const localSelectable = d.localEnabled && localAvailable;
   const remoteSelectable = d.remoteEnabled && d.remoteUrl.trim() !== '';
   if (d.defaultExecutor === 'remote' && !remoteSelectable && localSelectable) {
@@ -128,7 +132,15 @@ export function FfmpegExecutorSettings() {
     // A test result describes the draft it was run against — any edit to the
     // connection fields makes it stale.
     if ('remoteUrl' in patch || 'remoteAuth' in patch || 'saKeyJson' in patch) setTestResult(null);
-    setDraft((d) => (d ? withSelectableDefault({ ...d, ...patch }, status.localAvailable) : d));
+    setDraft((d) =>
+      d
+        ? withSelectableDefault(
+            { ...d, ...patch },
+            status.localAvailable,
+            status.envManaged.defaultExecutor,
+          )
+        : d,
+    );
   };
   const localSelectable = draft.localEnabled && status.localAvailable;
   const remoteSelectable = draft.remoteEnabled && draft.remoteUrl.trim() !== '';
@@ -154,7 +166,11 @@ export function FfmpegExecutorSettings() {
       const res = await testConnection({
         remoteUrl: draft.remoteUrl.trim() || null,
         remoteAuth: draft.remoteAuth,
-        ...(draft.saKeyJson.trim() ? { saKeyJson: draft.saKeyJson.trim() } : {}),
+        ...(draft.removeKey
+          ? { saKeyJson: null }
+          : draft.saKeyJson.trim()
+            ? { saKeyJson: draft.saKeyJson.trim() }
+            : {}),
       }).unwrap();
       setTestResult(res);
     } catch (err) {
@@ -288,7 +304,7 @@ export function FfmpegExecutorSettings() {
                 {status.envManaged.saKey && <EnvBadge name="FFMPEG_REMOTE_SA_KEY_JSON" />}
                 {status.hasSaKey && !status.envManaged.saKey && (
                   <Badge variant="outline" className="text-[10px]">
-                    Key stored ({status.saKeySource})
+                    Key stored
                   </Badge>
                 )}
               </div>

--- a/apps/frontend/src/components/settings/FfmpegExecutorSettings.tsx
+++ b/apps/frontend/src/components/settings/FfmpegExecutorSettings.tsx
@@ -64,6 +64,24 @@ function diff(s: FfmpegExecutorStatus, d: Draft): UpdateFfmpegExecutorDto {
   return out;
 }
 
+/**
+ * Keep the draft's default executor selectable: turning an executor off (or
+ * clearing the Worker URL) would otherwise leave a default the server rejects
+ * with a 400 on save. Moves to the other executor when that one is selectable;
+ * if neither is, leave it and let the server's message surface in the toast.
+ */
+function withSelectableDefault(d: Draft, localAvailable: boolean): Draft {
+  const localSelectable = d.localEnabled && localAvailable;
+  const remoteSelectable = d.remoteEnabled && d.remoteUrl.trim() !== '';
+  if (d.defaultExecutor === 'remote' && !remoteSelectable && localSelectable) {
+    return { ...d, defaultExecutor: 'local' };
+  }
+  if (d.defaultExecutor === 'local' && !localSelectable && remoteSelectable) {
+    return { ...d, defaultExecutor: 'remote' };
+  }
+  return d;
+}
+
 function EnvBadge({ name }: { name: string }) {
   return (
     <Badge variant="secondary" className="font-mono text-[10px]">
@@ -106,7 +124,12 @@ export function FfmpegExecutorSettings() {
   }
   if (isLoading || !draft || !status) return <Skeleton className="h-40 w-full" />;
 
-  const set = (patch: Partial<Draft>) => setDraft((d) => (d ? { ...d, ...patch } : d));
+  const set = (patch: Partial<Draft>) => {
+    // A test result describes the draft it was run against — any edit to the
+    // connection fields makes it stale.
+    if ('remoteUrl' in patch || 'remoteAuth' in patch || 'saKeyJson' in patch) setTestResult(null);
+    setDraft((d) => (d ? withSelectableDefault({ ...d, ...patch }, status.localAvailable) : d));
+  };
   const localSelectable = draft.localEnabled && status.localAvailable;
   const remoteSelectable = draft.remoteEnabled && draft.remoteUrl.trim() !== '';
   const showKeyEditor = !status.hasSaKey || replacingKey;
@@ -193,17 +216,15 @@ export function FfmpegExecutorSettings() {
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          {/* Only while the detail block is collapsed — it carries its own badge. */}
-          {status.envManaged.remoteUrl && !draft.remoteEnabled && <EnvBadge name="FFMPEG_REMOTE_URL" />}
-          <Switch
-            id="ffmpeg-remote"
-            aria-label="Remote"
-            checked={draft.remoteEnabled}
-            disabled={!status.storagePresignable}
-            onCheckedChange={(v) => set({ remoteEnabled: v })}
-          />
-        </div>
+        {/* An env-pinned Worker URL forces Remote on server-side (resolveWith), so
+            the switch is read-only rather than a toggle that snaps back. */}
+        <Switch
+          id="ffmpeg-remote"
+          aria-label="Remote"
+          checked={draft.remoteEnabled}
+          disabled={!status.storagePresignable || status.envManaged.remoteUrl}
+          onCheckedChange={(v) => set({ remoteEnabled: v })}
+        />
       </div>
 
       {draft.remoteEnabled && (
@@ -347,20 +368,29 @@ export function FfmpegExecutorSettings() {
             {testResult && (
               <div className="space-y-1 text-xs">
                 <div className="flex items-center gap-2">
-                  {testResult.worker && !testResult.error ? (
+                  {testResult.ok ? (
                     <CheckCircle2 className="h-4 w-4 text-green-600" />
                   ) : (
                     <XCircle className="h-4 w-4 text-destructive" />
                   )}
-                  {testResult.worker ? (
-                    <span>
-                      Worker {testResult.worker.version} · {testResult.worker.ffmpeg ?? 'no ffmpeg'}{' '}
-                      · ops {testResult.worker.ops.join(', ')}
-                      {testResult.latencyMs !== null && <> · {testResult.latencyMs} ms</>}
-                    </span>
-                  ) : (
-                    <span>{testResult.error}</span>
-                  )}
+                  <span>
+                    {testResult.worker && (
+                      <>
+                        Worker {testResult.worker.version} ·{' '}
+                        {testResult.worker.ffmpeg ?? 'no ffmpeg'} · ops{' '}
+                        {testResult.worker.ops.join(', ')}
+                        {testResult.latencyMs !== null && <> · {testResult.latencyMs} ms</>}
+                      </>
+                    )}
+                    {/* A reachable Worker can still report an error (e.g. a bad key). */}
+                    {testResult.error && (
+                      <>
+                        {testResult.worker ? ' · ' : ''}
+                        {testResult.error}
+                      </>
+                    )}
+                    {!testResult.worker && !testResult.error && 'No response from the Worker.'}
+                  </span>
                 </div>
                 <div className={testResult.readiness.ok ? 'text-muted-foreground' : 'text-destructive'}>
                   {testResult.readiness.ok

--- a/apps/frontend/src/components/settings/FfmpegExecutorSettings.tsx
+++ b/apps/frontend/src/components/settings/FfmpegExecutorSettings.tsx
@@ -1,0 +1,427 @@
+// Admin Settings → Features → Server video ops → Executor.
+// Configures WHICH executor runs ffmpeg jobs: Local server (ffmpeg in this
+// backend) and/or Remote (a Worker CE calls over HTTPS; Cloud Run is the
+// reference deployment). Fields pinned by env vars render read-only.
+// The service-account key is write-only: the API only ever says whether one
+// is stored, so this form has a "replace" flow rather than a value.
+import { useEffect, useMemo, useState } from 'react';
+import {
+  useGetFfmpegExecutorSettingsQuery,
+  useTestFfmpegExecutorConnectionMutation,
+  useUpdateFfmpegExecutorSettingsMutation,
+  type FfmpegExecutorName,
+  type FfmpegExecutorStatus,
+  type FfmpegExecutorTestResult,
+  type FfmpegRemoteAuth,
+  type UpdateFfmpegExecutorDto,
+} from '@/services/settingsApi';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/use-toast';
+import { CheckCircle2, Cloud, Server, XCircle } from 'lucide-react';
+
+interface Draft {
+  localEnabled: boolean;
+  remoteEnabled: boolean;
+  remoteUrl: string;
+  remoteAuth: FfmpegRemoteAuth;
+  defaultExecutor: FfmpegExecutorName;
+  /** Textarea contents; '' = nothing to send. */
+  saKeyJson: string;
+  /** "Remove key" clicked → send saKeyJson: null on save. */
+  removeKey: boolean;
+}
+
+function toDraft(s: FfmpegExecutorStatus): Draft {
+  return {
+    localEnabled: s.localEnabled,
+    remoteEnabled: s.remoteEnabled,
+    remoteUrl: s.remoteUrl ?? '',
+    remoteAuth: s.remoteAuth,
+    defaultExecutor: s.defaultExecutor,
+    saKeyJson: '',
+    removeKey: false,
+  };
+}
+
+/** Only the fields that differ from the saved status (the API is partial-update). */
+function diff(s: FfmpegExecutorStatus, d: Draft): UpdateFfmpegExecutorDto {
+  const out: UpdateFfmpegExecutorDto = {};
+  if (d.localEnabled !== s.localEnabled) out.localEnabled = d.localEnabled;
+  if (d.remoteEnabled !== s.remoteEnabled) out.remoteEnabled = d.remoteEnabled;
+  if (d.remoteUrl.trim() !== (s.remoteUrl ?? '')) out.remoteUrl = d.remoteUrl.trim() || null;
+  if (d.remoteAuth !== s.remoteAuth) out.remoteAuth = d.remoteAuth;
+  if (d.defaultExecutor !== s.defaultExecutor) out.defaultExecutor = d.defaultExecutor;
+  if (d.removeKey) out.saKeyJson = null;
+  else if (d.saKeyJson.trim()) out.saKeyJson = d.saKeyJson.trim();
+  return out;
+}
+
+function EnvBadge({ name }: { name: string }) {
+  return (
+    <Badge variant="secondary" className="font-mono text-[10px]">
+      Managed by {name}
+    </Badge>
+  );
+}
+
+function errorMessage(err: unknown): string {
+  return err && typeof err === 'object' && 'data' in err
+    ? (err as { data?: { message?: string } }).data?.message || 'An error occurred'
+    : 'An error occurred';
+}
+
+export function FfmpegExecutorSettings() {
+  const { toast } = useToast();
+  const { data: status, isLoading, error } = useGetFfmpegExecutorSettingsQuery();
+  const [update, { isLoading: saving }] = useUpdateFfmpegExecutorSettingsMutation();
+  const [testConnection, { isLoading: testing }] = useTestFfmpegExecutorConnectionMutation();
+  const [draft, setDraft] = useState<Draft | null>(null);
+  const [replacingKey, setReplacingKey] = useState(false);
+  const [testResult, setTestResult] = useState<FfmpegExecutorTestResult | null>(null);
+
+  useEffect(() => {
+    if (status) {
+      setDraft(toDraft(status));
+      setReplacingKey(false);
+    }
+  }, [status]);
+
+  const changes = useMemo(() => (status && draft ? diff(status, draft) : {}), [status, draft]);
+  const dirty = Object.keys(changes).length > 0;
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>Failed to load executor settings.</AlertDescription>
+      </Alert>
+    );
+  }
+  if (isLoading || !draft || !status) return <Skeleton className="h-40 w-full" />;
+
+  const set = (patch: Partial<Draft>) => setDraft((d) => (d ? { ...d, ...patch } : d));
+  const localSelectable = draft.localEnabled && status.localAvailable;
+  const remoteSelectable = draft.remoteEnabled && draft.remoteUrl.trim() !== '';
+  const showKeyEditor = !status.hasSaKey || replacingKey;
+
+  const onSave = async () => {
+    try {
+      await update(changes).unwrap();
+      toast({ title: 'Executor settings saved' });
+      setTestResult(null);
+    } catch (err) {
+      toast({
+        title: 'Failed to save executor settings',
+        description: errorMessage(err),
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const onTest = async () => {
+    setTestResult(null);
+    try {
+      const res = await testConnection({
+        remoteUrl: draft.remoteUrl.trim() || null,
+        remoteAuth: draft.remoteAuth,
+        ...(draft.saKeyJson.trim() ? { saKeyJson: draft.saKeyJson.trim() } : {}),
+      }).unwrap();
+      setTestResult(res);
+    } catch (err) {
+      toast({ title: 'Test failed', description: errorMessage(err), variant: 'destructive' });
+    }
+  };
+
+  return (
+    <div className="ml-8 space-y-4 rounded-lg border border-dashed p-4">
+      <div>
+        <Label className="text-sm font-medium">Executor</Label>
+        <p className="text-xs text-muted-foreground">
+          Where ffmpeg jobs run. Enable Local, Remote, or both, then pick the default. Steps can
+          still name an executor explicitly.
+        </p>
+      </div>
+
+      {/* Local server */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <Server className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <div>
+            <Label htmlFor="ffmpeg-local" className="text-sm font-medium">
+              Local server
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {status.localAvailable ? (
+                <>
+                  ffmpeg spawned by this backend · {status.localVersion} · memory floor: see Sizing
+                  in the docs
+                </>
+              ) : (
+                'ffmpeg is not installed on this server — the Local executor cannot be enabled'
+              )}
+            </p>
+          </div>
+        </div>
+        <Switch
+          id="ffmpeg-local"
+          aria-label="Local server"
+          checked={draft.localEnabled}
+          disabled={!status.localAvailable}
+          onCheckedChange={(v) => set({ localEnabled: v })}
+        />
+      </div>
+
+      {/* Remote (Worker) */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <Cloud className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <div>
+            <Label htmlFor="ffmpeg-remote" className="text-sm font-medium">
+              Remote (Worker)
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {status.storagePresignable
+                ? 'A Worker CE calls over HTTPS — bytes move bucket ↔ Worker via signed URLs and never touch this server. Cloud Run is the reference deployment.'
+                : 'Needs bucket storage (S3, GCS, MinIO, Azure) — the Worker moves bytes through signed URLs, which local filesystem storage cannot provide.'}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {/* Only while the detail block is collapsed — it carries its own badge. */}
+          {status.envManaged.remoteUrl && !draft.remoteEnabled && <EnvBadge name="FFMPEG_REMOTE_URL" />}
+          <Switch
+            id="ffmpeg-remote"
+            aria-label="Remote"
+            checked={draft.remoteEnabled}
+            disabled={!status.storagePresignable}
+            onCheckedChange={(v) => set({ remoteEnabled: v })}
+          />
+        </div>
+      </div>
+
+      {draft.remoteEnabled && (
+        <div className="ml-7 space-y-3">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <Label htmlFor="ffmpeg-remote-url" className="text-xs">
+                Worker URL
+              </Label>
+              {status.envManaged.remoteUrl && <EnvBadge name="FFMPEG_REMOTE_URL" />}
+            </div>
+            <Input
+              id="ffmpeg-remote-url"
+              placeholder="https://bffless-ffmpeg-xxxx-uc.a.run.app"
+              value={draft.remoteUrl}
+              disabled={status.envManaged.remoteUrl}
+              onChange={(e) => set({ remoteUrl: e.target.value })}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <Label className="text-xs">Auth</Label>
+              {status.envManaged.remoteAuth && <EnvBadge name="FFMPEG_REMOTE_AUTH" />}
+            </div>
+            <RadioGroup
+              value={draft.remoteAuth}
+              disabled={status.envManaged.remoteAuth}
+              onValueChange={(v) => set({ remoteAuth: v as FfmpegRemoteAuth })}
+              className="flex gap-4"
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem id="ffmpeg-auth-idtoken" value="google_id_token" />
+                <Label htmlFor="ffmpeg-auth-idtoken" className="text-xs font-normal">
+                  Google ID token (Cloud Run IAM)
+                </Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem id="ffmpeg-auth-none" value="none" />
+                <Label htmlFor="ffmpeg-auth-none" className="text-xs font-normal">
+                  None (private network only)
+                </Label>
+              </div>
+            </RadioGroup>
+            {draft.remoteAuth === 'none' && (
+              <Alert variant="destructive">
+                <AlertDescription className="text-xs">
+                  No authentication: anyone who can reach the Worker URL can run jobs on it. Only
+                  use on a private network (docker compose profile, VPC).
+                </AlertDescription>
+              </Alert>
+            )}
+          </div>
+
+          {draft.remoteAuth === 'google_id_token' && (
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Label htmlFor="ffmpeg-sa-key" className="text-xs">
+                  Service-account key (JSON)
+                </Label>
+                {status.envManaged.saKey && <EnvBadge name="FFMPEG_REMOTE_SA_KEY_JSON" />}
+                {status.hasSaKey && !status.envManaged.saKey && (
+                  <Badge variant="outline" className="text-[10px]">
+                    Key stored ({status.saKeySource})
+                  </Badge>
+                )}
+              </div>
+              {status.envManaged.saKey ? (
+                <p className="text-xs text-muted-foreground">
+                  Provided by the environment; not editable here.
+                </p>
+              ) : showKeyEditor ? (
+                <>
+                  <Textarea
+                    id="ffmpeg-sa-key"
+                    rows={4}
+                    placeholder='{"type": "service_account", ...}'
+                    className="font-mono text-xs"
+                    value={draft.saKeyJson}
+                    onChange={(e) => set({ saKeyJson: e.target.value, removeKey: false })}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Optional. Leave empty to use Application Default Credentials (works when CE
+                    itself runs on GCP). The key is stored encrypted and never shown again.
+                  </p>
+                  {replacingKey && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        setReplacingKey(false);
+                        set({ saKeyJson: '' });
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  )}
+                </>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setReplacingKey(true);
+                      set({ removeKey: false });
+                    }}
+                  >
+                    Replace key
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => set({ removeKey: !draft.removeKey, saKeyJson: '' })}
+                  >
+                    {draft.removeKey ? 'Keep key' : 'Remove key'}
+                  </Button>
+                  {draft.removeKey && (
+                    <span className="text-xs text-destructive">
+                      Key will be removed on save (ADC will be used).
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onTest}
+              disabled={testing || !draft.remoteUrl.trim()}
+            >
+              {testing ? 'Testing…' : 'Test connection'}
+            </Button>
+            {testResult && (
+              <div className="space-y-1 text-xs">
+                <div className="flex items-center gap-2">
+                  {testResult.worker && !testResult.error ? (
+                    <CheckCircle2 className="h-4 w-4 text-green-600" />
+                  ) : (
+                    <XCircle className="h-4 w-4 text-destructive" />
+                  )}
+                  {testResult.worker ? (
+                    <span>
+                      Worker {testResult.worker.version} · {testResult.worker.ffmpeg ?? 'no ffmpeg'}{' '}
+                      · ops {testResult.worker.ops.join(', ')}
+                      {testResult.latencyMs !== null && <> · {testResult.latencyMs} ms</>}
+                    </span>
+                  ) : (
+                    <span>{testResult.error}</span>
+                  )}
+                </div>
+                <div className={testResult.readiness.ok ? 'text-muted-foreground' : 'text-destructive'}>
+                  {testResult.readiness.ok
+                    ? 'Ready'
+                    : `Not ready: ${testResult.readiness.reason ?? 'unknown reason'}`}
+                </div>
+                <div className="text-muted-foreground">
+                  {testResult.credential === 'adc' &&
+                    'Using Application Default Credentials (no key stored) — this works when CE runs on GCP; elsewhere paste a service-account key.'}
+                  {testResult.credential === 'sa_key' && 'Using the stored service-account key.'}
+                  {testResult.credential === 'none' && 'No auth.'}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Default executor */}
+      <div className="space-y-1">
+        <div className="flex items-center gap-2">
+          <Label className="text-xs">Default executor</Label>
+          {status.envManaged.defaultExecutor && <EnvBadge name="FFMPEG_EXECUTOR" />}
+        </div>
+        <RadioGroup
+          value={draft.defaultExecutor}
+          disabled={status.envManaged.defaultExecutor}
+          onValueChange={(v) => set({ defaultExecutor: v as FfmpegExecutorName })}
+          className="flex gap-4"
+        >
+          <div className="flex items-center gap-2">
+            <RadioGroupItem
+              id="ffmpeg-default-local"
+              value="local"
+              disabled={!localSelectable}
+              aria-label="local"
+            />
+            <Label htmlFor="ffmpeg-default-local" className="text-xs font-normal">
+              Local server
+            </Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <RadioGroupItem
+              id="ffmpeg-default-remote"
+              value="remote"
+              disabled={!remoteSelectable}
+              aria-label="remote"
+            />
+            <Label htmlFor="ffmpeg-default-remote" className="text-xs font-normal">
+              Remote
+            </Label>
+          </div>
+        </RadioGroup>
+        <p className="text-xs text-muted-foreground">Only enabled executors can be the default.</p>
+      </div>
+
+      <div className="flex justify-end">
+        <Button type="button" size="sm" onClick={onSave} disabled={!dirty || saving}>
+          {saving ? 'Saving…' : 'Save executor settings'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -221,6 +221,7 @@ export const api = createApi({
     'PrimarySsl',
     'AppCatalog',
     'InstalledApp',
+    'FfmpegExecutor',
   ],
   endpoints: () => ({}),
 });

--- a/apps/frontend/src/services/settingsApi.ts
+++ b/apps/frontend/src/services/settingsApi.ts
@@ -186,6 +186,52 @@ export interface UpdateBrandingResponse {
   config: BrandingConfig;
 }
 
+// ─── ffmpeg executor settings (Server video ops → Executor) ───────────────
+// Mirrors the backend's FfmpegExecutorSettingsService types. The
+// service-account key is write-only: the API only ever reports whether one is
+// stored (`hasSaKey`/`saKeySource`), never its value.
+export type FfmpegExecutorName = 'local' | 'remote';
+export type FfmpegRemoteAuth = 'google_id_token' | 'none';
+
+export interface FfmpegExecutorStatus {
+  localAvailable: boolean;
+  localVersion: string | null;
+  localEnabled: boolean;
+  remoteEnabled: boolean;
+  remoteUrl: string | null;
+  remoteAuth: FfmpegRemoteAuth;
+  hasSaKey: boolean;
+  saKeySource: 'db' | 'env' | null;
+  defaultExecutor: FfmpegExecutorName;
+  storagePresignable: boolean;
+  envManaged: { defaultExecutor: boolean; remoteUrl: boolean; remoteAuth: boolean; saKey: boolean };
+}
+
+export interface UpdateFfmpegExecutorDto {
+  localEnabled?: boolean;
+  remoteEnabled?: boolean;
+  remoteUrl?: string | null;
+  remoteAuth?: FfmpegRemoteAuth;
+  defaultExecutor?: FfmpegExecutorName;
+  /** undefined = keep, null = clear, string = replace */
+  saKeyJson?: string | null;
+}
+
+export interface FfmpegExecutorTestDraft {
+  remoteUrl?: string | null;
+  remoteAuth?: FfmpegRemoteAuth;
+  saKeyJson?: string | null;
+}
+
+export interface FfmpegExecutorTestResult {
+  ok: boolean;
+  latencyMs: number | null;
+  worker?: { version: string; ffmpeg: string | null; ops: string[]; uptimeS: number };
+  error?: string;
+  readiness: { ok: boolean; reason?: string };
+  credential: 'sa_key' | 'adc' | 'none';
+}
+
 // ─── SSO provider types (story 0047) ─────────────────────────────────────────
 
 export type SsoProviderKind = 'google' | 'okta' | 'azure-ad' | 'oidc';
@@ -489,6 +535,23 @@ export const settingsApi = api.injectEndpoints({
       invalidatesTags: ['OAuthSettings', 'Integration'],
     }),
 
+    // ─── ffmpeg executor (Admin Settings → Features → Server video ops) ────
+    // Backend: FfmpegExecutorSettingsController (PipelinesModule). The test
+    // mutation runs against the *unsaved* draft, so it deliberately has no tags.
+    getFfmpegExecutorSettings: builder.query<FfmpegExecutorStatus, void>({
+      query: () => '/api/settings/ffmpeg-executor',
+      providesTags: ['FfmpegExecutor'],
+    }),
+
+    updateFfmpegExecutorSettings: builder.mutation<FfmpegExecutorStatus, UpdateFfmpegExecutorDto>({
+      query: (body) => ({ url: '/api/settings/ffmpeg-executor', method: 'PUT', body }),
+      invalidatesTags: ['FfmpegExecutor'],
+    }),
+
+    testFfmpegExecutorConnection: builder.mutation<FfmpegExecutorTestResult, FfmpegExecutorTestDraft>({
+      query: (body) => ({ url: '/api/settings/ffmpeg-executor/test', method: 'POST', body }),
+    }),
+
     // ─── SSO providers (story 0047) ─────────────────────────────────────────
     // CRUD over the `oidc_providers` table. Each mutation also triggers
     // backend syncOidcProviders() server-side, so the new buttons appear on
@@ -574,6 +637,10 @@ export const {
   useGetGoogleIntegrationQuery,
   useUpdateGoogleIntegrationMutation,
   useDeleteGoogleIntegrationMutation,
+  // ffmpeg executor hooks (Server video ops → Executor)
+  useGetFfmpegExecutorSettingsQuery,
+  useUpdateFfmpegExecutorSettingsMutation,
+  useTestFfmpegExecutorConnectionMutation,
   // SSO provider hooks (story 0047)
   useListSsoProvidersQuery,
   useGetSsoProviderQuery,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -262,6 +262,7 @@ services:
   ffmpeg-worker:
     # Remote executor for server video ops (docs: Server Video Ops → Remote executor).
     # Local-dev / private-network profile: plain http, no auth. Cloud Run is the reference deployment.
+    # Point CE at it with FFMPEG_REMOTE_URL=http://ffmpeg-worker:8080 FFMPEG_REMOTE_AUTH=none, or in Admin Settings → Features → Server video ops → Executor (Worker URL http://ffmpeg-worker:8080, auth None).
     image: ghcr.io/bffless/ce-ffmpeg-worker:${BACKEND_TAG:-latest}
     container_name: assethost-ffmpeg-worker
     profiles:

--- a/docs/superpowers/plans/2026-08-17-ffmpeg-remote-executor-settings.md
+++ b/docs/superpowers/plans/2026-08-17-ffmpeg-remote-executor-settings.md
@@ -1,0 +1,2055 @@
+# ffmpeg Remote Executor — Settings UI + DB config + Docs (Plan 2 of 3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an admin configure the ffmpeg executors (Local on/off, Remote on/off + Worker URL + auth + write-only encrypted SA key + default) from Admin Settings → Features → Server video ops, test the Worker connection, and read how to deploy/operate the Remote executor in the public docs.
+
+**Architecture:** A new single-row table `ffmpeg_executor_settings` (SA key AES-GCM-encrypted via `common/crypto/aes-gcm.ts`) is loaded and decrypted into memory by `FfmpegExecutorSettingsService` at boot and on every save; its `resolved()` merges the DB row *under* env (env wins per field) into the existing `FfmpegEnvConfig` shape. `FfmpegExecutorSelector` and `RemoteFfmpegExecutor` receive that resolver through two Nest injection tokens (`FFMPEG_CONFIG`, `FFMPEG_REMOTE_DEPS`) with `readFfmpegEnv` fallback, so every Plan 1 test seam and semantics stay intact. A small admin-only controller in `PipelinesModule` exposes `GET/PUT /api/settings/ffmpeg-executor` and `POST …/test`; the frontend adds an `FfmpegExecutorSettings` panel under the existing Server video ops toggle row.
+
+**Tech Stack:** NestJS 10 + Drizzle (Postgres) + Jest (backend); React 18 + RTK Query + shadcn/ui + Vitest (frontend); Docusaurus markdown (docs-public).
+
+**Spec:** `docs/superpowers/specs/2026-08-17-ffmpeg-remote-executor-design.md` §1.5 (Settings + capability) and §1.7 (Docs). Plan 1 (already merged, PR #684): `docs/superpowers/plans/2026-08-17-ffmpeg-remote-executor-core.md` — this plan is epic tasks **T5** and **T9** of bffless/apps#346.
+
+**Worktrees:** CE work in `repos/ce/.claude/worktrees/ffmpeg-remote-settings` (branch `feat/ffmpeg-remote-settings`, from origin/main c658c02). Docs work in `repos/docs-public/.claude/worktrees/ffmpeg-remote-executor` (branch `docs/ffmpeg-remote-executor`, from origin/main 48eac3d). **Always confirm `git rev-parse --show-toplevel` before editing** — the main checkouts are shared.
+
+## Global Constraints
+
+- **Env wins over DB, per field** (spec §1.5, restated by the user). Env-managed fields: `FFMPEG_EXECUTOR` → default executor; `FFMPEG_REMOTE_URL` → Worker URL *and* forces Remote enabled; `FFMPEG_REMOTE_AUTH` → auth mode; `FFMPEG_REMOTE_SA_KEY_JSON` → SA key. `''` counts as unset (compose passthrough), exactly like `ffmpeg-env.ts`. `FFMPEG_REMOTE_MAX_INFLIGHT`, `FFMPEG_WORKER_MIN_VERSION`, `FFMPEG_MAX_OUTPUT_BYTES` stay **env-only** (not in the DB, not in the UI). Note: this is deliberately the *opposite* of the `FFMPEG_HANDLER_ENABLED` feature flag (FeatureFlagsService resolves DB > env) — the spec sentence "matches FFMPEG_HANDLER_ENABLED" is inaccurate; do not "fix" the flag.
+- **The SA key is write-only.** It is stored encrypted (`encryptString` from `common/crypto/aes-gcm.ts`, requires `ENCRYPTION_KEY`), decrypted only into the in-process cache, and never appears in any HTTP response, log line, or error message. Status exposes only `hasSaKey` + `saKeySource: 'db' | 'env' | null`.
+- **Plan 1 behaviour unchanged.** With no DB row and no new env, `readFfmpegEnv()` semantics are identical: local enabled iff binaries present; remote enabled iff `FFMPEG_REMOTE_URL` set. All existing suites (`pipelines/ffmpeg/**/*.spec.ts`, `handlers/ffmpeg.handler.spec.ts`, `mcp/tools/proxy-rules.tools.ffmpeg.spec.ts`) must stay green; existing spec files may only be *added to*, never weakened.
+- **New `FfmpegEnvConfig` fields:** `localEnabled: boolean` (env reader: always `true`) and `remoteEnabled: boolean` (env reader: `remoteUrl !== null`). Selector: local iff `capability.isAvailable() && cfg.localEnabled`; remote iff `cfg.remoteEnabled && cfg.remoteUrl`.
+- **Validation is server-side (400 `BadRequestException`) and repeated in the UI copy:** Remote on ⇒ URL required and parseable; URL must be `https:` unless auth is `none`; SA key (when provided) must be JSON with `"type": "service_account"`; default executor must be one of the enabled ones; enabling Remote when the storage adapter cannot presign (local-FS) is refused (D3 settings-time error).
+- **Migration is a USER step.** Per CLAUDE.md, never run `drizzle-kit generate` or hand-write files under `apps/backend/drizzle/`. Task 1 ends by asking the user to run `cd repos/ce/apps/backend && pnpm db:generate` (a new table needs no interactive answers) — the plan proceeds without it; the service tolerates a missing table (warn once, env-only behaviour).
+- **Test-running gotchas (from Plan 1):** the worktree path contains "ffmpeg", so `pnpm jest ffmpeg` runs every suite — use `pnpm jest --testPathPattern 'src/.*ffmpeg'` (or the exact file). Backend `pnpm lint` has `--fix` baked in and rewrites ~300 unrelated files — lint with `npx eslint <files>` only. Frontend: `pnpm test:run <file>` (vitest); frontend `pnpm lint` already fails on main (58 pre-existing problems) — only check that *your* files are clean with `npx eslint <files>`.
+- **Backend test style:** Jest, `jest.mock('../db/client', …)` for Drizzle (pattern in `settings/google-integration-credentials.service.spec.ts`), `process.env.ENCRYPTION_KEY = Buffer.alloc(32, 7).toString('base64')` + `__resetKeyForTests()` around crypto. Loggers are `new Logger(<Class>.name)` logging object literals with an `event` key.
+- **Copy rules:** UI and docs say **Worker**, **Remote executor**, **Local server**, **Browser**; the auth mode is `google_id_token` / `none`; the image is `ghcr.io/bffless/ce-ffmpeg-worker:<ce-version>` (spec said `ffmpeg-worker` — as-built deviation, keep `ce-`). CE version for docs examples: `0.4.31`.
+- **Commits:** local commits only, conventional-commit messages; **never push or open a PR without asking** the user.
+
+---
+
+## File Structure
+
+**Backend (create):**
+- `apps/backend/src/db/schema/ffmpeg-executor-settings.schema.ts` — Drizzle table `ffmpeg_executor_settings` + row types.
+- `apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts` — load/decrypt/cache the row; `resolved()`; `getStatus()`; `update()`; `testConnection()`; validation.
+- `apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts`
+- `apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.controller.ts` — `GET/PUT /api/settings/ffmpeg-executor`, `POST /api/settings/ffmpeg-executor/test` (admin).
+- `apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.controller.spec.ts`
+- `apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-config.tokens.ts` — the two injection tokens.
+
+**Backend (modify):**
+- `apps/backend/src/db/schema/index.ts` — export the new schema.
+- `apps/backend/src/pipelines/ffmpeg/ffmpeg-env.ts` — `localEnabled`, `remoteEnabled` fields.
+- `apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-executor.selector.ts` — `enabled()` uses the new bits; env resolver injected via `FFMPEG_CONFIG`; error text no longer says "set FFMPEG_REMOTE_URL" only.
+- `apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.ts` — `deps` injected via `FFMPEG_REMOTE_DEPS`; `ready({fresh, env})` + `testConnection(overrides)`.
+- `apps/backend/src/pipelines/pipelines.module.ts` — providers (service, tokens), controller.
+- Existing specs (add cases only): `ffmpeg-env.spec.ts`, `ffmpeg-executor.selector.spec.ts`, `remote-ffmpeg.executor.spec.ts`.
+
+**Frontend (create):**
+- `apps/frontend/src/components/settings/FfmpegExecutorSettings.tsx` — the Executor panel.
+- `apps/frontend/src/components/settings/FfmpegExecutorSettings.test.tsx`
+
+**Frontend (modify):**
+- `apps/frontend/src/services/settingsApi.ts` — types + 3 endpoints, tag `FfmpegExecutor`.
+- `apps/frontend/src/services/api.ts` — add `'FfmpegExecutor'` to `tagTypes`.
+- `apps/frontend/src/components/settings/FeatureToggles.tsx` — registry entry gains optional `Panel`; renders it under the row.
+
+**Docs (modify, docs-public worktree):**
+- `docs/features/server-video-ops.md` — new *Remote executor* section (+ intro/mode table tweak).
+
+---
+
+### Task 1: Schema + env fields (`localEnabled` / `remoteEnabled`)
+
+**Files:**
+- Create: `apps/backend/src/db/schema/ffmpeg-executor-settings.schema.ts`
+- Modify: `apps/backend/src/db/schema/index.ts`
+- Modify: `apps/backend/src/pipelines/ffmpeg/ffmpeg-env.ts`
+- Test (add cases): `apps/backend/src/pipelines/ffmpeg/ffmpeg-env.spec.ts`
+
+**Interfaces:**
+- Produces: table `ffmpegExecutorSettings` with row type `FfmpegExecutorSettingsRow` (`id, localEnabled, remoteEnabled, remoteUrl, remoteAuth, saKeyEncrypted, defaultExecutor, createdAt, updatedAt, updatedByUserId`); `FfmpegEnvConfig.localEnabled: boolean`, `FfmpegEnvConfig.remoteEnabled: boolean`.
+
+- [ ] **Step 1: Write the failing env test**
+
+Append to `apps/backend/src/pipelines/ffmpeg/ffmpeg-env.spec.ts` (inside the top-level `describe`, matching the file's existing style — read the file first):
+
+```ts
+it('localEnabled is always true from env; remoteEnabled mirrors whether FFMPEG_REMOTE_URL is set', () => {
+  const off = readFfmpegEnv({});
+  expect(off.localEnabled).toBe(true);
+  expect(off.remoteEnabled).toBe(false);
+  const on = readFfmpegEnv({ FFMPEG_REMOTE_URL: 'https://w.example.com/' });
+  expect(on.remoteEnabled).toBe(true);
+  expect(on.remoteUrl).toBe('https://w.example.com');
+  expect(readFfmpegEnv({ FFMPEG_REMOTE_URL: '' }).remoteEnabled).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd apps/backend && pnpm jest src/pipelines/ffmpeg/ffmpeg-env.spec.ts`
+Expected: FAIL — `localEnabled` is `undefined`.
+
+- [ ] **Step 3: Add the two fields to `ffmpeg-env.ts`**
+
+In the `FfmpegEnvConfig` interface, before `executor`:
+
+```ts
+  /** Operator switch for the Local executor (DB-backed; env has no knob → always true here). */
+  localEnabled: boolean;
+  /** Operator switch for the Remote executor. From env alone: on iff FFMPEG_REMOTE_URL is set. */
+  remoteEnabled: boolean;
+```
+
+In `readFfmpegEnv`, compute `const remoteUrl = str(env.FFMPEG_REMOTE_URL);` before the returned object, then in the object replace `remoteUrl: str(env.FFMPEG_REMOTE_URL),` with:
+
+```ts
+    localEnabled: true,
+    remoteEnabled: remoteUrl !== null,
+    remoteUrl,
+```
+
+- [ ] **Step 4: Run env test → PASS; run the whole ffmpeg tree to check nothing else broke**
+
+Run: `cd apps/backend && pnpm jest --testPathPattern 'src/.*ffmpeg'`
+Expected: all PASS (type errors would show here since ts-jest compiles).
+
+- [ ] **Step 5: Create the schema file**
+
+`apps/backend/src/db/schema/ffmpeg-executor-settings.schema.ts`:
+
+```ts
+import { pgTable, uuid, boolean, varchar, text, timestamp } from 'drizzle-orm/pg-core';
+
+/**
+ * Instance-level configuration of the ffmpeg executors (Local server / Remote
+ * Worker) edited in Admin Settings → Features → Server video ops → Executor.
+ * Exactly one row (the service upserts; there is no natural key beyond "the
+ * instance"). Env vars override individual fields — FFMPEG_EXECUTOR,
+ * FFMPEG_REMOTE_URL, FFMPEG_REMOTE_AUTH, FFMPEG_REMOTE_SA_KEY_JSON — see
+ * `pipelines/ffmpeg/ffmpeg-executor-settings.service.ts` (`resolved()`).
+ *
+ * The service-account key is AES-256-GCM encrypted with common/crypto/aes-gcm.ts
+ * (same wire format as oidc_providers.config_encrypted) and is WRITE-ONLY: the
+ * API reports only whether one is stored.
+ *
+ * Spec: docs/superpowers/specs/2026-08-17-ffmpeg-remote-executor-design.md §1.5.
+ */
+export const ffmpegExecutorSettings = pgTable('ffmpeg_executor_settings', {
+  id: uuid('id').primaryKey().defaultRandom(),
+
+  // Local executor: ffmpeg spawned by this backend. Only meaningful when the
+  // binaries are present; off lets an admin force Remote on a box that has ffmpeg.
+  localEnabled: boolean('local_enabled').default(true).notNull(),
+
+  // Remote executor: a Worker CE calls over HTTPS (Cloud Run is the reference).
+  remoteEnabled: boolean('remote_enabled').default(false).notNull(),
+  remoteUrl: text('remote_url'),
+  // 'google_id_token' | 'none'
+  remoteAuth: varchar('remote_auth', { length: 32 }).default('google_id_token').notNull(),
+  // encryptString(<service-account JSON>) or null (= use ADC / no key)
+  saKeyEncrypted: text('sa_key_encrypted'),
+
+  // 'local' | 'remote' — which executor a step runs on unless it names one.
+  defaultExecutor: varchar('default_executor', { length: 16 }).default('local').notNull(),
+
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  updatedByUserId: uuid('updated_by_user_id'),
+});
+
+export type FfmpegExecutorSettingsRow = typeof ffmpegExecutorSettings.$inferSelect;
+export type NewFfmpegExecutorSettingsRow = typeof ffmpegExecutorSettings.$inferInsert;
+```
+
+Add to `apps/backend/src/db/schema/index.ts` (alphabetical-ish, next to the other feature tables):
+
+```ts
+export * from './ffmpeg-executor-settings.schema';
+```
+
+- [ ] **Step 6: Type-check the backend**
+
+Run: `cd apps/backend && npx tsc --noEmit -p tsconfig.json`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/backend/src/db/schema/ffmpeg-executor-settings.schema.ts apps/backend/src/db/schema/index.ts apps/backend/src/pipelines/ffmpeg/ffmpeg-env.ts apps/backend/src/pipelines/ffmpeg/ffmpeg-env.spec.ts
+git commit -m "feat(ffmpeg): ffmpeg_executor_settings table + localEnabled/remoteEnabled config bits"
+```
+
+- [ ] **Step 8: Hand the migration to the user (do NOT generate it yourself)**
+
+Report to the user (in the final summary is fine): *"Run `cd repos/ce/.claude/worktrees/ffmpeg-remote-settings/apps/backend && pnpm db:generate` — it will create `drizzle/0043_<name>.sql` for the new `ffmpeg_executor_settings` table; a new table needs no interactive answers. Then commit that file on the branch."* Everything below works without it (unit tests mock the DB; the service tolerates a missing table).
+
+---
+
+### Task 2: `FfmpegExecutorSettingsService` — load, resolve, status, update
+
+**Files:**
+- Create: `apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts`
+- Create: `apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `readFfmpegEnv`, `FfmpegEnvConfig` (Task 1 fields), `encryptString`/`decryptString` from `../../common/crypto/aes-gcm`, `db` from `../../db/client`, `ffmpegExecutorSettings` schema, `IStorageAdapter`/`STORAGE_ADAPTER` from `../../storage/storage.interface`, `FfmpegCapabilityService`.
+- Produces:
+  ```ts
+  class FfmpegExecutorSettingsService implements OnModuleInit {
+    reload(): Promise<void>;                       // DB → cache (tolerates missing table)
+    resolved(): FfmpegEnvConfig;                   // env over cached DB row — SYNC
+    envManaged(): FfmpegExecutorEnvManaged;        // which fields env pins
+    getStatus(): Promise<FfmpegExecutorStatus>;    // never includes the key
+    update(input: UpdateFfmpegExecutorInput, userId?: string): Promise<FfmpegExecutorStatus>;
+  }
+  interface FfmpegExecutorEnvManaged { defaultExecutor: boolean; remoteUrl: boolean; remoteAuth: boolean; saKey: boolean }
+  interface FfmpegExecutorStatus {
+    localAvailable: boolean; localVersion: string | null; localEnabled: boolean;
+    remoteEnabled: boolean; remoteUrl: string | null; remoteAuth: 'google_id_token' | 'none';
+    hasSaKey: boolean; saKeySource: 'db' | 'env' | null;
+    defaultExecutor: 'local' | 'remote';
+    storagePresignable: boolean;      // false on local-FS storage → Remote cannot be enabled
+    envManaged: FfmpegExecutorEnvManaged;
+  }
+  interface UpdateFfmpegExecutorInput {
+    localEnabled?: boolean; remoteEnabled?: boolean; remoteUrl?: string | null;
+    remoteAuth?: 'google_id_token' | 'none'; defaultExecutor?: 'local' | 'remote';
+    /** undefined = keep stored key; null = clear it; string = replace it */
+    saKeyJson?: string | null;
+  }
+  ```
+  (Task 4 adds `testConnection()` to this same service; Task 5's controller consumes all of it.)
+
+- [ ] **Step 1: Write the failing service tests**
+
+`apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts`:
+
+```ts
+import { BadRequestException } from '@nestjs/common';
+
+jest.mock('../../db/client', () => ({
+  db: {
+    select: jest.fn(),
+    insert: jest.fn(),
+    update: jest.fn(),
+  },
+}));
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { db } = require('../../db/client');
+
+import { FfmpegExecutorSettingsService } from './ffmpeg-executor-settings.service';
+import { encryptString, __resetKeyForTests } from '../../common/crypto/aes-gcm';
+
+const TEST_KEY = Buffer.alloc(32, 7).toString('base64');
+const SA_KEY = JSON.stringify({ type: 'service_account', client_email: 'x@p.iam.gserviceaccount.com' });
+
+/** A row as Drizzle would return it. */
+function row(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'row-1',
+    localEnabled: true,
+    remoteEnabled: false,
+    remoteUrl: null,
+    remoteAuth: 'google_id_token',
+    saKeyEncrypted: null,
+    defaultExecutor: 'local',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    updatedByUserId: null,
+    ...over,
+  };
+}
+
+function mockSelect(rows: unknown[]) {
+  db.select.mockReturnValue({
+    from: jest.fn().mockReturnValue({ limit: jest.fn().mockResolvedValue(rows) }),
+  });
+}
+function mockSelectThrows(err: Error) {
+  db.select.mockReturnValue({
+    from: jest.fn().mockReturnValue({ limit: jest.fn().mockRejectedValue(err) }),
+  });
+}
+
+function make(o: {
+  env?: NodeJS.ProcessEnv;
+  presign?: boolean;
+  localAvailable?: boolean;
+} = {}) {
+  const storage = {
+    getUrl: async () => 'https://bucket.example.com/x?sig=1',
+    ...(o.presign === false ? {} : { supportsPresignedUrls: () => true, getPresignedUploadUrl: async () => 'https://bucket.example.com/x?put=1' }),
+  };
+  const capability = {
+    isAvailable: () => o.localAvailable ?? true,
+    getVersion: () => (o.localAvailable ?? true ? 'ffmpeg version 6.1.1' : null),
+  };
+  const service = new FfmpegExecutorSettingsService(storage as never, capability as never, () => o.env ?? {});
+  return { service, storage, capability };
+}
+
+describe('FfmpegExecutorSettingsService', () => {
+  let originalKey: string | undefined;
+  beforeEach(() => {
+    originalKey = process.env.ENCRYPTION_KEY;
+    process.env.ENCRYPTION_KEY = TEST_KEY;
+    __resetKeyForTests();
+    jest.clearAllMocks();
+  });
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = originalKey;
+    __resetKeyForTests();
+  });
+
+  describe('resolved()', () => {
+    it('with no row behaves exactly like readFfmpegEnv (Plan 1 semantics)', async () => {
+      mockSelect([]);
+      const { service } = make({ env: { FFMPEG_REMOTE_URL: 'https://w.example.com' } });
+      await service.reload();
+      const cfg = service.resolved();
+      expect(cfg.localEnabled).toBe(true);
+      expect(cfg.remoteEnabled).toBe(true);
+      expect(cfg.remoteUrl).toBe('https://w.example.com');
+      expect(cfg.executor).toBe('local');
+    });
+
+    it('DB row fills fields env leaves unset; the SA key is decrypted into memory', async () => {
+      mockSelect([
+        row({
+          localEnabled: false,
+          remoteEnabled: true,
+          remoteUrl: 'https://db.example.com/',
+          remoteAuth: 'none',
+          saKeyEncrypted: encryptString(SA_KEY),
+          defaultExecutor: 'remote',
+        }),
+      ]);
+      const { service } = make();
+      await service.reload();
+      const cfg = service.resolved();
+      expect(cfg.localEnabled).toBe(false);
+      expect(cfg.remoteEnabled).toBe(true);
+      expect(cfg.remoteUrl).toBe('https://db.example.com'); // trailing slash stripped like env
+      expect(cfg.remoteAuth).toBe('none');
+      expect(cfg.remoteSaKeyJson).toBe(SA_KEY);
+      expect(cfg.executor).toBe('remote');
+    });
+
+    it('env wins per field, and FFMPEG_REMOTE_URL forces remoteEnabled', async () => {
+      mockSelect([
+        row({ remoteEnabled: false, remoteUrl: 'https://db.example.com', remoteAuth: 'none', defaultExecutor: 'remote', saKeyEncrypted: encryptString(SA_KEY) }),
+      ]);
+      const { service } = make({
+        env: {
+          FFMPEG_EXECUTOR: 'local',
+          FFMPEG_REMOTE_URL: 'https://env.example.com',
+          FFMPEG_REMOTE_AUTH: 'google_id_token',
+          FFMPEG_REMOTE_SA_KEY_JSON: '{"type":"service_account","env":true}',
+        },
+      });
+      await service.reload();
+      const cfg = service.resolved();
+      expect(cfg.executor).toBe('local');
+      expect(cfg.remoteEnabled).toBe(true);
+      expect(cfg.remoteUrl).toBe('https://env.example.com');
+      expect(cfg.remoteAuth).toBe('google_id_token');
+      expect(cfg.remoteSaKeyJson).toBe('{"type":"service_account","env":true}');
+      expect(service.envManaged()).toEqual({ defaultExecutor: true, remoteUrl: true, remoteAuth: true, saKey: true });
+    });
+
+    it("'' env values count as unset (compose passthrough)", async () => {
+      mockSelect([row({ remoteEnabled: true, remoteUrl: 'https://db.example.com', defaultExecutor: 'remote' })]);
+      const { service } = make({ env: { FFMPEG_EXECUTOR: '', FFMPEG_REMOTE_URL: '', FFMPEG_REMOTE_AUTH: '', FFMPEG_REMOTE_SA_KEY_JSON: '' } });
+      await service.reload();
+      expect(service.resolved().remoteUrl).toBe('https://db.example.com');
+      expect(service.envManaged()).toEqual({ defaultExecutor: false, remoteUrl: false, remoteAuth: false, saKey: false });
+    });
+
+    it('a missing table (pre-migration boot) is tolerated: env-only, no throw', async () => {
+      mockSelectThrows(new Error('relation "ffmpeg_executor_settings" does not exist'));
+      const { service } = make();
+      await expect(service.reload()).resolves.toBeUndefined();
+      expect(service.resolved().localEnabled).toBe(true);
+    });
+
+    it('an undecryptable key is treated as absent (does not poison the config)', async () => {
+      mockSelect([row({ saKeyEncrypted: 'not-a-ciphertext' })]);
+      const { service } = make();
+      await service.reload();
+      expect(service.resolved().remoteSaKeyJson).toBeNull();
+    });
+  });
+
+  describe('getStatus()', () => {
+    it('never includes the key; reports source + envManaged + storagePresignable', async () => {
+      mockSelect([row({ remoteEnabled: true, remoteUrl: 'https://db.example.com', saKeyEncrypted: encryptString(SA_KEY) })]);
+      const { service } = make();
+      await service.reload();
+      const status = await service.getStatus();
+      expect(JSON.stringify(status)).not.toContain('service_account');
+      expect(status).toEqual({
+        localAvailable: true,
+        localVersion: 'ffmpeg version 6.1.1',
+        localEnabled: true,
+        remoteEnabled: true,
+        remoteUrl: 'https://db.example.com',
+        remoteAuth: 'google_id_token',
+        hasSaKey: true,
+        saKeySource: 'db',
+        defaultExecutor: 'local',
+        storagePresignable: true,
+        envManaged: { defaultExecutor: false, remoteUrl: false, remoteAuth: false, saKey: false },
+      });
+    });
+
+    it("saKeySource is 'env' when FFMPEG_REMOTE_SA_KEY_JSON is set, storagePresignable false on local-FS", async () => {
+      mockSelect([]);
+      const { service } = make({ env: { FFMPEG_REMOTE_SA_KEY_JSON: SA_KEY }, presign: false });
+      await service.reload();
+      const status = await service.getStatus();
+      expect(status.hasSaKey).toBe(true);
+      expect(status.saKeySource).toBe('env');
+      expect(status.storagePresignable).toBe(false);
+    });
+  });
+
+  describe('update()', () => {
+    function mockWrite() {
+      const set = jest.fn().mockReturnValue({ where: jest.fn().mockResolvedValue(undefined) });
+      db.update.mockReturnValue({ set });
+      const values = jest.fn().mockResolvedValue(undefined);
+      db.insert.mockReturnValue({ values });
+      return { set, values };
+    }
+
+    it('inserts when no row exists, encrypts the key, refreshes the cache and returns status', async () => {
+      mockSelect([]);
+      const { values } = mockWrite();
+      const { service } = make();
+      await service.reload();
+      // After the write, reload() re-reads: return the row the write produced.
+      const status = await service.update(
+        { remoteEnabled: true, remoteUrl: 'https://w.example.com/', remoteAuth: 'google_id_token', defaultExecutor: 'remote', saKeyJson: SA_KEY },
+        'user-1',
+      ).catch((e) => { throw e; });
+      expect(values).toHaveBeenCalledTimes(1);
+      const inserted = values.mock.calls[0][0];
+      expect(inserted.remoteUrl).toBe('https://w.example.com');
+      expect(inserted.saKeyEncrypted).not.toContain('service_account');
+      expect(inserted.updatedByUserId).toBe('user-1');
+      expect(status.hasSaKey).toBe(true);
+      expect(status.defaultExecutor).toBe('remote');
+      expect(service.resolved().remoteSaKeyJson).toBe(SA_KEY);
+    });
+
+    it('updates the existing row; saKeyJson undefined keeps the stored key, null clears it', async () => {
+      const stored = encryptString(SA_KEY);
+      mockSelect([row({ remoteEnabled: true, remoteUrl: 'https://w.example.com', saKeyEncrypted: stored })]);
+      const { set } = mockWrite();
+      const { service } = make();
+      await service.reload();
+
+      await service.update({ remoteAuth: 'none' });
+      expect(set.mock.calls[0][0]).not.toHaveProperty('saKeyEncrypted');
+      expect(service.resolved().remoteSaKeyJson).toBe(SA_KEY);
+
+      await service.update({ saKeyJson: null });
+      expect(set.mock.calls[1][0].saKeyEncrypted).toBeNull();
+      expect(service.resolved().remoteSaKeyJson).toBeNull();
+    });
+
+    it('rejects: remote on without URL / bad URL / http with google_id_token / non-service-account key / default not enabled', async () => {
+      mockSelect([]);
+      mockWrite();
+      const { service } = make();
+      await service.reload();
+      await expect(service.update({ remoteEnabled: true, remoteUrl: null })).rejects.toBeInstanceOf(BadRequestException);
+      await expect(service.update({ remoteEnabled: true, remoteUrl: 'not a url' })).rejects.toBeInstanceOf(BadRequestException);
+      await expect(service.update({ remoteEnabled: true, remoteUrl: 'http://w.example.com', remoteAuth: 'google_id_token' })).rejects.toBeInstanceOf(BadRequestException);
+      await expect(service.update({ saKeyJson: '{"type":"authorized_user"}' })).rejects.toBeInstanceOf(BadRequestException);
+      await expect(service.update({ saKeyJson: '{not json' })).rejects.toBeInstanceOf(BadRequestException);
+      await expect(service.update({ defaultExecutor: 'remote' })).rejects.toBeInstanceOf(BadRequestException); // remote not enabled
+      await expect(service.update({ localEnabled: false })).rejects.toBeInstanceOf(BadRequestException); // default 'local' would not be enabled
+    });
+
+    it('http URL is fine with auth none; refuses Remote on non-presignable storage; refuses editing env-managed fields', async () => {
+      mockSelect([]);
+      mockWrite();
+      const ok = make();
+      await ok.service.reload();
+      await expect(ok.service.update({ remoteEnabled: true, remoteUrl: 'http://ffmpeg-worker:8080', remoteAuth: 'none' })).resolves.toBeDefined();
+
+      const localFs = make({ presign: false });
+      await localFs.service.reload();
+      await expect(localFs.service.update({ remoteEnabled: true, remoteUrl: 'https://w.example.com' })).rejects.toBeInstanceOf(BadRequestException);
+
+      const pinned = make({ env: { FFMPEG_REMOTE_URL: 'https://env.example.com' } });
+      await pinned.service.reload();
+      await expect(pinned.service.update({ remoteUrl: 'https://other.example.com' })).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/backend && pnpm jest src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts`
+Expected: FAIL — cannot find module `./ffmpeg-executor-settings.service`.
+
+- [ ] **Step 3: Implement the service**
+
+`apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts`:
+
+```ts
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  OnModuleInit,
+  Optional,
+} from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import { db } from '../../db/client';
+import { ffmpegExecutorSettings, type FfmpegExecutorSettingsRow } from '../../db/schema';
+import { decryptString, encryptString } from '../../common/crypto/aes-gcm';
+import { IStorageAdapter, STORAGE_ADAPTER } from '../../storage/storage.interface';
+import { FfmpegCapabilityService } from './ffmpeg-capability.service';
+import {
+  readFfmpegEnv,
+  type FfmpegEnvConfig,
+  type FfmpegExecutorSetting,
+  type FfmpegRemoteAuth,
+} from './ffmpeg-env';
+
+export interface FfmpegExecutorEnvManaged {
+  defaultExecutor: boolean;
+  remoteUrl: boolean;
+  remoteAuth: boolean;
+  saKey: boolean;
+}
+
+/** What the admin UI renders. The service-account key itself is NEVER part of this. */
+export interface FfmpegExecutorStatus {
+  localAvailable: boolean;
+  localVersion: string | null;
+  localEnabled: boolean;
+  remoteEnabled: boolean;
+  remoteUrl: string | null;
+  remoteAuth: FfmpegRemoteAuth;
+  hasSaKey: boolean;
+  saKeySource: 'db' | 'env' | null;
+  defaultExecutor: FfmpegExecutorSetting;
+  /** false on the local-FS adapter: a Worker cannot fetch CE-relative URLs (D3), so Remote cannot be enabled. */
+  storagePresignable: boolean;
+  envManaged: FfmpegExecutorEnvManaged;
+}
+
+export interface UpdateFfmpegExecutorInput {
+  localEnabled?: boolean;
+  remoteEnabled?: boolean;
+  remoteUrl?: string | null;
+  remoteAuth?: FfmpegRemoteAuth;
+  defaultExecutor?: FfmpegExecutorSetting;
+  /** undefined = keep the stored key; null = clear it; string = replace it. */
+  saKeyJson?: string | null;
+}
+
+/** The decrypted, in-memory shape of the DB row. */
+interface CachedSettings {
+  localEnabled: boolean;
+  remoteEnabled: boolean;
+  remoteUrl: string | null;
+  remoteAuth: FfmpegRemoteAuth;
+  saKeyJson: string | null;
+  defaultExecutor: FfmpegExecutorSetting;
+}
+
+/** '' counts as unset — compose passthrough materialises unconfigured vars as ''. */
+function envSet(env: NodeJS.ProcessEnv, key: string): boolean {
+  return (env[key] ?? '').trim() !== '';
+}
+
+/** Same normalisation `ffmpeg-env.ts` applies to FFMPEG_REMOTE_URL. */
+function normaliseUrl(raw: string | null | undefined): string | null {
+  if (raw === undefined || raw === null) return null;
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  return trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
+}
+
+/**
+ * Admin-editable executor configuration (spec §1.5). One DB row, decrypted into
+ * memory at boot and after every save so the executors can read it SYNCHRONOUSLY
+ * through `resolved()` — the same `FfmpegEnvConfig` shape `readFfmpegEnv()` returns,
+ * with env winning over the DB per field (FFMPEG_EXECUTOR, FFMPEG_REMOTE_URL,
+ * FFMPEG_REMOTE_AUTH, FFMPEG_REMOTE_SA_KEY_JSON). CE runs one backend process per
+ * instance, so an in-process cache refreshed on write is sufficient.
+ */
+@Injectable()
+export class FfmpegExecutorSettingsService implements OnModuleInit {
+  private readonly logger = new Logger(FfmpegExecutorSettingsService.name);
+  private cached: CachedSettings | null = null;
+  private warnedMissing = false;
+
+  constructor(
+    @Inject(STORAGE_ADAPTER) private readonly storageAdapter: IStorageAdapter,
+    private readonly capability: FfmpegCapabilityService,
+    /** Test seam: the process env to read. */
+    @Optional() private readonly processEnv: () => NodeJS.ProcessEnv = () => process.env,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    if (process.env.NODE_ENV === 'test') return;
+    await this.reload();
+  }
+
+  /** DB → cache. A missing table (instance not yet migrated) or a DB error leaves the cache empty = env-only. */
+  async reload(): Promise<void> {
+    let row: FfmpegExecutorSettingsRow | undefined;
+    try {
+      const rows = await db.select().from(ffmpegExecutorSettings).limit(1);
+      row = rows[0];
+    } catch (error) {
+      if (!this.warnedMissing) {
+        this.warnedMissing = true;
+        this.logger.warn({
+          event: 'ffmpeg_executor_settings_unavailable',
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      this.cached = null;
+      return;
+    }
+    this.cached = row ? this.decode(row) : null;
+  }
+
+  private decode(row: FfmpegExecutorSettingsRow): CachedSettings {
+    let saKeyJson: string | null = null;
+    if (row.saKeyEncrypted) {
+      try {
+        saKeyJson = decryptString(row.saKeyEncrypted);
+      } catch (error) {
+        this.logger.error({
+          event: 'ffmpeg_executor_sa_key_undecryptable',
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    return {
+      localEnabled: row.localEnabled,
+      remoteEnabled: row.remoteEnabled,
+      remoteUrl: normaliseUrl(row.remoteUrl),
+      remoteAuth: row.remoteAuth === 'none' ? 'none' : 'google_id_token',
+      saKeyJson,
+      defaultExecutor: row.defaultExecutor === 'remote' ? 'remote' : 'local',
+    };
+  }
+
+  envManaged(): FfmpegExecutorEnvManaged {
+    const env = this.processEnv();
+    return {
+      defaultExecutor: envSet(env, 'FFMPEG_EXECUTOR'),
+      remoteUrl: envSet(env, 'FFMPEG_REMOTE_URL'),
+      remoteAuth: envSet(env, 'FFMPEG_REMOTE_AUTH'),
+      saKey: envSet(env, 'FFMPEG_REMOTE_SA_KEY_JSON'),
+    };
+  }
+
+  /** The effective config: env over the cached DB row. Synchronous by design (executors call it per job). */
+  resolved(): FfmpegEnvConfig {
+    const env = readFfmpegEnv(this.processEnv());
+    const row = this.cached;
+    if (!row) return env;
+    const managed = this.envManaged();
+    const remoteUrl = managed.remoteUrl ? env.remoteUrl : row.remoteUrl;
+    return {
+      ...env,
+      localEnabled: row.localEnabled,
+      remoteEnabled: managed.remoteUrl ? true : row.remoteEnabled,
+      remoteUrl,
+      remoteAuth: managed.remoteAuth ? env.remoteAuth : row.remoteAuth,
+      remoteSaKeyJson: managed.saKey ? env.remoteSaKeyJson : row.saKeyJson,
+      executor: managed.defaultExecutor ? env.executor : row.defaultExecutor,
+    };
+  }
+
+  private storagePresignable(): boolean {
+    return typeof this.storageAdapter.getPresignedUploadUrl === 'function' && this.storageAdapter.supportsPresignedUrls?.() === true;
+  }
+
+  async getStatus(): Promise<FfmpegExecutorStatus> {
+    const cfg = this.resolved();
+    const managed = this.envManaged();
+    return {
+      localAvailable: this.capability.isAvailable(),
+      localVersion: this.capability.getVersion(),
+      localEnabled: cfg.localEnabled,
+      remoteEnabled: cfg.remoteEnabled,
+      remoteUrl: cfg.remoteUrl,
+      remoteAuth: cfg.remoteAuth,
+      hasSaKey: cfg.remoteSaKeyJson !== null,
+      saKeySource: cfg.remoteSaKeyJson === null ? null : managed.saKey ? 'env' : 'db',
+      defaultExecutor: cfg.executor,
+      storagePresignable: this.storagePresignable(),
+      envManaged: managed,
+    };
+  }
+
+  /**
+   * Validate → upsert → reload → status. Partial: only the provided fields change.
+   * `saKeyJson`: undefined keeps the stored key, null clears it, a string replaces it.
+   */
+  async update(input: UpdateFfmpegExecutorInput, userId?: string): Promise<FfmpegExecutorStatus> {
+    const managed = this.envManaged();
+    if (input.remoteUrl !== undefined && managed.remoteUrl) {
+      throw new BadRequestException('Worker URL is managed by FFMPEG_REMOTE_URL on this instance.');
+    }
+    if (input.remoteAuth !== undefined && managed.remoteAuth) {
+      throw new BadRequestException('Auth mode is managed by FFMPEG_REMOTE_AUTH on this instance.');
+    }
+    if (input.saKeyJson !== undefined && managed.saKey) {
+      throw new BadRequestException('The service-account key is managed by FFMPEG_REMOTE_SA_KEY_JSON on this instance.');
+    }
+    if (input.defaultExecutor !== undefined && managed.defaultExecutor) {
+      throw new BadRequestException('The default executor is managed by FFMPEG_EXECUTOR on this instance.');
+    }
+
+    const current: CachedSettings = this.cached ?? {
+      localEnabled: true,
+      remoteEnabled: false,
+      remoteUrl: null,
+      remoteAuth: 'google_id_token',
+      saKeyJson: null,
+      defaultExecutor: 'local',
+    };
+    const next: CachedSettings = {
+      localEnabled: input.localEnabled ?? current.localEnabled,
+      remoteEnabled: input.remoteEnabled ?? current.remoteEnabled,
+      remoteUrl: input.remoteUrl === undefined ? current.remoteUrl : normaliseUrl(input.remoteUrl),
+      remoteAuth: input.remoteAuth ?? current.remoteAuth,
+      saKeyJson: input.saKeyJson === undefined ? current.saKeyJson : input.saKeyJson,
+      defaultExecutor: input.defaultExecutor ?? current.defaultExecutor,
+    };
+
+    if (input.remoteAuth !== undefined && input.remoteAuth !== 'google_id_token' && input.remoteAuth !== 'none') {
+      throw new BadRequestException("Auth mode must be 'google_id_token' or 'none'.");
+    }
+    if (input.defaultExecutor !== undefined && input.defaultExecutor !== 'local' && input.defaultExecutor !== 'remote') {
+      throw new BadRequestException("Default executor must be 'local' or 'remote'.");
+    }
+    if (typeof next.saKeyJson === 'string') {
+      next.saKeyJson = next.saKeyJson.trim();
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(next.saKeyJson);
+      } catch {
+        throw new BadRequestException('Service-account key must be valid JSON.');
+      }
+      if (!parsed || typeof parsed !== 'object' || (parsed as { type?: unknown }).type !== 'service_account') {
+        throw new BadRequestException('Service-account key must be a Google service-account JSON key ("type": "service_account").');
+      }
+    }
+
+    // Validate the EFFECTIVE config (env pins applied) so a save can never leave the
+    // instance in a state the selector would refuse.
+    const effective = this.effectiveOf(next);
+    if (effective.remoteEnabled) {
+      if (!effective.remoteUrl) throw new BadRequestException('Remote executor needs a Worker URL.');
+      let url: URL;
+      try {
+        url = new URL(effective.remoteUrl);
+      } catch {
+        throw new BadRequestException(`Worker URL is not a valid URL: ${effective.remoteUrl}`);
+      }
+      if (effective.remoteAuth !== 'none' && url.protocol !== 'https:') {
+        throw new BadRequestException('Worker URL must be https:// when auth is Google ID token (use auth "none" only on a private network).');
+      }
+      if (!this.storagePresignable()) {
+        throw new BadRequestException('Remote executor needs bucket storage (S3, GCS, MinIO or Azure) — the Worker fetches inputs and uploads outputs via signed URLs, which local filesystem storage cannot provide.');
+      }
+    }
+    const enabled: FfmpegExecutorSetting[] = [];
+    if (this.capability.isAvailable() && effective.localEnabled) enabled.push('local');
+    if (effective.remoteEnabled && effective.remoteUrl) enabled.push('remote');
+    if (!enabled.includes(effective.executor)) {
+      throw new BadRequestException(
+        enabled.length === 0
+          ? 'At least one executor must be enabled (Local needs ffmpeg installed on this server; Remote needs a Worker URL).'
+          : `Default executor '${effective.executor}' is not enabled — pick one of: ${enabled.join(', ')}.`,
+      );
+    }
+
+    await this.persist(next, input.saKeyJson !== undefined, userId);
+    await this.reload();
+    return this.getStatus();
+  }
+
+  /** `resolved()` for a candidate row instead of the cached one. */
+  private effectiveOf(row: CachedSettings): FfmpegEnvConfig {
+    const saved = this.cached;
+    this.cached = row;
+    try {
+      return this.resolved();
+    } finally {
+      this.cached = saved;
+    }
+  }
+
+  private async persist(next: CachedSettings, keyChanged: boolean, userId?: string): Promise<void> {
+    const base = {
+      localEnabled: next.localEnabled,
+      remoteEnabled: next.remoteEnabled,
+      remoteUrl: next.remoteUrl,
+      remoteAuth: next.remoteAuth,
+      defaultExecutor: next.defaultExecutor,
+      updatedAt: new Date(),
+      updatedByUserId: userId ?? null,
+    };
+    const keyPatch = keyChanged
+      ? { saKeyEncrypted: next.saKeyJson === null ? null : encryptString(next.saKeyJson) }
+      : {};
+    try {
+      const existing = (await db.select().from(ffmpegExecutorSettings).limit(1))[0];
+      if (existing) {
+        await db
+          .update(ffmpegExecutorSettings)
+          .set({ ...base, ...keyPatch })
+          .where(eq(ffmpegExecutorSettings.id, existing.id));
+      } else {
+        await db.insert(ffmpegExecutorSettings).values({
+          ...base,
+          saKeyEncrypted: next.saKeyJson === null ? null : encryptString(next.saKeyJson),
+        });
+      }
+    } catch (error) {
+      this.logger.error({
+        event: 'ffmpeg_executor_settings_persist_failed',
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new InternalServerErrorException('Failed to save executor settings.');
+    }
+  }
+}
+```
+
+Note for the implementer: `IStorageAdapter.supportsPresignedUrls` and `getPresignedUploadUrl` are optional members — check `apps/backend/src/storage/storage.interface.ts` for the exact names before relying on them (the RemoteFfmpegExecutor uses `getPresignedUploadUrl` and `supportsPresignedUrls?.()` already; mirror it).
+
+- [ ] **Step 4: Run the spec until green; then the whole ffmpeg tree**
+
+Run: `cd apps/backend && pnpm jest src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts`
+Expected: PASS. If the `update` "inserts when no row exists" test fails on `reload()` after write (the mocked select still returns `[]`), that is expected — extend the test's `mockSelect` so the second `select` returns the inserted row: use `db.select.mockReturnValueOnce(...)` for the initial `[]`, then a `mockReturnValue` with the persisted row (`row({remoteEnabled:true, remoteUrl:'https://w.example.com', defaultExecutor:'remote', saKeyEncrypted: encryptString(SA_KEY)})`). Keep the assertions.
+
+Then: `pnpm jest --testPathPattern 'src/.*ffmpeg'` → all PASS.
+
+- [ ] **Step 5: Lint the two files and commit**
+
+```bash
+cd apps/backend && npx eslint src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts
+git add src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts
+git commit -m "feat(ffmpeg): FfmpegExecutorSettingsService — DB-backed executor config, env wins per field, write-only encrypted SA key"
+```
+
+---
+
+### Task 3: Wire the resolved config into the selector + remote executor (Nest tokens)
+
+**Files:**
+- Create: `apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-config.tokens.ts`
+- Modify: `apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-executor.selector.ts`
+- Modify: `apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.ts` (constructor only in this task)
+- Modify: `apps/backend/src/pipelines/pipelines.module.ts`
+- Test (add cases): `apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-executor.selector.spec.ts`
+
+**Interfaces:**
+- Consumes: `FfmpegExecutorSettingsService.resolved()` (Task 2), `FfmpegEnvConfig.localEnabled/remoteEnabled` (Task 1).
+- Produces: tokens `FFMPEG_CONFIG` (provides `() => FfmpegEnvConfig`) and `FFMPEG_REMOTE_DEPS` (provides `{ env: () => FfmpegEnvConfig }`); selector `enabled()` honours the two bits.
+
+- [ ] **Step 1: Add failing selector tests**
+
+Append to `apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-executor.selector.spec.ts` (the file's `make()` helper builds the selector from `readFfmpegEnv(envOver)`; add a variant that overrides the config object — read the helper first and add an optional `cfg?: Partial<FfmpegEnvConfig>` merged over `env`, i.e. `const env = { ...readFfmpegEnv(envOver), ...(o.cfg ?? {}) }`):
+
+```ts
+it('enabled(): localEnabled=false hides local even with binaries; remoteEnabled=false hides remote even with a URL', () => {
+  expect(make({ cfg: { localEnabled: false } }).selector.enabled()).toEqual([]);
+  expect(
+    make({ cfg: { remoteEnabled: false, remoteUrl: 'https://w.example.com' } }).selector.enabled(),
+  ).toEqual(['local']);
+  expect(
+    make({ cfg: { localEnabled: false, remoteEnabled: true, remoteUrl: 'https://w.example.com' } }).selector.enabled(),
+  ).toEqual(['remote']);
+});
+
+it("pick('remote') when remote is switched off says so without pointing only at the env var", async () => {
+  const { selector } = make({ cfg: { remoteEnabled: false } });
+  await expect(selector.pick('remote')).rejects.toThrow(/not enabled on this instance/);
+});
+```
+
+- [ ] **Step 2: Run to verify the first fails**
+
+Run: `cd apps/backend && pnpm jest src/pipelines/ffmpeg/executor/ffmpeg-executor.selector.spec.ts`
+Expected: the `localEnabled=false` assertion FAILS (`['local']` returned).
+
+- [ ] **Step 3: Tokens file**
+
+`apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-config.tokens.ts`:
+
+```ts
+import type { FfmpegEnvConfig } from '../ffmpeg-env';
+
+/**
+ * DI tokens through which the executors receive the EFFECTIVE ffmpeg config —
+ * env merged over the admin-saved DB row (FfmpegExecutorSettingsService.resolved()).
+ * Both are @Optional() at the injection sites and default to plain readFfmpegEnv(),
+ * so unit tests and older wiring keep working unchanged.
+ */
+export const FFMPEG_CONFIG = Symbol('FFMPEG_CONFIG');
+export type FfmpegConfigResolver = () => FfmpegEnvConfig;
+
+export const FFMPEG_REMOTE_DEPS = Symbol('FFMPEG_REMOTE_DEPS');
+export interface FfmpegRemoteDeps {
+  env?: FfmpegConfigResolver;
+}
+```
+
+- [ ] **Step 4: Selector changes**
+
+In `ffmpeg-executor.selector.ts`:
+- imports: add `Inject` to the `@nestjs/common` import; `import { FFMPEG_CONFIG, type FfmpegConfigResolver } from './ffmpeg-config.tokens';`
+- constructor last param becomes: `@Optional() @Inject(FFMPEG_CONFIG) private readonly env: FfmpegConfigResolver = readFfmpegEnv,`
+- `enabled()`:
+
+```ts
+  /** Executors an operator has enabled: local iff binaries present AND localEnabled; remote iff remoteEnabled AND a Worker URL. */
+  enabled(): FfmpegExecutorName[] {
+    const cfg = this.env();
+    const names: FfmpegExecutorName[] = [];
+    if (this.capability.isAvailable() && cfg.localEnabled) names.push('local');
+    if (cfg.remoteEnabled && cfg.remoteUrl) names.push('remote');
+    return names;
+  }
+```
+
+- in `pick()`, replace the remote message string with: `"ffmpeg_handler: executor 'remote' is not enabled on this instance (enable it in Admin Settings → Features → Server video ops, or set FFMPEG_REMOTE_URL)"`. Keep the local one.
+
+- [ ] **Step 5: RemoteFfmpegExecutor constructor**
+
+In `remote-ffmpeg.executor.ts`: import `FFMPEG_REMOTE_DEPS` from `'../ffmpeg-config.tokens'`; change the constructor's second parameter to `@Optional() @Inject(FFMPEG_REMOTE_DEPS) deps: Deps = {},` (keep the `Deps` interface as is — it is a superset of `FfmpegRemoteDeps`). Nothing else changes in this task.
+
+- [ ] **Step 6: Module wiring**
+
+In `apps/backend/src/pipelines/pipelines.module.ts`: import `FfmpegExecutorSettingsService` from `'./ffmpeg/ffmpeg-executor-settings.service'` and `FFMPEG_CONFIG, FFMPEG_REMOTE_DEPS` from `'./ffmpeg/executor/ffmpeg-config.tokens'`. In `providers`, next to `RemoteFfmpegExecutor, FfmpegExecutorSelector,` add:
+
+```ts
+    FfmpegExecutorSettingsService,
+    {
+      provide: FFMPEG_CONFIG,
+      useFactory: (settings: FfmpegExecutorSettingsService) => () => settings.resolved(),
+      inject: [FfmpegExecutorSettingsService],
+    },
+    {
+      provide: FFMPEG_REMOTE_DEPS,
+      useFactory: (settings: FfmpegExecutorSettingsService) => ({ env: () => settings.resolved() }),
+      inject: [FfmpegExecutorSettingsService],
+    },
+```
+
+Add `FfmpegExecutorSettingsService` to `exports` too (harmless, lets a future module reuse it).
+
+- [ ] **Step 7: Tests green + type-check + boot smoke**
+
+Run: `cd apps/backend && pnpm jest --testPathPattern 'src/.*ffmpeg' && npx tsc --noEmit -p tsconfig.json`
+Expected: PASS / no errors. Also confirm Nest can build the module graph: `pnpm jest src/pipelines/handlers/ffmpeg.handler.spec.ts` PASS (it constructs the handler by hand, so additionally run `pnpm build` (`nest build`) to make sure the DI decorators compile).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-config.tokens.ts apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-executor.selector.ts apps/backend/src/pipelines/ffmpeg/executor/ffmpeg-executor.selector.spec.ts apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.ts apps/backend/src/pipelines/pipelines.module.ts
+git commit -m "feat(ffmpeg): selector + remote executor read the admin-resolved config (FFMPEG_CONFIG / FFMPEG_REMOTE_DEPS)"
+```
+
+---
+
+### Task 4: Test connection — fresh readiness + draft overrides
+
+**Files:**
+- Modify: `apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.ts` (`ready`, `testConnection`)
+- Modify: `apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.ts` (add `testConnection`)
+- Test (add cases): `apps/backend/src/pipelines/ffmpeg/executor/remote/remote-ffmpeg.executor.spec.ts`, `apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.service.spec.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  // RemoteFfmpegExecutor
+  ready(opts?: { fresh?: boolean; env?: FfmpegEnvConfig }): Promise<FfmpegExecutorReadiness>;
+  testConnection(overrides?: Partial<Pick<FfmpegEnvConfig, 'remoteUrl' | 'remoteAuth' | 'remoteSaKeyJson'>>): Promise<WorkerHealth>;
+  // FfmpegExecutorSettingsService
+  testConnection(draft?: { remoteUrl?: string | null; remoteAuth?: 'google_id_token'|'none'; saKeyJson?: string | null }): Promise<FfmpegExecutorTestResult>;
+  interface FfmpegExecutorTestResult {
+    ok: boolean;                                   // health ok && readiness ok
+    latencyMs: number | null;                      // healthz round trip; null when unreachable
+    worker?: { version: string; ffmpeg: string | null; ops: string[]; uptimeS: number };
+    error?: string;                                // why /healthz failed
+    readiness: { ok: boolean; reason?: string };   // the selector's remote.reason for the same config
+    credential: 'sa_key' | 'adc' | 'none';         // 'adc' = google_id_token with no key stored
+  }
+  ```
+
+- [ ] **Step 1: Failing executor tests**
+
+Append to `remote-ffmpeg.executor.spec.ts` (its helper builds `new RemoteFfmpegExecutor(storage as never, { env, clientFactory, now })` — reuse it; look at how it fakes `WorkerClient.health()`):
+
+```ts
+it('ready({fresh:true}) bypasses the readiness cache and ready({env}) evaluates a candidate config', async () => {
+  const health = jest.fn(async () => ({ ok: true, version: '0.4.31', ffmpeg: 'ffmpeg version 6.1.1', ops: ['probe'], uptimeS: 1 }));
+  const { executor } = makeExecutor({ health }); // adapt to the file's helper name/shape
+  await executor.ready();
+  await executor.ready();
+  expect(health).toHaveBeenCalledTimes(1); // cached
+  await executor.ready({ fresh: true });
+  expect(health).toHaveBeenCalledTimes(2);
+  const candidate = { ...readFfmpegEnv({ FFMPEG_REMOTE_URL: 'https://other.example.com' }) };
+  const r = await executor.ready({ env: candidate });
+  expect(r.ok).toBe(true);
+});
+
+it('testConnection(overrides) hits the Worker at the override URL, uncached', async () => {
+  const seen: string[] = [];
+  const { executor } = makeExecutor({
+    clientFactory: (env) => { seen.push(env.remoteUrl!); return fakeClient(); }, // adapt to helper
+  });
+  await executor.testConnection({ remoteUrl: 'https://draft.example.com' });
+  expect(seen).toContain('https://draft.example.com');
+});
+```
+
+(If the file's helpers don't expose a `health` spy / `clientFactory` hook, add the smallest option to the helper — do not rewrite existing tests.)
+
+- [ ] **Step 2: Run → FAIL** (`ready` ignores the argument; `testConnection` ignores overrides).
+
+- [ ] **Step 3: Implement in `remote-ffmpeg.executor.ts`**
+
+Replace the `ready()` signature/head with:
+
+```ts
+  async ready(opts: { fresh?: boolean; env?: FfmpegEnvConfig } = {}): Promise<FfmpegExecutorReadiness> {
+    const env = opts.env ?? this.env();
+    if (!env.remoteUrl) return { ok: false, reason: 'no Worker URL configured (Admin Settings → Server video ops → Executor, or FFMPEG_REMOTE_URL)' };
+    ...
+    const entry = opts.fresh || opts.env ? this.freshEntry(env) : this.cacheEntry(env);
+```
+
+and add next to `cacheEntry`:
+
+```ts
+  /** An entry nobody else sees — for Test connection and candidate configs. */
+  private freshEntry(env: FfmpegEnvConfig): CacheEntry {
+    return { key: this.identity(env), at: this.now() };
+  }
+```
+
+Note: `entry.storage ??= …` / `entry.health ??= …` in the existing body keep working against the fresh entry. Also update the existing spec assertion that matched `'FFMPEG_REMOTE_URL is not set'` if there is one (only its expected string; search the spec for it).
+
+Replace `testConnection`:
+
+```ts
+  /** Uncached liveness check for the settings "Test connection" button; `overrides` = the unsaved form draft. */
+  async testConnection(
+    overrides: Partial<Pick<FfmpegEnvConfig, 'remoteUrl' | 'remoteAuth' | 'remoteSaKeyJson'>> = {},
+  ): Promise<WorkerHealth> {
+    const env: FfmpegEnvConfig = { ...this.env(), ...overrides };
+    if (!env.remoteUrl) throw new FfmpegExecutorUnavailableError('no Worker URL configured');
+    // Never memoise a draft's client over the live one — a draft may carry a different key.
+    const client = Object.keys(overrides).length ? this.clientFactory(env) : this.clientFor(env);
+    return client.health();
+  }
+```
+
+- [ ] **Step 4: Failing settings-service test**
+
+Append to `ffmpeg-executor-settings.service.spec.ts` a `describe('testConnection()')`. The service needs the `RemoteFfmpegExecutor` — add it as a 4th constructor param (`@Optional()` so Task 2's tests that pass 3 args keep compiling; update `make()` in the spec to pass a fake `remote`):
+
+```ts
+  describe('testConnection()', () => {
+    function makeWithRemote(o: { health?: () => Promise<any>; readiness?: { ok: boolean; reason?: string }; env?: NodeJS.ProcessEnv } = {}) {
+      const remote = {
+        testConnection: jest.fn(o.health ?? (async () => ({ ok: true, version: '0.4.31', ffmpeg: 'ffmpeg version 6.1.1', ops: ['probe', 'extract_audio', 'slice', 'concat'], uptimeS: 12 }))),
+        ready: jest.fn(async () => o.readiness ?? { ok: true, version: '0.4.31' }),
+      };
+      const { service } = make({ env: o.env });
+      (service as any).remote = remote; // or pass via constructor — match the implementation
+      return { service, remote };
+    }
+
+    it('returns worker health + latency + readiness; credential=adc when no key stored', async () => {
+      mockSelect([row({ remoteEnabled: true, remoteUrl: 'https://w.example.com' })]);
+      const { service, remote } = makeWithRemote();
+      await service.reload();
+      const res = await service.testConnection();
+      expect(res.ok).toBe(true);
+      expect(res.worker?.version).toBe('0.4.31');
+      expect(res.worker?.ops).toContain('slice');
+      expect(typeof res.latencyMs).toBe('number');
+      expect(res.readiness).toEqual({ ok: true });
+      expect(res.credential).toBe('adc');
+      expect(remote.ready).toHaveBeenCalledWith(expect.objectContaining({ fresh: true }));
+    });
+
+    it('draft overrides reach the executor; env-managed fields cannot be overridden; credential reflects the draft key', async () => {
+      mockSelect([]);
+      const { service, remote } = makeWithRemote({ env: { FFMPEG_REMOTE_AUTH: 'none' } });
+      await service.reload();
+      const res = await service.testConnection({ remoteUrl: 'https://draft.example.com', remoteAuth: 'google_id_token', saKeyJson: SA_KEY });
+      expect(remote.testConnection).toHaveBeenCalledWith(expect.objectContaining({ remoteUrl: 'https://draft.example.com', remoteSaKeyJson: SA_KEY }));
+      expect(remote.testConnection.mock.calls[0][0]).not.toHaveProperty('remoteAuth'); // pinned by env
+      expect(res.credential).toBe('none'); // effective auth is env's 'none'
+    });
+
+    it('unreachable worker → ok:false with error, latency null, readiness reason passed through', async () => {
+      mockSelect([row({ remoteEnabled: true, remoteUrl: 'https://w.example.com' })]);
+      const { service } = makeWithRemote({
+        health: async () => { throw new Error('worker unreachable: connect ECONNREFUSED'); },
+        readiness: { ok: false, reason: 'worker unreachable: connect ECONNREFUSED' },
+      });
+      await service.reload();
+      const res = await service.testConnection();
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/ECONNREFUSED/);
+      expect(res.latencyMs).toBeNull();
+      expect(res.readiness.reason).toMatch(/ECONNREFUSED/);
+    });
+  });
+```
+
+- [ ] **Step 5: Implement `testConnection` in the settings service**
+
+Constructor gains `@Optional() private readonly remote?: RemoteFfmpegExecutor,` as the 4th parameter (import from `./executor/remote/remote-ffmpeg.executor`). Beware circular import: `remote-ffmpeg.executor.ts` must NOT import the settings service (it doesn't — it only imports the tokens). Add:
+
+```ts
+export interface FfmpegExecutorTestDraft {
+  remoteUrl?: string | null;
+  remoteAuth?: FfmpegRemoteAuth;
+  saKeyJson?: string | null;
+}
+
+export interface FfmpegExecutorTestResult {
+  ok: boolean;
+  latencyMs: number | null;
+  worker?: { version: string; ffmpeg: string | null; ops: string[]; uptimeS: number };
+  error?: string;
+  readiness: { ok: boolean; reason?: string };
+  credential: 'sa_key' | 'adc' | 'none';
+}
+```
+
+and the method:
+
+```ts
+  /**
+   * Uncached "Test connection" for the admin UI. `draft` is the unsaved form; env-managed
+   * fields are ignored (env wins). Reports both the raw /healthz answer and what the
+   * selector's readiness check says about the same config, so the UI can show
+   * "reachable but not usable" (e.g. version too old, storage not presignable).
+   */
+  async testConnection(draft: FfmpegExecutorTestDraft = {}): Promise<FfmpegExecutorTestResult> {
+    if (!this.remote) throw new InternalServerErrorException('Remote executor is not wired.');
+    const managed = this.envManaged();
+    const overrides: Partial<Pick<FfmpegEnvConfig, 'remoteUrl' | 'remoteAuth' | 'remoteSaKeyJson'>> = {};
+    if (draft.remoteUrl !== undefined && !managed.remoteUrl) overrides.remoteUrl = normaliseUrl(draft.remoteUrl);
+    if (draft.remoteAuth !== undefined && !managed.remoteAuth) overrides.remoteAuth = draft.remoteAuth;
+    if (draft.saKeyJson !== undefined && !managed.saKey) overrides.remoteSaKeyJson = draft.saKeyJson === null ? null : draft.saKeyJson.trim();
+
+    const effective: FfmpegEnvConfig = { ...this.resolved(), ...overrides };
+    const credential: FfmpegExecutorTestResult['credential'] =
+      effective.remoteAuth === 'none' ? 'none' : effective.remoteSaKeyJson ? 'sa_key' : 'adc';
+
+    let worker: FfmpegExecutorTestResult['worker'];
+    let error: string | undefined;
+    let latencyMs: number | null = null;
+    const t0 = Date.now();
+    try {
+      const health = await this.remote.testConnection(overrides);
+      latencyMs = Date.now() - t0;
+      worker = { version: health.version, ffmpeg: health.ffmpeg, ops: health.ops, uptimeS: health.uptimeS };
+      if (!health.ok) error = 'worker reports not ok (no ffmpeg binary?)';
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+    const readiness = await this.remote.ready({ fresh: true, env: effective });
+    return {
+      ok: !error && readiness.ok,
+      latencyMs,
+      ...(worker ? { worker } : {}),
+      ...(error ? { error } : {}),
+      readiness: { ok: readiness.ok, ...(readiness.reason ? { reason: readiness.reason } : {}) },
+      credential,
+    };
+  }
+```
+
+Also update the spec's `make()` to construct with the fake remote as 4th arg instead of the `(service as any).remote` poke (do whichever keeps the spec honest — the constructor route is preferred).
+
+- [ ] **Step 6: Run everything**
+
+Run: `cd apps/backend && pnpm jest --testPathPattern 'src/.*ffmpeg' && npx tsc --noEmit -p tsconfig.json`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/backend/src/pipelines/ffmpeg
+git commit -m "feat(ffmpeg): Test connection — uncached worker health + fresh readiness for a settings draft"
+```
+
+---
+
+### Task 5: Admin endpoints (`/api/settings/ffmpeg-executor`)
+
+**Files:**
+- Create: `apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.controller.ts`
+- Create: `apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.controller.spec.ts`
+- Modify: `apps/backend/src/pipelines/pipelines.module.ts` (controllers)
+
+**Interfaces:**
+- Consumes: `FfmpegExecutorSettingsService.getStatus/update/testConnection` (Tasks 2, 4); guards `ApiKeyGuard, RolesGuard, Roles, CurrentUser` from `'../../auth'`.
+- Produces HTTP:
+  - `GET /api/settings/ffmpeg-executor` → `FfmpegExecutorStatus` (admin)
+  - `PUT /api/settings/ffmpeg-executor` body `UpdateFfmpegExecutorInput` → `FfmpegExecutorStatus` (admin)
+  - `POST /api/settings/ffmpeg-executor/test` body `FfmpegExecutorTestDraft` → `FfmpegExecutorTestResult` (admin)
+
+- [ ] **Step 1: Failing controller test**
+
+`ffmpeg-executor-settings.controller.spec.ts`:
+
+```ts
+import { FfmpegExecutorSettingsController } from './ffmpeg-executor-settings.controller';
+
+describe('FfmpegExecutorSettingsController', () => {
+  const service = {
+    getStatus: jest.fn(async () => ({ hasSaKey: false })),
+    update: jest.fn(async () => ({ hasSaKey: true })),
+    testConnection: jest.fn(async () => ({ ok: true })),
+  };
+  const controller = new FfmpegExecutorSettingsController(service as never);
+
+  it('GET returns status', async () => {
+    await expect(controller.getStatus()).resolves.toEqual({ hasSaKey: false });
+  });
+
+  it('PUT forwards the body + user id and returns the new status', async () => {
+    const body = { remoteEnabled: true, remoteUrl: 'https://w.example.com', saKeyJson: '{"type":"service_account"}' };
+    await expect(controller.update(body, { id: 'u1' })).resolves.toEqual({ hasSaKey: true });
+    expect(service.update).toHaveBeenCalledWith(body, 'u1');
+  });
+
+  it('POST /test forwards the draft', async () => {
+    await controller.test({ remoteUrl: 'https://draft.example.com' });
+    expect(service.testConnection).toHaveBeenCalledWith({ remoteUrl: 'https://draft.example.com' });
+  });
+
+  it('is admin-only on every route (guard + Roles metadata)', () => {
+    const roles = (m: string) => Reflect.getMetadata('roles', (FfmpegExecutorSettingsController.prototype as any)[m]);
+    expect(roles('getStatus')).toEqual(['admin']);
+    expect(roles('update')).toEqual(['admin']);
+    expect(roles('test')).toEqual(['admin']);
+  });
+});
+```
+
+(Check the metadata key the `Roles` decorator uses in `apps/backend/src/auth` — if it is not `'roles'`, use the exported constant instead.)
+
+- [ ] **Step 2: Run → FAIL (module not found)**
+
+- [ ] **Step 3: Controller**
+
+```ts
+import { Body, Controller, Get, Post, Put, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiKeyGuard, RolesGuard, Roles, CurrentUser } from '../../auth';
+import {
+  FfmpegExecutorSettingsService,
+  type FfmpegExecutorTestDraft,
+  type UpdateFfmpegExecutorInput,
+} from './ffmpeg-executor-settings.service';
+
+/**
+ * Admin Settings → Features → Server video ops → Executor. Admin-only; the
+ * service-account key is write-only (never in a response). Lives in
+ * PipelinesModule (not SettingsModule) because it depends on the executor
+ * services and SettingsModule must not import PipelinesModule.
+ */
+@ApiTags('settings')
+@Controller('api/settings/ffmpeg-executor')
+@UseGuards(ApiKeyGuard, RolesGuard)
+export class FfmpegExecutorSettingsController {
+  constructor(private readonly settings: FfmpegExecutorSettingsService) {}
+
+  @Get()
+  @Roles('admin')
+  @ApiOperation({ summary: 'ffmpeg executor settings (Local / Remote) — the SA key is never returned' })
+  @ApiResponse({ status: 200 })
+  getStatus() {
+    return this.settings.getStatus();
+  }
+
+  @Put()
+  @Roles('admin')
+  @ApiOperation({ summary: 'Update ffmpeg executor settings (partial; saKeyJson: string=replace, null=clear, absent=keep)' })
+  @ApiResponse({ status: 200 })
+  @ApiResponse({ status: 400, description: 'Invalid combination (see message)' })
+  update(@Body() body: UpdateFfmpegExecutorInput, @CurrentUser() user: { id: string }) {
+    return this.settings.update(body, user?.id);
+  }
+
+  @Post('test')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Test the Worker connection for the saved settings or an unsaved draft' })
+  @ApiResponse({ status: 200 })
+  test(@Body() body: FfmpegExecutorTestDraft = {}) {
+    return this.settings.testConnection(body ?? {});
+  }
+}
+```
+
+Register in `pipelines.module.ts` `controllers: [...]` → add `FfmpegExecutorSettingsController` (import from `'./ffmpeg/ffmpeg-executor-settings.controller'`).
+
+- [ ] **Step 4: Run tests + build**
+
+Run: `cd apps/backend && pnpm jest src/pipelines/ffmpeg/ffmpeg-executor-settings.controller.spec.ts && pnpm build`
+Expected: PASS, build ok.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.controller.ts apps/backend/src/pipelines/ffmpeg/ffmpeg-executor-settings.controller.spec.ts apps/backend/src/pipelines/pipelines.module.ts
+git commit -m "feat(ffmpeg): admin endpoints GET/PUT /api/settings/ffmpeg-executor + POST …/test"
+```
+
+---
+
+### Task 6: Frontend API slice
+
+**Files:**
+- Modify: `apps/frontend/src/services/api.ts` (`tagTypes`)
+- Modify: `apps/frontend/src/services/settingsApi.ts`
+
+**Interfaces:**
+- Produces hooks `useGetFfmpegExecutorSettingsQuery`, `useUpdateFfmpegExecutorSettingsMutation`, `useTestFfmpegExecutorConnectionMutation` and exported types `FfmpegExecutorStatus`, `UpdateFfmpegExecutorDto`, `FfmpegExecutorTestDraft`, `FfmpegExecutorTestResult` (mirror Task 2/4 shapes exactly).
+
+- [ ] **Step 1: Add the tag**
+
+In `apps/frontend/src/services/api.ts` `tagTypes` array add `'FfmpegExecutor',`.
+
+- [ ] **Step 2: Types + endpoints in `settingsApi.ts`**
+
+Types (near the other settings types):
+
+```ts
+// ─── ffmpeg executor settings (Server video ops → Executor) ───────────────
+export type FfmpegExecutorName = 'local' | 'remote';
+export type FfmpegRemoteAuth = 'google_id_token' | 'none';
+
+export interface FfmpegExecutorStatus {
+  localAvailable: boolean;
+  localVersion: string | null;
+  localEnabled: boolean;
+  remoteEnabled: boolean;
+  remoteUrl: string | null;
+  remoteAuth: FfmpegRemoteAuth;
+  hasSaKey: boolean;
+  saKeySource: 'db' | 'env' | null;
+  defaultExecutor: FfmpegExecutorName;
+  storagePresignable: boolean;
+  envManaged: { defaultExecutor: boolean; remoteUrl: boolean; remoteAuth: boolean; saKey: boolean };
+}
+
+export interface UpdateFfmpegExecutorDto {
+  localEnabled?: boolean;
+  remoteEnabled?: boolean;
+  remoteUrl?: string | null;
+  remoteAuth?: FfmpegRemoteAuth;
+  defaultExecutor?: FfmpegExecutorName;
+  /** undefined = keep, null = clear, string = replace */
+  saKeyJson?: string | null;
+}
+
+export interface FfmpegExecutorTestDraft {
+  remoteUrl?: string | null;
+  remoteAuth?: FfmpegRemoteAuth;
+  saKeyJson?: string | null;
+}
+
+export interface FfmpegExecutorTestResult {
+  ok: boolean;
+  latencyMs: number | null;
+  worker?: { version: string; ffmpeg: string | null; ops: string[]; uptimeS: number };
+  error?: string;
+  readiness: { ok: boolean; reason?: string };
+  credential: 'sa_key' | 'adc' | 'none';
+}
+```
+
+Endpoints (inside `endpoints: (builder) => ({ … })`, next to the Google-integration block):
+
+```ts
+    getFfmpegExecutorSettings: builder.query<FfmpegExecutorStatus, void>({
+      query: () => '/api/settings/ffmpeg-executor',
+      providesTags: ['FfmpegExecutor'],
+    }),
+    updateFfmpegExecutorSettings: builder.mutation<FfmpegExecutorStatus, UpdateFfmpegExecutorDto>({
+      query: (body) => ({ url: '/api/settings/ffmpeg-executor', method: 'PUT', body }),
+      invalidatesTags: ['FfmpegExecutor'],
+    }),
+    testFfmpegExecutorConnection: builder.mutation<FfmpegExecutorTestResult, FfmpegExecutorTestDraft>({
+      query: (body) => ({ url: '/api/settings/ffmpeg-executor/test', method: 'POST', body }),
+    }),
+```
+
+Export the hooks where the file exports the others: `useGetFfmpegExecutorSettingsQuery, useUpdateFfmpegExecutorSettingsMutation, useTestFfmpegExecutorConnectionMutation`.
+
+- [ ] **Step 3: Type-check + commit**
+
+Run: `cd apps/frontend && npx tsc --noEmit -p tsconfig.json` (or `pnpm build` if that is the project's check) → no errors.
+
+```bash
+git add apps/frontend/src/services/api.ts apps/frontend/src/services/settingsApi.ts
+git commit -m "feat(frontend): ffmpeg executor settings API slice"
+```
+
+---
+
+### Task 7: `FfmpegExecutorSettings` panel + registry hook in `FeatureToggles`
+
+**Files:**
+- Create: `apps/frontend/src/components/settings/FfmpegExecutorSettings.tsx`
+- Create: `apps/frontend/src/components/settings/FfmpegExecutorSettings.test.tsx`
+- Modify: `apps/frontend/src/components/settings/FeatureToggles.tsx`
+
+**Interfaces:**
+- Consumes: Task 6 hooks/types; shadcn `Switch, Input, Textarea, RadioGroup/RadioGroupItem, Button, Badge, Alert/AlertDescription, Label, Skeleton` from `@/components/ui/*`; `useToast` from `@/hooks/use-toast`.
+- Produces: `export function FfmpegExecutorSettings()`; `FeatureToggle.Panel?: React.ComponentType` rendered under the toggle row.
+
+UI contract (spec §1.5 + user's deliverable list):
+- **Local server** row: switch (`localEnabled`), subtitle: version line when `localAvailable` (`ffmpeg version 6.1.1`), or "ffmpeg is not installed on this server — the Local executor cannot be enabled" (switch disabled). Small note "Memory floor: see Sizing in the docs".
+- **Remote (Worker)** row: switch (`remoteEnabled`); when `storagePresignable === false` the switch is disabled with the note "Needs bucket storage (S3, GCS, MinIO, Azure) — the Worker moves bytes through signed URLs". Under it: **Worker URL** input; **Auth** select-ish radio (`Google ID token (Cloud Run IAM)` / `None (private network only)`); when `none` a **red** `Alert variant="destructive"`: "No authentication: anyone who can reach the Worker URL can run jobs on it. Only use on a private network (docker compose profile, VPC)."; **Service-account key (JSON)**: if `hasSaKey` show `Badge` "Key stored (db|env)" + button **Replace key** (reveals a `Textarea`) + button **Remove key** (sets `saKeyJson: null` on save); if none, show the Textarea directly with helper "Optional. Leave empty to use Application Default Credentials (works when CE itself runs on GCP)". Anything env-managed: control disabled + `Badge variant="secondary"`: "Managed by FFMPEG_REMOTE_URL" (etc.).
+- **Test connection** button → `useTestFfmpegExecutorConnectionMutation` with the current draft (`remoteUrl`, `remoteAuth`, and `saKeyJson` only if the textarea has content). Result line: ✓ "Worker 0.4.31 · ffmpeg version 6.1.1 · ops probe, extract_audio, slice, concat · 123 ms" or ✗ `error`; below it, readiness: "Ready" or "Not ready: <reason>"; and a credential note: `adc` → "Using Application Default Credentials (no key stored)"; `none` → "No auth"; `sa_key` → "Using the stored service-account key".
+- **Default executor** `RadioGroup` (`local` / `remote`); an item is disabled unless that executor is enabled in the *draft* (local: `localEnabled && localAvailable`; remote: `remoteEnabled && remoteUrl`); env-managed → whole group disabled + badge.
+- **Save** button (disabled while nothing changed / while saving) → PUT with only changed fields (`saKeyJson` included only when the textarea has content or Remove was clicked); toast success/failure using the server's `message` on 400.
+
+- [ ] **Step 1: Failing component test**
+
+`FfmpegExecutorSettings.test.tsx` (Vitest + Testing Library; look at `MySitesSection.test.tsx` for the store/provider wrapper pattern used in this repo and reuse it — the hooks are RTK Query so mock the three hooks via `vi.mock('@/services/settingsApi', …)`):
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { FfmpegExecutorSettings } from './FfmpegExecutorSettings';
+
+const update = vi.fn(() => ({ unwrap: () => Promise.resolve({}) }));
+const test = vi.fn(() => ({ unwrap: () => Promise.resolve({ ok: true, latencyMs: 42, worker: { version: '0.4.31', ffmpeg: 'ffmpeg version 6.1.1', ops: ['probe', 'slice'], uptimeS: 3 }, readiness: { ok: true }, credential: 'adc' }) }));
+let status: any;
+
+vi.mock('@/services/settingsApi', () => ({
+  useGetFfmpegExecutorSettingsQuery: () => ({ data: status, isLoading: false, error: undefined }),
+  useUpdateFfmpegExecutorSettingsMutation: () => [update, { isLoading: false }],
+  useTestFfmpegExecutorConnectionMutation: () => [test, { isLoading: false }],
+}));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+beforeEach(() => {
+  update.mockClear();
+  test.mockClear();
+  status = {
+    localAvailable: true, localVersion: 'ffmpeg version 6.1.1', localEnabled: true,
+    remoteEnabled: false, remoteUrl: null, remoteAuth: 'google_id_token', hasSaKey: false, saKeySource: null,
+    defaultExecutor: 'local', storagePresignable: true,
+    envManaged: { defaultExecutor: false, remoteUrl: false, remoteAuth: false, saKey: false },
+  };
+});
+
+describe('FfmpegExecutorSettings', () => {
+  it('shows the local version and disables the remote radio until Remote has a URL', () => {
+    render(<FfmpegExecutorSettings />);
+    expect(screen.getByText(/ffmpeg version 6\.1\.1/)).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /remote/i })).toBeDisabled();
+  });
+
+  it('shows the red banner for auth none', () => {
+    status.remoteEnabled = true; status.remoteUrl = 'http://ffmpeg-worker:8080'; status.remoteAuth = 'none';
+    render(<FfmpegExecutorSettings />);
+    expect(screen.getByText(/No authentication/)).toBeInTheDocument();
+  });
+
+  it('env-managed URL is read-only with a badge', () => {
+    status.remoteEnabled = true; status.remoteUrl = 'https://env.example.com'; status.envManaged.remoteUrl = true;
+    render(<FfmpegExecutorSettings />);
+    expect(screen.getByLabelText(/Worker URL/)).toBeDisabled();
+    expect(screen.getByText(/Managed by FFMPEG_REMOTE_URL/)).toBeInTheDocument();
+  });
+
+  it('Test connection sends the draft and renders version, ops, latency and the ADC note', async () => {
+    status.remoteEnabled = true;
+    render(<FfmpegExecutorSettings />);
+    fireEvent.change(screen.getByLabelText(/Worker URL/), { target: { value: 'https://draft.example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /Test connection/ }));
+    await waitFor(() => expect(test).toHaveBeenCalledWith(expect.objectContaining({ remoteUrl: 'https://draft.example.com' })));
+    expect(await screen.findByText(/0\.4\.31/)).toBeInTheDocument();
+    expect(screen.getByText(/42 ms/)).toBeInTheDocument();
+    expect(screen.getByText(/Application Default Credentials/)).toBeInTheDocument();
+  });
+
+  it('Save sends only changed fields; a pasted key is sent as saKeyJson; stored key offers Replace/Remove', async () => {
+    render(<FfmpegExecutorSettings />);
+    fireEvent.click(screen.getByRole('switch', { name: /Remote/ }));
+    fireEvent.change(screen.getByLabelText(/Worker URL/), { target: { value: 'https://w.example.com' } });
+    fireEvent.change(screen.getByLabelText(/Service-account key/), { target: { value: '{"type":"service_account"}' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Save/ }));
+    await waitFor(() => expect(update).toHaveBeenCalledWith({ remoteEnabled: true, remoteUrl: 'https://w.example.com', saKeyJson: '{"type":"service_account"}' }));
+
+    status.hasSaKey = true; status.saKeySource = 'db'; status.remoteEnabled = true; status.remoteUrl = 'https://w.example.com';
+    render(<FfmpegExecutorSettings />);
+    expect(screen.getByText(/Key stored/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Replace key/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Remove key/ })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL** (`cd apps/frontend && pnpm test:run src/components/settings/FfmpegExecutorSettings.test.tsx`).
+
+- [ ] **Step 3: Implement the component**
+
+`FfmpegExecutorSettings.tsx` — full implementation (adjust import paths for `RadioGroup` etc. to what `components/ui` exports):
+
+```tsx
+// Admin Settings → Features → Server video ops → Executor.
+// Configures WHICH executor runs ffmpeg jobs: Local server (ffmpeg in this
+// backend) and/or Remote (a Worker CE calls over HTTPS; Cloud Run is the
+// reference deployment). Fields pinned by env vars render read-only.
+// The service-account key is write-only: the API only ever says whether one
+// is stored, so this form has a "replace" flow rather than a value.
+import { useEffect, useMemo, useState } from 'react';
+import {
+  useGetFfmpegExecutorSettingsQuery,
+  useTestFfmpegExecutorConnectionMutation,
+  useUpdateFfmpegExecutorSettingsMutation,
+  type FfmpegExecutorName,
+  type FfmpegExecutorStatus,
+  type FfmpegExecutorTestResult,
+  type FfmpegRemoteAuth,
+  type UpdateFfmpegExecutorDto,
+} from '@/services/settingsApi';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/use-toast';
+import { CheckCircle2, Cloud, Server, XCircle } from 'lucide-react';
+
+interface Draft {
+  localEnabled: boolean;
+  remoteEnabled: boolean;
+  remoteUrl: string;
+  remoteAuth: FfmpegRemoteAuth;
+  defaultExecutor: FfmpegExecutorName;
+  /** Textarea contents; '' = nothing to send. */
+  saKeyJson: string;
+  /** "Remove key" clicked → send saKeyJson: null on save. */
+  removeKey: boolean;
+}
+
+function toDraft(s: FfmpegExecutorStatus): Draft {
+  return {
+    localEnabled: s.localEnabled,
+    remoteEnabled: s.remoteEnabled,
+    remoteUrl: s.remoteUrl ?? '',
+    remoteAuth: s.remoteAuth,
+    defaultExecutor: s.defaultExecutor,
+    saKeyJson: '',
+    removeKey: false,
+  };
+}
+
+/** Only the fields that differ from the saved status (the API is partial-update). */
+function diff(s: FfmpegExecutorStatus, d: Draft): UpdateFfmpegExecutorDto {
+  const out: UpdateFfmpegExecutorDto = {};
+  if (d.localEnabled !== s.localEnabled) out.localEnabled = d.localEnabled;
+  if (d.remoteEnabled !== s.remoteEnabled) out.remoteEnabled = d.remoteEnabled;
+  if (d.remoteUrl.trim() !== (s.remoteUrl ?? '')) out.remoteUrl = d.remoteUrl.trim() || null;
+  if (d.remoteAuth !== s.remoteAuth) out.remoteAuth = d.remoteAuth;
+  if (d.defaultExecutor !== s.defaultExecutor) out.defaultExecutor = d.defaultExecutor;
+  if (d.removeKey) out.saKeyJson = null;
+  else if (d.saKeyJson.trim()) out.saKeyJson = d.saKeyJson.trim();
+  return out;
+}
+
+function EnvBadge({ name }: { name: string }) {
+  return (
+    <Badge variant="secondary" className="font-mono text-[10px]">
+      Managed by {name}
+    </Badge>
+  );
+}
+
+function errorMessage(err: unknown): string {
+  return err && typeof err === 'object' && 'data' in err
+    ? (err as { data?: { message?: string } }).data?.message || 'An error occurred'
+    : 'An error occurred';
+}
+
+export function FfmpegExecutorSettings() {
+  const { toast } = useToast();
+  const { data: status, isLoading, error } = useGetFfmpegExecutorSettingsQuery();
+  const [update, { isLoading: saving }] = useUpdateFfmpegExecutorSettingsMutation();
+  const [testConnection, { isLoading: testing }] = useTestFfmpegExecutorConnectionMutation();
+  const [draft, setDraft] = useState<Draft | null>(null);
+  const [replacingKey, setReplacingKey] = useState(false);
+  const [testResult, setTestResult] = useState<FfmpegExecutorTestResult | null>(null);
+
+  useEffect(() => {
+    if (status) {
+      setDraft(toDraft(status));
+      setReplacingKey(false);
+    }
+  }, [status]);
+
+  const changes = useMemo(() => (status && draft ? diff(status, draft) : {}), [status, draft]);
+  const dirty = Object.keys(changes).length > 0;
+
+  if (isLoading || !draft || !status) return <Skeleton className="h-40 w-full" />;
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>Failed to load executor settings.</AlertDescription>
+      </Alert>
+    );
+  }
+
+  const set = (patch: Partial<Draft>) => setDraft((d) => (d ? { ...d, ...patch } : d));
+  const localSelectable = draft.localEnabled && status.localAvailable;
+  const remoteSelectable = draft.remoteEnabled && draft.remoteUrl.trim() !== '';
+  const showKeyEditor = !status.hasSaKey || replacingKey;
+
+  const onSave = async () => {
+    try {
+      await update(changes).unwrap();
+      toast({ title: 'Executor settings saved' });
+      setTestResult(null);
+    } catch (err) {
+      toast({ title: 'Failed to save executor settings', description: errorMessage(err), variant: 'destructive' });
+    }
+  };
+
+  const onTest = async () => {
+    setTestResult(null);
+    try {
+      const res = await testConnection({
+        remoteUrl: draft.remoteUrl.trim() || null,
+        remoteAuth: draft.remoteAuth,
+        ...(draft.saKeyJson.trim() ? { saKeyJson: draft.saKeyJson.trim() } : {}),
+      }).unwrap();
+      setTestResult(res);
+    } catch (err) {
+      toast({ title: 'Test failed', description: errorMessage(err), variant: 'destructive' });
+    }
+  };
+
+  return (
+    <div className="ml-8 space-y-4 rounded-lg border border-dashed p-4">
+      <div>
+        <Label className="text-sm font-medium">Executor</Label>
+        <p className="text-xs text-muted-foreground">
+          Where ffmpeg jobs run. Enable Local, Remote, or both, then pick the default. Steps can still name an executor explicitly.
+        </p>
+      </div>
+
+      {/* Local server */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <Server className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <div>
+            <Label htmlFor="ffmpeg-local" className="text-sm font-medium">Local server</Label>
+            <p className="text-xs text-muted-foreground">
+              {status.localAvailable
+                ? <>ffmpeg spawned by this backend · {status.localVersion} · memory floor: see Sizing in the docs</>
+                : 'ffmpeg is not installed on this server — the Local executor cannot be enabled'}
+            </p>
+          </div>
+        </div>
+        <Switch id="ffmpeg-local" aria-label="Local server" checked={draft.localEnabled} disabled={!status.localAvailable} onCheckedChange={(v) => set({ localEnabled: v })} />
+      </div>
+
+      {/* Remote */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <Cloud className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <div>
+            <Label htmlFor="ffmpeg-remote" className="text-sm font-medium">Remote (Worker)</Label>
+            <p className="text-xs text-muted-foreground">
+              {status.storagePresignable
+                ? 'A Worker CE calls over HTTPS — bytes move bucket ↔ Worker via signed URLs and never touch this server. Cloud Run is the reference deployment.'
+                : 'Needs bucket storage (S3, GCS, MinIO, Azure) — the Worker moves bytes through signed URLs, which local filesystem storage cannot provide.'}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {status.envManaged.remoteUrl && <EnvBadge name="FFMPEG_REMOTE_URL" />}
+          <Switch id="ffmpeg-remote" aria-label="Remote" checked={draft.remoteEnabled} disabled={!status.storagePresignable || status.envManaged.remoteUrl} onCheckedChange={(v) => set({ remoteEnabled: v })} />
+        </div>
+      </div>
+
+      {draft.remoteEnabled && (
+        <div className="ml-7 space-y-3">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <Label htmlFor="ffmpeg-remote-url" className="text-xs">Worker URL</Label>
+              {status.envManaged.remoteUrl && <EnvBadge name="FFMPEG_REMOTE_URL" />}
+            </div>
+            <Input id="ffmpeg-remote-url" placeholder="https://bffless-ffmpeg-xxxx-uc.a.run.app" value={draft.remoteUrl} disabled={status.envManaged.remoteUrl} onChange={(e) => set({ remoteUrl: e.target.value })} />
+          </div>
+
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <Label className="text-xs">Auth</Label>
+              {status.envManaged.remoteAuth && <EnvBadge name="FFMPEG_REMOTE_AUTH" />}
+            </div>
+            <RadioGroup value={draft.remoteAuth} disabled={status.envManaged.remoteAuth} onValueChange={(v) => set({ remoteAuth: v as FfmpegRemoteAuth })} className="flex gap-4">
+              <div className="flex items-center gap-2">
+                <RadioGroupItem id="ffmpeg-auth-idtoken" value="google_id_token" />
+                <Label htmlFor="ffmpeg-auth-idtoken" className="text-xs font-normal">Google ID token (Cloud Run IAM)</Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem id="ffmpeg-auth-none" value="none" />
+                <Label htmlFor="ffmpeg-auth-none" className="text-xs font-normal">None (private network only)</Label>
+              </div>
+            </RadioGroup>
+            {draft.remoteAuth === 'none' && (
+              <Alert variant="destructive">
+                <AlertDescription className="text-xs">
+                  No authentication: anyone who can reach the Worker URL can run jobs on it. Only use on a private network (docker compose profile, VPC).
+                </AlertDescription>
+              </Alert>
+            )}
+          </div>
+
+          {draft.remoteAuth === 'google_id_token' && (
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Label htmlFor="ffmpeg-sa-key" className="text-xs">Service-account key (JSON)</Label>
+                {status.envManaged.saKey && <EnvBadge name="FFMPEG_REMOTE_SA_KEY_JSON" />}
+                {status.hasSaKey && !status.envManaged.saKey && (
+                  <Badge variant="outline" className="text-[10px]">Key stored ({status.saKeySource})</Badge>
+                )}
+              </div>
+              {status.envManaged.saKey ? (
+                <p className="text-xs text-muted-foreground">Provided by the environment; not editable here.</p>
+              ) : showKeyEditor ? (
+                <>
+                  <Textarea id="ffmpeg-sa-key" rows={4} placeholder='{"type": "service_account", ...}' className="font-mono text-xs" value={draft.saKeyJson} onChange={(e) => set({ saKeyJson: e.target.value, removeKey: false })} />
+                  <p className="text-xs text-muted-foreground">
+                    Optional. Leave empty to use Application Default Credentials (works when CE itself runs on GCP). The key is stored encrypted and never shown again.
+                  </p>
+                  {replacingKey && (
+                    <Button type="button" variant="ghost" size="sm" onClick={() => { setReplacingKey(false); set({ saKeyJson: '' }); }}>Cancel</Button>
+                  )}
+                </>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <Button type="button" variant="outline" size="sm" onClick={() => { setReplacingKey(true); set({ removeKey: false }); }}>Replace key</Button>
+                  <Button type="button" variant="ghost" size="sm" onClick={() => set({ removeKey: !draft.removeKey, saKeyJson: '' })}>
+                    {draft.removeKey ? 'Keep key' : 'Remove key'}
+                  </Button>
+                  {draft.removeKey && <span className="text-xs text-destructive">Key will be removed on save (ADC will be used).</span>}
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Button type="button" variant="outline" size="sm" onClick={onTest} disabled={testing || !draft.remoteUrl.trim()}>
+              {testing ? 'Testing…' : 'Test connection'}
+            </Button>
+            {testResult && (
+              <div className="space-y-1 text-xs">
+                <div className="flex items-center gap-2">
+                  {testResult.worker && !testResult.error ? <CheckCircle2 className="h-4 w-4 text-green-600" /> : <XCircle className="h-4 w-4 text-destructive" />}
+                  {testResult.worker ? (
+                    <span>
+                      Worker {testResult.worker.version} · {testResult.worker.ffmpeg ?? 'no ffmpeg'} · ops {testResult.worker.ops.join(', ')}
+                      {testResult.latencyMs !== null && <> · {testResult.latencyMs} ms</>}
+                    </span>
+                  ) : (
+                    <span>{testResult.error}</span>
+                  )}
+                </div>
+                <div className={testResult.readiness.ok ? 'text-muted-foreground' : 'text-destructive'}>
+                  {testResult.readiness.ok ? 'Ready' : `Not ready: ${testResult.readiness.reason ?? 'unknown reason'}`}
+                </div>
+                <div className="text-muted-foreground">
+                  {testResult.credential === 'adc' && 'Using Application Default Credentials (no key stored) — this works when CE runs on GCP; elsewhere paste a service-account key.'}
+                  {testResult.credential === 'sa_key' && 'Using the stored service-account key.'}
+                  {testResult.credential === 'none' && 'No auth.'}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Default executor */}
+      <div className="space-y-1">
+        <div className="flex items-center gap-2">
+          <Label className="text-xs">Default executor</Label>
+          {status.envManaged.defaultExecutor && <EnvBadge name="FFMPEG_EXECUTOR" />}
+        </div>
+        <RadioGroup value={draft.defaultExecutor} disabled={status.envManaged.defaultExecutor} onValueChange={(v) => set({ defaultExecutor: v as FfmpegExecutorName })} className="flex gap-4">
+          <div className="flex items-center gap-2">
+            <RadioGroupItem id="ffmpeg-default-local" value="local" disabled={!localSelectable} aria-label="local" />
+            <Label htmlFor="ffmpeg-default-local" className="text-xs font-normal">Local server</Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <RadioGroupItem id="ffmpeg-default-remote" value="remote" disabled={!remoteSelectable} aria-label="remote" />
+            <Label htmlFor="ffmpeg-default-remote" className="text-xs font-normal">Remote</Label>
+          </div>
+        </RadioGroup>
+        <p className="text-xs text-muted-foreground">Only enabled executors can be the default.</p>
+      </div>
+
+      <div className="flex justify-end">
+        <Button type="button" size="sm" onClick={onSave} disabled={!dirty || saving}>
+          {saving ? 'Saving…' : 'Save executor settings'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Registry hook in `FeatureToggles.tsx`**
+
+- `type FeatureToggle` gains `Panel?: React.ComponentType;` (import `type ComponentType` from react).
+- The `FFMPEG_HANDLER_ENABLED` entry gains `Panel: FfmpegExecutorSettings,` (import from `./FfmpegExecutorSettings`).
+- In `FeatureToggles()` render:
+
+```tsx
+        {FEATURE_TOGGLES.map((toggle) => (
+          <div key={toggle.flagKey} className="space-y-3">
+            <FeatureToggleRow toggle={toggle} />
+            {toggle.Panel && <toggle.Panel />}
+          </div>
+        ))}
+```
+
+- [ ] **Step 5: Tests green; eslint on the two files; type-check**
+
+Run: `cd apps/frontend && pnpm test:run src/components/settings/FfmpegExecutorSettings.test.tsx && npx eslint src/components/settings/FfmpegExecutorSettings.tsx src/components/settings/FfmpegExecutorSettings.test.tsx src/components/settings/FeatureToggles.tsx && npx tsc --noEmit -p tsconfig.json`
+Expected: PASS / clean.
+
+- [ ] **Step 6: Visual smoke (headless)**
+
+The panel needs a live backend for data; a cheap check is the frontend dev server + `localdev-tools/shot.mjs` against `/admin/settings` (features tab) — it will render the loading skeleton/"couldn't reach server" fallback without a session, which is expected. Do it only to confirm the page still renders without console errors:
+
+```bash
+cd apps/frontend && (pnpm dev >/tmp/claude-1000/-home-rico-bffless/cc184474-b754-4a1c-969a-a24532b89610/scratchpad/fe.log 2>&1 &) && sleep 8
+cd /home/rico/bffless/localdev-tools && node shot.mjs http://localhost:5173/admin/settings --out /tmp/claude-1000/-home-rico-bffless/cc184474-b754-4a1c-969a-a24532b89610/scratchpad/features.png --full ; pkill -f "vite" || true
+```
+
+Expected: `consoleErrors:0` (failed `/api` requests are expected without a session).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/frontend/src/components/settings/FfmpegExecutorSettings.tsx apps/frontend/src/components/settings/FfmpegExecutorSettings.test.tsx apps/frontend/src/components/settings/FeatureToggles.tsx
+git commit -m "feat(frontend): Server video ops → Executor panel (Local/Remote, worker URL, auth, write-only SA key, test connection, default)"
+```
+
+---
+
+### Task 8: `.env.example` + compose comment touch-ups (CE)
+
+**Files:**
+- Modify: `.env.example` (§13, the `FFMPEG_EXECUTOR` … block ~lines 575–600)
+- Modify: `docker-compose.yml` (comment on the `ffmpeg-worker` service, ~line 263)
+
+- [ ] **Step 1: `.env.example`** — above the `# FFMPEG_EXECUTOR=local` line, add:
+
+```
+# These four (FFMPEG_EXECUTOR, FFMPEG_REMOTE_URL, FFMPEG_REMOTE_AUTH, FFMPEG_REMOTE_SA_KEY_JSON)
+# can instead be set in Admin Settings → Features → Server video ops → Executor. When an env
+# var is set it WINS over the admin value and the UI shows that field as env-managed.
+# FFMPEG_REMOTE_MAX_INFLIGHT / FFMPEG_WORKER_MIN_VERSION / FFMPEG_MAX_OUTPUT_BYTES are env-only.
+```
+
+- [ ] **Step 2: `docker-compose.yml`** — extend the `ffmpeg-worker` comment: `# Point CE at it with FFMPEG_REMOTE_URL=http://ffmpeg-worker:8080 FFMPEG_REMOTE_AUTH=none, or in Admin Settings → Features → Server video ops → Executor (Worker URL http://ffmpeg-worker:8080, auth None).`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .env.example docker-compose.yml
+git commit -m "docs(env): note the admin-settings alternative for the ffmpeg remote executor vars"
+```
+
+---
+
+### Task 9: Public docs — *Remote executor* section (docs-public worktree)
+
+**Files:**
+- Modify: `repos/docs-public/.claude/worktrees/ffmpeg-remote-executor/docs/features/server-video-ops.md`
+
+Work in the docs worktree (`git rev-parse --show-toplevel` must print `…/docs-public/.claude/worktrees/ffmpeg-remote-executor`).
+
+- [ ] **Step 1: Intro + modes**
+
+Replace the first paragraph after `# Server Video Ops` heading's second paragraph ("Server video ops are **off by default**…") by inserting, right after it, a new subsection:
+
+```markdown
+## Three ways to run video ops
+
+| Mode | Where ffmpeg runs | When to use |
+| --- | --- | --- |
+| **Browser** | ffmpeg.wasm in the visitor's tab | Always available; the fallback when server video ops are off or refused |
+| **Local server** | Native ffmpeg inside the CE backend container | 2 GB+ hosts; simplest, no extra moving parts |
+| **Remote** (since v0.4.31) | A separate **Worker** CE calls over HTTPS — Cloud Run is the reference deployment | Small hosts (1 GB droplets), bursty encodes, or when you don't want encodes competing with the API |
+
+"Server video ops" = Local server + Remote together: the app only sees `server: true` and the same four operations; **which executor runs a job** is chosen in Admin Settings (Local, Remote, or both, plus a default) and can be overridden per pipeline step (`executor: "remote"`).
+```
+
+- [ ] **Step 2: Append the Remote executor section** at the end of the file (after "For app and pipeline authors"), verbatim:
+
+````markdown
+## Remote executor
+
+The Remote executor sends each job to a **Worker** — a small stateless container image (`ghcr.io/bffless/ce-ffmpeg-worker`) that runs the ffmpeg command CE hands it. Bytes never touch your CE server: CE signs a download URL per input and an upload URL for the output, and the Worker moves data **bucket ↔ Worker** directly. That has two consequences:
+
+- **Bucket storage only** — S3, GCS, MinIO or Azure. The local filesystem adapter cannot hand a Worker a reachable URL, and Admin Settings refuses to enable Remote on it. (No bucket CORS is needed: Worker → bucket is server-to-server.)
+- The Worker needs no access to your database, secrets or CE API — only the signed URLs in the job.
+
+CE authenticates to the Worker with a **Google ID token** (Cloud Run IAM), minted from a service-account key you paste into Admin Settings (stored encrypted, never shown again) or from Application Default Credentials when CE itself runs on GCP. For private networks there is an `auth: none` mode (below).
+
+### Deploy the Worker on Cloud Run (one command + IAM)
+
+Replace `PROJECT` with your GCP project id and `0.4.31` with your CE version (the Worker image is versioned with CE; `:latest` follows the newest release).
+
+```bash
+gcloud run deploy bffless-ffmpeg --project PROJECT --image ghcr.io/bffless/ce-ffmpeg-worker:0.4.31 --region us-central1 --no-allow-unauthenticated --cpu 8 --memory 16Gi --concurrency 1 --timeout 3600 --max-instances 10 --cpu-boost --port 8080
+```
+
+Then create a caller identity CE will use, allow it to invoke the service, and download its key:
+
+```bash
+gcloud iam service-accounts create bffless-ffmpeg-caller --project PROJECT
+gcloud run services add-iam-policy-binding bffless-ffmpeg --project PROJECT --region us-central1 --member serviceAccount:bffless-ffmpeg-caller@PROJECT.iam.gserviceaccount.com --role roles/run.invoker
+gcloud iam service-accounts keys create key.json --iam-account bffless-ffmpeg-caller@PROJECT.iam.gserviceaccount.com
+```
+
+`gcloud run deploy` prints the service URL (`https://bffless-ffmpeg-xxxx-uc.a.run.app`).
+
+### Enable it in CE
+
+1. **Admin Settings → Features → Server video ops** — turn the feature on if it isn't already.
+2. In the **Executor** panel below it: switch **Remote** on, paste the **Worker URL**, keep **Auth: Google ID token**, paste the contents of `key.json` into **Service-account key** (skip it if CE runs on GCP with a service account that has `run.invoker` — ADC is used).
+3. Click **Test connection** — you should see the Worker version, its ffmpeg build, the four ops and the round-trip latency, plus "Ready".
+4. Pick **Default executor: Remote** (or leave Local as default and opt individual pipeline steps in with `executor: "remote"`), then **Save**.
+5. Optionally turn **Local server** off — on a 1 GB host that is the whole point: `server: true` with no ffmpeg on the box.
+
+The same settings can be pinned with env vars (they then win over the admin values and the UI shows the field as env-managed):
+
+| Variable | Purpose |
+| --- | --- |
+| `FFMPEG_EXECUTOR` | Default executor: `local` or `remote` |
+| `FFMPEG_REMOTE_URL` | Worker base URL (setting it enables Remote) |
+| `FFMPEG_REMOTE_AUTH` | `google_id_token` (default) or `none` |
+| `FFMPEG_REMOTE_SA_KEY_JSON` | Service-account key JSON (alternative to pasting it in the UI) |
+| `FFMPEG_REMOTE_MAX_INFLIGHT` | Max concurrent remote jobs from this instance (default 8; more → `FFMPEG_BUSY`) |
+| `FFMPEG_WORKER_MIN_VERSION` | Refuse Workers older than this version (unset = any) |
+| `FFMPEG_MAX_OUTPUT_BYTES` | Cap on one output object (default 2 GiB — a signed PUT is a single request) |
+
+Nested deadlines: Cloud Run `--timeout` ≥ `FFMPEG_JOB_MAX_SECONDS` (default 2 × `FFMPEG_MAX_SECONDS` = 3600 s) > the per-job ceiling CE sends the Worker. Keep `--timeout 3600` unless you raise the CE values.
+
+### Sizing the Worker
+
+`--concurrency 1` means one job per instance; parallelism = `--max-instances`. Size an instance for your **largest** input:
+
+| Typical input | `--cpu` | `--memory` | Notes |
+| --- | --- | --- | --- |
+| 1 h 720p | 4 | 4Gi | Slice/concat mostly stream-copy; extract_audio is cheap |
+| 2 h 1080p | 8 | 16Gi | Re-encode fallback for concat and audio-alongside slices need the headroom |
+| Short clips (< 10 min) | 2 | 2Gi | Fine for demos and CI |
+
+`--cpu-boost` shortens cold starts; the first job after idle still pays a few seconds of container start plus the input download.
+
+### What it costs (example)
+
+Cloud Run bills vCPU-seconds and GiB-seconds while a request is running, plus egress. Ballpark for one **10-minute slice of a 2 GB 1080p file** on the 8 vCPU / 16 Gi shape, ~90 s wall time: about **$0.02–0.03** of compute (2026 list prices for tier-1 regions, no committed use), plus **network egress**:
+
+- Bucket in the **same GCP region** as the Worker (GCS): input download is free, output upload is free.
+- Bucket on **another cloud or region** (S3, DigitalOcean Spaces, MinIO elsewhere): the Worker's download is that provider's egress (S3 ≈ $0.09/GB → ~$0.18 for the 2 GB input) and the upload back is Cloud Run egress. **Cross-cloud egress usually dwarfs the compute** — put the Worker next to the bucket when you can.
+
+There is no cost dashboard in CE; use GCP Billing (label the service, e.g. `--labels app=bffless-ffmpeg`).
+
+### Private network / local dev: `auth: none`
+
+For a Worker that is only reachable on a private network — the docker-compose profile below, CI, or a box behind your own VPN — you can skip Google auth. The UI shows a **red warning** for this mode because anyone who can reach the URL can run jobs.
+
+```bash
+# next to your CE compose files
+docker compose --profile ffmpeg-worker up -d
+```
+
+This starts `assethost-ffmpeg-worker` on the compose network (plain http, `WORKER_ALLOW_HTTP=1` so it accepts MinIO's http presigned URLs). Then in Admin Settings → Executor: **Worker URL** `http://ffmpeg-worker:8080`, **Auth: None**, Test connection, Save — or set `FFMPEG_EXECUTOR=remote FFMPEG_REMOTE_URL=http://ffmpeg-worker:8080 FFMPEG_REMOTE_AUTH=none` in `.env`.
+
+### Troubleshooting
+
+Start from the error code the app or pipeline log shows:
+
+- **`FFMPEG_EXECUTOR_UNAVAILABLE`** — the job could not be handed to any executor. Check, in order:
+  1. Is **Server video ops** on? (Admin Settings → Features.) With the flag off, `server: false` and apps stay in the browser — no error, just no server path.
+  2. Is the executor the step asked for **enabled**? A step with `executor: "remote"` fails with `not enabled on this instance` until Remote is on with a Worker URL; `executor: "local"` fails when ffmpeg isn't installed on the box or Local is switched off.
+  3. **Test connection** in the Executor panel: it tells you *why* the Worker isn't ready —
+     - `worker unreachable: …` → URL typo, service not deployed, or CE cannot reach `oauth2.googleapis.com` to mint the ID token (droplets need outbound HTTPS).
+     - `worker 0.4.28 is older than FFMPEG_WORKER_MIN_VERSION 0.4.31` → redeploy the Worker with the newer image (or clear the min-version).
+     - `local filesystem storage cannot be reached by a worker` / `storage adapter cannot presign` → Remote needs bucket storage; switch storage or use Local.
+     - `remote auth google_id_token requires an https worker URL` → Cloud Run URLs are https; `http://` is only allowed with auth `none`.
+- **HTTP 403 from the Worker** (shows as `worker unreachable: … 403`) — the caller identity lacks **`roles/run.invoker`** on the service, or you pasted the key of a *different* service account. Re-run the `add-iam-policy-binding` command above for the account whose key CE has. A 401 means no/invalid ID token: auth is set to `none` against an IAM-protected service, or the key JSON is not a `service_account` key.
+- **`FFMPEG_BUSY`** — more than `FFMPEG_REMOTE_MAX_INFLIGHT` jobs in flight from this CE, or the Worker returned 429/503 (all `--max-instances` busy). Raise one or both, or let the app retry.
+- **`FFMPEG_TIMEOUT`** — the job exceeded CE's per-job ceiling; raise `FFMPEG_MAX_SECONDS` (and keep Cloud Run `--timeout` ≥ `FFMPEG_JOB_MAX_SECONDS`).
+- **Job succeeded on the Worker but CE reports `FFMPEG_FAILED: output upload …`** — the signed PUT was refused: output larger than `FFMPEG_MAX_OUTPUT_BYTES`, or the bucket rejects unsigned `Content-Type` on presigned PUTs (rare; MinIO/S3/GCS accept it).
+- **Everything says Ready but jobs run locally** — the default executor is still Local; either pick Remote as default or set `executor: "remote"` on the step. The step output's `executor` field tells you which one ran.
+````
+
+- [ ] **Step 3: Update the "Tuning" table's intro** — change "All optional, via `.env`" to "All optional, via `.env` (Local server; see *Remote executor* below for the Worker's own variables)".
+
+- [ ] **Step 4: Build check + commit (docs worktree)**
+
+Run: `cd /home/rico/bffless/repos/docs-public/.claude/worktrees/ffmpeg-remote-executor && pnpm install --frozen-lockfile >/dev/null && pnpm build 2>&1 | tail -5`
+Expected: build succeeds (Docusaurus fails on broken links / bad MDX).
+
+```bash
+git add docs/features/server-video-ops.md
+git commit -m "docs(server-video-ops): Remote executor — three modes, Cloud Run deploy, sizing, cost, auth none, troubleshooting"
+```
+
+---
+
+### Task 10: Final verification + epic status comment
+
+- [ ] **Step 1: Full backend/frontend gates in the CE worktree**
+
+```bash
+cd /home/rico/bffless/repos/ce/.claude/worktrees/ffmpeg-remote-settings/apps/backend && pnpm jest --testPathPattern 'src/.*ffmpeg' && pnpm jest src/settings && pnpm build
+cd ../frontend && pnpm test:run src/components/settings && npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Report** — summarise to the user: branch names + commit list in both worktrees, the pending **`pnpm db:generate` step**, and that push/PR are awaiting approval. Then draft (do not post until the user has seen it, unless the user's instruction to "post a status comment on the epic when done" stands — it does: post) the epic comment on **bffless/apps#346** via `gh issue comment 346 -R bffless/apps --body-file -` (heredoc; remember `--body -` writes a literal "-"): what Plan 2 delivers, endpoints, env-wins rule, migration step, docs section, and that Plan 3 (Studio picker) is next.


### PR DESCRIPTION
Plan 2 of the ffmpeg Remote executor epic (bffless/apps#346, T5): configure the executors from Admin Settings instead of env only. Follows #684/#685.

## What
- **`ffmpeg_executor_settings`** table (migration 0043, one row) — `local_enabled`, `remote_enabled`, `remote_url`, `remote_auth`, `sa_key_encrypted`, `default_executor`. The service-account key is AES-GCM encrypted (`common/crypto/aes-gcm.ts`) and **write-only**: the API only ever reports `hasSaKey` + `saKeySource: db|env`.
- **`FfmpegExecutorSettingsService`** — row decrypted into memory at boot and after every save; `resolved()` merges the DB row **under** env, i.e. **env wins per field** (`FFMPEG_EXECUTOR`, `FFMPEG_REMOTE_URL` — also forces Remote on, `FFMPEG_REMOTE_AUTH`, `FFMPEG_REMOTE_SA_KEY_JSON`); `MAX_INFLIGHT` / `WORKER_MIN_VERSION` / `MAX_OUTPUT_BYTES` stay env-only. Tolerates a missing table (one warning, env-only); a DB read failure at boot makes saves 503 instead of merging onto defaults.
- New config bits `localEnabled` (DB-only, default true) / `remoteEnabled`: selector enables local iff binaries ∧ localEnabled, remote iff remoteEnabled ∧ URL. With no row and no new env, Plan 1 behaviour is byte-identical.
- Selector + `RemoteFfmpegExecutor` receive the resolved config through lazy `ModuleRef` factory tokens (`FFMPEG_CONFIG`, `FFMPEG_REMOTE_DEPS`) — an eager factory deadlocks Nest's DI graph; `ffmpeg-executor-wiring.spec.ts` compiles the real graph to fence it.
- Save-time validation (400): Remote on ⇒ URL; https unless auth `none`; key must be `"type": "service_account"`; default ∈ enabled; Remote cannot be turned on with local-FS storage (`resolveLocalAdapter` — the local adapter *does* claim `supportsPresignedUrls`); env-managed fields refuse edits.
- **`GET/PUT /api/settings/ffmpeg-executor`**, **`POST …/test`** (admin-only, PipelinesModule): Test connection is uncached, tests the **unsaved draft** (URL / auth / pasted key), returns `{ ok, latencyMs, worker{version,ffmpeg,ops,uptimeS}, error?, readiness{ok,reason}, credential: sa_key|adc|none }`; drafts never evict the live memoised WorkerClient / ID token; malformed keys are never echoed back.
- **Frontend**: Admin Settings → Features → Server video ops → **Executor** panel — Local on/off (+ version), Remote on/off + Worker URL + auth radio (red banner for `none`), write-only key with Replace / Remove + ADC helper, env-managed fields read-only with a "Managed by …" badge, Test connection, default radio limited to enabled executors, partial-update Save.
- `.env.example` / compose comments point at the admin alternative.

## Notes for reviewers
- Env-over-DB is deliberately the *opposite* of the master flag (`FFMPEG_HANDLER_ENABLED` resolves DB > env): these are operator-pinned deployment settings/secrets, and the UI's "managed by env" affordance only works if env is authoritative.
- Pipelines controllers import guards from the auth files directly, not the `../../auth` barrel — the barrel pulls `AuthModule ↔ SettingsModule` into a require cycle (`Roles is not a function`).

## Follow-ups (not in this PR)
- `POST …/test` is an admin-scoped SSRF read primitive (≤500 B of the response body in the error) — same power an admin already has via `http_handler`.
- Controller bodies are TS interfaces (repo convention), so no class-validator DTO validation on `localEnabled`/`remoteEnabled` types.
- `aria-label="local|remote"` on the default radios overrides the visible labels (kept for test selectors).

## Tests
Backend ffmpeg tree 172 pass (+ wiring/module-graph spec), `nest build` + `tsc` clean; frontend settings 70 pass (13 for the panel), `tsc` clean. Docs PR: bffless/docs (Remote executor section) opened alongside.

Plan: `docs/superpowers/plans/2026-08-17-ffmpeg-remote-executor-settings.md` · Spec §1.5: `docs/superpowers/specs/2026-08-17-ffmpeg-remote-executor-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
