### PR TITLE
feat(app-catalog): install an app into multiple projects, per-install updates and "Update all"

### DIFF
--- a/apps/backend/src/app-catalog/app-catalog.e2e-ish.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.e2e-ish.spec.ts
@@ -23,10 +23,8 @@ jest.mock('../db/client', () => {
   for (const method of methods) {
     chainable[method] = jest.fn(() => chainable);
   }
-  chainable.then = (
-    resolve: (value: unknown) => unknown,
-    reject: (reason: unknown) => unknown,
-  ) => Promise.resolve(queued.length > 0 ? queued.shift() : []).then(resolve, reject);
+  chainable.then = (resolve: (value: unknown) => unknown, reject: (reason: unknown) => unknown) =>
+    Promise.resolve(queued.length > 0 ? queued.shift() : []).then(resolve, reject);
   chainable.__queue = (result: unknown) => queued.push(result);
   chainable.__reset = () => {
     queued.length = 0;
@@ -68,8 +66,12 @@ function fetchResponse(bytes: Uint8Array): Response {
   return {
     ok: true,
     status: 200,
-    headers: { get: (name: string) => (name.toLowerCase() === 'content-length' ? String(bytes.byteLength) : null) },
-    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'content-length' ? String(bytes.byteLength) : null,
+    },
+    arrayBuffer: async () =>
+      bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
   } as unknown as Response;
 }
 
@@ -191,7 +193,9 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
     };
     domains = { create: jest.fn(), remove: jest.fn().mockResolvedValue(undefined) };
     projects = {
-      findOrCreateProject: jest.fn().mockResolvedValue({ id: 'proj-1', owner: 'acme', name: 'site' }),
+      findOrCreateProject: jest
+        .fn()
+        .mockResolvedValue({ id: 'proj-1', owner: 'acme', name: 'site' }),
       projectExists: jest.fn().mockResolvedValue(true),
       getProjectById: jest.fn().mockResolvedValue({ id: 'proj-1', owner: 'acme', name: 'site' }),
       deleteProject: jest.fn().mockResolvedValue(undefined),
@@ -203,7 +207,9 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
       deleteSchedule: jest.fn().mockResolvedValue(undefined),
     };
     schemas = { delete: jest.fn().mockResolvedValue(undefined), getByIdWithCount: jest.fn() };
-    config = { get: jest.fn((key: string) => (key === 'PRIMARY_DOMAIN' ? 'example.com' : undefined)) };
+    config = {
+      get: jest.fn((key: string) => (key === 'PRIMARY_DOMAIN' ? 'example.com' : undefined)),
+    };
 
     service = new AppInstallerService(
       jobs,
@@ -227,7 +233,9 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
 
   function queueInstallDb() {
     mockDb.__queue([]); // select existing installed_apps row (none)
-    mockDb.__queue([{ ...POST_UPDATE_ROW, id: 'ia-fixture', version: '1.0.0', status: 'installing' }]); // insert ... returning
+    mockDb.__queue([
+      { ...POST_UPDATE_ROW, id: 'ia-fixture', version: '1.0.0', status: 'installing' },
+    ]); // insert ... returning
     mockDb.__queue([]); // extra buffer (unused, non-`.returning()` awaits don't destructure)
   }
 
@@ -241,7 +249,14 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
         deleted: [],
         unchanged: [],
         pruneCandidates: [],
-        schemaResolutions: [{ name: 'fixture_items', action: 'create', targetSchemaId: 'sch-items', fieldMismatch: false }],
+        schemaResolutions: [
+          {
+            name: 'fixture_items',
+            action: 'create',
+            targetSchemaId: 'sch-items',
+            fieldMismatch: false,
+          },
+        ],
         missingSecrets: [],
         warnings: [],
         dryRun: false,
@@ -255,8 +270,18 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
         unchanged: [],
         pruneCandidates: [],
         schemaResolutions: [
-          { name: 'fixture_items', action: 'reuse', targetSchemaId: 'sch-items', fieldMismatch: false },
-          { name: 'fixture_notes', action: 'create', targetSchemaId: 'sch-notes', fieldMismatch: false },
+          {
+            name: 'fixture_items',
+            action: 'reuse',
+            targetSchemaId: 'sch-items',
+            fieldMismatch: false,
+          },
+          {
+            name: 'fixture_notes',
+            action: 'create',
+            targetSchemaId: 'sch-notes',
+            fieldMismatch: false,
+          },
         ],
         missingSecrets: [],
         warnings: [],
@@ -308,6 +333,71 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
     expect(Object.keys(deployed).sort()).toEqual(['apps/fixture-app/dist/index.html']);
   });
 
+  it('installs v1 AGAIN into a second project: a second row keyed (app, project B), scoped to B end to end', async () => {
+    // `installed_apps` is unique on (app_id, project_id), so the same app in a
+    // second project is a fresh row with its own version trail — the first
+    // project's install is not consulted or touched anywhere in this run.
+    projects.getProjectById.mockResolvedValue({ id: 'proj-2', owner: 'acme', name: 'blog' });
+    ruleSets.syncRuleSet.mockReset().mockResolvedValue({
+      ruleSetId: 'rs-b2',
+      created: [{ pathPattern: '/api/items', method: 'GET' }],
+      updated: [],
+      deleted: [],
+      unchanged: [],
+      pruneCandidates: [],
+      schemaResolutions: [],
+      missingSecrets: [],
+      warnings: [],
+      dryRun: false,
+      setCreated: true,
+    });
+    mockDb.__queue([]); // select existing (app, proj-2) row: none — project A's row doesn't match
+    mockDb.__queue([
+      {
+        ...POST_UPDATE_ROW,
+        id: 'ia-fixture-b',
+        projectId: 'proj-2',
+        version: '1.0.0',
+        status: 'installing',
+      },
+    ]);
+    mockDb.__queue([]);
+
+    const { jobId } = service.startInstall(
+      ENTRY_V1,
+      { projectId: 'proj-2' },
+      'user-1',
+      'fixture-blog',
+    );
+    await service.whenIdle();
+
+    const job = jobs.get(jobId)!;
+    expect(job.status).toBe('succeeded');
+    expect(job.installedAppId).toBe('ia-fixture-b');
+
+    const inserted = mockDb.values.mock.calls[0][0] as {
+      appId: string;
+      projectId: string;
+      version: string;
+    };
+    expect(inserted).toMatchObject({ appId: 'fixture-app', projectId: 'proj-2', version: '1.0.0' });
+
+    // Every side effect is scoped to project B.
+    for (const call of ruleSets.syncRuleSet.mock.calls) expect(call[0]).toBe('proj-2');
+    const deployDto = deployments.createDeploymentFromFiles.mock.calls[0][1] as {
+      repository: string;
+      alias: string;
+    };
+    expect(deployDto.repository).toBe('acme/blog');
+    expect(deployDto.alias).toBe('fixture-app'); // alias is per project, so the manifest default is reused
+    expect(preflight.projectGates).toHaveBeenCalledWith(
+      expect.anything(),
+      { projectId: 'proj-2' },
+      'user-1',
+      'fixture-blog',
+    );
+  });
+
   it('updates to v2 from real bundle bytes: same alias redeployed, prune false, version bumped', async () => {
     const installedAfterV1: InstalledApp = {
       ...POST_UPDATE_ROW,
@@ -330,7 +420,14 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
         deleted: [],
         unchanged: [{ pathPattern: '/api/items', method: 'GET' }],
         pruneCandidates: [],
-        schemaResolutions: [{ name: 'fixture_items', action: 'reuse', targetSchemaId: 'sch-items', fieldMismatch: false }],
+        schemaResolutions: [
+          {
+            name: 'fixture_items',
+            action: 'reuse',
+            targetSchemaId: 'sch-items',
+            fieldMismatch: false,
+          },
+        ],
         missingSecrets: [],
         warnings: [],
         dryRun: false,
@@ -344,15 +441,27 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
         unchanged: [{ pathPattern: '/api/notes', method: 'GET' }],
         pruneCandidates: [],
         schemaResolutions: [
-          { name: 'fixture_items', action: 'reuse', targetSchemaId: 'sch-items', fieldMismatch: false },
-          { name: 'fixture_notes', action: 'reuse', targetSchemaId: 'sch-notes', fieldMismatch: false },
+          {
+            name: 'fixture_items',
+            action: 'reuse',
+            targetSchemaId: 'sch-items',
+            fieldMismatch: false,
+          },
+          {
+            name: 'fixture_notes',
+            action: 'reuse',
+            targetSchemaId: 'sch-notes',
+            fieldMismatch: false,
+          },
         ],
         missingSecrets: [],
         warnings: [],
         dryRun: false,
         setCreated: false,
       });
-    deployments.createDeploymentFromFiles.mockResolvedValue(deployResponse({ deploymentId: 'dep-fixture-2' }));
+    deployments.createDeploymentFromFiles.mockResolvedValue(
+      deployResponse({ deploymentId: 'dep-fixture-2' }),
+    );
     mockDb.__queue([]); // final record update — startUpdate takes the row directly, no db read
 
     const { jobId } = service.startUpdate(installedAfterV1, ENTRY_V2, 'user-1', { prune: false });
@@ -407,7 +516,8 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
   describe('uninstall (post v1-install, v2-update state)', () => {
     beforeEach(() => {
       schemas.getByIdWithCount = jest.fn((id: string) => {
-        if (id === 'sch-items') return Promise.resolve({ id, name: 'fixture_items', recordCount: 5 });
+        if (id === 'sch-items')
+          return Promise.resolve({ id, name: 'fixture_items', recordCount: 5 });
         return Promise.resolve({ id, name: 'fixture_notes', recordCount: 12 });
       });
     });
@@ -420,7 +530,12 @@ describe('App catalog orchestration (fixture bundle, real bytes + real manifest 
 
       expect(schemas.delete).not.toHaveBeenCalled();
       expect(ruleSets.delete).toHaveBeenCalledTimes(2);
-      expect(deployments.deleteAlias).toHaveBeenCalledWith('acme/site', 'fixture-app', 'user-1', 'admin');
+      expect(deployments.deleteAlias).toHaveBeenCalledWith(
+        'acme/site',
+        'fixture-app',
+        'user-1',
+        'admin',
+      );
       expect(deployments.deleteDeployment).toHaveBeenCalledWith('dep-fixture-2', 'user-1', 'admin');
       expect(summary.dataTables.deleted).toEqual([]);
       expect(summary.dataTables.kept.slice().sort()).toEqual(['fixture_items', 'fixture_notes']);

--- a/apps/backend/src/app-catalog/app-catalog.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.spec.ts
@@ -6,10 +6,8 @@ jest.mock('../db/client', () => {
   for (const method of methods) {
     chainable[method] = jest.fn(() => chainable);
   }
-  chainable.then = (
-    resolve: (value: unknown) => unknown,
-    reject: (reason: unknown) => unknown,
-  ) => Promise.resolve(queued.length > 0 ? queued.shift() : []).then(resolve, reject);
+  chainable.then = (resolve: (value: unknown) => unknown, reject: (reason: unknown) => unknown) =>
+    Promise.resolve(queued.length > 0 ? queued.shift() : []).then(resolve, reject);
   chainable.__queue = (result: unknown) => queued.push(result);
   chainable.__reset = () => {
     queued.length = 0;
@@ -132,11 +130,15 @@ describe('AppCatalogService', () => {
     };
     config = { get: jest.fn().mockReturnValue(undefined) };
     registry = {
-      getRegistry: jest.fn().mockResolvedValue({ ok: true, registry: { schemaVersion: 1, apps: [] } }),
+      getRegistry: jest
+        .fn()
+        .mockResolvedValue({ ok: true, registry: { schemaVersion: 1, apps: [] } }),
     };
     bundle = { fetchBundle: jest.fn() };
     preflight = {
-      instanceGates: jest.fn().mockResolvedValue([{ id: 'storage', status: 'pass', message: 'ok' }]),
+      instanceGates: jest
+        .fn()
+        .mockResolvedValue([{ id: 'storage', status: 'pass', message: 'ok' }]),
       projectGates: jest.fn().mockResolvedValue({
         gates: [{ id: 'dns', status: 'pass', message: 'ok' }],
         syncPlans: [],
@@ -181,7 +183,9 @@ describe('AppCatalogService', () => {
 
   describe('ejectPayload', () => {
     it('derives BFFLESS_URL from https://admin.PRIMARY_DOMAIN when PUBLIC_ORIGIN is unset', async () => {
-      config.get.mockImplementation((key: string) => (key === 'PRIMARY_DOMAIN' ? 'example.com' : undefined));
+      config.get.mockImplementation((key: string) =>
+        key === 'PRIMARY_DOMAIN' ? 'example.com' : undefined,
+      );
       mockDb.__queue([ROW]);
 
       const payload = await service.ejectPayload('ia-1');
@@ -244,6 +248,7 @@ describe('AppCatalogService', () => {
           registryVersion: '1.0.0',
           gates: [{ id: 'storage', status: 'pass', message: 'ok' }],
           installable: true,
+          installs: [],
         },
       ]);
     });
@@ -287,7 +292,9 @@ describe('AppCatalogService', () => {
         ok: true,
         registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
       });
-      preflight.instanceGates.mockResolvedValue([{ id: 'storage', status: 'fail', message: 'nope' }]);
+      preflight.instanceGates.mockResolvedValue([
+        { id: 'storage', status: 'fail', message: 'nope' },
+      ]);
       mockDb.__queue([]);
 
       const result = await service.listCatalog();
@@ -306,17 +313,53 @@ describe('AppCatalogService', () => {
       const result = await service.listCatalog();
 
       expect(result.data).toHaveLength(1);
-      expect(result.data[0].installed).toEqual({
-        installedAppId: 'ia-1',
-        version: '1.0.0',
-        projectId: 'proj-1',
-        projectName: 'acme/site',
-        alias: 'handoff',
-        appUrl: undefined,
-        status: 'installed',
-        updateAvailable: true, // 1.1.0 > 1.0.0
-        manualSteps: [{ id: 'always-step', title: 'Always', body: 'always applies' }],
+      expect(result.data[0].installs).toEqual([
+        {
+          installedAppId: 'ia-1',
+          version: '1.0.0',
+          projectId: 'proj-1',
+          projectName: 'acme/site',
+          alias: 'handoff',
+          appUrl: undefined,
+          status: 'installed',
+          updateAvailable: true, // 1.1.0 > 1.0.0
+          installedAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          manualSteps: [{ id: 'always-step', title: 'Always', body: 'always applies' }],
+        },
+      ]);
+    });
+
+    it('lists every install of the same app, oldest first, each with its own version and updateAvailable', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [{ ...HANDOFF_ENTRY, version: '1.1.0' }] },
       });
+      const rowB = {
+        ...ROW,
+        id: 'ia-2',
+        projectId: 'proj-2',
+        version: '1.1.0',
+        installedAt: new Date('2026-02-01T00:00:00Z'),
+        updatedAt: new Date('2026-03-01T00:00:00Z'),
+      };
+      // Most recently touched row first in the DB result — ordering must not
+      // depend on it.
+      mockDb.__queue([rowB, ROW]);
+      projects.getProjectById.mockImplementation(async (id: string) =>
+        id === 'proj-2'
+          ? { id: 'proj-2', owner: 'acme', name: 'blog' }
+          : { id: 'proj-1', owner: 'acme', name: 'site' },
+      );
+
+      const result = await service.listCatalog();
+
+      expect(result.data).toHaveLength(1);
+      const installs = result.data[0].installs;
+      expect(installs.map((i) => i.installedAppId)).toEqual(['ia-1', 'ia-2']);
+      expect(installs.map((i) => i.projectName)).toEqual(['acme/site', 'acme/blog']);
+      expect(installs.map((i) => i.version)).toEqual(['1.0.0', '1.1.0']);
+      expect(installs.map((i) => i.updateAvailable)).toEqual([true, false]);
     });
 
     it('does not treat a CachingStorageAdapter-wrapped local adapter as bucket storage (regression: live droplet Redis cache)', async () => {
@@ -334,7 +377,7 @@ describe('AppCatalogService', () => {
 
       const result = await service.listCatalog();
 
-      expect(result.data[0].installed!.manualSteps).toEqual([
+      expect(result.data[0].installs[0].manualSteps).toEqual([
         { id: 'always-step', title: 'Always', body: 'always applies' },
       ]);
     });
@@ -348,7 +391,7 @@ describe('AppCatalogService', () => {
 
       const result = await service.listCatalog();
 
-      expect(result.data[0].installed!.updateAvailable).toBe(false);
+      expect(result.data[0].installs[0].updateAvailable).toBe(false);
     });
 
     it('degrades to registryError while still listing installed apps', async () => {
@@ -362,7 +405,7 @@ describe('AppCatalogService', () => {
       expect(result.data[0].id).toBe('handoff');
       expect(result.data[0].registryVersion).toBeUndefined();
       expect(result.data[0].installable).toBe(false);
-      expect(result.data[0].installed!.installedAppId).toBe('ia-1');
+      expect(result.data[0].installs[0].installedAppId).toBe('ia-1');
       // instanceGates computed from the stored manifest's requires, not a registry entry.
       expect(preflight.instanceGates).toHaveBeenCalledWith(undefined);
     });
@@ -380,7 +423,26 @@ describe('AppCatalogService', () => {
       expect(result.data).toHaveLength(1);
       expect(result.data[0].registryVersion).toBeUndefined();
       expect(result.data[0].installable).toBe(false);
-      expect(result.data[0].installed!.installedAppId).toBe('ia-1');
+      expect(result.data[0].installs[0].installedAppId).toBe('ia-1');
+    });
+
+    it('renders a delisted app with two installs as one entry carrying both installs', async () => {
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [] },
+      });
+      mockDb.__queue([LEGACY_ROW, { ...LEGACY_ROW, id: 'ia-legacy-2', projectId: 'proj-2' }]);
+
+      const result = await service.listCatalog();
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].id).toBe('legacy-app');
+      expect(result.data[0].installable).toBe(false);
+      expect(result.data[0].installs.map((i) => i.installedAppId)).toEqual([
+        'ia-legacy',
+        'ia-legacy-2',
+      ]);
+      expect(result.data[0].installs.every((i) => i.updateAvailable === false)).toBe(true);
     });
 
     it('lists multiple unrelated installed-only apps alongside registry apps', async () => {
@@ -415,7 +477,7 @@ describe('AppCatalogService', () => {
 
         const result = await service.listCatalog();
 
-        expect(result.data[0].installed!.appUrl).toBe('https://files.example.com');
+        expect(result.data[0].installs[0].appUrl).toBe('https://files.example.com');
       });
 
       it('links http:// when the serving model has no certificate for the host yet (ce#584)', async () => {
@@ -430,10 +492,10 @@ describe('AppCatalogService', () => {
         const result = await service.listCatalog();
 
         expect(certStep.schemeFor).toHaveBeenCalledWith('files.example.com', false);
-        expect(result.data[0].installed!.appUrl).toBe('http://files.example.com');
+        expect(result.data[0].installs[0].appUrl).toBe('http://files.example.com');
       });
 
-      it('passes the row\'s sslEnabled through, so an edge-terminated install still links https', async () => {
+      it("passes the row's sslEnabled through, so an edge-terminated install still links https", async () => {
         registry.getRegistry.mockResolvedValue({
           ok: true,
           registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
@@ -444,7 +506,7 @@ describe('AppCatalogService', () => {
         const result = await service.listCatalog();
 
         expect(certStep.schemeFor).toHaveBeenCalledWith('files.example.com', true);
-        expect(result.data[0].installed!.appUrl).toBe('https://files.example.com');
+        expect(result.data[0].installs[0].appUrl).toBe('https://files.example.com');
       });
 
       it('yields undefined appUrl when domainId points at a since-deleted mapping', async () => {
@@ -457,7 +519,7 @@ describe('AppCatalogService', () => {
 
         const result = await service.listCatalog();
 
-        expect(result.data[0].installed!.appUrl).toBeUndefined();
+        expect(result.data[0].installs[0].appUrl).toBeUndefined();
       });
 
       it('yields undefined appUrl with no domainId lookup at all when the row has none', async () => {
@@ -469,7 +531,7 @@ describe('AppCatalogService', () => {
 
         const result = await service.listCatalog();
 
-        expect(result.data[0].installed!.appUrl).toBeUndefined();
+        expect(result.data[0].installs[0].appUrl).toBeUndefined();
         // No domainId anywhere -> the batch query is skipped entirely (only
         // the installedApps row select happened).
         expect(mockDb.select).toHaveBeenCalledTimes(1);
@@ -480,7 +542,13 @@ describe('AppCatalogService', () => {
           ok: true,
           registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
         });
-        const rowA = { ...ROW, id: 'ia-1', appId: 'handoff', manifest: MANIFEST_WITH_DOMAIN, domainId: 'dom-1' };
+        const rowA = {
+          ...ROW,
+          id: 'ia-1',
+          appId: 'handoff',
+          manifest: MANIFEST_WITH_DOMAIN,
+          domainId: 'dom-1',
+        };
         const rowB = { ...LEGACY_ROW, id: 'ia-legacy', appId: 'legacy-app', domainId: 'dom-2' };
         mockDb.__queue([rowA, rowB]);
         mockDb.__queue([
@@ -497,8 +565,8 @@ describe('AppCatalogService', () => {
 
         const handoff = result.data.find((e) => e.id === 'handoff')!;
         const legacy = result.data.find((e) => e.id === 'legacy-app')!;
-        expect(handoff.installed!.appUrl).toBe('https://files.example.com');
-        expect(legacy.installed!.appUrl).toBe('https://legacy.example.com');
+        expect(handoff.installs[0].appUrl).toBe('https://files.example.com');
+        expect(legacy.installs[0].appUrl).toBe('https://legacy.example.com');
       });
     });
   });
@@ -533,7 +601,7 @@ describe('AppCatalogService', () => {
       mockDb.__queue([{ id: 'dom-1', domain: 'reader.example.com' }]);
 
       const result = await service.listCatalog();
-      const steps = result.data[0].installed!.manualSteps;
+      const steps = result.data[0].installs[0].manualSteps;
 
       expect(steps[0].deepLink).toBe('/repo/acme/site/settings?tab=members');
       expect(steps[1].body).toBe('Allow PUT from reader.example.com.');
@@ -551,7 +619,7 @@ describe('AppCatalogService', () => {
 
       const result = await service.listCatalog();
 
-      expect(result.data[0].installed!.manualSteps.map((s) => s.id)).toContain(
+      expect(result.data[0].installs[0].manualSteps.map((s) => s.id)).toContain(
         'provision-wildcard-cert',
       );
     });
@@ -564,7 +632,7 @@ describe('AppCatalogService', () => {
 
       const result = await service.listCatalog();
 
-      expect(result.data[0].installed!.manualSteps.map((s) => s.id)).not.toContain(
+      expect(result.data[0].installs[0].manualSteps.map((s) => s.id)).not.toContain(
         'provision-wildcard-cert',
       );
     });
@@ -577,8 +645,8 @@ describe('AppCatalogService', () => {
 
       const result = await service.listCatalog();
 
-      expect(result.data[0].installed).toBeDefined();
-      expect(result.data[0].installed!.manualSteps.map((s) => s.id)).not.toContain(
+      expect(result.data[0].installs).toHaveLength(1);
+      expect(result.data[0].installs[0].manualSteps.map((s) => s.id)).not.toContain(
         'provision-wildcard-cert',
       );
       expect(warnSpy).toHaveBeenCalled();
@@ -591,16 +659,32 @@ describe('AppCatalogService', () => {
         ok: true,
         registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
       });
-      bundle.fetchBundle.mockResolvedValue({ manifest: MANIFEST, files: {}, sha256: 'a'.repeat(64) });
+      bundle.fetchBundle.mockResolvedValue({
+        manifest: MANIFEST,
+        files: {},
+        sha256: 'a'.repeat(64),
+      });
       preflight.projectGates.mockResolvedValue({
         gates: [{ id: 'dns', status: 'pass', message: 'ok' }],
-        syncPlans: [{ ruleSet: 'handoff', created: 1, updated: 0, unchanged: 0, pruneCandidates: 0, schemaResolutions: [] }],
+        syncPlans: [
+          {
+            ruleSet: 'handoff',
+            created: 1,
+            updated: 0,
+            unchanged: 0,
+            pruneCandidates: 0,
+            schemaResolutions: [],
+          },
+        ],
         appHost: 'handoff.example.com',
       });
 
       const result = await service.preflight('handoff', { projectId: 'proj-1' } as never, 'user-1');
 
-      expect(bundle.fetchBundle).toHaveBeenCalledWith(HANDOFF_ENTRY.bundleUrl, HANDOFF_ENTRY.sha256);
+      expect(bundle.fetchBundle).toHaveBeenCalledWith(
+        HANDOFF_ENTRY.bundleUrl,
+        HANDOFF_ENTRY.sha256,
+      );
       expect(preflight.projectGates).toHaveBeenCalledWith(
         { manifest: MANIFEST, files: {}, sha256: 'a'.repeat(64) },
         { projectId: 'proj-1' },
@@ -648,8 +732,145 @@ describe('AppCatalogService', () => {
       expect(result.appUrl).toBe('https://my-app.example.com');
     });
 
+    describe('suggestedSubdomain (install-again into another project)', () => {
+      const MANIFEST_WITH_DEFAULT_HOST: AppManifest = {
+        ...MANIFEST,
+        install: { ...MANIFEST.install, domain: { subdomain: 'handoff' } },
+      };
+      const mappedDefault = { id: 'dom-1' };
+
+      beforeEach(() => {
+        config.get.mockImplementation((key: string) =>
+          key === 'PRIMARY_DOMAIN' ? 'example.com' : undefined,
+        );
+        registry.getRegistry.mockResolvedValue({
+          ok: true,
+          registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
+        });
+        bundle.fetchBundle.mockResolvedValue({
+          manifest: MANIFEST_WITH_DEFAULT_HOST,
+          files: {},
+          sha256: 'a'.repeat(64),
+        });
+      });
+
+      it('suggests <default>-<project> when the manifest default host is already mapped', async () => {
+        mockDb.__queue([mappedDefault]); // default host lookup: taken
+        mockDb.__queue([]); // candidate host lookup: free
+        mockDb.__queue([]); // candidate alias lookup: free
+
+        const result = await service.preflight(
+          'handoff',
+          { projectId: 'proj-1' } as never,
+          'user-1',
+        );
+
+        expect(result.suggestedSubdomain).toBe('handoff-site');
+      });
+
+      it('walks to -2 when the first candidate host is mapped', async () => {
+        mockDb.__queue([mappedDefault]); // default taken
+        mockDb.__queue([{ id: 'dom-2' }]); // candidate 1 host taken
+        mockDb.__queue([]); // candidate 2 host free
+        mockDb.__queue([]); // candidate 2 alias free
+
+        const result = await service.preflight(
+          'handoff',
+          { projectId: 'proj-1' } as never,
+          'user-1',
+        );
+
+        expect(result.suggestedSubdomain).toBe('handoff-site-2');
+      });
+
+      it('treats an alias of the candidate name anywhere as taken (wildcard route collision)', async () => {
+        mockDb.__queue([mappedDefault]); // default taken
+        mockDb.__queue([]); // candidate 1 host free
+        mockDb.__queue([{ id: 'al-1' }]); // candidate 1 alias taken
+        mockDb.__queue([]); // candidate 2 host free
+        mockDb.__queue([]); // candidate 2 alias free
+
+        const result = await service.preflight(
+          'handoff',
+          { projectId: 'proj-1' } as never,
+          'user-1',
+        );
+
+        expect(result.suggestedSubdomain).toBe('handoff-site-2');
+      });
+
+      it('uses the new project name for a newProject target', async () => {
+        mockDb.__queue([mappedDefault]);
+        mockDb.__queue([]);
+        mockDb.__queue([]);
+
+        const result = await service.preflight(
+          'handoff',
+          { newProject: { owner: 'acme', name: 'Docs Site' } } as never,
+          'user-1',
+        );
+
+        expect(result.suggestedSubdomain).toBe('handoff-docs-site');
+      });
+
+      it('suggests nothing when the default host is free', async () => {
+        mockDb.__queue([]); // default host lookup: free
+
+        const result = await service.preflight(
+          'handoff',
+          { projectId: 'proj-1' } as never,
+          'user-1',
+        );
+
+        expect(result.suggestedSubdomain).toBeUndefined();
+        expect(mockDb.select).toHaveBeenCalledTimes(1);
+      });
+
+      it('suggests nothing when the operator already chose a subdomain', async () => {
+        const result = await service.preflight(
+          'handoff',
+          { projectId: 'proj-1', subdomain: 'mine' } as never,
+          'user-1',
+        );
+
+        expect(result.suggestedSubdomain).toBeUndefined();
+        expect(mockDb.select).not.toHaveBeenCalled();
+      });
+
+      it('suggests nothing when the manifest has no default subdomain or PRIMARY_DOMAIN is unset', async () => {
+        bundle.fetchBundle.mockResolvedValue({
+          manifest: MANIFEST,
+          files: {},
+          sha256: 'a'.repeat(64),
+        });
+        const noDomain = await service.preflight(
+          'handoff',
+          { projectId: 'proj-1' } as never,
+          'user-1',
+        );
+        expect(noDomain.suggestedSubdomain).toBeUndefined();
+
+        bundle.fetchBundle.mockResolvedValue({
+          manifest: MANIFEST_WITH_DEFAULT_HOST,
+          files: {},
+          sha256: 'a'.repeat(64),
+        });
+        config.get.mockReturnValue(undefined);
+        const noPrimary = await service.preflight(
+          'handoff',
+          { projectId: 'proj-1' } as never,
+          'user-1',
+        );
+        expect(noPrimary.suggestedSubdomain).toBeUndefined();
+        expect(mockDb.select).not.toHaveBeenCalled();
+      });
+    });
+
     it('throws NotFoundException for an app id not in the registry', async () => {
-      registry.getRegistry.mockResolvedValue({ ok: true, registry: { schemaVersion: 1, apps: [] } });
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [] },
+      });
 
       await expect(
         service.preflight('unknown-app', { projectId: 'proj-1' } as never, 'user-1'),
@@ -670,7 +891,9 @@ describe('AppCatalogService', () => {
         registry: { schemaVersion: 1, apps: [HANDOFF_ENTRY] },
       });
 
-      await expect(service.preflight('handoff', {} as never, 'user-1')).rejects.toThrow(BadRequestException);
+      await expect(service.preflight('handoff', {} as never, 'user-1')).rejects.toThrow(
+        BadRequestException,
+      );
       expect(bundle.fetchBundle).not.toHaveBeenCalled();
     });
 
@@ -733,11 +956,14 @@ describe('AppCatalogService', () => {
     });
 
     it('throws NotFoundException for an unknown app id', async () => {
-      registry.getRegistry.mockResolvedValue({ ok: true, registry: { schemaVersion: 1, apps: [] } });
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [] },
+      });
 
-      await expect(service.install('unknown', { projectId: 'proj-1' } as never, 'user-1')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        service.install('unknown', { projectId: 'proj-1' } as never, 'user-1'),
+      ).rejects.toThrow(NotFoundException);
       expect(installer.startInstall).not.toHaveBeenCalled();
     });
   });
@@ -764,14 +990,21 @@ describe('AppCatalogService', () => {
     it('throws NotFoundException when the installed app row does not exist', async () => {
       mockDb.__queue([]);
 
-      await expect(service.updateInstalled('missing', false, 'user-1')).rejects.toThrow(NotFoundException);
+      await expect(service.updateInstalled('missing', false, 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('throws NotFoundException when the app is no longer in the registry', async () => {
-      registry.getRegistry.mockResolvedValue({ ok: true, registry: { schemaVersion: 1, apps: [] } });
+      registry.getRegistry.mockResolvedValue({
+        ok: true,
+        registry: { schemaVersion: 1, apps: [] },
+      });
       mockDb.__queue([ROW]);
 
-      await expect(service.updateInstalled('ia-1', false, 'user-1')).rejects.toThrow(NotFoundException);
+      await expect(service.updateInstalled('ia-1', false, 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 

--- a/apps/backend/src/app-catalog/app-catalog.service.ts
+++ b/apps/backend/src/app-catalog/app-catalog.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { eq, inArray } from 'drizzle-orm';
 import { db } from '../db/client';
 import {
+  deploymentAliases,
   domainMappings,
   installedApps,
   type InstalledApp,
@@ -28,7 +29,13 @@ import {
 import { AppInstallJobsService, type InstallJob } from './app-install-jobs.service';
 import { AppCertStepService } from './app-cert-step.service';
 import { compareSemver } from './ce-version.util';
-import { manualStepApplies, interpolateStep, type StepPlaceholders } from './app-manifest.util';
+import {
+  manualStepApplies,
+  interpolateStep,
+  isReservedSubdomain,
+  type StepPlaceholders,
+} from './app-manifest.util';
+import { suggestSubdomain } from './suggest-subdomain.util';
 import type { AppManifest, AppManualStep, AppRegistryEntry } from './app-manifest.types';
 import type { PreflightRequestDto } from './app-catalog.dtos';
 
@@ -70,17 +77,29 @@ export interface CatalogEntry {
   gates: GateResult[];
   /** Every instance gate passed AND the app is present in the registry. */
   installable: boolean;
-  installed?: {
-    installedAppId: string;
-    version: string;
-    projectId: string;
-    projectName: string;
-    alias: string;
-    appUrl?: string;
-    status: InstalledAppStatus;
-    updateAvailable: boolean;
-    manualSteps: AppManualStep[];
-  };
+  /**
+   * Every install of this app on the instance, oldest first. An app can be
+   * installed into many projects (`installed_apps` is unique on
+   * `(app_id, project_id)`), each on its own version — so this is a list, and
+   * `updateAvailable` is per element. Empty when the app isn't installed.
+   */
+  installs: InstalledSummary[];
+}
+
+/** One installed_apps row, as the catalog presents it. */
+export interface InstalledSummary {
+  installedAppId: string;
+  version: string;
+  projectId: string;
+  projectName: string;
+  alias: string;
+  appUrl?: string;
+  status: InstalledAppStatus;
+  updateAvailable: boolean;
+  /** ISO timestamps — the per-install version trail (`updatedAt` moves on every update job). */
+  installedAt: string;
+  updatedAt: string;
+  manualSteps: AppManualStep[];
 }
 
 export interface CatalogListResult {
@@ -93,6 +112,12 @@ export interface PreflightResult {
   syncPlans: SyncPlanSummary[];
   appHost: string | null;
   appUrl?: string;
+  /**
+   * A free subdomain the wizard can prefill when the manifest's default host
+   * is already mapped (the app is being installed again, into another
+   * project). Only computed when the request carries no `subdomain` of its own.
+   */
+  suggestedSubdomain?: string;
 }
 
 /**
@@ -161,28 +186,97 @@ export class AppCatalogService {
   }
 
   /** Combined instance + project gates, for the install wizard's preview screen. */
-  async preflight(appId: string, dto: PreflightRequestDto, userId: string): Promise<PreflightResult> {
+  async preflight(
+    appId: string,
+    dto: PreflightRequestDto,
+    userId: string,
+  ): Promise<PreflightResult> {
     const entry = await this.requireRegistryEntry(appId);
     const target = this.toInstallTarget(dto);
     const bundle = await this.bundleService.fetchBundle(entry.bundleUrl, entry.sha256);
 
     const instanceGates = await this.preflightService.instanceGates(entry.requires);
-    const { gates: projectGates, syncPlans, appHost } = await this.preflightService.projectGates(
+    const {
+      gates: projectGates,
+      syncPlans,
+      appHost,
+    } = await this.preflightService.projectGates(
       bundle,
       this.toPreflightTarget(target),
       userId,
       dto.subdomain,
     );
 
+    const suggestedSubdomain =
+      dto.subdomain === undefined
+        ? await this.suggestFreeSubdomain(bundle.manifest, target)
+        : undefined;
+
     return {
       gates: [...instanceGates, ...projectGates],
       syncPlans,
       appHost,
       appUrl: appHost ? `https://${appHost}` : undefined,
+      ...(suggestedSubdomain ? { suggestedSubdomain } : {}),
     };
   }
 
-  async install(appId: string, dto: PreflightRequestDto, userId: string): Promise<{ jobId: string }> {
+  /**
+   * Install-again support: when the manifest's default host is already mapped
+   * (by this app's install in another project, typically), propose
+   * `<default>-<project>` so the operator isn't left to invent a host that
+   * clears the name-collision gate. `undefined` whenever the default is free,
+   * the manifest has no default host, or no candidate turns out to be free.
+   */
+  private async suggestFreeSubdomain(
+    manifest: AppManifest,
+    target: InstallTarget,
+  ): Promise<string | undefined> {
+    const defaultSubdomain = manifest.install.domain?.subdomain;
+    const primaryDomain = this.configService.get<string>('PRIMARY_DOMAIN') || '';
+    if (!defaultSubdomain || !primaryDomain) return undefined;
+
+    if (!(await this.hostIsMapped(`${defaultSubdomain}.${primaryDomain}`))) return undefined;
+
+    const projectName = target.projectId
+      ? (await this.projectsService.getProjectById(target.projectId)).name
+      : target.newProject?.name;
+    if (!projectName) return undefined;
+
+    return suggestSubdomain({
+      defaultSubdomain,
+      projectName,
+      isReserved: isReservedSubdomain,
+      isTaken: async (candidate) =>
+        (await this.hostIsMapped(`${candidate}.${primaryDomain}`)) ||
+        (await this.aliasExistsAnywhere(candidate)),
+    });
+  }
+
+  private async hostIsMapped(host: string): Promise<boolean> {
+    const [row] = await db
+      .select({ id: domainMappings.id })
+      .from(domainMappings)
+      .where(eq(domainMappings.domain, host))
+      .limit(1);
+    return Boolean(row);
+  }
+
+  /** Any project's alias of that name would answer at `<name>.PRIMARY_DOMAIN` via the wildcard route. */
+  private async aliasExistsAnywhere(alias: string): Promise<boolean> {
+    const [row] = await db
+      .select({ id: deploymentAliases.id })
+      .from(deploymentAliases)
+      .where(eq(deploymentAliases.alias, alias))
+      .limit(1);
+    return Boolean(row);
+  }
+
+  async install(
+    appId: string,
+    dto: PreflightRequestDto,
+    userId: string,
+  ): Promise<{ jobId: string }> {
     const entry = await this.requireRegistryEntry(appId);
     const target = this.toInstallTarget(dto);
     return this.installerService.startInstall(entry, target, userId, dto.subdomain);
@@ -217,7 +311,10 @@ export class AppCatalogService {
    * click away from that. An update has its own, non-destructive rollback: the
    * alias's deployment history still points at the previous version.
    */
-  async undoJob(jobId: string, userId: string): Promise<{ removed: string[]; failures?: string[] }> {
+  async undoJob(
+    jobId: string,
+    userId: string,
+  ): Promise<{ removed: string[]; failures?: string[] }> {
     const job = this.getJob(jobId);
     if (job.kind === 'update') {
       throw new BadRequestException(
@@ -236,7 +333,11 @@ export class AppCatalogService {
     return this.installerService.uninstallPreview(installedAppId);
   }
 
-  uninstall(installedAppId: string, deleteData: boolean, userId: string): Promise<UninstallSummary> {
+  uninstall(
+    installedAppId: string,
+    deleteData: boolean,
+    userId: string,
+  ): Promise<UninstallSummary> {
     return this.installerService.uninstall(installedAppId, userId, { deleteData });
   }
 
@@ -293,11 +394,9 @@ export class AppCatalogService {
       registryVersion: entry.version,
       gates,
       installable: gates.every((gate) => gate.status !== 'fail'),
+      installs: await this.buildInstalledSummaries(rows, entry.version, domainsById),
     };
-    if (rows.length === 0) return base;
-
-    const row = pickPrimaryRow(rows);
-    return { ...base, installed: await this.buildInstalledSummary(row, entry.version, domainsById) };
+    return base;
   }
 
   /** An installed app whose app id isn't (or no longer is) in the registry. */
@@ -305,8 +404,10 @@ export class AppCatalogService {
     rows: InstalledApp[],
     domainsById: Map<string, DomainRef>,
   ): Promise<CatalogEntry> {
-    const row = pickPrimaryRow(rows);
-    const manifest = row.manifest as AppManifest;
+    // Every row of a delisted app carries the same app's manifest (possibly at
+    // different versions); the metadata fields read here are stable across
+    // versions, so any row will do — take the oldest install's.
+    const manifest = sortByInstalledAt(rows)[0].manifest as AppManifest;
     const gates = await this.preflightService.instanceGates(manifest.requires);
 
     // `description`/`thumbnailUrl`/`screenshots` are registry-only (the store
@@ -322,15 +423,27 @@ export class AppCatalogService {
       sourceUrl: manifest.sourceUrl,
       gates,
       installable: false, // no registry entry to install/reinstall from
-      installed: await this.buildInstalledSummary(row, undefined, domainsById),
+      installs: await this.buildInstalledSummaries(rows, undefined, domainsById),
     };
+  }
+
+  private async buildInstalledSummaries(
+    rows: InstalledApp[],
+    registryVersion: string | undefined,
+    domainsById: Map<string, DomainRef>,
+  ): Promise<InstalledSummary[]> {
+    return Promise.all(
+      sortByInstalledAt(rows).map((row) =>
+        this.buildInstalledSummary(row, registryVersion, domainsById),
+      ),
+    );
   }
 
   private async buildInstalledSummary(
     row: InstalledApp,
     registryVersion: string | undefined,
     domainsById: Map<string, DomainRef>,
-  ): Promise<NonNullable<CatalogEntry['installed']>> {
+  ): Promise<InstalledSummary> {
     const manifest = row.manifest as AppManifest;
     const project = await this.projectsService.getProjectById(row.projectId);
     const updateAvailable =
@@ -349,6 +462,8 @@ export class AppCatalogService {
       appUrl,
       status: row.status,
       updateAvailable,
+      installedAt: row.installedAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
       manualSteps: [
         ...this.applicableManualSteps(manifest, { projectPath, appHost }),
         ...(await this.certManualStep(appHost)),
@@ -404,7 +519,9 @@ export class AppCatalogService {
    * installed row.
    */
   private async fetchDomainsById(rows: InstalledApp[]): Promise<Map<string, DomainRef>> {
-    const domainIds = [...new Set(rows.map((row) => row.domainId).filter((id): id is string => Boolean(id)))];
+    const domainIds = [
+      ...new Set(rows.map((row) => row.domainId).filter((id): id is string => Boolean(id))),
+    ];
     if (domainIds.length === 0) return new Map();
 
     const mappings = await db
@@ -453,10 +570,7 @@ export class AppCatalogService {
     return `${scheme}://${ref.domain}`;
   }
 
-  private applicableManualSteps(
-    manifest: AppManifest,
-    values: StepPlaceholders,
-  ): AppManualStep[] {
+  private applicableManualSteps(manifest: AppManifest, values: StepPlaceholders): AppManualStep[] {
     const ctx = this.instanceContext();
     return (manifest.install.manualSteps ?? [])
       .filter((step) => manualStepApplies(step, ctx))
@@ -510,12 +624,7 @@ export class AppCatalogService {
   }
 }
 
-/**
- * An app can (in principle) be installed into more than one project, but
- * `CatalogEntry.installed` is singular — the catalog is a browse view, not a
- * per-project inventory. Picks the most recently touched row so the entry
- * reflects whatever the operator did last.
- */
-function pickPrimaryRow(rows: InstalledApp[]): InstalledApp {
-  return rows.reduce((latest, row) => (row.updatedAt > latest.updatedAt ? row : latest));
+/** Oldest install first — a stable order that doesn't reshuffle on every update. */
+function sortByInstalledAt(rows: InstalledApp[]): InstalledApp[] {
+  return [...rows].sort((a, b) => a.installedAt.getTime() - b.installedAt.getTime());
 }

--- a/apps/backend/src/app-catalog/suggest-subdomain.util.spec.ts
+++ b/apps/backend/src/app-catalog/suggest-subdomain.util.spec.ts
@@ -1,0 +1,85 @@
+import { slugify, suggestSubdomain } from './suggest-subdomain.util';
+
+describe('suggestSubdomain', () => {
+  const never = async () => false;
+  const notReserved = () => false;
+
+  it('proposes <default>-<project> when it is free', async () => {
+    await expect(
+      suggestSubdomain({
+        defaultSubdomain: 'studio',
+        projectName: 'blog',
+        isTaken: never,
+        isReserved: notReserved,
+      }),
+    ).resolves.toBe('studio-blog');
+  });
+
+  it('slugifies the project name', async () => {
+    await expect(
+      suggestSubdomain({
+        defaultSubdomain: 'studio',
+        projectName: 'My Blog_2026!',
+        isTaken: never,
+        isReserved: notReserved,
+      }),
+    ).resolves.toBe('studio-my-blog-2026');
+  });
+
+  it('appends -2, -3, … while candidates are taken', async () => {
+    const taken = new Set(['studio-blog', 'studio-blog-2']);
+    await expect(
+      suggestSubdomain({
+        defaultSubdomain: 'studio',
+        projectName: 'blog',
+        isTaken: async (s) => taken.has(s),
+        isReserved: notReserved,
+      }),
+    ).resolves.toBe('studio-blog-3');
+  });
+
+  it('skips reserved candidates without probing them', async () => {
+    const probed: string[] = [];
+    await expect(
+      suggestSubdomain({
+        defaultSubdomain: 'ad',
+        projectName: 'min',
+        isTaken: async (s) => {
+          probed.push(s);
+          return false;
+        },
+        isReserved: (s) => s === 'ad-min',
+      }),
+    ).resolves.toBe('ad-min-2');
+    expect(probed).toEqual(['ad-min-2']);
+  });
+
+  it('gives up after maxAttempts', async () => {
+    await expect(
+      suggestSubdomain({
+        defaultSubdomain: 'studio',
+        projectName: 'blog',
+        isTaken: async () => true,
+        isReserved: notReserved,
+        maxAttempts: 3,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when the inputs slugify to nothing', async () => {
+    await expect(
+      suggestSubdomain({
+        defaultSubdomain: '!!!',
+        projectName: '???',
+        isTaken: never,
+        isReserved: notReserved,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('slugify', () => {
+  it('collapses and trims separators', () => {
+    expect(slugify('--Hello  World--')).toBe('hello-world');
+  });
+});

--- a/apps/backend/src/app-catalog/suggest-subdomain.util.ts
+++ b/apps/backend/src/app-catalog/suggest-subdomain.util.ts
@@ -1,0 +1,42 @@
+/**
+ * suggestSubdomain — picks a free subdomain for a SECOND install of an app
+ * whose manifest-default host is already taken (typically by the same app's
+ * install in another project). Pure apart from the injected `isTaken` probe,
+ * so the candidate walk is unit-testable without a database.
+ *
+ * Candidates: `<default>-<project>` (project name slugified), then
+ * `<default>-<project>-2`, `-3`, … up to `maxAttempts`. Reserved subdomains
+ * are skipped the same way the preflight gate would reject them. Returns
+ * `undefined` when nothing free turns up — the wizard then falls back to the
+ * plain collision message and the operator types one.
+ */
+export interface SuggestSubdomainInput {
+  defaultSubdomain: string;
+  projectName: string;
+  /** True when the candidate is already in use as a host or an alias anywhere on the instance. */
+  isTaken: (subdomain: string) => Promise<boolean>;
+  isReserved: (subdomain: string) => boolean;
+  maxAttempts?: number;
+}
+
+export async function suggestSubdomain(input: SuggestSubdomainInput): Promise<string | undefined> {
+  const { defaultSubdomain, projectName, isTaken, isReserved, maxAttempts = 10 } = input;
+  const base = trimSlug(`${slugify(defaultSubdomain)}-${slugify(projectName)}`);
+  if (!base) return undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const candidate = attempt === 1 ? base : `${base}-${attempt}`;
+    if (isReserved(candidate)) continue;
+    if (!(await isTaken(candidate))) return candidate;
+  }
+  return undefined;
+}
+
+/** Lower-case, non [a-z0-9] runs → single '-', no leading/trailing '-'. */
+export function slugify(value: string): string {
+  return trimSlug(value.toLowerCase().replace(/[^a-z0-9]+/g, '-'));
+}
+
+function trimSlug(value: string): string {
+  return value.replace(/-{2,}/g, '-').replace(/^-+|-+$/g, '');
+}

--- a/apps/frontend/src/components/app-catalog/AppCard.tsx
+++ b/apps/frontend/src/components/app-catalog/AppCard.tsx
@@ -2,23 +2,20 @@ import { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Switch } from '@/components/ui/switch';
-import { Label } from '@/components/ui/label';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { useToast } from '@/hooks/use-toast';
-import { useUpdateAppMutation, type CatalogEntry } from '@/services/appCatalogApi';
+import type { CatalogEntry } from '@/services/appCatalogApi';
 import { UninstallDialog } from './UninstallDialog';
 import { EjectPanel } from './EjectPanel';
 import { GateBlockedCta } from './GateBlockedCta';
+import { InstallUpdateButton } from './InstallUpdateButton';
 import { RemoteImage } from './RemoteImage';
 import { SetupNotes } from './SetupNotes';
-import { hasAppDetails } from './catalogEntry';
+import { hasAppDetails, updatableInstalls } from './catalogEntry';
 import { ExternalLink, MoreVertical } from 'lucide-react';
 
 interface AppCardProps {
@@ -33,6 +30,11 @@ interface AppCardProps {
    * reuses the same Working/Done job-progress screens as install.
    */
   onUpdateStarted: (entry: CatalogEntry, jobId: string) => void;
+  /**
+   * Opens the details dialog with the sequential "update every install"
+   * runner armed. Only offered when two or more installs have an update.
+   */
+  onUpdateAll: (entry: CatalogEntry) => void;
 }
 
 /**
@@ -44,51 +46,52 @@ interface AppCardProps {
  *   dialog via `onInstall`).
  * - not installed, a gate fails → disabled CTA showing the gate's message,
  *   plus a "Why?" popover with the gate's remediation/deepLink.
- * - installed → "Installed · v{version}" badge, an "Open" link to `appUrl`,
- *   and an overflow menu (Update, Uninstall, Eject).
- * - installed + update available → an additional primary "Update to
- *   v{registryVersion}" button that opens a confirm popover (prune toggle,
- *   default off) before firing the update — unless an instance gate fails, in
- *   which case the update is blocked by the same disabled gate CTA as install
- *   (the update job re-runs those gates and would refuse anyway).
+ * - installed in ONE project → "Installed · v{version}" badge, an "Open"
+ *   link to `appUrl`, and an overflow menu (Install in another project,
+ *   Uninstall, Eject).
+ * - one install + update available → an additional primary "Update to
+ *   v{registryVersion}" button (`InstallUpdateButton`: confirm popover with
+ *   the prune toggle, default off) — unless an instance gate fails, in which
+ *   case the update is blocked by the same disabled gate CTA as install (the
+ *   update job re-runs those gates and would refuse anyway).
+ * - installed in SEVERAL projects → "Installed in N projects" badge, an
+ *   "Update all (k)" CTA when k installs have an update, and "Manage
+ *   installs", which opens the details dialog's per-install list where
+ *   Open/Update/Uninstall/Eject live for each row. The card itself never
+ *   guesses which install an action should hit.
  *
  * Uninstall and Eject are delegated to dedicated dialogs (`UninstallDialog`,
- * `EjectPanel`) that each load their own preview/payload data; Update fires
- * `useUpdateAppMutation` here and hands the job off to the shared
- * `InstallDialog` (mounted by the page) for progress.
+ * `EjectPanel`) that each load their own preview/payload data for the install
+ * they're handed; an update hands its job off to the shared `InstallDialog`
+ * (mounted by the page) for progress.
  *
- * An installed card also carries its app's setup notes (titles collapsed,
- * bodies expanding in place) — CE can't perform them, so they live where the
- * app lives rather than behind a one-shot dialog.
+ * A single-install card also carries that install's setup notes (titles
+ * collapsed, bodies expanding in place) — CE can't perform them, so they live
+ * where the app lives rather than behind a one-shot dialog. With several
+ * installs the notes are per install, in the details dialog.
  *
  * Store metadata from the registry (ce#590) rides on top: a `thumbnailUrl`
  * banner and a `category` badge here, with the long-form description and
  * screenshots one click away in `AppDetailsDialog`.
  */
-export function AppCard({ entry, onInstall, onDetails, onUpdateStarted }: AppCardProps) {
-  const { toast } = useToast();
-  const { installed } = entry;
+export function AppCard({ entry, onInstall, onDetails, onUpdateStarted, onUpdateAll }: AppCardProps) {
+  const { installs } = entry;
+  // The card has room to act on ONE install. With several, it summarises and
+  // hands off to the details dialog's per-install list.
+  const soleInstall = installs.length === 1 ? installs[0] : undefined;
+  const updatable = updatableInstalls(entry);
   const failedGate = entry.gates.find((gate) => gate.status === 'fail');
   const showDetails = hasAppDetails(entry);
 
-  const [updateApp, { isLoading: isUpdating }] = useUpdateAppMutation();
-  const [updatePopoverOpen, setUpdatePopoverOpen] = useState(false);
-  const [prune, setPrune] = useState(false);
   const [ejectOpen, setEjectOpen] = useState(false);
   const [uninstallOpen, setUninstallOpen] = useState(false);
 
-  const handleConfirmUpdate = async () => {
-    if (!installed) return;
-    try {
-      const result = await updateApp({ id: installed.installedAppId, prune }).unwrap();
-      setUpdatePopoverOpen(false);
-      setPrune(false);
-      onUpdateStarted(entry, result.jobId);
-    } catch (err) {
-      const message = (err as { data?: { message?: string } })?.data?.message ?? 'Update failed';
-      toast({ title: 'Error', description: message, variant: 'destructive' });
-    }
-  };
+  const installedBadge =
+    installs.length === 0
+      ? null
+      : soleInstall
+        ? `Installed · v${soleInstall.version}`
+        : `Installed in ${installs.length} projects${updatable.length > 0 ? ` · ${updatable.length} update${updatable.length === 1 ? '' : 's'} available` : ''}`;
 
   const banner = (
     <div className="aspect-video w-full overflow-hidden bg-muted">
@@ -152,7 +155,7 @@ export function AppCard({ entry, onInstall, onDetails, onUpdateStarted }: AppCar
               {entry.category}
             </Badge>
           )}
-          {installed && <Badge variant="secondary">{`Installed · v${installed.version}`}</Badge>}
+          {installedBadge && <Badge variant="secondary">{installedBadge}</Badge>}
         </div>
 
         {/*
@@ -162,7 +165,7 @@ export function AppCard({ entry, onInstall, onDetails, onUpdateStarted }: AppCar
           notes are worth finding — before this they were reachable only by
           triggering an Update.
         */}
-        {installed && <SetupNotes steps={installed.manualSteps} />}
+        {soleInstall && <SetupNotes steps={soleInstall.manualSteps} />}
       </CardContent>
 
       <CardFooter className="flex flex-wrap items-center gap-2">
@@ -177,52 +180,21 @@ export function AppCard({ entry, onInstall, onDetails, onUpdateStarted }: AppCar
           </Button>
         )}
 
-        {!installed && !failedGate && (
+        {installs.length === 0 && !failedGate && (
           <Button disabled={!entry.installable} onClick={() => onInstall(entry)}>
             Install
           </Button>
         )}
 
-        {!installed && failedGate && <GateBlockedCta gate={failedGate} />}
+        {installs.length === 0 && failedGate && <GateBlockedCta gate={failedGate} />}
 
-        {installed && (
+        {soleInstall && (
           <>
-            {/*
-              A failing instance gate blocks the update the same way it blocks
-              an install — the job would refuse at its preflight step — so the
-              Update CTA becomes the same disabled, explained button rather
-              than an action that only fails after the user commits to it.
-            */}
-            {installed.updateAvailable && entry.registryVersion && failedGate && (
-              <GateBlockedCta gate={failedGate} />
-            )}
+            <InstallUpdateButton entry={entry} install={soleInstall} onUpdateStarted={onUpdateStarted} />
 
-            {installed.updateAvailable && entry.registryVersion && !failedGate && (
-              <Popover open={updatePopoverOpen} onOpenChange={setUpdatePopoverOpen}>
-                <PopoverTrigger asChild>
-                  <Button disabled={isUpdating}>{`Update to v${entry.registryVersion}`}</Button>
-                </PopoverTrigger>
-                <PopoverContent className="space-y-3">
-                  <div className="flex items-center justify-between gap-3">
-                    <Label htmlFor={`prune-${entry.id}`} className="font-normal">
-                      Reset to the app&apos;s shipped rules (prune)
-                    </Label>
-                    <Switch
-                      id={`prune-${entry.id}`}
-                      checked={prune}
-                      onCheckedChange={setPrune}
-                    />
-                  </div>
-                  <Button className="w-full" onClick={handleConfirmUpdate} disabled={isUpdating}>
-                    {isUpdating ? 'Starting…' : 'Confirm update'}
-                  </Button>
-                </PopoverContent>
-              </Popover>
-            )}
-
-            {installed.appUrl && (
-              <Button asChild variant={installed.updateAvailable ? 'outline' : 'default'}>
-                <a href={installed.appUrl} target="_blank" rel="noopener noreferrer">
+            {soleInstall.appUrl && (
+              <Button asChild variant={soleInstall.updateAvailable ? 'outline' : 'default'}>
+                <a href={soleInstall.appUrl} target="_blank" rel="noopener noreferrer">
                   Open
                   <ExternalLink className="h-4 w-4 ml-1" />
                 </a>
@@ -236,13 +208,50 @@ export function AppCard({ entry, onInstall, onDetails, onUpdateStarted }: AppCar
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
+                {/*
+                  Installing again is deliberately behind the overflow: the
+                  common action on an installed card is Open/Update, and a
+                  second primary "Install" next to "Installed" reads as a bug.
+                */}
+                <DropdownMenuItem disabled={!entry.installable || Boolean(failedGate)} onSelect={() => onInstall(entry)}>
+                  Install in another project
+                </DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => setUninstallOpen(true)}>Uninstall</DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => setEjectOpen(true)}>Eject</DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
 
-            <UninstallDialog entry={entry} open={uninstallOpen} onOpenChange={setUninstallOpen} />
-            <EjectPanel entry={entry} open={ejectOpen} onOpenChange={setEjectOpen} />
+            <UninstallDialog entry={entry} install={soleInstall} open={uninstallOpen} onOpenChange={setUninstallOpen} />
+            <EjectPanel entry={entry} install={soleInstall} open={ejectOpen} onOpenChange={setEjectOpen} />
+          </>
+        )}
+
+        {installs.length > 1 && (
+          <>
+            {/*
+              Several installs: the card can't pick one to Open/Update, so it
+              offers the batch action and a way into the per-install list.
+            */}
+            {updatable.length > 0 && !failedGate && (
+              <Button onClick={() => onUpdateAll(entry)}>{`Update all (${updatable.length})`}</Button>
+            )}
+            {updatable.length > 0 && failedGate && <GateBlockedCta gate={failedGate} />}
+            <Button variant={updatable.length > 0 ? 'outline' : 'default'} onClick={() => onDetails(entry)}>
+              Manage installs
+            </Button>
+
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" aria-label="More actions">
+                  <MoreVertical className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem disabled={!entry.installable || Boolean(failedGate)} onSelect={() => onInstall(entry)}>
+                  Install in another project
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </>
         )}
       </CardFooter>

--- a/apps/frontend/src/components/app-catalog/AppCatalogGrid.tsx
+++ b/apps/frontend/src/components/app-catalog/AppCatalogGrid.tsx
@@ -34,7 +34,11 @@ export function AppCatalogGrid({
   // catalog, and a stale snapshot here would never pick that up (the Done
   // screen's setup notes would appear stuck on the pre-update list).
   const [installTargetSnapshot, setInstallTargetSnapshot] = useState<CatalogEntry | null>(null);
-  const [detailsTargetSnapshot, setDetailsTargetSnapshot] = useState<CatalogEntry | null>(null);
+  const [detailsTargetSnapshot, setDetailsTargetSnapshot] = useState<{
+    entry: CatalogEntry;
+    /** True when opened from the card's "Update all" CTA — arms the batch runner. */
+    autoUpdateAll: boolean;
+  } | null>(null);
   const [updateTargetSnapshot, setUpdateTargetSnapshot] = useState<{
     entry: CatalogEntry;
     jobId: string;
@@ -44,7 +48,7 @@ export function AppCatalogGrid({
     ? (entries.find((e) => e.id === installTargetSnapshot.id) ?? installTargetSnapshot)
     : null;
   const detailsTarget = detailsTargetSnapshot
-    ? (entries.find((e) => e.id === detailsTargetSnapshot.id) ?? detailsTargetSnapshot)
+    ? (entries.find((e) => e.id === detailsTargetSnapshot.entry.id) ?? detailsTargetSnapshot.entry)
     : null;
   const updateTarget = updateTargetSnapshot
     ? {
@@ -63,7 +67,8 @@ export function AppCatalogGrid({
             key={entry.id}
             entry={entry}
             onInstall={setInstallTargetSnapshot}
-            onDetails={setDetailsTargetSnapshot}
+            onDetails={(entry) => setDetailsTargetSnapshot({ entry, autoUpdateAll: false })}
+            onUpdateAll={(entry) => setDetailsTargetSnapshot({ entry, autoUpdateAll: true })}
             onUpdateStarted={(updatedEntry, jobId) =>
               setUpdateTargetSnapshot({ entry: updatedEntry, jobId })
             }
@@ -82,6 +87,13 @@ export function AppCatalogGrid({
             setDetailsTargetSnapshot(null);
             setInstallTargetSnapshot(entry);
           }}
+          // The update-progress dialog stacks over the details dialog on
+          // purpose: the per-install list is the context the operator came
+          // from and is still useful (other rows) once the job finishes.
+          onUpdateStarted={(updatedEntry, jobId) =>
+            setUpdateTargetSnapshot({ entry: updatedEntry, jobId })
+          }
+          autoUpdateAll={detailsTargetSnapshot?.autoUpdateAll}
         />
       )}
 

--- a/apps/frontend/src/components/app-catalog/AppDetailsDialog.tsx
+++ b/apps/frontend/src/components/app-catalog/AppDetailsDialog.tsx
@@ -12,6 +12,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { RemoteImage } from './RemoteImage';
 import { GateBlockedCta } from './GateBlockedCta';
+import { InstallsList } from './InstallsList';
 import type { CatalogEntry } from '@/services/appCatalogApi';
 import { ExternalLink } from 'lucide-react';
 
@@ -21,6 +22,10 @@ interface AppDetailsDialogProps {
   onOpenChange: (open: boolean) => void;
   /** Hands off to the install wizard — the page swaps this dialog for it. */
   onInstall: (entry: CatalogEntry) => void;
+  /** A per-install Update was accepted — the page shows the job's progress dialog. */
+  onUpdateStarted: (entry: CatalogEntry, jobId: string) => void;
+  /** Start the "update all installs" batch as soon as the dialog opens (card CTA). */
+  autoUpdateAll?: boolean;
 }
 
 /**
@@ -35,8 +40,15 @@ interface AppDetailsDialogProps {
  * HTML stays inert, and react-markdown's default URL transform already drops
  * `javascript:` hrefs. Don't add `rehype-raw` here.
  */
-export function AppDetailsDialog({ entry, open, onOpenChange, onInstall }: AppDetailsDialogProps) {
-  const { installed } = entry;
+export function AppDetailsDialog({
+  entry,
+  open,
+  onOpenChange,
+  onInstall,
+  onUpdateStarted,
+  autoUpdateAll,
+}: AppDetailsDialogProps) {
+  const { installs } = entry;
   const failedGate = entry.gates.find((gate) => gate.status === 'fail');
   const screenshots = entry.screenshots ?? [];
 
@@ -66,7 +78,12 @@ export function AppDetailsDialog({ entry, open, onOpenChange, onInstall }: AppDe
                     {entry.category}
                   </Badge>
                 )}
-                {installed && <Badge variant="secondary">{`Installed · v${installed.version}`}</Badge>}
+                {installs.length === 1 && (
+                  <Badge variant="secondary">{`Installed · v${installs[0].version}`}</Badge>
+                )}
+                {installs.length > 1 && (
+                  <Badge variant="secondary">{`Installed in ${installs.length} projects`}</Badge>
+                )}
               </div>
             </div>
           </div>
@@ -76,6 +93,15 @@ export function AppDetailsDialog({ entry, open, onOpenChange, onInstall }: AppDe
         </DialogHeader>
 
         <div className="min-h-0 flex-1 space-y-4 overflow-y-auto">
+          {installs.length > 0 && (
+            <InstallsList
+              entry={entry}
+              onUpdateStarted={onUpdateStarted}
+              onViewJob={onUpdateStarted}
+              autoUpdateAll={autoUpdateAll}
+            />
+          )}
+
           {screenshots.length > 0 && (
             <div className="grid gap-3 sm:grid-cols-2">
               {screenshots.map((src) => (
@@ -133,17 +159,21 @@ export function AppDetailsDialog({ entry, open, onOpenChange, onInstall }: AppDe
             Close
           </Button>
 
-          {!installed && failedGate && <GateBlockedCta gate={failedGate} />}
+          {failedGate && <GateBlockedCta gate={failedGate} />}
 
-          {!installed && !failedGate && (
-            <Button disabled={!entry.installable} onClick={() => onInstall(entry)}>
-              Install
+          {!failedGate && (
+            <Button
+              variant={installs.length > 0 ? 'outline' : 'default'}
+              disabled={!entry.installable}
+              onClick={() => onInstall(entry)}
+            >
+              {installs.length > 0 ? 'Install in another project' : 'Install'}
             </Button>
           )}
 
-          {installed?.appUrl && (
+          {installs.length === 1 && installs[0].appUrl && (
             <Button asChild>
-              <a href={installed.appUrl} target="_blank" rel="noopener noreferrer">
+              <a href={installs[0].appUrl} target="_blank" rel="noopener noreferrer">
                 Open
                 <ExternalLink className="h-4 w-4 ml-1" />
               </a>

--- a/apps/frontend/src/components/app-catalog/EjectPanel.tsx
+++ b/apps/frontend/src/components/app-catalog/EjectPanel.tsx
@@ -16,12 +16,18 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { useToast } from '@/hooks/use-toast';
-import { useGetEjectPayloadQuery, type CatalogEntry } from '@/services/appCatalogApi';
+import {
+  useGetEjectPayloadQuery,
+  type CatalogEntry,
+  type InstalledSummary,
+} from '@/services/appCatalogApi';
 import { useCreateApiKeyMutation } from '@/services/apiKeysApi';
 import { Check, Copy, ExternalLink, Key } from 'lucide-react';
 
 interface EjectPanelProps {
   entry: CatalogEntry;
+  /** The install being ejected — an app can be installed in several projects, so the caller picks. */
+  install: InstalledSummary;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -33,14 +39,13 @@ interface EjectPanelProps {
  * buttons and lets the user mint the deploy API key for the secrets list
  * inline, without leaving the panel.
  */
-export function EjectPanel({ entry, open, onOpenChange }: EjectPanelProps) {
+export function EjectPanel({ entry, install, open, onOpenChange }: EjectPanelProps) {
   const { toast } = useToast();
-  const { installed } = entry;
   const [copiedField, setCopiedField] = useState<string | null>(null);
   const [mintedKeys, setMintedKeys] = useState<Record<string, string>>({});
 
-  const { data: payload, isFetching } = useGetEjectPayloadQuery(installed?.installedAppId ?? '', {
-    skip: !open || !installed,
+  const { data: payload, isFetching } = useGetEjectPayloadQuery(install.installedAppId, {
+    skip: !open,
   });
   const [createApiKey, { isLoading: isMinting }] = useCreateApiKeyMutation();
 
@@ -62,7 +67,7 @@ export function EjectPanel({ entry, open, onOpenChange }: EjectPanelProps) {
     try {
       const response = await createApiKey({
         name: `${entry.name} eject — ${secretName}`,
-        repository: installed?.projectName,
+        repository: install.projectName,
       }).unwrap();
       setMintedKeys((prev) => ({ ...prev, [secretName]: response.key }));
       toast({
@@ -184,9 +189,7 @@ export function EjectPanel({ entry, open, onOpenChange }: EjectPanelProps) {
                   ))}
                 </ul>
                 <p className="mt-1 text-xs text-muted-foreground">
-                  {installed?.projectName
-                    ? `Scoped to ${installed.projectName}.`
-                    : 'Minted as a global key — no project scope available for this install.'}
+                  {`Scoped to ${install.projectName}.`}
                 </p>
               </div>
             )}

--- a/apps/frontend/src/components/app-catalog/InstallDialog.tsx
+++ b/apps/frontend/src/components/app-catalog/InstallDialog.tsx
@@ -128,6 +128,10 @@ export function InstallDialog({
   // empty — the manifest default is only shown as a placeholder (see
   // `defaultSubdomainLabel` below), never forced into the field's value.
   const [subdomain, setSubdomain] = useState('');
+  // Set the moment the operator types in the subdomain field. A server-side
+  // suggestion (install-again: the default host is taken) may prefill the
+  // field, but only while it is untouched — it must never overwrite typing.
+  const [subdomainTouched, setSubdomainTouched] = useState(false);
   // Seeded once from the FIRST preflight response's appHost, so later
   // preflights (e.g. after a project change) don't keep overwriting a
   // placeholder the operator is already looking at.
@@ -186,6 +190,7 @@ export function InstallDialog({
       setNewOwner('');
       setNewName('');
       setSubdomain('');
+      setSubdomainTouched(false);
       setDefaultSubdomainLabel(undefined);
       setSelectedProjectId(undefined);
       setLastJobStatus(undefined);
@@ -249,6 +254,19 @@ export function InstallDialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [preflightData?.appHost]);
 
+  // Install-again: the manifest's default host already belongs to another
+  // install (typically this app in another project), so the backend proposes
+  // a free `<default>-<project>` subdomain. Adopt it while the field is
+  // untouched — that re-runs preflight with the override and clears the
+  // collision gate without the operator having to invent a host.
+  useEffect(() => {
+    const suggested = preflightData?.suggestedSubdomain;
+    if (suggested && !subdomainTouched && !trimmedSubdomain) {
+      setSubdomain(suggested);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [preflightData?.suggestedSubdomain]);
+
   const handleProjectChange = (value: string) => {
     if (value === NEW_PROJECT_VALUE) {
       setCreatingNew(true);
@@ -287,8 +305,15 @@ export function InstallDialog({
     undoJob(jobId);
   };
 
-  const manualSteps = entry.installed?.manualSteps ?? job?.manualSteps ?? [];
-  const doneAppUrl = entry.installed?.appUrl ?? job?.appUrl;
+  // The Done screen reads the LIVE install this job produced (the catalog is
+  // refetched on the job's terminal status), matched by the job's row id so a
+  // second install of the same app never shows the first install's notes/URL.
+  const jobInstall = job?.installedAppId
+    ? entry.installs.find((install) => install.installedAppId === job.installedAppId)
+    : undefined;
+  const manualSteps = jobInstall?.manualSteps ?? job?.manualSteps ?? [];
+  const doneAppUrl = jobInstall?.appUrl ?? job?.appUrl;
+  const isInstallAgain = !isUpdate && entry.installs.length > 0;
 
   const screen: 'review' | 'working' | 'done' = !jobId
     ? 'review'
@@ -314,7 +339,9 @@ export function InstallDialog({
               ? `${entry.name} ${isUpdate ? 'updated' : 'installed'}`
               : isUpdate
                 ? `Updating ${entry.name}`
-                : `Install ${entry.name}`}
+                : isInstallAgain
+                  ? `Install ${entry.name} in another project`
+                  : `Install ${entry.name}`}
           </DialogTitle>
           {screen === 'review' && (
             <DialogDescription>
@@ -378,9 +405,17 @@ export function InstallDialog({
                 <Input
                   id="install-subdomain"
                   value={subdomain}
-                  onChange={(e) => setSubdomain(e.target.value)}
+                  onChange={(e) => {
+                    setSubdomainTouched(true);
+                    setSubdomain(e.target.value);
+                  }}
                   placeholder={defaultSubdomainLabel}
                 />
+                {isInstallAgain && defaultSubdomainLabel && trimmedSubdomain && trimmedSubdomain !== defaultSubdomainLabel && (
+                  <p className="text-xs text-muted-foreground">
+                    {describeDefaultHostOwner(entry, defaultSubdomainLabel)}
+                  </p>
+                )}
                 {preflightData?.appUrl && (
                   <p className="text-xs text-muted-foreground">
                     Will be available at <code className="text-xs">{preflightData.appUrl}</code>
@@ -561,4 +596,25 @@ export function InstallDialog({
       </DialogContent>
     </Dialog>
   );
+}
+
+/**
+ * "`handoff.example.com` is used by the install in acme/site" — names which
+ * existing install owns the manifest-default host, so a prefilled or hand-typed
+ * alternative reads as deliberate rather than as the wizard ignoring the
+ * default. Falls back to generic wording when no install's URL matches (the
+ * default may be mapped by something that isn't this app).
+ */
+function describeDefaultHostOwner(entry: CatalogEntry, defaultSubdomain: string): string {
+  const owner = entry.installs.find((install) => {
+    if (!install.appUrl) return false;
+    try {
+      return new URL(install.appUrl).hostname.split('.')[0] === defaultSubdomain;
+    } catch {
+      return false;
+    }
+  });
+  return owner
+    ? `The default subdomain "${defaultSubdomain}" is used by the install in ${owner.projectName}.`
+    : `The default subdomain "${defaultSubdomain}" is already in use.`;
 }

--- a/apps/frontend/src/components/app-catalog/InstallUpdateButton.tsx
+++ b/apps/frontend/src/components/app-catalog/InstallUpdateButton.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { useToast } from '@/hooks/use-toast';
+import { useUpdateAppMutation, type CatalogEntry, type InstalledSummary } from '@/services/appCatalogApi';
+import { GateBlockedCta } from './GateBlockedCta';
+
+interface InstallUpdateButtonProps {
+  entry: CatalogEntry;
+  /** The install to move to `entry.registryVersion`. */
+  install: InstalledSummary;
+  /** Fired once the update job has been accepted — the parent shows its progress. */
+  onUpdateStarted: (entry: CatalogEntry, jobId: string) => void;
+  size?: 'default' | 'sm';
+  variant?: 'default' | 'outline';
+}
+
+/**
+ * InstallUpdateButton — "Update to vX" for ONE install, with the prune toggle
+ * confirm popover. Shared by the catalog card (single-install case) and the
+ * per-install rows in the details dialog so both fire exactly the same
+ * mutation with the same confirm step. Renders nothing when this install has
+ * no update; renders the disabled, explained gate CTA instead when an instance
+ * gate fails (the job would refuse at its preflight step anyway).
+ */
+export function InstallUpdateButton({
+  entry,
+  install,
+  onUpdateStarted,
+  size = 'default',
+  variant = 'default',
+}: InstallUpdateButtonProps) {
+  const { toast } = useToast();
+  const [updateApp, { isLoading: isUpdating }] = useUpdateAppMutation();
+  const [open, setOpen] = useState(false);
+  const [prune, setPrune] = useState(false);
+
+  if (!install.updateAvailable || !entry.registryVersion) return null;
+
+  const failedGate = entry.gates.find((gate) => gate.status === 'fail');
+  if (failedGate) return <GateBlockedCta gate={failedGate} />;
+
+  const handleConfirm = async () => {
+    try {
+      const result = await updateApp({ id: install.installedAppId, prune }).unwrap();
+      setOpen(false);
+      setPrune(false);
+      onUpdateStarted(entry, result.jobId);
+    } catch (err) {
+      const message = (err as { data?: { message?: string } })?.data?.message ?? 'Update failed';
+      toast({ title: 'Error', description: message, variant: 'destructive' });
+    }
+  };
+
+  const switchId = `prune-${install.installedAppId}`;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button size={size} variant={variant} disabled={isUpdating}>
+          {`Update to v${entry.registryVersion}`}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <Label htmlFor={switchId} className="font-normal">
+            Reset to the app&apos;s shipped rules (prune)
+          </Label>
+          <Switch id={switchId} checked={prune} onCheckedChange={setPrune} />
+        </div>
+        <Button className="w-full" onClick={handleConfirm} disabled={isUpdating}>
+          {isUpdating ? 'Starting…' : 'Confirm update'}
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/frontend/src/components/app-catalog/InstallsList.tsx
+++ b/apps/frontend/src/components/app-catalog/InstallsList.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useRef, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { formatRelativeTime } from '@/lib/utils';
+import type { CatalogEntry, InstalledSummary } from '@/services/appCatalogApi';
+import { EjectPanel } from './EjectPanel';
+import { GateBlockedCta } from './GateBlockedCta';
+import { InstallUpdateButton } from './InstallUpdateButton';
+import { SetupNotes } from './SetupNotes';
+import { UninstallDialog } from './UninstallDialog';
+import { installHost, updatableInstalls } from './catalogEntry';
+import { useSequentialUpdates, type SequentialUpdateState } from './useSequentialUpdates';
+import { ExternalLink, Loader2, MoreVertical } from 'lucide-react';
+
+interface InstallsListProps {
+  entry: CatalogEntry;
+  /** A single update started from one row — the parent shows its progress dialog. */
+  onUpdateStarted: (entry: CatalogEntry, jobId: string) => void;
+  /** Opens the update-progress dialog for an already-running/finished job (batch rows). */
+  onViewJob: (entry: CatalogEntry, jobId: string) => void;
+  /** Start the "update all" batch as soon as this mounts (the card's "Update all" CTA). */
+  autoUpdateAll?: boolean;
+}
+
+/**
+ * InstallsList — the per-install inventory for one catalog app: where it is
+ * installed (project + host), which version each install is on and when it
+ * last moved, and the per-install actions (Open, Update, Uninstall, Eject).
+ * When two or more installs have an update it also offers "Update all", which
+ * runs them one after another (`useSequentialUpdates`) and reports progress
+ * inline on each row.
+ */
+export function InstallsList({ entry, onUpdateStarted, onViewJob, autoUpdateAll }: InstallsListProps) {
+  const { installs } = entry;
+  const updatable = updatableInstalls(entry);
+  const failedGate = entry.gates.find((gate) => gate.status === 'fail');
+  const batch = useSequentialUpdates();
+  const [prune, setPrune] = useState(false);
+
+  // Arm the batch once, on first mount, when the caller asked for it — not on
+  // every re-render the catalog refetch triggers while the batch is running.
+  const armedRef = useRef(false);
+  useEffect(() => {
+    if (!autoUpdateAll || armedRef.current || failedGate) return;
+    armedRef.current = true;
+    batch.start(updatable, prune);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoUpdateAll]);
+
+  const showBatchControls = updatable.length > 1 || batch.running || Object.keys(batch.states).length > 0;
+
+  return (
+    <section className="space-y-3" aria-label="Installs">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold">
+          {`Installed in ${installs.length} project${installs.length === 1 ? '' : 's'}`}
+        </h3>
+        {showBatchControls && !failedGate && entry.registryVersion && (
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
+              <Switch
+                id={`prune-all-${entry.id}`}
+                checked={prune}
+                onCheckedChange={setPrune}
+                disabled={batch.running}
+              />
+              <Label htmlFor={`prune-all-${entry.id}`} className="text-xs font-normal text-muted-foreground">
+                Reset to shipped rules (prune)
+              </Label>
+            </div>
+            <Button
+              size="sm"
+              onClick={() => batch.start(updatable, prune)}
+              disabled={batch.running || updatable.length === 0}
+            >
+              {batch.running ? (
+                <>
+                  <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                  Updating…
+                </>
+              ) : (
+                `Update all (${updatable.length})`
+              )}
+            </Button>
+          </div>
+        )}
+        {showBatchControls && failedGate && <GateBlockedCta gate={failedGate} />}
+      </div>
+
+      <ul className="divide-y rounded-md border" aria-label="Installed projects">
+        {installs.map((install) => (
+          <InstallRow
+            key={install.installedAppId}
+            entry={entry}
+            install={install}
+            batchState={batch.states[install.installedAppId]}
+            batchRunning={batch.running}
+            onUpdateStarted={onUpdateStarted}
+            onViewJob={onViewJob}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+interface InstallRowProps {
+  entry: CatalogEntry;
+  install: InstalledSummary;
+  batchState?: SequentialUpdateState;
+  batchRunning: boolean;
+  onUpdateStarted: (entry: CatalogEntry, jobId: string) => void;
+  onViewJob: (entry: CatalogEntry, jobId: string) => void;
+}
+
+function InstallRow({ entry, install, batchState, batchRunning, onUpdateStarted, onViewJob }: InstallRowProps) {
+  const [uninstallOpen, setUninstallOpen] = useState(false);
+  const [ejectOpen, setEjectOpen] = useState(false);
+  const host = installHost(install);
+
+  return (
+    <li className="flex flex-col gap-2 p-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0 space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium">{install.projectName}</span>
+          <Badge variant="secondary">{`v${install.version}`}</Badge>
+          {install.status !== 'installed' && <Badge variant="outline">{install.status}</Badge>}
+          {batchState && <BatchBadge state={batchState} />}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {host ? `${host} · ` : ''}
+          {hasBeenUpdated(install)
+            ? `updated ${formatRelativeTime(install.updatedAt)}`
+            : `installed ${formatRelativeTime(install.installedAt)}`}
+        </p>
+        {batchState?.error && <p className="text-xs text-destructive">{batchState.error}</p>}
+        <SetupNotes steps={install.manualSteps} />
+      </div>
+
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        {batchState?.jobId && batchState.status !== 'queued' ? (
+          <Button size="sm" variant="outline" onClick={() => onViewJob(entry, batchState.jobId!)}>
+            {batchState.status === 'conflicts' ? 'Review conflicts' : 'View'}
+          </Button>
+        ) : (
+          !batchRunning && (
+            <InstallUpdateButton
+              entry={entry}
+              install={install}
+              onUpdateStarted={onUpdateStarted}
+              size="sm"
+            />
+          )
+        )}
+
+        {install.appUrl && (
+          <Button asChild size="sm" variant="outline">
+            <a href={install.appUrl} target="_blank" rel="noopener noreferrer">
+              Open
+              <ExternalLink className="ml-1 h-3.5 w-3.5" />
+            </a>
+          </Button>
+        )}
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" aria-label={`More actions for ${install.projectName}`}>
+              <MoreVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem disabled={batchRunning} onSelect={() => setUninstallOpen(true)}>
+              Uninstall
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setEjectOpen(true)}>Eject</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <UninstallDialog entry={entry} install={install} open={uninstallOpen} onOpenChange={setUninstallOpen} />
+        <EjectPanel entry={entry} install={install} open={ejectOpen} onOpenChange={setEjectOpen} />
+      </div>
+    </li>
+  );
+}
+
+/**
+ * The install job's final "record" step bumps `updated_at` a few ms after the
+ * row was created, so a strict inequality would call every fresh install
+ * "updated". Only a later update job moves it by more than this.
+ */
+function hasBeenUpdated(install: InstalledSummary): boolean {
+  return Date.parse(install.updatedAt) - Date.parse(install.installedAt) > 60_000;
+}
+
+function BatchBadge({ state }: { state: SequentialUpdateState }) {
+  switch (state.status) {
+    case 'queued':
+      return <Badge variant="outline">Queued</Badge>;
+    case 'running':
+      return (
+        <Badge variant="outline">
+          <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+          Updating
+        </Badge>
+      );
+    case 'succeeded':
+      return <Badge variant="secondary">Updated</Badge>;
+    case 'conflicts':
+      return <Badge variant="secondary">Updated · conflicts</Badge>;
+    case 'failed':
+      return <Badge variant="destructive">Failed</Badge>;
+  }
+}

--- a/apps/frontend/src/components/app-catalog/UninstallDialog.tsx
+++ b/apps/frontend/src/components/app-catalog/UninstallDialog.tsx
@@ -16,10 +16,13 @@ import {
   useGetUninstallPreviewQuery,
   useUninstallAppMutation,
   type CatalogEntry,
+  type InstalledSummary,
 } from '@/services/appCatalogApi';
 
 interface UninstallDialogProps {
   entry: CatalogEntry;
+  /** The install being removed — an app can be installed in several projects, so the caller picks. */
+  install: InstalledSummary;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -31,14 +34,13 @@ interface UninstallDialogProps {
  * preview (`useGetUninstallPreviewQuery`) so the "delete data tables"
  * checkbox can show the actual record counts before the user commits.
  */
-export function UninstallDialog({ entry, open, onOpenChange }: UninstallDialogProps) {
+export function UninstallDialog({ entry, install, open, onOpenChange }: UninstallDialogProps) {
   const { toast } = useToast();
-  const { installed } = entry;
   const [deleteData, setDeleteData] = useState(false);
   const [failures, setFailures] = useState<string[] | null>(null);
 
-  const { data: preview } = useGetUninstallPreviewQuery(installed?.installedAppId ?? '', {
-    skip: !open || !installed,
+  const { data: preview } = useGetUninstallPreviewQuery(install.installedAppId, {
+    skip: !open,
   });
   const [uninstallApp, { isLoading }] = useUninstallAppMutation();
 
@@ -56,9 +58,8 @@ export function UninstallDialog({ entry, open, onOpenChange }: UninstallDialogPr
   };
 
   const handleConfirm = async () => {
-    if (!installed) return;
     try {
-      const summary = await uninstallApp({ id: installed.installedAppId, deleteData }).unwrap();
+      const summary = await uninstallApp({ id: install.installedAppId, deleteData }).unwrap();
       // The backend deliberately keeps the installed_apps row when some
       // cleanup steps fail, so the user can retry — don't tell them it
       // succeeded, and don't close the dialog out from under a retry.
@@ -86,8 +87,7 @@ export function UninstallDialog({ entry, open, onOpenChange }: UninstallDialogPr
         <DialogHeader>
           <DialogTitle>{`Uninstall ${entry.name}?`}</DialogTitle>
           <DialogDescription>
-            Removes the app&apos;s rule sets, alias, domain, and deployment. Your data tables
-            and uploaded files are kept.
+            {`Removes the app's rule sets, alias, domain, and deployment from ${install.projectName}. Your data tables and uploaded files are kept.`}
           </DialogDescription>
         </DialogHeader>
 
@@ -135,7 +135,7 @@ export function UninstallDialog({ entry, open, onOpenChange }: UninstallDialogPr
           <Button variant="outline" onClick={() => handleOpenChange(false)}>
             Cancel
           </Button>
-          <Button variant="destructive" onClick={handleConfirm} disabled={isLoading || !installed}>
+          <Button variant="destructive" onClick={handleConfirm} disabled={isLoading}>
             {isLoading ? 'Uninstalling…' : failures ? 'Retry uninstall' : 'Uninstall'}
           </Button>
         </DialogFooter>

--- a/apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/AppCard.test.tsx
@@ -27,7 +27,44 @@ const baseEntry: CatalogEntry = {
   summary: 'Share files with clients',
   gates: [],
   installable: true,
+  installs: [],
 };
+
+const installA: CatalogEntry['installs'][number] = {
+  installedAppId: 'installed-1',
+  installedAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  version: '1.2.0',
+  projectId: 'proj-1',
+  projectName: 'acme/handoff',
+  alias: 'production',
+  appUrl: 'https://handoff.example.com',
+  status: 'installed',
+  updateAvailable: true,
+  manualSteps: [],
+};
+const installB: CatalogEntry['installs'][number] = {
+  ...installA,
+  installedAppId: 'installed-2',
+  projectId: 'proj-2',
+  projectName: 'acme/blog',
+  appUrl: 'https://handoff-blog.example.com',
+  version: '2.0.0',
+  updateAvailable: false,
+};
+
+function renderCard(entry: CatalogEntry, overrides: Partial<Parameters<typeof AppCard>[0]> = {}) {
+  const props = {
+    entry,
+    onInstall: vi.fn(),
+    onDetails: vi.fn(),
+    onUpdateStarted: vi.fn(),
+    onUpdateAll: vi.fn(),
+    ...overrides,
+  };
+  render(<AppCard {...props} />);
+  return props;
+}
 
 beforeEach(() => {
   updateTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({ jobId: 'job-1' }) });
@@ -35,7 +72,7 @@ beforeEach(() => {
 
 describe('AppCard', () => {
   it('renders an enabled Install button when installable', () => {
-    render(<AppCard entry={baseEntry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />);
+    render(<AppCard entry={baseEntry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} onUpdateAll={vi.fn()} />);
 
     const button = screen.getByRole('button', { name: /install/i });
     expect(button).toBeEnabled();
@@ -56,7 +93,7 @@ describe('AppCard', () => {
       ],
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} onUpdateAll={vi.fn()} />);
 
     expect(screen.getByText('Requires bucket storage')).toBeInTheDocument();
     const button = screen.getByRole('button', { name: /requires bucket storage/i });
@@ -67,8 +104,10 @@ describe('AppCard', () => {
   it('shows the Installed badge and an Open link when installed', () => {
     const entry: CatalogEntry = {
       ...baseEntry,
-      installed: {
+      installs: [{
         installedAppId: 'installed-1',
+        installedAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         version: '1.2.0',
         projectId: 'proj-1',
         projectName: 'acme/handoff',
@@ -77,10 +116,10 @@ describe('AppCard', () => {
         status: 'installed',
         updateAvailable: false,
         manualSteps: [],
-      },
+      }],
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} onUpdateAll={vi.fn()} />);
 
     expect(screen.getByText('Installed · v1.2.0')).toBeInTheDocument();
     const openLink = screen.getByRole('link', { name: /open/i });
@@ -91,8 +130,10 @@ describe('AppCard', () => {
     const entry: CatalogEntry = {
       ...baseEntry,
       registryVersion: '2.0.0',
-      installed: {
+      installs: [{
         installedAppId: 'installed-1',
+        installedAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         version: '1.2.0',
         projectId: 'proj-1',
         projectName: 'acme/handoff',
@@ -101,10 +142,10 @@ describe('AppCard', () => {
         status: 'installed',
         updateAvailable: true,
         manualSteps: [],
-      },
+      }],
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} onUpdateAll={vi.fn()} />);
 
     expect(screen.getByRole('button', { name: /update to v2\.0\.0/i })).toBeInTheDocument();
   });
@@ -124,8 +165,10 @@ describe('AppCard', () => {
           remediation: 'Upgrade this BFFless CE instance to v0.4.0 or later.',
         },
       ],
-      installed: {
+      installs: [{
         installedAppId: 'installed-1',
+        installedAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         version: '1.2.0',
         projectId: 'proj-1',
         projectName: 'acme/handoff',
@@ -134,10 +177,10 @@ describe('AppCard', () => {
         status: 'installed',
         updateAvailable: true,
         manualSteps: [],
-      },
+      }],
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} onUpdateAll={vi.fn()} />);
 
     expect(screen.queryByRole('button', { name: /update to v2\.0\.0/i })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /requires ce v0\.4\.0 or later/i })).toBeDisabled();
@@ -150,8 +193,10 @@ describe('AppCard', () => {
     const entry: CatalogEntry = {
       ...baseEntry,
       registryVersion: '2.0.0',
-      installed: {
+      installs: [{
         installedAppId: 'installed-1',
+        installedAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         version: '1.2.0',
         projectId: 'proj-1',
         projectName: 'acme/handoff',
@@ -160,10 +205,10 @@ describe('AppCard', () => {
         status: 'installed',
         updateAvailable: true,
         manualSteps: [],
-      },
+      }],
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={onUpdateStarted} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={onUpdateStarted} onUpdateAll={vi.fn()} />);
 
     fireEvent.click(screen.getByRole('button', { name: /update to v2\.0\.0/i }));
 
@@ -186,7 +231,7 @@ describe('AppCard', () => {
     };
 
     const { container } = render(
-      <AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />,
+      <AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} onUpdateAll={vi.fn()} />,
     );
 
     expect(screen.getByText('files')).toBeInTheDocument();
@@ -197,7 +242,7 @@ describe('AppCard', () => {
     // A de-listed installed app renders from its stored manifest, which never
     // carries description/screenshots — a Details button would open nothing.
     render(
-      <AppCard entry={baseEntry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />,
+      <AppCard entry={baseEntry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} onUpdateAll={vi.fn()} />,
     );
 
     expect(screen.queryByRole('button', { name: /^details$/i })).not.toBeInTheDocument();
@@ -212,7 +257,7 @@ describe('AppCard', () => {
     };
 
     render(
-      <AppCard entry={entry} onInstall={vi.fn()} onDetails={onDetails} onUpdateStarted={vi.fn()} />,
+      <AppCard entry={entry} onInstall={vi.fn()} onDetails={onDetails} onUpdateStarted={vi.fn()} onUpdateAll={vi.fn()} />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: /^details$/i }));
@@ -227,8 +272,10 @@ describe('AppCard', () => {
     const entry: CatalogEntry = {
       ...baseEntry,
       registryVersion: '2.0.0',
-      installed: {
+      installs: [{
         installedAppId: 'installed-1',
+        installedAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         version: '1.2.0',
         projectId: 'proj-1',
         projectName: 'acme/handoff',
@@ -237,10 +284,10 @@ describe('AppCard', () => {
         status: 'installed',
         updateAvailable: true,
         manualSteps: [],
-      },
+      }],
     };
 
-    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={onUpdateStarted} />);
+    render(<AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={onUpdateStarted} onUpdateAll={vi.fn()} />);
 
     fireEvent.click(screen.getByRole('button', { name: /update to v2\.0\.0/i }));
     fireEvent.click(screen.getByRole('switch', { name: /reset to the app's shipped rules \(prune\)/i }));
@@ -252,8 +299,10 @@ describe('AppCard', () => {
   describe('setup notes', () => {
     const installedWithNotes: CatalogEntry = {
       ...baseEntry,
-      installed: {
+      installs: [{
         installedAppId: 'installed-1',
+        installedAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         version: '1.0.0',
         projectId: 'proj-1',
         projectName: 'acme/site',
@@ -269,7 +318,7 @@ describe('AppCard', () => {
             deepLink: '/repo/acme/site/settings?tab=members',
           },
         ],
-      },
+      }],
     };
 
     it('shows the note title on an installed card', () => {
@@ -279,6 +328,7 @@ describe('AppCard', () => {
           onInstall={vi.fn()}
           onDetails={vi.fn()}
           onUpdateStarted={vi.fn()}
+          onUpdateAll={vi.fn()}
         />,
       );
 
@@ -293,6 +343,7 @@ describe('AppCard', () => {
           onInstall={vi.fn()}
           onDetails={vi.fn()}
           onUpdateStarted={vi.fn()}
+          onUpdateAll={vi.fn()}
         />,
       );
 
@@ -304,10 +355,10 @@ describe('AppCard', () => {
     it('renders no setup notes block when the app has none', () => {
       const entry: CatalogEntry = {
         ...installedWithNotes,
-        installed: { ...installedWithNotes.installed!, manualSteps: [] },
+        installs: [{ ...installedWithNotes.installs[0], manualSteps: [] }],
       };
       render(
-        <AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />,
+        <AppCard entry={entry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} onUpdateAll={vi.fn()} />,
       );
 
       expect(screen.queryByText(/Setup notes/)).not.toBeInTheDocument();
@@ -315,10 +366,68 @@ describe('AppCard', () => {
 
     it('renders no setup notes block when the app is not installed', () => {
       render(
-        <AppCard entry={baseEntry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} />,
+        <AppCard entry={baseEntry} onInstall={vi.fn()} onDetails={vi.fn()} onUpdateStarted={vi.fn()} onUpdateAll={vi.fn()} />,
       );
 
       expect(screen.queryByText(/Setup notes/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('one install', () => {
+    it('offers "Install in another project" in the overflow menu, wired to onInstall', async () => {
+      const entry: CatalogEntry = { ...baseEntry, installs: [{ ...installA, updateAvailable: false }] };
+      const props = renderCard(entry);
+
+      // No primary Install CTA next to "Installed" — installing again is in the overflow.
+      expect(screen.queryByRole('button', { name: /^install$/i })).not.toBeInTheDocument();
+      await userEvent.click(screen.getByRole('button', { name: /more actions/i }));
+      await userEvent.click(await screen.findByRole('menuitem', { name: /install in another project/i }));
+
+      expect(props.onInstall).toHaveBeenCalledWith(entry);
+    });
+  });
+
+  describe('several installs', () => {
+    const twoInstalls: CatalogEntry = {
+      ...baseEntry,
+      registryVersion: '2.0.0',
+      installs: [installA, installB],
+    };
+
+    it('summarises the installs and the pending updates instead of acting on one', () => {
+      renderCard(twoInstalls);
+
+      expect(screen.getByText('Installed in 2 projects · 1 update available')).toBeInTheDocument();
+      // Per-install actions live in the details dialog, not on the card.
+      expect(screen.queryByRole('link', { name: /open/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /update to v2\.0\.0/i })).not.toBeInTheDocument();
+    });
+
+    it('"Update all (k)" hands off to onUpdateAll and "Manage installs" to onDetails', () => {
+      const props = renderCard(twoInstalls);
+
+      fireEvent.click(screen.getByRole('button', { name: /update all \(1\)/i }));
+      expect(props.onUpdateAll).toHaveBeenCalledWith(twoInstalls);
+
+      fireEvent.click(screen.getByRole('button', { name: /manage installs/i }));
+      expect(props.onDetails).toHaveBeenCalledWith(twoInstalls);
+    });
+
+    it('hides "Update all" when no install has an update, keeps Manage installs', () => {
+      renderCard({ ...twoInstalls, installs: [{ ...installA, updateAvailable: false }, installB] });
+
+      expect(screen.queryByRole('button', { name: /update all/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /manage installs/i })).toBeInTheDocument();
+      expect(screen.getByText('Installed in 2 projects')).toBeInTheDocument();
+    });
+
+    it('still offers "Install in another project" in the overflow', async () => {
+      const props = renderCard(twoInstalls);
+
+      await userEvent.click(screen.getByRole('button', { name: /more actions/i }));
+      await userEvent.click(await screen.findByRole('menuitem', { name: /install in another project/i }));
+
+      expect(props.onInstall).toHaveBeenCalledWith(twoInstalls);
     });
   });
 });

--- a/apps/frontend/src/components/app-catalog/__tests__/AppDetailsDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/AppDetailsDialog.test.tsx
@@ -1,8 +1,34 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { AppDetailsDialog } from '../AppDetailsDialog';
 import { hasAppDetails } from '../catalogEntry';
 import type { CatalogEntry } from '@/services/appCatalogApi';
+import type { SequentialUpdates } from '../useSequentialUpdates';
+
+const updateTrigger = vi.fn();
+const batch: SequentialUpdates = { states: {}, running: false, start: vi.fn() };
+
+vi.mock('@/services/appCatalogApi', () => ({
+  useUpdateAppMutation: () => [updateTrigger, { isLoading: false }],
+  useUninstallAppMutation: () => [vi.fn(), { isLoading: false }],
+  useGetUninstallPreviewQuery: () => ({ data: undefined }),
+  useGetEjectPayloadQuery: () => ({ data: undefined, isFetching: false }),
+}));
+vi.mock('@/services/apiKeysApi', () => ({
+  useCreateApiKeyMutation: () => [vi.fn(), { isLoading: false }],
+}));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+// The batch runner talks to the store; its sequencing is covered in
+// useSequentialUpdates.test.ts. Here it's a stub whose calls/state we control.
+vi.mock('../useSequentialUpdates', () => ({ useSequentialUpdates: () => batch }));
+
+beforeEach(() => {
+  updateTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({ jobId: 'job-1' }) });
+  (batch.start as ReturnType<typeof vi.fn>).mockReset();
+  batch.states = {};
+  batch.running = false;
+});
 
 const baseEntry: CatalogEntry = {
   id: 'handoff',
@@ -19,14 +45,60 @@ const baseEntry: CatalogEntry = {
   sourceUrl: 'https://github.com/bffless/apps',
   gates: [],
   installable: true,
+  installs: [],
 };
 
+const installA: CatalogEntry['installs'][number] = {
+  installedAppId: 'installed-1',
+  installedAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  version: '1.0.0',
+  projectId: 'proj-1',
+  projectName: 'acme/handoff',
+  alias: 'production',
+  appUrl: 'https://handoff.example.com',
+  status: 'installed',
+  updateAvailable: false,
+  manualSteps: [],
+};
+const installB: CatalogEntry['installs'][number] = {
+  ...installA,
+  installedAppId: 'installed-2',
+  projectId: 'proj-2',
+  projectName: 'acme/blog',
+  appUrl: 'https://handoff-blog.example.com',
+  version: '0.9.0',
+  updateAvailable: true,
+  manualSteps: [{ id: 'cors', title: 'Configure CORS', body: 'Allow the app origin.' }],
+};
+
+/** Direct rows of the installs list (setup notes and markdown render nested <li>s of their own). */
+function installRows(): HTMLElement[] {
+  const list = screen.getByRole('list', { name: /installed projects/i });
+  return Array.from(list.querySelectorAll<HTMLElement>(':scope > li'));
+}
+
+function renderDialog(entry: CatalogEntry, overrides: Partial<Parameters<typeof AppDetailsDialog>[0]> = {}) {
+  const props = {
+    entry,
+    open: true,
+    onOpenChange: vi.fn(),
+    onInstall: vi.fn(),
+    onUpdateStarted: vi.fn(),
+    ...overrides,
+  };
+  render(<AppDetailsDialog {...props} />);
+  return props;
+}
+
 describe('hasAppDetails', () => {
-  it('is true when there is a description or screenshots, false otherwise', () => {
+  it('is true when there is a description, screenshots, or at least one install', () => {
     expect(hasAppDetails(baseEntry)).toBe(true);
     expect(hasAppDetails({ ...baseEntry, description: undefined })).toBe(true);
     expect(hasAppDetails({ ...baseEntry, screenshots: [] })).toBe(true);
     expect(hasAppDetails({ ...baseEntry, description: undefined, screenshots: [] })).toBe(false);
+    // An installed app always has a details view: that's where its installs are managed.
+    expect(hasAppDetails({ ...baseEntry, description: undefined, screenshots: [], installs: [installA] })).toBe(true);
   });
 });
 
@@ -38,6 +110,7 @@ describe('AppDetailsDialog', () => {
         open
         onOpenChange={vi.fn()}
         onInstall={vi.fn()}
+        onUpdateStarted={vi.fn()}
       />,
     );
 
@@ -65,6 +138,7 @@ describe('AppDetailsDialog', () => {
         open
         onOpenChange={vi.fn()}
         onInstall={vi.fn()}
+        onUpdateStarted={vi.fn()}
       />,
     );
 
@@ -75,7 +149,7 @@ describe('AppDetailsDialog', () => {
   it('hands off to the install wizard when Install is clicked', () => {
     const onInstall = vi.fn();
     render(
-      <AppDetailsDialog entry={baseEntry} open onOpenChange={vi.fn()} onInstall={onInstall} />,
+      <AppDetailsDialog entry={baseEntry} open onOpenChange={vi.fn()} onInstall={onInstall} onUpdateStarted={vi.fn()} />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
@@ -96,35 +170,133 @@ describe('AppDetailsDialog', () => {
       ],
     };
 
-    render(<AppDetailsDialog entry={entry} open onOpenChange={vi.fn()} onInstall={vi.fn()} />);
+    render(<AppDetailsDialog entry={entry} open onOpenChange={vi.fn()} onInstall={vi.fn()} onUpdateStarted={vi.fn()} />);
 
     expect(screen.queryByRole('button', { name: /^install$/i })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /requires bucket storage/i })).toBeDisabled();
   });
 
-  it('shows Open instead of Install for an installed app', () => {
-    const entry: CatalogEntry = {
-      ...baseEntry,
-      installed: {
-        installedAppId: 'installed-1',
-        version: '1.0.0',
-        projectId: 'proj-1',
-        projectName: 'acme/handoff',
-        alias: 'production',
-        appUrl: 'https://handoff.example.com',
-        status: 'installed',
-        updateAvailable: false,
-        manualSteps: [],
-      },
-    };
-
-    render(<AppDetailsDialog entry={entry} open onOpenChange={vi.fn()} onInstall={vi.fn()} />);
+  it('shows Open and "Install in another project" for a single-install app', () => {
+    const entry: CatalogEntry = { ...baseEntry, installs: [installA] };
+    const props = renderDialog(entry);
 
     expect(screen.queryByRole('button', { name: /^install$/i })).not.toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /open/i })).toHaveAttribute(
-      'href',
-      'https://handoff.example.com',
-    );
+    // Footer Open (the sole install) plus the row's Open — both point at the same host.
+    for (const link of screen.getAllByRole('link', { name: /open/i })) {
+      expect(link).toHaveAttribute('href', 'https://handoff.example.com');
+    }
     expect(screen.getByText('Installed · v1.0.0')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /install in another project/i }));
+    expect(props.onInstall).toHaveBeenCalledWith(entry);
+  });
+
+  describe('installs section', () => {
+    const twoInstalls: CatalogEntry = { ...baseEntry, registryVersion: '1.0.0', installs: [installA, installB] };
+
+    it('lists every install with project, host, version and per-install actions', () => {
+      renderDialog(twoInstalls);
+
+      const section = screen.getByRole('region', { name: /installs/i });
+      expect(within(section).getByText('Installed in 2 projects')).toBeInTheDocument();
+      const rows = installRows();
+      expect(rows).toHaveLength(2);
+
+      expect(within(rows[0]).getByText('acme/handoff')).toBeInTheDocument();
+      expect(within(rows[0]).getByText('v1.0.0')).toBeInTheDocument();
+      expect(within(rows[0]).getByText(/handoff\.example\.com/)).toBeInTheDocument();
+      expect(within(rows[0]).queryByRole('button', { name: /update to/i })).not.toBeInTheDocument();
+
+      expect(within(rows[1]).getByText('acme/blog')).toBeInTheDocument();
+      expect(within(rows[1]).getByText('v0.9.0')).toBeInTheDocument();
+      expect(within(rows[1]).getByRole('button', { name: /update to v1\.0\.0/i })).toBeInTheDocument();
+      expect(within(rows[1]).getByRole('link', { name: /open/i })).toHaveAttribute(
+        'href',
+        'https://handoff-blog.example.com',
+      );
+      // Setup notes are per install.
+      expect(within(rows[1]).getByText('Configure CORS')).toBeInTheDocument();
+      expect(within(rows[0]).queryByText('Configure CORS')).not.toBeInTheDocument();
+      // No single footer Open when the dialog can't know which install is meant.
+      expect(screen.getAllByRole('link', { name: /open/i })).toHaveLength(2);
+    });
+
+    it('fires a per-install update for the right row and hands the job to onUpdateStarted', async () => {
+      const props = renderDialog(twoInstalls);
+      const rows = installRows();
+
+      fireEvent.click(within(rows[1]).getByRole('button', { name: /update to v1\.0\.0/i }));
+      fireEvent.click(await screen.findByRole('button', { name: /confirm update/i }));
+
+      expect(updateTrigger).toHaveBeenCalledWith({ id: 'installed-2', prune: false });
+      await vi.waitFor(() => expect(props.onUpdateStarted).toHaveBeenCalledWith(twoInstalls, 'job-1'));
+    });
+
+    it('offers "Update all" only when two or more installs have an update, and starts the batch with them', () => {
+      const bothUpdatable: CatalogEntry = {
+        ...twoInstalls,
+        installs: [{ ...installA, updateAvailable: true }, installB],
+      };
+      renderDialog(bothUpdatable);
+
+      fireEvent.click(screen.getByRole('button', { name: /update all \(2\)/i }));
+      expect(batch.start).toHaveBeenCalledWith(bothUpdatable.installs, false);
+    });
+
+    it('arms the batch on mount when autoUpdateAll is set', () => {
+      const bothUpdatable: CatalogEntry = {
+        ...twoInstalls,
+        installs: [{ ...installA, updateAvailable: true }, installB],
+      };
+      renderDialog(bothUpdatable, { autoUpdateAll: true });
+
+      expect(batch.start).toHaveBeenCalledTimes(1);
+      expect(batch.start).toHaveBeenCalledWith(bothUpdatable.installs, false);
+    });
+
+    it('renders batch progress inline and swaps Update for View / Review conflicts', () => {
+      batch.running = true;
+      batch.states = {
+        'installed-1': { status: 'running', jobId: 'job-a' },
+        'installed-2': { status: 'queued' },
+      };
+      const bothUpdatable: CatalogEntry = {
+        ...twoInstalls,
+        installs: [{ ...installA, updateAvailable: true }, installB],
+      };
+      const { rerender } = render(
+        <AppDetailsDialog entry={bothUpdatable} open onOpenChange={vi.fn()} onInstall={vi.fn()} onUpdateStarted={vi.fn()} />,
+      );
+      let rows = installRows();
+      expect(within(rows[0]).getByText('Updating')).toBeInTheDocument();
+      expect(within(rows[1]).getByText('Queued')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /update to/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /updating…/i })).toBeDisabled();
+
+      batch.running = false;
+      batch.states = {
+        'installed-1': { status: 'succeeded', jobId: 'job-a' },
+        'installed-2': { status: 'conflicts', jobId: 'job-b' },
+      };
+      const onUpdateStarted = vi.fn();
+      rerender(
+        <AppDetailsDialog entry={bothUpdatable} open onOpenChange={vi.fn()} onInstall={vi.fn()} onUpdateStarted={onUpdateStarted} />,
+      );
+      rows = installRows();
+      expect(within(rows[0]).getByText('Updated')).toBeInTheDocument();
+      expect(within(rows[1]).getByText('Updated · conflicts')).toBeInTheDocument();
+      fireEvent.click(within(rows[1]).getByRole('button', { name: /review conflicts/i }));
+      expect(onUpdateStarted).toHaveBeenCalledWith(bothUpdatable, 'job-b');
+    });
+
+    it('uninstall from a row targets that install', async () => {
+      renderDialog(twoInstalls);
+      const rows = installRows();
+
+      await userEvent.click(within(rows[1]).getByRole('button', { name: /more actions for acme\/blog/i }));
+      await userEvent.click(await screen.findByRole('menuitem', { name: /uninstall/i }));
+
+      expect(await screen.findByText(/from acme\/blog\./)).toBeInTheDocument();
+    });
   });
 });

--- a/apps/frontend/src/components/app-catalog/__tests__/EjectPanel.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/EjectPanel.test.tsx
@@ -36,18 +36,23 @@ const entry: CatalogEntry = {
   name: 'Handoff',
   gates: [],
   installable: true,
-  installed: {
-    installedAppId: 'installed-1',
-    version: '1.2.0',
-    projectId: 'proj-1',
-    projectName: 'acme/handoff',
-    alias: 'production',
-    appUrl: 'https://handoff.example.com',
-    status: 'installed',
-    updateAvailable: false,
-    manualSteps: [],
-  },
+  installs: [
+    {
+      installedAppId: 'installed-1',
+      installedAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      version: '1.2.0',
+      projectId: 'proj-1',
+      projectName: 'acme/handoff',
+      alias: 'production',
+      appUrl: 'https://handoff.example.com',
+      status: 'installed',
+      updateAvailable: false,
+      manualSteps: [],
+    },
+  ],
 };
+const install = entry.installs[0];
 
 function makePayload(overrides: Partial<EjectPayload> = {}): EjectPayload {
   return {
@@ -76,7 +81,7 @@ beforeEach(() => {
 
 describe('EjectPanel', () => {
   it('renders the fork link and Actions variables with copy buttons', () => {
-    render(<EjectPanel entry={entry} open onOpenChange={vi.fn()} />);
+    render(<EjectPanel entry={entry} install={install} open onOpenChange={vi.fn()} />);
 
     expect(screen.getByRole('link', { name: /fork on github/i })).toHaveAttribute(
       'href',
@@ -89,7 +94,7 @@ describe('EjectPanel', () => {
   });
 
   it('renders the secrets list with an inline Mint API key button', () => {
-    render(<EjectPanel entry={entry} open onOpenChange={vi.fn()} />);
+    render(<EjectPanel entry={entry} install={install} open onOpenChange={vi.fn()} />);
 
     expect(screen.getByText('BFFLESS_API_KEY')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /mint api key/i })).toBeInTheDocument();
@@ -103,7 +108,7 @@ describe('EjectPanel', () => {
     };
     createApiKeyTrigger.mockReturnValue({ unwrap: () => Promise.resolve(response) });
 
-    render(<EjectPanel entry={entry} open onOpenChange={vi.fn()} />);
+    render(<EjectPanel entry={entry} install={install} open onOpenChange={vi.fn()} />);
     fireEvent.click(screen.getByRole('button', { name: /mint api key/i }));
 
     expect(createApiKeyTrigger).toHaveBeenCalledWith(
@@ -113,13 +118,13 @@ describe('EjectPanel', () => {
   });
 
   it('renders the workflow name to run', () => {
-    render(<EjectPanel entry={entry} open onOpenChange={vi.fn()} />);
+    render(<EjectPanel entry={entry} install={install} open onOpenChange={vi.fn()} />);
 
     expect(screen.getByText('deploy-handoff.yml')).toBeInTheDocument();
   });
 
   it('renders the continuity note verbatim', () => {
-    render(<EjectPanel entry={entry} open onOpenChange={vi.fn()} />);
+    render(<EjectPanel entry={entry} install={install} open onOpenChange={vi.fn()} />);
 
     expect(
       screen.getByText(

--- a/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/InstallDialog.test.tsx
@@ -65,6 +65,23 @@ const baseEntry: CatalogEntry = {
   summary: 'Share files with clients',
   gates: [],
   installable: true,
+  installs: [],
+};
+
+const existingInstall: CatalogEntry['installs'][number] = {
+  installedAppId: 'installed-1',
+  installedAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  version: '1.0.0',
+  projectId: 'proj-1',
+  projectName: 'acme/handoff-site',
+  alias: 'production',
+  appUrl: 'https://handoff.example.com',
+  status: 'installed',
+  updateAvailable: false,
+  manualSteps: [
+    { id: 'installed-step', title: 'Rotate the signing secret', body: 'Do it in Settings.' },
+  ],
 };
 
 function makePreflight(overrides: Partial<PreflightResponse> = {}): PreflightResponse {
@@ -556,23 +573,8 @@ describe('InstallDialog — Done screen', () => {
     ).toBeInTheDocument();
   });
 
-  it('prefers the durable entry.installed manual steps over the job’s', async () => {
-    const entryWithInstall: CatalogEntry = {
-      ...baseEntry,
-      installed: {
-        installedAppId: 'installed-1',
-        version: '1.0.0',
-        projectId: 'proj-1',
-        projectName: 'acme/handoff-site',
-        alias: 'production',
-        appUrl: 'https://handoff.example.com',
-        status: 'installed',
-        updateAvailable: false,
-        manualSteps: [
-          { id: 'installed-step', title: 'Rotate the signing secret', body: 'Do it in Settings.' },
-        ],
-      },
-    };
+  it('prefers the durable catalog install’s manual steps (matched by the job’s installedAppId) over the job’s', async () => {
+    const entryWithInstall: CatalogEntry = { ...baseEntry, installs: [existingInstall] };
     jobQueryResult = {
       data: makeJob({
         status: 'succeeded',
@@ -586,6 +588,89 @@ describe('InstallDialog — Done screen', () => {
 
     expect(await screen.findByText('Rotate the signing secret')).toBeInTheDocument();
     expect(screen.queryByText('Set the SIGNING_SECRET')).not.toBeInTheDocument();
+  });
+
+  it('never shows ANOTHER install’s notes/URL: a second install’s Done screen matches on installedAppId', async () => {
+    // The app is already installed in project A; this job installed it into B.
+    const entryWithInstall: CatalogEntry = { ...baseEntry, installs: [existingInstall] };
+    jobQueryResult = {
+      data: makeJob({
+        status: 'succeeded',
+        installedAppId: 'installed-2',
+        appUrl: 'https://handoff-blog.example.com',
+        manualSteps: [{ id: 'job-step', title: 'Set the SIGNING_SECRET', body: 'From the job.' }],
+      }),
+    };
+
+    render(<InstallDialog entry={entryWithInstall} open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+
+    expect(await screen.findByText('Set the SIGNING_SECRET')).toBeInTheDocument();
+    expect(screen.queryByText('Rotate the signing secret')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /open/i })).toHaveAttribute(
+      'href',
+      'https://handoff-blog.example.com',
+    );
+  });
+});
+
+describe('InstallDialog — install again (app already installed elsewhere)', () => {
+  const entryWithInstall: CatalogEntry = { ...baseEntry, installs: [existingInstall] };
+
+  it('titles the wizard as installing in another project', () => {
+    render(<InstallDialog entry={entryWithInstall} open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByRole('heading', { name: 'Install Handoff in another project' })).toBeInTheDocument();
+  });
+
+  it('prefills the suggested subdomain from preflight and explains which install owns the default', () => {
+    preflightState = {
+      data: makePreflight({
+        gates: [{ id: 'name-collision', status: 'fail', message: 'The domain "handoff.example.com" is already mapped' }],
+        appHost: 'handoff.example.com',
+        appUrl: 'https://handoff.example.com',
+        suggestedSubdomain: 'handoff-blog',
+      }),
+      isLoading: false,
+    };
+
+    render(<InstallDialog entry={entryWithInstall} open onOpenChange={vi.fn()} />);
+
+    const input = screen.getByLabelText(/subdomain/i) as HTMLInputElement;
+    expect(input.value).toBe('handoff-blog');
+    expect(
+      screen.getByText('The default subdomain "handoff" is used by the install in acme/handoff-site.'),
+    ).toBeInTheDocument();
+  });
+
+  it('does not overwrite a subdomain the operator already typed', () => {
+    preflightState = { data: makePreflight({ appHost: 'handoff.example.com' }), isLoading: false };
+    const { rerender } = render(<InstallDialog entry={entryWithInstall} open onOpenChange={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText(/subdomain/i), { target: { value: 'mine' } });
+
+    preflightState = {
+      data: makePreflight({ appHost: 'mine.example.com', suggestedSubdomain: 'handoff-blog' }),
+      isLoading: false,
+    };
+    rerender(<InstallDialog entry={entryWithInstall} open onOpenChange={vi.fn()} />);
+
+    expect((screen.getByLabelText(/subdomain/i) as HTMLInputElement).value).toBe('mine');
+  });
+
+  it('uses generic wording when no existing install owns the default host', () => {
+    const unrelated: CatalogEntry = {
+      ...baseEntry,
+      installs: [{ ...existingInstall, appUrl: 'https://files.example.com' }],
+    };
+    preflightState = {
+      data: makePreflight({ appHost: 'handoff.example.com', suggestedSubdomain: 'handoff-blog' }),
+      isLoading: false,
+    };
+
+    render(<InstallDialog entry={unrelated} open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText('The default subdomain "handoff" is already in use.')).toBeInTheDocument();
   });
 });
 

--- a/apps/frontend/src/components/app-catalog/__tests__/UninstallDialog.test.tsx
+++ b/apps/frontend/src/components/app-catalog/__tests__/UninstallDialog.test.tsx
@@ -33,18 +33,23 @@ const entry: CatalogEntry = {
   name: 'Handoff',
   gates: [],
   installable: true,
-  installed: {
-    installedAppId: 'installed-1',
-    version: '1.2.0',
-    projectId: 'proj-1',
-    projectName: 'acme/handoff',
-    alias: 'production',
-    appUrl: 'https://handoff.example.com',
-    status: 'installed',
-    updateAvailable: false,
-    manualSteps: [],
-  },
+  installs: [
+    {
+      installedAppId: 'installed-1',
+      installedAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      version: '1.2.0',
+      projectId: 'proj-1',
+      projectName: 'acme/handoff',
+      alias: 'production',
+      appUrl: 'https://handoff.example.com',
+      status: 'installed',
+      updateAvailable: false,
+      manualSteps: [],
+    },
+  ],
 };
+const install = entry.installs[0];
 
 function makePreview(overrides: Partial<UninstallPreview> = {}): UninstallPreview {
   return {
@@ -67,11 +72,11 @@ beforeEach(() => {
 
 describe('UninstallDialog', () => {
   it('shows the default keeps-data copy without the checkbox checked', () => {
-    render(<UninstallDialog entry={entry} open onOpenChange={vi.fn()} />);
+    render(<UninstallDialog entry={entry} install={install} open onOpenChange={vi.fn()} />);
 
     expect(
       screen.getByText(
-        "Removes the app's rule sets, alias, domain, and deployment. Your data tables and uploaded files are kept.",
+        "Removes the app's rule sets, alias, domain, and deployment from acme/handoff. Your data tables and uploaded files are kept.",
       ),
     ).toBeInTheDocument();
     expect(screen.getByRole('checkbox', { name: /also delete the app's data tables/i })).not.toBeChecked();
@@ -79,7 +84,7 @@ describe('UninstallDialog', () => {
   });
 
   it('reveals the real record counts only after the checkbox is checked', () => {
-    render(<UninstallDialog entry={entry} open onOpenChange={vi.fn()} />);
+    render(<UninstallDialog entry={entry} install={install} open onOpenChange={vi.fn()} />);
 
     const checkbox = screen.getByRole('checkbox', { name: /also delete the app's data tables/i });
     fireEvent.click(checkbox);
@@ -89,7 +94,7 @@ describe('UninstallDialog', () => {
   });
 
   it('lists reused tables as kept regardless of the checkbox', () => {
-    render(<UninstallDialog entry={entry} open onOpenChange={vi.fn()} />);
+    render(<UninstallDialog entry={entry} install={install} open onOpenChange={vi.fn()} />);
 
     expect(screen.getByText(/users/)).toBeInTheDocument();
 
@@ -100,7 +105,7 @@ describe('UninstallDialog', () => {
   });
 
   it('confirms uninstall with deleteData: false by default', () => {
-    render(<UninstallDialog entry={entry} open onOpenChange={vi.fn()} />);
+    render(<UninstallDialog entry={entry} install={install} open onOpenChange={vi.fn()} />);
 
     fireEvent.click(screen.getByRole('button', { name: /^uninstall$/i }));
 
@@ -108,7 +113,7 @@ describe('UninstallDialog', () => {
   });
 
   it('confirms uninstall with deleteData: true when the checkbox is checked', () => {
-    render(<UninstallDialog entry={entry} open onOpenChange={vi.fn()} />);
+    render(<UninstallDialog entry={entry} install={install} open onOpenChange={vi.fn()} />);
 
     fireEvent.click(screen.getByRole('checkbox', { name: /also delete the app's data tables/i }));
     fireEvent.click(screen.getByRole('button', { name: /^uninstall$/i }));
@@ -118,7 +123,7 @@ describe('UninstallDialog', () => {
 
   it('shows a summary toast and closes the dialog on success', async () => {
     const onOpenChange = vi.fn();
-    render(<UninstallDialog entry={entry} open onOpenChange={onOpenChange} />);
+    render(<UninstallDialog entry={entry} install={install} open onOpenChange={onOpenChange} />);
 
     fireEvent.click(screen.getByRole('button', { name: /^uninstall$/i }));
 
@@ -136,7 +141,7 @@ describe('UninstallDialog', () => {
     };
     uninstallTrigger.mockReturnValue({ unwrap: () => Promise.resolve(partialSummary) });
 
-    render(<UninstallDialog entry={entry} open onOpenChange={onOpenChange} />);
+    render(<UninstallDialog entry={entry} install={install} open onOpenChange={onOpenChange} />);
 
     fireEvent.click(screen.getByRole('button', { name: /^uninstall$/i }));
 

--- a/apps/frontend/src/components/app-catalog/__tests__/useSequentialUpdates.test.ts
+++ b/apps/frontend/src/components/app-catalog/__tests__/useSequentialUpdates.test.ts
@@ -1,0 +1,165 @@
+import { act, renderHook } from '@testing-library/react';
+import { vi } from 'vitest';
+import { useSequentialUpdates } from '../useSequentialUpdates';
+import type { InstallJob, InstalledSummary } from '@/services/appCatalogApi';
+
+/**
+ * The hook talks to the store through `useUpdateAppMutation` (start a job) and
+ * `appCatalogApi.endpoints.getInstallJob.initiate` (poll it). Both are stubbed
+ * so the test controls exactly when each job starts and how it ends; the
+ * assertions are about ORDER and about what each failure mode does to the
+ * rest of the batch.
+ */
+const updateTrigger = vi.fn();
+const initiate = vi.fn();
+const dispatch = vi.fn((action: unknown) => action);
+const invalidateTags = vi.fn((tags: string[]) => ({ type: 'invalidate', tags }));
+
+vi.mock('@/services/appCatalogApi', () => ({
+  useUpdateAppMutation: () => [updateTrigger],
+  appCatalogApi: { endpoints: { getInstallJob: { initiate: (...args: unknown[]) => initiate(...args) } } },
+}));
+vi.mock('@/store/hooks', () => ({ useAppDispatch: () => dispatch }));
+vi.mock('@/services/api', () => ({ api: { util: { invalidateTags: (tags: string[]) => invalidateTags(tags) } } }));
+
+const install = (id: string): InstalledSummary => ({
+  installedAppId: id,
+  installedAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  version: '1.0.0',
+  projectId: `proj-${id}`,
+  projectName: `acme/${id}`,
+  alias: 'app',
+  status: 'installed',
+  updateAvailable: true,
+  manualSteps: [],
+});
+
+const job = (id: string, status: InstallJob['status'], extra: Partial<InstallJob> = {}): InstallJob =>
+  ({ id, kind: 'update', appId: 'app', projectId: null, status, steps: [], createdAt: '', ...extra }) as InstallJob;
+
+/** Queue of job snapshots per jobId; each poll shifts one (last one sticks). */
+let jobFeeds: Record<string, InstallJob[]>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  updateTrigger.mockReset();
+  initiate.mockReset();
+  dispatch.mockClear();
+  invalidateTags.mockClear();
+  jobFeeds = {};
+  initiate.mockImplementation((jobId: string) => ({
+    unwrap: () => {
+      const feed = jobFeeds[jobId] ?? [];
+      const next = feed.length > 1 ? feed.shift()! : feed[0];
+      return next ? Promise.resolve(next) : Promise.reject({ data: { message: 'no such job' } });
+    },
+    unsubscribe: vi.fn(),
+  }));
+  updateTrigger.mockImplementation(({ id }: { id: string }) => ({
+    unwrap: () => Promise.resolve({ jobId: `job-${id}` }),
+  }));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function flush() {
+  // Let pending promises settle, then advance past one poll interval, repeatedly.
+  for (let i = 0; i < 10; i++) {
+    await act(async () => {
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+  }
+}
+
+describe('useSequentialUpdates', () => {
+  it('runs installs one at a time, in order, and refetches the catalog at the end', async () => {
+    jobFeeds['job-a'] = [job('job-a', 'running'), job('job-a', 'succeeded')];
+    jobFeeds['job-b'] = [job('job-b', 'succeeded')];
+    const { result } = renderHook(() => useSequentialUpdates());
+
+    act(() => result.current.start([install('a'), install('b')], false));
+    expect(result.current.running).toBe(true);
+    // The first install starts synchronously; the second waits its turn.
+    expect(result.current.states).toEqual({ a: { status: 'running' }, b: { status: 'queued' } });
+
+    await flush();
+
+    // b's update was only fired after a's job reached a terminal status.
+    expect(updateTrigger.mock.calls.map((c) => c[0])).toEqual([
+      { id: 'a', prune: false },
+      { id: 'b', prune: false },
+    ]);
+    const firstBStart = updateTrigger.mock.invocationCallOrder[1];
+    const lastAPoll = initiate.mock.invocationCallOrder.filter((_, i) => initiate.mock.calls[i][0] === 'job-a').at(-1)!;
+    expect(firstBStart).toBeGreaterThan(lastAPoll);
+
+    expect(result.current.running).toBe(false);
+    expect(result.current.states).toEqual({
+      a: { status: 'succeeded', jobId: 'job-a' },
+      b: { status: 'succeeded', jobId: 'job-b' },
+    });
+    expect(invalidateTags).toHaveBeenCalledWith(['AppCatalog', 'InstalledApp']);
+  });
+
+  it('passes prune through and flags a succeeded job with conflicts', async () => {
+    jobFeeds['job-a'] = [job('job-a', 'succeeded', { conflicts: [{} as never] })];
+    const { result } = renderHook(() => useSequentialUpdates());
+
+    act(() => result.current.start([install('a')], true));
+    await flush();
+
+    expect(updateTrigger).toHaveBeenCalledWith({ id: 'a', prune: true });
+    expect(result.current.states.a).toEqual({ status: 'conflicts', jobId: 'job-a' });
+  });
+
+  it('a failed job does not stop the batch — the next install still runs', async () => {
+    jobFeeds['job-a'] = [job('job-a', 'failed', { error: 'deploy exploded' })];
+    jobFeeds['job-b'] = [job('job-b', 'succeeded')];
+    const { result } = renderHook(() => useSequentialUpdates());
+
+    act(() => result.current.start([install('a'), install('b')], false));
+    await flush();
+
+    expect(result.current.states).toEqual({
+      a: { status: 'failed', jobId: 'job-a', error: 'deploy exploded' },
+      b: { status: 'succeeded', jobId: 'job-b' },
+    });
+  });
+
+  it('a REJECTED start stops the batch — later installs are marked skipped, not attempted', async () => {
+    updateTrigger.mockImplementation(({ id }: { id: string }) => ({
+      unwrap: () =>
+        id === 'a'
+          ? Promise.reject({ data: { message: 'Another install job is already running' } })
+          : Promise.resolve({ jobId: `job-${id}` }),
+    }));
+    const { result } = renderHook(() => useSequentialUpdates());
+
+    act(() => result.current.start([install('a'), install('b')], false));
+    await flush();
+
+    expect(updateTrigger).toHaveBeenCalledTimes(1);
+    expect(result.current.states.a).toEqual({ status: 'failed', error: 'Another install job is already running' });
+    expect(result.current.states.b.status).toBe('failed');
+    expect(result.current.states.b.error).toMatch(/skipped/i);
+    expect(result.current.running).toBe(false);
+  });
+
+  it('ignores start while a batch is running', async () => {
+    jobFeeds['job-a'] = [job('job-a', 'running')]; // never finishes
+    const { result } = renderHook(() => useSequentialUpdates());
+
+    act(() => result.current.start([install('a')], false));
+    act(() => result.current.start([install('b')], false));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(updateTrigger).toHaveBeenCalledTimes(1);
+    expect(result.current.states.b).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/components/app-catalog/catalogEntry.ts
+++ b/apps/frontend/src/components/app-catalog/catalogEntry.ts
@@ -1,12 +1,30 @@
-import type { CatalogEntry } from '@/services/appCatalogApi';
+import type { CatalogEntry, InstalledSummary } from '@/services/appCatalogApi';
 
 /**
- * True when the registry gave this app enough store metadata to be worth a
- * details view. Shared so `AppCard` renders its "Details" affordance under
- * exactly the same condition `AppDetailsDialog` would render content for — an
- * app with neither a description nor screenshots (a de-listed installed app,
- * or one published without a `catalog/` dir) gets no dead-end button.
+ * True when the details view has something to show: store metadata from the
+ * registry (description / screenshots), or at least one install — the
+ * details dialog is also where the per-install list lives, so an installed
+ * app always has a details view even when it was published without a
+ * `catalog/` dir or has since been de-listed. Shared so `AppCard` renders its
+ * "Details" affordance under exactly the same condition `AppDetailsDialog`
+ * would render content for.
  */
 export function hasAppDetails(entry: CatalogEntry): boolean {
-  return Boolean(entry.description || entry.screenshots?.length);
+  return Boolean(entry.description || entry.screenshots?.length || entry.installs.length > 0);
+}
+
+/** Installs that can move to the registry version right now. */
+export function updatableInstalls(entry: CatalogEntry): InstalledSummary[] {
+  if (!entry.registryVersion) return [];
+  return entry.installs.filter((install) => install.updateAvailable);
+}
+
+/** Pulls the host out of an install's URL for compact display (`files.example.com`). */
+export function installHost(install: InstalledSummary): string | undefined {
+  if (!install.appUrl) return undefined;
+  try {
+    return new URL(install.appUrl).host;
+  } catch {
+    return undefined;
+  }
 }

--- a/apps/frontend/src/components/app-catalog/useSequentialUpdates.ts
+++ b/apps/frontend/src/components/app-catalog/useSequentialUpdates.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAppDispatch } from '@/store/hooks';
+import { api } from '@/services/api';
+import {
+  appCatalogApi,
+  useUpdateAppMutation,
+  type InstallJob,
+  type InstalledSummary,
+} from '@/services/appCatalogApi';
+
+export type SequentialUpdateStatus = 'queued' | 'running' | 'succeeded' | 'conflicts' | 'failed';
+
+export interface SequentialUpdateState {
+  status: SequentialUpdateStatus;
+  jobId?: string;
+  error?: string;
+}
+
+export interface SequentialUpdates {
+  /** Per-install progress, keyed by `installedAppId`. Empty until `start` is called. */
+  states: Record<string, SequentialUpdateState>;
+  running: boolean;
+  /** Kicks off the batch. No-op while one is already running. */
+  start: (installs: InstalledSummary[], prune: boolean) => void;
+}
+
+const TERMINAL_JOB_STATUSES = new Set<InstallJob['status']>(['succeeded', 'failed', 'undone']);
+const POLL_INTERVAL_MS = 1000;
+
+/**
+ * useSequentialUpdates — "Update all" for an app installed in several
+ * projects. The backend's install-job registry is single-flight (a second
+ * `updateApp` while one runs is a 400), so the batch is serialised here: fire
+ * the update for one install, poll its job to a terminal status, then move to
+ * the next. Each install's state is exposed so a list can render progress
+ * inline; a finished job's id lets the row open the shared `InstallDialog`
+ * (update mode) for the full step log and conflict resolution.
+ *
+ * A failed job does NOT stop the batch — the remaining installs are
+ * independent rows and one project's failure says nothing about another's —
+ * but a *rejected* start (e.g. another job already running) does, since every
+ * later start would be rejected the same way. The catalog is re-fetched once
+ * the batch ends so every row's version/updateAvailable is fresh.
+ */
+export function useSequentialUpdates(): SequentialUpdates {
+  const dispatch = useAppDispatch();
+  const [updateApp] = useUpdateAppMutation();
+  const [states, setStates] = useState<Record<string, SequentialUpdateState>>({});
+  const [running, setRunning] = useState(false);
+  const runningRef = useRef(false);
+  const unmountedRef = useRef(false);
+
+  useEffect(() => {
+    unmountedRef.current = false;
+    return () => {
+      unmountedRef.current = true;
+    };
+  }, []);
+
+  const setState = useCallback((id: string, next: SequentialUpdateState) => {
+    if (unmountedRef.current) return;
+    setStates((prev) => ({ ...prev, [id]: next }));
+  }, []);
+
+  const pollJob = useCallback(
+    async (jobId: string): Promise<InstallJob> => {
+      for (;;) {
+        const sub = dispatch(appCatalogApi.endpoints.getInstallJob.initiate(jobId, { forceRefetch: true }));
+        try {
+          const job = await sub.unwrap();
+          if (TERMINAL_JOB_STATUSES.has(job.status)) return job;
+        } finally {
+          sub.unsubscribe();
+        }
+        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+      }
+    },
+    [dispatch],
+  );
+
+  const start = useCallback(
+    (installs: InstalledSummary[], prune: boolean) => {
+      if (runningRef.current || installs.length === 0) return;
+      runningRef.current = true;
+      setRunning(true);
+      setStates(Object.fromEntries(installs.map((i) => [i.installedAppId, { status: 'queued' as const }])));
+
+      void (async () => {
+        let stopped = false;
+        for (const install of installs) {
+          const id = install.installedAppId;
+          if (stopped) {
+            setState(id, { status: 'failed', error: 'Skipped — an earlier update could not be started.' });
+            continue;
+          }
+          setState(id, { status: 'running' });
+          let jobId: string;
+          try {
+            ({ jobId } = await updateApp({ id, prune }).unwrap());
+          } catch (err) {
+            const message = (err as { data?: { message?: string } })?.data?.message ?? 'Update failed to start';
+            setState(id, { status: 'failed', error: message });
+            stopped = true;
+            continue;
+          }
+          setState(id, { status: 'running', jobId });
+          try {
+            const job = await pollJob(jobId);
+            if (job.status === 'succeeded') {
+              setState(id, { status: job.conflicts?.length ? 'conflicts' : 'succeeded', jobId });
+            } else {
+              setState(id, { status: 'failed', jobId, error: job.error ?? `Update ${job.status}` });
+            }
+          } catch (err) {
+            const message = (err as { data?: { message?: string } })?.data?.message ?? 'Lost track of the update job';
+            setState(id, { status: 'failed', jobId, error: message });
+          }
+        }
+        runningRef.current = false;
+        if (!unmountedRef.current) {
+          setRunning(false);
+          dispatch(api.util.invalidateTags(['AppCatalog', 'InstalledApp']));
+        }
+      })();
+    },
+    [dispatch, pollJob, setState, updateApp],
+  );
+
+  return { states, running, start };
+}

--- a/apps/frontend/src/pages/AppsPage.test.tsx
+++ b/apps/frontend/src/pages/AppsPage.test.tsx
@@ -64,17 +64,21 @@ function makeEntry(manualSteps: AppManualStep[]): CatalogEntry {
     gates: [],
     installable: true,
     registryVersion: '2.0.0',
-    installed: {
-      installedAppId: 'installed-1',
-      version: '1.0.0',
-      projectId: 'proj-1',
-      projectName: 'acme/handoff-site',
-      alias: 'production',
-      appUrl: 'https://handoff.example.com',
-      status: 'installed',
-      updateAvailable: true,
-      manualSteps,
-    },
+    installs: [
+      {
+        installedAppId: 'installed-1',
+        installedAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        version: '1.0.0',
+        projectId: 'proj-1',
+        projectName: 'acme/handoff-site',
+        alias: 'production',
+        appUrl: 'https://handoff.example.com',
+        status: 'installed',
+        updateAvailable: true,
+        manualSteps,
+      },
+    ],
   };
 }
 
@@ -123,6 +127,7 @@ describe('AppsPage — details dialog', () => {
             category: 'files',
             screenshots: ['https://apps.example.com/assets/handoff/screenshots/01.png'],
             gates: [],
+            installs: [],
             installable: true,
             registryVersion: '1.0.0',
           },

--- a/apps/frontend/src/services/appCatalogApi.ts
+++ b/apps/frontend/src/services/appCatalogApi.ts
@@ -81,17 +81,28 @@ export interface CatalogEntry {
   gates: GateResult[];
   /** Every instance gate passed AND the app is present in the registry. */
   installable: boolean;
-  installed?: {
-    installedAppId: string;
-    version: string;
-    projectId: string;
-    projectName: string;
-    alias: string;
-    appUrl?: string;
-    status: InstalledAppStatus;
-    updateAvailable: boolean;
-    manualSteps: AppManualStep[];
-  };
+  /**
+   * Every install of this app on the instance, oldest first — an app can be
+   * installed into many projects, each on its own version, so `updateAvailable`
+   * is per element. Empty when the app isn't installed anywhere.
+   */
+  installs: InstalledSummary[];
+}
+
+/** One installed_apps row, as the catalog presents it. */
+export interface InstalledSummary {
+  installedAppId: string;
+  version: string;
+  projectId: string;
+  projectName: string;
+  alias: string;
+  appUrl?: string;
+  status: InstalledAppStatus;
+  updateAvailable: boolean;
+  /** ISO timestamps — `updatedAt` moves on every update job. */
+  installedAt: string;
+  updatedAt: string;
+  manualSteps: AppManualStep[];
 }
 
 export interface CatalogListResult {
@@ -131,6 +142,12 @@ export interface PreflightResponse {
   syncPlans: SyncPlanSummary[];
   appHost: string | null;
   appUrl?: string;
+  /**
+   * A free subdomain to prefill when the manifest's default host is already
+   * mapped (install-again into another project). Only present when the request
+   * carried no `subdomain`.
+   */
+  suggestedSubdomain?: string;
 }
 
 export type InstallStepId =

--- a/docs/superpowers/specs/2026-08-19-app-multi-install-design.md
+++ b/docs/superpowers/specs/2026-08-19-app-multi-install-design.md
@@ -1,0 +1,40 @@
+# App catalog: one app, many installs
+
+**Date:** 2026-08-19 · **Status:** implemented alongside this note · **Builds on:** [2026-07-30 app-catalog 1-click install](./2026-07-30-app-catalog-1-click-install-design.md)
+
+## Problem
+
+The catalog treated app↔install as one-to-one. Once an app was installed anywhere the card
+hid **Install**, and Update / Open / Uninstall / Eject all acted on "the" install. The real use
+case is installing the same app (e.g. Studio) into project `foo` *and* project `bar`, each on
+its own version, with update becoming one-to-many.
+
+## What was already true
+
+- `installed_apps` is unique on **`(app_id, project_id)`**, not `app_id`. `version`,
+  `installed_at`, `updated_at` are per row. **No schema change was needed.**
+- `POST /api/admin/apps/installed/:id/update`, uninstall, eject and undo are keyed by
+  `installed_apps.id`. Three-way "preserve your edits" sync is per rule set ⇒ per project, so
+  it works unchanged per install.
+- Preflight's name-collision gate scopes rule-set/alias checks to the target project; the only
+  cross-install collision is the **host** (`domain_mappings.domain` is global, plus the
+  cross-namespace alias trap), already addressable via the `subdomain` override.
+
+The one-to-one lived in exactly two places: the read model (`CatalogEntry.installed` singular,
+`pickPrimaryRow` collapsing N rows) and the UI bound to it.
+
+## Decisions
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | `CatalogEntry.installs: InstalledSummary[]` (rename, always present) replaces `installed?` | A rename makes TypeScript flag every consumer; `updateAvailable`, `installedAt`, `updatedAt` are per element — the per-install version trail. |
+| 2 | Update fan-out is **client-serialised** (`useSequentialUpdates`), no bulk endpoint | The install-job registry is single-flight; a queue server-side would be a second job system for one button. A failed job does not stop the batch; a *rejected start* does. |
+| 3 | Card = summary, **details dialog = per-install list** | A grid tile can act on one install; with several it shows "Installed in N projects · k updates" + *Update all* + *Manage installs*, and the dialog's `InstallsList` carries Open/Update/Uninstall/Eject per row. A single install keeps today's card exactly, plus "Install in another project" in the overflow. |
+| 4 | Preflight returns **`suggestedSubdomain`** when the manifest default host is already mapped | `<default>-<project>` (slugified, `-2`, `-3`… on collision, reserved names skipped). The wizard prefills it only while the field is untouched, and names which install owns the default. |
+| 5 | Done screen matches the install by the job's `installedAppId` | So a second install's notes/URL are its own, never the first install's. |
+
+## Out of scope
+
+- Installing the same app twice **into the same project** — `(app_id, project_id)` stays unique.
+- A server-side bulk-update job; a CLI/MCP surface for installs.
+- `bffless/docs` app-catalog page update (follow-up PR).


### PR DESCRIPTION
## Summary

Lets the same catalog app be installed into several projects (e.g. Studio in `foo` *and* `bar`), each on its own version, with update becoming one-to-many.

**No schema change.** `installed_apps` was already unique on `(app_id, project_id)` and every lifecycle route (`/installed/:id/update`, uninstall, eject, undo) is keyed by row id; three-way "preserve your edits" sync is per project. The 1:1 lived only in the read model (`CatalogEntry.installed` singular, `pickPrimaryRow`) and the UI bound to it.

### Backend
- `CatalogEntry.installs: InstalledSummary[]` replaces `installed?` (deliberate rename so every consumer is flagged). Per-install `version`, `updateAvailable`, `installedAt`/`updatedAt`.
- `PreflightResult.suggestedSubdomain` — `<default>-<project>` (slug, `-2`/`-3` on collision, reserved skipped), only when the manifest default host is already mapped. `suggest-subdomain.util.ts` is pure apart from the injected probe.

### Frontend
- **AppCard**: 1 install → exactly today's card + "Install in another project" in ⋮. ≥2 → `Installed in N projects · k updates available`, **Update all (k)**, **Manage installs**.
- **AppDetailsDialog** → new `InstallsList`: each install with project, host, version, last updated, setup notes, and Open / Update / Uninstall / Eject.
- **`useSequentialUpdates`**: client-serialised "Update all" (the job registry is single-flight). A failed job continues the batch; a *rejected start* stops it. Rows show inline status + View / Review conflicts (reuses `InstallDialog` update mode + `ConflictResolver`).
- **InstallDialog**: prefills the suggested subdomain while the field is untouched and says which install owns the default; Done screen matches the install by the job's `installedAppId` so a second install never shows the first's notes/URL.
- `InstallUpdateButton` shared by card + rows; `UninstallDialog`/`EjectPanel` take `install` explicitly.

Spec note: `docs/superpowers/specs/2026-08-19-app-multi-install-design.md`.

## Test plan
- [x] Backend: 198 suites / 3315 tests green; new cases for `installs[]` (2 rows same app, delisted app with 2 rows), `suggestedSubdomain` (taken default, `-2` walk, alias collision, newProject, no-op cases), e2e-ish "install again into project B".
- [x] Frontend: 88 files / 948 tests green; `tsc` clean; `vite build` ok. New tests for card 0/1/≥2 branches, Installs section, per-row update, Update all + autoUpdateAll, batch progress rendering, `useSequentialUpdates` sequencing/failure semantics, wizard auto-suggest + Done-screen matching.
- [x] Headless full stack (real registry, real Rivulet bundle): install into `acme/site`; "Install in another project" → `acme/blog` prefilled `reader-blog` with owner hint; second install's Done screen shows its own URL; card shows "Installed in 2 projects"; Manage lists both; with a local registry bumped to 9.9.9, **Update all (2)** ran both jobs sequentially (DB `updated_at` 1 s apart); uninstalling `blog` from its row left `site` intact.

## Notes
- The three touched backend files were prettier-formatted by `eslint --fix` (backend on `main` isn't prettier-clean) — a little extra diff in `app-catalog.service.ts` and its specs.
- Follow-ups (not in this PR): `bffless/docs` app-catalog page; a live bucket-storage check with Studio ×2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
