### PR TITLE
docs(compose): record the SuperTokens pin-bump migration rule

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -93,11 +93,13 @@ services:
       - assethost-network
 
   supertokens:
-    # Pinned: an unpinned (latest) tag let core 12.1.0 slip in, whose in-place
-    # upgrade migration misses two session_info columns (prev_refresh_token_hash_2,
-    # refresh_token_rotated_at) and breaks session refresh/regenerate with 500s
-    # (signin reports "Failed to sign in" even though the session is created).
-    # Bump deliberately after verifying the upgrade migration on an existing DB.
+    # PINNED. SuperTokens does not auto-migrate columns: the core only CREATEs
+    # missing tables on boot, and each postgresql-plugin release ships manual SQL
+    # in its CHANGELOG "### Migration" section. Bumping this tag means shipping
+    # that SQL to existing installs (11.x -> 12.x added app_id_to_user_id
+    # .time_joined, see ce#695; >=12.1.0 adds two session_info columns, see
+    # ce#658). Verify a bump by booting the new tag against a DB created by the
+    # old tag and signing up - fresh-DB tests miss this class entirely.
     image: registry.supertokens.io/supertokens/supertokens-postgresql:12.0.10
     container_name: assethost-supertokens
     profiles:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,11 +52,13 @@ services:
       retries: 5
 
   supertokens:
-    # Pinned: an unpinned (latest) tag let core 12.1.0 slip in, whose in-place
-    # upgrade migration misses two session_info columns (prev_refresh_token_hash_2,
-    # refresh_token_rotated_at) and breaks session refresh/regenerate with 500s
-    # (signin reports "Failed to sign in" even though the session is created).
-    # Bump deliberately after verifying the upgrade migration on an existing DB.
+    # PINNED. SuperTokens does not auto-migrate columns: the core only CREATEs
+    # missing tables on boot, and each postgresql-plugin release ships manual SQL
+    # in its CHANGELOG "### Migration" section. Bumping this tag means shipping
+    # that SQL to existing installs (11.x -> 12.x added app_id_to_user_id
+    # .time_joined, see ce#695; >=12.1.0 adds two session_info columns, see
+    # ce#658). Verify a bump by booting the new tag against a DB created by the
+    # old tag and signing up - fresh-DB tests miss this class entirely.
     image: registry.supertokens.io/supertokens/supertokens-postgresql:12.0.10
     container_name: assethost-supertokens-dev
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,11 +175,13 @@ services:
       - assethost-network
 
   supertokens:
-    # Pinned: an unpinned (latest) tag let core 12.1.0 slip in, whose in-place
-    # upgrade migration misses two session_info columns (prev_refresh_token_hash_2,
-    # refresh_token_rotated_at) and breaks session refresh/regenerate with 500s
-    # (signin reports "Failed to sign in" even though the session is created).
-    # Bump deliberately after verifying the upgrade migration on an existing DB.
+    # PINNED. SuperTokens does not auto-migrate columns: the core only CREATEs
+    # missing tables on boot, and each postgresql-plugin release ships manual SQL
+    # in its CHANGELOG "### Migration" section. Bumping this tag means shipping
+    # that SQL to existing installs (11.x -> 12.x added app_id_to_user_id
+    # .time_joined, see ce#695; >=12.1.0 adds two session_info columns, see
+    # ce#658). Verify a bump by booting the new tag against a DB created by the
+    # old tag and signing up - fresh-DB tests miss this class entirely.
     image: registry.supertokens.io/supertokens/supertokens-postgresql:12.0.10
     container_name: assethost-supertokens
     profiles:


### PR DESCRIPTION
## Why

ce#695 (verified by local repro) showed the pinned SuperTokens core never migrates columns on existing DBs — every postgresql-plugin release ships manual SQL in its CHANGELOG `### Migration` section. The comment on the pin only told the #658 (`session_info`) story and implied the 11→12.0.10 upgrade was clean; it isn't (signup fails on any pre-12 DB).

## Change

Comment-only, in the three compose files: state the rule (bumping the tag = shipping that release's migration SQL, with the two known cases) and the verification recipe (boot new tag against a DB created by the old tag, then sign up). No image or config change; `docker compose config` still validates.

Refs #695, #658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
