### PR TITLE
fix(deployments): keep nested .bffless/ directories in zip deployments

### DIFF
--- a/apps/backend/src/deployments/deployments.service.ts
+++ b/apps/backend/src/deployments/deployments.service.ts
@@ -45,6 +45,7 @@ import {
   DeleteCommitResponseDto,
 } from './deployments.dto';
 import { generatePreviewAliasName } from './preview-alias.util';
+import { isHiddenZipEntry } from './zip-entry.util';
 
 @Injectable()
 export class DeploymentsService {
@@ -312,14 +313,9 @@ export class DeploymentsService {
         // Get file path (remove leading slash if present)
         const filePath = entryPath.replace(/^\/+/, '');
 
-        // Skip hidden files and system files, but allow .bffless/ (skills directory)
-        const isHiddenFile =
-          (filePath.startsWith('.') && !filePath.startsWith('.bffless/')) ||
-          filePath.includes('/__MACOSX/') ||
-          filePath.includes('/.') || // Hidden files in subdirectories (e.g., assets/.DS_Store)
-          filePath === '.DS_Store';
-
-        if (isHiddenFile) {
+        // Skip hidden files and system files; `.bffless/` directories are kept at any
+        // depth (skills, workflows — the actions zip them under the build path).
+        if (isHiddenZipEntry(filePath)) {
           fileCount--; // Don't count these
           continue;
         }

--- a/apps/backend/src/deployments/zip-entry.util.spec.ts
+++ b/apps/backend/src/deployments/zip-entry.util.spec.ts
@@ -1,0 +1,34 @@
+import { isHiddenZipEntry } from './zip-entry.util';
+
+describe('isHiddenZipEntry', () => {
+  it('keeps ordinary files at any depth', () => {
+    expect(isHiddenZipEntry('index.html')).toBe(false);
+    expect(isHiddenZipEntry('apps/site/dist/assets/app.js')).toBe(false);
+  });
+
+  it('keeps a top-level .bffless directory (skills, workflows)', () => {
+    expect(isHiddenZipEntry('.bffless/skills/demo/SKILL.md')).toBe(false);
+    expect(isHiddenZipEntry('.bffless/workflows/index.json')).toBe(false);
+  });
+
+  it('keeps a nested .bffless directory — upload-artifact zips under the build path', () => {
+    expect(isHiddenZipEntry('apps/workflow/hello-dist/.bffless/workflows/index.json')).toBe(false);
+    expect(isHiddenZipEntry('dist/.bffless/skills/demo/SKILL.md')).toBe(false);
+  });
+
+  it('drops every other dot entry, at any depth, including dotfiles inside .bffless', () => {
+    expect(isHiddenZipEntry('.DS_Store')).toBe(true);
+    expect(isHiddenZipEntry('.git/HEAD')).toBe(true);
+    expect(isHiddenZipEntry('assets/.DS_Store')).toBe(true);
+    expect(isHiddenZipEntry('dist/.hidden/secret.txt')).toBe(true);
+    expect(isHiddenZipEntry('.bffless/.DS_Store')).toBe(true);
+    expect(isHiddenZipEntry('dist/.bffless/.git/config')).toBe(true);
+  });
+
+  it('drops __MACOSX resource forks and does not confuse .bffless-lookalikes', () => {
+    expect(isHiddenZipEntry('__MACOSX/dist/._index.html')).toBe(true);
+    expect(isHiddenZipEntry('dist/__MACOSX/._app.js')).toBe(true);
+    expect(isHiddenZipEntry('.bfflessx/file')).toBe(true);
+    expect(isHiddenZipEntry('.bffless')).toBe(true); // a file literally named .bffless
+  });
+});

--- a/apps/backend/src/deployments/zip-entry.util.ts
+++ b/apps/backend/src/deployments/zip-entry.util.ts
@@ -1,0 +1,22 @@
+/**
+ * The one dot-directory a deployment may ship: BFFless itself reads `.bffless/skills`,
+ * `.bffless/workflows`, … from a deployment, and upload-artifact keeps it when walking a
+ * build directory. Kept at ANY depth — the actions zip under the build path
+ * (`apps/site/dist/.bffless/…`) and base-path serving re-keys it to the root.
+ */
+const KEPT_DOT_DIR = '.bffless';
+
+/**
+ * Whether a zip entry is a hidden/system file that must not become a deployment asset:
+ * any path segment that starts with `.` (except a `.bffless` directory segment) or an
+ * `__MACOSX` resource-fork directory.
+ */
+export function isHiddenZipEntry(filePath: string): boolean {
+  const segments = filePath.split('/');
+  return segments.some((segment, index) => {
+    if (segment === '__MACOSX') return true;
+    if (!segment.startsWith('.')) return false;
+    const isDirectory = index < segments.length - 1;
+    return !(segment === KEPT_DOT_DIR && isDirectory);
+  });
+}


### PR DESCRIPTION
## Why

`createDeploymentFromZip` allowed `.bffless/` only at the zip root and dropped any entry whose path contains `/.`. Both `bffless/upload-artifact` and the catalog installer zip a bundle **under its build path** (`apps/site/dist/.bffless/…`), so `.bffless/skills` and `.bffless/workflows` were silently stripped — the reason Studio ships its skills at `dist/bffless/skills` and the Workflow harness had to work around it (bffless/apps#361).

## Change

- New `deployments/zip-entry.util.ts` → `isHiddenZipEntry(path)`: hidden if any path segment starts with `.` (except a `.bffless` **directory** segment, at any depth) or is `__MACOSX`. Dotfiles inside `.bffless/` stay hidden; a *file* literally named `.bffless` and `.bffless-lookalikes` stay hidden.
- `deployments.service.ts` uses it in place of the inline four-clause check (behaviour otherwise identical: `.DS_Store`, `assets/.DS_Store`, `__MACOSX/…` still dropped).
- `zip-entry.util.spec.ts` written first (failed on `main`), 5 cases.

Serving already works for dot paths (verified live on j5s: `/.bffless/workflows/index.json` → 200 once the file exists); this only fixes ingestion. Companion action change: bffless/upload-artifact#21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
