### PR TITLE
fix(deployments): scope unfiltered alias and deployment lists to the caller's projects

### DIFF
--- a/apps/backend/src/deployments/deployments.service.spec.ts
+++ b/apps/backend/src/deployments/deployments.service.spec.ts
@@ -147,6 +147,7 @@ describe('DeploymentsService', () => {
 
     mockPermissionsService = {
       getUserProjectRole: jest.fn().mockResolvedValue('contributor'),
+      listUserProjects: jest.fn().mockResolvedValue([mockProjectId]),
       addUserToProject: jest.fn().mockResolvedValue(undefined),
       removeUserFromProject: jest.fn().mockResolvedValue(undefined),
       updateUserProjectRole: jest.fn().mockResolvedValue(undefined),
@@ -795,15 +796,54 @@ describe('DeploymentsService', () => {
       expect(result.data[0].alias).toBe('main');
     });
 
-    it('should filter by allowed repositories for non-admin', async () => {
+    it('lists every alias for an admin when no repository filter is given', async () => {
       setupMockChain([[mockAlias, { ...mockAlias, repository: 'other/repo' }]]);
+
+      const result = await service.listAliases({}, mockUserId, 'admin');
+
+      expect(mockPermissionsService.listUserProjects).not.toHaveBeenCalled();
+      expect(result.data).toHaveLength(2);
+    });
+
+    // Regression: bffless/ce#701. Without a ?repository= filter the query was
+    // unscoped, so any authenticated user got every alias on the instance -
+    // while ?repository= on a project they had no role on answered [].
+    it('scopes the unfiltered list to the projects a non-admin has a role on', async () => {
+      setupMockChain([[mockAlias]]);
+      mockPermissionsService.listUserProjects.mockResolvedValueOnce([mockProjectId]);
 
       const result = await service.listAliases({}, mockUserId, 'user');
 
-      // Phase 3H.7: allowedRepositories removed - now returns all aliases user has access to
-      // This test no longer filters by repository since authorization is project-based
-      expect(result.data).toHaveLength(2);
-      expect(result.data[0].repository).toBe(mockRepository);
+      expect(mockPermissionsService.listUserProjects).toHaveBeenCalledWith(mockUserId);
+      expect(result.data).toHaveLength(1);
+    });
+
+    it('returns [] for a non-admin with no project roles and no repository filter', async () => {
+      setupMockChain([[mockAlias]]);
+      mockPermissionsService.listUserProjects.mockResolvedValueOnce([]);
+
+      const result = await service.listAliases({}, mockUserId, 'user');
+
+      expect(result.data).toEqual([]);
+      expect(mockDb.select).not.toHaveBeenCalled();
+    });
+
+    it('returns [] for a repository filter with no owner/name separator', async () => {
+      setupMockChain([[mockAlias]]);
+
+      const result = await service.listAliases({ repository: 'xyz' }, mockUserId, 'user');
+
+      expect(result.data).toEqual([]);
+      expect(mockDb.select).not.toHaveBeenCalled();
+    });
+
+    it('returns [] when a non-admin filters by a project they have no role on', async () => {
+      setupMockChain([[mockAlias]]);
+      mockPermissionsService.getUserProjectRole.mockResolvedValueOnce(null);
+
+      const result = await service.listAliases({ repository: mockRepository }, mockUserId, 'user');
+
+      expect(result.data).toEqual([]);
     });
 
     // Regression: bffless/ce alias access-control readback bug.
@@ -886,6 +926,37 @@ describe('DeploymentsService', () => {
       const result = await service.listDeployments({ isPublic: true }, mockUserId, 'admin');
 
       expect(result.data).toBeDefined();
+    });
+
+    // Regression: bffless/ce#701 (same leak as listAliases).
+    it('scopes the unfiltered list to the projects a non-admin has a role on', async () => {
+      setupMockChain([[{ asset: mockAsset, project: mockProject }], []]);
+      mockPermissionsService.listUserProjects.mockResolvedValueOnce([mockProjectId]);
+
+      const result = await service.listDeployments({}, mockUserId, 'user');
+
+      expect(mockPermissionsService.listUserProjects).toHaveBeenCalledWith(mockUserId);
+      expect(result.data).toBeDefined();
+    });
+
+    it('returns an empty page for a non-admin with no project roles', async () => {
+      setupMockChain([[{ asset: mockAsset, project: mockProject }], []]);
+      mockPermissionsService.listUserProjects.mockResolvedValueOnce([]);
+
+      const result = await service.listDeployments({ page: 1, limit: 10 }, mockUserId, 'user');
+
+      expect(result.data).toEqual([]);
+      expect(result.meta.total).toBe(0);
+      expect(mockDb.select).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty page for a repository filter with no owner/name separator', async () => {
+      setupMockChain([[{ asset: mockAsset, project: mockProject }], []]);
+
+      const result = await service.listDeployments({ repository: 'xyz' }, mockUserId, 'user');
+
+      expect(result.data).toEqual([]);
+      expect(mockDb.select).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/deployments/deployments.service.ts
+++ b/apps/backend/src/deployments/deployments.service.ts
@@ -757,50 +757,53 @@ export class DeploymentsService {
 
     // Build where conditions
     const conditions: SQL<unknown>[] = [];
+    const isAdmin = userRole === 'admin';
+
+    const emptyPage = (): ListDeploymentsResponseDto => ({
+      data: [],
+      meta: {
+        page,
+        limit,
+        total: 0,
+        totalPages: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
+    });
 
     // Filters
     if (query.repository) {
       // Phase 3H: Convert repository string to projectId
       const [owner, name] = query.repository.split('/');
-      if (owner && name) {
-        try {
-          const project = await this.projectsService.getProjectByOwnerName(owner, name);
-
-          // Phase 3H.6: Check project access for non-admin users
-          if (userRole !== 'admin') {
-            const role = await this.permissionsService.getUserProjectRole(userId, project.id);
-            if (!role) {
-              // User has no access to this project
-              return {
-                data: [],
-                meta: {
-                  page,
-                  limit,
-                  total: 0,
-                  totalPages: 0,
-                  hasNextPage: false,
-                  hasPreviousPage: false,
-                },
-              };
-            }
-          }
-
-          conditions.push(eq(assets.projectId, project.id));
-        } catch (error) {
-          // Project not found - return empty results
-          return {
-            data: [],
-            meta: {
-              page,
-              limit,
-              total: 0,
-              totalPages: 0,
-              hasNextPage: false,
-              hasPreviousPage: false,
-            },
-          };
-        }
+      if (!owner || !name) {
+        // #701: an unparsable filter must not fall through to the unscoped list
+        return emptyPage();
       }
+      try {
+        const project = await this.projectsService.getProjectByOwnerName(owner, name);
+
+        // Phase 3H.6: Check project access for non-admin users
+        if (!isAdmin) {
+          const role = await this.permissionsService.getUserProjectRole(userId, project.id);
+          if (!role) {
+            // User has no access to this project
+            return emptyPage();
+          }
+        }
+
+        conditions.push(eq(assets.projectId, project.id));
+      } catch (error) {
+        // Project not found - return empty results
+        return emptyPage();
+      }
+    } else if (!isAdmin) {
+      // #701: same leak as listAliases - the unscoped list is restricted to the
+      // projects the caller has a role on.
+      const projectIds = await this.permissionsService.listUserProjects(userId);
+      if (projectIds.length === 0) {
+        return emptyPage();
+      }
+      conditions.push(inArray(assets.projectId, projectIds));
     }
     if (query.branch) {
       conditions.push(eq(assets.branch, query.branch));
@@ -1574,29 +1577,41 @@ export class DeploymentsService {
     userRole: string,
   ): Promise<ListAliasesResponseDto> {
     const conditions: SQL<unknown>[] = [];
+    const isAdmin = userRole === 'admin';
 
     if (query.repository) {
       // Phase 3H: Convert repository string to projectId
       const [owner, name] = query.repository.split('/');
-      if (owner && name) {
-        try {
-          const project = await this.projectsService.getProjectByOwnerName(owner, name);
-
-          // Phase 3H.6: Check project access for non-admin users
-          if (userRole !== 'admin') {
-            const role = await this.permissionsService.getUserProjectRole(userId, project.id);
-            if (!role) {
-              // User has no access to this project
-              return { data: [] };
-            }
-          }
-
-          conditions.push(eq(deploymentAliases.projectId, project.id));
-        } catch (error) {
-          // Project not found - return empty results
-          return { data: [] };
-        }
+      if (!owner || !name) {
+        // #701: an unparsable filter must not fall through to the unscoped list
+        return { data: [] };
       }
+      try {
+        const project = await this.projectsService.getProjectByOwnerName(owner, name);
+
+        // Phase 3H.6: Check project access for non-admin users
+        if (!isAdmin) {
+          const role = await this.permissionsService.getUserProjectRole(userId, project.id);
+          if (!role) {
+            // User has no access to this project
+            return { data: [] };
+          }
+        }
+
+        conditions.push(eq(deploymentAliases.projectId, project.id));
+      } catch (error) {
+        // Project not found - return empty results
+        return { data: [] };
+      }
+    } else if (!isAdmin) {
+      // #701: the unscoped list is restricted to the projects the caller has a
+      // role on. Without this it returned every alias on the instance, which
+      // contradicted the ?repository= path above (that one answers []).
+      const projectIds = await this.permissionsService.listUserProjects(userId);
+      if (projectIds.length === 0) {
+        return { data: [] };
+      }
+      conditions.push(inArray(deploymentAliases.projectId, projectIds));
     }
 
     // By default, exclude auto-preview aliases from the list


### PR DESCRIPTION
Fixes #701.

## The hole

`GET /api/aliases` and `GET /api/deployments` only constrained the query by project when `?repository=owner/name` **both** parsed *and* passed the role check. Every other path left the where-clause project-free:

| Request | Before | After |
| --- | --- | --- |
| `?repository=<project you have a role on>` | that project's rows | unchanged |
| `?repository=<project you have no role on>` | `[]` | unchanged |
| `?repository=xyz` (no `/`) | **every row on the instance** | `[]` |
| no `repository` | **every row on the instance** | rows for projects you have a role on (`[]` if none) |
| any of the above, as a global admin | everything | unchanged |

Found walking the Workflow harness M2 live checklist on j5s.dev as a member with a global role but no project role: the unscoped list handed back `bffless/workflow` and `bffless/apps` aliases to a caller with zero project permissions, while the scoped list for those same projects correctly answered `[]`. The two paths disagreed about what a caller may see.

`listDeployments` had the identical hole — same shape, same file. Fixing only `listAliases` would have left the leak one endpoint over, so both are fixed here.

## The fix

The unscoped branch now reuses `permissionsService.listUserProjects(userId)`, which is exactly the set the `?repository=` path admits, so the two paths can no longer disagree. An unparsable `repository` returns empty rather than falling through. Admins short-circuit as before.

## Behavior change worth knowing

`api-key.guard.ts:73` pins **every** API-key caller to `role: 'user'`, admin keys included. So an unscoped list via an API key now returns only projects that key's user holds a permission row on. That constraint already applied to the `?repository=` path for those same keys; this makes the unscoped path match rather than being the way around it.

CE's own frontend is unaffected — it reads `/api/repo/:owner/:repo/aliases`, never the unscoped list.

## Not included

The issue's aside — granting a project role appearing to flip the target's **global** role from `member` to `user` — is not addressed here, and I could not reproduce it in code: `grantPermission` never writes `users.role`, and `member` is already permitted to hold project `viewer` (`PROJECT_ROLES_BY_GLOBAL_ROLE`). The only writes to `users.role` are the Users tab (`users.service.updateRole`) and the onboarding `assign_role` action. Most likely an operator promotion in the Users tab rather than a side effect, but it deserves its own look before #701 is closed on that point.

## Verification

- 6 new regression tests across both endpoints. Each was confirmed to **fail** against the unpatched service (stashed the service change, re-ran: 6 failed) and pass with it.
- Full backend suite: 199 suites passed / 2 skipped, 3327 tests passed.
- `tsc --noEmit` clean; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
