### PR TITLE
feat(cli): --path-prefix for rules build, push and diff

### DIFF
--- a/packages/cli/docs/reference.md
+++ b/packages/cli/docs/reference.md
@@ -448,10 +448,23 @@ matching) is a `rules build` warning, not an error.
 
 `rules build|push|diff --path-prefix /api/hello` prepends the prefix to every **derived** `pathPattern`
 (`rules/echo/post/` → `POST /api/hello/echo`). A manifest with an explicit `pathPattern:` is left verbatim —
-that is how a generated `/w/hello/*` forwarder lives in the same set. Pipeline default names and the
-derived `order:` are unaffected (a uniform prefix keeps specificity order). Written for BFFless Workflow
-implementations, which author prefix-free rules and are published under one alias-named prefix per
-deploy (`bffless/publish-workflow`); `rules diff` needs the same flag or it reports permanent drift.
+that is how a generated `/w/hello/*` forwarder lives in the same set. A root rule (`rules/get.rule.yaml`,
+which derives `/`) becomes the bare prefix itself (`/api/hello`, not `/api/hello/`) so it still matches
+CE's exact-string matcher. Pipeline default names stay prefix-free.
+
+`order:` is derived from the *exported* (post-prefix) `pathPattern`, since CE's request matcher selects
+the first match by ascending `order` over what it actually sees on the wire. In practice: relative order
+among derived rules is unchanged by a uniform prefix (it adds the same segments to every one of them),
+but an explicit `pathPattern:` rule ranks against the *prefixed* patterns — so an explicit catch-all
+(e.g. `pathPattern: /api/hello/*`) published under `--path-prefix /api/hello` correctly orders *after*
+the specific derived routes it shares that prefix with, as intended, rather than swallowing them.
+
+The prefix applies to every rule set resolved in one invocation. Changing the prefix of an
+already-published set orphans the old, now-unreferenced `(pathPattern, method)` rules — sync identity is
+`(pathPattern, method)` — so pass `--prune` when republishing under a new prefix. `rules pull` and
+`rules dev` have no `--path-prefix`; only `build`, `push`, and `diff` take it, and `diff` needs the same
+flag passed or it reports permanent drift. Written for BFFless Workflow implementations, which author
+prefix-free rules and are published under one alias-named prefix per deploy (`bffless/publish-workflow`).
 
 ## `runHandler` — Vitest usage
 

--- a/packages/cli/docs/reference.md
+++ b/packages/cli/docs/reference.md
@@ -444,6 +444,15 @@ when the stored value equals the derived one. Two rules landing on the same nume
 (an explicit value colliding with another rule's derived one, or two explicit values
 matching) is a `rules build` warning, not an error.
 
+### Path prefix (`--path-prefix`)
+
+`rules build|push|diff --path-prefix /api/hello` prepends the prefix to every **derived** `pathPattern`
+(`rules/echo/post/` → `POST /api/hello/echo`). A manifest with an explicit `pathPattern:` is left verbatim —
+that is how a generated `/w/hello/*` forwarder lives in the same set. Pipeline default names and the
+derived `order:` are unaffected (a uniform prefix keeps specificity order). Written for BFFless Workflow
+implementations, which author prefix-free rules and are published under one alias-named prefix per
+deploy (`bffless/publish-workflow`); `rules diff` needs the same flag or it reports permanent drift.
+
 ## `runHandler` — Vitest usage
 
 `bffless/harness` exports `runHandler(code, data?, opts?)` and

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -23,10 +23,10 @@ export interface BuildOutcome {
 }
 
 /** Build a single rule-set directory. Never throws — build failures are reported via `ok: false`. */
-export async function buildOne(setDir: string, opts?: { output?: string }): Promise<BuildOutcome> {
+export async function buildOne(setDir: string, opts?: { output?: string; pathPrefix?: string }): Promise<BuildOutcome> {
   let result;
   try {
-    result = await buildRuleSet(setDir);
+    result = await buildRuleSet(setDir, { pathPrefix: opts?.pathPrefix });
   } catch (err) {
     return { ok: false, summary: err instanceof Error ? err.message : String(err) };
   }

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -61,6 +61,7 @@ function alignLocalSchemaIdsToLive(local: RuleSetExport, live: RuleSetExport): R
 }
 
 export interface DiffOptions {
+  pathPrefix?: string;
   apiUrl?: string;
   apiKey?: string;
   project?: string;
@@ -84,7 +85,7 @@ export async function runDiffOne(
 ): Promise<DiffOutcome> {
   let local: RuleSetExport;
   try {
-    local = (await buildRuleSet(setDir)).export;
+    local = (await buildRuleSet(setDir, { pathPrefix: opts.pathPrefix })).export;
   } catch (err) {
     return { status: 'error', message: err instanceof Error ? err.message : String(err) };
   }

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -20,6 +20,7 @@ import type { SyncRequestBody, SyncResponse, SyncRuleRef } from '../api/sync-typ
 
 export interface PushOptions {
   nameSuffix?: string;
+  pathPrefix?: string;
   prune?: boolean;
   dryRun?: boolean;
   strictSchemas?: boolean;
@@ -106,7 +107,7 @@ export async function runPushOne(
 ): Promise<PushOutcome> {
   let built;
   try {
-    built = await buildRuleSet(setDir);
+    built = await buildRuleSet(setDir, { pathPrefix: opts.pathPrefix });
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }

--- a/packages/cli/src/compile/build.ts
+++ b/packages/cli/src/compile/build.ts
@@ -13,7 +13,14 @@ import {
   parseYamlFile,
 } from '../format/manifest.js';
 import type { RuleManifest } from '../format/manifest.js';
-import { relPathToPattern, deriveOrders, METHOD_STEMS, UUID_RE, defaultPipelineName } from '../format/routes.js';
+import {
+  relPathToPattern,
+  deriveOrders,
+  METHOD_STEMS,
+  UUID_RE,
+  defaultPipelineName,
+  applyPathPrefix,
+} from '../format/routes.js';
 import { applyRuleDefaults } from '../format/defaults.js';
 import { canonicalizeExport } from '../format/canonical.js';
 import { walkSchemaRefs } from '../format/schema-refs.js';
@@ -228,7 +235,10 @@ interface Compiled {
   manifestPath: string;
 }
 
-export async function buildRuleSet(setDir: string, opts?: { exportedAt?: string }): Promise<BuildResult> {
+export async function buildRuleSet(
+  setDir: string,
+  opts?: { exportedAt?: string; pathPrefix?: string },
+): Promise<BuildResult> {
   const rulesetPath = path.join(setDir, 'ruleset.yaml');
   if (!existsSync(rulesetPath)) throw new Error(`not a rule set (no ruleset.yaml): ${setDir}`);
   const ruleset = parseYamlFile(rulesetPath, RulesetManifestSchema);
@@ -290,7 +300,12 @@ export async function buildRuleSet(setDir: string, opts?: { exportedAt?: string 
       method = stemMethod;
     }
 
-    const pathPattern = manifest.pathPattern ?? relPathToPattern(d.dirSegments);
+    // Derive specificity/order from the pre-prefix pattern (`orderPattern`) so a --path-prefix
+    // mount decision never perturbs authored route priority — it just decorates the exported
+    // pathPattern. An explicit `manifest.pathPattern` is never prefixed, so it's the same value
+    // either way.
+    const orderPattern = manifest.pathPattern ?? relPathToPattern(d.dirSegments);
+    const pathPattern = manifest.pathPattern ?? applyPathPrefix(orderPattern, opts?.pathPrefix);
     const pipelineDefaultName = defaultPipelineName(d.dirSegments, d.methodStem);
 
     // headerConfig.add must carry empty-string placeholders only — never real secret values.
@@ -375,20 +390,22 @@ export async function buildRuleSet(setDir: string, opts?: { exportedAt?: string 
 
     compiled.push({
       partial,
-      descriptor: { pathPattern, method },
+      descriptor: { pathPattern: orderPattern, method },
       explicitOrder: manifest.order,
       manifestPath: d.manifestPath,
     });
   }
 
-  // Duplicate (pathPattern, method) — mirrors the DB unique key.
+  // Duplicate (pathPattern, method) — mirrors the DB unique key. Uses the final
+  // exported pathPattern (partial.pathPattern), not the order-derivation descriptor, so a
+  // --path-prefix that happens to collide two rules is still caught.
   const seen = new Map<string, string>();
   for (const c of compiled) {
-    const key = `${c.descriptor.pathPattern} ${c.descriptor.method ?? ''}`;
+    const key = `${c.partial.pathPattern} ${c.descriptor.method ?? ''}`;
     const prior = seen.get(key);
     if (prior) {
       throw new Error(
-        `duplicate rule (${c.descriptor.pathPattern} ${c.descriptor.method ?? 'ANY'}) defined in both ${prior} and ${c.manifestPath}`,
+        `duplicate rule (${c.partial.pathPattern} ${c.descriptor.method ?? 'ANY'}) defined in both ${prior} and ${c.manifestPath}`,
       );
     }
     seen.set(key, c.manifestPath);

--- a/packages/cli/src/compile/build.ts
+++ b/packages/cli/src/compile/build.ts
@@ -20,6 +20,7 @@ import {
   UUID_RE,
   defaultPipelineName,
   applyPathPrefix,
+  assertPathPrefix,
 } from '../format/routes.js';
 import { applyRuleDefaults } from '../format/defaults.js';
 import { canonicalizeExport } from '../format/canonical.js';
@@ -239,6 +240,12 @@ export async function buildRuleSet(
   setDir: string,
   opts?: { exportedAt?: string; pathPrefix?: string },
 ): Promise<BuildResult> {
+  // Validate eagerly: applyPathPrefix only runs for rules with a *derived* pathPattern, so a
+  // rule set whose every rule has an explicit `pathPattern:` would otherwise accept a garbage
+  // --path-prefix silently (it's never applied). The inner applyPathPrefix call stays too —
+  // this is belt-and-suspenders, not a replacement.
+  if (opts?.pathPrefix !== undefined) assertPathPrefix(opts.pathPrefix);
+
   const rulesetPath = path.join(setDir, 'ruleset.yaml');
   if (!existsSync(rulesetPath)) throw new Error(`not a rule set (no ruleset.yaml): ${setDir}`);
   const ruleset = parseYamlFile(rulesetPath, RulesetManifestSchema);
@@ -300,12 +307,16 @@ export async function buildRuleSet(
       method = stemMethod;
     }
 
-    // Derive specificity/order from the pre-prefix pattern (`orderPattern`) so a --path-prefix
-    // mount decision never perturbs authored route priority — it just decorates the exported
-    // pathPattern. An explicit `manifest.pathPattern` is never prefixed, so it's the same value
-    // either way.
-    const orderPattern = manifest.pathPattern ?? relPathToPattern(d.dirSegments);
-    const pathPattern = manifest.pathPattern ?? applyPathPrefix(orderPattern, opts?.pathPrefix);
+    // Order/specificity is derived from this same, final (post-prefix) pathPattern — CE's
+    // request matcher selects the first match by ascending `order` over the *exported*
+    // patterns, so ranking must reflect what CE actually sees. A uniform --path-prefix adds
+    // the same literal segments to every derived pattern's literalCount and shifts every
+    // wildcard index by the same amount, so it provably cannot change the *relative* order
+    // among derived rules — nothing authored is perturbed. What it CAN legitimately change is
+    // a derived rule's rank against an explicit, never-prefixed `pathPattern:` escape hatch
+    // (e.g. a catch-all `/api/hello/*` should rank after the specific prefixed routes it
+    // shares a prefix with) — see docs/reference.md's "Path prefix" section.
+    const pathPattern = manifest.pathPattern ?? applyPathPrefix(relPathToPattern(d.dirSegments), opts?.pathPrefix);
     const pipelineDefaultName = defaultPipelineName(d.dirSegments, d.methodStem);
 
     // headerConfig.add must carry empty-string placeholders only — never real secret values.
@@ -390,15 +401,15 @@ export async function buildRuleSet(
 
     compiled.push({
       partial,
-      descriptor: { pathPattern: orderPattern, method },
+      descriptor: { pathPattern, method },
       explicitOrder: manifest.order,
       manifestPath: d.manifestPath,
     });
   }
 
-  // Duplicate (pathPattern, method) — mirrors the DB unique key. Uses the final
-  // exported pathPattern (partial.pathPattern), not the order-derivation descriptor, so a
-  // --path-prefix that happens to collide two rules is still caught.
+  // Duplicate (pathPattern, method) — mirrors the DB unique key. Keyed on the final exported
+  // pathPattern (partial.pathPattern) so a --path-prefix collision (an explicit `pathPattern:`
+  // rule landing on the same string as a prefixed derived one) is still caught.
   const seen = new Map<string, string>();
   for (const c of compiled) {
     const key = `${c.partial.pathPattern} ${c.descriptor.method ?? ''}`;

--- a/packages/cli/src/format/routes.ts
+++ b/packages/cli/src/format/routes.ts
@@ -155,3 +155,25 @@ export function deriveOrders<T extends { pathPattern: string; method?: string }>
   sorted.forEach((rule, position) => map.set(rule, position));
   return map;
 }
+
+const PATH_PREFIX_RE = /^\/[A-Za-z0-9._-]+(\/[A-Za-z0-9._-]+)*$/;
+
+/** `--path-prefix`: a literal, absolute, `..`/`*`-free path with no trailing slash. */
+export function assertPathPrefix(prefix: string): void {
+  if (!PATH_PREFIX_RE.test(prefix) || prefix.split('/').includes('..')) {
+    throw new Error(
+      `--path-prefix must start with "/", contain only literal segments and end without "/" (got ${JSON.stringify(prefix)})`,
+    );
+  }
+}
+
+/**
+ * Prepend `prefix` to a *derived* pattern (`/echo` → `/api/hello/echo`). Explicit `pathPattern:`
+ * manifests are never passed through here — the escape hatch means "exactly this pattern", which
+ * is how a publish-time forwarder (`/w/<alias>/*`) rides inside a prefixed set (spec 06).
+ */
+export function applyPathPrefix(pattern: string, prefix?: string): string {
+  if (!prefix) return pattern;
+  assertPathPrefix(prefix);
+  return `${prefix}${pattern}`;
+}

--- a/packages/cli/src/format/routes.ts
+++ b/packages/cli/src/format/routes.ts
@@ -158,9 +158,10 @@ export function deriveOrders<T extends { pathPattern: string; method?: string }>
 
 const PATH_PREFIX_RE = /^\/[A-Za-z0-9._-]+(\/[A-Za-z0-9._-]+)*$/;
 
-/** `--path-prefix`: a literal, absolute, `..`/`*`-free path with no trailing slash. */
+/** `--path-prefix`: a literal, absolute, `.`/`..`/`*`-free path with no trailing slash. */
 export function assertPathPrefix(prefix: string): void {
-  if (!PATH_PREFIX_RE.test(prefix) || prefix.split('/').includes('..')) {
+  const hasDotSegment = prefix.split('/').some((seg) => seg === '.' || seg === '..');
+  if (!PATH_PREFIX_RE.test(prefix) || hasDotSegment) {
     throw new Error(
       `--path-prefix must start with "/", contain only literal segments and end without "/" (got ${JSON.stringify(prefix)})`,
     );
@@ -171,9 +172,13 @@ export function assertPathPrefix(prefix: string): void {
  * Prepend `prefix` to a *derived* pattern (`/echo` → `/api/hello/echo`). Explicit `pathPattern:`
  * manifests are never passed through here — the escape hatch means "exactly this pattern", which
  * is how a publish-time forwarder (`/w/<alias>/*`) rides inside a prefixed set (spec 06).
+ *
+ * A root rule derives to `/` (e.g. `rules/get.rule.yaml`); prepending naively would yield a
+ * trailing-slash pattern (`/api/hello/`) that CE's exact-string matcher never matches for
+ * `GET /api/hello`, so the root case returns the bare prefix instead.
  */
 export function applyPathPrefix(pattern: string, prefix?: string): string {
   if (!prefix) return pattern;
   assertPathPrefix(prefix);
-  return `${prefix}${pattern}`;
+  return pattern === '/' ? prefix : `${prefix}${pattern}`;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -72,7 +72,11 @@ rules
   .description('Compile an authoring rule-set directory to a canonical export JSON')
   .argument('[dirs...]', 'rule-set directories (defaults to .bffless/config.json ruleSets)')
   .option('-o, --output <file>', 'output file path (only valid with a single resolved rule set)')
-  .action(async (dirs: string[], opts: { output?: string }) => {
+  .option(
+    '--path-prefix <prefix>',
+    'prepend a literal prefix to every derived pathPattern (explicit pathPattern: manifests are left verbatim), e.g. /api/hello (spec: workflow implementations)',
+  )
+  .action(async (dirs: string[], opts: { output?: string; pathPrefix?: string }) => {
     const resolved = resolveDirsOrReport(dirs);
     if (!resolved) {
       process.exitCode = 1;
@@ -88,7 +92,7 @@ rules
     let ok = true;
     for (const dir of resolved) {
       if (multi) console.log(`\n${dir}:`);
-      const result = await buildOne(dir, { output: opts.output });
+      const result = await buildOne(dir, { output: opts.output, pathPrefix: opts.pathPrefix });
       if (!result.ok) {
         ok = false;
         console.error(result.summary);
@@ -197,6 +201,10 @@ rules
   .option('--prune', 'delete live rules that are absent from the local rule set')
   .option('--strict-schemas', 'fail when a name-reused schema has mismatched field definitions')
   .option('--name-suffix <suffix>', 'rename the set to <name>-<suffix> before syncing (e.g. pr-42 previews)')
+  .option(
+    '--path-prefix <prefix>',
+    'prepend a literal prefix to every derived pathPattern (explicit pathPattern: manifests are left verbatim), e.g. /api/hello (spec: workflow implementations)',
+  )
   .option('--api-url <url>', 'API base URL (overrides BFFLESS_API_URL and config apiUrl)')
   .option('--api-key <key>', 'API key (overrides BFFLESS_API_KEY; sent as X-API-Key)')
   .option('--project <idOrName>', 'project UUID, owner/name, or name (overrides config project)')
@@ -208,6 +216,7 @@ rules
         prune?: boolean;
         strictSchemas?: boolean;
         nameSuffix?: string;
+        pathPrefix?: string;
         apiUrl?: string;
         apiKey?: string;
         project?: string;
@@ -242,10 +251,14 @@ rules
       '(compile/auth/network failure).',
   )
   .argument('[dirs...]', 'rule-set directories (defaults to .bffless/config.json ruleSets)')
+  .option(
+    '--path-prefix <prefix>',
+    'prepend a literal prefix to every derived pathPattern (explicit pathPattern: manifests are left verbatim), e.g. /api/hello (spec: workflow implementations)',
+  )
   .option('--api-url <url>', 'API base URL (overrides BFFLESS_API_URL and config apiUrl)')
   .option('--api-key <key>', 'API key (overrides BFFLESS_API_KEY; sent as X-API-Key)')
   .option('--project <idOrName>', 'project UUID, owner/name, or name (overrides config project)')
-  .action(async (dirs: string[], opts: { apiUrl?: string; apiKey?: string; project?: string }) => {
+  .action(async (dirs: string[], opts: { pathPrefix?: string; apiUrl?: string; apiKey?: string; project?: string }) => {
     const resolved = resolveDirsOrReport(dirs);
     if (!resolved) {
       process.exitCode = 2;

--- a/packages/cli/src/lib.ts
+++ b/packages/cli/src/lib.ts
@@ -42,3 +42,4 @@ export { ApiClient, createClient, ApiError } from './api/client.js';
 export type { ClientDeps, FetchLike } from './api/client.js';
 export { CLI_REMEDIATION, resolveRemediation } from './api/remediation.js';
 export type { Remediation } from './api/remediation.js';
+export { applyPathPrefix, assertPathPrefix } from './format/routes.js';

--- a/packages/cli/test/build.test.ts
+++ b/packages/cli/test/build.test.ts
@@ -350,9 +350,60 @@ describe('buildRuleSet with pathPrefix', () => {
     const echo = out.rules.find((r) => r.pathPattern === '/api/hello/echo')!;
     expect(echo.pipelineConfig?.name).toBe('echo POST');
   });
-  it('derives the same order with and without a prefix', async () => {
+  it('derives the same relative order among derived rules with and without a prefix', async () => {
+    // Order is derived from the final (post-prefix) pathPattern — CE's matcher selects by
+    // ascending `order` over what it actually sees on the wire. A uniform prefix adds the same
+    // literal segments to every derived rule's literalCount, so their RELATIVE order can't
+    // change even though the absolute numbers can shift (see "an explicit catch-all..." below
+    // for why the numbers legitimately do shift). Assert relative order via pipelineConfig.name
+    // (prefix-free) rather than comparing raw order numbers.
     const a = await buildRuleSet(plainDir, { exportedAt: EXPORTED_AT });
     const b = await buildRuleSet(plainDir, { exportedAt: EXPORTED_AT, pathPrefix: '/api/hello' });
-    expect(a.export.rules.map((r) => r.order)).toEqual(b.export.rules.map((r) => r.order));
+    const derivedNamesByOrder = (out: RuleSetExport) =>
+      out.rules
+        .filter((r) => r.pipelineConfig !== undefined) // excludes the /w/hello/* forwarder (no pipeline)
+        .slice()
+        .sort((x, y) => (x.order ?? 0) - (y.order ?? 0))
+        .map((r) => r.pipelineConfig!.name);
+    expect(derivedNamesByOrder(a.export)).toEqual(derivedNamesByOrder(b.export));
+  });
+
+  it('an explicit catch-all pathPattern ranks after the specific prefixed derived route it shares a prefix with', async () => {
+    const dir = scratchSet({
+      'ruleset.yaml': 'name: overlap\n',
+      'rules/echo/post/rule.yaml':
+        'pipeline:\n  steps:\n    - name: respond\n      handler: response_handler\n      config:\n        body: \'{}\'\n        status: 200\n',
+      'rules/_custom/catchall/any.rule.yaml':
+        'pathPattern: /api/hello/*\ntargetUrl: https://catchall.example.test\n',
+    });
+    const { export: out } = await buildRuleSet(dir, { exportedAt: EXPORTED_AT, pathPrefix: '/api/hello' });
+    const echo = out.rules.find((r) => r.pathPattern === '/api/hello/echo')!;
+    const catchall = out.rules.find((r) => r.pathPattern === '/api/hello/*')!;
+    expect(echo.order).toBeLessThan(catchall.order!);
+  });
+
+  it('an explicit pathPattern colliding with a prefixed derived pattern is a duplicate-rule error', async () => {
+    const dir = scratchSet({
+      'ruleset.yaml': 'name: collide\n',
+      'rules/echo/post/rule.yaml':
+        'pipeline:\n  steps:\n    - name: respond\n      handler: response_handler\n      config:\n        body: \'{}\'\n        status: 200\n',
+      'rules/_custom/explicit/post.rule.yaml':
+        'pathPattern: /api/hello/echo\ntargetUrl: https://explicit.example.test\n',
+    });
+    await expect(buildRuleSet(dir, { exportedAt: EXPORTED_AT, pathPrefix: '/api/hello' })).rejects.toThrow(
+      /duplicate rule/,
+    );
+  });
+
+  it('validates --path-prefix eagerly even when every rule has an explicit pathPattern', async () => {
+    // applyPathPrefix only runs for a *derived* pathPattern, so a set whose rules are all
+    // explicit would otherwise silently accept a garbage prefix (it's never applied).
+    const dir = scratchSet({
+      'ruleset.yaml': 'name: explicit-only\n',
+      'rules/_custom/only/get.rule.yaml': 'pathPattern: /w/hello/*\ntargetUrl: https://hello.example.test\n',
+    });
+    await expect(buildRuleSet(dir, { exportedAt: EXPORTED_AT, pathPrefix: 'not-absolute' })).rejects.toThrow(
+      /--path-prefix/,
+    );
   });
 });

--- a/packages/cli/test/build.test.ts
+++ b/packages/cli/test/build.test.ts
@@ -8,6 +8,7 @@ import type { RuleSetExport } from '../src/format/types.js';
 
 const basicDir = path.resolve('test/fixtures/synthetic/basic');
 const tsHandlersDir = path.resolve('test/fixtures/synthetic/ts-handlers');
+const plainDir = path.resolve('test/fixtures/synthetic/plain');
 const EXPORTED_AT = '2026-07-11T00:00:00.000Z';
 
 /** Some restricted environments (e.g. certain CI/container setups) can't create symlinks.
@@ -335,5 +336,23 @@ describe('buildRuleSet', () => {
     const res = await buildRuleSet(dir, { exportedAt: EXPORTED_AT });
     const step = res.export.rules[0].pipelineConfig?.steps[0];
     expect(step?.config.payload).toBe('export const x = 1; // not bundled, just inlined verbatim\n');
+  });
+});
+
+describe('buildRuleSet with pathPrefix', () => {
+  it('prefixes every derived pathPattern and leaves explicit ones verbatim', async () => {
+    const { export: out } = await buildRuleSet(plainDir, { exportedAt: EXPORTED_AT, pathPrefix: '/api/hello' });
+    const patterns = out.rules.map((r) => `${r.method ?? 'ANY'} ${r.pathPattern}`).sort();
+    expect(patterns).toEqual(['GET /api/hello/job', 'GET /w/hello/*', 'POST /api/hello/echo']);
+  });
+  it('keeps pipeline default names prefix-free', async () => {
+    const { export: out } = await buildRuleSet(plainDir, { exportedAt: EXPORTED_AT, pathPrefix: '/api/hello' });
+    const echo = out.rules.find((r) => r.pathPattern === '/api/hello/echo')!;
+    expect(echo.pipelineConfig?.name).toBe('echo POST');
+  });
+  it('derives the same order with and without a prefix', async () => {
+    const a = await buildRuleSet(plainDir, { exportedAt: EXPORTED_AT });
+    const b = await buildRuleSet(plainDir, { exportedAt: EXPORTED_AT, pathPrefix: '/api/hello' });
+    expect(a.export.rules.map((r) => r.order)).toEqual(b.export.rules.map((r) => r.order));
   });
 });

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -82,6 +82,34 @@ describe('bffless rules build', () => {
     expect(result.status).not.toBe(0);
     expect(result.stderr).not.toContain('at buildRuleSet'); // no stack trace leaking through
   });
+
+  it('--path-prefix rewrites derived patterns in the written export', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'bffless-cli-test-plain-'));
+    cpSync(path.resolve('test/fixtures/synthetic/plain'), dir, { recursive: true });
+    const out = path.join(dir, 'out.json');
+    const result = run(['rules', 'build', dir, '-o', out, '--path-prefix', '/api/hello']);
+    expect(result.status, result.stderr).toBe(0);
+    const exp = JSON.parse(readFileSync(out, 'utf8'));
+    expect(exp.rules.map((r: { pathPattern: string }) => r.pathPattern).sort()).toEqual([
+      '/api/hello/echo',
+      '/api/hello/job',
+      '/w/hello/*',
+    ]);
+  });
+
+  it('--path-prefix rejects a relative prefix with a usage error', () => {
+    const result = run([
+      'rules',
+      'build',
+      path.resolve('test/fixtures/synthetic/plain'),
+      '-o',
+      '/dev/null',
+      '--path-prefix',
+      'api/hello',
+    ]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/--path-prefix must start with/);
+  });
 });
 
 describe('bffless rules validate', () => {

--- a/packages/cli/test/fixtures/synthetic/plain/rules/_custom/forward/get.rule.yaml
+++ b/packages/cli/test/fixtures/synthetic/plain/rules/_custom/forward/get.rule.yaml
@@ -1,0 +1,4 @@
+pathPattern: /w/hello/*
+targetUrl: https://hello.example.test
+forwardCookies: true
+order: 5

--- a/packages/cli/test/fixtures/synthetic/plain/rules/echo/post/echo.fn.js
+++ b/packages/cli/test/fixtures/synthetic/plain/rules/echo/post/echo.fn.js
@@ -1,0 +1,1 @@
+function handler({ request }) { return { text: String((request.body || {}).text || '') } }

--- a/packages/cli/test/fixtures/synthetic/plain/rules/echo/post/rule.yaml
+++ b/packages/cli/test/fixtures/synthetic/plain/rules/echo/post/rule.yaml
@@ -1,0 +1,5 @@
+pipeline:
+  steps:
+    - name: echo
+      handler: function_handler
+      code: ./echo.fn.js

--- a/packages/cli/test/fixtures/synthetic/plain/rules/job/get.rule.yaml
+++ b/packages/cli/test/fixtures/synthetic/plain/rules/job/get.rule.yaml
@@ -1,0 +1,8 @@
+pipeline:
+  steps:
+    - name: respond
+      handler: response_handler
+      config:
+        body: '{}'
+        status: 200
+        contentType: application/json

--- a/packages/cli/test/fixtures/synthetic/plain/ruleset.yaml
+++ b/packages/cli/test/fixtures/synthetic/plain/ruleset.yaml
@@ -1,0 +1,1 @@
+name: plain

--- a/packages/cli/test/lib.test.ts
+++ b/packages/cli/test/lib.test.ts
@@ -18,6 +18,8 @@ describe('bffless/lib entry', () => {
     expect(typeof lib.applyNameSuffix).toBe('function');
     expect(typeof lib.resolveRemediation).toBe('function');
     expect(lib.CLI_REMEDIATION.apiKey).toContain('--api-key');
+    expect(typeof lib.applyPathPrefix).toBe('function');
+    expect(typeof lib.assertPathPrefix).toBe('function');
   });
 
   it('importing it never runs commander (no side effects), even with bogus argv', async () => {

--- a/packages/cli/test/push.test.ts
+++ b/packages/cli/test/push.test.ts
@@ -228,6 +228,19 @@ describe('rules push', () => {
     expect(result.ok, result.error).toBe(true);
     expect(d.sentBody().rules[0].pipelineConfig?.validators).toEqual([{ type: 'auth_required', config: {} }]);
   });
+
+  it('sends prefixed pathPatterns in the sync body when pathPrefix is set', async () => {
+    const d = pushDeps(syncResponse());
+    const result = await runPushOne(
+      path.resolve('test/fixtures/synthetic/plain'),
+      { pathPrefix: '/api/hello' },
+      '/nowhere',
+      d,
+    );
+    expect(result.ok, result.error).toBe(true);
+    const body = d.sentBody();
+    expect(body.rules.map((r) => r.pathPattern).sort()).toEqual(['/api/hello/echo', '/api/hello/job', '/w/hello/*']);
+  });
 });
 
 describe('applyNameSuffix', () => {

--- a/packages/cli/test/routes.test.ts
+++ b/packages/cli/test/routes.test.ts
@@ -5,6 +5,8 @@ import {
   sortRulesBySpecificity,
   deriveOrders,
   defaultPipelineName,
+  applyPathPrefix,
+  assertPathPrefix,
 } from '../src/format/routes.js';
 
 /** Real pathPatterns pulled from packages/cli/test/fixtures/real/*.json (Task 4 brief). */
@@ -332,5 +334,20 @@ describe('deriveOrders', () => {
     const orders = deriveOrders(rules);
     expect(orders.size).toBe(3);
     for (const r of rules) expect(orders.has(r)).toBe(true);
+  });
+});
+
+describe('applyPathPrefix', () => {
+  it('prepends a literal prefix to a derived pattern', () => {
+    expect(applyPathPrefix('/echo', '/api/hello')).toBe('/api/hello/echo');
+    expect(applyPathPrefix('/items/*', '/api/studio-pr-12')).toBe('/api/studio-pr-12/items/*');
+  });
+  it('is the identity without a prefix', () => {
+    expect(applyPathPrefix('/echo', undefined)).toBe('/echo');
+  });
+  it('rejects a prefix that is not a clean absolute literal path', () => {
+    for (const bad of ['api/hello', '/api/hello/', '/api/*', '/a/../b', '', '/']) {
+      expect(() => assertPathPrefix(bad)).toThrow(/--path-prefix/);
+    }
   });
 });

--- a/packages/cli/test/routes.test.ts
+++ b/packages/cli/test/routes.test.ts
@@ -345,8 +345,13 @@ describe('applyPathPrefix', () => {
   it('is the identity without a prefix', () => {
     expect(applyPathPrefix('/echo', undefined)).toBe('/echo');
   });
+  it('does not double the slash for a root rule pattern (rules/get.rule.yaml derives "/")', () => {
+    // Naively prepending would yield "/api/hello/", which CE's exact-string matcher never
+    // matches for `GET /api/hello` — the root case must collapse to the bare prefix.
+    expect(applyPathPrefix('/', '/api/hello')).toBe('/api/hello');
+  });
   it('rejects a prefix that is not a clean absolute literal path', () => {
-    for (const bad of ['api/hello', '/api/hello/', '/api/*', '/a/../b', '', '/']) {
+    for (const bad of ['api/hello', '/api/hello/', '/api/*', '/a/../b', '', '/', '/./api']) {
       expect(() => assertPathPrefix(bad)).toThrow(/--path-prefix/);
     }
   });


### PR DESCRIPTION
Phase 1 of the Workflow M3 plan (bffless/apps#359; `docs/superpowers/plans/2026-08-27-workflow-m3-publish-headless-studio.md` in bffless/apps, Tasks 1–2, Decision 3). Releases as **`bffless@0.4.0`**; `deploy-proxy-rules@1.3.0` and the new `bffless/publish-workflow` action build on it.

## What

`bffless rules build|push|diff --path-prefix <prefix>` prepends a literal prefix to every **derived** `pathPattern`: `rules/echo/post/` → `POST /api/hello/echo`. A BFFless Workflow implementation authors prefix-free rules in its own repo and is published under one alias-named prefix per deploy; `rules diff` needs the same flag or it reports permanent drift.

- **Exemption rule (Decision 3, adjusted):** a manifest with an explicit `pathPattern:` is left verbatim — the escape hatch already means "exactly this pattern", and it is how a generated `/w/<alias>/*` forwarder rides inside the same prefixed set.
- Pipeline default names stay prefix-free (`echo POST`). Relative order among derived rules is unchanged (a uniform prefix cannot reorder them); explicit `pathPattern:` rules rank against the *prefixed* patterns, so an explicit catch-all under the same prefix orders after the specific derived routes.
- A root rule (`rules/get.rule.yaml`) under a prefix becomes the prefix itself (`/api/hello`, not `/api/hello/`).
- The prefix is validated eagerly (absolute, literal segments, no `.`/`..`/`*`, no trailing slash) — a bad prefix fails `build` with exit 1 and `push`/`diff` through their error paths, even for a set with no derived rules.
- Duplicate-rule detection is keyed on the exported `(pathPattern, method)`, mirroring the sync validator.
- `bffless/lib` exports `applyPathPrefix` + `assertPathPrefix`; `buildRuleSet(setDir, { exportedAt?, pathPrefix? })`, `PushOptions.pathPrefix`, `DiffOptions.pathPrefix`, `buildOne(setDir, { output?, pathPrefix? })`. Existing callers (e.g. `deploy-proxy-rules`) compile unchanged.
- Docs: new "Path prefix" subsection in `packages/cli/docs/reference.md` (multi-set scope, `--prune` when a published set's prefix changes, `pull`/`dev` have no flag).

Fixture `test/fixtures/synthetic/plain/` (prefix-free `echo`, `job`, explicit `/w/hello/*` forwarder) + new tests incl. an explicit-catch-all overlap test and a dedup collision test; full CLI suite 422/422. Review note: the "same relative order with and without a prefix" test is weak on this fixture — the overlap test is the real guard for the ordering rule.

## After merge

Please cut the release: release-please → `bffless-v0.4.0` → `publish-cli`. `deploy-proxy-rules` (path-prefix input) and `publish-workflow` wait on `npm view bffless version` = `0.4.x`.

Spec: `apps/workflow/docs/spec/06-discovery-publishing-files.md` (bffless/apps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AbZjWm2jdgtQrRoJKEobQ
