### PR TITLE
fix(video): install a font so drawtext can render frame labels

### DIFF
--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -40,8 +40,13 @@ FROM node:20-alpine
 # util-linux-misc provides prlimit, which caps ffmpeg's address space so a
 # runaway encode kills ffmpeg, never the backend. Absence of either is fine —
 # the capability probe degrades to off and apps fall back to client-side wasm.
+# font-noto is what makes `drawtext` usable (the frames op's `draw` block): the
+# filter takes no explicit fontfile= and resolves a family through fontconfig,
+# and Alpine ships no fonts. Without it every labelled still fails with "Cannot
+# find a valid font for the family Sans"; CE retries un-drawn, so sheets still
+# come back — silently unlabelled. Measured 2026-08-29 on this package list.
 RUN npm install -g pnpm && \
-    apk add --no-cache netcat-openbsd nginx python3 make g++ ffmpeg util-linux-misc && \
+    apk add --no-cache netcat-openbsd nginx python3 make g++ ffmpeg font-noto util-linux-misc && \
     ln -sf python3 /usr/bin/python
 
 WORKDIR /app

--- a/workers/ffmpeg/Dockerfile
+++ b/workers/ffmpeg/Dockerfile
@@ -1,6 +1,12 @@
 FROM node:20-alpine
 # Same ffmpeg package line as docker/backend.Dockerfile so flags/versions match the local executor.
-RUN apk add --no-cache ffmpeg
+# font-noto is NOT optional: ffmpeg's `drawtext` (the frames op's `draw` block) takes no explicit
+# fontfile=, so it resolves a family through fontconfig. Alpine ships no fonts, and without one the
+# filter fails to initialise with "Cannot find a valid font for the family Sans" — which CE catches
+# and retries un-drawn, so sheets still come back, silently unlabelled (`drawn: false`).
+# Measured on ghcr.io/bffless/ce-ffmpeg-worker:preview-2026-08-17-305246f7d910 (2026-08-29):
+# fc-list found 0 fonts and every labelled still failed; adding font-noto made the same argv render.
+RUN apk add --no-cache ffmpeg font-noto
 ARG VERSION=dev
 ENV WORKER_VERSION=$VERSION PORT=8080 NODE_ENV=production
 WORKDIR /app


### PR DESCRIPTION
Both CE images ship `ffmpeg` **with** `drawtext` but **no fonts**, so the `frames` op's `draw` block never renders. Found by running the op end-to-end on the live j5s Cloud Run Worker after v0.4.35 deployed.

## What happens today

`drawtext` takes no explicit `fontfile=`, so it resolves a family through fontconfig. Alpine ships no fonts. Measured on the live Worker image (`preview-2026-08-17-305246f7d910`) and on the backend image's package list, both 2026-08-29:

```
fc-list  →  0
[Parsed_drawtext_1] Cannot find a valid font for the family Sans
[AVFilterGraph] Error initializing filters
```

Adding `font-noto` to the same image makes the identical argv render (`WROTE: 8175 bytes`).

## It fails safely, which is why nobody noticed

CE catches the failure and retries the job un-drawn, so sheets still come back — silently unlabelled, with `drawn: false` reported honestly. The live probe, and the Worker's own Cloud Run logs:

```
{"id":"shot","ok":false,"code":"FFMPEG_FAILED","bytesIn":100438617,"bytesOut":0}
{"id":"shot","ok":true,                        "bytesIn":100438617,"bytesOut":133529}
```

Two jobs — the labelled attempt, then the un-labelled retry. The degrade path works exactly as designed. But the burned-in clock is the whole point of a contact sheet for an LLM, so "works, unlabelled" is not the intended outcome.

## The fix

One package in each image:

- `workers/ffmpeg/Dockerfile` — `apk add --no-cache ffmpeg font-noto`
- `docker/backend.Dockerfile` — same, for the **local** executor, which has the identical gap

Both carry a comment recording the failure string and the measurement, so the package doesn't look incidental and get dropped.

## Corrections this forces elsewhere

- **ce#706's PR body says "no Worker redeploy needed".** Precise version: none is needed for `frames` to *work* — proven live on the untouched Worker (100 MB source → 4 stills → one 2×2 sheet in 6 s). One **is** needed for `draw` labels to render.
- **bffless/docs#72 says CE's own image has fontconfig and a font.** That is currently false; it becomes true when this merges. I'll update that PR either way.

## Follow-up, not fixed here

The retry re-downloads the whole source: `bytesIn` is 100 MB on *both* jobs above. The docs describe the retry as "one more full pass over every still and sheet" — it is also a second full input transfer, which on a large source is the dominant cost. Worth either saying so in the docs or having the Worker report its filter set in `/health` so CE can suppress the draw up front, the way it already does for a probed local executor.

## Deploying

Needs a Worker rebuild + Cloud Run redeploy to take effect on j5s; the backend image picks it up on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tKrw1ubJhhwHUxZ3L9B2u
