### PR TITLE
fix(docker): pin pnpm to 9 in the image builds

### DIFF
--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -2,7 +2,12 @@
 FROM node:20-alpine AS builder
 
 # Install pnpm
-RUN npm install -g pnpm
+# pnpm is PINNED to 9 to match every CI workflow (pnpm/action-setup version: 9) and the
+# pnpm-9 lockfile. Unpinned, `npm install -g pnpm` installs pnpm 10+, which hard-fails the
+# install with ERR_PNPM_IGNORED_BUILDS for @nestjs/core/bcrypt/sharp/browser-tabs-lock
+# rather than running their build scripts. That bomb sat behind a cached layer and went off
+# the first time an unrelated edit to this RUN line invalidated the cache (v0.4.36, #708).
+RUN npm install -g pnpm@9
 
 WORKDIR /app
 
@@ -45,7 +50,7 @@ FROM node:20-alpine
 # and Alpine ships no fonts. Without it every labelled still fails with "Cannot
 # find a valid font for the family Sans"; CE retries un-drawn, so sheets still
 # come back — silently unlabelled. Measured 2026-08-29 on this package list.
-RUN npm install -g pnpm && \
+RUN npm install -g pnpm@9 && \
     apk add --no-cache netcat-openbsd nginx python3 make g++ ffmpeg font-noto util-linux-misc && \
     ln -sf python3 /usr/bin/python
 

--- a/docker/backend.umbrel.Dockerfile
+++ b/docker/backend.umbrel.Dockerfile
@@ -8,7 +8,12 @@
 FROM node:20-alpine AS builder
 
 # Install pnpm
-RUN npm install -g pnpm
+# pnpm is PINNED to 9 to match every CI workflow (pnpm/action-setup version: 9) and the
+# pnpm-9 lockfile. Unpinned, `npm install -g pnpm` installs pnpm 10+, which hard-fails the
+# install with ERR_PNPM_IGNORED_BUILDS for @nestjs/core/bcrypt/sharp/browser-tabs-lock
+# rather than running their build scripts. That bomb sat behind a cached layer and went off
+# the first time an unrelated edit to this RUN line invalidated the cache (v0.4.36, #708).
+RUN npm install -g pnpm@9
 
 WORKDIR /app
 
@@ -44,7 +49,7 @@ FROM node:20-alpine
 # util-linux-misc provides prlimit, which caps ffmpeg's address space so a
 # runaway encode kills ffmpeg, never the backend. Absence of either is fine —
 # the capability probe degrades to off and apps fall back to client-side wasm.
-RUN npm install -g pnpm && \
+RUN npm install -g pnpm@9 && \
     apk add --no-cache netcat-openbsd nginx python3 make g++ ffmpeg util-linux-misc && \
     ln -sf python3 /usr/bin/python
 

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -5,7 +5,12 @@ FROM node:20-alpine AS builder
 ARG VITE_API_URL=
 
 # Install pnpm
-RUN npm install -g pnpm
+# pnpm is PINNED to 9 to match every CI workflow (pnpm/action-setup version: 9) and the
+# pnpm-9 lockfile. Unpinned, `npm install -g pnpm` installs pnpm 10+, which hard-fails the
+# install with ERR_PNPM_IGNORED_BUILDS for @nestjs/core/bcrypt/sharp/browser-tabs-lock
+# rather than running their build scripts. That bomb sat behind a cached layer and went off
+# the first time an unrelated edit to this RUN line invalidated the cache (v0.4.36, #708).
+RUN npm install -g pnpm@9
 
 WORKDIR /app
 


### PR DESCRIPTION
**v0.4.36's image build is broken on `main`** ([run 33227729324](https://github.com/bffless/ce/actions/runs/33227729324)). This fixes it.

```
. prepare: sh: husky: not found
Error: ERR_PNPM_IGNORED_BUILDS
  × installing dependencies
  ╰─▶ Ignored build scripts: @nestjs/core@10.4.20, bcrypt@5.1.1,
      browser-tabs-lock@1.3.0, sharp@0.34.5
ERROR: process "/bin/sh -c pnpm install --prod --frozen-lockfile --filter backend"
       did not complete successfully: exit code: 1
```

## Cause: an unpinned pnpm behind a cached layer

Every Dockerfile does `RUN npm install -g pnpm` — **unpinned**, so it installs whatever is latest at build time. Every CI workflow pins `pnpm/action-setup` to **version 9**, and the lockfile is a pnpm-9 lockfile. pnpm 10 changed behaviour: dependencies with build scripts must be approved (`onlyBuiltDependencies` / `pnpm approve-builds`) or the install **fails** instead of skipping them.

So the images had been silently drifting to a pnpm that cannot install this lockfile. The only reason it kept working is that the layer was cached.

**#708 (the font fix) edited the same `RUN` line in `docker/backend.Dockerfile`**, invalidating that cache — so the next build installed pnpm 10 and the latent break went off. The font change is not the defect; it was the trigger. Any edit to that line, a base-image bump, or an ordinary cache eviction would have done the same, at a less convenient moment.

## The fix

`pnpm@9` in all five places across the three images — not just the one that happened to blow up, since the others carry the identical bomb:

| File | Occurrences |
|---|---|
| `docker/backend.Dockerfile` | 2 (builder + runtime) |
| `docker/backend.umbrel.Dockerfile` | 2 |
| `docker/frontend.Dockerfile` | 1 |

A comment above the first occurrence in each records the failure mode and why the pin matters, so it isn't "tidied" back to unpinned later.

## Verified locally

Full `docker build -f docker/backend.Dockerfile` — succeeds. And in the resulting image:

```
pnpm: 9.15.9
fonts: 25
drawtext: OK
```

So this also confirms #708's font fix works in a real built image, which the broken build had prevented anyone from seeing.

## Follow-up, not done here

Pinning to a major (`pnpm@9`) still floats the minor. The durable fix is a `packageManager` field in `package.json` plus corepack, so the images and CI read one source. Worth its own change — this PR is deliberately the minimum that unbreaks `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tKrw1ubJhhwHUxZ3L9B2u
