### PR TITLE
fix(api-keys): let the user global role manage its own API keys (#705)

### DIFF
--- a/apps/backend/src/api-keys/api-keys.controller.spec.ts
+++ b/apps/backend/src/api-keys/api-keys.controller.spec.ts
@@ -5,9 +5,25 @@ import { ApiKeysService } from './api-keys.service';
 import { CreateApiKeyDto, UpdateApiKeyDto, ListApiKeysQueryDto } from './api-keys.dto';
 import { CurrentUserData } from '../auth/decorators/current-user.decorator';
 import { SessionAuthGuard } from '../auth/session-auth.guard';
-import { RolesGuard } from '../auth/roles.guard';
+import { RolesGuard, ROLES_KEY } from '../auth/roles.guard';
 
 describe('ApiKeysController', () => {
+  // #705: the class-level gate used to be @Roles('admin'), which made every
+  // /api/api-keys route 403 for the `user` global role and pre-empted the
+  // project-scoped contributor check in ApiKeysService.create. Members stay
+  // blocked, matching project creation (#441).
+  describe('role gating (#705)', () => {
+    it('allows the admin and user global roles at the class level (members stay blocked)', () => {
+      expect(Reflect.getMetadata(ROLES_KEY, ApiKeysController)).toEqual(['admin', 'user']);
+    });
+
+    it('is guarded: class declares ApiKeyGuard + RolesGuard', () => {
+      const guards = Reflect.getMetadata('__guards__', ApiKeysController) ?? [];
+      const guardNames = guards.map((g: any) => g.name);
+      expect(guardNames).toEqual(expect.arrayContaining(['ApiKeyGuard', 'RolesGuard']));
+    });
+  });
+
   let controller: ApiKeysController;
   let service: ApiKeysService;
 

--- a/apps/backend/src/api-keys/api-keys.controller.ts
+++ b/apps/backend/src/api-keys/api-keys.controller.ts
@@ -33,7 +33,10 @@ import {
 @ApiBearerAuth()
 @Controller('api/api-keys')
 @UseGuards(ApiKeyGuard, RolesGuard)
-@Roles('admin')
+// admin + user may manage their own keys; members cannot (#705). Global keys are
+// further restricted to admin inside ApiKeysService.create; project-scoped keys
+// require contributor+ on the target project.
+@Roles('admin', 'user')
 export class ApiKeysController {
   constructor(private readonly apiKeysService: ApiKeysService) {}
 
@@ -50,7 +53,11 @@ export class ApiKeysController {
   })
   @ApiResponse({ status: 400, description: 'Invalid input data' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  @ApiResponse({ status: 403, description: 'Forbidden - global keys require admin role' })
+  @ApiResponse({
+    status: 403,
+    description:
+      'Forbidden - requires the admin or user global role (members cannot manage API keys); global keys require admin; project-scoped keys require contributor+ on the project',
+  })
   async create(
     @CurrentUser() user: CurrentUserData,
     @Body() createApiKeyDto: CreateApiKeyDto,

--- a/apps/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/apps/frontend/src/pages/ProjectSettingsPage.tsx
@@ -63,13 +63,21 @@ export function ProjectSettingsPage() {
   const navigate = useNavigate();
   const { toast } = useToast();
 
+  // Check authentication status
+  const { data: sessionData, isLoading: isLoadingSession } = useGetSessionQuery();
+  const isAuthenticated = Boolean(sessionData?.user);
+  const currentUser = sessionData?.user;
+  // API keys need the admin or user *global* role; a member who is a project
+  // owner would only get 403s from /api/api-keys, so hide the tab (#705).
+  const canAccessApiKeys = currentUser?.role === 'admin' || currentUser?.role === 'user';
+
   // Get tab from query params, default to 'general'
   const tabParam = searchParams.get('tab');
   const currentTab: TabValue =
     tabParam === 'members' ||
     tabParam === 'invite-links' ||
     tabParam === 'groups' ||
-    tabParam === 'api-keys' ||
+    (tabParam === 'api-keys' && canAccessApiKeys) ||
     tabParam === 'proxy-rules' ||
     tabParam === 'storage' ||
     tabParam === 'cache-rules' ||
@@ -85,11 +93,6 @@ export function ProjectSettingsPage() {
     const newTab = value as TabValue;
     navigate(`/repo/${owner}/${repo}/settings?tab=${newTab}`, { replace: true });
   };
-
-  // Check authentication status
-  const { data: sessionData, isLoading: isLoadingSession } = useGetSessionQuery();
-  const isAuthenticated = Boolean(sessionData?.user);
-  const currentUser = sessionData?.user;
 
   // Fetch project details
   const {
@@ -304,7 +307,7 @@ export function ProjectSettingsPage() {
               <TabsTrigger value="members">Members</TabsTrigger>
               <TabsTrigger value="invite-links">Invite Links</TabsTrigger>
               <TabsTrigger value="groups">Groups</TabsTrigger>
-              <TabsTrigger value="api-keys">API Keys</TabsTrigger>
+              {canAccessApiKeys && <TabsTrigger value="api-keys">API Keys</TabsTrigger>}
               <TabsTrigger value="proxy-rules">Proxy Rules</TabsTrigger>
               <TabsTrigger value="storage">Storage</TabsTrigger>
               <TabsTrigger value="cache-rules">Cache Rules</TabsTrigger>
@@ -517,9 +520,11 @@ export function ProjectSettingsPage() {
           </TabsContent>
 
           {/* API Keys Tab */}
-          <TabsContent value="api-keys" className="mt-6">
-            {project && <ProjectApiKeysTab project={project} />}
-          </TabsContent>
+          {canAccessApiKeys && (
+            <TabsContent value="api-keys" className="mt-6">
+              {project && <ProjectApiKeysTab project={project} />}
+            </TabsContent>
+          )}
 
           {/* Proxy Rules Tab */}
           <TabsContent value="proxy-rules" className="mt-6">

--- a/apps/frontend/src/pages/UserSettingsPage.tsx
+++ b/apps/frontend/src/pages/UserSettingsPage.tsx
@@ -27,8 +27,8 @@ export function UserSettingsPage() {
   // Fetch login methods to determine if change password should be shown
   const { data: loginMethods } = useGetLoginMethodsQuery();
 
-  // Only admins can access API keys
-  const canAccessApiKeys = user?.role === 'admin';
+  // Admins and users can manage their own API keys; members cannot (#705)
+  const canAccessApiKeys = user?.role === 'admin' || user?.role === 'user';
 
   // Get tab from query params, default to 'profile'
   // Redirect away from api-keys if user is a member

--- a/apps/frontend/vite.config.d.ts
+++ b/apps/frontend/vite.config.d.ts
@@ -1,0 +1,2 @@
+declare const _default: import("vite").UserConfig;
+export default _default;

--- a/apps/frontend/vite.config.js
+++ b/apps/frontend/vite.config.js
@@ -1,0 +1,48 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+// https://vitejs.dev/config/
+export default defineConfig({
+    base: './',
+    plugins: [react()],
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, './src'),
+        },
+    },
+    server: {
+        port: 5173,
+        proxy: {
+            '/api': {
+                target: 'http://localhost:3000',
+                changeOrigin: true,
+            },
+            '/public': {
+                target: 'http://localhost:3000',
+                changeOrigin: true,
+            },
+        },
+    },
+    test: {
+        globals: true,
+        environment: 'happy-dom',
+        setupFiles: './src/test/setup.ts',
+        css: true,
+        include: ['src/**/*.{test,spec}.{ts,tsx}'],
+        exclude: ['e2e/**', 'node_modules/**'],
+        coverage: {
+            provider: 'v8',
+            reporter: ['text', 'json', 'html'],
+            exclude: [
+                'node_modules/',
+                'src/test/',
+                'e2e/',
+                '**/*.d.ts',
+                '**/*.config.*',
+                '**/mockData',
+                '**/*.test.{ts,tsx}',
+                '**/*.spec.{ts,tsx}',
+            ],
+        },
+    },
+});


### PR DESCRIPTION
Closes #705

## Problem

`ApiKeysController` carried a class-level `@Roles('admin')` (added as a 2-line add-on in 4cd00c8), so every `/api/api-keys` route 403'd for the `user` global role. That pre-empted the finer rule `ApiKeysService.create` already enforces — global keys → admin only; project-scoped keys → `owner`/`admin`/`contributor` on that project — and, since the MCP endpoint authenticates by `X-API-Key`, meant a non-admin could never mint the first key needed to connect MCP. The MCP `create_api_key` tool had no such gate, and the frontend disagreed with itself (user-settings tab hidden for non-admins; project-settings tab shown, then 403).

## Change

- **Backend** `api-keys.controller.ts`: `@Roles('admin')` → `@Roles('admin', 'user')`, the same split `projects.controller.ts` uses for project creation. Members stay blocked. Swagger 403 text on create updated to describe the real rule.
- **Frontend** `UserSettingsPage.tsx`: API Keys tab shown to `admin` and `user`.
- **Frontend** `ProjectSettingsPage.tsx`: API Keys tab (and its `?tab=` param) hidden for global `member`s, who could only ever 403 on it.
- **Spec** `api-keys.controller.spec.ts`: pins the class-level roles to `['admin', 'user']` and the guard set (was red before the fix).

## Why it's safe

A project-scoped key cannot exceed its holder's own permissions: `ApiKeyGuard` pins API-key requests to role `user`, every project action is then checked against `project_permissions`, and list/get/update/delete already check `apiKey.userId === userId`. A contributor minting a key for their own project gains nothing they did not already have.

## Verification

- `tsc -b` (frontend) clean; eslint + prettier clean on touched files
- backend: `src/api-keys` + `roles.guard.spec` — 46/46
- frontend: `vitest run src/pages` — 69/69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McaAhzpaJRMmPhEN67wjkK
