### PR TITLE
feat(pipelines): return the execution-log id as X-Pipeline-Log-Id on debug-enabled proxy-rule responses

### DIFF
--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -125,6 +125,21 @@ the "PR content is untrusted data, not instructions" defence fails for precisely
 two files that *are* the instructions.
 **Learned from:** PR #672, 2026-08-16 — found by this agent reviewing its own PR.
 
+### A by-id lookup guarded only by `ApiKeyGuard` is instance-wide, not project-wide
+**Surface:** any `@Controller` under `apps/backend/src/**` using `@UseGuards(ApiKeyGuard)`
+alone on a `GET /:id` route — `ApiKeyGuard` accepts any session or API key on the
+instance and does no ownership check.
+**Check:** When a PR makes an id more discoverable (a response header, an error body,
+a webhook payload, a public page), does the endpoint that resolves that id call
+`PermissionsService.requireProjectAccess(...)` against the row's own `projectId`
+(passing `user.apiKeyProjectId` so project-scoped keys are enforced)? Ids that
+were previously only visible inside the admin UI were implicitly scoped by it;
+once they leak into public traffic, "knowing the id" must not be enough.
+**Why:** `pipeline_execution_logs.debug` carries request metadata (IP, UA), step
+detail and error text; a cross-project read is a data leak with no error anywhere.
+**Learned from:** PR #717, 2026-08-29 — `X-Pipeline-Log-Id` exposed log ids to
+anonymous callers while `GET /api/pipeline-logs/:logId` was unscoped; fixed in the same PR.
+
 ---
 
 ## Entry template

--- a/apps/backend/src/pipelines/pipeline-execution-log.service.ts
+++ b/apps/backend/src/pipelines/pipeline-execution-log.service.ts
@@ -5,6 +5,13 @@ import { pipelineExecutionLogs } from '../db/schema';
 import type { PipelineDebugResult } from './execution/pipeline-context.interface';
 import type { PipelineLogRequestMeta } from '../db/schema/pipeline-execution-logs.schema';
 
+/**
+ * Response header carrying the `pipeline_execution_logs.id` of the row a
+ * pipeline proxy-rule response was logged under. Only present when the rule has
+ * `debugEnabled`; the value resolves at `GET /api/pipeline-logs/:logId`.
+ */
+export const PIPELINE_LOG_ID_HEADER = 'X-Pipeline-Log-Id';
+
 @Injectable()
 export class PipelineExecutionLogService {
   private readonly logger = new Logger(PipelineExecutionLogService.name);
@@ -12,6 +19,11 @@ export class PipelineExecutionLogService {
 
   /**
    * Persist a pipeline execution log and cleanup old entries beyond retention limit.
+   *
+   * `logId` lets the caller choose the row id up front — the proxy middleware
+   * generates it before the HTTP response goes out so it can be echoed back as
+   * `X-Pipeline-Log-Id` while the insert itself stays fire-and-forget. When
+   * omitted the DB default (random uuid) applies. Resolves to the row id.
    */
   async log(
     proxyRuleId: string,
@@ -20,7 +32,8 @@ export class PipelineExecutionLogService {
     requestMeta: PipelineLogRequestMeta,
     method: string,
     path: string,
-  ): Promise<void> {
+    logId?: string,
+  ): Promise<string> {
     // Determine status code
     let statusCode = 500;
     if (result.success && result.response) {
@@ -36,30 +49,36 @@ export class PipelineExecutionLogService {
 
     const stepsCount = result.debug?.steps?.length ?? 0;
 
-    await db.insert(pipelineExecutionLogs).values({
-      projectId,
-      proxyRuleId,
-      success: result.success,
-      statusCode,
-      method,
-      path,
-      durationMs: result.debug?.totalDurationMs ?? 0,
-      stepsCount,
-      errorCode: result.error?.code ?? null,
-      errorMessage: result.error?.message ?? null,
-      errorStep: result.error?.step ?? null,
-      requestMeta,
-      debug: result.debug ?? {
-        validators: [],
-        steps: [],
-        totalDurationMs: 0,
-        startTime: '',
-        endTime: '',
-      },
-    });
+    const [inserted] = await db
+      .insert(pipelineExecutionLogs)
+      .values({
+        ...(logId ? { id: logId } : {}),
+        projectId,
+        proxyRuleId,
+        success: result.success,
+        statusCode,
+        method,
+        path,
+        durationMs: result.debug?.totalDurationMs ?? 0,
+        stepsCount,
+        errorCode: result.error?.code ?? null,
+        errorMessage: result.error?.message ?? null,
+        errorStep: result.error?.step ?? null,
+        requestMeta,
+        debug: result.debug ?? {
+          validators: [],
+          steps: [],
+          totalDurationMs: 0,
+          startTime: '',
+          endTime: '',
+        },
+      })
+      .returning({ id: pipelineExecutionLogs.id });
 
     // Cleanup old entries beyond retention limit
     await this.cleanup(proxyRuleId, this.DEFAULT_RETENTION);
+
+    return inserted.id;
   }
 
   /**

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
-import { ProxyRulesController } from './proxy-rules.controller';
+import { NotFoundException, ForbiddenException } from '@nestjs/common';
+import { ProxyRulesController, PipelineLogsController } from './proxy-rules.controller';
+import { PermissionsService } from '../permissions/permissions.service';
 import { ProxyRulesService } from './proxy-rules.service';
 import { PipelineExecutionService } from '../pipelines/execution';
 import { PipelineExecutionLogService } from '../pipelines/pipeline-execution-log.service';
@@ -344,5 +345,81 @@ describe('ProxyRulesController', () => {
         undefined,
       );
     });
+  });
+});
+
+describe('PipelineLogsController', () => {
+  let controller: PipelineLogsController;
+  let mockLogService: { getById: jest.Mock };
+  let mockPermissionsService: { requireProjectAccess: jest.Mock };
+
+  const log = {
+    id: 'log-1',
+    projectId: 'project-a',
+    proxyRuleId: 'rule-1',
+    success: false,
+    statusCode: 400,
+    method: 'POST',
+    path: '/api/items',
+    durationMs: 12,
+    stepsCount: 1,
+    errorCode: 'VALIDATION_ERROR',
+    errorMessage: 'bad input',
+    errorStep: 'validate',
+    requestMeta: { ip: '203.0.113.9', userAgent: 'curl/8' },
+    debug: { validators: [], steps: [], totalDurationMs: 12, startTime: '', endTime: '' },
+    createdAt: new Date(),
+  };
+
+  beforeEach(() => {
+    mockLogService = { getById: jest.fn().mockResolvedValue(log) };
+    mockPermissionsService = { requireProjectAccess: jest.fn().mockResolvedValue(undefined) };
+    controller = new PipelineLogsController(
+      mockLogService as unknown as PipelineExecutionLogService,
+      mockPermissionsService as unknown as PermissionsService,
+    );
+  });
+
+  it('returns the log to a caller authorized on its project', async () => {
+    const user: CurrentUserData = { id: 'user-1', role: 'user', apiKeyProjectId: undefined };
+    await expect(controller.getLogDetail('log-1', user)).resolves.toBe(log);
+    // Scoped to the log's own project (not a caller-supplied one), read-level role.
+    expect(mockPermissionsService.requireProjectAccess).toHaveBeenCalledWith(
+      'project-a',
+      'user-1',
+      'user',
+      'viewer',
+      undefined,
+    );
+  });
+
+  it('forwards the API key project scope so a key minted for another project is refused', async () => {
+    const user: CurrentUserData = { id: 'user-1', role: 'user', apiKeyProjectId: 'project-b' };
+    mockPermissionsService.requireProjectAccess.mockRejectedValue(
+      new ForbiddenException('API key is not authorized for this project'),
+    );
+    await expect(controller.getLogDetail('log-1', user)).rejects.toThrow(ForbiddenException);
+    expect(mockPermissionsService.requireProjectAccess).toHaveBeenCalledWith(
+      'project-a',
+      'user-1',
+      'user',
+      'viewer',
+      'project-b',
+    );
+  });
+
+  it('does not return the log when the caller has no role on its project', async () => {
+    const user: CurrentUserData = { id: 'outsider', role: 'user' };
+    mockPermissionsService.requireProjectAccess.mockRejectedValue(
+      new ForbiddenException('You do not have access to this project'),
+    );
+    await expect(controller.getLogDetail('log-1', user)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('404s on an unknown id without consulting permissions', async () => {
+    mockLogService.getById.mockResolvedValue(null);
+    const user: CurrentUserData = { id: 'user-1', role: 'admin' };
+    await expect(controller.getLogDetail('missing', user)).rejects.toThrow(NotFoundException);
+    expect(mockPermissionsService.requireProjectAccess).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.ts
@@ -37,6 +37,7 @@ import { PipelineUser } from '../pipelines/execution/pipeline-context.interface'
 import { DeploymentsService } from '../deployments/deployments.service';
 import { ProjectsService } from '../projects/projects.service';
 import { UserGroupsService } from '../user-groups/user-groups.service';
+import { PermissionsService } from '../permissions/permissions.service';
 
 /**
  * Controller for individual proxy rule operations.
@@ -373,17 +374,36 @@ export class ProxyRulesController {
 @Controller('api/pipeline-logs')
 @UseGuards(ApiKeyGuard)
 export class PipelineLogsController {
-  constructor(private readonly executionLogService: PipelineExecutionLogService) {}
+  constructor(
+    private readonly executionLogService: PipelineExecutionLogService,
+    private readonly permissionsService: PermissionsService,
+  ) {}
 
   @Get(':logId')
   @ApiOperation({ summary: 'Get a single pipeline execution log' })
   @ApiParam({ name: 'logId', type: 'string' })
   @ApiResponse({ status: 200, description: 'Full execution log with debug data' })
-  async getLogDetail(@Param('logId', ParseUUIDPipe) logId: string) {
+  @ApiResponse({ status: 403, description: "Not authorized for the log's project" })
+  @ApiResponse({ status: 404, description: 'Log not found' })
+  async getLogDetail(
+    @Param('logId', ParseUUIDPipe) logId: string,
+    @CurrentUser() user: CurrentUserData,
+  ) {
     const log = await this.executionLogService.getById(logId);
     if (!log) {
       throw new NotFoundException(`Pipeline log ${logId} not found`);
     }
+    // Log ids are handed to whoever hits a debug-enabled rule (X-Pipeline-Log-Id),
+    // including anonymous public traffic, so knowing an id must not be enough:
+    // the caller has to be a member of the log's project (or a system admin /
+    // an API key scoped to that project). Debug payloads carry request metadata.
+    await this.permissionsService.requireProjectAccess(
+      log.projectId,
+      user.id,
+      user.role,
+      'viewer',
+      user.apiKeyProjectId,
+    );
     return log;
   }
 }

--- a/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
@@ -538,4 +538,141 @@ describe('ProxyMiddleware', () => {
       expect(result).toBe('blocked');
     });
   });
+
+  describe('handlePipelineExecution — X-Pipeline-Log-Id (#716)', () => {
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+    const pipelineRule = (overrides: Record<string, unknown> = {}) =>
+      createMockRule({
+        proxyType: 'pipeline',
+        targetUrl: 'pipeline',
+        pipelineConfig: {
+          name: 'test',
+          steps: [{ name: 'respond', handlerType: 'response_handler', config: {} }],
+        },
+        debugEnabled: true,
+        ...overrides,
+      });
+
+    const createPipelineResponse = (): Response & { headersSent: boolean } =>
+      ({
+        headersSent: false,
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+        send: jest.fn(),
+        setHeader: jest.fn(),
+        end: jest.fn(),
+      }) as unknown as Response & { headersSent: boolean };
+
+    /** Let the fire-and-forget persistLog() chain run to completion. */
+    const flushAsync = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+    const logIdHeaderValue = (res: Response): string | undefined => {
+      const call = (res.setHeader as jest.Mock).mock.calls.find(
+        ([name]) => name === 'X-Pipeline-Log-Id',
+      );
+      return call?.[1];
+    };
+
+    beforeEach(() => {
+      // Avoid SuperTokens / DB lookups: treat every request as anonymous.
+      jest.spyOn(middleware as any, 'getOptionalUser').mockResolvedValue(undefined);
+    });
+
+    it('returns the execution-log id as X-Pipeline-Log-Id on a successful response and persists the log under that id', async () => {
+      mockPipelineExecutionService.executePipelineWithDebug.mockResolvedValue({
+        success: true,
+        response: { status: 200, headers: { 'X-Custom': 'yes' }, body: { ok: true } },
+      } as any);
+      const req = createMockRequest('/public/owner/repo/sha123/api/items');
+      const res = createPipelineResponse();
+
+      await (middleware as any).handlePipelineExecution(req, res, pipelineRule(), 'project-1');
+      await flushAsync();
+
+      const logId = logIdHeaderValue(res);
+      expect(logId).toMatch(UUID_RE);
+      // Pipeline-authored headers are still applied.
+      expect(res.setHeader).toHaveBeenCalledWith('X-Custom', 'yes');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith({ ok: true });
+
+      expect(mockExecutionLogService.log).toHaveBeenCalledTimes(1);
+      const logArgs = mockExecutionLogService.log.mock.calls[0];
+      expect(logArgs[0]).toBe('rule-1');
+      expect(logArgs[1]).toBe('project-1');
+      expect(logArgs[6]).toBe(logId);
+    });
+
+    it('returns the same header on a failed pipeline response so the caller can find the failing run', async () => {
+      mockPipelineExecutionService.executePipelineWithDebug.mockResolvedValue({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: 'bad input', step: 'validate' },
+      } as any);
+      const req = createMockRequest('/public/owner/repo/sha123/api/items');
+      const res = createPipelineResponse();
+
+      await (middleware as any).handlePipelineExecution(req, res, pipelineRule(), 'project-1');
+      await flushAsync();
+
+      const logId = logIdHeaderValue(res);
+      expect(logId).toMatch(UUID_RE);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: 'bad input', step: 'validate' },
+      });
+      expect(mockExecutionLogService.log).toHaveBeenCalledTimes(1);
+      expect(mockExecutionLogService.log.mock.calls[0][6]).toBe(logId);
+    });
+
+    it('issues a fresh id per request', async () => {
+      const ids = new Set<string>();
+      for (let i = 0; i < 3; i++) {
+        const res = createPipelineResponse();
+        await (middleware as any).handlePipelineExecution(
+          createMockRequest('/public/owner/repo/sha123/api/items'),
+          res,
+          pipelineRule(),
+          'project-1',
+        );
+        ids.add(logIdHeaderValue(res) as string);
+      }
+      await flushAsync();
+      expect(ids.size).toBe(3);
+    });
+
+    it('does not emit the header (and writes no log) when debugEnabled is false', async () => {
+      const req = createMockRequest('/public/owner/repo/sha123/api/items');
+      const res = createPipelineResponse();
+
+      await (middleware as any).handlePipelineExecution(
+        req,
+        res,
+        pipelineRule({ debugEnabled: false }),
+        'project-1',
+      );
+      await flushAsync();
+
+      expect(logIdHeaderValue(res)).toBeUndefined();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(mockExecutionLogService.log).not.toHaveBeenCalled();
+    });
+
+    it('does not emit the header when a handler already streamed the response (nothing is logged for it)', async () => {
+      const req = createMockRequest('/public/owner/repo/sha123/api/stream');
+      const res = createPipelineResponse();
+      mockPipelineExecutionService.executePipelineWithDebug.mockImplementation(async () => {
+        res.headersSent = true;
+        return { success: true } as any;
+      });
+
+      await (middleware as any).handlePipelineExecution(req, res, pipelineRule(), 'project-1');
+      await flushAsync();
+
+      expect(logIdHeaderValue(res)).toBeUndefined();
+      expect(res.send).not.toHaveBeenCalled();
+      expect(mockExecutionLogService.log).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -21,10 +21,14 @@ import { EmailFormHandlerService } from './email-form-handler.service';
 import { ProxyRule, ProxyType, PipelineConfig } from '../db/schema/proxy-rules.schema';
 import { ConfigService } from '@nestjs/config';
 import { PipelineExecutionService } from '../pipelines/execution';
-import { PipelineExecutionLogService } from '../pipelines/pipeline-execution-log.service';
+import {
+  PipelineExecutionLogService,
+  PIPELINE_LOG_ID_HEADER,
+} from '../pipelines/pipeline-execution-log.service';
 import { PipelineUser } from '../pipelines/execution/pipeline-context.interface';
 import { Pipeline, PipelineStep } from '../pipelines/types';
 import multer from 'multer';
+import { randomUUID } from 'crypto';
 import { CustomDomainAuthService } from '../auth/custom-domain-auth.service';
 import { VisibilityService, AccessControlInfo } from '../domains/visibility.service';
 import { PermissionsService } from '../permissions/permissions.service';
@@ -1195,12 +1199,21 @@ export class ProxyMiddleware implements NestMiddleware {
         return;
       }
 
+      // When this rule persists execution logs, choose the row id up front so the
+      // response can carry it (X-Pipeline-Log-Id) while the insert below stays
+      // fire-and-forget. A caller that gets a failed response can then fetch
+      // GET /api/pipeline-logs/:id directly instead of matching by timestamp.
+      const logId = rule.debugEnabled ? randomUUID() : undefined;
+
       if (result.success && result.response) {
         // Set response headers if provided
         if (result.response.headers) {
           for (const [key, value] of Object.entries(result.response.headers)) {
             res.setHeader(key, value);
           }
+        }
+        if (logId) {
+          res.setHeader(PIPELINE_LOG_ID_HEADER, logId);
         }
         // Use res.send (not res.json): for string bodies (text/plain, text/html,
         // application/x-sh, etc.) res.json would JSON.stringify the string and
@@ -1221,6 +1234,9 @@ export class ProxyMiddleware implements NestMiddleware {
         } else if (errorCode === 'RATE_LIMIT_EXCEEDED') {
           statusCode = 429;
         }
+        if (logId) {
+          res.setHeader(PIPELINE_LOG_ID_HEADER, logId);
+        }
         res.status(statusCode).json({
           success: false,
           error: result.error,
@@ -1229,7 +1245,7 @@ export class ProxyMiddleware implements NestMiddleware {
 
       // Fire-and-forget: persist execution log if debug is enabled
       // Wait for post-steps to complete so their debug info is included
-      if (rule.debugEnabled) {
+      if (rule.debugEnabled && logId) {
         const persistLog = async () => {
           if (result.postStepsPromise) {
             try {
@@ -1252,6 +1268,7 @@ export class ProxyMiddleware implements NestMiddleware {
             },
             req.method,
             req.path,
+            logId,
           );
         };
         persistLog().catch((err) =>

--- a/packages/cli/docs/reference.md
+++ b/packages/cli/docs/reference.md
@@ -170,7 +170,7 @@ validation error (the schema is `.strict()`).
 | `pipeline` | authoring sugar (see below) | Mutually exclusive with `pipelineConfig` (schema-level `.refine()` rejects both). |
 | `pipelineConfig` | canonical `{ name, description?, steps: PipelineStep[], postSteps?, validators? }` | Same shape as the compiled export's `pipelineConfig` — use this when you already have canonical JSON to paste in; `steps[].handlerType`/`.config` (not `handler`). |
 | `isEnabled` | `boolean` | Default `true`. |
-| `debugEnabled` | `boolean` | Default `false`. |
+| `debugEnabled` | `boolean` | Default `false`. When `true` the server persists an execution log per request (admin panel → rule → Logs) and every response from the rule carries an `X-Pipeline-Log-Id` header naming that log (`GET /api/pipeline-logs/<id>`). Rules-as-code is the source of truth: a debug toggle flipped in the admin panel is reset by the next `rules push` unless it is also set here. |
 | `description` | `string` | Free text. |
 
 **The `pipeline:` sugar.** `pipeline: { name?, description?, steps: Step[], postSteps?,


### PR DESCRIPTION
Closes #716

## Summary
When a pipeline proxy rule has debug logging on, every request is recorded under `/proxy-rules/<set>/<rule>/logs`, but a caller that got a failed response had no way to find *its* row except by guessing on timestamps. After this PR, every response from a debug-enabled pipeline rule carries an `X-Pipeline-Log-Id` header with the id of the log row for that exact request, resolvable at `GET /api/pipeline-logs/<id>`. Callers such as the Workflow harness can store it on the step and link straight to the debug data. Response latency is unchanged: the id is chosen before the response goes out and the log write stays fire-and-forget.

The second half of #716 (make `debugEnabled` survive `bffless rules push`) already works end to end: `debugEnabled: true` in `rule.yaml` compiles, syncs, and lands on the rule. What the reporter hit is the intended source-of-truth behaviour — a toggle flipped in the admin panel is reset by the next push because the YAML omits the key (absent means `false`). This PR documents that in the CLI reference rather than adding a second `debug:` spelling.

## Behaviour changes
- Pipeline proxy-rule responses, rule with `debugEnabled: true`: before → no correlation to the execution log; after → response includes `X-Pipeline-Log-Id: <uuid>` on both success and error (4xx/5xx) responses. Additive: a new header only.
- Pipeline proxy-rule responses, `debugEnabled: false` (the default): none — no header, no log, exactly as before.
- Responses a handler streamed itself (`res.headersSent`): none — these were never logged, so no header is emitted for them either.
- `PipelineExecutionLogService.log()` gains an optional trailing `logId` parameter and now resolves to the row id (was `void`). Existing callers (onboarding executor) are unaffected.
- `GET /api/pipeline-logs/:logId`: before → any valid session or API key on the instance could read any log by id; after → the caller must be a member of the log's project (viewer or higher), a system admin, or hold an API key scoped to that project; otherwise 403. This closes a pre-existing gap the CI review pointed out, because the header now makes ids reachable by anonymous traffic. The admin UI (project members) and the MCP tools (call the service directly) are unaffected.
- Rules-as-code: no code change. `debugEnabled` in `rule.yaml` behaves exactly as before; the reference doc now spells out the header and the "YAML wins over the admin toggle on push" semantics.

## Why
Live-debugging the Workflow harness's Studio port (bffless/apps#424, #427) showed that a failing pipeline call gives the caller an HTTP response and nothing that ties it to the debug row the server just wrote. Pre-generating the id (`crypto.randomUUID()`) and inserting with that explicit id was chosen over awaiting the insert because the log must wait for post-steps to finish, which happens *after* the response is sent; blocking would add latency and change the response timing of every debug-enabled rule.

## What changed
- backend: `apps/backend/src/proxy-rules/proxy.middleware.ts` generates the id when `rule.debugEnabled`, sets the header on both response branches (after pipeline-authored headers, so it cannot be clobbered), and passes it into the insert. `apps/backend/src/pipelines/pipeline-execution-log.service.ts` exports `PIPELINE_LOG_ID_HEADER`, accepts the optional `logId`, inserts with it, and returns the row id.
- backend (review follow-up): `apps/backend/src/proxy-rules/proxy-rules.controller.ts` — `PipelineLogsController.getLogDetail` calls `PermissionsService.requireProjectAccess` against the log's `projectId`, the same helper `ProxyRulesService` uses for writes.
- checklist: `.claude/ce-pr-review-checklist.md` — new entry on by-id lookups guarded only by `ApiKeyGuard`, from the review of this PR.
- tests: `apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts` — new `PipelineLogsController` block (4 tests): authorized read; project-scoped key for another project refused; non-member refused; 404 without consulting permissions. `apps/backend/src/proxy-rules/proxy.middleware.spec.ts` — new `handlePipelineExecution` block (5 tests): header + same id logged on success; on failure; fresh id per request; no header/no log when debug is off; no header when a handler already streamed.
- docs: `packages/cli/docs/reference.md` — `debugEnabled` row now describes the header and the push-resets-the-admin-toggle semantics.

## Compatibility
- Migrations: none. `pipeline_execution_logs.id` already has a `defaultRandom()`; supplying an explicit id on insert is a plain client-side choice.
- API/CLI contract: a new response header (additive), plus a tightened authorization on `GET /api/pipeline-logs/:logId` (403 for callers outside the log's project — a security fix; no field, endpoint or param shape changed). Otherwise no field, endpoint, or query param removed or renamed. The published CLI does not read it. `POST /api/deployments/zip` untouched.
- Pipeline / proxy-rule semantics: no change to handler behaviour, expression evaluation, or template substitution; stored rule sets behave identically. The header is gated on the existing per-rule `debugEnabled` flag, so it is opt-in per rule.
- Env vars, nginx generation, storage layout: untouched.

## Verification
- `pnpm --filter backend exec tsc --noEmit` — exit 0
- `pnpm --filter frontend exec tsc --noEmit` — exit 0
- `cd apps/backend && pnpm test -- "proxy-rules.controller.spec|proxy.middleware.spec"` — 2 suites, 45 passed (9 new)
- `cd apps/backend && pnpm test -- "proxy-rules|onboarding-rules|pipeline-execution"` — 19 suites, 370 passed
- `pnpm --filter backend format:check` / `pnpm --filter frontend format:check` — both clean
- Part-2 check: compiled the CLI's `basic` synthetic fixture with `debugEnabled: true` appended to one `rule.yaml` through `buildRuleSet()` — that rule exports `debugEnabled: true`, the others `false`; `sync-plan.util.ts` compares and writes the field, so a push carries it to the DB.

## Out of scope / follow-ups
- Admin UI has no deep link to a single log by id (`PipelineLogDetail` is only reached from the paginated list). A `?log=<id>` route on the rule Logs page would let the harness link straight into the panel; the API side (`GET /api/pipeline-logs/:id`) already exists.
- Cross-origin callers need `Access-Control-Expose-Headers: X-Pipeline-Log-Id` to read it from `fetch`; the pipeline middleware sets no CORS headers today (only the email form handler does), so a rule's `response_handler` would have to add it. Same-origin callers (an app on its own BFFless domain) are unaffected.
- Streamed responses are neither logged nor given the header — pre-existing gap, unchanged here.
- Whether to accept a `debug:` alias for `debugEnabled` in `rule.yaml` is a product call; I did not add a second spelling because `rules diff` / canonical forms key on the existing name. The public docs site (`docs-public`) could mirror the new reference-doc sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7xFduepv6vrYu3KeppnhP

