### PR TITLE
fix(proxy-rules): scope by-id rule routes to the rule's project

### DIFF
--- a/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
@@ -17,6 +17,15 @@ describe('ProxyRulesController', () => {
   let mockDeploymentsService: jest.Mocked<DeploymentsService>;
   let mockProjectsService: jest.Mocked<ProjectsService>;
   let mockUserGroupsService: jest.Mocked<UserGroupsService>;
+  let mockExecutionLogService: {
+    log: jest.Mock;
+    getByRuleId: jest.Mock;
+    getCountByRuleId: jest.Mock;
+    deleteByRuleId: jest.Mock;
+  };
+  let mockPermissionsService: { requireProjectAccess: jest.Mock };
+
+  const mockRuleSet = { id: 'rule-set-1', projectId: 'project-1' };
 
   const mockUser: CurrentUserData = {
     id: 'user-1',
@@ -55,6 +64,7 @@ describe('ProxyRulesController', () => {
       getRulesByRuleSetId: jest.fn(),
       getEffectiveRulesForRuleSet: jest.fn(),
       getRuleById: jest.fn(),
+      getRuleSetById: jest.fn().mockResolvedValue(mockRuleSet),
       create: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
@@ -77,9 +87,14 @@ describe('ProxyRulesController', () => {
       getGroupIdsForUser: jest.fn(),
     } as unknown as jest.Mocked<UserGroupsService>;
 
-    const mockExecutionLogService = {
+    mockExecutionLogService = {
       log: jest.fn().mockResolvedValue(undefined),
+      getByRuleId: jest.fn().mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 20 }),
+      getCountByRuleId: jest.fn().mockResolvedValue(0),
+      deleteByRuleId: jest.fn().mockResolvedValue(undefined),
     };
+
+    mockPermissionsService = { requireProjectAccess: jest.fn().mockResolvedValue(undefined) };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ProxyRulesController],
@@ -90,6 +105,7 @@ describe('ProxyRulesController', () => {
         { provide: DeploymentsService, useValue: mockDeploymentsService },
         { provide: ProjectsService, useValue: mockProjectsService },
         { provide: UserGroupsService, useValue: mockUserGroupsService },
+        { provide: PermissionsService, useValue: mockPermissionsService },
       ],
     }).compile();
 
@@ -101,17 +117,161 @@ describe('ProxyRulesController', () => {
       const mockRule = createMockRule();
       mockProxyRulesService.getRuleById.mockResolvedValue(mockRule);
 
-      const result = await controller.getRule('rule-1');
+      const result = await controller.getRule('rule-1', mockUser);
 
       expect(result.id).toBe('rule-1');
       expect(result.ruleSetId).toBe('rule-set-1');
       expect(mockProxyRulesService.getRuleById).toHaveBeenCalledWith('rule-1');
+      // Scoped to the rule set's own project, read-level role.
+      expect(mockPermissionsService.requireProjectAccess).toHaveBeenCalledWith(
+        'project-1',
+        'user-1',
+        'admin',
+        'viewer',
+        undefined,
+      );
     });
 
     it('should throw NotFoundException when rule not found', async () => {
       mockProxyRulesService.getRuleById.mockResolvedValue(null);
 
-      await expect(controller.getRule('non-existent')).rejects.toThrow(NotFoundException);
+      await expect(controller.getRule('non-existent', mockUser)).rejects.toThrow(NotFoundException);
+      expect(mockPermissionsService.requireProjectAccess).not.toHaveBeenCalled();
+    });
+  });
+
+  // Rule ids are not secrets (X-Pipeline-Log-Id, logs, exports), and ApiKeyGuard
+  // only proves the caller has *a* credential on the instance. Every by-id route
+  // must therefore scope to the rule's own project, mirroring update/delete.
+  describe('project scoping of by-id routes', () => {
+    const outsider: CurrentUserData = { id: 'outsider', email: 'o@example.com', role: 'user' };
+    const forbidden = new ForbiddenException('You do not have access to this project');
+
+    const pipelineRule = () =>
+      createMockRule({
+        proxyType: 'pipeline' as const,
+        pipelineConfig: {
+          name: 'Test Pipeline',
+          steps: [{ id: 'step-1', handlerType: 'response_handler', config: {}, isEnabled: true }],
+        },
+      });
+
+    beforeEach(() => {
+      mockProxyRulesService.getRuleById.mockResolvedValue(createMockRule());
+      mockPermissionsService.requireProjectAccess.mockRejectedValue(forbidden);
+    });
+
+    it('GET :id refuses a caller with no role on the project', async () => {
+      await expect(controller.getRule('rule-1', outsider)).rejects.toThrow(ForbiddenException);
+      expect(mockPermissionsService.requireProjectAccess).toHaveBeenCalledWith(
+        'project-1',
+        'outsider',
+        'user',
+        'viewer',
+        undefined,
+      );
+    });
+
+    it('GET :id/logs refuses a caller with no role on the project', async () => {
+      await expect(controller.getRuleLogs('rule-1', outsider)).rejects.toThrow(ForbiddenException);
+      expect(mockPermissionsService.requireProjectAccess).toHaveBeenCalledWith(
+        'project-1',
+        'outsider',
+        'user',
+        'viewer',
+        undefined,
+      );
+      expect(mockExecutionLogService.getByRuleId).not.toHaveBeenCalled();
+    });
+
+    it('GET :id/logs/count refuses a caller with no role on the project', async () => {
+      await expect(controller.getRuleLogCount('rule-1', outsider)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockPermissionsService.requireProjectAccess).toHaveBeenCalledWith(
+        'project-1',
+        'outsider',
+        'user',
+        'viewer',
+        undefined,
+      );
+      expect(mockExecutionLogService.getCountByRuleId).not.toHaveBeenCalled();
+    });
+
+    it('DELETE :id/logs refuses a caller with no role and requires contributor', async () => {
+      await expect(controller.clearRuleLogs('rule-1', outsider)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockPermissionsService.requireProjectAccess).toHaveBeenCalledWith(
+        'project-1',
+        'outsider',
+        'user',
+        'contributor',
+        undefined,
+      );
+      expect(mockExecutionLogService.deleteByRuleId).not.toHaveBeenCalled();
+    });
+
+    it('POST :id/test refuses a caller with no role and requires contributor', async () => {
+      mockProxyRulesService.getRuleById.mockResolvedValue(pipelineRule());
+
+      await expect(
+        controller.testPipelineRule('rule-1', {}, outsider, { file: undefined } as any),
+      ).rejects.toThrow(ForbiddenException);
+      expect(mockPermissionsService.requireProjectAccess).toHaveBeenCalledWith(
+        'project-1',
+        'outsider',
+        'user',
+        'contributor',
+        undefined,
+      );
+      expect(mockPipelineExecutionService.executePipelineWithDebug).not.toHaveBeenCalled();
+    });
+
+    it('forwards the API key project scope so a key minted for another project is refused', async () => {
+      const scopedKey: CurrentUserData = {
+        id: 'user-1',
+        role: 'user',
+        apiKeyProjectId: 'project-b',
+      };
+      mockPermissionsService.requireProjectAccess.mockRejectedValue(
+        new ForbiddenException('API key is not authorized for this project'),
+      );
+
+      await expect(controller.getRuleLogs('rule-1', scopedKey)).rejects.toThrow(ForbiddenException);
+      expect(mockPermissionsService.requireProjectAccess).toHaveBeenCalledWith(
+        'project-1',
+        'user-1',
+        'user',
+        'viewer',
+        'project-b',
+      );
+    });
+
+    it('GET :id/logs/count 404s on an unknown id without consulting permissions', async () => {
+      mockProxyRulesService.getRuleById.mockResolvedValue(null);
+
+      await expect(controller.getRuleLogCount('missing', mockUser)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockPermissionsService.requireProjectAccess).not.toHaveBeenCalled();
+      expect(mockExecutionLogService.getCountByRuleId).not.toHaveBeenCalled();
+    });
+
+    it('serves logs, count and clear to an authorized caller', async () => {
+      mockPermissionsService.requireProjectAccess.mockResolvedValue(undefined);
+
+      await controller.getRuleLogs('rule-1', mockUser, '2', '50');
+      expect(mockExecutionLogService.getByRuleId).toHaveBeenCalledWith('rule-1', 2, 50);
+
+      await expect(controller.getRuleLogCount('rule-1', mockUser)).resolves.toEqual({
+        count: 0,
+      });
+
+      await expect(controller.clearRuleLogs('rule-1', mockUser)).resolves.toEqual({
+        success: true,
+      });
+      expect(mockExecutionLogService.deleteByRuleId).toHaveBeenCalledWith('rule-1');
     });
   });
 
@@ -171,10 +331,7 @@ describe('ProxyRulesController', () => {
         ...overrides,
       });
 
-    const mockRuleSet = { id: 'rule-set-1', projectId: 'project-1' };
-
     beforeEach(() => {
-      mockProxyRulesService.getRuleSetById = jest.fn().mockResolvedValue(mockRuleSet);
       mockPipelineExecutionService.executePipelineWithDebug.mockResolvedValue({
         success: true,
         response: { status: 200, body: {} },

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.ts
@@ -60,18 +60,56 @@ export class ProxyRulesController {
     @Inject(forwardRef(() => ProjectsService))
     private readonly projectsService: ProjectsService,
     private readonly userGroupsService: UserGroupsService,
+    private readonly permissionsService: PermissionsService,
   ) {}
+
+  /**
+   * Load a rule by id and require that the caller has `level` access to the
+   * project that owns it.
+   *
+   * `ApiKeyGuard` only proves the caller has *some* session or API key on the
+   * instance; rule ids are not secrets (they surface in X-Pipeline-Log-Id,
+   * logs, exports), so by-id routes must scope to the rule's own project the
+   * same way ProxyRulesService.update/delete do. Unknown ids 404 before any
+   * permission check so the response shape matches the sibling routes.
+   */
+  private async resolveRuleForUser(
+    id: string,
+    user: CurrentUserData,
+    level: 'viewer' | 'contributor',
+  ): Promise<{
+    rule: NonNullable<Awaited<ReturnType<ProxyRulesService['getRuleById']>>>;
+    ruleSet: NonNullable<Awaited<ReturnType<ProxyRulesService['getRuleSetById']>>>;
+  }> {
+    const rule = await this.proxyRulesService.getRuleById(id);
+    if (!rule) {
+      throw new NotFoundException(`Proxy rule ${id} not found`);
+    }
+    const ruleSet = await this.proxyRulesService.getRuleSetById(rule.ruleSetId);
+    if (!ruleSet) {
+      throw new NotFoundException(`Rule set ${rule.ruleSetId} not found`);
+    }
+    await this.permissionsService.requireProjectAccess(
+      ruleSet.projectId,
+      user.id,
+      user.role,
+      level,
+      user.apiKeyProjectId,
+    );
+    return { rule, ruleSet };
+  }
 
   @Get(':id')
   @ApiOperation({ summary: 'Get a specific proxy rule' })
   @ApiParam({ name: 'id', type: 'string' })
   @ApiResponse({ status: 200, description: 'Proxy rule details', type: ProxyRuleResponseDto })
+  @ApiResponse({ status: 403, description: "Not authorized for the rule's project" })
   @ApiResponse({ status: 404, description: 'Rule not found' })
-  async getRule(@Param('id', ParseUUIDPipe) id: string): Promise<ProxyRuleResponseDto> {
-    const rule = await this.proxyRulesService.getRuleById(id);
-    if (!rule) {
-      throw new NotFoundException(`Proxy rule ${id} not found`);
-    }
+  async getRule(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: CurrentUserData,
+  ): Promise<ProxyRuleResponseDto> {
+    const { rule } = await this.resolveRuleForUser(id, user, 'viewer');
     return rule as ProxyRuleResponseDto;
   }
 
@@ -115,15 +153,15 @@ export class ProxyRulesController {
   @ApiOperation({ summary: 'List pipeline execution logs for a rule' })
   @ApiParam({ name: 'id', type: 'string' })
   @ApiResponse({ status: 200, description: 'Paginated execution logs' })
+  @ApiResponse({ status: 403, description: "Not authorized for the rule's project" })
+  @ApiResponse({ status: 404, description: 'Rule not found' })
   async getRuleLogs(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: CurrentUserData,
     @Query('page') page?: string,
     @Query('pageSize') pageSize?: string,
   ) {
-    const rule = await this.proxyRulesService.getRuleById(id);
-    if (!rule) {
-      throw new NotFoundException(`Proxy rule ${id} not found`);
-    }
+    await this.resolveRuleForUser(id, user, 'viewer');
     return this.executionLogService.getByRuleId(
       id,
       page ? parseInt(page, 10) : 1,
@@ -135,7 +173,13 @@ export class ProxyRulesController {
   @ApiOperation({ summary: 'Get log count for a rule' })
   @ApiParam({ name: 'id', type: 'string' })
   @ApiResponse({ status: 200, description: 'Log count' })
-  async getRuleLogCount(@Param('id', ParseUUIDPipe) id: string) {
+  @ApiResponse({ status: 403, description: "Not authorized for the rule's project" })
+  @ApiResponse({ status: 404, description: 'Rule not found' })
+  async getRuleLogCount(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: CurrentUserData,
+  ) {
+    await this.resolveRuleForUser(id, user, 'viewer');
     return { count: await this.executionLogService.getCountByRuleId(id) };
   }
 
@@ -143,14 +187,14 @@ export class ProxyRulesController {
   @ApiOperation({ summary: 'Clear all execution logs for a rule' })
   @ApiParam({ name: 'id', type: 'string' })
   @ApiResponse({ status: 200, description: 'Logs cleared' })
+  @ApiResponse({ status: 403, description: "Not authorized for the rule's project" })
+  @ApiResponse({ status: 404, description: 'Rule not found' })
   async clearRuleLogs(
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser() user: CurrentUserData,
   ) {
-    const rule = await this.proxyRulesService.getRuleById(id);
-    if (!rule) {
-      throw new NotFoundException(`Proxy rule ${id} not found`);
-    }
+    // Destructive: same level as PATCH/DELETE on the rule itself.
+    await this.resolveRuleForUser(id, user, 'contributor');
     await this.executionLogService.deleteByRuleId(id);
     return { success: true };
   }
@@ -165,6 +209,7 @@ export class ProxyRulesController {
     type: PipelineTestResultDto,
   })
   @ApiResponse({ status: 400, description: 'Rule is not a pipeline type' })
+  @ApiResponse({ status: 403, description: "Not authorized for the rule's project" })
   @ApiResponse({ status: 404, description: 'Rule not found' })
   async testPipelineRule(
     @Param('id', ParseUUIDPipe) id: string,
@@ -184,19 +229,12 @@ export class ProxyRulesController {
     } else {
       dto = body;
     }
-    const rule = await this.proxyRulesService.getRuleById(id);
-    if (!rule) {
-      throw new NotFoundException(`Proxy rule ${id} not found`);
-    }
+    // Running a rule executes it with the owning project's context, so it is
+    // a contributor-level action like editing the rule (PATCH :id).
+    const { rule, ruleSet } = await this.resolveRuleForUser(id, user, 'contributor');
 
     if (rule.proxyType !== 'pipeline' || !rule.pipelineConfig) {
       throw new BadRequestException('This endpoint only works for pipeline-type proxy rules');
-    }
-
-    // Get the rule set to find the project ID
-    const ruleSet = await this.proxyRulesService.getRuleSetById(rule.ruleSetId);
-    if (!ruleSet) {
-      throw new NotFoundException('Rule set not found');
     }
 
     // Build a pipeline-like object from the proxy rule's pipeline config


### PR DESCRIPTION
Closes #718

## Summary
Five routes under `/api/proxy-rules/:id` (get rule, list logs, count logs, clear logs, test rule) only checked that the caller had *some* session or API key on the instance, not that they belonged to the project owning the rule. Anyone who learned a rule's UUID — and they leak via `X-Pipeline-Log-Id`, logs and rules-as-code exports — could read another project's rule config (including decrypted header config), read or wipe its execution logs, or run its pipeline. These routes now resolve the rule's project and enforce membership the same way editing and deleting a rule already did. Members of the project see no difference; cross-project callers get `403`.

## Behaviour changes
- `GET /api/proxy-rules/:id`, `GET :id/logs`, `GET :id/logs/count`: before → any authenticated caller got `200`; after → `403` unless the caller has at least `viewer` on the rule's project (system admins and project-scoped API keys for that project still pass).
- `DELETE /api/proxy-rules/:id/logs`, `POST /api/proxy-rules/:id/test`: before → any authenticated caller; after → `403` unless `contributor` or higher, matching `PATCH :id` / `DELETE :id`.
- `GET :id/logs/count`: before → `{ count: 0 }` for an unknown id (never loaded the rule); after → `404`, consistent with its siblings.
- `POST :id/test` on a non-pipeline rule: the project check now runs before the "not a pipeline rule" `400`, so an outsider gets `403` rather than learning the rule's type.
- Additive: `403` responses documented in Swagger for all five routes. No request/response shape changes.

## Why
This is the remaining backlog of the gap #717 closed for `GET /api/pipeline-logs/:logId`: `ApiKeyGuard` alone makes a by-id lookup instance-wide, and `ProxyRulesService.getRuleById` is a bare `WHERE id = ?`. The write paths (`update`/`delete`) already resolved the rule set's `projectId` and called `requireProjectAccess`, so this reuses exactly that model at the same `contributor` level for the destructive/executing routes and `viewer` for reads. Unknown ids still `404` before any permission check so the response shape does not depend on the caller.

## What changed
- **backend** — `apps/backend/src/proxy-rules/proxy-rules.controller.ts`: inject `PermissionsService`; new private `resolveRuleForUser(id, user, level)` (rule → rule set → `requireProjectAccess`); all five routes call it and take `@CurrentUser()`. `testPipelineRule`'s existing rule-set lookup is folded into the helper.
- **tests** — `apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts`: `PermissionsService` mock wired into the test module; one `403` case per route asserting the project id and level passed; API-key project scope forwarded; `logs/count` 404 on unknown id; authorized happy path for logs/count/clear.

## Compatibility
- **API contract:** additive only — no fields, params or endpoints removed; the CLI (`packages/cli`) and frontend (`proxyRulesApi.ts`) call these routes with the same shapes. The only observable change is cross-project requests going from `200` to `403`, which is the security fix.
- **Migrations / env vars / nginx / storage layout:** untouched.
- **Pipeline / proxy-rule semantics:** no change to how stored rules execute; only who may hit the management routes.

## Verification
- `pnpm --filter backend exec tsc --noEmit` → exit 0
- `pnpm --filter frontend exec tsc --noEmit` → exit 0
- `cd apps/backend && pnpm test -- proxy-rules.controller.spec` → 1 suite, 24 tests passed (15 existing + 9 new)
- `pnpm --filter backend format:check` and `pnpm --filter frontend format:check` → "All matched files use Prettier code style!"

## Out of scope / follow-ups
- `GET /api/proxy-rules/:id` still returns the decrypted `headerConfig` to any project viewer; whether secrets should require `contributor` is a product call and not changed here.
- `ProxyRulesService.getRuleById` remains an unscoped lookup for internal callers (the proxy execution path needs it); the scoping lives at the controller edge, consistent with #717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7xFduepv6vrYu3KeppnhP
