### PR TITLE
feat(proxy-rules): adopt additive schema fields on sync (opt-in, owner-scoped)

### DIFF
--- a/apps/backend/drizzle/0046_blue_cloak.sql
+++ b/apps/backend/drizzle/0046_blue_cloak.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "pipeline_schemas" ADD COLUMN "source" jsonb;

--- a/apps/backend/drizzle/meta/0046_snapshot.json
+++ b/apps/backend/drizzle/meta/0046_snapshot.json
@@ -1,0 +1,7449 @@
+{
+  "id": "0b767d87-32b3-4b36-879e-5080d6fa79ee",
+  "prevId": "2dd4b81c-8cf6-41a4-b688-7e3a466b9a1c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alias_proxy_rule_sets": {
+      "name": "alias_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alias_proxy_rule_sets_alias_ruleset_unique": {
+          "name": "alias_proxy_rule_sets_alias_ruleset_unique",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_alias_id_idx": {
+          "name": "alias_proxy_rule_sets_alias_id_idx",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_rule_set_id_idx": {
+          "name": "alias_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk": {
+          "name": "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "deployment_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_project_id_idx": {
+          "name": "api_keys_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_path": {
+          "name": "original_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_number": {
+          "name": "workflow_run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'commits'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_project_id_idx": {
+          "name": "assets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_type_idx": {
+          "name": "assets_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_path_idx": {
+          "name": "assets_project_commit_path_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_branch_idx": {
+          "name": "assets_project_branch_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_idx": {
+          "name": "assets_project_commit_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_created_at_idx": {
+          "name": "assets_project_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_committed_at_idx": {
+          "name": "assets_project_committed_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_path_idx": {
+          "name": "assets_deployment_path_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_id_idx": {
+          "name": "assets_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_size_idx": {
+          "name": "assets_deployment_size_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_uploaded_by_users_id_fk": {
+          "name": "assets_uploaded_by_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist_entries": {
+      "name": "blocklist_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prefix'"
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklist_entries_blocklist_id_idx": {
+          "name": "blocklist_entries_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocklist_entries_unique": {
+          "name": "blocklist_entries_unique",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocklist_entries_blocklist_id_blocklists_id_fk": {
+          "name": "blocklist_entries_blocklist_id_blocklists_id_fk",
+          "tableFrom": "blocklist_entries",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklists": {
+      "name": "blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklists_name_unique": {
+          "name": "blocklists_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cache_rules": {
+      "name": "cache_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_max_age": {
+          "name": "browser_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "cdn_max_age": {
+          "name": "cdn_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stale_while_revalidate": {
+          "name": "stale_while_revalidate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immutable": {
+          "name": "immutable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cacheability": {
+          "name": "cacheability",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cache_rules_project_pattern_unique": {
+          "name": "cache_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_id_idx": {
+          "name": "cache_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_priority_idx": {
+          "name": "cache_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cache_rules_project_id_projects_id_fk": {
+          "name": "cache_rules_project_id_projects_id_fk",
+          "tableFrom": "cache_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_aliases": {
+      "name": "deployment_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_preview": {
+          "name": "is_auto_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployment_aliases_project_alias_unique": {
+          "name": "deployment_aliases_project_alias_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_project_id_idx": {
+          "name": "deployment_aliases_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_alias_unique": {
+          "name": "deployment_aliases_repository_alias_unique",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_idx": {
+          "name": "deployment_aliases_repository_idx",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_commit_sha_idx": {
+          "name": "deployment_aliases_commit_sha_idx",
+          "columns": [
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_deployment_id_idx": {
+          "name": "deployment_aliases_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_aliases_project_id_projects_id_fk": {
+          "name": "deployment_aliases_project_id_projects_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_blocklists": {
+      "name": "domain_blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_blocklists_domain_blocklist_unique": {
+          "name": "domain_blocklists_domain_blocklist_unique",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_blocklists_domain_mapping_id_idx": {
+          "name": "domain_blocklists_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_blocklists_blocklist_id_idx": {
+          "name": "domain_blocklists_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_blocklists_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "domain_blocklists_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "domain_blocklists",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_blocklists_blocklist_id_blocklists_id_fk": {
+          "name": "domain_blocklists_blocklist_id_blocklists_id_fk",
+          "tableFrom": "domain_blocklists",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_mappings": {
+      "name": "domain_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_type": {
+          "name": "domain_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ssl_expires_at": {
+          "name": "ssl_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_verified": {
+          "name": "dns_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dns_verified_at": {
+          "name": "dns_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_renew_ssl": {
+          "name": "auto_renew_ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_renewed_at": {
+          "name": "ssl_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_status": {
+          "name": "ssl_renewal_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_error": {
+          "name": "ssl_renewal_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sticky_sessions_enabled": {
+          "name": "sticky_sessions_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sticky_session_duration": {
+          "name": "sticky_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 86400
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_mappings_project_id_idx": {
+          "name": "domain_mappings_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_domain_idx": {
+          "name": "domain_mappings_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_is_active_idx": {
+          "name": "domain_mappings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_mappings_project_id_projects_id_fk": {
+          "name": "domain_mappings_project_id_projects_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_mappings_created_by_users_id_fk": {
+          "name": "domain_mappings_created_by_users_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_mappings_domain_unique": {
+          "name": "domain_mappings_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_redirects": {
+      "name": "domain_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_domain": {
+          "name": "source_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_domain_id": {
+          "name": "target_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_redirects_target_domain_id_idx": {
+          "name": "domain_redirects_target_domain_id_idx",
+          "columns": [
+            {
+              "expression": "target_domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_redirects_source_domain_idx": {
+          "name": "domain_redirects_source_domain_idx",
+          "columns": [
+            {
+              "expression": "source_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_redirects_target_domain_id_domain_mappings_id_fk": {
+          "name": "domain_redirects_target_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "target_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_redirects_created_by_users_id_fk": {
+          "name": "domain_redirects_created_by_users_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_redirects_source_domain_unique": {
+          "name": "domain_redirects_source_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_rules": {
+      "name": "domain_traffic_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_key": {
+          "name": "condition_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_value": {
+          "name": "condition_value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_rules_domain_id_idx": {
+          "name": "domain_traffic_rules_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_traffic_rules_domain_id_priority_idx": {
+          "name": "domain_traffic_rules_domain_id_priority_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_rules_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_rules_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_rules",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_weights": {
+      "name": "domain_traffic_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_weights_domain_id_idx": {
+          "name": "domain_traffic_weights_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_weights_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_weights_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_weights",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_traffic_weights_domain_alias_unique": {
+          "name": "domain_traffic_weights_domain_alias_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain_id",
+            "alias"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flags_key_idx": {
+          "name": "feature_flags_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ffmpeg_executor_settings": {
+      "name": "ffmpeg_executor_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "local_enabled": {
+          "name": "local_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "remote_enabled": {
+          "name": "remote_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "remote_connection_id": {
+          "name": "remote_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_executor": {
+          "name": "default_executor",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ffmpeg_executor_settings_remote_connection_id_remote_connections_id_fk": {
+          "name": "ffmpeg_executor_settings_remote_connection_id_remote_connections_id_fk",
+          "tableFrom": "ffmpeg_executor_settings",
+          "tableTo": "remote_connections",
+          "columnsFrom": [
+            "remote_connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_integration_credentials": {
+      "name": "google_integration_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured": {
+          "name": "configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "google_integration_credentials_service_unique": {
+          "name": "google_integration_credentials_service_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installed_apps": {
+      "name": "installed_apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_set_ids": {
+          "name": "rule_set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "schema_ids": {
+          "name": "schema_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "bundle_sha256": {
+          "name": "bundle_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'installing'"
+        },
+        "created_resources": {
+          "name": "created_resources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "installed_by": {
+          "name": "installed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "installed_apps_project_id_idx": {
+          "name": "installed_apps_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "installed_apps_project_id_projects_id_fk": {
+          "name": "installed_apps_project_id_projects_id_fk",
+          "tableFrom": "installed_apps",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "installed_apps_installed_by_users_id_fk": {
+          "name": "installed_apps_installed_by_users_id_fk",
+          "tableFrom": "installed_apps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "installed_apps_app_project_unique": {
+          "name": "installed_apps_app_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oidc_providers_provider_id_unique": {
+          "name": "oidc_providers_provider_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rule_executions": {
+      "name": "onboarding_rule_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rule_executions_user_idx": {
+          "name": "onboarding_rule_executions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_rule_idx": {
+          "name": "onboarding_rule_executions_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_executed_at_idx": {
+          "name": "onboarding_rule_executions_executed_at_idx",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_status_idx": {
+          "name": "onboarding_rule_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rule_executions_rule_id_onboarding_rules_id_fk": {
+          "name": "onboarding_rule_executions_rule_id_onboarding_rules_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "onboarding_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "onboarding_rule_executions_user_id_users_id_fk": {
+          "name": "onboarding_rule_executions_user_id_users_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rules": {
+      "name": "onboarding_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_signup'"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rules_enabled_trigger_idx": {
+          "name": "onboarding_rules_enabled_trigger_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rules_priority_idx": {
+          "name": "onboarding_rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rules_created_by_users_id_fk": {
+          "name": "onboarding_rules_created_by_users_id_fk",
+          "tableFrom": "onboarding_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_preferences": {
+      "name": "path_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spa_mode": {
+          "name": "spa_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_path_preferences_project_id": {
+          "name": "idx_path_preferences_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_preferences_project_id_projects_id_fk": {
+          "name": "path_preferences_project_id_projects_id_fk",
+          "tableFrom": "path_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "path_preferences_project_filepath_unique": {
+          "name": "path_preferences_project_filepath_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "filepath"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_redirects": {
+      "name": "path_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'100'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "path_redirects_domain_mapping_id_idx": {
+          "name": "path_redirects_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "path_redirects_source_path_idx": {
+          "name": "path_redirects_source_path_idx",
+          "columns": [
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_redirects_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "path_redirects_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "path_redirects_created_by_users_id_fk": {
+          "name": "path_redirects_created_by_users_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_token": {
+          "name": "upload_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_token_idx": {
+          "name": "pending_uploads_token_idx",
+          "columns": [
+            {
+              "expression": "upload_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_project_idx": {
+          "name": "pending_uploads_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_project_id_projects_id_fk": {
+          "name": "pending_uploads_project_id_projects_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_uploaded_by_users_id_fk": {
+          "name": "pending_uploads_uploaded_by_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_uploads_upload_token_unique": {
+          "name": "pending_uploads_upload_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data_embeddings": {
+      "name": "pipeline_data_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_data_id": {
+          "name": "pipeline_data_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_embeddings_data_id_idx": {
+          "name": "pipeline_data_embeddings_data_id_idx",
+          "columns": [
+            {
+              "expression": "pipeline_data_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_embeddings_schema_field_idx": {
+          "name": "pipeline_data_embeddings_schema_field_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk": {
+          "name": "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_data",
+          "columnsFrom": [
+            "pipeline_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data": {
+      "name": "pipeline_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_project_id_idx": {
+          "name": "pipeline_data_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_schema_id_idx": {
+          "name": "pipeline_data_schema_id_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_created_at_idx": {
+          "name": "pipeline_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_project_id_projects_id_fk": {
+          "name": "pipeline_data_project_id_projects_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_created_by_users_id_fk": {
+          "name": "pipeline_data_created_by_users_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_execution_logs": {
+      "name": "pipeline_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_id": {
+          "name": "proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps_count": {
+          "name": "steps_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_step": {
+          "name": "error_step",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_meta": {
+          "name": "request_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_exec_logs_rule_created_idx": {
+          "name": "pipeline_exec_logs_rule_created_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_project_idx": {
+          "name": "pipeline_exec_logs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_created_idx": {
+          "name": "pipeline_exec_logs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_execution_logs_project_id_projects_id_fk": {
+          "name": "pipeline_execution_logs_project_id_projects_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schedules": {
+      "name": "pipeline_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_proxy_rule_id": {
+          "name": "target_proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schedules_project_id_idx": {
+          "name": "pipeline_schedules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_schedules_target_proxy_rule_id_idx": {
+          "name": "pipeline_schedules_target_proxy_rule_id_idx",
+          "columns": [
+            {
+              "expression": "target_proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_schedules_enabled_next_run_idx": {
+          "name": "pipeline_schedules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schedules_project_id_projects_id_fk": {
+          "name": "pipeline_schedules_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schedules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_schedules_target_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_schedules_target_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_schedules",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "target_proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schemas": {
+      "name": "pipeline_schemas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schemas_project_id_idx": {
+          "name": "pipeline_schemas_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schemas_project_id_projects_id_fk": {
+          "name": "pipeline_schemas_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schemas",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pipeline_schemas_project_name_unique": {
+          "name": "pipeline_schemas_project_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.primary_content": {
+      "name": "primary_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "www_enabled": {
+          "name": "www_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'redirect-to-www'"
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "primary_content_project_id_projects_id_fk": {
+          "name": "primary_content_project_id_projects_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "primary_content_configured_by_users_id_fk": {
+          "name": "primary_content_configured_by_users_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_default_proxy_rule_sets": {
+      "name": "project_default_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_default_proxy_rule_sets_project_ruleset_unique": {
+          "name": "project_default_proxy_rule_sets_project_ruleset_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_project_id_idx": {
+          "name": "project_default_proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_rule_set_id_idx": {
+          "name": "project_default_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_default_proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "project_default_proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite_links": {
+      "name": "project_invite_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guest'"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invite_links_project_id_idx": {
+          "name": "project_invite_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_token_idx": {
+          "name": "project_invite_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_is_active_idx": {
+          "name": "project_invite_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_links_project_id_projects_id_fk": {
+          "name": "project_invite_links_project_id_projects_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_links_created_by_users_id_fk": {
+          "name": "project_invite_links_created_by_users_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_links_token_unique": {
+          "name": "project_invite_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_group_permissions": {
+      "name": "project_group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_group_permissions_project_idx": {
+          "name": "project_group_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_permissions_group_idx": {
+          "name": "project_group_permissions_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_permissions_project_id_projects_id_fk": {
+          "name": "project_group_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_group_id_user_groups_id_fk": {
+          "name": "project_group_permissions_group_id_user_groups_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_granted_by_users_id_fk": {
+          "name": "project_group_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_group_permissions_unique": {
+          "name": "project_group_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "group_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_permissions": {
+      "name": "project_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_permissions_project_idx": {
+          "name": "project_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_permissions_user_idx": {
+          "name": "project_permissions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_permissions_project_id_projects_id_fk": {
+          "name": "project_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_user_id_users_id_fk": {
+          "name": "project_permissions_user_id_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_granted_by_users_id_fk": {
+          "name": "project_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_permissions_unique": {
+          "name": "project_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_secrets": {
+      "name": "project_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_secrets_project_name_unique": {
+          "name": "project_secrets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_secrets_project_id_idx": {
+          "name": "project_secrets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_secrets_project_id_projects_id_fk": {
+          "name": "project_secrets_project_id_projects_id_fk",
+          "tableFrom": "project_secrets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_found'"
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authenticated'"
+        },
+        "allow_public_signup": {
+          "name": "allow_public_signup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_providers": {
+          "name": "ai_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_services": {
+          "name": "ai_services",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_proxy_rule_set_id": {
+          "name": "default_proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_created_by_idx": {
+          "name": "projects_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_owner_idx": {
+          "name": "projects_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_owner_name_unique": {
+          "name": "projects_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_set_revisions": {
+      "name": "proxy_rule_set_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_set_revisions_set_created_idx": {
+          "name": "proxy_rule_set_revisions_set_created_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_set_revisions_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rule_set_revisions_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rule_set_revisions",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_sets": {
+      "name": "proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_sets_project_name_unique": {
+          "name": "proxy_rule_sets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_project_id_idx": {
+          "name": "proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_environment_idx": {
+          "name": "proxy_rule_sets_environment_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rules": {
+      "name": "proxy_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "methods": {
+          "name": "methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strip_prefix": {
+          "name": "strip_prefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "preserve_host": {
+          "name": "preserve_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forward_cookies": {
+          "name": "forward_cookies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "header_config": {
+          "name": "header_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_transform": {
+          "name": "auth_transform",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_rewrite": {
+          "name": "internal_rewrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proxy_type": {
+          "name": "proxy_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external_proxy'"
+        },
+        "email_handler_config": {
+          "name": "email_handler_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "debug_enabled": {
+          "name": "debug_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rules_rule_set_path_method_unique": {
+          "name": "proxy_rules_rule_set_path_method_unique",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_id_idx": {
+          "name": "proxy_rules_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_order_idx": {
+          "name": "proxy_rules_rule_set_order_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_proxy_type_idx": {
+          "name": "proxy_rules_proxy_type_idx",
+          "columns": [
+            {
+              "expression": "proxy_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rules_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rules_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rules",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_connections": {
+      "name": "remote_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google_id_token'"
+        },
+        "credential_encrypted": {
+          "name": "credential_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_inflight": {
+          "name": "max_inflight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "health_path": {
+          "name": "health_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/health'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "remote_connections_name_unique": {
+          "name": "remote_connections_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_header_rules": {
+      "name": "response_header_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_policy": {
+          "name": "frame_policy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sameorigin'"
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_header_rules_project_pattern_unique": {
+          "name": "response_header_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_id_idx": {
+          "name": "response_header_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_priority_idx": {
+          "name": "response_header_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "response_header_rules_project_id_projects_id_fk": {
+          "name": "response_header_rules_project_id_projects_id_fk",
+          "tableFrom": "response_header_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_logs": {
+      "name": "retention_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_count": {
+          "name": "asset_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "freed_bytes": {
+          "name": "freed_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_partial": {
+          "name": "is_partial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_logs_project_id_idx": {
+          "name": "retention_logs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_rule_id_idx": {
+          "name": "retention_logs_rule_id_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_deleted_at_idx": {
+          "name": "retention_logs_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_project_deleted_at_idx": {
+          "name": "retention_logs_project_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_logs_project_id_projects_id_fk": {
+          "name": "retention_logs_project_id_projects_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retention_logs_rule_id_retention_rules_id_fk": {
+          "name": "retention_logs_rule_id_retention_rules_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "retention_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_rules": {
+      "name": "retention_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_pattern": {
+          "name": "branch_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_branches": {
+          "name": "exclude_branches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keep_with_alias": {
+          "name": "keep_with_alias",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "keep_minimum": {
+          "name": "keep_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "path_patterns": {
+          "name": "path_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_mode": {
+          "name": "path_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_summary": {
+          "name": "last_run_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_rules_project_id_idx": {
+          "name": "retention_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_next_run_idx": {
+          "name": "retention_rules_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_enabled_next_run_idx": {
+          "name": "retention_rules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_rules_project_id_projects_id_fk": {
+          "name": "retention_rules_project_id_projects_id_fk",
+          "tableFrom": "retention_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "share_links_project_id_idx": {
+          "name": "share_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_domain_mapping_id_idx": {
+          "name": "share_links_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_token_idx": {
+          "name": "share_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_is_active_idx": {
+          "name": "share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_project_id_projects_id_fk": {
+          "name": "share_links_project_id_projects_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "share_links_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_created_by_users_id_fk": {
+          "name": "share_links_created_by_users_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "share_links_token_unique": {
+          "name": "share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_challenges": {
+      "name": "ssl_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "base_domain": {
+          "name": "base_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_type": {
+          "name": "challenge_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_name": {
+          "name": "record_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_value": {
+          "name": "record_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_data": {
+          "name": "order_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authz_data": {
+          "name": "authz_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_authorization": {
+          "name": "key_authorization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_challenges_base_domain_idx": {
+          "name": "ssl_challenges_base_domain_idx",
+          "columns": [
+            {
+              "expression": "base_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_challenges_status_idx": {
+          "name": "ssl_challenges_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ssl_challenges_base_domain_unique": {
+          "name": "ssl_challenges_base_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "base_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_renewal_history": {
+      "name": "ssl_renewal_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_type": {
+          "name": "certificate_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_expires_at": {
+          "name": "new_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_renewal_history_domain_id_idx": {
+          "name": "ssl_renewal_history_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_renewal_history_created_at_idx": {
+          "name": "ssl_renewal_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssl_renewal_history_domain_id_domain_mappings_id_fk": {
+          "name": "ssl_renewal_history_domain_id_domain_mappings_id_fk",
+          "tableFrom": "ssl_renewal_history",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_settings": {
+      "name": "ssl_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_config": {
+      "name": "system_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_setup_complete": {
+          "name": "is_setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_config": {
+          "name": "storage_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_provider": {
+          "name": "email_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_config": {
+          "name": "email_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_configured": {
+          "name": "email_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "smtp_config": {
+          "name": "smtp_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_configured": {
+          "name": "smtp_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_config": {
+          "name": "cache_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwt_secret": {
+          "name": "jwt_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_salt": {
+          "name": "api_key_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_public_signups": {
+          "name": "allow_public_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "telemetry_enabled": {
+          "name": "telemetry_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "telemetry_last_sent": {
+          "name": "telemetry_last_sent",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_config": {
+          "name": "branding_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_ip_rollups": {
+      "name": "traffic_ip_rollups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_paths": {
+          "name": "sample_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "sample_user_agents": {
+          "name": "sample_user_agents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_ip_rollups_ip_unique": {
+          "name": "traffic_ip_rollups_ip_unique",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_request_count_idx": {
+          "name": "traffic_ip_rollups_request_count_idx",
+          "columns": [
+            {
+              "expression": "request_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_last_seen_idx": {
+          "name": "traffic_ip_rollups_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_requests": {
+      "name": "traffic_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_version": {
+          "name": "http_version",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referer": {
+          "name": "referer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_requests_timestamp_idx": {
+          "name": "traffic_requests_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_ip_idx": {
+          "name": "traffic_requests_ip_idx",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_status_idx": {
+          "name": "traffic_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_classification_idx": {
+          "name": "traffic_requests_classification_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_group_members": {
+      "name": "user_group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_members_group_idx": {
+          "name": "user_group_members_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_group_members_user_idx": {
+          "name": "user_group_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_group_members_group_id_user_groups_id_fk": {
+          "name": "user_group_members_group_id_user_groups_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_user_id_users_id_fk": {
+          "name": "user_group_members_user_id_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_added_by_users_id_fk": {
+          "name": "user_group_members_added_by_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_group_members_unique": {
+          "name": "user_group_members_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_groups_created_by_idx": {
+          "name": "user_groups_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_created_by_users_id_fk": {
+          "name": "user_groups_created_by_users_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_verified_at": {
+          "name": "oidc_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_invitations_email": {
+          "name": "idx_workspace_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_invitations_token": {
+          "name": "idx_workspace_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invitations_invited_by_users_id_fk": {
+          "name": "workspace_invitations_invited_by_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_accepted_user_id_users_id_fk": {
+          "name": "workspace_invitations_accepted_user_id_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitations_token_unique": {
+          "name": "workspace_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1787090149129,
       "tag": "0045_chubby_vampiro",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1788039854342,
+      "tag": "0046_blue_cloak",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema/pipeline-schemas.schema.ts
+++ b/apps/backend/src/db/schema/pipeline-schemas.schema.ts
@@ -50,6 +50,22 @@ export interface SchemaField {
 export type SchemaKind = 'upload' | 'chat' | 'state';
 
 /**
+ * Provenance of a schema that the rules-as-code sync created or adopted
+ * fields onto (bffless/ce#721). Mirrors `ProxyRuleSetSource` on rule sets:
+ * it records WHICH rule set (by name — the identity a sync works in) owns the
+ * schema, so a later sync of a *different* set that happens to bundle the
+ * same schema name can never write fields onto it. `null` means "not
+ * stamped": every schema that predates the column, and any schema created
+ * from the dashboard or the schema API.
+ */
+export interface PipelineSchemaSource {
+  /** Name of the rule set whose sync created (or first adopted fields onto) this schema. */
+  ruleSetName: string;
+  /** ISO timestamp of the sync that last wrote this stamp. */
+  syncedAt: string;
+}
+
+/**
  * Pipeline schemas table - defines data structures for pipeline data storage
  */
 export const pipelineSchemas = pgTable(
@@ -78,6 +94,12 @@ export const pipelineSchemas = pgTable(
      * upgrade and consumers fall back to their field-shape heuristics.
      */
     kind: varchar('kind', { length: 32 }).$type<SchemaKind>(),
+    /**
+     * Which rule-set sync owns this schema, when one does. Nullable on
+     * purpose: existing rows keep null, and the sync's field adoption
+     * (bffless/ce#721) falls back to reference-based ownership for them.
+     */
+    source: jsonb('source').$type<PipelineSchemaSource>(),
     createdAt: timestamp('created_at').notNull().defaultNow(),
     updatedAt: timestamp('updated_at').notNull().defaultNow(),
   },

--- a/apps/backend/src/pipelines/pipeline-schemas.service.ts
+++ b/apps/backend/src/pipelines/pipeline-schemas.service.ts
@@ -7,6 +7,8 @@ import {
   PipelineSchema,
   NewPipelineSchema,
   SchemaKind,
+  SchemaField,
+  PipelineSchemaSource,
 } from '../db/schema';
 import { PermissionsService } from '../permissions/permissions.service';
 import { CreatePipelineSchemaDto, UpdatePipelineSchemaDto } from './dto';
@@ -94,6 +96,10 @@ export class PipelineSchemasService {
     userId: string,
     userRole: string,
     apiKeyProjectId?: string | null,
+    // Internal-only (never read from the request DTO): the rules-as-code sync
+    // stamps which rule set created the schema so a later sync of a
+    // DIFFERENT set can't adopt fields onto it (bffless/ce#721).
+    source?: PipelineSchemaSource,
   ): Promise<PipelineSchema> {
     await this.permissionsService.requireProjectAccess(
       dto.projectId,
@@ -121,6 +127,7 @@ export class PipelineSchemasService {
         // Declared intent, never inferred — absent means "not declared", which
         // is what every pre-existing schema carries (bffless/ce#633).
         kind: dto.kind ?? null,
+        source: source ?? null,
       } as NewPipelineSchema)
       .returning();
 
@@ -144,6 +151,47 @@ export class PipelineSchemasService {
       .update(pipelineSchemas)
       .set({ kind, updatedAt: new Date() })
       .where(and(eq(pipelineSchemas.id, id), isNull(pipelineSchemas.kind)));
+  }
+
+  /**
+   * Append fields onto a schema — the rules-as-code sync's opt-in field
+   * adoption (bffless/ce#721). The caller has already established that
+   * `fields` is the live list plus new OPTIONAL fields only (planFieldAdoption)
+   * and that the syncing rule set owns the schema; this method is the guarded
+   * write.
+   *
+   * Optimistic: the UPDATE is conditioned on `version` still being
+   * `expectedVersion`, so two concurrent syncs can't clobber each other's
+   * read-modify-write of the field list. Returns the updated row, or `null`
+   * when the version moved underneath us (the caller reloads and re-plans).
+   * Bumps `version` like {@link update} does for a field change, and stamps
+   * `source` so ownership is recorded from the first adoption onwards.
+   */
+  async adoptFields(
+    id: string,
+    expectedVersion: number,
+    fields: SchemaField[],
+    source: PipelineSchemaSource,
+  ): Promise<PipelineSchema | null> {
+    const [updated] = await db
+      .update(pipelineSchemas)
+      .set({
+        fields: fields.map((f) => ({ ...f, required: f.required ?? false })),
+        version: expectedVersion + 1,
+        source,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(pipelineSchemas.id, id), eq(pipelineSchemas.version, expectedVersion)))
+      .returning();
+
+    if (updated) {
+      this.logger.log(
+        `Adopted fields onto schema ${id} for rule set "${source.ruleSetName}" ` +
+          `(now ${fields.length} fields, version ${expectedVersion} → ${updated.version})`,
+      );
+    }
+
+    return updated ?? null;
   }
 
   /**

--- a/apps/backend/src/proxy-rules/dto/sync-proxy-rule-set.dto.spec.ts
+++ b/apps/backend/src/proxy-rules/dto/sync-proxy-rule-set.dto.spec.ts
@@ -150,7 +150,7 @@ describe('SyncProxyRuleSetDto', () => {
           fields: [{ name: 'body', type: 'text', required: true }],
         },
       ],
-      options: { prune: true, dryRun: true, strictSchemas: true },
+      options: { prune: true, dryRun: true, strictSchemas: true, adoptFields: true },
       source: {
         repo: 'bffless/apps',
         path: 'apps/studio/.bffless/proxy-rules/studio',
@@ -159,6 +159,17 @@ describe('SyncProxyRuleSetDto', () => {
     });
 
     expect(await validate(dto)).toEqual([]);
+  });
+
+  it('rejects a non-boolean options.adoptFields', async () => {
+    const dto = plainToInstance(SyncProxyRuleSetDto, {
+      ruleSet: { name: 'studio' },
+      rules: [],
+      options: { adoptFields: 'yes' },
+    });
+
+    const errors = await validate(dto);
+    expect(errors.map((e) => e.property)).toContain('options');
   });
 
   it('rejects a nested rule with a forbidden targetUrl', async () => {

--- a/apps/backend/src/proxy-rules/dto/sync-proxy-rule-set.dto.ts
+++ b/apps/backend/src/proxy-rules/dto/sync-proxy-rule-set.dto.ts
@@ -150,6 +150,18 @@ export class SyncOptionsDto {
 
   @ApiPropertyOptional({
     description:
+      'Adopt purely additive schema changes (new optional fields only) onto a name-reused schema ' +
+      'that this rule set owns, instead of warning about them. Removed, retyped or newly-required ' +
+      'fields, and schemas owned by another rule set or the dashboard, keep the warn/strictSchemas ' +
+      'behaviour. Default: off (warn only).',
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  adoptFields?: boolean;
+
+  @ApiPropertyOptional({
+    description:
       'Resolve rules edited locally since this set was last synced by comparing against the most recent sync revision. ' +
       "'overwrite' (default) keeps two-way behaviour — the payload always wins, which is what rules-as-code CI wants. " +
       "'preserve' keeps the local edit and reports it, for app upgrades over a customized install.",
@@ -322,6 +334,14 @@ export class SyncSchemaResolutionDto {
       'kind is never rewritten.',
   })
   kindAdopted: boolean;
+
+  @ApiProperty({
+    type: [String],
+    description:
+      'Names of payload fields appended to the reused schema under options.adoptFields ' +
+      '(under dryRun: the fields that would be). Empty when nothing was adopted or the schema was created.',
+  })
+  fieldsAdopted: string[];
 }
 
 /**

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
@@ -105,6 +105,7 @@ describe('ProxyRuleSetsService', () => {
     getByProjectId: jest.fn(),
     create: jest.fn(),
     adoptKind: jest.fn(),
+    adoptFields: jest.fn(),
   };
 
   // Plain-object mock, per the brief: the DB-mock result slots must not change
@@ -677,6 +678,7 @@ describe('ProxyRuleSetsService', () => {
           targetSchemaId: 'existing-comments-id',
           fieldMismatch: false,
           kindAdopted: false,
+          fieldsAdopted: [],
         },
       ]);
       expect(result.warnings).toEqual([]);
@@ -699,6 +701,7 @@ describe('ProxyRuleSetsService', () => {
         targetSchemaId: 'existing-comments-id',
         fieldMismatch: true,
         kindAdopted: false,
+        fieldsAdopted: [],
       });
       expect(result.warnings).toEqual([
         'Schema "comments": field "body": type string (incoming) vs text (existing)',
@@ -749,6 +752,8 @@ describe('ProxyRuleSetsService', () => {
         'user-1',
         'admin',
         'project-1',
+        // No ruleSetName in these direct calls → no ownership stamp.
+        undefined,
       );
       expect(result.idMap.get('src-1')).toBe('created-brand-new');
       expect(result.resolutions).toEqual([
@@ -758,6 +763,7 @@ describe('ProxyRuleSetsService', () => {
           targetSchemaId: 'created-brand-new',
           fieldMismatch: false,
           kindAdopted: false,
+          fieldsAdopted: [],
         },
       ]);
       expect(result.warnings).toEqual([]);
@@ -777,6 +783,7 @@ describe('ProxyRuleSetsService', () => {
           targetSchemaId: null,
           fieldMismatch: false,
           kindAdopted: false,
+          fieldsAdopted: [],
         },
       ]);
       expect(result.idMap.has('src-1')).toBe(false);
@@ -806,6 +813,7 @@ describe('ProxyRuleSetsService', () => {
           targetSchemaId: 'existing-comments-id',
           fieldMismatch: false,
           kindAdopted: false,
+          fieldsAdopted: [],
         },
         {
           name: 'votes',
@@ -813,6 +821,7 @@ describe('ProxyRuleSetsService', () => {
           targetSchemaId: 'existing-votes-id',
           fieldMismatch: true,
           kindAdopted: false,
+          fieldsAdopted: [],
         },
         {
           name: 'brand-new',
@@ -820,6 +829,7 @@ describe('ProxyRuleSetsService', () => {
           targetSchemaId: 'created-brand-new',
           fieldMismatch: false,
           kindAdopted: false,
+          fieldsAdopted: [],
         },
       ]);
       expect(result.warnings).toEqual([
@@ -886,6 +896,7 @@ describe('ProxyRuleSetsService', () => {
           targetSchemaId: 'existing-comments-id',
           fieldMismatch: false,
           kindAdopted: false,
+          fieldsAdopted: [],
         },
       ]);
       expect(result.idMap.get('src-1')).toBe('existing-comments-id');
@@ -1566,6 +1577,7 @@ describe('ProxyRuleSetsService', () => {
           targetSchemaId: 'target-comments-id',
           fieldMismatch: false,
           kindAdopted: false,
+          fieldsAdopted: [],
         },
       ]);
       expect(result.created).toEqual([{ pathPattern: '/api/comments', method: 'GET' }]);
@@ -1605,6 +1617,7 @@ describe('ProxyRuleSetsService', () => {
           name: 'uploads',
           action: 'reuse',
           kindAdopted: true,
+          fieldsAdopted: [],
         });
         expect(result.warnings).toEqual([]);
       });
@@ -1666,8 +1679,414 @@ describe('ProxyRuleSetsService', () => {
           'user-1',
           'admin',
           'project-1',
+          // Stamped with the syncing set so a later sync can prove ownership (#721).
+          expect.objectContaining({ ruleSetName: 'api-backend' }),
         );
         expect(result.schemaResolutions[0]).toMatchObject({ action: 'create', kindAdopted: false });
+      });
+    });
+
+    /**
+     * bffless/ce#721 — a field added to a `*.schema.yaml` after the schema's
+     * first deploy used to be warn-only: the rule half of the change synced,
+     * the schema half was silently dropped, and the deploy was green. With
+     * `options.adoptFields` a PURELY ADDITIVE diff (new optional fields) on a
+     * schema THIS set owns is appended to the live schema. Everything else —
+     * removed/retyped/newly-required fields, schemas owned by another set or
+     * by the dashboard, adoptFields unset — keeps today's warn/strict path.
+     */
+    describe('schema field adoption', () => {
+      const liveFields = [
+        { name: 'id', type: 'string', required: true },
+        { name: 'status', type: 'string', required: false },
+      ];
+      const liveSchema = (overrides: Record<string, unknown> = {}) => ({
+        id: 'live-runs',
+        projectId: 'project-1',
+        name: 'workflow_runs',
+        kind: null,
+        version: 3,
+        fields: liveFields,
+        source: null,
+        ...overrides,
+      });
+      const ownedSchema = (overrides: Record<string, unknown> = {}) =>
+        liveSchema({
+          source: { ruleSetName: 'api-backend', syncedAt: '2026-08-01T00:00:00Z' },
+          ...overrides,
+        });
+
+      /** Payload schema = live fields + `unattended` (optional) unless overridden. */
+      const payloadSchema = (fields?: unknown[]) => ({
+        id: 'src-runs',
+        name: 'workflow_runs',
+        fields: fields ?? [...liveFields, { name: 'unattended', type: 'boolean', required: false }],
+      });
+      /** A rule that references the payload schema, so the set "uses" it. */
+      const referencingRule = (schemaId = 'src-runs') => ({
+        pathPattern: '/api/workflow/runs',
+        method: 'POST',
+        pipelineConfig: {
+          name: 'create-run',
+          steps: [{ handlerType: 'data_create', config: { schemaId } }],
+        },
+      });
+      const adoptDto = (overrides: Record<string, unknown> = {}) =>
+        syncDto({
+          rules: [referencingRule()],
+          schemas: [payloadSchema()],
+          options: { adoptFields: true },
+          ...overrides,
+        });
+
+      beforeEach(() => {
+        mockPipelineSchemasService.adoptFields.mockImplementation(
+          async (id: string, expectedVersion: number, fields: unknown[], source: unknown) => ({
+            ...liveSchema(),
+            id,
+            version: expectedVersion + 1,
+            fields,
+            source,
+          }),
+        );
+      });
+
+      it('adopts a new optional field onto a schema this set owns and reports it', async () => {
+        mockDb.__setResults([[mockProject], []]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([ownedSchema()]);
+
+        const result = await sync(adoptDto());
+
+        expect(mockPipelineSchemasService.adoptFields).toHaveBeenCalledTimes(1);
+        expect(mockPipelineSchemasService.adoptFields).toHaveBeenCalledWith(
+          'live-runs',
+          3,
+          [...liveFields, { name: 'unattended', type: 'boolean', required: false }],
+          expect.objectContaining({ ruleSetName: 'api-backend' }),
+        );
+        expect(result.schemaResolutions).toEqual([
+          {
+            name: 'workflow_runs',
+            action: 'reuse',
+            targetSchemaId: 'live-runs',
+            fieldMismatch: false,
+            kindAdopted: false,
+            fieldsAdopted: ['unattended'],
+          },
+        ]);
+        expect(result.warnings).toEqual([]);
+      });
+
+      it('keeps existing behaviour exactly when adoptFields is unset: warning, no write', async () => {
+        mockDb.__setResults([[mockProject], []]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([ownedSchema()]);
+
+        const result = await sync(adoptDto({ options: {} }));
+
+        expect(mockPipelineSchemasService.adoptFields).not.toHaveBeenCalled();
+        expect(result.schemaResolutions[0]).toMatchObject({
+          fieldMismatch: true,
+          fieldsAdopted: [],
+        });
+        expect(result.warnings).toEqual([
+          'Schema "workflow_runs": field "unattended" is only in the incoming definition',
+        ]);
+      });
+
+      it('dryRun: writes nothing and reports the would-be adoption', async () => {
+        mockDb.__setResults([[mockProject], []]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([ownedSchema()]);
+
+        const result = await sync(adoptDto({ options: { adoptFields: true, dryRun: true } }));
+
+        expect(mockPipelineSchemasService.adoptFields).not.toHaveBeenCalled();
+        expect(mockDb.transaction).not.toHaveBeenCalled();
+        expect(result.dryRun).toBe(true);
+        expect(result.schemaResolutions[0]).toMatchObject({
+          fieldMismatch: false,
+          fieldsAdopted: ['unattended'],
+        });
+        expect(result.warnings).toEqual([]);
+      });
+
+      it('satisfies strictSchemas: an adopted diff is no longer a mismatch', async () => {
+        mockDb.__setResults([[mockProject], []]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([ownedSchema()]);
+
+        const result = await sync(
+          adoptDto({ options: { adoptFields: true, strictSchemas: true } }),
+        );
+
+        expect(result.schemaResolutions[0].fieldsAdopted).toEqual(['unattended']);
+        expect(mockPipelineSchemasService.adoptFields).toHaveBeenCalledTimes(1);
+      });
+
+      it.each([
+        [
+          'a removed field',
+          [
+            { name: 'id', type: 'string', required: true },
+            { name: 'unattended', type: 'boolean' },
+          ],
+        ],
+        [
+          'a retyped field',
+          [...liveFields.map((f) => (f.name === 'status' ? { ...f, type: 'number' } : f))],
+        ],
+        [
+          'an optional field made required',
+          [...liveFields.map((f) => (f.name === 'status' ? { ...f, required: true } : f))],
+        ],
+        [
+          'a NEW required field',
+          [...liveFields, { name: 'unattended', type: 'boolean', required: true }],
+        ],
+      ])('never writes a non-additive diff (%s), even with adoptFields', async (_label, fields) => {
+        mockDb.__setResults([[mockProject], []]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([ownedSchema()]);
+
+        const result = await sync(adoptDto({ schemas: [payloadSchema(fields)] }));
+
+        expect(mockPipelineSchemasService.adoptFields).not.toHaveBeenCalled();
+        expect(result.schemaResolutions[0]).toMatchObject({
+          fieldMismatch: true,
+          fieldsAdopted: [],
+        });
+        expect(result.warnings.length).toBeGreaterThan(0);
+        expect(result.warnings.every((w) => w.startsWith('Schema "workflow_runs":'))).toBe(true);
+      });
+
+      it('non-additive diff under strictSchemas still fails, adoptFields or not', async () => {
+        mockDb.__setResults([[mockProject], []]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([ownedSchema()]);
+
+        await expect(
+          sync(
+            adoptDto({
+              schemas: [
+                payloadSchema([
+                  ...liveFields,
+                  { name: 'unattended', type: 'boolean', required: true },
+                ]),
+              ],
+              options: { adoptFields: true, strictSchemas: true },
+            }),
+          ),
+        ).rejects.toThrow('Schema field mismatch (strictSchemas)');
+        expect(mockPipelineSchemasService.adoptFields).not.toHaveBeenCalled();
+      });
+
+      it('refuses a schema owned by a different rule set and names the owner', async () => {
+        mockDb.__setResults([[mockProject], []]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([
+          ownedSchema({ source: { ruleSetName: 'other-app', syncedAt: '2026-08-01T00:00:00Z' } }),
+        ]);
+
+        const result = await sync(adoptDto());
+
+        expect(mockPipelineSchemasService.adoptFields).not.toHaveBeenCalled();
+        expect(result.schemaResolutions[0]).toMatchObject({
+          fieldMismatch: true,
+          fieldsAdopted: [],
+        });
+        expect(result.warnings).toEqual([
+          expect.stringContaining('not adopted — the schema is owned by rule set "other-app"'),
+          'Schema "workflow_runs": field "unattended" is only in the incoming definition',
+        ]);
+      });
+
+      it('a name-suffix preview set never adopts onto the production-owned schema', async () => {
+        mockDb.__setResults([[mockProject], []]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([ownedSchema()]);
+
+        const result = await sync(adoptDto({ ruleSet: { name: 'api-backend-pr-42' } }));
+
+        expect(mockPipelineSchemasService.adoptFields).not.toHaveBeenCalled();
+        expect(result.warnings[0]).toContain('owned by rule set "api-backend"');
+      });
+
+      it('refuses a bundled schema that no rule in the payload references', async () => {
+        mockDb.__setResults([[mockProject], []]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([ownedSchema()]);
+
+        const result = await sync(adoptDto({ rules: [baseRule()] }));
+
+        expect(mockPipelineSchemasService.adoptFields).not.toHaveBeenCalled();
+        expect(result.warnings[0]).toContain(
+          'not adopted — no rule in rule set "api-backend" references the schema',
+        );
+      });
+
+      describe('unstamped (legacy / dashboard-created) schema: ownership by references', () => {
+        const rulesReferencing = (schemaId: string) => [
+          {
+            id: 'r',
+            pathPattern: '/x',
+            method: null,
+            pipelineConfig: { steps: [{ handlerType: 'data_create', config: { schemaId } }] },
+          },
+        ];
+
+        it('adopts (and stamps) when this set is the only rule set referencing it', async () => {
+          mockDb.__setResults([[mockProject], []]);
+          mockPipelineSchemasService.getByProjectId.mockResolvedValue([liveSchema()]);
+          jest
+            .spyOn(service, 'listByProject')
+            .mockResolvedValue([
+              createMockRuleSet({ id: 'rule-set-1', name: 'api-backend' }),
+              createMockRuleSet({ id: 'rule-set-2', name: 'other-app' }),
+            ] as never);
+          mockProxyRulesService.getRulesByRuleSetId.mockImplementation(async (id: string) =>
+            id === 'rule-set-1' ? rulesReferencing('live-runs') : rulesReferencing('some-other'),
+          );
+
+          const result = await sync(adoptDto());
+
+          expect(mockPipelineSchemasService.adoptFields).toHaveBeenCalledWith(
+            'live-runs',
+            3,
+            expect.any(Array),
+            expect.objectContaining({ ruleSetName: 'api-backend' }),
+          );
+          expect(result.schemaResolutions[0].fieldsAdopted).toEqual(['unattended']);
+        });
+
+        it('refuses when another rule set also references it, naming that set', async () => {
+          mockDb.__setResults([[mockProject], []]);
+          mockPipelineSchemasService.getByProjectId.mockResolvedValue([liveSchema()]);
+          jest
+            .spyOn(service, 'listByProject')
+            .mockResolvedValue([
+              createMockRuleSet({ id: 'rule-set-1', name: 'api-backend' }),
+              createMockRuleSet({ id: 'rule-set-2', name: 'api-backend-pr-7' }),
+            ] as never);
+          mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue(
+            rulesReferencing('live-runs'),
+          );
+
+          const result = await sync(adoptDto());
+
+          expect(mockPipelineSchemasService.adoptFields).not.toHaveBeenCalled();
+          expect(result.warnings[0]).toContain('also referenced by rule set(s) "api-backend-pr-7"');
+          expect(result.warnings[0]).toContain('ownership is ambiguous');
+        });
+
+        it('refuses when only other rule sets reference it', async () => {
+          mockDb.__setResults([[mockProject], []]);
+          mockPipelineSchemasService.getByProjectId.mockResolvedValue([liveSchema()]);
+          jest
+            .spyOn(service, 'listByProject')
+            .mockResolvedValue([
+              createMockRuleSet({ id: 'rule-set-2', name: 'other-app' }),
+            ] as never);
+          mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue(
+            rulesReferencing('live-runs'),
+          );
+
+          const result = await sync(adoptDto());
+
+          expect(mockPipelineSchemasService.adoptFields).not.toHaveBeenCalled();
+          expect(result.warnings[0]).toContain(
+            'referenced by rule set(s) "other-app", not by "api-backend"',
+          );
+        });
+
+        it('refuses a dashboard-created schema no rule set references (first sync of a new set)', async () => {
+          mockDb.__setResults([[mockProject], []]);
+          mockPipelineSchemasService.getByProjectId.mockResolvedValue([liveSchema()]);
+          jest.spyOn(service, 'listByProject').mockResolvedValue([] as never);
+
+          const result = await sync(adoptDto());
+
+          expect(mockPipelineSchemasService.adoptFields).not.toHaveBeenCalled();
+          expect(result.warnings[0]).toContain('no live rule set references it');
+        });
+      });
+
+      describe('concurrent change (optimistic version check)', () => {
+        it('reloads, re-plans and retries once when the version moved', async () => {
+          mockDb.__setResults([[mockProject], []]);
+          mockPipelineSchemasService.getByProjectId.mockResolvedValue([ownedSchema()]);
+          // Someone added `note` in between: the fresh row is at version 4.
+          const fresh = ownedSchema({
+            version: 4,
+            fields: [...liveFields, { name: 'note', type: 'text', required: false }],
+          });
+          mockPipelineSchemasService.adoptFields
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ ...fresh, version: 5 });
+          mockPipelineSchemasService.getById.mockResolvedValue(fresh);
+
+          const result = await sync(
+            adoptDto({
+              schemas: [
+                payloadSchema([
+                  ...liveFields,
+                  { name: 'note', type: 'text', required: false },
+                  { name: 'unattended', type: 'boolean', required: false },
+                ]),
+              ],
+            }),
+          );
+
+          expect(mockPipelineSchemasService.adoptFields).toHaveBeenCalledTimes(2);
+          expect(mockPipelineSchemasService.adoptFields).toHaveBeenLastCalledWith(
+            'live-runs',
+            4,
+            [...fresh.fields, { name: 'unattended', type: 'boolean', required: false }],
+            expect.objectContaining({ ruleSetName: 'api-backend' }),
+          );
+          expect(result.schemaResolutions[0]).toMatchObject({
+            fieldMismatch: false,
+            fieldsAdopted: ['unattended'],
+          });
+          expect(result.warnings).toEqual([]);
+        });
+
+        it('gives up with a warning when the fresh diff is no longer additive', async () => {
+          mockDb.__setResults([[mockProject], []]);
+          mockPipelineSchemasService.getByProjectId.mockResolvedValue([ownedSchema()]);
+          mockPipelineSchemasService.adoptFields.mockResolvedValue(null);
+          // `status` was retyped in between: the payload now disagrees with live.
+          mockPipelineSchemasService.getById.mockResolvedValue(
+            ownedSchema({
+              version: 4,
+              fields: liveFields.map((f) => (f.name === 'status' ? { ...f, type: 'number' } : f)),
+            }),
+          );
+
+          const result = await sync(adoptDto());
+
+          expect(mockPipelineSchemasService.adoptFields).toHaveBeenCalledTimes(1);
+          expect(result.schemaResolutions[0]).toMatchObject({
+            fieldMismatch: true,
+            fieldsAdopted: [],
+          });
+          expect(result.warnings).toEqual([
+            expect.stringContaining('"unattended" not adopted — the schema changed concurrently'),
+          ]);
+        });
+
+        it('reports nothing adopted when the concurrent writer already added the same fields', async () => {
+          mockDb.__setResults([[mockProject], []]);
+          mockPipelineSchemasService.getByProjectId.mockResolvedValue([ownedSchema()]);
+          mockPipelineSchemasService.adoptFields.mockResolvedValue(null);
+          mockPipelineSchemasService.getById.mockResolvedValue(
+            ownedSchema({
+              version: 4,
+              fields: [...liveFields, { name: 'unattended', type: 'boolean', required: false }],
+            }),
+          );
+
+          const result = await sync(adoptDto());
+
+          expect(mockPipelineSchemasService.adoptFields).toHaveBeenCalledTimes(1);
+          expect(result.schemaResolutions[0]).toMatchObject({
+            fieldMismatch: false,
+            fieldsAdopted: [],
+          });
+          expect(result.warnings).toEqual([]);
+        });
       });
     });
 

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
@@ -56,9 +56,12 @@ import { ProxyRulesService } from './proxy-rules.service';
 import { collectSchemaIds, remapSchemaIds } from './schema-refs.util';
 import {
   compareSchemaFields,
+  planFieldAdoption,
   type ComparableSchemaField,
+  type FieldAdoptionPlan,
   type SchemaResolution,
 } from './schema-sync.util';
+import type { PipelineSchema, PipelineSchemaSource } from '../db/schema/pipeline-schemas.schema';
 import {
   buildExportEnvelope,
   canonicalRuleCompare,
@@ -813,6 +816,17 @@ export class ProxyRuleSetsService {
    * failures write-free even though schema creation runs outside the rule
    * transaction.
    *
+   * `adoptFields` (opt-in, bffless/ce#721): when a reused schema's diff is
+   * purely additive — new OPTIONAL fields only, nothing removed, retyped or
+   * newly required (planFieldAdoption) — AND the rule set being synced owns
+   * the schema ({@link fieldAdoptionBlocker}), the new fields are appended to
+   * the live schema (version bump, `source` stamp) instead of being warned
+   * about, and the resolution reports them in `fieldsAdopted`. Any other
+   * diff, or a schema this set doesn't own, keeps the warn/strict behaviour
+   * exactly. Under `dryRun` nothing is written and `fieldsAdopted` lists what
+   * would be. Schemas created by a live sync are stamped with
+   * `source.ruleSetName` so ownership is provable on the next sync.
+   *
    * Duplicate names WITHIN the incoming schemas → 400 (ambiguous payload).
    * Empty/undefined schemas → empty result with no DB access.
    */
@@ -821,7 +835,16 @@ export class ProxyRuleSetsService {
     schemas:
       | { id: string; name: string; kind?: SchemaKind; fields: ComparableSchemaField[] }[]
       | undefined,
-    options: { strictSchemas: boolean; dryRun: boolean },
+    options: {
+      strictSchemas: boolean;
+      dryRun: boolean;
+      /** Opt-in additive field adoption (default off — today's warn-only behaviour). */
+      adoptFields?: boolean;
+      /** Name of the set being synced — the ownership identity for adoption and the create stamp. */
+      ruleSetName?: string;
+      /** Source-side schema ids referenced by the payload's rules (collectSchemaIds). */
+      referencedSchemaIds?: Set<string>;
+    },
     userId: string,
     userRole: string,
     apiKeyProjectId?: string | null,
@@ -861,12 +884,54 @@ export class ProxyRuleSetsService {
     // strict throw can list ALL mismatches and precede ANY creation.
     const pendingCreates: { schema: (typeof schemas)[number]; resolution: SchemaResolution }[] = [];
     const pendingKindAdoptions: { schemaId: string; kind: SchemaKind }[] = [];
+    const pendingFieldAdoptions: {
+      schema: (typeof schemas)[number];
+      existing: PipelineSchema;
+      plan: FieldAdoptionPlan;
+      resolution: SchemaResolution;
+    }[] = [];
     const strictFailures: string[] = [];
+    // Loaded at most once per resolve, and only when an unstamped schema is a
+    // field-adoption candidate (see fieldAdoptionBlocker).
+    let projectSchemaRefs: Promise<{ name: string; schemaIds: Set<string> }[]> | undefined;
+    const loadProjectSchemaRefs = () => {
+      projectSchemaRefs ??= this.loadRuleSetSchemaRefs(projectId, apiKeyProjectId);
+      return projectSchemaRefs;
+    };
     for (const schema of schemas) {
       const existing = existingByName.get(schema.name);
       if (existing) {
         const { match, mismatches } = compareSchemaFields(schema.fields, existing.fields);
         idMap.set(schema.id, existing.id);
+
+        // Field adoption (opt-in): a purely additive diff on a schema this set
+        // owns is applied rather than warned about. Anything else falls
+        // through to the mismatch warnings below, untouched.
+        let fieldsAdopted: string[] = [];
+        let effectiveMismatches = mismatches;
+        let adoptionPlan: FieldAdoptionPlan | undefined;
+        if (!match && options.adoptFields) {
+          const plan = planFieldAdoption(schema.fields, existing.fields);
+          if (plan.additive) {
+            const blocker = await this.fieldAdoptionBlocker(
+              existing,
+              schema.id,
+              options,
+              loadProjectSchemaRefs,
+            );
+            if (blocker) {
+              warnings.push(
+                `Schema "${schema.name}": additive field(s) ${plan.added
+                  .map((f) => `"${f}"`)
+                  .join(', ')} not adopted — ${blocker}`,
+              );
+            } else {
+              fieldsAdopted = plan.added;
+              effectiveMismatches = [];
+              adoptionPlan = plan;
+            }
+          }
+        }
 
         // Kind is adopted, never overwritten: filling a null is unambiguous and
         // is the only route by which a schema that predates the column can ever
@@ -883,14 +948,19 @@ export class ProxyRuleSetsService {
         }
         if (kindAdopted) pendingKindAdoptions.push({ schemaId: existing.id, kind: schema.kind! });
 
-        resolutions.push({
+        const resolution: SchemaResolution = {
           name: schema.name,
           action: 'reuse',
           targetSchemaId: existing.id,
-          fieldMismatch: !match,
+          fieldMismatch: effectiveMismatches.length > 0,
           kindAdopted,
-        });
-        for (const mismatch of mismatches) {
+          fieldsAdopted,
+        };
+        resolutions.push(resolution);
+        if (adoptionPlan) {
+          pendingFieldAdoptions.push({ schema, existing, plan: adoptionPlan, resolution });
+        }
+        for (const mismatch of effectiveMismatches) {
           warnings.push(`Schema "${schema.name}": ${mismatch}`);
           strictFailures.push(`Schema "${schema.name}": ${mismatch}`);
         }
@@ -900,9 +970,10 @@ export class ProxyRuleSetsService {
           action: 'create',
           targetSchemaId: null,
           fieldMismatch: false,
-          // A schema created by this sync carries the payload's kind from birth;
-          // nothing was adopted onto an existing row.
+          // A schema created by this sync carries the payload's kind and every
+          // payload field from birth; nothing was adopted onto an existing row.
           kindAdopted: false,
+          fieldsAdopted: [],
         };
         resolutions.push(resolution);
         pendingCreates.push({ schema, resolution });
@@ -920,8 +991,16 @@ export class ProxyRuleSetsService {
     // Pass 2 — perform creations (live sync only; dryRun reports the plan with
     // targetSchemaId null and touches nothing).
     if (!options.dryRun) {
+      const stamp: PipelineSchemaSource | undefined = options.ruleSetName
+        ? { ruleSetName: options.ruleSetName, syncedAt: new Date().toISOString() }
+        : undefined;
       for (const { schemaId, kind } of pendingKindAdoptions) {
         await this.pipelineSchemasService.adoptKind(schemaId, kind);
+      }
+      for (const pending of pendingFieldAdoptions) {
+        // `stamp` is always set here: adoption is only planned when
+        // fieldAdoptionBlocker saw a ruleSetName.
+        await this.performFieldAdoption(pending, stamp!, warnings);
       }
       for (const { schema, resolution } of pendingCreates) {
         const created = await this.pipelineSchemasService.create(
@@ -929,6 +1008,7 @@ export class ProxyRuleSetsService {
           userId,
           userRole,
           apiKeyProjectId,
+          stamp,
         );
         idMap.set(schema.id, created.id);
         resolution.targetSchemaId = created.id;
@@ -936,6 +1016,148 @@ export class ProxyRuleSetsService {
     }
 
     return { idMap, resolutions, warnings };
+  }
+
+  /**
+   * Why a purely additive field diff must NOT be adopted onto `existing`, or
+   * `null` when the syncing rule set owns the schema (bffless/ce#721).
+   *
+   * All of a project's apps share one schema namespace, so "same name" is not
+   * "same schema": app B's sync must never grow app A's `jobs`. Ownership is:
+   * - the payload actually references the schema from a rule in THIS set
+   *   (a bundled-but-unused schema is not evidence of ownership); and
+   * - `existing.source.ruleSetName` — stamped when a sync created the schema
+   *   or first adopted onto it — equals the set being synced. A `name-suffix`
+   *   preview (`<name>-pr-42`) therefore never adopts onto production's
+   *   schema even if a caller passes `adoptFields`.
+   * - For an UNSTAMPED schema (predates the column, or dashboard/API-created)
+   *   ownership falls back to references: adopt only when this set is the one
+   *   and only rule set in the project whose rules reference it. Anything
+   *   ambiguous stays warn-only, and the message says who else references it.
+   */
+  private async fieldAdoptionBlocker(
+    existing: PipelineSchema,
+    sourceSchemaId: string,
+    options: { ruleSetName?: string; referencedSchemaIds?: Set<string> },
+    loadProjectSchemaRefs: () => Promise<{ name: string; schemaIds: Set<string> }[]>,
+  ): Promise<string | null> {
+    const setName = options.ruleSetName;
+    if (!setName) return 'the sync has no rule set name to attribute ownership to';
+    if (!options.referencedSchemaIds?.has(sourceSchemaId)) {
+      return `no rule in rule set "${setName}" references the schema`;
+    }
+
+    if (existing.source?.ruleSetName) {
+      if (existing.source.ruleSetName === setName) return null;
+      return (
+        `the schema is owned by rule set "${existing.source.ruleSetName}" (created by its sync); ` +
+        'add the field from that set, or in the dashboard'
+      );
+    }
+
+    const referencing = (await loadProjectSchemaRefs())
+      .filter((set) => set.schemaIds.has(existing.id))
+      .map((set) => set.name);
+    const quoted = (names: string[]) => names.map((n) => `"${n}"`).join(', ');
+    if (referencing.length === 1 && referencing[0] === setName) return null;
+    if (referencing.length === 0) {
+      return (
+        'the schema predates sync ownership tracking and no live rule set references it, ' +
+        `so it cannot be attributed to "${setName}"; add the field in the dashboard`
+      );
+    }
+    const others = referencing.filter((n) => n !== setName);
+    if (others.length === referencing.length) {
+      return (
+        `the schema predates sync ownership tracking and is referenced by rule set(s) ${quoted(others)}, ` +
+        `not by "${setName}"; add the field from the owning set, or in the dashboard`
+      );
+    }
+    return (
+      `the schema predates sync ownership tracking and is also referenced by rule set(s) ${quoted(others)}, ` +
+      'so ownership is ambiguous; add the field in the dashboard'
+    );
+  }
+
+  /**
+   * Every rule set in the project with the set of schema ids its rules
+   * reference — the reference-based ownership fallback for schemas that carry
+   * no `source` stamp (see fieldAdoptionBlocker).
+   */
+  private async loadRuleSetSchemaRefs(
+    projectId: string,
+    apiKeyProjectId?: string | null,
+  ): Promise<{ name: string; schemaIds: Set<string> }[]> {
+    const sets = await this.listByProject(projectId, apiKeyProjectId);
+    const result: { name: string; schemaIds: Set<string> }[] = [];
+    for (const set of sets) {
+      const rules = await this.proxyRulesService.getRulesByRuleSetId(set.id);
+      result.push({
+        name: set.name,
+        schemaIds: collectSchemaIds(rules.map((rule) => rule.pipelineConfig)),
+      });
+    }
+    return result;
+  }
+
+  /**
+   * Live half of field adoption: the optimistic write, with ONE retry.
+   *
+   * `adoptFields` is conditioned on the schema's `version` being the one we
+   * planned against. If it moved (a concurrent sync, or a dashboard edit
+   * between our read and our write) we reload, re-plan against the fresh
+   * field list and try once more; if the diff is no longer purely additive —
+   * or the retry loses too — the adoption is dropped with a warning and the
+   * resolution flips back to `fieldMismatch: true`, exactly what a sync
+   * without `adoptFields` would have reported. If the concurrent writer
+   * already added the same fields there is nothing left to adopt, and the
+   * resolution reports an empty `fieldsAdopted` with no mismatch.
+   */
+  private async performFieldAdoption(
+    pending: {
+      schema: { name: string; fields: ComparableSchemaField[] };
+      existing: PipelineSchema;
+      plan: FieldAdoptionPlan;
+      resolution: SchemaResolution;
+    },
+    stamp: PipelineSchemaSource,
+    warnings: string[],
+  ): Promise<void> {
+    const { schema, existing, plan, resolution } = pending;
+    const updated = await this.pipelineSchemasService.adoptFields(
+      existing.id,
+      existing.version,
+      plan.merged,
+      stamp,
+    );
+    if (updated) return;
+
+    const fresh = await this.pipelineSchemasService.getById(existing.id);
+    if (fresh) {
+      const replan = planFieldAdoption(schema.fields, fresh.fields);
+      if (replan.additive) {
+        const retried = await this.pipelineSchemasService.adoptFields(
+          fresh.id,
+          fresh.version,
+          replan.merged,
+          stamp,
+        );
+        if (retried) {
+          resolution.fieldsAdopted = replan.added;
+          return;
+        }
+      } else if (compareSchemaFields(schema.fields, fresh.fields).match) {
+        resolution.fieldsAdopted = [];
+        return;
+      }
+    }
+
+    resolution.fieldsAdopted = [];
+    resolution.fieldMismatch = true;
+    warnings.push(
+      `Schema "${schema.name}": field(s) ${plan.added.map((f) => `"${f}"`).join(', ')} not adopted — ` +
+        'the schema changed concurrently; re-run the sync',
+    );
   }
 
   /**
@@ -1010,6 +1232,7 @@ export class ProxyRuleSetsService {
     const conflictPolicy = dto.options?.conflictPolicy ?? 'overwrite';
     const dryRun = dto.options?.dryRun ?? false;
     const strictSchemas = dto.options?.strictSchemas ?? false;
+    const adoptFields = dto.options?.adoptFields ?? false;
 
     // Same bridging as importRuleSet: the DTO config classes are structural
     // mirrors of the schema's config types.
@@ -1034,7 +1257,14 @@ export class ProxyRuleSetsService {
         kind: schema.kind,
         fields: schema.fields,
       })),
-      { strictSchemas, dryRun },
+      {
+        strictSchemas,
+        dryRun,
+        adoptFields,
+        ruleSetName: name,
+        // Source-side ids: rules are remapped only after resolution.
+        referencedSchemaIds: collectSchemaIds(dtoRules.map((rule) => rule.pipelineConfig)),
+      },
       userId,
       userRole,
       apiKeyProjectId,

--- a/apps/backend/src/proxy-rules/schema-sync.util.spec.ts
+++ b/apps/backend/src/proxy-rules/schema-sync.util.spec.ts
@@ -1,4 +1,8 @@
-import { compareSchemaFields, type ComparableSchemaField } from './schema-sync.util';
+import {
+  compareSchemaFields,
+  planFieldAdoption,
+  type ComparableSchemaField,
+} from './schema-sync.util';
 import type { SchemaField } from '../db/schema/pipeline-schemas.schema';
 
 describe('schema-sync.util', () => {
@@ -98,6 +102,86 @@ describe('schema-sync.util', () => {
 
     it('matches two empty field lists', () => {
       expect(compareSchemaFields([], [])).toEqual({ match: true, mismatches: [] });
+    });
+  });
+  /** bffless/ce#721 — the only shape the sync will ever write onto a live schema. */
+  describe('planFieldAdoption', () => {
+    const live: SchemaField[] = [
+      { name: 'id', type: 'string', required: true },
+      { name: 'status', type: 'string', required: false, default: 'queued' },
+    ];
+
+    it('is additive for new optional fields: live fields kept as-is, new ones appended', () => {
+      const plan = planFieldAdoption(
+        [
+          { name: 'unattended', type: 'boolean', required: false },
+          { name: 'status', type: 'string' }, // absent required == false, order irrelevant
+          { name: 'id', type: 'string', required: true },
+          { name: 'note', type: 'text', default: '' },
+        ],
+        live,
+      );
+      expect(plan.additive).toBe(true);
+      expect(plan.added).toEqual(['unattended', 'note']);
+      expect(plan.merged).toEqual([
+        ...live,
+        { name: 'unattended', type: 'boolean', required: false },
+        { name: 'note', type: 'text', required: false, default: '' },
+      ]);
+    });
+
+    it('is not additive when the lists already match (nothing to adopt)', () => {
+      expect(planFieldAdoption(live, live)).toEqual({ additive: false, added: [], merged: [] });
+    });
+
+    it.each([
+      [
+        'a live field is missing from the payload',
+        [{ name: 'id', type: 'string', required: true }],
+      ],
+      [
+        'a field is retyped',
+        [...live.map((f) => (f.name === 'status' ? { ...f, type: 'text' as const } : f))],
+      ],
+      [
+        'an optional field becomes required',
+        [...live.map((f) => (f.name === 'status' ? { ...f, required: true } : f))],
+      ],
+      [
+        'a required field becomes optional',
+        [...live.map((f) => (f.name === 'id' ? { ...f, required: false } : f))],
+      ],
+      [
+        'a NEW field is required',
+        [...live, { name: 'unattended', type: 'boolean' as const, required: true }],
+      ],
+      [
+        'a mix of an additive and a destructive change',
+        [
+          { name: 'id', type: 'string' as const, required: true },
+          { name: 'unattended', type: 'boolean' as const },
+        ],
+      ],
+    ])('is not additive when %s', (_label, incoming) => {
+      expect(planFieldAdoption(incoming as ComparableSchemaField[], live)).toEqual({
+        additive: false,
+        added: [],
+        merged: [],
+      });
+    });
+
+    it('ignores `default` differences on existing fields (not part of schema identity)', () => {
+      const plan = planFieldAdoption(
+        [
+          { name: 'id', type: 'string', required: true },
+          { name: 'status', type: 'string', required: false, default: 'other' },
+          { name: 'unattended', type: 'boolean' },
+        ],
+        live,
+      );
+      expect(plan.additive).toBe(true);
+      // The live entry (with ITS default) is what survives.
+      expect(plan.merged[1]).toEqual(live[1]);
     });
   });
 });

--- a/apps/backend/src/proxy-rules/schema-sync.util.ts
+++ b/apps/backend/src/proxy-rules/schema-sync.util.ts
@@ -36,6 +36,84 @@ export interface SchemaResolution {
    * schema that already declares a kind keeps it.
    */
   kindAdopted: boolean;
+  /**
+   * Names of payload fields the sync added to the live schema because the
+   * caller opted in (`options.adoptFields`), the diff was purely additive,
+   * and this rule set owns the schema — see planFieldAdoption. Under dryRun
+   * the fields that WOULD be added. Empty for a create (the new schema
+   * carries every payload field from birth) and whenever nothing was adopted.
+   */
+  fieldsAdopted: string[];
+}
+
+/**
+ * Outcome of {@link planFieldAdoption}.
+ *
+ * - `additive: true` — every difference between the payload and the live
+ *   field list is a NEW optional field (`added` names them, `merged` is the
+ *   live list with them appended). This is the only shape the rules-as-code
+ *   sync will ever write onto an existing schema (bffless/ce#721).
+ * - `additive: false` — either the lists already match (`added` is empty) or
+ *   the diff removes, retypes, or newly requires a field. Both are left to
+ *   compareSchemaFields' warning / strict path; nothing is written.
+ */
+export interface FieldAdoptionPlan {
+  additive: boolean;
+  added: string[];
+  merged: SchemaField[];
+}
+
+/**
+ * Decide whether the payload's field list is a purely additive superset of the
+ * live one, and if so produce the merged list.
+ *
+ * "Purely additive" means: every live field is still present with the same
+ * `type` and the same (`?? false`-normalized) `required`; every payload-only
+ * field is optional. A payload-only field that is `required: true` is NOT
+ * additive — existing rows would fail validation the moment it landed.
+ * Field order is live-first: the live entries are kept as-is (including any
+ * `default` the dashboard set), the new ones are appended in payload order
+ * with `required` normalized to `false`, mirroring `PipelineSchemasService`.
+ *
+ * `default` is not compared (compareSchemaFields ignores it too): it does not
+ * participate in schema identity.
+ */
+export function planFieldAdoption(
+  incoming: ComparableSchemaField[],
+  existing: ComparableSchemaField[],
+): FieldAdoptionPlan {
+  const notAdditive: FieldAdoptionPlan = { additive: false, added: [], merged: [] };
+  const existingByName = new Map(existing.map((f) => [f.name, f]));
+  const incomingNames = new Set(incoming.map((f) => f.name));
+
+  for (const field of existing) {
+    if (!incomingNames.has(field.name)) return notAdditive;
+  }
+
+  const added: SchemaField[] = [];
+  for (const field of incoming) {
+    const live = existingByName.get(field.name);
+    if (live) {
+      if (field.type !== live.type) return notAdditive;
+      if ((field.required ?? false) !== (live.required ?? false)) return notAdditive;
+      continue;
+    }
+    if (field.required ?? false) return notAdditive;
+    added.push({
+      name: field.name,
+      type: field.type,
+      required: false,
+      ...(field.default !== undefined ? { default: field.default } : {}),
+    });
+  }
+
+  if (added.length === 0) return notAdditive;
+
+  return {
+    additive: true,
+    added: added.map((f) => f.name),
+    merged: [...(existing as SchemaField[]), ...added],
+  };
 }
 
 /**

--- a/packages/cli/src/api/sync-types.ts
+++ b/packages/cli/src/api/sync-types.ts
@@ -17,13 +17,15 @@ export interface SyncSchemaResolution {
   fieldMismatch: boolean;
   /** The declared `kind` was written onto a live schema that had none. */
   kindAdopted?: boolean;
+  /** Payload fields appended to the live schema under `options.adoptFields` (would-be, under dryRun). */
+  fieldsAdopted?: string[];
 }
 
 export interface SyncRequestBody {
   ruleSet: { name: string; description?: string; environment?: string };
   rules: ExportedRule[];
   schemas?: ExportedSchema[];
-  options?: { prune?: boolean; dryRun?: boolean; strictSchemas?: boolean };
+  options?: { prune?: boolean; dryRun?: boolean; strictSchemas?: boolean; adoptFields?: boolean };
   source?: { repo?: string; path?: string; gitSha?: string };
 }
 

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -5,6 +5,9 @@
  *
  * - `--name-suffix pr-42` renames the compiled set to `<name>-pr-42` before syncing —
  *   the preview-deploy pattern (a PR gets its own live set without touching production's).
+ * - `--adopt-fields` asks the server to append new optional fields from `*.schema.yaml` onto
+ *   the live schema this set owns (otherwise a changed schema is warn-only). It is sent only
+ *   when set, so an older server (which rejects unknown options) still accepts the push.
  * - `source` metadata (repo/gitSha/path) is attached best-effort from the GitHub Actions
  *   env or local git (see api/git-source.ts) so the server can stamp provenance.
  * - Exit semantics (enforced by the caller via `ok`): any HTTP or compile error is a
@@ -24,6 +27,7 @@ export interface PushOptions {
   prune?: boolean;
   dryRun?: boolean;
   strictSchemas?: boolean;
+  adoptFields?: boolean;
   apiUrl?: string;
   apiKey?: string;
   project?: string;
@@ -93,6 +97,13 @@ export function formatSyncReport(setName: string, res: SyncResponse): string {
   if (adopted.length > 0) {
     lines.push(`  declared kind adopted by: ${adopted.map((r) => r.name).join(', ')}`);
   }
+  const withFields = res.schemaResolutions.filter((r) => r.fieldsAdopted && r.fieldsAdopted.length > 0);
+  if (withFields.length > 0) {
+    const verb = res.dryRun ? 'fields that would be adopted' : 'fields adopted';
+    for (const r of withFields) {
+      lines.push(`  ${verb} by ${r.name}: ${r.fieldsAdopted!.join(', ')}`);
+    }
+  }
 
   for (const w of res.warnings) lines.push(`  warning: ${w}`);
 
@@ -126,6 +137,8 @@ export async function runPushOne(
       prune: opts.prune ?? false,
       dryRun: opts.dryRun ?? false,
       strictSchemas: opts.strictSchemas ?? false,
+      // Only when set: servers predating the option reject unknown keys (400).
+      ...(opts.adoptFields ? { adoptFields: true } : {}),
     },
     ...(source ? { source } : {}),
   };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -200,6 +200,10 @@ rules
   .option('--dry-run', 'compute and print the change plan without writing anything')
   .option('--prune', 'delete live rules that are absent from the local rule set')
   .option('--strict-schemas', 'fail when a name-reused schema has mismatched field definitions')
+  .option(
+    '--adopt-fields',
+    'append new optional fields from *.schema.yaml onto a live schema this set owns (default: warn only; never removes, retypes or requires a field)',
+  )
   .option('--name-suffix <suffix>', 'rename the set to <name>-<suffix> before syncing (e.g. pr-42 previews)')
   .option(
     '--path-prefix <prefix>',
@@ -215,6 +219,7 @@ rules
         dryRun?: boolean;
         prune?: boolean;
         strictSchemas?: boolean;
+        adoptFields?: boolean;
         nameSuffix?: string;
         pathPrefix?: string;
         apiUrl?: string;

--- a/packages/cli/test/push.test.ts
+++ b/packages/cli/test/push.test.ts
@@ -90,6 +90,41 @@ describe('rules push', () => {
     expect(result.report).toContain('- ANY /api/old');
   });
 
+  it('--adopt-fields is forwarded only when set (older servers reject unknown options)', async () => {
+    const d = pushDeps(syncResponse());
+    const result = await runPushOne(basicSrcDir, { adoptFields: true }, '/nowhere', d);
+    expect(result.ok, result.error).toBe(true);
+    expect(d.sentBody().options).toEqual({
+      prune: false,
+      dryRun: false,
+      strictSchemas: false,
+      adoptFields: true,
+    });
+  });
+
+  it('reports adopted schema fields (and would-be adoptions under dry run)', () => {
+    const resolution = {
+      name: 'workflow_runs',
+      action: 'reuse' as const,
+      targetSchemaId: SET_UUID,
+      fieldMismatch: false,
+      fieldsAdopted: ['unattended', 'note'],
+    };
+    expect(formatSyncReport('basic', syncResponse({ schemaResolutions: [resolution] }))).toContain(
+      'fields adopted by workflow_runs: unattended, note',
+    );
+    expect(
+      formatSyncReport('basic', syncResponse({ dryRun: true, schemaResolutions: [resolution] })),
+    ).toContain('fields that would be adopted by workflow_runs: unattended, note');
+    // Older servers omit the key entirely; nothing is printed.
+    expect(
+      formatSyncReport(
+        'basic',
+        syncResponse({ schemaResolutions: [{ ...resolution, fieldsAdopted: undefined }] }),
+      ),
+    ).not.toContain('adopted');
+  });
+
   it('--name-suffix renames the set in the payload and the report', async () => {
     const d = pushDeps(syncResponse({ setCreated: true }));
     const result = await runPushOne(basicSrcDir, { nameSuffix: 'pr-42' }, '/nowhere', d);


### PR DESCRIPTION
Closes #721

## Summary
When a team adds a field to a `*.schema.yaml` after the schema's first deploy, the rules-as-code sync (`bffless/deploy-proxy-rules`, `bffless rules push`) updates the rules but leaves the live schema untouched — it only warns, and the deploy stays green. The new field silently never exists in the database (this is how `workflow_runs.unattended` got lost on j5s.dev). This PR adds an opt-in `adoptFields` mode: when the only difference is new optional fields, and the schema belongs to the rule set being synced, the sync appends them to the live schema and reports exactly what it adopted. Anything riskier — a removed, retyped or newly-required field, or a schema that another rule set or the dashboard owns — behaves exactly as today.

## Behaviour changes
All additive; nothing changes unless a caller opts in.

- Sync request: `options.adoptFields` (boolean, default `false`) is accepted on `PUT /api/proxy-rule-sets/project/:id/sync`. Unset → today's behaviour, byte for byte (warning, no write).
- Sync response: every `schemaResolutions[]` entry gains `fieldsAdopted: string[]` (empty unless adoption happened; under `dryRun`, the fields that *would* be adopted).
- With `adoptFields: true`, a reused schema whose payload diff is purely additive (new fields, all `required: false`; every live field keeps name/type/required) → live schema gains the fields, `version` bumps, `fieldMismatch: false`, no warning, and `strictSchemas` is satisfied. Removed / retyped / optional→required / new *required* field → warning (or `strictSchemas` 400) as before, never written.
- Ownership guard: adoption happens only when (a) a rule in the payload references the schema, and (b) the schema is owned by this rule set. Ownership is a new `source.ruleSetName` stamp on schemas that a live sync creates or adopts onto; a differently-named set (including `--name-suffix pr-N` previews) gets a warning naming the owner instead. Schemas with no stamp (everything created before this change, or from the dashboard) fall back to references: adopted only when this set is the *sole* rule set in the project referencing them; otherwise a warning says which other sets do.
- Concurrency: the write is `UPDATE … WHERE version = <planned>`; on a lost race it reloads, re-plans and retries once, else drops the adoption with a warning.
- `pipeline_schemas` rows (and therefore `GET /api/pipeline-schemas/*` responses) carry a new nullable `source` field. Exports never include it (export builds `{id,name,kind,fields}` explicitly).
- CLI: `bffless rules push --adopt-fields`. The option is only sent when set, so a new CLI still works against an older server (whose `ValidationPipe` rejects unknown keys). The report prints `fields adopted by <schema>: a, b` (or `fields that would be adopted …` under `--dry-run`).

## Why
`resolveSchemasByName` compares fields and warns; `kind` already had an "adopt, never overwrite" carve-out (#633) but fields did not, so a green deploy could ship a rule writing `unattended: request.body.unattended` into a schema that had no such field. The issue asked for adoption that is opt-in, purely additive, scoped to the owning rule set, race-safe and dry-run aware, and that is what this implements. Ownership needed a stamp on the schema (there was no way to tell "created by set A's sync" from "created by the dashboard"), mirroring `source` on rule sets; the reference-based fallback is what makes the fix reach schemas that predate the stamp, such as the motivating `workflow_runs`.

## What changed
- **backend / schema:** `apps/backend/src/db/schema/pipeline-schemas.schema.ts` — `PipelineSchemaSource` type and nullable `source` jsonb column (**migration not yet generated — see below**).
- **backend / sync:** `apps/backend/src/proxy-rules/schema-sync.util.ts` — `planFieldAdoption()` (pure additive-diff planner) and `fieldsAdopted` on `SchemaResolution`; `apps/backend/src/proxy-rules/proxy-rule-sets.service.ts` — ownership check (`fieldAdoptionBlocker`), reference fallback, pass-2 write with one retry, `source` stamp on sync-created schemas; `apps/backend/src/pipelines/pipeline-schemas.service.ts` — `adoptFields()` optimistic write, `create()` accepts an internal `source` stamp.
- **backend / API:** `apps/backend/src/proxy-rules/dto/sync-proxy-rule-set.dto.ts` — `adoptFields` option and `fieldsAdopted` response field (Swagger documented).
- **CLI:** `packages/cli/src/index.ts`, `packages/cli/src/commands/push.ts`, `packages/cli/src/api/sync-types.ts` — `--adopt-fields`, conditional send, report line.
- **tests:** `schema-sync.util.spec.ts` (planner: additive / no-op / 6 non-additive shapes / default handling), `proxy-rule-sets.service.spec.ts` (adopt, opt-out, dryRun, strict, 4 non-additive shapes, foreign owner, preview suffix, unreferenced payload schema, 4 unstamped-fallback cases, 3 concurrency cases), `sync-proxy-rule-set.dto.spec.ts`, `packages/cli/test/push.test.ts`.

## Compatibility
- **DB migration:** the schema file adds a nullable `source jsonb` column with no default and no backfill — forward-safe (old image reads the table fine; new image boots on old rows as `null`). **The Drizzle migration has not been generated** (no local DB on the agent host); the user must run `cd apps/backend && pnpm db:generate` and commit the resulting `drizzle/00xx_*.sql` + snapshot to this branch before merge. Expected diff: `ALTER TABLE "pipeline_schemas" ADD COLUMN "source" jsonb;` — no prompts expected (pure column add).
- **API / CLI contract:** additive only. Old CLI → new server: identical behaviour (option absent). New CLI → old server: `--adopt-fields` is the only new key and is omitted unless set; `fieldsAdopted` is read as optional.
- **Pipeline / proxy-rule semantics:** no stored rule set behaves differently; adoption is opt-in per request and only ever appends optional fields (metadata over the JSON `data` column — no data rewrite). Rollback replays through `syncRuleSet` without `adoptFields`, unchanged.
- **GitHub Actions `@v1`, env vars, nginx generation, storage layout:** untouched.

## Verification
Run in the worktree on this branch:
- `pnpm --filter backend exec tsc --noEmit` — clean.
- `pnpm --filter frontend exec tsc --noEmit` — clean.
- `pnpm --filter backend format:check` / `pnpm --filter frontend format:check` — "All matched files use Prettier code style!" (both).
- `cd apps/backend && pnpm test -- proxy-rule-sets.service.spec schema-sync.util.spec sync-proxy-rule-set.dto.spec` — 3 suites, **129 passed**, 0 failed.
- `cd apps/backend && pnpm test` (full) — **200 suites passed, 3552 tests passed**, 2 suites / 47 tests pre-existing skips, 0 failed.
- `cd packages/cli && pnpm test` (tsc build + vitest) — **29 files, 424 tests passed**.

## Out of scope / follow-ups
- `bffless/deploy-proxy-rules`: add an `adopt-fields` input (default `false`) passed as `options.adoptFields`, plus `::warning::` annotations for `fieldsAdopted` and for unadopted mismatches (issue's follow-up item).
- `bffless/skills` proxy-rules skill: document `--adopt-fields` / `options.adoptFields`.
- Legacy schemas referenced by both a production set and live preview sets stay warn-only until the previews are removed (or the field is added in the dashboard); once adopted or re-created, the `source` stamp makes previews irrelevant. A one-off backfill of `source` from rule-set references could be added if this bites in practice.
- The `strictSchemas` 400 lists only the field mismatches, not the ownership reason (which is in `warnings[]`); could be folded into the error text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLEDVJp6BS2rn76Jhwvjq4
