### PR TITLE
fix(pipelines): always persist an execution log for failed runs

### DIFF
--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -140,6 +140,20 @@ detail and error text; a cross-project read is a data leak with no error anywher
 **Learned from:** PR #717, 2026-08-29 — `X-Pipeline-Log-Id` exposed log ids to
 anonymous callers while `GET /api/pipeline-logs/:logId` was unscoped; fixed in the same PR.
 
+### Pipeline execution logging is on the public request hot path
+**Surface:** `apps/backend/src/proxy-rules/proxy.middleware.ts` (handlePipelineExecution),
+`apps/backend/src/pipelines/pipeline-execution-log.service.ts`
+**Check:** When persistence conditions change (e.g. "always log on X"), does the
+condition key off actual execution/infra failure, or off `!result.success` broadly?
+`result.success` is also false for ordinary validator outcomes (VALIDATION_ERROR,
+AUTH_REQUIRED, AUTHORIZATION_ERROR, RATE_LIMIT_EXCEEDED) reachable by anonymous public
+traffic on every request.
+**Why:** Widening what gets logged widens it for routine client-side rejections too,
+adding DB write load (insert + per-rule retention cleanup) precisely under bot/scanner
+traffic or rate-limit pressure, and can crowd the small per-rule retention window
+(50 rows) with 4xx noise instead of the 5xx rows operators actually need.
+**Learned from:** PR #725, 2026-08-30.
+
 ---
 
 ## Entry template

--- a/apps/backend/src/pipelines/pipeline-execution-log.service.ts
+++ b/apps/backend/src/pipelines/pipeline-execution-log.service.ts
@@ -8,8 +8,9 @@ import type { PipelineLogRequestMeta } from '../db/schema/pipeline-execution-log
 /**
  * Response header carrying the `pipeline_execution_logs.id` of the row a
  * pipeline proxy-rule response was logged under. Present when the rule has
- * `debugEnabled`, and on every failed run regardless of debug mode (#724);
- * the value resolves at `GET /api/pipeline-logs/:logId`.
+ * `debugEnabled`, and on 500-class execution failures regardless of debug mode
+ * (#724 — client-fault 4xx outcomes stay debug-gated); the value resolves at
+ * `GET /api/pipeline-logs/:logId`.
  */
 export const PIPELINE_LOG_ID_HEADER = 'X-Pipeline-Log-Id';
 

--- a/apps/backend/src/pipelines/pipeline-execution-log.service.ts
+++ b/apps/backend/src/pipelines/pipeline-execution-log.service.ts
@@ -7,8 +7,9 @@ import type { PipelineLogRequestMeta } from '../db/schema/pipeline-execution-log
 
 /**
  * Response header carrying the `pipeline_execution_logs.id` of the row a
- * pipeline proxy-rule response was logged under. Only present when the rule has
- * `debugEnabled`; the value resolves at `GET /api/pipeline-logs/:logId`.
+ * pipeline proxy-rule response was logged under. Present when the rule has
+ * `debugEnabled`, and on every failed run regardless of debug mode (#724);
+ * the value resolves at `GET /api/pipeline-logs/:logId`.
  */
 export const PIPELINE_LOG_ID_HEADER = 'X-Pipeline-Log-Id';
 

--- a/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
@@ -675,8 +675,8 @@ describe('ProxyMiddleware', () => {
       expect(mockExecutionLogService.log).not.toHaveBeenCalled();
     });
 
-    describe('failed runs are always logged, even with debug off (#724)', () => {
-      it('persists exactly one row with the error fields when a pipeline fails with debugEnabled false', async () => {
+    describe('execution failures (500-class) are always logged, even with debug off (#724)', () => {
+      it('persists exactly one row with the error fields when a pipeline hits an execution failure with debugEnabled false', async () => {
         mockPipelineExecutionService.executePipelineWithDebug.mockResolvedValue({
           success: false,
           error: { code: 'STEP_EXECUTION_ERROR', message: 'boom', step: 'register' },
@@ -711,6 +711,28 @@ describe('ProxyMiddleware', () => {
         expect(method).toBe('GET');
         expect(path).toBe('/public/owner/repo/sha123/api/items');
         expect(persistedId).toBe(logId);
+      });
+
+      it('writes no row for a client-fault validator failure with debugEnabled false (4xx stays debug-gated)', async () => {
+        mockPipelineExecutionService.executePipelineWithDebug.mockResolvedValue({
+          success: false,
+          error: { code: 'RATE_LIMIT_EXCEEDED', message: 'too many requests' },
+        } as any);
+        const req = createMockRequest('/public/owner/repo/sha123/api/items');
+        const res = createPipelineResponse();
+
+        await (middleware as any).handlePipelineExecution(
+          req,
+          res,
+          pipelineRule({ debugEnabled: false }),
+          'project-1',
+        );
+        await flushAsync();
+
+        // Rate limiting keeps shedding traffic cheaply: no header, no DB write.
+        expect(logIdHeaderValue(res)).toBeUndefined();
+        expect(res.status).toHaveBeenCalledWith(429);
+        expect(mockExecutionLogService.log).not.toHaveBeenCalled();
       });
 
       it('writes no row for a successful run with debugEnabled false (volume unchanged for healthy rules)', async () => {

--- a/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
@@ -674,5 +674,123 @@ describe('ProxyMiddleware', () => {
       expect(res.send).not.toHaveBeenCalled();
       expect(mockExecutionLogService.log).not.toHaveBeenCalled();
     });
+
+    describe('failed runs are always logged, even with debug off (#724)', () => {
+      it('persists exactly one row with the error fields when a pipeline fails with debugEnabled false', async () => {
+        mockPipelineExecutionService.executePipelineWithDebug.mockResolvedValue({
+          success: false,
+          error: { code: 'STEP_EXECUTION_ERROR', message: 'boom', step: 'register' },
+        } as any);
+        const req = createMockRequest('/public/owner/repo/sha123/api/items');
+        const res = createPipelineResponse();
+
+        await (middleware as any).handlePipelineExecution(
+          req,
+          res,
+          pipelineRule({ debugEnabled: false }),
+          'project-1',
+        );
+        await flushAsync();
+
+        // The failed answer still carries the row id.
+        const logId = logIdHeaderValue(res);
+        expect(logId).toMatch(UUID_RE);
+        expect(res.status).toHaveBeenCalledWith(500);
+
+        expect(mockExecutionLogService.log).toHaveBeenCalledTimes(1);
+        const [ruleId, projectId, result, , method, path, persistedId] =
+          mockExecutionLogService.log.mock.calls[0];
+        expect(ruleId).toBe('rule-1');
+        expect(projectId).toBe('project-1');
+        expect(result.success).toBe(false);
+        expect(result.error).toEqual({
+          code: 'STEP_EXECUTION_ERROR',
+          message: 'boom',
+          step: 'register',
+        });
+        expect(method).toBe('GET');
+        expect(path).toBe('/public/owner/repo/sha123/api/items');
+        expect(persistedId).toBe(logId);
+      });
+
+      it('writes no row for a successful run with debugEnabled false (volume unchanged for healthy rules)', async () => {
+        const req = createMockRequest('/public/owner/repo/sha123/api/items');
+        const res = createPipelineResponse();
+
+        await (middleware as any).handlePipelineExecution(
+          req,
+          res,
+          pipelineRule({ debugEnabled: false }),
+          'project-1',
+        );
+        await flushAsync();
+
+        expect(logIdHeaderValue(res)).toBeUndefined();
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(mockExecutionLogService.log).not.toHaveBeenCalled();
+      });
+
+      it('logs a thrown execution error under PIPELINE_EXECUTION_ERROR with debug off', async () => {
+        mockPipelineExecutionService.executePipelineWithDebug.mockRejectedValue(
+          new Error('connection reset'),
+        );
+        const req = createMockRequest('/public/owner/repo/sha123/api/items');
+        const res = createPipelineResponse();
+
+        await (middleware as any).handlePipelineExecution(
+          req,
+          res,
+          pipelineRule({ debugEnabled: false }),
+          'project-1',
+        );
+        await flushAsync();
+
+        const logId = logIdHeaderValue(res);
+        expect(logId).toMatch(UUID_RE);
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({
+          error: 'Pipeline execution failed',
+          code: 'PIPELINE_EXECUTION_ERROR',
+          message: 'connection reset',
+        });
+
+        expect(mockExecutionLogService.log).toHaveBeenCalledTimes(1);
+        const [ruleId, projectId, result, , , , persistedId] =
+          mockExecutionLogService.log.mock.calls[0];
+        expect(ruleId).toBe('rule-1');
+        expect(projectId).toBe('project-1');
+        expect(result).toEqual({
+          success: false,
+          error: { code: 'PIPELINE_EXECUTION_ERROR', message: 'connection reset' },
+        });
+        expect(persistedId).toBe(logId);
+      });
+
+      it('still logs a thrown error when the response already streamed (no header, one row)', async () => {
+        const req = createMockRequest('/public/owner/repo/sha123/api/stream');
+        const res = createPipelineResponse();
+        mockPipelineExecutionService.executePipelineWithDebug.mockImplementation(async () => {
+          res.headersSent = true;
+          throw new Error('stream died');
+        });
+
+        await (middleware as any).handlePipelineExecution(
+          req,
+          res,
+          pipelineRule({ debugEnabled: false }),
+          'project-1',
+        );
+        await flushAsync();
+
+        expect(logIdHeaderValue(res)).toBeUndefined();
+        expect(res.json).not.toHaveBeenCalled();
+        expect(mockExecutionLogService.log).toHaveBeenCalledTimes(1);
+        const [, , result] = mockExecutionLogService.log.mock.calls[0];
+        expect(result.error).toEqual({
+          code: 'PIPELINE_EXECUTION_ERROR',
+          message: 'stream died',
+        });
+      });
+    });
   });
 });

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -25,7 +25,10 @@ import {
   PipelineExecutionLogService,
   PIPELINE_LOG_ID_HEADER,
 } from '../pipelines/pipeline-execution-log.service';
-import { PipelineUser } from '../pipelines/execution/pipeline-context.interface';
+import {
+  PipelineUser,
+  PipelineDebugResult,
+} from '../pipelines/execution/pipeline-context.interface';
 import { Pipeline, PipelineStep } from '../pipelines/types';
 import multer from 'multer';
 import { randomUUID } from 'crypto';
@@ -1155,6 +1158,9 @@ export class ProxyMiddleware implements NestMiddleware {
       })),
     };
 
+    // Hoisted so the outer catch can attribute its failure log to the caller.
+    let user: { id: string; email?: string; role?: string } | undefined;
+
     try {
       // If pipeline has file_upload_handler, parse multipart before executing
       const uploadStep = pipelineConfig.steps.find((s) => s.handlerType === 'file_upload_handler');
@@ -1167,7 +1173,7 @@ export class ProxyMiddleware implements NestMiddleware {
       }
 
       // Extract user from session if available (optional - don't fail if not authenticated)
-      const user = await this.getOptionalUser(req, res);
+      user = await this.getOptionalUser(req, res);
 
       // Enrich with group memberships for the sandboxed pipeline context. Group
       // lookup must never take the request down: on failure, degrade to "no groups".
@@ -1199,11 +1205,15 @@ export class ProxyMiddleware implements NestMiddleware {
         return;
       }
 
-      // When this rule persists execution logs, choose the row id up front so the
-      // response can carry it (X-Pipeline-Log-Id) while the insert below stays
-      // fire-and-forget. A caller that gets a failed response can then fetch
-      // GET /api/pipeline-logs/:id directly instead of matching by timestamp.
-      const logId = rule.debugEnabled ? randomUUID() : undefined;
+      // When this run persists an execution log, choose the row id up front so
+      // the response can carry it (X-Pipeline-Log-Id) while the insert below
+      // stays fire-and-forget. A caller that gets a failed response can then
+      // fetch GET /api/pipeline-logs/:id directly instead of matching by
+      // timestamp. Failed runs are always logged (#724) so production rules
+      // leave a record without debug mode; successful runs stay debug-gated,
+      // so a healthy rule's log volume is unchanged.
+      const shouldPersistLog = rule.debugEnabled || !result.success;
+      const logId = shouldPersistLog ? randomUUID() : undefined;
 
       if (result.success && result.response) {
         // Set response headers if provided
@@ -1243,9 +1253,11 @@ export class ProxyMiddleware implements NestMiddleware {
         });
       }
 
-      // Fire-and-forget: persist execution log if debug is enabled
-      // Wait for post-steps to complete so their debug info is included
-      if (rule.debugEnabled && logId) {
+      // Fire-and-forget: persist execution log when debug is enabled or the
+      // run failed. Wait for post-steps to complete so their debug info is
+      // included (with debug off, result.debug is absent and the log service
+      // stores a minimal envelope).
+      if (logId) {
         const persistLog = async () => {
           if (result.postStepsPromise) {
             try {
@@ -1276,17 +1288,42 @@ export class ProxyMiddleware implements NestMiddleware {
         );
       }
     } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
       this.logger.error(
         `Pipeline execution failed: ${error instanceof Error ? error.message : String(error)}`,
         error instanceof Error ? error.stack : undefined,
       );
+      // A thrown error is a failed run: always persist a log row (#724) so the
+      // failure is visible even with debug off, and let the response carry the
+      // row id when it hasn't gone out yet.
+      const logId = randomUUID();
       if (!res.headersSent) {
+        res.setHeader(PIPELINE_LOG_ID_HEADER, logId);
         res.status(500).json({
           error: 'Pipeline execution failed',
           code: 'PIPELINE_EXECUTION_ERROR',
-          message: error instanceof Error ? error.message : 'Unknown error',
+          message,
         });
       }
+      const failedResult: PipelineDebugResult = {
+        success: false,
+        error: { code: 'PIPELINE_EXECUTION_ERROR', message },
+      };
+      this.executionLogService
+        .log(
+          rule.id,
+          projectId,
+          failedResult,
+          {
+            ip: req.ip,
+            userAgent: req.headers['user-agent'],
+            userId: user?.id,
+          },
+          req.method,
+          req.path,
+          logId,
+        )
+        .catch((err) => this.logger.error('Failed to persist pipeline execution log', err));
     }
   }
 

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -51,6 +51,21 @@ interface CacheEntry {
   expiry: number;
 }
 
+/**
+ * Pipeline error codes that map to a 4xx response (see the status mapping in
+ * handlePipelineExecution): validator outcomes an anonymous caller can trigger
+ * on any public rule. These stay debug-gated for execution-log persistence;
+ * everything else in a failed result is treated as an execution failure and is
+ * always logged (#724). Expressed as an exclusion list so a future unmapped
+ * error code defaults to "persist" (fail-visible), matching its 500 response.
+ */
+const CLIENT_FAULT_ERROR_CODES: ReadonlySet<string> = new Set([
+  'VALIDATION_ERROR', // 400
+  'AUTH_REQUIRED', // 401
+  'AUTHORIZATION_ERROR', // 403
+  'RATE_LIMIT_EXCEEDED', // 429
+]);
+
 @Injectable()
 export class ProxyMiddleware implements NestMiddleware {
   private readonly logger = new Logger(ProxyMiddleware.name);
@@ -1209,10 +1224,17 @@ export class ProxyMiddleware implements NestMiddleware {
       // the response can carry it (X-Pipeline-Log-Id) while the insert below
       // stays fire-and-forget. A caller that gets a failed response can then
       // fetch GET /api/pipeline-logs/:id directly instead of matching by
-      // timestamp. Failed runs are always logged (#724) so production rules
-      // leave a record without debug mode; successful runs stay debug-gated,
-      // so a healthy rule's log volume is unchanged.
-      const shouldPersistLog = rule.debugEnabled || !result.success;
+      // timestamp. Execution failures (the unmapped-to-4xx bucket that answers
+      // 500) are always logged (#724) so production rules leave a record
+      // without debug mode. Successes AND client-fault validator outcomes
+      // (400/401/403/429) stay debug-gated: those are triggerable by anonymous
+      // public traffic on every request, and logging them would add DB write
+      // load exactly under rate-limit/bot pressure and crowd the small
+      // per-rule retention window with 4xx noise. An unmapped error code
+      // defaults to "persist" (fail-visible).
+      const isExecutionFailure =
+        !result.success && !CLIENT_FAULT_ERROR_CODES.has(result.error?.code ?? '');
+      const shouldPersistLog = rule.debugEnabled || isExecutionFailure;
       const logId = shouldPersistLog ? randomUUID() : undefined;
 
       if (result.success && result.response) {
@@ -1254,9 +1276,9 @@ export class ProxyMiddleware implements NestMiddleware {
       }
 
       // Fire-and-forget: persist execution log when debug is enabled or the
-      // run failed. Wait for post-steps to complete so their debug info is
-      // included (with debug off, result.debug is absent and the log service
-      // stores a minimal envelope).
+      // run hit an execution failure. Wait for post-steps to complete so their
+      // debug info is included (with debug off, result.debug is absent and the
+      // log service stores a minimal envelope).
       if (logId) {
         const persistLog = async () => {
           if (result.postStepsPromise) {
@@ -1293,9 +1315,9 @@ export class ProxyMiddleware implements NestMiddleware {
         `Pipeline execution failed: ${error instanceof Error ? error.message : String(error)}`,
         error instanceof Error ? error.stack : undefined,
       );
-      // A thrown error is a failed run: always persist a log row (#724) so the
-      // failure is visible even with debug off, and let the response carry the
-      // row id when it hasn't gone out yet.
+      // A thrown error is an execution failure (answered as 500): always
+      // persist a log row (#724) so the failure is visible even with debug
+      // off, and let the response carry the row id when it hasn't gone out yet.
       const logId = randomUUID();
       if (!res.headersSent) {
         res.setHeader(PIPELINE_LOG_ID_HEADER, logId);


### PR DESCRIPTION
Closes #724

## Summary
A pipeline proxy rule only wrote an execution-log row when its debug mode was on, so a rule that failed in production — with debug off, as it should be — left no record of why (bffless/apps#490: two 500s out of 169 calls, nothing in `list_pipeline_logs`). Execution failures (the 500-class: thrown errors and any error code not in the 4xx mapping) are now always persisted with their error code, message, and failing step, and the failed HTTP response carries the log's id in `X-Pipeline-Log-Id` so the caller can fetch the row directly. Successes and client-fault 4xx outcomes keep today's debug-gated behaviour, so a healthy — or merely rate-limited — rule's log volume is unchanged.

## Behaviour changes
- Execution failure (500-class), debug off: before → no log row, bare error response; after → one `pipeline_execution_logs` row (errorCode/errorMessage/errorStep, minimal debug envelope) and an `X-Pipeline-Log-Id` header on the response.
- Thrown execution errors (the outer catch answering `PIPELINE_EXECUTION_ERROR`): before → container log only; after → also persisted as a failed log row, header included when the response hasn't already streamed.
- Client-fault validator outcomes (`VALIDATION_ERROR` 400, `AUTH_REQUIRED` 401, `AUTHORIZATION_ERROR` 403, `RATE_LIMIT_EXCEEDED` 429): unchanged — logged only when debug is on, exactly like successes. These are anonymously triggerable on public rules; always logging them would turn rate limiting into DB write load and let 4xx noise evict the 500 rows from the 50-row per-rule retention window.
- Successful runs and debug-on rules: unchanged.

## Why
A rule that runs cleanly in production leaves debug off, but then a failure is invisible everywhere except the container log — the incident in bffless/apps#490 could only be diagnosed by timing correlation. The retention cleanup (50 rows per rule) already bounds the table, so the cost of genuine failure rows is budgeted. The persist condition is expressed as a 4xx exclusion list rather than a 5xx enumeration, so a future unmapped error code defaults to "persist" (fail-visible), matching its 500 response. Scope narrowed to 500-class per the automated review's Finding 1.

## What changed
- Backend: `apps/backend/src/proxy-rules/proxy.middleware.ts` — new `CLIENT_FAULT_ERROR_CODES` exclusion set; mint a `logId` and persist when `rule.debugEnabled || (failed && not client-fault)`; the outer catch now builds a minimal failed result and fire-and-forgets a log under `PIPELINE_EXECUTION_ERROR` (user hoisted so the row keeps its `userId` attribution).
- Backend: `apps/backend/src/pipelines/pipeline-execution-log.service.ts` — doc comment on `PIPELINE_LOG_ID_HEADER` updated to match.
- Tests: `apps/backend/src/proxy-rules/proxy.middleware.spec.ts` — new describe block: execution failure with debug off writes exactly one row with error fields; `RATE_LIMIT_EXCEEDED` with debug off writes none; successful run with debug off writes none; thrown error is logged under `PIPELINE_EXECUTION_ERROR` (with and without headers already sent).
- Process: `.claude/ce-pr-review-checklist.md` — added the reviewer's proposed "Pipeline execution logging is on the public request hot path" entry.

## Compatibility
- Pipeline semantics: response bodies, status mapping, and validation behaviour are untouched; the change is observability-only and additive. Stored rule sets behave identically toward callers apart from the extra response header on 500-class failures.
- `X-Pipeline-Log-Id` now reaches anonymous callers of debug-off rules on execution failures; `GET /api/pipeline-logs/:logId` is already project-scoped via `PermissionsService.requireProjectAccess` (PR #717 checklist entry verified), so knowing an id is not enough to read it.
- Log volume: 4xx client-fault outcomes stay debug-gated, so anonymous traffic cannot inflate writes; genuine failure rows are bounded by the existing per-rule retention (`DEFAULT_RETENTION` = 50) enforced on every insert.
- No migrations, env vars, nginx generation, storage layout, or CLI contract changes.

## Verification
- `pnpm --filter backend exec tsc --noEmit` — clean; `pnpm --filter frontend exec tsc --noEmit` — clean.
- `pnpm test -- proxy.middleware.spec` — 34/34 passed (includes 5 new tests).
- Full backend suite (`jest --runInBand`): 200 suites passed, 3556 tests passed, 47 skipped (pre-existing skips), exit 0.
- `pnpm --filter backend format:check` — clean.

## Out of scope / follow-ups
- Logging successful runs without debug, and changing the error→status mapping (explicitly out of scope in #724).
- The harness-side fix for bffless/apps#490 (bounded concurrency + retry) is tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn8HigXHxygxe9UiduKJTb
