### PR TITLE
feat(pipelines): mcp_handler — a generic MCP server step over sibling rules

### DIFF
--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -20,6 +20,7 @@ by independently-versioned clients. A change is breaking if it breaks **an old c
 talking to a new server**, or **a new server booting on old data**.
 
 ### DB migrations must be forward-safe
+
 **Surface:** `apps/backend/drizzle/*.sql`
 **Check:** Any `DROP COLUMN`, `DROP TABLE`, rename, type narrowing, or `NOT NULL`
 added without a `DEFAULT` / backfill. Also: was the migration hand-written? Drizzle
@@ -27,35 +28,39 @@ migrations must be generated via `pnpm db:generate`, never authored by hand.
 **Why:** `docker/backend-entrypoint.sh` runs `node dist/db/migrate.js` on every
 container start and **hard-fails the boot** if it errors. A bad migration doesn't
 degrade — it bricks the upgrade for every self-hoster. During a rolling deploy the
-*old* image also runs against the *new* schema, so a dropped column breaks the still-live pods.
+_old_ image also runs against the _new_ schema, so a dropped column breaks the still-live pods.
 **Prefer:** expand → migrate → contract across two releases, not one destructive step.
 
 ### The published CLI is a pinned client
+
 **Surface:** `apps/backend/src/**` API responses vs `packages/cli/`
 **Check:** Does the PR remove or rename an API field, endpoint, or query param the
-CLI reads? Is `packages/cli` updated in lockstep — and does it still work *unupdated*?
+CLI reads? Is `packages/cli` updated in lockstep — and does it still work _unupdated_?
 **Why:** `packages/cli` publishes to npm as `bffless` and is release-please'd
 separately from the server. Users run whatever version they installed against
 whatever server they run. Server changes must be additive.
 
 ### The GitHub Actions are frozen at `@v1`
+
 **Surface:** the `POST /api/deployments/zip` contract and its auth
 **Check:** Any change to the deployment upload endpoint, its multipart field names,
 alias/proxy-rule-set attach params, or its API-key auth.
 **Why:** Consumers pin `bffless/upload-artifact@v1`, and the actions ncc-freeze their
-code into `dist/` — an npm CLI release does *not* reach them. They will keep sending
+code into `dist/` — an npm CLI release does _not_ reach them. They will keep sending
 the old shape indefinitely.
 
 ### Pipeline / proxy-rule semantics are live customer data
+
 **Surface:** `apps/backend/src/pipelines/`, `apps/backend/src/proxy-rules/`
 **Check:** Changes to handler behaviour, expression evaluation, or template
-substitution. Would an *existing stored rule set* behave differently after this merge?
+substitution. Would an _existing stored rule set_ behave differently after this merge?
 **Why:** Rule sets are user-authored data already running in production. A semantics
 change silently alters live APIs with no redeploy and no error. This is the highest-risk
 category in the repo because nothing fails loudly.
 **Ask:** is the new behaviour opt-in, or does it retroactively apply to every stored rule?
 
 ### Env vars are an upgrade contract
+
 **Surface:** `.env.example` (large — several hundred documented vars), `docker-compose*.yml`
 **Check:** Renamed or newly-required env vars. Is the old name still read as a
 fallback? Does a self-hoster who doesn't touch their `.env` still boot?
@@ -63,8 +68,9 @@ fallback? Does a self-hoster who doesn't touch their `.env` still boot?
 default is a breaking change even though no code signature changed.
 
 ### Generated nginx config must keep serving existing domains
+
 **Surface:** `apps/backend/src/domains/nginx-config.service.ts`, `docker/nginx*.conf`
-**Check:** Does the diff change generated config for *already-configured* domains?
+**Check:** Does the diff change generated config for _already-configured_ domains?
 Are the contract specs in `apps/backend/src/domains/` still green — in particular
 `nginx-serving-contract.spec.ts`, `nginx-config.service.spec.ts`,
 `nginx-templates.spec.ts`, `nginx-config-presigned.spec.ts`?
@@ -74,6 +80,7 @@ change that edits generation without touching them as suspicious.
 `server` blocks it wasn't aimed at.
 
 ### Storage paths and layout are permanent
+
 **Surface:** `apps/backend/src/storage/`, `apps/backend/src/deployments/`
 **Check:** Changes to storage key layout, path derivation, or `storage_path` semantics.
 **Why:** Existing objects are already written at the old keys. Changing derivation
@@ -81,6 +88,7 @@ orphans them — the data isn't lost, it's just unreachable, which is worse beca
 looks fine until someone requests an old file.
 
 ### Installed apps carry user customization
+
 **Surface:** `apps/backend/src/app-catalog/`
 **Check:** Does an app update overwrite state the user is allowed to customize?
 **Why:** There's a defined contract for what survives a 1-click app update. Silently
@@ -91,9 +99,11 @@ widening what gets overwritten destroys user work during a routine update.
 ## Part 2 — Release and process mechanics
 
 ### The PR title becomes the commit message
+
 CE squash-merges and runs release-please. **The PR title is the only commit message
 that survives.** A title that isn't a valid conventional commit blocks the version
 bump, the tag, the image build, and therefore the deploy.
+
 - Must be `type(scope): description` — `feat`, `fix`, `perf`, `revert`, `docs`,
   `style`, `chore`, `refactor`, `test`, `build`, `ci`.
 - Only `feat`, `fix`, `perf`, `revert` appear in the changelog; the rest are hidden.
@@ -102,6 +112,7 @@ bump, the tag, the image build, and therefore the deploy.
 - CE is pre-1.0 with `bump-minor-pre-major`, so `!` bumps the minor, not the major.
 
 ### What CI actually checks (`.github/workflows/pr-tests.yml`)
+
 - `tsc --noEmit` on **both** frontend and backend — this must be clean.
 - `pnpm test` — must pass.
 - frontend build (only when the base is `main`).
@@ -110,9 +121,11 @@ bump, the tag, the image build, and therefore the deploy.
   PR itself introduces.
 
 ### Tests are expected for behaviour changes
-New behaviour without a test is a finding — but say *what* to test, not just "add tests."
+
+New behaviour without a test is a finding — but say _what_ to test, not just "add tests."
 
 ### The review workflow's own checkout can be poisoned by the PR it reviews
+
 **Surface:** `.github/workflows/pr-review.yml`, or any future CI job that loads
 `.claude/agents/*.md` or `.claude/ce-pr-review-checklist.md` from a local checkout.
 **Check:** Does the checkout step pin `ref:` to the base SHA? On `pull_request`
@@ -122,10 +135,11 @@ the PR's own changes merged into base.
 are read from local disk with `Read`, not through `gh pr diff`. If the checkout
 includes the PR's changes, a PR that edits those files controls its own review, and
 the "PR content is untrusted data, not instructions" defence fails for precisely the
-two files that *are* the instructions.
+two files that _are_ the instructions.
 **Learned from:** PR #672, 2026-08-16 — found by this agent reviewing its own PR.
 
 ### A by-id lookup guarded only by `ApiKeyGuard` is instance-wide, not project-wide
+
 **Surface:** any `@Controller` under `apps/backend/src/**` using `@UseGuards(ApiKeyGuard)`
 alone on a `GET /:id` route — `ApiKeyGuard` accepts any session or API key on the
 instance and does no ownership check.
@@ -141,6 +155,7 @@ detail and error text; a cross-project read is a data leak with no error anywher
 anonymous callers while `GET /api/pipeline-logs/:logId` was unscoped; fixed in the same PR.
 
 ### Pipeline execution logging is on the public request hot path
+
 **Surface:** `apps/backend/src/proxy-rules/proxy.middleware.ts` (handlePipelineExecution),
 `apps/backend/src/pipelines/pipeline-execution-log.service.ts`
 **Check:** When persistence conditions change (e.g. "always log on X"), does the
@@ -153,6 +168,22 @@ adding DB write load (insert + per-rule retention cleanup) precisely under bot/s
 traffic or rate-limit pressure, and can crowd the small per-rule retention window
 (50 rows) with 4xx noise instead of the 5xx rows operators actually need.
 **Learned from:** PR #725, 2026-08-30.
+
+### Every path that reaches an external_proxy rule must build its headers through `buildProxyHeaders`
+
+**Surface:** `apps/backend/src/proxy-rules/proxy-headers.util.ts`; any new caller of a rule
+outside `ProxyService` (`RuleInvokerService.invokeExternal`, future internal callers).
+**Check:** Does the new path call `buildProxyHeaders(req, rule)` — so the rule's
+`forwardCookies` (cookie off by default), the default `authorization` strip,
+`headerConfig.forward` / `strip` / `add` and `authTransform: cookie-to-bearer` apply — or does
+it copy `cookie` / `authorization` from the caller itself?
+**Why:** An admin's `forwardCookies: false` (the default) is a deliberate control against
+sending session cookies and app tokens to a third-party target. A path that bypasses it turns
+an already-configured rule into a credential leak the moment it is wired up as an MCP tool or
+resource sibling — with no error anywhere.
+**Learned from:** PR #731, 2026-09-03 — the invoker forwarded both headers unconditionally
+(flagged on four review passes); fixed in the same PR by lifting `ProxyService.buildHeaders`
+into the shared util and testing the four control cases.
 
 ---
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -125,3 +125,13 @@ _Avoid_: "rate limit" (this is a concurrency ceiling, not a rate)
 **`remote_request`**:
 The pipeline step handler that calls a named Remote connection: resolves the connection, acquires its Fuse, sends the request with the connection's own identity, and always resolves with a step output (`ok`/`status`/`body`) rather than throwing on a non-2xx — a later step branches on the result.
 _Avoid_: "the remote handler" (ambiguous with the ffmpeg Remote executor)
+
+## Pipelines
+
+**MCP handler**:
+A pipeline step (`mcp_handler`) that answers as a stateless MCP server from its own config — tools and `ui://` resources mapped to Sibling rules of the same alias, executed in-process as the caller. App-agnostic: the app's rule set *is* the server; CE owns only the envelope. Not CE's own platform-admin MCP server (`@rekog/mcp-nest`, a different thing on a different path).
+_Avoid_: "the MCP server" (ambiguous with the platform-admin one), "MCP endpoint" (the app's rule, not the handler)
+
+**Sibling rule**:
+Another rule of the same alias's effective rule sets, invoked in-process by `RuleInvokerService` with the caller's identity and the sibling's own validators (`auth_required`, `requiredScopes`, `rate_limit`) — never the deployment visibility gate twice, and never nested (a sibling that is itself an MCP handler is refused). How an MCP tool runs, and the runtime cousin of the `alias://` idea (#698).
+_Avoid_: "internal call", "sub-pipeline"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -133,5 +133,5 @@ A pipeline step (`mcp_handler`) that answers as a stateless MCP server from its 
 _Avoid_: "the MCP server" (ambiguous with the platform-admin one), "MCP endpoint" (the app's rule, not the handler)
 
 **Sibling rule**:
-Another rule of the same alias's effective rule sets, invoked in-process by `RuleInvokerService` with the caller's identity and the sibling's own validators (`auth_required`, `requiredScopes`, `rate_limit`) — never the deployment visibility gate twice, and never nested (a sibling that is itself an MCP handler is refused). How an MCP tool runs, and the runtime cousin of the `alias://` idea (#698).
+Another rule of the same alias's effective rule sets, invoked in-process by `RuleInvokerService` with the caller's identity and the sibling's own validators (`auth_required`, `requiredScopes`, `rate_limit`) — and, for an `external_proxy` sibling, its own header controls (`forwardCookies`, `authTransform`, `headerConfig`), exactly as at the edge — never the deployment visibility gate twice, and never nested (a sibling that is itself an MCP handler is refused). How an MCP tool runs, and the runtime cousin of the `alias://` idea (#698).
 _Avoid_: "internal call", "sub-pipeline"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,10 +1,10 @@
 # CE Domain Glossary
 
-The ubiquitous language for Community Edition. A glossary, not a spec — define what terms *mean*, not how they're implemented.
+The ubiquitous language for Community Edition. A glossary, not a spec — define what terms _mean_, not how they're implemented.
 
 ## Authentication
 
-The most-confused area is *which auth path a deployed app should use*, which is decided entirely by *which kind of domain the app is served from*.
+The most-confused area is _which auth path a deployed app should use_, which is decided entirely by _which kind of domain the app is served from_.
 
 **Primary domain**:
 The single domain SuperTokens is configured against. Its auth cookies (`sAccessToken`) are valid on it and all of its subdomains.
@@ -13,7 +13,7 @@ The single domain SuperTokens is configured against. Its auth cookies (`sAccessT
 A host under the primary domain (e.g. `handoff.j5s.dev` under `j5s.dev`). Shares the primary domain's SuperTokens cookies — so apps here authenticate via the **SuperTokens session path**, not the relay.
 
 **Custom domain**:
-A cross-origin host that is *not* under the primary domain (e.g. `app.acme.com`, or **`localhost`** during local/automated testing). SuperTokens cookies cannot reach it, so apps here authenticate via the **admin login relay**, which mints its own cookie. `localhost` qualifying as a custom domain is why a local headless browser (e.g. Sandcastle's Playwright) gets a `bffless_access` cookie, never an `sAccessToken`.
+A cross-origin host that is _not_ under the primary domain (e.g. `app.acme.com`, or **`localhost`** during local/automated testing). SuperTokens cookies cannot reach it, so apps here authenticate via the **admin login relay**, which mints its own cookie. `localhost` qualifying as a custom domain is why a local headless browser (e.g. Sandcastle's Playwright) gets a `bffless_access` cookie, never an `sAccessToken`.
 
 **SuperTokens session path**:
 Authentication via the `/api/auth/*` reverse proxy straight to SuperTokens. The correct path for the primary domain and its subdomains. Yields an `sAccessToken`.
@@ -21,7 +21,7 @@ _Avoid_: "the api/auth proxy"
 
 **Admin login relay**:
 Authentication via the `/_bffless/auth/*` endpoints, intended **only for custom (cross-origin) domains** where SuperTokens cookies can't reach. It mints a `bffless_access` cookie and adds custom-domain-specific behaviour on top. A common mistake (especially by code-gen) is defaulting to the relay without checking which domain the app sits on.
-_Avoid_: "the _bffless endpoint", "bffless auth"
+_Avoid_: "the \_bffless endpoint", "bffless auth"
 
 **sAccessToken**:
 The SuperTokens session cookie. Valid on the primary domain and its subdomains.
@@ -34,7 +34,7 @@ An `X-API-Key` credential scoped to one project, authenticating the data layer (
 _Avoid_: "the project key", "access key"
 
 **App token**:
-A member-bound, project-bound, scoped bearer credential (`Authorization: Bearer bfat_…`) the member mints in *Settings → App Tokens*, or an OAuth client obtains on the member's behalf. Wherever a session is accepted for content or pipelines — the deployment visibility gate, `auth_required` — the token *is* the member, narrowed by its scopes: effective permission is what the member may do ∩ what the token was granted, so a token never elevates. On the admin API it behaves as a project-scoped API key does (project-fenced, role pinned). Not an API key: an API key is pinned to role `user` and bound to no person.
+A member-bound, project-bound, scoped bearer credential (`Authorization: Bearer bfat_…`) the member mints in _Settings → App Tokens_, or an OAuth client obtains on the member's behalf. Wherever a session is accepted for content or pipelines — the deployment visibility gate, `auth_required` — the token _is_ the member, narrowed by its scopes: effective permission is what the member may do ∩ what the token was granted, so a token never elevates. On the admin API it behaves as a project-scoped API key does (project-fenced, role pinned). Not an API key: an API key is pinned to role `user` and bound to no person.
 _Avoid_: "personal access token", "PAT", "bearer" alone (a SuperTokens JWT is also a bearer)
 
 **Scope**:
@@ -89,7 +89,7 @@ ffmpeg spawned by the CE backend on the instance itself, subject to that box's m
 _Avoid_: "server" alone, "in-process"
 
 **Remote**:
-ffmpeg run by a Worker that CE calls over HTTPS with signed storage URLs, so the bytes never pass through the instance. Cloud Run is the *reference deployment*, not the name — any host running the Worker image is Remote.
+ffmpeg run by a Worker that CE calls over HTTPS with signed storage URLs, so the bytes never pass through the instance. Cloud Run is the _reference deployment_, not the name — any host running the Worker image is Remote.
 _Avoid_: "cloud run mode", "cloud"
 
 **Server video ops**:
@@ -129,7 +129,7 @@ _Avoid_: "the remote handler" (ambiguous with the ffmpeg Remote executor)
 ## Pipelines
 
 **MCP handler**:
-A pipeline step (`mcp_handler`) that answers as a stateless MCP server from its own config — tools and `ui://` resources mapped to Sibling rules of the same alias, executed in-process as the caller. App-agnostic: the app's rule set *is* the server; CE owns only the envelope. Not CE's own platform-admin MCP server (`@rekog/mcp-nest`, a different thing on a different path).
+A pipeline step (`mcp_handler`) that answers as a stateless MCP server from its own config — tools and `ui://` resources mapped to Sibling rules of the same alias, executed in-process as the caller. App-agnostic: the app's rule set _is_ the server; CE owns only the envelope. Not CE's own platform-admin MCP server (`@rekog/mcp-nest`, a different thing on a different path).
 _Avoid_: "the MCP server" (ambiguous with the platform-admin one), "MCP endpoint" (the app's rule, not the handler)
 
 **Sibling rule**:

--- a/apps/backend/src/mcp/tools/proxy-rules.tools.ts
+++ b/apps/backend/src/mcp/tools/proxy-rules.tools.ts
@@ -33,6 +33,7 @@ export const pipelineStepSchema = z.object({
       'ffmpeg_handler',
       'http_request',
       'remote_request',
+      'mcp_handler',
       'stripe_checkout',
       'stripe_webhook',
       'signed_url',

--- a/apps/backend/src/pipelines/execution/step-handler.interface.ts
+++ b/apps/backend/src/pipelines/execution/step-handler.interface.ts
@@ -1141,3 +1141,56 @@ export type { HttpRequestHandlerConfig } from '../handlers/http-request.handler'
 
 // RemoteRequestHandlerConfig is defined in handlers/remote-request.handler.ts
 export type { RemoteRequestHandlerConfig } from '../handlers/remote-request.handler';
+
+/**
+ * `mcp_handler` — one step that answers as a stateless Streamable-HTTP MCP
+ * server described entirely by this config. Tools and `ui://` resources map
+ * to sibling rules of the same alias, invoked in-process as the caller with
+ * the sibling's own validators (`RuleInvokerService`). App-agnostic: the
+ * app's rule set is the server (apps#554 spec 10, D22).
+ */
+export interface McpToolDecl {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
+  /** MCP Apps: `['model']` (default) or `['app']` — app-only tools are callable but listed with `_meta.ui.visibility`. */
+  visibility?: Array<'model' | 'app'>;
+  _meta?: Record<string, unknown>;
+  /** The sibling rule that answers the tool; `arguments` go as the body (POST) or the query (GET). */
+  rule: { path: string; method?: 'GET' | 'POST' };
+}
+
+export interface McpResourceDecl {
+  uri: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+  rule: { path: string; method?: 'GET' };
+}
+
+export interface McpResourceTemplateDecl {
+  /** RFC 6570 level 1: `{var}` one segment, `{var+}` a slash-carrying tail. */
+  uriTemplate: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+  /** The sibling path with the same variables, e.g. `/w/{impl}/{path+}`. */
+  rule: { path: string };
+}
+
+export interface McpHandlerConfig extends BaseHandlerConfig {
+  serverInfo: { name: string; version: string };
+  instructions?: string;
+  /** Newest first; defaults to the three the MCP spec has published. */
+  protocolVersions?: string[];
+  tools: McpToolDecl[];
+  resources?: {
+    static?: McpResourceDecl[];
+    templates?: McpResourceTemplateDecl[];
+    /** A sibling whose JSON answer is the resources array (or `{ resources }`) — what the app enumerates. */
+    list?: { rule: { path: string; method?: 'GET' } };
+    /** `_meta.ui.csp` for every resource; entries may be `$app` (the request's origin) or `$storage` (the storage backend's). */
+    csp?: { connectDomains?: string[]; resourceDomains?: string[] };
+  };
+}

--- a/apps/backend/src/pipelines/function-runner.cache.spec.ts
+++ b/apps/backend/src/pipelines/function-runner.cache.spec.ts
@@ -1,0 +1,32 @@
+import { FunctionRunnerService, SCRIPT_CACHE_MAX } from './function-runner.service';
+
+describe('FunctionRunnerService — compiled-script cache', () => {
+  const code = (n: number) => `function handler(data) { return { n: ${n}, echo: data.request } }`;
+
+  it('compiles the same code once across runs and reuses the Script', async () => {
+    const service = new FunctionRunnerService();
+    const a = await service.run(code(1), { request: 'a' });
+    const b = await service.run(code(1), { request: 'b' });
+    expect(a.output).toEqual({ n: 1, echo: 'a' });
+    expect(b.output).toEqual({ n: 1, echo: 'b' });
+    expect(service.cachedScripts()).toBe(1);
+    expect(service.hasCachedScript(code(1))).toBe(true);
+    await service.run(code(2), { request: 'c' });
+    expect(service.cachedScripts()).toBe(2);
+  });
+
+  it('memoises validation, including a failure', () => {
+    const service = new FunctionRunnerService();
+    const bad = 'function handler() { return eval("1") }';
+    expect(service.validateCode(bad).valid).toBe(false);
+    expect(service.validateCode(bad)).toBe(service.validateCode(bad));
+  });
+
+  it('evicts the least recently inserted entry past the cap', async () => {
+    const service = new FunctionRunnerService();
+    for (let i = 0; i < SCRIPT_CACHE_MAX + 1; i += 1) await service.run(code(1000 + i), {});
+    expect(service.cachedScripts()).toBe(SCRIPT_CACHE_MAX);
+    expect(service.hasCachedScript(code(1000))).toBe(false);
+    expect(service.hasCachedScript(code(1000 + SCRIPT_CACHE_MAX))).toBe(true);
+  });
+});

--- a/apps/backend/src/pipelines/function-runner.service.ts
+++ b/apps/backend/src/pipelines/function-runner.service.ts
@@ -2,6 +2,37 @@ import { Injectable, Logger } from '@nestjs/common';
 import * as vm from 'vm';
 import { createHash, createHmac, randomBytes, randomUUID, timingSafeEqual } from 'crypto';
 
+/** Compiled scripts kept per distinct code (sha256); a rule's function is compiled once, not per request. */
+export const SCRIPT_CACHE_MAX = 64;
+
+/** A tiny insertion-ordered LRU over Map. */
+class LruMap<V> {
+  private readonly map = new Map<string, V>();
+  constructor(private readonly max: number) {}
+  get(key: string): V | undefined {
+    const value = this.map.get(key);
+    if (value !== undefined) {
+      this.map.delete(key);
+      this.map.set(key, value);
+    }
+    return value;
+  }
+  set(key: string, value: V): void {
+    if (this.map.has(key)) this.map.delete(key);
+    this.map.set(key, value);
+    if (this.map.size > this.max) {
+      const oldest = this.map.keys().next().value as string;
+      this.map.delete(oldest);
+    }
+  }
+  has(key: string): boolean {
+    return this.map.has(key);
+  }
+  get size(): number {
+    return this.map.size;
+  }
+}
+
 /**
  * Crypto helpers exposed to pipeline function handlers as the global `utils`
  * (also passed on the handler argument, so both `utils.sign(...)` and
@@ -114,6 +145,27 @@ export class FunctionRunnerService {
   private signingKeyCache: Buffer | null = null;
 
   /**
+   * Compiled wrapper scripts by code hash. A `vm.Script` is context-free —
+   * `runInContext` binds it to a fresh sandbox per run — so compiling once per
+   * distinct code is safe, and it is what makes a 250 KB bundled handler cost
+   * its compile once per rule version rather than once per request.
+   */
+  private readonly scripts = new LruMap<vm.Script>(SCRIPT_CACHE_MAX);
+  private readonly validations = new LruMap<ValidationResult>(SCRIPT_CACHE_MAX);
+
+  private static keyOf(code: string): string {
+    return createHash('sha256').update(code).digest('hex');
+  }
+
+  /** Test seams. */
+  cachedScripts(): number {
+    return this.scripts.size;
+  }
+  hasCachedScript(code: string): boolean {
+    return this.scripts.has(FunctionRunnerService.keyOf(code));
+  }
+
+  /**
    * Derive the pipeline signing key once, from a dedicated env var when set,
    * otherwise from the (required, stable) ENCRYPTION_KEY so signatures survive
    * restarts without extra configuration. Never exposed to the sandbox.
@@ -170,6 +222,15 @@ export class FunctionRunnerService {
    * Checks for prohibited patterns that could be used to escape the sandbox.
    */
   validateCode(code: string): ValidationResult {
+    const key = FunctionRunnerService.keyOf(code);
+    const memo = this.validations.get(key);
+    if (memo) return memo;
+    const result = this.validateCodeUncached(code);
+    this.validations.set(key, result);
+    return result;
+  }
+
+  private validateCodeUncached(code: string): ValidationResult {
     const errors: string[] = [];
 
     for (const pattern of PROHIBITED_PATTERNS) {
@@ -322,10 +383,15 @@ export class FunctionRunnerService {
         })();
       `;
 
-      // Compile and run
-      const script = new vm.Script(wrappedCode, {
-        filename: 'user-function.js',
-      });
+      // Compile once per distinct code, run per request
+      const key = FunctionRunnerService.keyOf(code);
+      let script = this.scripts.get(key);
+      if (!script) {
+        script = new vm.Script(wrappedCode, {
+          filename: 'user-function.js',
+        });
+        this.scripts.set(key, script);
+      }
 
       // Run with timeout
       await new Promise<void>((resolve, reject) => {

--- a/apps/backend/src/pipelines/handlers/index.ts
+++ b/apps/backend/src/pipelines/handlers/index.ts
@@ -28,3 +28,4 @@ export * from './data-upsert-many.handler';
 export * from './delay.handler';
 export * from './ffmpeg.handler';
 export * from './remote-request.handler';
+export * from './mcp.handler';

--- a/apps/backend/src/pipelines/handlers/mcp.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/mcp.handler.spec.ts
@@ -1,0 +1,206 @@
+import { McpHandler } from './mcp.handler';
+import { StepHandlerRegistry } from '../execution/step-handler.registry';
+import { PipelineContext } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+import { ConfigurationError } from '../errors';
+import { McpHandlerConfig } from '../execution/step-handler.interface';
+
+const config: McpHandlerConfig = {
+  serverInfo: { name: 's', version: '1' },
+  tools: [
+    {
+      name: 'app.read',
+      description: 'r',
+      inputSchema: { type: 'object' },
+      rule: { path: '/api/app/read' },
+    },
+  ],
+  resources: { csp: { connectDomains: ['$app', '$storage'] } },
+};
+
+function make() {
+  const registry = { register: jest.fn() } as unknown as StepHandlerRegistry;
+  const invoker = { invoke: jest.fn() };
+  const storage = { getUrl: jest.fn().mockResolvedValue('https://storage.example/bucket/x?sig=1') };
+  const handler = new McpHandler(registry, invoker as never, storage as never);
+  return { handler, invoker, storage, registry };
+}
+
+function ctx(over: Partial<PipelineContext> = {}): PipelineContext {
+  return {
+    request: { headers: {}, cookies: {} } as never,
+    user: { id: 'u', credential: 'app_token', scopes: ['app:read'] },
+    stepOutputs: {},
+    projectId: 'proj-1',
+    pipelineId: 'pipe-1',
+    deployment: { owner: 'o', repo: 'r', commitSha: 'c', alias: 'workflow' },
+    metadata: {
+      path: '/api/app/mcp',
+      method: 'POST',
+      headers: { 'x-forwarded-host': 'h.example' },
+      query: {},
+      body: {},
+    },
+    ...over,
+  };
+}
+const step = (c: McpHandlerConfig = config): PipelineStep =>
+  ({ id: 'mcp', name: 'mcp', handlerType: 'mcp_handler', config: c }) as PipelineStep;
+
+describe('McpHandler', () => {
+  it('registers as mcp_handler', () => {
+    const { registry, handler } = make();
+    expect(handler.type).toBe('mcp_handler');
+    expect(registry.register).toHaveBeenCalledWith(handler);
+  });
+
+  describe('validateConfig', () => {
+    it('accepts the sample and refuses duplicates, a bad path, a bad method, a bad visibility', () => {
+      const { handler } = make();
+      expect(() => handler.validateConfig(config)).not.toThrow();
+      expect(() =>
+        handler.validateConfig({ ...config, tools: [config.tools[0], config.tools[0]] }),
+      ).toThrow(ConfigurationError);
+      expect(() =>
+        handler.validateConfig({
+          ...config,
+          tools: [{ ...config.tools[0], rule: { path: 'api/x' } }],
+        }),
+      ).toThrow(/rule.path/);
+      expect(() =>
+        handler.validateConfig({
+          ...config,
+          tools: [{ ...config.tools[0], rule: { path: '/x', method: 'PUT' as never } }],
+        }),
+      ).toThrow(/method/);
+      expect(() =>
+        handler.validateConfig({
+          ...config,
+          tools: [{ ...config.tools[0], visibility: ['host' as never] }],
+        }),
+      ).toThrow(/visibility/);
+      expect(() =>
+        handler.validateConfig({ ...config, serverInfo: { name: 's' } as never }),
+      ).toThrow(/serverInfo/);
+      expect(() =>
+        handler.validateConfig({
+          ...config,
+          resources: {
+            templates: [{ uriTemplate: 'ui://x/static', name: 'n', rule: { path: '/p' } }],
+          },
+        }),
+      ).toThrow(/variable/);
+    });
+  });
+
+  describe('execute', () => {
+    it('answers tools/list with terminates: true and the JSON body', async () => {
+      const { handler } = make();
+      const result = await handler.execute(
+        ctx({
+          metadata: { ...ctx().metadata, body: { jsonrpc: '2.0', id: 1, method: 'tools/list' } },
+        }),
+        step(),
+      );
+      expect(result.success).toBe(true);
+      expect(result.terminates).toBe(true);
+      const output = result.output as {
+        status: number;
+        body: string;
+        headers: Record<string, string>;
+      };
+      expect(output.status).toBe(200);
+      expect(JSON.parse(output.body).result.tools[0].name).toBe('app.read');
+      expect(output.headers['Content-Type']).toBe('application/json');
+    });
+
+    it('routes tools/call to the invoker with the caller, the alias, the parent request and depth 1', async () => {
+      const { handler, invoker } = make();
+      invoker.invoke.mockResolvedValue({
+        ok: true,
+        answer: {
+          status: 200,
+          body: { content: [{ type: 'text', text: 'ok' }] },
+          headers: {},
+          contentType: 'application/json',
+        },
+      });
+      const c = ctx({
+        metadata: {
+          ...ctx().metadata,
+          body: {
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'tools/call',
+            params: { name: 'app.read', arguments: { a: 1 } },
+          },
+        },
+      });
+      const result = await handler.execute(c, step());
+      expect(invoker.invoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: 'proj-1',
+          alias: 'workflow',
+          path: '/api/app/read',
+          method: 'POST',
+          body: { a: 1 },
+          user: c.user,
+          parent: c.request,
+          depth: 1,
+        }),
+      );
+      expect(JSON.parse((result.output as { body: string }).body).result).toEqual({
+        content: [{ type: 'text', text: 'ok' }],
+      });
+    });
+
+    it('increments the depth from the parent request marker', async () => {
+      const { handler, invoker } = make();
+      invoker.invoke.mockResolvedValue({ ok: false, failure: { kind: 'recursion' } });
+      const c = ctx({
+        request: { headers: {}, __invokeDepth: 1 } as never,
+        metadata: {
+          ...ctx().metadata,
+          body: { jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'app.read' } },
+        },
+      });
+      await handler.execute(c, step());
+      expect(invoker.invoke).toHaveBeenCalledWith(expect.objectContaining({ depth: 2 }));
+    });
+
+    it('answers GET with 405', async () => {
+      const { handler } = make();
+      const result = await handler.execute(
+        ctx({ metadata: { ...ctx().metadata, method: 'GET' } }),
+        step(),
+      );
+      expect((result.output as { status: number; headers: Record<string, string> }).status).toBe(
+        405,
+      );
+      expect((result.output as { headers: Record<string, string> }).headers.Allow).toBe('POST');
+    });
+
+    it('derives the CSP origins from the host and a storage probe, cached per project', async () => {
+      const { handler, storage } = make();
+      const body = { jsonrpc: '2.0', id: 3, method: 'resources/list' };
+      const cfg: McpHandlerConfig = {
+        ...config,
+        resources: {
+          static: [{ uri: 'ui://s/v.html', name: 'v', rule: { path: '/v.html' } }],
+          csp: { connectDomains: ['$app', '$storage'] },
+        },
+      };
+      const first = await handler.execute(
+        ctx({ metadata: { ...ctx().metadata, body } }),
+        step(cfg),
+      );
+      await handler.execute(ctx({ metadata: { ...ctx().metadata, body } }), step(cfg));
+      const resources = JSON.parse((first.output as { body: string }).body).result.resources;
+      expect(resources[0]._meta.ui.csp.connectDomains).toEqual([
+        'https://h.example',
+        'https://storage.example',
+      ]);
+      expect(storage.getUrl).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/backend/src/pipelines/handlers/mcp.handler.ts
+++ b/apps/backend/src/pipelines/handlers/mcp.handler.ts
@@ -1,0 +1,182 @@
+import { Inject, Injectable, Logger, forwardRef } from '@nestjs/common';
+import { StepHandler, McpHandlerConfig, McpToolDecl } from '../execution/step-handler.interface';
+import { StepHandlerRegistry } from '../execution/step-handler.registry';
+import { PipelineContext, StepResult } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+import { ConfigurationError } from '../errors';
+import { IStorageAdapter, STORAGE_ADAPTER } from '../../storage/storage.interface';
+import { INVOKE_DEPTH_KEY, RuleInvokerService } from '../../proxy-rules/rule-invoker.service';
+import { answer } from '../mcp/protocol';
+import { matchTemplate } from '../mcp/resources';
+
+const STORAGE_ORIGIN_TTL_MS = 5 * 60 * 1000;
+const VISIBILITY = new Set(['model', 'app']);
+
+/**
+ * MCP Handler
+ *
+ * One step that answers as a stateless Streamable-HTTP MCP server described by
+ * its config: tools and `ui://` resources mapped to sibling rules of the same
+ * alias, executed in-process as the caller (`RuleInvokerService`) with the
+ * sibling's own validators — so a tool's scope is whatever `auth_required`
+ * on its sibling says. App-agnostic: the rule set is the server. Never a CE
+ * endpoint, never `/_bffless/*`, and not CE's own platform-admin MCP server
+ * (apps#554 spec 10, D22).
+ */
+@Injectable()
+export class McpHandler implements StepHandler<McpHandlerConfig> {
+  readonly type = 'mcp_handler' as const;
+  private readonly logger = new Logger(McpHandler.name);
+  private readonly storageOrigins = new Map<string, { origin: string; expiry: number }>();
+
+  constructor(
+    private readonly registry: StepHandlerRegistry,
+    @Inject(forwardRef(() => RuleInvokerService))
+    private readonly invoker: RuleInvokerService,
+    @Inject(STORAGE_ADAPTER) private readonly storageAdapter: IStorageAdapter,
+  ) {
+    this.registry.register(this);
+  }
+
+  validateConfig(config: McpHandlerConfig): void {
+    const fail = (message: string): never => {
+      throw new ConfigurationError(message, 'mcp_handler');
+    };
+    if (
+      !config.serverInfo ||
+      typeof config.serverInfo.name !== 'string' ||
+      typeof config.serverInfo.version !== 'string'
+    ) {
+      fail('serverInfo.name and serverInfo.version are required strings');
+    }
+    if (config.instructions !== undefined && typeof config.instructions !== 'string')
+      fail('instructions must be a string');
+    if (
+      config.protocolVersions !== undefined &&
+      (!Array.isArray(config.protocolVersions) ||
+        config.protocolVersions.some((v) => typeof v !== 'string'))
+    ) {
+      fail('protocolVersions must be an array of strings');
+    }
+    if (!Array.isArray(config.tools)) fail('tools must be an array');
+    const names = new Set<string>();
+    for (const tool of config.tools as McpToolDecl[]) {
+      if (!tool || typeof tool.name !== 'string' || tool.name === '')
+        fail('each tool needs a name');
+      if (names.has(tool.name)) fail(`duplicate tool name: ${tool.name}`);
+      names.add(tool.name);
+      if (typeof tool.description !== 'string')
+        fail(`tool ${tool.name}: description must be a string`);
+      if (!tool.inputSchema || typeof tool.inputSchema !== 'object')
+        fail(`tool ${tool.name}: inputSchema must be an object`);
+      if (!tool.rule || typeof tool.rule.path !== 'string' || !tool.rule.path.startsWith('/'))
+        fail(`tool ${tool.name}: rule.path must start with /`);
+      if (
+        tool.rule.method !== undefined &&
+        tool.rule.method !== 'GET' &&
+        tool.rule.method !== 'POST'
+      )
+        fail(`tool ${tool.name}: rule.method must be GET or POST`);
+      if (
+        tool.visibility !== undefined &&
+        (!Array.isArray(tool.visibility) || tool.visibility.some((v) => !VISIBILITY.has(v)))
+      ) {
+        fail(`tool ${tool.name}: visibility must be a subset of [model, app]`);
+      }
+    }
+    const resources = config.resources;
+    if (resources !== undefined) {
+      for (const r of resources.static ?? []) {
+        if (
+          typeof r.uri !== 'string' ||
+          typeof r.name !== 'string' ||
+          typeof r.rule?.path !== 'string'
+        )
+          fail('each static resource needs uri, name and rule.path');
+      }
+      for (const t of resources.templates ?? []) {
+        if (typeof t.uriTemplate !== 'string' || typeof t.rule?.path !== 'string')
+          fail('each resource template needs uriTemplate and rule.path');
+        if (!/\{[a-zA-Z_][a-zA-Z0-9_]*\+?\}/.test(t.uriTemplate))
+          fail(`resource template ${t.uriTemplate} declares no {variable}`);
+        // A template must at least match its own literal shape — a syntax check.
+        matchTemplate(t.uriTemplate, t.uriTemplate.replace(/\{[^}]+\}/g, 'x'));
+      }
+      if (resources.list !== undefined && typeof resources.list.rule?.path !== 'string')
+        fail('resources.list.rule.path is required');
+      const csp = resources.csp;
+      if (csp !== undefined) {
+        for (const key of ['connectDomains', 'resourceDomains'] as const) {
+          const list = csp[key];
+          if (
+            list !== undefined &&
+            (!Array.isArray(list) || list.some((v) => typeof v !== 'string'))
+          )
+            fail(`csp.${key} must be an array of strings`);
+        }
+      }
+    }
+  }
+
+  async execute(context: PipelineContext, step: PipelineStep): Promise<StepResult> {
+    const config = step.config as McpHandlerConfig;
+    const request = context.request as unknown as Record<string, unknown>;
+    const parentDepth =
+      typeof request[INVOKE_DEPTH_KEY] === 'number' ? (request[INVOKE_DEPTH_KEY] as number) : 0;
+    const host =
+      firstHeader(context.metadata.headers['x-forwarded-host']) ??
+      firstHeader(context.metadata.headers.host) ??
+      '';
+
+    const result = await answer(
+      config,
+      { method: context.metadata.method, body: context.metadata.body },
+      {
+        invoke: (path, method, args) =>
+          this.invoker.invoke({
+            projectId: context.projectId,
+            alias: context.deployment?.alias,
+            deployment: context.deployment,
+            path,
+            method,
+            query: method === 'GET' ? args : undefined,
+            body: method === 'POST' ? args : undefined,
+            user: context.user,
+            parent: context.request,
+            depth: parentDepth + 1,
+          }),
+        origins: async () => ({
+          app: host === '' ? '' : `https://${host}`,
+          storage: await this.storageOrigin(context.projectId),
+        }),
+      },
+    );
+
+    return {
+      success: true,
+      terminates: true,
+      output: { status: result.status, body: result.body, headers: result.headers },
+    };
+  }
+
+  /** The storage backend's public origin, from a presigned GET of a probe key; cached per project. */
+  private async storageOrigin(projectId: string): Promise<string> {
+    const cached = this.storageOrigins.get(projectId);
+    if (cached && cached.expiry > Date.now()) return cached.origin;
+    let origin = '';
+    try {
+      const url = await this.storageAdapter.getUrl(`.mcp-csp-probe/${projectId}`, 60);
+      const match = url.match(/^(https?:\/\/[^/?#]+)/i);
+      origin = match ? match[1] : '';
+    } catch (error) {
+      this.logger.debug(`storage origin probe failed: ${String(error)}`);
+    }
+    this.storageOrigins.set(projectId, { origin, expiry: Date.now() + STORAGE_ORIGIN_TTL_MS });
+    return origin;
+  }
+}
+
+function firstHeader(value: string | string[] | undefined): string | undefined {
+  const first = Array.isArray(value) ? value[0] : value;
+  return typeof first === 'string' && first !== '' ? first.split(',')[0].trim() : undefined;
+}

--- a/apps/backend/src/pipelines/mcp/jsonrpc.spec.ts
+++ b/apps/backend/src/pipelines/mcp/jsonrpc.spec.ts
@@ -1,0 +1,53 @@
+import {
+  ERR,
+  PROTOCOL_VERSIONS,
+  errorResponse,
+  negotiateVersion,
+  okResponse,
+  parseMessage,
+} from './jsonrpc';
+
+describe('jsonrpc', () => {
+  it('parses a request, defaulting params', () => {
+    expect(parseMessage({ jsonrpc: '2.0', id: 1, method: 'tools/list' })).toEqual({
+      kind: 'request',
+      id: 1,
+      method: 'tools/list',
+      params: {},
+    });
+  });
+  it('treats a message without an id as a notification', () => {
+    expect(parseMessage({ jsonrpc: '2.0', method: 'notifications/initialized' })).toEqual({
+      kind: 'notification',
+      method: 'notifications/initialized',
+      params: {},
+    });
+  });
+  it('refuses batches, non-objects, wrong versions and missing methods, keeping the id when present', () => {
+    expect(parseMessage([]).kind).toBe('invalid');
+    expect(parseMessage('x').kind).toBe('invalid');
+    expect(parseMessage({ jsonrpc: '1.0', id: 3, method: 'x' })).toMatchObject({
+      kind: 'invalid',
+      id: 3,
+    });
+    expect(parseMessage({ jsonrpc: '2.0', id: 'a' })).toMatchObject({ kind: 'invalid', id: 'a' });
+  });
+  it('negotiates the version', () => {
+    expect(negotiateVersion('2025-03-26', PROTOCOL_VERSIONS)).toBe('2025-03-26');
+    expect(negotiateVersion('1999-01-01', PROTOCOL_VERSIONS)).toBe('2025-06-18');
+    expect(negotiateVersion(undefined, PROTOCOL_VERSIONS)).toBe('2025-06-18');
+  });
+  it('builds envelopes', () => {
+    expect(okResponse(1, { a: 1 })).toEqual({ jsonrpc: '2.0', id: 1, result: { a: 1 } });
+    expect(errorResponse(null, ERR.METHOD_NOT_FOUND, 'nope')).toEqual({
+      jsonrpc: '2.0',
+      id: null,
+      error: { code: -32601, message: 'nope' },
+    });
+    expect(errorResponse(2, ERR.INTERNAL, 'x', { y: 1 }).error).toEqual({
+      code: -32603,
+      message: 'x',
+      data: { y: 1 },
+    });
+  });
+});

--- a/apps/backend/src/pipelines/mcp/jsonrpc.ts
+++ b/apps/backend/src/pipelines/mcp/jsonrpc.ts
@@ -1,0 +1,80 @@
+/**
+ * The JSON-RPC 2.0 envelope of a stateless Streamable-HTTP MCP server: one
+ * message per POST, one body per answer — no batches (the profile answers one
+ * message), no SSE, no session id. Owned by CE's `mcp_handler`; the shape the
+ * Workflow harness's prototype endpoint proved against claude.ai (apps#554).
+ */
+
+export const PROTOCOL_VERSIONS = ['2025-06-18', '2025-03-26', '2024-11-05'] as const;
+export const LATEST_PROTOCOL_VERSION: string = PROTOCOL_VERSIONS[0];
+
+export const ERR = {
+  PARSE: -32700,
+  INVALID_REQUEST: -32600,
+  METHOD_NOT_FOUND: -32601,
+  INVALID_PARAMS: -32602,
+  INTERNAL: -32603,
+  /** `resources/read` of a URI the server does not serve (MCP's own code). */
+  RESOURCE_NOT_FOUND: -32002,
+} as const;
+
+export type Id = string | number | null;
+
+export type Message =
+  | { kind: 'request'; id: Id; method: string; params: Record<string, unknown> }
+  | { kind: 'notification'; method: string; params: Record<string, unknown> }
+  | { kind: 'invalid'; id: Id; message: string };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function idOf(value: unknown): Id {
+  return typeof value === 'string' || typeof value === 'number' ? value : null;
+}
+
+/**
+ * One JSON-RPC 2.0 message from a request body. A batch (an array) is
+ * `invalid`, as is anything without `jsonrpc: "2.0"` and a string `method`.
+ * A message without an `id` is a notification (answered 202, nothing else).
+ */
+export function parseMessage(body: unknown): Message {
+  if (Array.isArray(body)) {
+    return {
+      kind: 'invalid',
+      id: null,
+      message: 'Batches are not accepted: POST one JSON-RPC message',
+    };
+  }
+  if (!isPlainObject(body)) {
+    return { kind: 'invalid', id: null, message: 'The body must be one JSON-RPC 2.0 object' };
+  }
+  const id = idOf(body.id);
+  if (body.jsonrpc !== '2.0') return { kind: 'invalid', id, message: 'jsonrpc must be "2.0"' };
+  if (typeof body.method !== 'string' || body.method === '') {
+    return { kind: 'invalid', id, message: 'method must be a string' };
+  }
+  const params = isPlainObject(body.params) ? body.params : {};
+  if (!Object.prototype.hasOwnProperty.call(body, 'id') || body.id === undefined) {
+    return { kind: 'notification', method: body.method, params };
+  }
+  return { kind: 'request', id, method: body.method, params };
+}
+
+export function okResponse(id: Id, result: unknown): { jsonrpc: '2.0'; id: Id; result: unknown } {
+  return { jsonrpc: '2.0', id, result };
+}
+
+export function errorResponse(
+  id: Id,
+  code: number,
+  message: string,
+  data?: unknown,
+): { jsonrpc: '2.0'; id: Id; error: { code: number; message: string; data?: unknown } } {
+  return { jsonrpc: '2.0', id, error: { code, message, ...(data === undefined ? {} : { data }) } };
+}
+
+/** The version to answer `initialize` with: the client's when we speak it, else our newest. */
+export function negotiateVersion(requested: unknown, supported: readonly string[]): string {
+  return typeof requested === 'string' && supported.includes(requested) ? requested : supported[0];
+}

--- a/apps/backend/src/pipelines/mcp/protocol.spec.ts
+++ b/apps/backend/src/pipelines/mcp/protocol.spec.ts
@@ -1,0 +1,232 @@
+import type { McpHandlerConfig } from '../execution/step-handler.interface';
+import { answer, type ProtocolDeps } from './protocol';
+
+const config: McpHandlerConfig = {
+  serverInfo: { name: 'test-server', version: '1.2.3' },
+  instructions: 'hello',
+  tools: [
+    {
+      name: 'app.read',
+      description: 'r',
+      inputSchema: { type: 'object' },
+      annotations: { readOnlyHint: true },
+      rule: { path: '/api/app/read', method: 'GET' },
+    },
+    {
+      name: 'app.write',
+      description: 'w',
+      inputSchema: { type: 'object' },
+      rule: { path: '/api/app/write' },
+    },
+    {
+      name: 'app.hidden',
+      description: 'h',
+      inputSchema: { type: 'object' },
+      visibility: ['app'],
+      rule: { path: '/api/app/hidden' },
+    },
+  ],
+  resources: {
+    static: [{ uri: 'ui://app/view.html', name: 'View', rule: { path: '/view.html' } }],
+    templates: [
+      {
+        uriTemplate: 'ui://app/{impl}/{path+}',
+        name: 'island',
+        rule: { path: '/w/{impl}/{path+}' },
+      },
+    ],
+    list: { rule: { path: '/api/app/resources' } },
+    csp: { connectDomains: ['$app', '$storage'], resourceDomains: ['$storage'] },
+  },
+};
+
+type Call = { path: string; method: string; args: Record<string, unknown> };
+
+function deps(
+  answers: Record<
+    string,
+    | { status: number; body: unknown; headers?: Record<string, string> }
+    | { failure: 'no_rule' | 'recursion' }
+  >,
+) {
+  const calls: Call[] = [];
+  const d: ProtocolDeps = {
+    async invoke(path, method, args) {
+      calls.push({ path, method, args });
+      const a = answers[path];
+      if (!a) return { ok: false, failure: { kind: 'no_rule' } };
+      if ('failure' in a) return { ok: false, failure: { kind: a.failure } };
+      return {
+        ok: true,
+        answer: {
+          status: a.status,
+          body: a.body,
+          headers: a.headers ?? {},
+          contentType: 'application/json',
+        },
+      };
+    },
+    async origins() {
+      return { app: 'https://h.example', storage: 'https://storage.example' };
+    },
+  };
+  return { d, calls };
+}
+
+const post = (body: unknown) => ({ method: 'POST', body });
+const msg = (method: string, params: Record<string, unknown> = {}, id: number | null = 1) =>
+  post({ jsonrpc: '2.0', id, method, params });
+const parsed = (a: { body: string }) =>
+  JSON.parse(a.body) as {
+    id: unknown;
+    result?: Record<string, unknown>;
+    error?: { code: number; message: string };
+  };
+
+describe('protocol', () => {
+  it('answers GET and DELETE with 405 Allow: POST', async () => {
+    const { d } = deps({});
+    const get = await answer(config, { method: 'GET', body: undefined }, d);
+    expect(get.status).toBe(405);
+    expect(get.headers.Allow).toBe('POST');
+    expect(parsed(get).error?.code).toBe(-32600);
+    expect((await answer(config, { method: 'DELETE', body: undefined }, d)).status).toBe(405);
+  });
+  it('answers a notification with 202 and an empty body, an invalid body with -32600, an unknown method with -32601', async () => {
+    const { d } = deps({});
+    expect(
+      await answer(config, post({ jsonrpc: '2.0', method: 'notifications/initialized' }), d),
+    ).toMatchObject({ status: 202, body: '' });
+    expect(parsed(await answer(config, post([]), d)).error?.code).toBe(-32600);
+    expect(parsed(await answer(config, msg('prompts/list'), d)).error?.code).toBe(-32601);
+  });
+  it('initialize negotiates the version and echoes serverInfo + instructions; ping is {}', async () => {
+    const { d } = deps({});
+    expect(
+      parsed(await answer(config, msg('initialize', { protocolVersion: '2025-03-26' }), d)).result,
+    ).toEqual({
+      protocolVersion: '2025-03-26',
+      capabilities: { tools: {}, resources: {} },
+      serverInfo: { name: 'test-server', version: '1.2.3' },
+      instructions: 'hello',
+    });
+    expect(
+      parsed(await answer(config, msg('initialize', { protocolVersion: '1999' }), d)).result
+        ?.protocolVersion,
+    ).toBe('2025-06-18');
+    expect(parsed(await answer(config, msg('ping'), d)).result).toEqual({});
+    expect((await answer(config, msg('ping'), d)).headers['Cache-Control']).toBe('no-store');
+  });
+  it('tools/list projects the declarations', async () => {
+    const { d } = deps({});
+    const tools = parsed(await answer(config, msg('tools/list'), d)).result?.tools as Array<
+      Record<string, unknown>
+    >;
+    expect(tools.map((t) => t.name)).toEqual(['app.read', 'app.write', 'app.hidden']);
+    expect(tools[2]._meta).toEqual({ ui: { visibility: ['app'] } });
+    expect(JSON.stringify(tools)).not.toContain('"rule"');
+  });
+  it('tools/call routes to the sibling: arguments as query for GET, body for POST; slash-tolerant names; verbatim CallToolResult bodies', async () => {
+    const { d, calls } = deps({
+      '/api/app/read': {
+        status: 200,
+        body: { content: [{ type: 'text', text: 'ok' }], structuredContent: { n: 1 } },
+      },
+      '/api/app/write': { status: 200, body: { wrote: true } },
+    });
+    const read = parsed(
+      await answer(config, msg('tools/call', { name: 'app/read', arguments: { runId: 'r' } }), d),
+    ).result;
+    expect(read).toEqual({ content: [{ type: 'text', text: 'ok' }], structuredContent: { n: 1 } });
+    expect(calls[0]).toEqual({ path: '/api/app/read', method: 'GET', args: { runId: 'r' } });
+    const write = parsed(
+      await answer(config, msg('tools/call', { name: 'app.write', arguments: { a: 1 } }), d),
+    ).result;
+    expect(write).toEqual({
+      content: [{ type: 'text', text: '{"wrote":true}' }],
+      structuredContent: { wrote: true },
+    });
+    expect(calls[1]).toEqual({ path: '/api/app/write', method: 'POST', args: { a: 1 } });
+  });
+  it('tools/call: an unknown tool, a missing rule, a refused scope are tool errors, never protocol errors', async () => {
+    const { d } = deps({
+      '/api/app/write': {
+        status: 403,
+        body: { success: false, error: { code: 'AUTHORIZATION_ERROR', message: 'x' } },
+        headers: { 'WWW-Authenticate': 'Bearer error="insufficient_scope", scope="app:write"' },
+      },
+    });
+    const unknown = parsed(await answer(config, msg('tools/call', { name: 'nope' }), d));
+    expect(unknown.error).toBeUndefined();
+    expect(unknown.result).toMatchObject({
+      isError: true,
+      structuredContent: { errors: { tool: 'No such tool' } },
+    });
+    const noRule = parsed(await answer(config, msg('tools/call', { name: 'app.read' }), d)).result;
+    expect(noRule).toMatchObject({
+      isError: true,
+      structuredContent: { errors: { tool: 'no rule answers /api/app/read' } },
+    });
+    const scope = parsed(await answer(config, msg('tools/call', { name: 'app.write' }), d)).result;
+    expect(scope).toMatchObject({
+      isError: true,
+      content: [{ type: 'text', text: 'insufficient_scope: missing app:write' }],
+    });
+  });
+  it('resources/list merges static and listed resources with the derived CSP', async () => {
+    const { d } = deps({
+      '/api/app/resources': {
+        status: 200,
+        body: [{ uri: 'ui://app/hello/islands/x.html', name: 'x' }, { nope: 1 }],
+      },
+    });
+    const resources = parsed(await answer(config, msg('resources/list'), d)).result
+      ?.resources as Array<Record<string, unknown>>;
+    expect(resources.map((r) => r.uri)).toEqual([
+      'ui://app/view.html',
+      'ui://app/hello/islands/x.html',
+    ]);
+    expect(resources[0].mimeType).toBe('text/html;profile=mcp-app');
+    expect(resources[1]._meta).toEqual({
+      ui: {
+        csp: {
+          connectDomains: ['https://h.example', 'https://storage.example'],
+          resourceDomains: ['https://storage.example'],
+        },
+        prefersBorder: true,
+      },
+    });
+  });
+  it('resources/read serves a static and a templated resource, and -32002 otherwise', async () => {
+    const { d, calls } = deps({
+      '/view.html': { status: 200, body: '<html>view</html>' },
+      '/w/hello/islands/x.html': { status: 200, body: '<html>island</html>' },
+      '/w/hello/gone.html': { status: 404, body: 'no' },
+    });
+    const fixed = parsed(
+      await answer(config, msg('resources/read', { uri: 'ui://app/view.html' }), d),
+    ).result?.contents as Array<Record<string, unknown>>;
+    expect(fixed[0]).toMatchObject({
+      uri: 'ui://app/view.html',
+      mimeType: 'text/html;profile=mcp-app',
+      text: '<html>view</html>',
+    });
+    const island = parsed(
+      await answer(config, msg('resources/read', { uri: 'ui://app/hello/islands/x.html' }), d),
+    ).result?.contents as Array<Record<string, unknown>>;
+    expect(island[0].text).toBe('<html>island</html>');
+    expect(calls[1]).toMatchObject({ path: '/w/hello/islands/x.html', method: 'GET' });
+    expect(
+      parsed(await answer(config, msg('resources/read', { uri: 'ui://app/hello/gone.html' }), d))
+        .error,
+    ).toMatchObject({ code: -32002 });
+    expect(
+      parsed(await answer(config, msg('resources/read', { uri: 'ui://elsewhere/x' }), d)).error
+        ?.code,
+    ).toBe(-32002);
+    expect(
+      parsed(await answer(config, msg('resources/read', { uri: 'ui://app/hello/../x' }), d)).error
+        ?.code,
+    ).toBe(-32002);
+  });
+});

--- a/apps/backend/src/pipelines/mcp/protocol.ts
+++ b/apps/backend/src/pipelines/mcp/protocol.ts
@@ -1,0 +1,204 @@
+import type { McpHandlerConfig } from '../execution/step-handler.interface';
+import type { InvokeAnswer, InvokeFailure } from '../../proxy-rules/rule-invoker.service';
+import {
+  ERR,
+  PROTOCOL_VERSIONS,
+  errorResponse,
+  negotiateVersion,
+  okResponse,
+  parseMessage,
+} from './jsonrpc';
+import { DEFAULT_RESOURCE_MIME, expandPath, listedTools, matchTemplate, uiMeta } from './resources';
+import { invokeFailureResult, noSuchTool, toolResultFromAnswer } from './results';
+
+/** What the handler hands the protocol: how to run a sibling, and where the instance is. */
+export interface ProtocolDeps {
+  invoke(
+    path: string,
+    method: 'GET' | 'POST',
+    args: Record<string, unknown>,
+  ): Promise<{ ok: true; answer: InvokeAnswer } | { ok: false; failure: InvokeFailure }>;
+  origins(): Promise<{ app: string; storage: string }>;
+}
+
+export interface ProtocolAnswer {
+  status: number;
+  body: string;
+  headers: Record<string, string>;
+}
+
+const NO_STORE = { 'Cache-Control': 'no-store' };
+const JSON_HEADERS = { ...NO_STORE, 'Content-Type': 'application/json' };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+const json = (value: unknown, status = 200): ProtocolAnswer => ({
+  status,
+  body: JSON.stringify(value),
+  headers: JSON_HEADERS,
+});
+
+/**
+ * One HTTP request → one answer, the stateless Streamable-HTTP profile
+ * (Phase 3 plan, Decisions 12/17): GET/DELETE → 405; a notification → 202
+ * empty; everything else one JSON body. Method by method it is the shape the
+ * Workflow prototype proved against claude.ai — kept check for check.
+ */
+export async function answer(
+  config: McpHandlerConfig,
+  request: { method: string; body: unknown },
+  deps: ProtocolDeps,
+): Promise<ProtocolAnswer> {
+  if (request.method.toUpperCase() !== 'POST') {
+    return {
+      status: 405,
+      body: JSON.stringify(
+        errorResponse(
+          null,
+          ERR.INVALID_REQUEST,
+          'Method Not Allowed: this MCP endpoint is stateless — POST one JSON-RPC message',
+        ),
+      ),
+      headers: { ...JSON_HEADERS, Allow: 'POST' },
+    };
+  }
+
+  const message = parseMessage(request.body);
+  if (message.kind === 'invalid')
+    return json(errorResponse(message.id, ERR.INVALID_REQUEST, message.message));
+  if (message.kind === 'notification') return { status: 202, body: '', headers: NO_STORE };
+
+  const { id, method, params } = message;
+  const versions = config.protocolVersions?.length
+    ? config.protocolVersions
+    : [...PROTOCOL_VERSIONS];
+
+  switch (method) {
+    case 'initialize':
+      return json(
+        okResponse(id, {
+          protocolVersion: negotiateVersion(params.protocolVersion, versions),
+          capabilities: { tools: {}, resources: {} },
+          serverInfo: config.serverInfo,
+          ...(config.instructions ? { instructions: config.instructions } : {}),
+        }),
+      );
+    case 'ping':
+      return json(okResponse(id, {}));
+    case 'tools/list':
+      return json(okResponse(id, { tools: listedTools(config.tools) }));
+    case 'tools/call':
+      return json(okResponse(id, await callTool(config, params, deps)));
+    case 'resources/list':
+      return json(okResponse(id, { resources: await listResources(config, deps) }));
+    case 'resources/read':
+      return json(await readResource(config, id, params, deps));
+    default:
+      return json(errorResponse(id, ERR.METHOD_NOT_FOUND, `Method not found: ${method}`));
+  }
+}
+
+async function callTool(
+  config: McpHandlerConfig,
+  params: Record<string, unknown>,
+  deps: ProtocolDeps,
+) {
+  const name = typeof params.name === 'string' ? params.name : '';
+  const canonical = name.replace(/\//g, '.');
+  const tool = config.tools.find((t) => t.name === canonical || t.name === name);
+  if (!tool) return noSuchTool(name || '(none)');
+  const args = isPlainObject(params.arguments) ? params.arguments : {};
+  const method = tool.rule.method ?? 'POST';
+  const result = await deps.invoke(tool.rule.path, method, args);
+  if (!result.ok) return invokeFailureResult(result.failure, tool.name, tool.rule.path);
+  return toolResultFromAnswer(result.answer, tool.name);
+}
+
+async function listResources(config: McpHandlerConfig, deps: ProtocolDeps) {
+  const origins = await deps.origins();
+  const meta = uiMeta(config.resources?.csp, origins);
+  const out: Array<Record<string, unknown>> = [];
+  for (const r of config.resources?.static ?? []) {
+    out.push({
+      uri: r.uri,
+      name: r.name,
+      ...(r.description ? { description: r.description } : {}),
+      mimeType: r.mimeType ?? DEFAULT_RESOURCE_MIME,
+      _meta: meta,
+    });
+  }
+  const list = config.resources?.list;
+  if (list) {
+    const result = await deps.invoke(list.rule.path, list.rule.method ?? 'GET', {});
+    if (result.ok && result.answer.status >= 200 && result.answer.status < 300) {
+      const body = result.answer.body;
+      const entries = Array.isArray(body)
+        ? body
+        : isPlainObject(body) && Array.isArray(body.resources)
+          ? body.resources
+          : [];
+      for (const entry of entries) {
+        if (!isPlainObject(entry) || typeof entry.uri !== 'string') continue;
+        out.push({
+          uri: entry.uri,
+          name: typeof entry.name === 'string' ? entry.name : entry.uri,
+          ...(typeof entry.description === 'string' ? { description: entry.description } : {}),
+          mimeType: typeof entry.mimeType === 'string' ? entry.mimeType : DEFAULT_RESOURCE_MIME,
+          _meta: meta,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+async function readResource(
+  config: McpHandlerConfig,
+  id: string | number | null,
+  params: Record<string, unknown>,
+  deps: ProtocolDeps,
+) {
+  const uri = typeof params.uri === 'string' ? params.uri : '';
+  const notFound = (why?: string) =>
+    errorResponse(
+      id,
+      ERR.RESOURCE_NOT_FOUND,
+      `Resource not found: ${uri}${why ? ` (${why})` : ''}`,
+    );
+  let target: { path: string; method: 'GET'; mimeType: string } | null = null;
+  const fixed = config.resources?.static?.find((r) => r.uri === uri);
+  if (fixed)
+    target = {
+      path: fixed.rule.path,
+      method: 'GET',
+      mimeType: fixed.mimeType ?? DEFAULT_RESOURCE_MIME,
+    };
+  if (!target) {
+    for (const t of config.resources?.templates ?? []) {
+      const vars = matchTemplate(t.uriTemplate, uri);
+      if (vars) {
+        target = {
+          path: expandPath(t.rule.path, vars),
+          method: 'GET',
+          mimeType: t.mimeType ?? DEFAULT_RESOURCE_MIME,
+        };
+        break;
+      }
+    }
+  }
+  if (!target) return notFound();
+  const result = await deps.invoke(target.path, 'GET', {});
+  if (!result.ok)
+    return notFound(result.failure.kind === 'error' ? result.failure.message : result.failure.kind);
+  const { status, body } = result.answer;
+  if (status < 200 || status >= 300) return notFound(`${status}`);
+  const text = typeof body === 'string' ? body : JSON.stringify(body);
+  const origins = await deps.origins();
+  return okResponse(id, {
+    contents: [
+      { uri, mimeType: target.mimeType, text, _meta: uiMeta(config.resources?.csp, origins) },
+    ],
+  });
+}

--- a/apps/backend/src/pipelines/mcp/resources.spec.ts
+++ b/apps/backend/src/pipelines/mcp/resources.spec.ts
@@ -1,0 +1,74 @@
+import { expandPath, listedTools, matchTemplate, uiMeta } from './resources';
+
+describe('resources', () => {
+  it('matches level-1 templates: {var} one segment, {var+} a tail', () => {
+    expect(
+      matchTemplate('ui://bffless/{impl}/{path+}', 'ui://bffless/hello/islands/pick-line.html'),
+    ).toEqual({
+      impl: 'hello',
+      path: 'islands/pick-line.html',
+    });
+    expect(matchTemplate('ui://bffless/{impl}/{path+}', 'ui://other/hello/x.html')).toBeNull();
+    expect(matchTemplate('ui://bffless/{impl}/x.html', 'ui://bffless/a/b/x.html')).toBeNull();
+    expect(matchTemplate('ui://bffless/{impl}/{path+}', 'ui://bffless/hello/../secret')).toBeNull();
+    expect(matchTemplate('ui://bffless/{impl}/{path+}', 'ui://bffless/hello/a//b')).toBeNull();
+  });
+  it('expands the sibling path, encoding segments', () => {
+    expect(expandPath('/w/{impl}/{path+}', { impl: 'hello', path: 'islands/pick line.html' })).toBe(
+      '/w/hello/islands/pick%20line.html',
+    );
+    expect(expandPath('/w/{impl}/x', { impl: 'a/b' })).toBe('/w/a%2Fb/x');
+  });
+  it('generates _meta.ui from the csp tokens and drops empty origins', () => {
+    expect(
+      uiMeta(
+        { connectDomains: ['$app', '$storage'], resourceDomains: ['$storage'] },
+        { app: 'https://h', storage: '' },
+      ),
+    ).toEqual({
+      ui: { csp: { connectDomains: ['https://h'], resourceDomains: [] }, prefersBorder: true },
+    });
+    expect(uiMeta(undefined, { app: 'https://h', storage: 'https://s' }).ui.csp).toEqual({
+      connectDomains: [],
+      resourceDomains: [],
+    });
+    expect(
+      uiMeta(
+        { connectDomains: ['https://cdn.example', '$storage'] },
+        { app: 'https://h', storage: 'https://s' },
+      ).ui.csp.connectDomains,
+    ).toEqual(['https://cdn.example', 'https://s']);
+  });
+  it('lists tools without their rule mapping, mapping app visibility into _meta.ui', () => {
+    const listed = listedTools([
+      {
+        name: 'a',
+        description: 'd',
+        inputSchema: { type: 'object' },
+        annotations: { readOnlyHint: true },
+        rule: { path: '/x' },
+      },
+      {
+        name: 'b',
+        description: 'd',
+        inputSchema: { type: 'object' },
+        visibility: ['app'],
+        _meta: { ui: { resourceUri: 'ui://x' } },
+        rule: { path: '/y' },
+      },
+    ]);
+    expect(listed[0]).toEqual({
+      name: 'a',
+      description: 'd',
+      inputSchema: { type: 'object' },
+      annotations: { readOnlyHint: true },
+    });
+    expect(listed[1]).toEqual({
+      name: 'b',
+      description: 'd',
+      inputSchema: { type: 'object' },
+      _meta: { ui: { resourceUri: 'ui://x', visibility: ['app'] } },
+    });
+    expect(JSON.stringify(listed)).not.toContain('rule');
+  });
+});

--- a/apps/backend/src/pipelines/mcp/resources.ts
+++ b/apps/backend/src/pipelines/mcp/resources.ts
@@ -1,0 +1,105 @@
+import type { McpHandlerConfig, McpToolDecl } from '../execution/step-handler.interface';
+
+/**
+ * `ui://` resources and the listed tools of an `mcp_handler` (Phase 3 plan,
+ * Decisions 13/16): URI templates (RFC 6570 level 1 — `{var}` one segment,
+ * `{var+}` a slash-carrying tail), the generated `_meta.ui` CSP, and the
+ * `tools/list` projection (never the `rule` mapping, never a `scope`).
+ */
+
+export const DEFAULT_RESOURCE_MIME = 'text/html;profile=mcp-app';
+
+const VAR = /\{([a-zA-Z_][a-zA-Z0-9_]*)(\+?)\}/g;
+
+interface Compiled {
+  regex: RegExp;
+  names: string[];
+}
+
+function compile(template: string): Compiled {
+  const names: string[] = [];
+  let source = '^';
+  let last = 0;
+  for (const match of template.matchAll(VAR)) {
+    source += escapeRegex(template.slice(last, match.index));
+    names.push(match[1]);
+    source += match[2] === '+' ? '(.+)' : '([^/]+)';
+    last = (match.index ?? 0) + match[0].length;
+  }
+  source += escapeRegex(template.slice(last)) + '$';
+  return { regex: new RegExp(source), names };
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** The template's variables for `uri`, or null when it does not match. A `..` segment in any value is refused (null). */
+export function matchTemplate(template: string, uri: string): Record<string, string> | null {
+  const { regex, names } = compile(template);
+  const match = uri.match(regex);
+  if (!match) return null;
+  const vars: Record<string, string> = {};
+  names.forEach((name, i) => {
+    vars[name] = match[i + 1];
+  });
+  for (const value of Object.values(vars)) {
+    if (value.split('/').some((segment) => segment === '..' || segment === '.' || segment === ''))
+      return null;
+  }
+  return vars;
+}
+
+/** `{var}` → encodeURIComponent(value); `{var+}` → the value with its slashes kept and each segment encoded. */
+export function expandPath(pathTemplate: string, vars: Record<string, string>): string {
+  return pathTemplate.replace(VAR, (_all, name: string, plus: string) => {
+    const value = vars[name] ?? '';
+    return plus === '+'
+      ? value.split('/').map(encodeURIComponent).join('/')
+      : encodeURIComponent(value);
+  });
+}
+
+export interface UiMeta {
+  ui: { csp: { connectDomains: string[]; resourceDomains: string[] }; prefersBorder: true };
+}
+
+/** `$app` → the request's public origin; `$storage` → the storage backend's; empties dropped. */
+export function uiMeta(
+  csp: NonNullable<McpHandlerConfig['resources']>['csp'] | undefined,
+  origins: { app: string; storage: string },
+): UiMeta {
+  const resolve = (entries: string[] | undefined) =>
+    (entries ?? [])
+      .map((entry) =>
+        entry === '$app' ? origins.app : entry === '$storage' ? origins.storage : entry,
+      )
+      .filter((origin) => origin !== '');
+  return {
+    ui: {
+      csp: {
+        connectDomains: resolve(csp?.connectDomains),
+        resourceDomains: resolve(csp?.resourceDomains),
+      },
+      prefersBorder: true,
+    },
+  };
+}
+
+/** The `tools/list` projection of a declaration: never `rule`, `visibility: ['app']` as `_meta.ui.visibility`. */
+export function listedTools(tools: McpToolDecl[]): Array<Record<string, unknown>> {
+  return tools.map((tool) => {
+    const meta: Record<string, unknown> = { ...(tool._meta ?? {}) };
+    if (tool.visibility && tool.visibility.includes('app')) {
+      const ui = (meta.ui ?? {}) as Record<string, unknown>;
+      meta.ui = { ...ui, visibility: tool.visibility };
+    }
+    return {
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+      ...(tool.annotations ? { annotations: tool.annotations } : {}),
+      ...(Object.keys(meta).length ? { _meta: meta } : {}),
+    };
+  });
+}

--- a/apps/backend/src/pipelines/mcp/results.spec.ts
+++ b/apps/backend/src/pipelines/mcp/results.spec.ts
@@ -1,0 +1,112 @@
+import { invokeFailureResult, toolResultFromAnswer } from './results';
+
+const answer = (status: number, body: unknown, headers: Record<string, string> = {}) => ({
+  status,
+  body,
+  headers,
+  contentType: 'application/json',
+});
+
+describe('toolResultFromAnswer (Decision 15)', () => {
+  it('passes a body that already is a CallToolResult through verbatim', () => {
+    const body = {
+      content: [{ type: 'text', text: 'Run x is running' }],
+      structuredContent: { runId: 'x' },
+    };
+    expect(toolResultFromAnswer(answer(200, body), 't')).toBe(body);
+  });
+  it('wraps a plain object, a string and a scalar', () => {
+    expect(toolResultFromAnswer(answer(200, { a: 1 }), 't')).toEqual({
+      content: [{ type: 'text', text: '{"a":1}' }],
+      structuredContent: { a: 1 },
+    });
+    expect(toolResultFromAnswer(answer(200, 'HI'), 't')).toEqual({
+      content: [{ type: 'text', text: 'HI' }],
+      structuredContent: { text: 'HI' },
+    });
+    expect(toolResultFromAnswer(answer(200, 3), 't').structuredContent).toEqual({ value: 3 });
+  });
+  it('names a 401 as errors.auth', () => {
+    const r = toolResultFromAnswer(
+      answer(401, {
+        success: false,
+        error: { code: 'AUTH_REQUIRED', message: 'Authentication required' },
+      }),
+      'workflow.status',
+    );
+    expect(r.isError).toBe(true);
+    expect(r.structuredContent?.errors).toEqual({
+      auth: 'workflow.status needs a signed-in caller: Authentication required',
+    });
+    expect(r._meta).toEqual({ bffless: { status: 401 } });
+  });
+  it('names the missing scope from the WWW-Authenticate header, or from the error details', () => {
+    const viaHeader = toolResultFromAnswer(
+      answer(
+        403,
+        {
+          success: false,
+          error: {
+            code: 'AUTHORIZATION_ERROR',
+            message: 'insufficient_scope: missing workflow:run',
+          },
+        },
+        {
+          'WWW-Authenticate':
+            'Bearer error="insufficient_scope", scope="workflow:run workflow:files"',
+        },
+      ),
+      'workflow.submit',
+    );
+    expect(viaHeader.content[0].text).toBe(
+      'insufficient_scope: missing workflow:run, workflow:files',
+    );
+    expect(viaHeader.structuredContent?.errors).toEqual({
+      scope: 'missing workflow:run, workflow:files',
+    });
+    const viaDetails = toolResultFromAnswer(
+      answer(403, {
+        success: false,
+        error: {
+          code: 'AUTHORIZATION_ERROR',
+          message: 'x',
+          details: { code: 'insufficient_scope', missingScopes: ['workflow:run'] },
+        },
+      }),
+      'workflow.submit',
+    );
+    expect(viaDetails.structuredContent?.errors).toEqual({ scope: 'missing workflow:run' });
+  });
+  it('flattens any other failure to code: message with the status in _meta', () => {
+    const r = toolResultFromAnswer(
+      answer(500, { success: false, error: { code: 'STEP_FAILED', message: 'boom' } }),
+      't',
+    );
+    expect(r.content[0].text).toBe('STEP_FAILED: boom');
+    expect(r.structuredContent?.errors).toEqual({ pipeline: 'STEP_FAILED: boom' });
+    expect(r._meta).toEqual({ bffless: { status: 500 } });
+    const text = toolResultFromAnswer(answer(502, 'Bad Gateway'), 't');
+    expect(text.content[0].text).toBe('HTTP_502: Bad Gateway');
+    const forbidden = toolResultFromAnswer(answer(403, { message: 'Access denied' }), 't');
+    expect(forbidden.structuredContent?.errors).toEqual({ pipeline: 'HTTP_403: Access denied' });
+  });
+});
+
+describe('invokeFailureResult', () => {
+  it('words each failure kind', () => {
+    expect(
+      invokeFailureResult({ kind: 'no_rule' }, 'workflow.list', '/api/x').structuredContent?.errors,
+    ).toEqual({ tool: 'no rule answers /api/x' });
+    expect(invokeFailureResult({ kind: 'recursion' }, 't', '/p').structuredContent?.errors).toEqual(
+      { tool: 'MCP_RECURSION' },
+    );
+    expect(
+      invokeFailureResult({ kind: 'unsupported', proxyType: 'internal_rewrite' }, 't', '/p')
+        .content[0].text,
+    ).toContain('internal_rewrite');
+    expect(
+      invokeFailureResult({ kind: 'error', message: 'ECONNREFUSED' }, 't', '/p').structuredContent
+        ?.errors,
+    ).toEqual({ tool: 'ECONNREFUSED' });
+  });
+});

--- a/apps/backend/src/pipelines/mcp/results.ts
+++ b/apps/backend/src/pipelines/mcp/results.ts
@@ -1,0 +1,128 @@
+import type { InvokeAnswer, InvokeFailure } from '../../proxy-rules/rule-invoker.service';
+
+/**
+ * A tool's answer, from what its sibling rule answered (Phase 3 plan, Decision
+ * 15). Every result is an MCP `CallToolResult`: prose in `content[0].text`
+ * (agent hosts are text-only to the model), data in `structuredContent`.
+ */
+export interface CallToolResultLike {
+  content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+  _meta?: Record<string, unknown>;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** `structuredContent` must be an object: a string body becomes `{ text }`, any other non-object `{ value }`. */
+export function structured(body: unknown): Record<string, unknown> {
+  if (isPlainObject(body)) return body;
+  return typeof body === 'string' ? { text: body } : { value: body };
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+export function textResult(
+  text: string,
+  structuredContent?: Record<string, unknown>,
+): CallToolResultLike {
+  return { content: [{ type: 'text', text }], ...(structuredContent ? { structuredContent } : {}) };
+}
+
+export function errorResult(
+  text: string,
+  structuredContent?: Record<string, unknown>,
+): CallToolResultLike {
+  return { isError: true, ...textResult(text, structuredContent) };
+}
+
+export function noSuchTool(name: string): CallToolResultLike {
+  return errorResult(`No such tool: ${name}`, { errors: { tool: 'No such tool' } });
+}
+
+/** A body that already IS a CallToolResult (a `content` array) is passed through verbatim. */
+function isCallToolResult(body: unknown): body is CallToolResultLike {
+  return isPlainObject(body) && Array.isArray(body.content);
+}
+
+/** The missing scopes a 403's `WWW-Authenticate: Bearer error="insufficient_scope", scope="a b"` names. */
+function missingScopesOf(answer: InvokeAnswer): string[] {
+  const header = answer.headers['www-authenticate'] ?? answer.headers['WWW-Authenticate'];
+  const match = typeof header === 'string' ? header.match(/scope="([^"]*)"/) : null;
+  if (match) return match[1].split(/\s+/).filter(Boolean);
+  const body = answer.body as { error?: { details?: { missingScopes?: string[] } } } | undefined;
+  return body?.error?.details?.missingScopes ?? [];
+}
+
+/**
+ * Decision 15: 2xx `content[]` → verbatim; other 2xx → wrapped; 401 →
+ * `errors.auth`; 403 insufficient_scope → `errors.scope` naming the scope;
+ * any other non-2xx → `errors.pipeline: '<code>: <message>'` + `_meta.bffless.status`.
+ */
+export function toolResultFromAnswer(answer: InvokeAnswer, toolName: string): CallToolResultLike {
+  const { status, body } = answer;
+  if (status >= 200 && status < 300) {
+    if (isCallToolResult(body)) return body;
+    return textResult(typeof body === 'string' ? body : JSON.stringify(body), structured(body));
+  }
+  const b = structured(body);
+  const error = isPlainObject(b.error) ? b.error : b;
+  if (status === 401) {
+    const text = `${toolName} needs a signed-in caller: ${str(error.message) ?? 'authentication required'}`;
+    return {
+      ...errorResult(text, { errors: { auth: text }, status }),
+      _meta: { bffless: { status } },
+    };
+  }
+  const missing = status === 403 ? missingScopesOf(answer) : [];
+  if (missing.length > 0) {
+    const text = `insufficient_scope: missing ${missing.join(', ')}`;
+    return {
+      ...errorResult(text, { errors: { scope: `missing ${missing.join(', ')}` }, status }),
+      _meta: { bffless: { status } },
+    };
+  }
+  const code = str(error.code) ?? str(b.code) ?? str(b.error as unknown) ?? `HTTP_${status}`;
+  const message =
+    str(error.message) ??
+    str(b.message) ??
+    str(typeof body === 'string' ? body : undefined) ??
+    `${toolName} failed with status ${status}`;
+  const text = `${code}: ${message}`;
+  return {
+    ...errorResult(text, { errors: { pipeline: text }, status }),
+    _meta: { bffless: { status } },
+  };
+}
+
+export function invokeFailureResult(
+  failure: InvokeFailure,
+  toolName: string,
+  path: string,
+): CallToolResultLike {
+  switch (failure.kind) {
+    case 'no_rule':
+      return errorResult(`${toolName} is declared but no rule answers ${path}`, {
+        errors: { tool: `no rule answers ${path}` },
+      });
+    case 'unsupported':
+      return errorResult(
+        `${toolName} maps to a ${failure.proxyType} rule, which a tool cannot invoke`,
+        {
+          errors: { tool: `unsupported rule type ${failure.proxyType}` },
+        },
+      );
+    case 'recursion':
+      return errorResult(`${toolName} would invoke another MCP server (MCP_RECURSION)`, {
+        errors: { tool: 'MCP_RECURSION' },
+      });
+    default:
+      return errorResult(`${toolName} failed: ${failure.message}`, {
+        errors: { tool: failure.message },
+      });
+  }
+}

--- a/apps/backend/src/pipelines/pipelines.module.ts
+++ b/apps/backend/src/pipelines/pipelines.module.ts
@@ -55,6 +55,7 @@ import {
   DataUpsertManyHandler,
   DelayHandler,
   FfmpegHandler,
+  McpHandler,
 } from './handlers';
 import { FfmpegCapabilityService } from './ffmpeg/ffmpeg-capability.service';
 import { FfmpegRunnerService } from './ffmpeg/ffmpeg-runner.service';
@@ -178,6 +179,7 @@ import {
     DataUpsertManyHandler,
     DelayHandler,
     FfmpegHandler,
+    McpHandler,
     // Server-side video ops (Task 2/4/5) — consumed by FfmpegHandler, not otherwise registered
     FfmpegCapabilityService,
     FfmpegRunnerService,

--- a/apps/backend/src/pipelines/types.ts
+++ b/apps/backend/src/pipelines/types.ts
@@ -96,7 +96,8 @@ export type HandlerType =
   | 'data_upsert_many'
   | 'delay'
   | 'ffmpeg_handler'
-  | 'remote_request';
+  | 'remote_request'
+  | 'mcp_handler';
 
 /**
  * Pipeline step definition for execution.

--- a/apps/backend/src/proxy-rules/pipeline-from-rule.ts
+++ b/apps/backend/src/proxy-rules/pipeline-from-rule.ts
@@ -1,0 +1,72 @@
+import { PipelineConfig, ProxyRule } from '../db/schema/proxy-rules.schema';
+import { Pipeline, PipelineStep } from '../pipelines/types';
+
+/**
+ * A `Pipeline` from a pipeline proxy rule's stored config — shared by the edge
+ * (`ProxyMiddleware.handlePipelineExecution`) and the in-process invoker, so a
+ * sibling rule is built exactly as the edge builds it.
+ */
+export function pipelineFromRule(
+  rule: ProxyRule,
+  projectId: string,
+): (Pipeline & { steps: PipelineStep[] }) | null {
+  const pipelineConfig = rule.pipelineConfig as PipelineConfig | null;
+  if (!pipelineConfig || !pipelineConfig.steps || pipelineConfig.steps.length === 0) {
+    return null;
+  }
+  return {
+    id: rule.id,
+    projectId,
+    name: pipelineConfig.name || `Pipeline for ${rule.pathPattern}`,
+    validators: pipelineConfig.validators || [],
+    steps: pipelineConfig.steps.map((step, index) => ({
+      id: step.id || `step-${index}`,
+      pipelineId: rule.id,
+      name: step.name || `step_${index + 1}`, // Fallback for legacy data without names
+      handlerType: step.handlerType,
+      config: step.config,
+      order: index,
+      isEnabled: step.isEnabled !== false,
+    })),
+    postSteps: pipelineConfig.postSteps?.map((step, index) => ({
+      id: step.id || `post-step-${index}`,
+      pipelineId: rule.id,
+      name: step.name || `post_step_${index + 1}`,
+      handlerType: step.handlerType,
+      config: step.config,
+      order: index,
+      isEnabled: step.isEnabled !== false,
+    })),
+  };
+}
+
+/** The HTTP status a failed pipeline answers with, by its error code — the edge's table. */
+export function statusForPipelineError(code: string | undefined): number {
+  switch (code) {
+    case 'VALIDATION_ERROR':
+      return 400;
+    case 'AUTH_REQUIRED':
+      return 401;
+    case 'AUTHORIZATION_ERROR':
+      return 403;
+    case 'RATE_LIMIT_EXCEEDED':
+      return 429;
+    default:
+      return 500;
+  }
+}
+
+/** `WWW-Authenticate` for a scope refusal (RFC 6750 §3.1), or undefined. */
+export function insufficientScopeHeader(
+  error: { code?: string; details?: unknown } | undefined,
+): string | undefined {
+  const details = error?.details as { code?: string; missingScopes?: string[] } | undefined;
+  if (
+    error?.code === 'AUTHORIZATION_ERROR' &&
+    details?.code === 'insufficient_scope' &&
+    details.missingScopes?.length
+  ) {
+    return `Bearer error="insufficient_scope", scope="${details.missingScopes.join(' ')}"`;
+  }
+  return undefined;
+}

--- a/apps/backend/src/proxy-rules/proxy-headers.util.ts
+++ b/apps/backend/src/proxy-rules/proxy-headers.util.ts
@@ -1,0 +1,140 @@
+import { Logger } from '@nestjs/common';
+import { Request } from 'express';
+import { ProxyRule, ProxyHeaderConfig } from '../db/schema/proxy-rules.schema';
+
+/**
+ * The headers an `external_proxy` rule sends to its target, built from the
+ * caller's request under the rule's own controls — `forwardCookies` (cookie
+ * off by default), `authorization` stripped by default, `headerConfig.forward` /
+ * `strip` / `add`, and `authTransform: cookie-to-bearer`. One implementation for
+ * every path that reaches such a rule: the edge (`ProxyService`) and the
+ * in-process sibling call (`RuleInvokerService`). A new caller of a rule must
+ * come through here rather than copy headers itself, or the rule's controls
+ * silently stop applying to it.
+ */
+export function buildProxyHeaders(
+  req: Request,
+  rule: ProxyRule,
+  logger?: Logger,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const config: ProxyHeaderConfig = rule.headerConfig || {};
+
+  // Default safe headers to forward
+  // NOTE: content-length is intentionally NOT forwarded because:
+  // 1. The body may be re-serialized (changing its length)
+  // 2. If body parsing failed, we send null body but original content-length
+  // 3. This mismatch causes the receiving server to hang waiting for bytes
+  // Let fetch() calculate the correct content-length from the actual body
+  const defaultForwardHeaders = [
+    'accept',
+    'accept-language',
+    'content-type',
+    'user-agent',
+    'x-request-id',
+  ];
+
+  // Add cookie to forward list if forwardCookies is enabled
+  if (rule.forwardCookies) {
+    defaultForwardHeaders.push('cookie');
+  }
+
+  const forwardHeaders = config.forward || defaultForwardHeaders;
+
+  // Default headers to strip (hop-by-hop + sensitive)
+  const defaultStripHeaders = [
+    'host',
+    'connection',
+    'keep-alive',
+    'transfer-encoding',
+    'authorization', // Strip by default for security
+  ];
+
+  // Only strip cookies if forwardCookies is false (default behavior)
+  if (!rule.forwardCookies) {
+    defaultStripHeaders.push('cookie');
+  }
+
+  const stripHeaders = config.strip || defaultStripHeaders;
+
+  // Create a set for faster lookup
+  const stripSet = new Set(stripHeaders.map((h) => h.toLowerCase()));
+  const forwardSet = new Set(forwardHeaders.map((h) => h.toLowerCase()));
+
+  // Copy allowed headers
+  for (const [key, value] of Object.entries(req.headers)) {
+    const lowerKey = key.toLowerCase();
+    if (forwardSet.has(lowerKey) && !stripSet.has(lowerKey) && typeof value === 'string') {
+      headers[key] = value;
+    }
+  }
+
+  // Add configured headers (already decrypted by ProxyRulesService)
+  if (config.add) {
+    Object.assign(headers, config.add);
+  }
+
+  // Apply authTransform (e.g., cookie-to-bearer token)
+  // This matches nginx behavior for domain mappings
+  if (rule.authTransform?.type === 'cookie-to-bearer') {
+    const cookieValue = extractCookieValue(req, rule.authTransform.cookieName);
+    if (cookieValue) {
+      headers['authorization'] = `Bearer ${cookieValue}`;
+      logger?.debug(
+        `Applied cookie-to-bearer: ${rule.authTransform.cookieName} -> Authorization header`,
+      );
+    } else {
+      logger?.debug(
+        `Cookie "${rule.authTransform.cookieName}" not found for cookie-to-bearer transform`,
+      );
+    }
+  }
+
+  // Set host header based on preserveHost setting
+  if (!rule.preserveHost) {
+    try {
+      headers['host'] = new URL(rule.targetUrl).host;
+    } catch {
+      // If URL parsing fails, don't set host header
+    }
+  }
+
+  // Add forwarding headers — preserve the original client IP from the proxy chain
+  const existingForwardedFor = req.headers['x-forwarded-for'];
+  if (existingForwardedFor) {
+    headers['x-forwarded-for'] = String(existingForwardedFor);
+  } else {
+    headers['x-forwarded-for'] = req.ip || req.socket?.remoteAddress || '';
+  }
+  headers['x-forwarded-proto'] = req.protocol;
+  headers['x-forwarded-host'] = req.hostname;
+
+  return headers;
+}
+
+/** A cookie's value from the parsed jar when present, else from the raw header. */
+export function extractCookieValue(req: Request, cookieName: string): string | null {
+  // First try parsed cookies (if cookie-parser middleware is used)
+  if (req.cookies && req.cookies[cookieName]) {
+    return req.cookies[cookieName];
+  }
+
+  // Fall back to parsing Cookie header manually
+  const cookieHeader = req.headers.cookie;
+  if (!cookieHeader) {
+    return null;
+  }
+
+  const cookies = cookieHeader.split(';').reduce(
+    (acc, cookie) => {
+      const [name, ...valueParts] = cookie.trim().split('=');
+      if (name) {
+        acc[name] = valueParts.join('='); // Handle values with '=' in them
+      }
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+
+  return cookies[cookieName] || null;
+}

--- a/apps/backend/src/proxy-rules/proxy-rules.module.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.module.ts
@@ -7,6 +7,7 @@ import { ProxyRuleSetRevisionsService } from './proxy-rule-set-revisions.service
 import { ProxyService } from './proxy.service';
 import { ProxyMiddleware } from './proxy.middleware';
 import { EmailFormHandlerService } from './email-form-handler.service';
+import { RuleInvokerService } from './rule-invoker.service';
 import { PermissionsModule } from '../permissions/permissions.module';
 import { DomainsModule } from '../domains/domains.module';
 import { PipelinesModule } from '../pipelines/pipelines.module';
@@ -31,8 +32,15 @@ import { UserGroupsModule } from '../user-groups/user-groups.module';
     ProxyService,
     ProxyMiddleware,
     EmailFormHandlerService,
+    RuleInvokerService,
   ],
-  exports: [ProxyRulesService, ProxyRuleSetsService, ProxyRuleSetRevisionsService, ProxyService],
+  exports: [
+    ProxyRulesService,
+    ProxyRuleSetsService,
+    ProxyRuleSetRevisionsService,
+    ProxyService,
+    RuleInvokerService,
+  ],
 })
 export class ProxyRulesModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -38,7 +38,12 @@ import { VisibilityService, AccessControlInfo } from '../domains/visibility.serv
 import { PermissionsService } from '../permissions/permissions.service';
 import { TrafficRoutingService } from '../domains/traffic-routing.service';
 import { UserGroupsService } from '../user-groups/user-groups.service';
-import { matchesMethod } from './method-match';
+import {
+  findMatchingRule as findMatchingRuleShared,
+  matchesPattern as matchesPatternShared,
+  resolveProjectDefaultRuleSetIds as resolveProjectDefaultRuleSetIdsShared,
+  resolveRuleSetIdsForAlias as resolveRuleSetIdsForAliasShared,
+} from './rule-resolution';
 
 interface ParsedPublicPath {
   owner: string;
@@ -1015,58 +1020,19 @@ export class ProxyMiddleware implements NestMiddleware {
     };
   }
 
-  /**
-   * Resolve rule set IDs for an alias.
-   * Checks join table first, falls back to legacy proxyRuleSetId column.
-   */
-  private async resolveRuleSetIdsForAlias(
+  /** Rule resolution lives in `rule-resolution.ts`, shared with the in-process invoker. */
+  private resolveRuleSetIdsForAlias(
     aliasId: string,
     legacyProxyRuleSetId: string | null,
   ): Promise<string[]> {
-    // Check join table first
-    const joinRows = await db
-      .select({ proxyRuleSetId: aliasProxyRuleSets.proxyRuleSetId })
-      .from(aliasProxyRuleSets)
-      .where(eq(aliasProxyRuleSets.aliasId, aliasId))
-      .orderBy(asc(aliasProxyRuleSets.order));
-
-    if (joinRows.length > 0) {
-      return joinRows.map((r) => r.proxyRuleSetId);
-    }
-
-    // Fall back to legacy column
-    if (legacyProxyRuleSetId) {
-      return [legacyProxyRuleSetId];
-    }
-
-    return [];
+    return resolveRuleSetIdsForAliasShared(aliasId, legacyProxyRuleSetId);
   }
 
-  /**
-   * Resolve default rule set IDs for a project.
-   * Checks join table first, falls back to legacy defaultProxyRuleSetId column.
-   */
-  private async resolveProjectDefaultRuleSetIds(
+  private resolveProjectDefaultRuleSetIds(
     projectId: string,
     legacyDefaultProxyRuleSetId: string | null,
   ): Promise<string[]> {
-    // Check join table first
-    const joinRows = await db
-      .select({ proxyRuleSetId: projectDefaultProxyRuleSets.proxyRuleSetId })
-      .from(projectDefaultProxyRuleSets)
-      .where(eq(projectDefaultProxyRuleSets.projectId, projectId))
-      .orderBy(asc(projectDefaultProxyRuleSets.order));
-
-    if (joinRows.length > 0) {
-      return joinRows.map((r) => r.proxyRuleSetId);
-    }
-
-    // Fall back to legacy column
-    if (legacyDefaultProxyRuleSetId) {
-      return [legacyDefaultProxyRuleSetId];
-    }
-
-    return [];
+    return resolveProjectDefaultRuleSetIdsShared(projectId, legacyDefaultProxyRuleSetId);
   }
 
   /**
@@ -1127,26 +1093,7 @@ export class ProxyMiddleware implements NestMiddleware {
    * - If rule.method is set, it must match the request method (case-insensitive)
    */
   private findMatchingRule(rules: ProxyRule[], subpath: string, method?: string): ProxyRule | null {
-    const requestMethod = method?.toUpperCase();
-
-    for (const rule of rules) {
-      if (!rule.isEnabled) {
-        continue;
-      }
-
-      // Check path pattern first
-      if (!this.matchesPattern(rule.pathPattern, subpath)) {
-        continue;
-      }
-
-      // Check method(s): methods[] wins, else single method, else any (case-insensitive)
-      if (!matchesMethod(rule, requestMethod)) {
-        continue;
-      }
-
-      return rule;
-    }
-    return null;
+    return findMatchingRuleShared(rules, subpath, method);
   }
 
   /**
@@ -1671,19 +1618,6 @@ export class ProxyMiddleware implements NestMiddleware {
    * - Middle:  '/api/uploads/feedback-*' matches '/api/uploads/feedback-screenshots'
    */
   private matchesPattern(pattern: string, path: string): boolean {
-    if (pattern === path) return true;
-    if (!pattern.includes('*')) return false;
-
-    // Note: '/prefix/*' matches '/prefix/' and '/prefix/<sub>' but NOT the bare
-    // '/prefix' — the wildcard requires a path separator. This lets a same-named
-    // client-side SPA route (e.g. bare '/auth') fall through to the SPA fallback
-    // while subpaths (e.g. '/auth/signin') are still proxied. To also match the
-    // bare prefix, use '/prefix*' or add an explicit '/prefix' rule.
-
-    // Glob → regex: escape regex metacharacters (but not '*'), then replace
-    // '*' with '.*' and anchor. Handles trailing, leading, and middle wildcards.
-    const regexSource =
-      '^' + pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$';
-    return new RegExp(regexSource).test(path);
+    return matchesPatternShared(pattern, path);
   }
 }

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -13,7 +13,6 @@ import {
   users,
   apiKeys,
   aliasProxyRuleSets,
-  projectDefaultProxyRuleSets,
 } from '../db/schema';
 import { ProxyRulesService } from './proxy-rules.service';
 import { ProxyService } from './proxy.service';
@@ -34,7 +33,6 @@ import {
   pipelineFromRule,
   statusForPipelineError,
 } from './pipeline-from-rule';
-import { Pipeline, PipelineStep } from '../pipelines/types';
 import multer from 'multer';
 import { randomUUID } from 'crypto';
 import { CustomDomainAuthService } from '../auth/custom-domain-auth.service';

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -29,6 +29,11 @@ import {
   PipelineUser,
   PipelineDebugResult,
 } from '../pipelines/execution/pipeline-context.interface';
+import {
+  insufficientScopeHeader,
+  pipelineFromRule,
+  statusForPipelineError,
+} from './pipeline-from-rule';
 import { Pipeline, PipelineStep } from '../pipelines/types';
 import multer from 'multer';
 import { randomUUID } from 'crypto';
@@ -1107,9 +1112,9 @@ export class ProxyMiddleware implements NestMiddleware {
     projectId: string,
     deployment?: { owner: string; repo: string; commitSha: string; alias?: string },
   ): Promise<void> {
-    const pipelineConfig = rule.pipelineConfig as PipelineConfig | null;
-
-    if (!pipelineConfig || !pipelineConfig.steps || pipelineConfig.steps.length === 0) {
+    // Built the way the in-process invoker builds a sibling (pipeline-from-rule.ts).
+    const pipeline = pipelineFromRule(rule, projectId);
+    if (!pipeline) {
       this.logger.error(`Pipeline rule ${rule.id} has no pipeline configuration`);
       res.status(500).json({
         error: 'Pipeline configuration missing',
@@ -1117,35 +1122,10 @@ export class ProxyMiddleware implements NestMiddleware {
       });
       return;
     }
-
-    // Build Pipeline object from proxy rule config
-    const pipeline: Pipeline & { steps: PipelineStep[] } = {
-      id: rule.id,
-      projectId: projectId,
-      name: pipelineConfig.name || `Pipeline for ${rule.pathPattern}`,
-      validators: pipelineConfig.validators || [],
-      steps: pipelineConfig.steps.map((step, index) => ({
-        id: step.id || `step-${index}`,
-        pipelineId: rule.id,
-        name: step.name || `step_${index + 1}`, // Fallback for legacy data without names
-        handlerType: step.handlerType,
-        config: step.config,
-        order: index,
-        isEnabled: step.isEnabled !== false,
-      })),
-      postSteps: pipelineConfig.postSteps?.map((step, index) => ({
-        id: step.id || `post-step-${index}`,
-        pipelineId: rule.id,
-        name: step.name || `post_step_${index + 1}`,
-        handlerType: step.handlerType,
-        config: step.config,
-        order: index,
-        isEnabled: step.isEnabled !== false,
-      })),
-    };
+    const pipelineConfig = rule.pipelineConfig as PipelineConfig;
 
     // Hoisted so the outer catch can attribute its failure log to the caller.
-    let user: { id: string; email?: string; role?: string } | undefined;
+    let user: PipelineUser | undefined;
 
     try {
       // If pipeline has file_upload_handler, parse multipart before executing
@@ -1226,26 +1206,12 @@ export class ProxyMiddleware implements NestMiddleware {
         res.status(result.response.status).send(result.response.body);
       } else {
         // Pipeline failed - map error codes to appropriate HTTP status codes
-        const errorCode = result.error?.code;
-        let statusCode = 500;
-        if (errorCode === 'VALIDATION_ERROR') {
-          statusCode = 400;
-        } else if (errorCode === 'AUTH_REQUIRED') {
-          statusCode = 401;
-        } else if (errorCode === 'AUTHORIZATION_ERROR') {
-          statusCode = 403;
-          // RFC 6750 §3.1: a token that lacks the rule's scope is told which one.
-          const details = result.error?.details as
-            | { code?: string; missingScopes?: string[] }
-            | undefined;
-          if (details?.code === 'insufficient_scope' && details.missingScopes?.length) {
-            res.setHeader(
-              'WWW-Authenticate',
-              `Bearer error="insufficient_scope", scope="${details.missingScopes.join(' ')}"`,
-            );
-          }
-        } else if (errorCode === 'RATE_LIMIT_EXCEEDED') {
-          statusCode = 429;
+        // (pipeline-from-rule.ts, shared with the in-process invoker)
+        const statusCode = statusForPipelineError(result.error?.code);
+        // RFC 6750 §3.1: a token that lacks the rule's scope is told which one.
+        const scopeHeader = insufficientScopeHeader(result.error);
+        if (scopeHeader) {
+          res.setHeader('WWW-Authenticate', scopeHeader);
         }
         if (logId) {
           res.setHeader(PIPELINE_LOG_ID_HEADER, logId);

--- a/apps/backend/src/proxy-rules/proxy.service.ts
+++ b/apps/backend/src/proxy-rules/proxy.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { Readable } from 'stream';
-import { ProxyRule, ProxyHeaderConfig } from '../db/schema/proxy-rules.schema';
+import { ProxyRule } from '../db/schema/proxy-rules.schema';
+import { buildProxyHeaders, extractCookieValue } from './proxy-headers.util';
 
 @Injectable()
 export class ProxyService {
@@ -143,131 +144,17 @@ export class ProxyService {
   }
 
   /**
-   * Build headers for the proxied request
+   * Build headers for the proxied request (shared with the in-process invoker).
    */
   private buildHeaders(req: Request, rule: ProxyRule): Record<string, string> {
-    const headers: Record<string, string> = {};
-    const config: ProxyHeaderConfig = rule.headerConfig || {};
-
-    // Default safe headers to forward
-    // NOTE: content-length is intentionally NOT forwarded because:
-    // 1. The body may be re-serialized (changing its length)
-    // 2. If body parsing failed, we send null body but original content-length
-    // 3. This mismatch causes the receiving server to hang waiting for bytes
-    // Let fetch() calculate the correct content-length from the actual body
-    const defaultForwardHeaders = [
-      'accept',
-      'accept-language',
-      'content-type',
-      'user-agent',
-      'x-request-id',
-    ];
-
-    // Add cookie to forward list if forwardCookies is enabled
-    if (rule.forwardCookies) {
-      defaultForwardHeaders.push('cookie');
-    }
-
-    const forwardHeaders = config.forward || defaultForwardHeaders;
-
-    // Default headers to strip (hop-by-hop + sensitive)
-    const defaultStripHeaders = [
-      'host',
-      'connection',
-      'keep-alive',
-      'transfer-encoding',
-      'authorization', // Strip by default for security
-    ];
-
-    // Only strip cookies if forwardCookies is false (default behavior)
-    if (!rule.forwardCookies) {
-      defaultStripHeaders.push('cookie');
-    }
-
-    const stripHeaders = config.strip || defaultStripHeaders;
-
-    // Create a set for faster lookup
-    const stripSet = new Set(stripHeaders.map((h) => h.toLowerCase()));
-    const forwardSet = new Set(forwardHeaders.map((h) => h.toLowerCase()));
-
-    // Copy allowed headers
-    for (const [key, value] of Object.entries(req.headers)) {
-      const lowerKey = key.toLowerCase();
-      if (forwardSet.has(lowerKey) && !stripSet.has(lowerKey) && typeof value === 'string') {
-        headers[key] = value;
-      }
-    }
-
-    // Add configured headers (already decrypted by ProxyRulesService)
-    if (config.add) {
-      Object.assign(headers, config.add);
-    }
-
-    // Apply authTransform (e.g., cookie-to-bearer token)
-    // This matches nginx behavior for domain mappings
-    if (rule.authTransform?.type === 'cookie-to-bearer') {
-      const cookieValue = this.extractCookieValue(req, rule.authTransform.cookieName);
-      if (cookieValue) {
-        headers['authorization'] = `Bearer ${cookieValue}`;
-        this.logger.debug(
-          `Applied cookie-to-bearer: ${rule.authTransform.cookieName} -> Authorization header`,
-        );
-      } else {
-        this.logger.debug(
-          `Cookie "${rule.authTransform.cookieName}" not found for cookie-to-bearer transform`,
-        );
-      }
-    }
-
-    // Set host header based on preserveHost setting
-    if (!rule.preserveHost) {
-      try {
-        headers['host'] = new URL(rule.targetUrl).host;
-      } catch {
-        // If URL parsing fails, don't set host header
-      }
-    }
-
-    // Add forwarding headers — preserve the original client IP from the proxy chain
-    const existingForwardedFor = req.headers['x-forwarded-for'];
-    if (existingForwardedFor) {
-      headers['x-forwarded-for'] = String(existingForwardedFor);
-    } else {
-      headers['x-forwarded-for'] = req.ip || req.socket?.remoteAddress || '';
-    }
-    headers['x-forwarded-proto'] = req.protocol;
-    headers['x-forwarded-host'] = req.hostname;
-
-    return headers;
+    return buildProxyHeaders(req, rule, this.logger);
   }
 
   /**
    * Extract a cookie value from the request
    */
   private extractCookieValue(req: Request, cookieName: string): string | null {
-    // First try parsed cookies (if cookie-parser middleware is used)
-    if (req.cookies && req.cookies[cookieName]) {
-      return req.cookies[cookieName];
-    }
-
-    // Fall back to parsing Cookie header manually
-    const cookieHeader = req.headers.cookie;
-    if (!cookieHeader) {
-      return null;
-    }
-
-    const cookies = cookieHeader.split(';').reduce(
-      (acc, cookie) => {
-        const [name, ...valueParts] = cookie.trim().split('=');
-        if (name) {
-          acc[name] = valueParts.join('='); // Handle values with '=' in them
-        }
-        return acc;
-      },
-      {} as Record<string, string>,
-    );
-
-    return cookies[cookieName] || null;
+    return extractCookieValue(req, cookieName);
   }
 
   /**

--- a/apps/backend/src/proxy-rules/rule-invoker.service.spec.ts
+++ b/apps/backend/src/proxy-rules/rule-invoker.service.spec.ts
@@ -1,0 +1,270 @@
+import { RuleInvokerService, buildTargetUrl, MAX_INVOKE_DEPTH } from './rule-invoker.service';
+import { Request } from 'express';
+
+jest.mock('../db/client', () => ({
+  db: {
+    select: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockResolvedValue([]),
+    limit: jest.fn(),
+  },
+}));
+const mockDb = jest.requireMock('../db/client').db;
+
+const project = { id: 'proj-1', owner: 'o', name: 'r', defaultProxyRuleSetId: 'set-default' };
+const aliasRow = { id: 'alias-1', alias: 'workflow', proxyRuleSetId: 'set-1' };
+
+const rule = (over: Record<string, unknown> = {}) => ({
+  id: 'rule-1',
+  ruleSetId: 'set-1',
+  pathPattern: '/api/app/*',
+  method: null,
+  methods: null,
+  targetUrl: 'http://internal/pipeline',
+  stripPrefix: true,
+  order: 0,
+  timeout: 30000,
+  preserveHost: false,
+  forwardCookies: false,
+  headerConfig: null,
+  authTransform: null,
+  internalRewrite: false,
+  proxyType: 'pipeline',
+  emailHandlerConfig: null,
+  pipelineConfig: {
+    name: 'p',
+    steps: [{ name: 'respond', handlerType: 'response_handler', config: { body: '{}' } }],
+    validators: [],
+  },
+  isEnabled: true,
+  debugEnabled: false,
+  bypassVisibility: false,
+  description: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...over,
+});
+
+const parent = {
+  headers: {
+    cookie: 'sAccessToken=abc',
+    authorization: 'Bearer bfat_x',
+    host: 'localhost:3000',
+    'x-forwarded-host': 'h.example',
+    'content-length': '12',
+    'user-agent': 'ua',
+  },
+  cookies: { a: 'b' },
+  ip: '1.2.3.4',
+  socket: {},
+  protocol: 'https',
+  secure: true,
+} as unknown as Request;
+
+function make(rules: unknown[]) {
+  const proxyRulesService = {
+    getEffectiveRulesForMultipleRuleSets: jest.fn().mockResolvedValue(rules),
+  };
+  const execution = {
+    executePipelineWithDebug: jest.fn().mockResolvedValue({
+      success: true,
+      response: {
+        status: 200,
+        body: { ok: true },
+        headers: { 'Content-Type': 'application/json' },
+      },
+    }),
+  };
+  const service = new RuleInvokerService(proxyRulesService as never, execution as never);
+  return { service, proxyRulesService, execution };
+}
+
+const base = {
+  projectId: 'proj-1',
+  alias: 'workflow' as string | undefined,
+  deployment: { owner: 'o', repo: 'r', commitSha: 'c', alias: 'workflow' },
+  path: '/api/app/read',
+  method: 'POST' as const,
+  body: { a: 1 },
+  user: { id: 'u', credential: 'app_token' as const, scopes: ['app:read'] },
+  parent,
+  depth: 1,
+};
+
+describe('RuleInvokerService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb.limit.mockReset();
+    mockDb.limit.mockResolvedValueOnce([project]).mockResolvedValueOnce([aliasRow]);
+    mockDb.orderBy.mockResolvedValue([{ proxyRuleSetId: 'set-1' }]);
+  });
+
+  it('runs a pipeline sibling as the caller on a synthetic request without a res, and answers its response', async () => {
+    const { service, execution } = make([rule()]);
+    const result = await service.invoke(base);
+    expect(result).toEqual({
+      ok: true,
+      answer: {
+        status: 200,
+        body: { ok: true },
+        headers: { 'Content-Type': 'application/json' },
+        contentType: 'application/json',
+      },
+    });
+    const [pipeline, synthetic, user, options] = execution.executePipelineWithDebug.mock.calls[0];
+    expect(pipeline).toMatchObject({
+      id: 'rule-1',
+      projectId: 'proj-1',
+      steps: [{ handlerType: 'response_handler' }],
+    });
+    expect(user).toBe(base.user);
+    expect(options).toEqual({ deployment: base.deployment, captureDebug: false });
+    expect(synthetic.path).toBe('/api/app/read');
+    expect(synthetic.method).toBe('POST');
+    expect(synthetic.body).toEqual({ a: 1 });
+    expect(synthetic.headers.cookie).toBe('sAccessToken=abc');
+    expect(synthetic.headers.authorization).toBe('Bearer bfat_x');
+    expect(synthetic.headers['content-length']).toBeUndefined();
+    expect(synthetic.res).toBeUndefined();
+    expect(synthetic.get('User-Agent')).toBe('ua');
+    expect(synthetic.__invokeDepth).toBe(1);
+  });
+
+  it('maps a failed pipeline to the edge status table and carries the scope header', async () => {
+    const { service, execution } = make([rule()]);
+    execution.executePipelineWithDebug.mockResolvedValueOnce({
+      success: false,
+      error: {
+        code: 'AUTHORIZATION_ERROR',
+        message: 'insufficient_scope: missing app:write',
+        details: { code: 'insufficient_scope', missingScopes: ['app:write'] },
+      },
+    });
+    const result = await service.invoke(base);
+    expect(result).toMatchObject({
+      ok: true,
+      answer: {
+        status: 403,
+        headers: { 'WWW-Authenticate': 'Bearer error="insufficient_scope", scope="app:write"' },
+      },
+    });
+    execution.executePipelineWithDebug.mockResolvedValueOnce({
+      success: false,
+      error: { code: 'AUTH_REQUIRED', message: 'x' },
+    });
+    mockDb.limit.mockResolvedValueOnce([project]).mockResolvedValueOnce([aliasRow]);
+    expect(await service.invoke(base)).toMatchObject({ ok: true, answer: { status: 401 } });
+  });
+
+  it('answers no_rule when nothing matches, unsupported for an internal rewrite, recursion for depth and for an mcp_handler sibling', async () => {
+    const { service } = make([rule({ pathPattern: '/other/*' })]);
+    expect(await service.invoke(base)).toEqual({ ok: false, failure: { kind: 'no_rule' } });
+
+    const rewrite = make([rule({ proxyType: 'internal_rewrite' })]);
+    mockDb.limit.mockResolvedValueOnce([project]).mockResolvedValueOnce([aliasRow]);
+    expect(await rewrite.service.invoke(base)).toEqual({
+      ok: false,
+      failure: { kind: 'unsupported', proxyType: 'internal_rewrite' },
+    });
+
+    const nested = make([
+      rule({
+        pipelineConfig: {
+          name: 'p',
+          steps: [{ name: 'mcp', handlerType: 'mcp_handler', config: {} }],
+        },
+      }),
+    ]);
+    mockDb.limit.mockResolvedValueOnce([project]).mockResolvedValueOnce([aliasRow]);
+    expect(await nested.service.invoke(base)).toEqual({
+      ok: false,
+      failure: { kind: 'recursion' },
+    });
+
+    const deep = make([rule()]);
+    expect(await deep.service.invoke({ ...base, depth: MAX_INVOKE_DEPTH + 1 })).toEqual({
+      ok: false,
+      failure: { kind: 'recursion' },
+    });
+  });
+
+  it("fetches an external_proxy sibling in-process with the caller's cookie and authorization", async () => {
+    const { service } = make([
+      rule({
+        proxyType: 'external_proxy',
+        targetUrl: 'http://localhost:3000/api/aliases',
+        pathPattern: '/api/app/aliases',
+        stripPrefix: true,
+      }),
+    ]);
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: async () => '{"data":[]}',
+    } as unknown as Response);
+    const result = await service.invoke({
+      ...base,
+      path: '/api/app/aliases',
+      method: 'GET',
+      body: undefined,
+      query: { repository: 'o/r' },
+    });
+    expect(result).toEqual({
+      ok: true,
+      answer: { status: 200, body: { data: [] }, headers: {}, contentType: 'application/json' },
+    });
+    const [url, init] = fetchSpy.mock.calls[0] as [
+      URL,
+      RequestInit & { headers: Record<string, string> },
+    ];
+    expect(url.toString()).toBe('http://localhost:3000/api/aliases?repository=o%2Fr');
+    expect(init.headers.cookie).toBe('sAccessToken=abc');
+    expect(init.headers.authorization).toBe('Bearer bfat_x');
+    expect(init.headers['x-forwarded-host']).toBe('h.example');
+    expect(init.headers['x-original-uri']).toBe('/api/app/aliases');
+    fetchSpy.mockRestore();
+  });
+
+  it("caches the alias's rules for a short window", async () => {
+    const { service, proxyRulesService } = make([rule()]);
+    await service.invoke(base);
+    mockDb.limit.mockResolvedValueOnce([project]).mockResolvedValueOnce([aliasRow]);
+    await service.invoke(base);
+    expect(proxyRulesService.getEffectiveRulesForMultipleRuleSets).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('buildTargetUrl (ProxyService parity)', () => {
+  const r = (over: Record<string, unknown>) =>
+    rule({ proxyType: 'external_proxy', ...over }) as never;
+  it('strips the matched prefix onto the target path', () => {
+    expect(
+      buildTargetUrl(
+        r({ pathPattern: '/api/platform/*', targetUrl: 'http://host/api' }),
+        '/api/platform/organizations',
+      ).toString(),
+    ).toBe('http://host/api/organizations');
+    expect(
+      buildTargetUrl(
+        r({
+          pathPattern: '/w/hello/*',
+          targetUrl: 'http://localhost:3000/public/o/r/alias/hello/dist',
+        }),
+        '/w/hello/islands/x.html',
+      ).toString(),
+    ).toBe('http://localhost:3000/public/o/r/alias/hello/dist/islands/x.html');
+    expect(
+      buildTargetUrl(
+        r({ pathPattern: '/env.json', targetUrl: 'http://host/cfg/env.json' }),
+        '/env.json',
+      ).toString(),
+    ).toBe('http://host/cfg/env.json');
+    expect(
+      buildTargetUrl(
+        r({ pathPattern: '/api/*', targetUrl: 'http://host', stripPrefix: false }),
+        '/api/x',
+      ).toString(),
+    ).toBe('http://host/api/x');
+  });
+});

--- a/apps/backend/src/proxy-rules/rule-invoker.service.spec.ts
+++ b/apps/backend/src/proxy-rules/rule-invoker.service.spec.ts
@@ -194,41 +194,100 @@ describe('RuleInvokerService', () => {
     });
   });
 
-  it("fetches an external_proxy sibling in-process with the caller's cookie and authorization", async () => {
-    const { service } = make([
+  describe("external_proxy siblings honour the rule's own header controls (ProxyService parity)", () => {
+    const mockFetch = () =>
+      jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: async () => '{"data":[]}',
+      } as unknown as Response);
+    const external = (over: Record<string, unknown> = {}) =>
       rule({
         proxyType: 'external_proxy',
         targetUrl: 'http://localhost:3000/api/aliases',
         pathPattern: '/api/app/aliases',
         stripPrefix: true,
+        ...over,
+      });
+    const call = (service: RuleInvokerService) =>
+      service.invoke({
+        ...base,
+        path: '/api/app/aliases',
+        method: 'GET',
+        body: undefined,
+        query: { repository: 'o/r' },
+      });
+    const sent = (spy: jest.SpyInstance) =>
+      (spy.mock.calls[0] as [URL, RequestInit & { headers: Record<string, string> }])[1].headers;
+
+    it('at the defaults (forwardCookies false, no authTransform) neither cookie nor authorization leaves', async () => {
+      const { service } = make([external()]);
+      const fetchSpy = mockFetch();
+      const result = await call(service);
+      expect(result).toEqual({
+        ok: true,
+        answer: { status: 200, body: { data: [] }, headers: {}, contentType: 'application/json' },
+      });
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.toString()).toBe('http://localhost:3000/api/aliases?repository=o%2Fr');
+      const headers = sent(fetchSpy);
+      expect(headers.cookie).toBeUndefined();
+      expect(headers.authorization).toBeUndefined();
+      expect(headers['content-type']).toBeUndefined();
+      expect(headers['x-forwarded-host']).toBe('h.example');
+      expect(headers['x-original-uri']).toBe('/api/app/aliases');
+      expect(headers['user-agent']).toBe('ua');
+      fetchSpy.mockRestore();
+    });
+
+    it('forwardCookies: true sends the cookie and still strips authorization', async () => {
+      const { service } = make([external({ forwardCookies: true })]);
+      const fetchSpy = mockFetch();
+      await call(service);
+      const headers = sent(fetchSpy);
+      expect(headers.cookie).toBe('sAccessToken=abc');
+      expect(headers.authorization).toBeUndefined();
+      fetchSpy.mockRestore();
+    });
+
+    it("headerConfig.forward/strip are the rule's to set — authorization goes only when listed", async () => {
+      const { service } = make([
+        external({ headerConfig: { forward: ['authorization', 'accept'], strip: ['host'] } }),
+      ]);
+      const fetchSpy = mockFetch();
+      await call(service);
+      const headers = sent(fetchSpy);
+      expect(headers.authorization).toBe('Bearer bfat_x');
+      expect(headers.cookie).toBeUndefined();
+      fetchSpy.mockRestore();
+    });
+
+    it('authTransform cookie-to-bearer turns the named cookie into the bearer, as the edge does', async () => {
+      const { service } = make([
+        external({ authTransform: { type: 'cookie-to-bearer', cookieName: 'sAccessToken' } }),
+      ]);
+      const fetchSpy = mockFetch();
+      await call(service);
+      const headers = sent(fetchSpy);
+      expect(headers.authorization).toBe('Bearer abc');
+      expect(headers.cookie).toBeUndefined();
+      fetchSpy.mockRestore();
+    });
+  });
+
+  it('refuses a sibling whose mcp_handler hides in postSteps', async () => {
+    const { service, execution } = make([
+      rule({
+        pipelineConfig: {
+          name: 'p',
+          steps: [{ name: 'respond', handlerType: 'response_handler', config: { body: '{}' } }],
+          postSteps: [{ name: 'again', handlerType: 'mcp_handler', config: {} }],
+          validators: [],
+        },
       }),
     ]);
-    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
-      status: 200,
-      headers: new Headers({ 'content-type': 'application/json' }),
-      text: async () => '{"data":[]}',
-    } as unknown as Response);
-    const result = await service.invoke({
-      ...base,
-      path: '/api/app/aliases',
-      method: 'GET',
-      body: undefined,
-      query: { repository: 'o/r' },
-    });
-    expect(result).toEqual({
-      ok: true,
-      answer: { status: 200, body: { data: [] }, headers: {}, contentType: 'application/json' },
-    });
-    const [url, init] = fetchSpy.mock.calls[0] as [
-      URL,
-      RequestInit & { headers: Record<string, string> },
-    ];
-    expect(url.toString()).toBe('http://localhost:3000/api/aliases?repository=o%2Fr');
-    expect(init.headers.cookie).toBe('sAccessToken=abc');
-    expect(init.headers.authorization).toBe('Bearer bfat_x');
-    expect(init.headers['x-forwarded-host']).toBe('h.example');
-    expect(init.headers['x-original-uri']).toBe('/api/app/aliases');
-    fetchSpy.mockRestore();
+    expect(await service.invoke(base)).toEqual({ ok: false, failure: { kind: 'recursion' } });
+    expect(execution.executePipelineWithDebug).not.toHaveBeenCalled();
   });
 
   it("caches the alias's rules for a short window", async () => {

--- a/apps/backend/src/proxy-rules/rule-invoker.service.spec.ts
+++ b/apps/backend/src/proxy-rules/rule-invoker.service.spec.ts
@@ -1,4 +1,9 @@
-import { RuleInvokerService, buildTargetUrl, MAX_INVOKE_DEPTH } from './rule-invoker.service';
+import {
+  RuleInvokerService,
+  buildTargetUrl,
+  publicPrefixOf,
+  MAX_INVOKE_DEPTH,
+} from './rule-invoker.service';
 import { Request } from 'express';
 
 jest.mock('../db/client', () => ({
@@ -266,5 +271,47 @@ describe('buildTargetUrl (ProxyService parity)', () => {
         '/api/x',
       ).toString(),
     ).toBe('http://host/api/x');
+  });
+});
+
+describe('publicPrefixOf', () => {
+  it("keeps the edge's rewrite shape for a sibling", () => {
+    const p = (path: string, original?: string) =>
+      ({ path, headers: original ? { 'x-original-uri': original } : {} }) as unknown as Request;
+    expect(
+      publicPrefixOf(
+        p('/public/o/r/alias/workflow/dist/api/workflow/mcp', '/api/workflow/mcp?x=1'),
+      ),
+    ).toBe('/public/o/r/alias/workflow/dist');
+    expect(publicPrefixOf(p('/api/workflow/mcp', '/api/workflow/mcp'))).toBe('');
+    expect(publicPrefixOf(p('/public/o/r/alias/workflow/dist/api/workflow/mcp'))).toBe('');
+  });
+  it("gives the synthetic request the parent's prefix and the sibling path as x-original-uri", async () => {
+    const proxyRulesService = {
+      getEffectiveRulesForMultipleRuleSets: jest.fn().mockResolvedValue([rule()]),
+    };
+    const execution = {
+      executePipelineWithDebug: jest
+        .fn()
+        .mockResolvedValue({ success: true, response: { status: 200, body: {} } }),
+    };
+    const service = new RuleInvokerService(proxyRulesService as never, execution as never);
+    mockDb.limit.mockReset();
+    mockDb.limit.mockResolvedValueOnce([project]).mockResolvedValueOnce([aliasRow]);
+    const parentEdge = {
+      ...parent,
+      path: '/public/o/r/alias/workflow/dist/api/workflow/mcp',
+      headers: { ...parent.headers, 'x-original-uri': '/api/workflow/mcp' },
+    } as unknown as Request;
+    await service.invoke({
+      ...base,
+      parent: parentEdge,
+      query: { a: '1' },
+      method: 'GET',
+      body: undefined,
+    });
+    const synthetic = execution.executePipelineWithDebug.mock.calls[0][1];
+    expect(synthetic.path).toBe('/public/o/r/alias/workflow/dist/api/app/read');
+    expect(synthetic.headers['x-original-uri']).toBe('/api/app/read?a=1');
   });
 });

--- a/apps/backend/src/proxy-rules/rule-invoker.service.ts
+++ b/apps/backend/src/proxy-rules/rule-invoker.service.ts
@@ -1,0 +1,318 @@
+import { Inject, Injectable, Logger, forwardRef } from '@nestjs/common';
+import { and, eq } from 'drizzle-orm';
+import { Request } from 'express';
+import { db } from '../db/client';
+import { deploymentAliases, projects } from '../db/schema';
+import { ProxyRule } from '../db/schema/proxy-rules.schema';
+import { PipelineExecutionService } from '../pipelines/execution';
+import { PipelineContext, PipelineUser } from '../pipelines/execution/pipeline-context.interface';
+import { ProxyRulesService } from './proxy-rules.service';
+import {
+  insufficientScopeHeader,
+  pipelineFromRule,
+  statusForPipelineError,
+} from './pipeline-from-rule';
+import { findMatchingRule, resolveEffectiveRuleSetIds } from './rule-resolution';
+
+export interface InvokeRequest {
+  projectId: string;
+  /** The alias whose rule sets are searched — the calling rule's own (`context.deployment.alias`). */
+  alias: string | undefined;
+  deployment: PipelineContext['deployment'];
+  /** Public-relative, e.g. `/api/workflow/mcp-tools/status`. */
+  path: string;
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  query?: Record<string, unknown>;
+  body?: unknown;
+  /** The caller — passed through unchanged; the sibling's validators judge it. */
+  user: PipelineUser | undefined;
+  /** The parent request: headers, cookies, ip, user-agent are copied onto the synthetic one. */
+  parent: Request;
+  /** The parent's depth + 1; beyond MAX_INVOKE_DEPTH is refused. */
+  depth: number;
+}
+
+export interface InvokeAnswer {
+  status: number;
+  body: unknown;
+  headers: Record<string, string>;
+  contentType: string;
+}
+
+export const MAX_INVOKE_DEPTH = 1;
+
+export type InvokeFailure =
+  | { kind: 'no_rule' }
+  | { kind: 'unsupported'; proxyType: string }
+  | { kind: 'recursion' }
+  | { kind: 'error'; message: string };
+
+export type InvokeResult =
+  | { ok: true; answer: InvokeAnswer }
+  | { ok: false; failure: InvokeFailure };
+
+/** Marker the synthetic request carries so a sibling that is itself an `mcp_handler` can refuse to recurse. */
+export const INVOKE_DEPTH_KEY = '__invokeDepth';
+
+const RULE_CACHE_TTL = 10_000;
+const DROPPED_HEADERS = new Set(['content-length', 'host', 'transfer-encoding']);
+
+/**
+ * Execute a sibling rule of the same alias in-process, as the caller (Phase 3
+ * plan, Decision 14). The rule is resolved exactly as the edge resolves it
+ * (`rule-resolution.ts`), its validators run, the visibility gate does not
+ * (the caller already passed it for this alias), and the answer is the
+ * `{ status, body, headers }` the edge would have sent.
+ */
+@Injectable()
+export class RuleInvokerService {
+  private readonly logger = new Logger(RuleInvokerService.name);
+  private readonly ruleCache = new Map<string, { rules: ProxyRule[]; expiry: number }>();
+
+  constructor(
+    @Inject(forwardRef(() => ProxyRulesService))
+    private readonly proxyRulesService: ProxyRulesService,
+    @Inject(forwardRef(() => PipelineExecutionService))
+    private readonly pipelineExecutionService: PipelineExecutionService,
+  ) {}
+
+  async invoke(req: InvokeRequest): Promise<InvokeResult> {
+    if (req.depth > MAX_INVOKE_DEPTH) return { ok: false, failure: { kind: 'recursion' } };
+
+    const rule = await this.resolveRule(req);
+    if (!rule) return { ok: false, failure: { kind: 'no_rule' } };
+
+    const proxyType =
+      rule.proxyType && rule.proxyType !== 'external_proxy'
+        ? rule.proxyType
+        : rule.internalRewrite
+          ? 'internal_rewrite'
+          : 'external_proxy';
+
+    if (proxyType === 'pipeline') return this.invokePipeline(rule, req);
+    if (proxyType === 'external_proxy') return this.invokeExternal(rule, req);
+    return { ok: false, failure: { kind: 'unsupported', proxyType } };
+  }
+
+  private async resolveRule(req: InvokeRequest): Promise<ProxyRule | null> {
+    const [project] = await db
+      .select()
+      .from(projects)
+      .where(eq(projects.id, req.projectId))
+      .limit(1);
+    if (!project) return null;
+    let alias: { id: string; proxyRuleSetId: string | null } | null = null;
+    if (req.alias) {
+      const [row] = await db
+        .select()
+        .from(deploymentAliases)
+        .where(
+          and(eq(deploymentAliases.projectId, project.id), eq(deploymentAliases.alias, req.alias)),
+        )
+        .limit(1);
+      if (row) alias = { id: row.id, proxyRuleSetId: row.proxyRuleSetId };
+    }
+    const ids = await resolveEffectiveRuleSetIds(
+      { id: project.id, defaultProxyRuleSetId: project.defaultProxyRuleSetId },
+      alias,
+    );
+    if (ids.length === 0) return null;
+    const rules = await this.cachedRules(ids);
+    return findMatchingRule(rules, req.path, req.method);
+  }
+
+  private async cachedRules(ids: string[]): Promise<ProxyRule[]> {
+    const key = ids.join(',');
+    const cached = this.ruleCache.get(key);
+    if (cached && cached.expiry > Date.now()) return cached.rules;
+    const rules = await this.proxyRulesService.getEffectiveRulesForMultipleRuleSets(ids);
+    this.ruleCache.set(key, { rules, expiry: Date.now() + RULE_CACHE_TTL });
+    return rules;
+  }
+
+  private async invokePipeline(rule: ProxyRule, req: InvokeRequest): Promise<InvokeResult> {
+    const pipeline = pipelineFromRule(rule, req.projectId);
+    if (!pipeline)
+      return { ok: false, failure: { kind: 'error', message: 'Pipeline configuration missing' } };
+    if (pipeline.steps.some((step) => step.handlerType === 'mcp_handler')) {
+      return { ok: false, failure: { kind: 'recursion' } };
+    }
+
+    const synthetic = this.syntheticRequest(req);
+    const result = await this.pipelineExecutionService.executePipelineWithDebug(
+      pipeline,
+      synthetic,
+      req.user,
+      { deployment: req.deployment, captureDebug: false },
+    );
+
+    if (result.success && result.response) {
+      const headers = { ...(result.response.headers ?? {}) };
+      return {
+        ok: true,
+        answer: {
+          status: result.response.status,
+          body: result.response.body,
+          headers,
+          contentType: headers['Content-Type'] ?? headers['content-type'] ?? 'application/json',
+        },
+      };
+    }
+    const status = statusForPipelineError(result.error?.code);
+    const headers: Record<string, string> = {};
+    const scope = insufficientScopeHeader(result.error);
+    if (scope) headers['WWW-Authenticate'] = scope;
+    return {
+      ok: true,
+      answer: {
+        status,
+        body: { success: false, error: result.error },
+        headers,
+        contentType: 'application/json',
+      },
+    };
+  }
+
+  /**
+   * An `external_proxy` sibling: the in-process fetch the forwarder would make,
+   * with the caller's cookie and authorization carried onward and the two
+   * headers CE's own routing reads (`x-forwarded-host`, `x-original-uri`).
+   */
+  private async invokeExternal(rule: ProxyRule, req: InvokeRequest): Promise<InvokeResult> {
+    let target: URL;
+    try {
+      target = buildTargetUrl(rule, req.path);
+    } catch (error) {
+      return { ok: false, failure: { kind: 'error', message: `bad targetUrl: ${String(error)}` } };
+    }
+    for (const [key, value] of Object.entries(req.query ?? {})) {
+      target.searchParams.set(key, typeof value === 'string' ? value : JSON.stringify(value));
+    }
+    const parent = req.parent.headers;
+    const headers: Record<string, string> = {
+      accept: 'application/json, text/plain, */*',
+      'x-forwarded-host': first(parent['x-forwarded-host']) ?? first(parent.host) ?? '',
+      'x-original-uri': req.path,
+    };
+    const cookie = first(parent.cookie);
+    if (cookie) headers.cookie = cookie;
+    const authorization = first(parent.authorization);
+    if (authorization) headers.authorization = authorization;
+    const hasBody = req.body !== undefined && req.method !== 'GET';
+    if (hasBody) headers['content-type'] = 'application/json';
+    try {
+      const res = await fetch(target, {
+        method: req.method,
+        headers,
+        ...(hasBody ? { body: JSON.stringify(req.body) } : {}),
+        signal: AbortSignal.timeout(rule.timeout ?? 30_000),
+      });
+      const contentType = res.headers.get('content-type') ?? '';
+      const text = await res.text();
+      let body: unknown = text;
+      if (contentType.includes('json')) {
+        try {
+          body = text === '' ? null : JSON.parse(text);
+        } catch {
+          body = text;
+        }
+      }
+      const answerHeaders: Record<string, string> = {};
+      const wwwAuth = res.headers.get('www-authenticate');
+      if (wwwAuth) answerHeaders['WWW-Authenticate'] = wwwAuth;
+      return {
+        ok: true,
+        answer: { status: res.status, body, headers: answerHeaders, contentType },
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        failure: { kind: 'error', message: error instanceof Error ? error.message : String(error) },
+      };
+    }
+  }
+
+  /**
+   * The request a sibling pipeline sees: the parent's headers (minus the ones
+   * that describe the parent's own body), cookies, ip and user agent, with the
+   * sibling's path/method/query/body. Deliberately no `res`: a streaming
+   * handler falls back to its non-streaming branch, and file serving refuses.
+   */
+  private syntheticRequest(req: InvokeRequest): Request {
+    const headers: Record<string, string | string[] | undefined> = {};
+    for (const [key, value] of Object.entries(req.parent.headers)) {
+      if (!DROPPED_HEADERS.has(key.toLowerCase())) headers[key.toLowerCase()] = value;
+    }
+    headers['content-type'] = 'application/json';
+    const query = req.query ?? {};
+    const qs = Object.keys(query).length
+      ? '?' +
+        Object.entries(query)
+          .map(
+            ([k, v]) =>
+              `${encodeURIComponent(k)}=${encodeURIComponent(typeof v === 'string' ? v : JSON.stringify(v))}`,
+          )
+          .join('&')
+      : '';
+    const synthetic = {
+      path: req.path,
+      method: req.method,
+      url: `${req.path}${qs}`,
+      originalUrl: `${req.path}${qs}`,
+      headers,
+      query,
+      body: req.body ?? {},
+      cookies: (req.parent as Request & { cookies?: unknown }).cookies ?? {},
+      ip: req.parent.ip,
+      socket: req.parent.socket,
+      protocol: req.parent.protocol,
+      secure: req.parent.secure,
+      get: (name: string) => {
+        const value = headers[name.toLowerCase()];
+        return Array.isArray(value) ? value[0] : value;
+      },
+      header: (name: string) => {
+        const value = headers[name.toLowerCase()];
+        return Array.isArray(value) ? value[0] : value;
+      },
+      [INVOKE_DEPTH_KEY]: req.depth,
+    };
+    return synthetic as unknown as Request;
+  }
+}
+
+function first(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/** `ProxyService.buildTargetUrl`'s rule, restated for the invoker (that one is private and needs an Express request). */
+export function buildTargetUrl(rule: ProxyRule, subpath: string): URL {
+  const baseUrl = new URL(rule.targetUrl);
+  const append = rule.stripPrefix ? stripMatchedPrefix(rule.pathPattern, subpath) : subpath;
+  return new URL(joinPaths(baseUrl.pathname, append), baseUrl.origin);
+}
+
+function joinPaths(basePath: string, appendPath: string): string {
+  if (appendPath === '') return basePath;
+  const normalizedBase = basePath.replace(/\/+$/, '');
+  const normalizedAppend = appendPath.startsWith('/') ? appendPath : '/' + appendPath;
+  if (!normalizedBase) return normalizedAppend;
+  return normalizedBase + normalizedAppend;
+}
+
+function stripMatchedPrefix(pattern: string, path: string): string {
+  // Verbatim ProxyService.stripMatchedPrefix
+  if (pattern.endsWith('/*')) {
+    const prefix = pattern.slice(0, -2);
+    if (path.startsWith(prefix + '/')) {
+      return path.substring(prefix.length) || '/';
+    }
+    if (path === prefix) {
+      return '/';
+    }
+  }
+  if (path === pattern) {
+    return '';
+  }
+  return path;
+}

--- a/apps/backend/src/proxy-rules/rule-invoker.service.ts
+++ b/apps/backend/src/proxy-rules/rule-invoker.service.ts
@@ -13,6 +13,7 @@ import {
   statusForPipelineError,
 } from './pipeline-from-rule';
 import { findMatchingRule, resolveEffectiveRuleSetIds } from './rule-resolution';
+import { buildProxyHeaders } from './proxy-headers.util';
 
 export interface InvokeRequest {
   projectId: string;
@@ -134,7 +135,8 @@ export class RuleInvokerService {
     const pipeline = pipelineFromRule(rule, req.projectId);
     if (!pipeline)
       return { ok: false, failure: { kind: 'error', message: 'Pipeline configuration missing' } };
-    if (pipeline.steps.some((step) => step.handlerType === 'mcp_handler')) {
+    const allSteps = [...pipeline.steps, ...(pipeline.postSteps ?? [])];
+    if (allSteps.some((step) => step.handlerType === 'mcp_handler')) {
       return { ok: false, failure: { kind: 'recursion' } };
     }
 
@@ -188,18 +190,17 @@ export class RuleInvokerService {
     for (const [key, value] of Object.entries(req.query ?? {})) {
       target.searchParams.set(key, typeof value === 'string' ? value : JSON.stringify(value));
     }
+    // The rule's own header controls decide what of the caller reaches the target —
+    // the same `forwardCookies` / `authTransform` / `headerConfig` the edge applies.
+    // An in-process call is not a licence to forward the caller's credential.
     const parent = req.parent.headers;
-    const headers: Record<string, string> = {
-      accept: 'application/json, text/plain, */*',
-      'x-forwarded-host': first(parent['x-forwarded-host']) ?? first(parent.host) ?? '',
-      'x-original-uri': req.path,
-    };
-    const cookie = first(parent.cookie);
-    if (cookie) headers.cookie = cookie;
-    const authorization = first(parent.authorization);
-    if (authorization) headers.authorization = authorization;
+    const headers = buildProxyHeaders(req.parent, rule, this.logger);
+    headers.accept = 'application/json, text/plain, */*';
+    headers['x-forwarded-host'] = first(parent['x-forwarded-host']) ?? first(parent.host) ?? '';
+    headers['x-original-uri'] = req.path;
     const hasBody = req.body !== undefined && req.method !== 'GET';
     if (hasBody) headers['content-type'] = 'application/json';
+    else delete headers['content-type'];
     try {
       const res = await fetch(target, {
         method: req.method,

--- a/apps/backend/src/proxy-rules/rule-invoker.service.ts
+++ b/apps/backend/src/proxy-rules/rule-invoker.service.ts
@@ -254,11 +254,17 @@ export class RuleInvokerService {
           )
           .join('&')
       : '';
+    // The edge rewrites a domain request to `/public/<owner>/<repo>/alias/<a>/<dir><public path>`
+    // and keeps the public path in `x-original-uri`; a sibling sees the same shape, so a
+    // function that derives the alias's in-process base from `request.path` (the way the
+    // Workflow prototype did) keeps working — and CE's routing reads the two headers.
+    const prefix = publicPrefixOf(req.parent);
+    headers['x-original-uri'] = `${req.path}${qs}`;
     const synthetic = {
-      path: req.path,
+      path: `${prefix}${req.path}`,
       method: req.method,
-      url: `${req.path}${qs}`,
-      originalUrl: `${req.path}${qs}`,
+      url: `${prefix}${req.path}${qs}`,
+      originalUrl: `${prefix}${req.path}${qs}`,
       headers,
       query,
       body: req.body ?? {},
@@ -279,6 +285,21 @@ export class RuleInvokerService {
     };
     return synthetic as unknown as Request;
   }
+}
+
+/**
+ * `/public/<owner>/<repo>/alias/<a>/<dir>` from the parent: its `path` minus the
+ * public-relative path `x-original-uri` carries (query dropped). `''` when the
+ * parent was not a rewritten domain request.
+ */
+export function publicPrefixOf(parent: Request): string {
+  const path = typeof parent.path === 'string' ? parent.path : '';
+  if (!path.startsWith('/public/')) return '';
+  const original = first(parent.headers['x-original-uri']);
+  const originalPath = original ? original.split('?')[0] : '';
+  if (originalPath !== '' && path.endsWith(originalPath))
+    return path.slice(0, -originalPath.length);
+  return '';
 }
 
 function first(value: string | string[] | undefined): string | undefined {

--- a/apps/backend/src/proxy-rules/rule-resolution.spec.ts
+++ b/apps/backend/src/proxy-rules/rule-resolution.spec.ts
@@ -1,0 +1,96 @@
+import {
+  findMatchingRule,
+  matchesPattern,
+  resolveEffectiveRuleSetIds,
+  resolveProjectDefaultRuleSetIds,
+  resolveRuleSetIdsForAlias,
+} from './rule-resolution';
+
+jest.mock('../db/client', () => ({
+  db: {
+    select: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn(),
+  },
+}));
+const mockDb = jest.requireMock('../db/client').db;
+
+const rule = (over: Record<string, unknown> = {}) =>
+  ({
+    id: 'r',
+    pathPattern: '/api/*',
+    method: null,
+    methods: null,
+    isEnabled: true,
+    ...over,
+  }) as never;
+
+describe('rule-resolution', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('matchesPattern (lifted verbatim from the middleware)', () => {
+    it('matches exact, trailing, leading and middle wildcards', () => {
+      expect(matchesPattern('/api/users', '/api/users')).toBe(true);
+      expect(matchesPattern('/api/*', '/api/users')).toBe(true);
+      expect(matchesPattern('/api/*', '/api/')).toBe(true);
+      expect(matchesPattern('/api/*', '/api')).toBe(false);
+      expect(matchesPattern('*.json', '/data/x.json')).toBe(true);
+      expect(matchesPattern('/api/*/users', '/api/v2/users')).toBe(true);
+      expect(matchesPattern('/api/x', '/api/y')).toBe(false);
+      expect(matchesPattern('/api/a.b', '/api/aXb')).toBe(false);
+    });
+  });
+
+  describe('findMatchingRule', () => {
+    it('skips disabled rules, honours methods[] then method, first match wins', () => {
+      const rules = [
+        rule({ id: 'off', isEnabled: false }),
+        rule({ id: 'post-only', method: 'POST' }),
+        rule({ id: 'get-head', methods: ['GET', 'HEAD'] }),
+        rule({ id: 'any' }),
+      ];
+      expect(findMatchingRule(rules, '/api/x', 'GET')).toMatchObject({ id: 'get-head' });
+      expect(findMatchingRule(rules, '/api/x', 'post')).toMatchObject({ id: 'post-only' });
+      expect(findMatchingRule(rules, '/api/x', 'DELETE')).toMatchObject({ id: 'any' });
+      expect(findMatchingRule(rules, '/other', 'GET')).toBeNull();
+    });
+  });
+
+  describe('resolveRuleSetIdsForAlias / resolveProjectDefaultRuleSetIds / resolveEffectiveRuleSetIds', () => {
+    it('prefers join rows in order, then the legacy column, then nothing', async () => {
+      mockDb.orderBy.mockResolvedValueOnce([{ proxyRuleSetId: 'b' }, { proxyRuleSetId: 'a' }]);
+      expect(await resolveRuleSetIdsForAlias('alias-1', 'legacy')).toEqual(['b', 'a']);
+      mockDb.orderBy.mockResolvedValueOnce([]);
+      expect(await resolveRuleSetIdsForAlias('alias-1', 'legacy')).toEqual(['legacy']);
+      mockDb.orderBy.mockResolvedValueOnce([]);
+      expect(await resolveProjectDefaultRuleSetIds('p', null)).toEqual([]);
+    });
+
+    it('falls back from the alias to the project defaults exactly as the middleware does', async () => {
+      mockDb.orderBy
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ proxyRuleSetId: 'default' }]);
+      expect(
+        await resolveEffectiveRuleSetIds(
+          { id: 'p', defaultProxyRuleSetId: null },
+          { id: 'alias-1', proxyRuleSetId: null },
+        ),
+      ).toEqual(['default']);
+      mockDb.orderBy.mockResolvedValueOnce([{ proxyRuleSetId: 'mine' }]);
+      expect(
+        await resolveEffectiveRuleSetIds(
+          { id: 'p', defaultProxyRuleSetId: 'x' },
+          { id: 'alias-1', proxyRuleSetId: null },
+        ),
+      ).toEqual(['mine']);
+      mockDb.orderBy.mockResolvedValueOnce([]);
+      expect(
+        await resolveEffectiveRuleSetIds(
+          { id: 'p', defaultProxyRuleSetId: 'legacy-default' },
+          null,
+        ),
+      ).toEqual(['legacy-default']);
+    });
+  });
+});

--- a/apps/backend/src/proxy-rules/rule-resolution.ts
+++ b/apps/backend/src/proxy-rules/rule-resolution.ts
@@ -1,0 +1,134 @@
+import { asc, eq } from 'drizzle-orm';
+import { db } from '../db/client';
+import { aliasProxyRuleSets, projectDefaultProxyRuleSets } from '../db/schema';
+import { ProxyRule } from '../db/schema/proxy-rules.schema';
+import { matchesMethod } from './method-match';
+
+/**
+ * Rule resolution, shared by the edge (`ProxyMiddleware`) and the in-process
+ * invoker (`RuleInvokerService`, the `mcp_handler`'s sibling calls) — pure
+ * functions over the db client, lifted verbatim out of the middleware so the
+ * two paths cannot drift: a sibling rule is found exactly as the edge would
+ * find it.
+ */
+
+/**
+ * Resolve rule set IDs for an alias.
+ * Checks join table first, falls back to legacy proxyRuleSetId column.
+ */
+export async function resolveRuleSetIdsForAlias(
+  aliasId: string,
+  legacyProxyRuleSetId: string | null,
+): Promise<string[]> {
+  const joinRows = await db
+    .select({ proxyRuleSetId: aliasProxyRuleSets.proxyRuleSetId })
+    .from(aliasProxyRuleSets)
+    .where(eq(aliasProxyRuleSets.aliasId, aliasId))
+    .orderBy(asc(aliasProxyRuleSets.order));
+
+  if (joinRows.length > 0) {
+    return joinRows.map((r) => r.proxyRuleSetId);
+  }
+
+  if (legacyProxyRuleSetId) {
+    return [legacyProxyRuleSetId];
+  }
+
+  return [];
+}
+
+/**
+ * Resolve default rule set IDs for a project.
+ * Checks join table first, falls back to legacy defaultProxyRuleSetId column.
+ */
+export async function resolveProjectDefaultRuleSetIds(
+  projectId: string,
+  legacyDefaultProxyRuleSetId: string | null,
+): Promise<string[]> {
+  const joinRows = await db
+    .select({ proxyRuleSetId: projectDefaultProxyRuleSets.proxyRuleSetId })
+    .from(projectDefaultProxyRuleSets)
+    .where(eq(projectDefaultProxyRuleSets.projectId, projectId))
+    .orderBy(asc(projectDefaultProxyRuleSets.order));
+
+  if (joinRows.length > 0) {
+    return joinRows.map((r) => r.proxyRuleSetId);
+  }
+
+  if (legacyDefaultProxyRuleSetId) {
+    return [legacyDefaultProxyRuleSetId];
+  }
+
+  return [];
+}
+
+/**
+ * The effective rule-set ids for (project, alias): the alias's sets (join
+ * table → legacy column), else the project's defaults — the middleware's
+ * order, exactly.
+ */
+export async function resolveEffectiveRuleSetIds(
+  project: { id: string; defaultProxyRuleSetId: string | null },
+  alias: { id: string; proxyRuleSetId: string | null } | null,
+): Promise<string[]> {
+  let ids: string[] = [];
+  if (alias) {
+    ids = await resolveRuleSetIdsForAlias(alias.id, alias.proxyRuleSetId);
+  }
+  if (ids.length === 0) {
+    ids = await resolveProjectDefaultRuleSetIds(project.id, project.defaultProxyRuleSetId);
+  }
+  return ids;
+}
+
+/**
+ * Match a path against a rule pattern. Supports exact matches and glob
+ * wildcards — trailing (`/api/*`), leading (`*.json`) and middle
+ * (`/api/*​/users`).
+ *
+ * Note: '/prefix/*' matches '/prefix/' and '/prefix/<sub>' but NOT the bare
+ * '/prefix' — the wildcard requires a path separator. This lets a same-named
+ * client-side SPA route (e.g. bare '/auth') fall through to the SPA fallback
+ * while subpaths (e.g. '/auth/signin') are still proxied. To also match the
+ * bare prefix, use '/prefix*' or add an explicit '/prefix' rule.
+ */
+export function matchesPattern(pattern: string, path: string): boolean {
+  if (pattern === path) return true;
+  if (!pattern.includes('*')) return false;
+
+  // Glob → regex: escape regex metacharacters (but not '*'), then replace
+  // '*' with '.*' and anchor. Handles trailing, leading, and middle wildcards.
+  const regexSource =
+    '^' + pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$';
+  return new RegExp(regexSource).test(path);
+}
+
+/**
+ * Find the first enabled rule matching (path, method) — rules are already in
+ * priority order (set order, then rule order).
+ */
+export function findMatchingRule(
+  rules: ProxyRule[],
+  subpath: string,
+  method?: string,
+): ProxyRule | null {
+  const requestMethod = method?.toUpperCase();
+
+  for (const rule of rules) {
+    if (!rule.isEnabled) {
+      continue;
+    }
+
+    if (!matchesPattern(rule.pathPattern, subpath)) {
+      continue;
+    }
+
+    // Check method(s): methods[] wins, else single method, else any (case-insensitive)
+    if (!matchesMethod(rule, requestMethod)) {
+      continue;
+    }
+
+    return rule;
+  }
+  return null;
+}

--- a/apps/frontend/src/components/pipelines/PipelineConfig.tsx
+++ b/apps/frontend/src/components/pipelines/PipelineConfig.tsx
@@ -112,6 +112,7 @@ const HANDLER_GROUPS: { label: string; types: HandlerType[] }[] = [
       'remote_request',
       'xml_feed_parse',
       'delay',
+      'mcp_handler',
     ],
   },
 ];

--- a/apps/frontend/src/components/pipelines/handlers/HandlerConfigWrapper.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/HandlerConfigWrapper.tsx
@@ -462,6 +462,7 @@ export function getHandlerDisplayName(type: HandlerType): string {
     vector_search: 'Vector Search',
     http_request: 'HTTP Request',
     remote_request: 'Remote Request',
+    mcp_handler: 'MCP Server',
     stripe_checkout: 'Stripe Checkout',
     stripe_webhook: 'Stripe Webhook',
     signed_url: 'Signed URL',
@@ -503,6 +504,8 @@ export function getHandlerDescription(type: HandlerType): string {
     http_request: 'Make an outbound HTTP request to an external URL',
     remote_request:
       'Call an admin-configured remote connection (Cloud Run etc.) with the platform identity',
+    mcp_handler:
+      'Answer as a stateless MCP server from this step’s config: tools and ui:// resources mapped to sibling rules, run as the caller. Authored as code (rules-as-code); no form editor',
     stripe_checkout: 'Create a Stripe Checkout Session and return the payment URL',
     stripe_webhook: 'Verify Stripe webhook signature and parse the event',
     signed_url: 'Generate a time-limited presigned URL for a file in storage',

--- a/apps/frontend/src/services/pipelinesApi.ts
+++ b/apps/frontend/src/services/pipelinesApi.ts
@@ -50,6 +50,7 @@ export type HandlerType =
   | 'vector_search'
   | 'http_request'
   | 'remote_request'
+  | 'mcp_handler'
   | 'stripe_checkout'
   | 'stripe_webhook'
   | 'signed_url'


### PR DESCRIPTION
Closes #728 — story 8 of the Workflow M5 agent-embedding epic (bffless/apps#554); plan `docs/superpowers/plans/2026-09-03-workflow-m5-phase3-ce-auth.md` on the apps epic branch (Phase B, Tasks 9–14, Decisions 12–18). Rebased onto `main` (#730 landed); this diff stands on its own.


## The request path

One MCP call, from a host to the app's rule and back. CE owns only the envelope and the in-process hop; the app's rule set is the server.

```mermaid
sequenceDiagram
    participant Host as MCP host (claude.ai, ChatGPT)
    participant Edge as nginx / proxy middleware
    participant MCP as mcp_handler step<br/>(the app's /api/…/mcp rule)
    participant Inv as RuleInvokerService
    participant Sib as sibling rule<br/>(same alias)

    Host->>Edge: POST /api/workflow/mcp  (jsonrpc tools/call)
    Edge->>Edge: visibility gate · auth_required (session or Bearer app token)
    Edge->>MCP: run the rule's pipeline
    MCP->>MCP: parse envelope · tools[name] → rule.path
    MCP->>Inv: invoke(path, method, args, parent request, depth 1)
    alt pipeline sibling
        Inv->>Sib: synthetic request (parent headers, cookies, ip — no res)
        Sib->>Sib: its own validators — auth_required + requiredScopes, rate_limit
        Sib-->>Inv: {status, body}
    else external_proxy sibling
        Inv->>Inv: buildProxyHeaders(parent, rule)<br/>forwardCookies · authTransform · headerConfig — as at the edge
        Inv->>Sib: fetch(targetUrl)
        Sib-->>Inv: {status, body}
    end
    Inv-->>MCP: answer
    MCP->>MCP: results.ts — content[] verbatim, 401 → errors.auth, 403 → errors.scope
    MCP-->>Host: CallToolResult
```

The visibility gate and `auth_required` run once, at the edge, for the MCP rule; each sibling then applies **its own** validators and — for an `external_proxy` sibling — **its own** header controls. Depth is capped at 1; a sibling that is itself an `mcp_handler` is refused.

## What is new, by file

```text
apps/backend/src/
├── pipelines/
│   ├── handlers/mcp.handler.ts        # the step: config → a stateless MCP server
│   └── mcp/
│       ├── jsonrpc.ts                 # envelope: batch/invalid → -32600, 405, 202
│       ├── protocol.ts                # initialize · ping · tools/* · resources/*
│       ├── resources.ts               # ui:// static + RFC 6570 templates, CSP $app/$storage
│       └── results.ts                 # sibling answer → CallToolResult / errors.*
└── proxy-rules/
    ├── rule-resolution.ts             # lifted from the middleware; edge + invoker share it
    ├── pipeline-from-rule.ts          # Pipeline construction + error→status table, shared
    ├── proxy-headers.util.ts          # ProxyService.buildHeaders lifted; edge + invoker share it
    └── rule-invoker.service.ts        # runs a sibling in-process as the caller
```

## The header-control fix (review finding 1)

An `external_proxy` sibling used to receive the caller's credential no matter what the rule said. Now the rule decides, through the same function the edge uses:

```diff
 invokeExternal(rule, req)
-  headers = { accept, x-forwarded-host, x-original-uri }
-  headers.cookie        = parent.cookie          # always
-  headers.authorization = parent.authorization   # always
+  headers = buildProxyHeaders(parent, rule)      # forwardCookies (off by default)
+                                                 # authorization stripped unless headerConfig lists it
+                                                 # authTransform cookie-to-bearer honoured
+  headers.accept / x-forwarded-host / x-original-uri set on top
   fetch(targetUrl, { headers })
```

A rule authored with `forwardCookies: false` behaves the same whether reached from the edge or from an MCP tool. Consequence for apps: a forwarder whose target needs a Bearer app token must list `authorization` in `headerConfig.forward` (the Workflow CLI's `/w/<alias>/*` forwarder now does — bffless/apps#584).

## What

**`mcp_handler`** — a new step type, a peer of `function_handler`, that knows nothing about any app: one step answers as a stateless Streamable-HTTP MCP server described entirely by its config — `serverInfo`, `instructions`, `tools[]` (`name`, `description`, `inputSchema`, `annotations`, `visibility: ['app']` for MCP-Apps app-only tools, `_meta`, and `rule: { path, method }` — the sibling rule that answers it), and `resources` (`static[]`, `templates[]` with RFC 6570 level-1 `{var}`/`{var+}` mapped to a sibling path, `list.rule` for what the app enumerates, and a `csp` whose entries may be `$app` / `$storage` — resolved per instance into every resource's `_meta.ui`). The handler owns the envelope the Workflow harness's `function_handler` prototype proved against claude.ai: `initialize` (version negotiation, `instructions`), `ping`, `tools/list`, `tools/call`, `resources/list`, `resources/read`; a notification → 202 empty; batch/invalid → -32600; unknown method → -32601; unknown resource → -32002; GET/DELETE → 405 `Allow: POST`; `Cache-Control: no-store`; `terminates: true`.

**`RuleInvokerService`** (`proxy-rules/`) — runs a sibling rule of the same alias **in-process as the caller**: rule resolution lifted verbatim out of the middleware into `rule-resolution.ts` (shared, so the edge and the invoker cannot drift), the `Pipeline` construction and the error→status table likewise into `pipeline-from-rule.ts`; a `pipeline` sibling runs through `executePipelineWithDebug` on a synthetic request (the parent's headers/cookies/ip, no `res` — a streaming handler falls back, file serving refuses) with the sibling's own validators (`auth_required` + `requiredScopes`, `rate_limit`); an `external_proxy` sibling is fetched in-process with its headers built by `buildProxyHeaders` — `ProxyService.buildHeaders` lifted into a shared util, so the rule's own `forwardCookies` / `authTransform` / `headerConfig` apply exactly as at the edge (cookie off and `authorization` stripped by default) — plus CE's own `x-forwarded-host`/`x-original-uri`; `internal_rewrite`/`email_form_handler` are unsupported. The visibility gate is not re-run (the caller passed it for this alias); recursion is capped (depth 1; a sibling containing an `mcp_handler` → `MCP_RECURSION`). Rules are cached 10 s per set combination, as the middleware caches.

**Answer mapping** (`pipelines/mcp/results.ts`) — a 2xx body that already carries `content[]` is the `CallToolResult` verbatim (the app keeps its prose); other 2xx wrapped; 401 → `errors.auth`; 403 `insufficient_scope` → `errors.scope: 'missing <scope>'` naming the scope (read from `WWW-Authenticate` or the error details); other non-2xx → `errors.pipeline: '<code>: <message>'` + `_meta.bffless.status`.

**Compiled-script cache** (`FunctionRunnerService`) — `vm.Script`s and `validateCode` results are memoised by code hash (LRU 64): a function is compiled once per distinct code, not per request — the second half of the per-request cost the prototype measured (~0.5 s per call on 250 KB bundles).

**Enum sites** — `HandlerType`, the admin MCP's `create_proxy_rule` enum, the rule editor's picker/labels (config is authored as code; no form editor). Nothing touches CE's `@rekog/mcp-nest` server (D22).

## Backwards compatibility
No migration. A new handler type (additive; an older CLI/UI simply never emits it). The middleware's rule resolution, pipeline construction and status mapping are refactors with the middleware's spec untouched and green. The script cache is invisible to rules.

## Verification
Run in the worktree at the branch tip (stacked on #730):

```
pnpm --filter backend exec tsc --noEmit      exit 0
pnpm --filter frontend exec tsc --noEmit     exit 0
pnpm --filter backend test                   Test Suites: 213 passed, 2 skipped (215) · Tests: 3648 passed, 47 skipped (3695)
pnpm --filter frontend test                  Test Files: 90 passed (90) · Tests: 960 passed (960)
pnpm --filter backend format:check           All matched files use Prettier code style!
pnpm --filter frontend format:check          All matched files use Prettier code style!
```

New specs (86 tests across the story-8 files): `proxy-rules/rule-resolution.spec.ts`, `proxy-rules/rule-invoker.service.spec.ts` (pipeline sibling on a synthetic request without `res`, the status table + scope header, no_rule/unsupported/recursion, the external_proxy fetch under the rule's header controls (defaults strip both credentials; `forwardCookies`; `headerConfig.forward`; `authTransform` cookie-to-bearer), an `mcp_handler` hidden in `postSteps` refused, the rules cache, `buildTargetUrl` parity with `ProxyService`, the `/public` prefix kept on a sibling), `pipelines/mcp/{jsonrpc,results,resources,protocol}.spec.ts` (the whole method table the prototype proved: 405, 202, -32600, -32601, -32002, version negotiation, tools/list projection, tools/call routing GET-as-query/POST-as-body, verbatim `content[]`, `errors.auth`/`errors.scope`/`errors.pipeline`, resources static + templated + listed with the derived CSP), `pipelines/handlers/mcp.handler.spec.ts` (config validation, terminates, invoker wiring, depth, 405, storage probe cached), `pipelines/function-runner.cache.spec.ts`. The middleware's own spec is unchanged and green.

**Consumer proof pending:** the Workflow harness's rule set on `mcp_handler` (apps#554 story 8 apps PR) — the prototype's 24-check `mcp` live walk must pass unchanged against it once this ships on j5s.
