### PR TITLE
fix(auth): bound the app-token last-used throttle map; checklist entry for new FKs

### DIFF
--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -80,6 +80,21 @@ change that edits generation without touching them as suspicious.
 orphans them — the data isn't lost, it's just unreachable, which is worse because it
 looks fine until someone requests an old file.
 
+### New `projectId`/`userId` foreign keys must cascade or join the manual delete-cleanup lists
+**Surface:** `apps/backend/src/db/schema/*.schema.ts` (any new `.references(() => projects.id)` /
+`.references(() => users.id)`), `apps/backend/src/projects/projects.service.ts` (`deleteProject`),
+`apps/backend/src/users/users.service.ts` (`delete`)
+**Check:** Does a new table's `projectId`/`userId` column set `onDelete: 'cascade'`/`'set null'`,
+or (if left at Drizzle's `NO ACTION` default) is it added to the explicit cleanup list in
+`deleteProject()`/`UsersService.delete()`? `deleteProject()`'s own comment enumerates every
+projectId-referencing table it knows about — a new table absent from both is a silent trap.
+**Why:** Without either, deleting a project or user that has any row in the new table throws a
+Postgres FK violation mid-delete, and because those deletes are not in a transaction the earlier
+steps (aliases and assets already removed) are not rolled back — a corrupted, half-deleted project.
+A schema spec pinning `getTableConfig(table).foreignKeys[].onDelete` keeps it from regressing.
+**Learned from:** PR #730 — `app_tokens.project_id` (NOT NULL, no `onDelete`) was not in
+`deleteProject()`'s cleanup; deleting a project with any (even revoked) app token would have failed.
+
 ### Installed apps carry user customization
 **Surface:** `apps/backend/src/app-catalog/`
 **Check:** Does an app update overwrite state the user is allowed to customize?

--- a/apps/backend/src/auth/app-token.util.spec.ts
+++ b/apps/backend/src/auth/app-token.util.spec.ts
@@ -15,6 +15,7 @@ const mockDb = jest.requireMock('../db/client').db;
 
 import {
   APP_TOKEN_PREFIX,
+  LAST_USED_MAP_MAX,
   LAST_USED_WRITE_INTERVAL_MS,
   bearerAppToken,
   hashToken,
@@ -144,6 +145,22 @@ describe('app-token.util', () => {
       await resolveAppToken('Bearer bfat_x');
       expect(mockDb.update).toHaveBeenCalledTimes(2);
       (Date.now as jest.Mock).mockRestore();
+    });
+
+    it('bounds the last-used throttle map', async () => {
+      for (let i = 0; i < LAST_USED_MAP_MAX + 5; i += 1) {
+        mockDb.limit
+          .mockResolvedValueOnce([tokenRow({ id: `tok-${i}` })])
+          .mockResolvedValueOnce([userRow()]);
+        await resolveAppToken('Bearer bfat_x');
+      }
+      // The first token's entry was evicted, so its next use writes again.
+      const writes = mockDb.update.mock.calls.length;
+      mockDb.limit
+        .mockResolvedValueOnce([tokenRow({ id: 'tok-0' })])
+        .mockResolvedValueOnce([userRow()]);
+      await resolveAppToken('Bearer bfat_x');
+      expect(mockDb.update.mock.calls.length).toBe(writes + 1);
     });
 
     it('never throws on a db failure', async () => {

--- a/apps/backend/src/auth/app-token.util.ts
+++ b/apps/backend/src/auth/app-token.util.ts
@@ -66,6 +66,8 @@ export function mintToken(): { raw: string; hash: string; prefix: string } {
 }
 
 const lastUsedWrites = new Map<string, number>();
+/** Bound the throttle map: past this many distinct tokens the oldest entries are dropped (a dropped entry only costs one extra write). */
+export const LAST_USED_MAP_MAX = 1000;
 
 /** Test seam. */
 export function resetLastUsedThrottle(): void {
@@ -117,6 +119,10 @@ async function touchLastUsed(tokenId: string): Promise<void> {
   const last = lastUsedWrites.get(tokenId);
   if (last !== undefined && now - last < LAST_USED_WRITE_INTERVAL_MS) return;
   lastUsedWrites.set(tokenId, now);
+  if (lastUsedWrites.size > LAST_USED_MAP_MAX) {
+    const oldest = lastUsedWrites.keys().next().value as string;
+    lastUsedWrites.delete(oldest);
+  }
   try {
     await db
       .update(appTokens)


### PR DESCRIPTION
Follow-up to #730 (merged at `8e23c6f` while this landed on the branch): the review's low note — the in-memory `last_used_at` throttle map never evicted — is closed (oldest entry dropped past 1000 tokens; a dropped entry costs one extra write; test added), and the review's checklist entry (new `projectId`/`userId` foreign keys must cascade or join the manual delete-cleanup lists) is folded into `.claude/ce-pr-review-checklist.md`.

No migration, no behaviour change beyond the bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sd1UdizNNZjGLZxyy8FY11