### PR TITLE
feat(auth): OAuth 2.1 authorization server — DCR, PKCE, RFC 8414/9728/8707; access tokens are app tokens

### DIFF
--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -88,6 +88,7 @@ orphans them — the data isn't lost, it's just unreachable, which is worse beca
 looks fine until someone requests an old file.
 
 ### New `projectId`/`userId` foreign keys must cascade or join the manual delete-cleanup lists
+
 **Surface:** `apps/backend/src/db/schema/*.schema.ts` (any new `.references(() => projects.id)` /
 `.references(() => users.id)`), `apps/backend/src/projects/projects.service.ts` (`deleteProject`),
 `apps/backend/src/users/users.service.ts` (`delete`)
@@ -225,7 +226,17 @@ grant family) never fires if both requests see the pre-update row.
 **Learned from:** PR #734, 2026-09-03 — `exchangeCode` / `refresh` marked rows used with a
 plain `UPDATE … WHERE hash = ?`; fixed in the same PR with `… AND … IS NULL RETURNING`.
 
-> > > > > > > 02d3564 (fix(auth): OAuth review findings — www alternate on resource lookup, atomic single-use consume, member-only consent)
+### A leftover git conflict marker doesn't fail CI — check markdown/doc diffs by eye
+
+**Surface:** any file outside `src/**/*.{ts,tsx}` (prettier/tsc-checked) — markdown docs,
+`.claude/ce-pr-review-checklist.md`, `CONTEXT.md`, ADRs.
+**Check:** Does a diff to a non-code file contain a raw `<<<<<<<` / `=======` / `>>>>>>>`
+sequence, or its markdown-blockquote-mangled form (`> > > > > > > <hash> (<message>)`)?
+**Why:** `tsc --noEmit` and `pnpm test` don't touch markdown, so a botched rebase that leaves
+a conflict-marker remnant in a doc file is invisible to CI — and when the file is the review
+checklist itself, it is the one file the review process treats as ground truth.
+**Learned from:** PR #734, 2026-09-03 — a `>>>>>>> 02d3564 (…)` trailer was left in this file,
+reformatted into a nested blockquote by prettier, and shipped through three review passes.
 
 ---
 

--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -200,6 +200,33 @@ resource sibling — with no error anywhere.
 (flagged on four review passes); fixed in the same PR by lifting `ProxyService.buildHeaders`
 into the shared util and testing the four control cases.
 
+### Domain-scoped lookups must check the www/non-www alternate, everywhere
+
+**Surface:** any new code that resolves a hostname to a `domain_mappings` row —
+grep for `eq(domainMappings.domain, ...)` outside `apps/backend/src/domains/`.
+**Check:** Does the query also check the www/non-www alternate the way
+`VisibilityService` / `TrafficRoutingService` do, or does it assume the caller-supplied
+host exactly matches what is stored?
+**Why:** A primary domain with "Redirect to www" stores one variant; anything a client
+(not nginx) supplies the other variant to silently 400s / 404s for a supported setup.
+**Learned from:** PR #734, 2026-09-03 — `OAuthService.resolveResource` resolved the RFC 8707
+`resource` host with a bare `eq()`; fixed in the same PR (`resourceHosts()`).
+
+### One-time codes and tokens need an atomic "consume" UPDATE, not check-then-set
+
+**Surface:** any single-use credential (authorization codes, refresh-token rotation,
+one-time signup / reset tokens) implemented as a SELECT that checks a `usedAt` /
+`rotatedAt` column followed by a separate UPDATE.
+**Check:** Does the UPDATE carry the not-yet-used condition in its WHERE
+(`… AND used_at IS NULL`) and does the code act on the returned row count, or can two
+concurrent requests both pass the earlier SELECT?
+**Why:** OAuth 2.1's replay defence (a reused code / refresh token revokes the whole
+grant family) never fires if both requests see the pre-update row.
+**Learned from:** PR #734, 2026-09-03 — `exchangeCode` / `refresh` marked rows used with a
+plain `UPDATE … WHERE hash = ?`; fixed in the same PR with `… AND … IS NULL RETURNING`.
+
+> > > > > > > 02d3564 (fix(auth): OAuth review findings — www alternate on resource lookup, atomic single-use consume, member-only consent)
+
 ---
 
 ## Entry template

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,7 +46,7 @@ A per-rule opt-out of the deployment visibility gate (`bypassVisibility: true` i
 _Avoid_: "public rule" (deployment visibility is a different setting)
 
 **Authorization server**:
-CE's built-in OAuth 2.1 server on the admin host (`/api/oauth/*`; RFC 8414 metadata at `/.well-known/oauth-authorization-server`). Clients register themselves (RFC 7591, public clients only); a member consents per project and per scope on `/oauth/consent`; the access token *is* an App token, bound to the project the RFC 8707 `resource` named. Not SuperTokens' OAuth2Provider recipe (ADR-0005).
+CE's built-in OAuth 2.1 server on the admin host (`/api/oauth/*`; RFC 8414 metadata at `/.well-known/oauth-authorization-server`). Clients register themselves (RFC 7591, public clients only); a member consents per project and per scope on `/oauth/consent`; the access token _is_ an App token, bound to the project the RFC 8707 `resource` named. Not SuperTokens' OAuth2Provider recipe (ADR-0005).
 _Avoid_: "SuperTokens OAuth", "SSO" (that is the member's own login, the other direction)
 
 **Protected-resource document**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,6 +45,14 @@ _Avoid_: "permission" (that is the member's project role), "role"
 A per-rule opt-out of the deployment visibility gate (`bypassVisibility: true` in rules-as-code) for endpoints a caller reaches before it has any credential — OAuth discovery under `/.well-known`, a webhook receiver. The rule's own validators still run; internal rewrites are unaffected.
 _Avoid_: "public rule" (deployment visibility is a different setting)
 
+**Authorization server**:
+CE's built-in OAuth 2.1 server on the admin host (`/api/oauth/*`; RFC 8414 metadata at `/.well-known/oauth-authorization-server`). Clients register themselves (RFC 7591, public clients only); a member consents per project and per scope on `/oauth/consent`; the access token *is* an App token, bound to the project the RFC 8707 `resource` named. Not SuperTokens' OAuth2Provider recipe (ADR-0005).
+_Avoid_: "SuperTokens OAuth", "SSO" (that is the member's own login, the other direction)
+
+**Protected-resource document**:
+An app-shipped `/.well-known/oauth-protected-resource` rule (served despite visibility — Bypass visibility) naming the resource, the Authorization server and the app's scopes (RFC 9728). How a client finds the server from the app; CE points at it in `WWW-Authenticate` on API 401s.
+_Avoid_: "discovery endpoint" (CE has none for apps)
+
 **Owner session**:
 A browser session authenticated as the project owner, which login-gated SPA routes accept. The thing an automated client holding a Project API key currently cannot obtain.
 

--- a/apps/backend/drizzle/0048_confused_violations.sql
+++ b/apps/backend/drizzle/0048_confused_violations.sql
@@ -1,0 +1,44 @@
+CREATE TABLE "oauth_authorization_codes" (
+	"code_hash" varchar(64) PRIMARY KEY NOT NULL,
+	"client_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"scopes" jsonb NOT NULL,
+	"code_challenge" varchar(128) NOT NULL,
+	"redirect_uri" text NOT NULL,
+	"resource" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"used_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "oauth_clients" (
+	"client_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"client_name" varchar(255) NOT NULL,
+	"redirect_uris" jsonb NOT NULL,
+	"grant_types" jsonb DEFAULT '["authorization_code","refresh_token"]'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"last_used_at" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE "oauth_refresh_tokens" (
+	"token_hash" varchar(64) PRIMARY KEY NOT NULL,
+	"family_id" uuid NOT NULL,
+	"client_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"scopes" jsonb NOT NULL,
+	"app_token_id" uuid,
+	"expires_at" timestamp NOT NULL,
+	"rotated_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "oauth_authorization_codes" ADD CONSTRAINT "oauth_authorization_codes_client_id_oauth_clients_client_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."oauth_clients"("client_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oauth_authorization_codes" ADD CONSTRAINT "oauth_authorization_codes_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oauth_authorization_codes" ADD CONSTRAINT "oauth_authorization_codes_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oauth_refresh_tokens" ADD CONSTRAINT "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."oauth_clients"("client_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oauth_refresh_tokens" ADD CONSTRAINT "oauth_refresh_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oauth_refresh_tokens" ADD CONSTRAINT "oauth_refresh_tokens_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "oauth_refresh_tokens" ADD CONSTRAINT "oauth_refresh_tokens_app_token_id_app_tokens_id_fk" FOREIGN KEY ("app_token_id") REFERENCES "public"."app_tokens"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "oauth_refresh_tokens_family_idx" ON "oauth_refresh_tokens" USING btree ("family_id");

--- a/apps/backend/drizzle/meta/0048_snapshot.json
+++ b/apps/backend/drizzle/meta/0048_snapshot.json
@@ -1,0 +1,7932 @@
+{
+  "id": "0068a30b-e124-43f2-84fc-a11a3b3e1fe7",
+  "prevId": "82214e3e-d181-4c93-b590-0bf0b47dcb2e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alias_proxy_rule_sets": {
+      "name": "alias_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alias_proxy_rule_sets_alias_ruleset_unique": {
+          "name": "alias_proxy_rule_sets_alias_ruleset_unique",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_alias_id_idx": {
+          "name": "alias_proxy_rule_sets_alias_id_idx",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alias_proxy_rule_sets_rule_set_id_idx": {
+          "name": "alias_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk": {
+          "name": "alias_proxy_rule_sets_alias_id_deployment_aliases_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "deployment_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "alias_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "alias_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_project_id_idx": {
+          "name": "api_keys_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_keys_project_id_projects_id_fk": {
+          "name": "api_keys_project_id_projects_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_tokens": {
+      "name": "app_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_tokens_user_id_idx": {
+          "name": "app_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_tokens_project_id_idx": {
+          "name": "app_tokens_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_tokens_user_id_users_id_fk": {
+          "name": "app_tokens_user_id_users_id_fk",
+          "tableFrom": "app_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_tokens_project_id_projects_id_fk": {
+          "name": "app_tokens_project_id_projects_id_fk",
+          "tableFrom": "app_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_tokens_token_hash_unique": {
+          "name": "app_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_path": {
+          "name": "original_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_number": {
+          "name": "workflow_run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'commits'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_project_id_idx": {
+          "name": "assets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_type_idx": {
+          "name": "assets_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_path_idx": {
+          "name": "assets_project_commit_path_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_branch_idx": {
+          "name": "assets_project_branch_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_commit_idx": {
+          "name": "assets_project_commit_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_created_at_idx": {
+          "name": "assets_project_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_project_committed_at_idx": {
+          "name": "assets_project_committed_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_path_idx": {
+          "name": "assets_deployment_path_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_id_idx": {
+          "name": "assets_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_deployment_size_idx": {
+          "name": "assets_deployment_size_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_uploaded_by_users_id_fk": {
+          "name": "assets_uploaded_by_users_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist_entries": {
+      "name": "blocklist_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prefix'"
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklist_entries_blocklist_id_idx": {
+          "name": "blocklist_entries_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocklist_entries_unique": {
+          "name": "blocklist_entries_unique",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocklist_entries_blocklist_id_blocklists_id_fk": {
+          "name": "blocklist_entries_blocklist_id_blocklists_id_fk",
+          "tableFrom": "blocklist_entries",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklists": {
+      "name": "blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocklists_name_unique": {
+          "name": "blocklists_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cache_rules": {
+      "name": "cache_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_max_age": {
+          "name": "browser_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "cdn_max_age": {
+          "name": "cdn_max_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stale_while_revalidate": {
+          "name": "stale_while_revalidate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immutable": {
+          "name": "immutable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cacheability": {
+          "name": "cacheability",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cache_rules_project_pattern_unique": {
+          "name": "cache_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_id_idx": {
+          "name": "cache_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cache_rules_project_priority_idx": {
+          "name": "cache_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cache_rules_project_id_projects_id_fk": {
+          "name": "cache_rules_project_id_projects_id_fk",
+          "tableFrom": "cache_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_aliases": {
+      "name": "deployment_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_preview": {
+          "name": "is_auto_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployment_aliases_project_alias_unique": {
+          "name": "deployment_aliases_project_alias_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_project_id_idx": {
+          "name": "deployment_aliases_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_alias_unique": {
+          "name": "deployment_aliases_repository_alias_unique",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_repository_idx": {
+          "name": "deployment_aliases_repository_idx",
+          "columns": [
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_commit_sha_idx": {
+          "name": "deployment_aliases_commit_sha_idx",
+          "columns": [
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_aliases_deployment_id_idx": {
+          "name": "deployment_aliases_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_aliases_project_id_projects_id_fk": {
+          "name": "deployment_aliases_project_id_projects_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "deployment_aliases_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "deployment_aliases",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_blocklists": {
+      "name": "domain_blocklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocklist_id": {
+          "name": "blocklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_blocklists_domain_blocklist_unique": {
+          "name": "domain_blocklists_domain_blocklist_unique",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_blocklists_domain_mapping_id_idx": {
+          "name": "domain_blocklists_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_blocklists_blocklist_id_idx": {
+          "name": "domain_blocklists_blocklist_id_idx",
+          "columns": [
+            {
+              "expression": "blocklist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_blocklists_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "domain_blocklists_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "domain_blocklists",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_blocklists_blocklist_id_blocklists_id_fk": {
+          "name": "domain_blocklists_blocklist_id_blocklists_id_fk",
+          "tableFrom": "domain_blocklists",
+          "tableTo": "blocklists",
+          "columnsFrom": [
+            "blocklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_mappings": {
+      "name": "domain_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_type": {
+          "name": "domain_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_target": {
+          "name": "redirect_target",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ssl_expires_at": {
+          "name": "ssl_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_verified": {
+          "name": "dns_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dns_verified_at": {
+          "name": "dns_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_renew_ssl": {
+          "name": "auto_renew_ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_renewed_at": {
+          "name": "ssl_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_status": {
+          "name": "ssl_renewal_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_renewal_error": {
+          "name": "ssl_renewal_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sticky_sessions_enabled": {
+          "name": "sticky_sessions_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sticky_session_duration": {
+          "name": "sticky_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 86400
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_mappings_project_id_idx": {
+          "name": "domain_mappings_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_domain_idx": {
+          "name": "domain_mappings_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_mappings_is_active_idx": {
+          "name": "domain_mappings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_mappings_project_id_projects_id_fk": {
+          "name": "domain_mappings_project_id_projects_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_mappings_created_by_users_id_fk": {
+          "name": "domain_mappings_created_by_users_id_fk",
+          "tableFrom": "domain_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_mappings_domain_unique": {
+          "name": "domain_mappings_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_redirects": {
+      "name": "domain_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_domain": {
+          "name": "source_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_domain_id": {
+          "name": "target_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl_enabled": {
+          "name": "ssl_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nginx_config_path": {
+          "name": "nginx_config_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_redirects_target_domain_id_idx": {
+          "name": "domain_redirects_target_domain_id_idx",
+          "columns": [
+            {
+              "expression": "target_domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_redirects_source_domain_idx": {
+          "name": "domain_redirects_source_domain_idx",
+          "columns": [
+            {
+              "expression": "source_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_redirects_target_domain_id_domain_mappings_id_fk": {
+          "name": "domain_redirects_target_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "target_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_redirects_created_by_users_id_fk": {
+          "name": "domain_redirects_created_by_users_id_fk",
+          "tableFrom": "domain_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_redirects_source_domain_unique": {
+          "name": "domain_redirects_source_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_rules": {
+      "name": "domain_traffic_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_key": {
+          "name": "condition_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_value": {
+          "name": "condition_value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_rules_domain_id_idx": {
+          "name": "domain_traffic_rules_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_traffic_rules_domain_id_priority_idx": {
+          "name": "domain_traffic_rules_domain_id_priority_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_rules_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_rules_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_rules",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_traffic_weights": {
+      "name": "domain_traffic_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_traffic_weights_domain_id_idx": {
+          "name": "domain_traffic_weights_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_traffic_weights_domain_id_domain_mappings_id_fk": {
+          "name": "domain_traffic_weights_domain_id_domain_mappings_id_fk",
+          "tableFrom": "domain_traffic_weights",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "domain_traffic_weights_domain_alias_unique": {
+          "name": "domain_traffic_weights_domain_alias_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain_id",
+            "alias"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flags_key_idx": {
+          "name": "feature_flags_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ffmpeg_executor_settings": {
+      "name": "ffmpeg_executor_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "local_enabled": {
+          "name": "local_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "remote_enabled": {
+          "name": "remote_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "remote_connection_id": {
+          "name": "remote_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_executor": {
+          "name": "default_executor",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ffmpeg_executor_settings_remote_connection_id_remote_connections_id_fk": {
+          "name": "ffmpeg_executor_settings_remote_connection_id_remote_connections_id_fk",
+          "tableFrom": "ffmpeg_executor_settings",
+          "tableTo": "remote_connections",
+          "columnsFrom": [
+            "remote_connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_integration_credentials": {
+      "name": "google_integration_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configured": {
+          "name": "configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "google_integration_credentials_service_unique": {
+          "name": "google_integration_credentials_service_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installed_apps": {
+      "name": "installed_apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_set_ids": {
+          "name": "rule_set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "schema_ids": {
+          "name": "schema_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "bundle_sha256": {
+          "name": "bundle_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'installing'"
+        },
+        "created_resources": {
+          "name": "created_resources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "installed_by": {
+          "name": "installed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "installed_apps_project_id_idx": {
+          "name": "installed_apps_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "installed_apps_project_id_projects_id_fk": {
+          "name": "installed_apps_project_id_projects_id_fk",
+          "tableFrom": "installed_apps",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "installed_apps_installed_by_users_id_fk": {
+          "name": "installed_apps_installed_by_users_id_fk",
+          "tableFrom": "installed_apps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "installed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "installed_apps_app_project_unique": {
+          "name": "installed_apps_app_project_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "code_hash": {
+          "name": "code_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_authorization_codes_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_authorization_codes_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_user_id_users_id_fk": {
+          "name": "oauth_authorization_codes_user_id_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_project_id_projects_id_fk": {
+          "name": "oauth_authorization_codes_project_id_projects_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"authorization_code\",\"refresh_token\"]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_token_id": {
+          "name": "app_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_family_idx": {
+          "name": "oauth_refresh_tokens_family_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_user_id_users_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_project_id_projects_id_fk": {
+          "name": "oauth_refresh_tokens_project_id_projects_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_app_token_id_app_tokens_id_fk": {
+          "name": "oauth_refresh_tokens_app_token_id_app_tokens_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "app_tokens",
+          "columnsFrom": [
+            "app_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oidc_providers_provider_id_unique": {
+          "name": "oidc_providers_provider_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rule_executions": {
+      "name": "onboarding_rule_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rule_executions_user_idx": {
+          "name": "onboarding_rule_executions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_rule_idx": {
+          "name": "onboarding_rule_executions_rule_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_executed_at_idx": {
+          "name": "onboarding_rule_executions_executed_at_idx",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rule_executions_status_idx": {
+          "name": "onboarding_rule_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rule_executions_rule_id_onboarding_rules_id_fk": {
+          "name": "onboarding_rule_executions_rule_id_onboarding_rules_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "onboarding_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "onboarding_rule_executions_user_id_users_id_fk": {
+          "name": "onboarding_rule_executions_user_id_users_id_fk",
+          "tableFrom": "onboarding_rule_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_rules": {
+      "name": "onboarding_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_signup'"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_rules_enabled_trigger_idx": {
+          "name": "onboarding_rules_enabled_trigger_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_rules_priority_idx": {
+          "name": "onboarding_rules_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_rules_created_by_users_id_fk": {
+          "name": "onboarding_rules_created_by_users_id_fk",
+          "tableFrom": "onboarding_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_preferences": {
+      "name": "path_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filepath": {
+          "name": "filepath",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spa_mode": {
+          "name": "spa_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_path_preferences_project_id": {
+          "name": "idx_path_preferences_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_preferences_project_id_projects_id_fk": {
+          "name": "path_preferences_project_id_projects_id_fk",
+          "tableFrom": "path_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "path_preferences_project_filepath_unique": {
+          "name": "path_preferences_project_filepath_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "filepath"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.path_redirects": {
+      "name": "path_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'301'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'100'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "path_redirects_domain_mapping_id_idx": {
+          "name": "path_redirects_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "path_redirects_source_path_idx": {
+          "name": "path_redirects_source_path_idx",
+          "columns": [
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "path_redirects_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "path_redirects_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "path_redirects_created_by_users_id_fk": {
+          "name": "path_redirects_created_by_users_id_fk",
+          "tableFrom": "path_redirects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "upload_token": {
+          "name": "upload_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_path": {
+          "name": "base_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_token_idx": {
+          "name": "pending_uploads_token_idx",
+          "columns": [
+            {
+              "expression": "upload_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_project_idx": {
+          "name": "pending_uploads_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_project_id_projects_id_fk": {
+          "name": "pending_uploads_project_id_projects_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "pending_uploads_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pending_uploads_uploaded_by_users_id_fk": {
+          "name": "pending_uploads_uploaded_by_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_uploads_upload_token_unique": {
+          "name": "pending_uploads_upload_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data_embeddings": {
+      "name": "pipeline_data_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_data_id": {
+          "name": "pipeline_data_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_embeddings_data_id_idx": {
+          "name": "pipeline_data_embeddings_data_id_idx",
+          "columns": [
+            {
+              "expression": "pipeline_data_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_embeddings_schema_field_idx": {
+          "name": "pipeline_data_embeddings_schema_field_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk": {
+          "name": "pipeline_data_embeddings_pipeline_data_id_pipeline_data_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_data",
+          "columnsFrom": [
+            "pipeline_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_embeddings_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data_embeddings",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_data": {
+      "name": "pipeline_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_id": {
+          "name": "schema_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_data_project_id_idx": {
+          "name": "pipeline_data_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_schema_id_idx": {
+          "name": "pipeline_data_schema_id_idx",
+          "columns": [
+            {
+              "expression": "schema_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_data_created_at_idx": {
+          "name": "pipeline_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_data_project_id_projects_id_fk": {
+          "name": "pipeline_data_project_id_projects_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_schema_id_pipeline_schemas_id_fk": {
+          "name": "pipeline_data_schema_id_pipeline_schemas_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "pipeline_schemas",
+          "columnsFrom": [
+            "schema_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_data_created_by_users_id_fk": {
+          "name": "pipeline_data_created_by_users_id_fk",
+          "tableFrom": "pipeline_data",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_execution_logs": {
+      "name": "pipeline_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_id": {
+          "name": "proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps_count": {
+          "name": "steps_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_step": {
+          "name": "error_step",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_meta": {
+          "name": "request_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_exec_logs_rule_created_idx": {
+          "name": "pipeline_exec_logs_rule_created_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_project_idx": {
+          "name": "pipeline_exec_logs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_exec_logs_created_idx": {
+          "name": "pipeline_exec_logs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_execution_logs_project_id_projects_id_fk": {
+          "name": "pipeline_execution_logs_project_id_projects_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_execution_logs_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_execution_logs",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schedules": {
+      "name": "pipeline_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_proxy_rule_id": {
+          "name": "target_proxy_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schedules_project_id_idx": {
+          "name": "pipeline_schedules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_schedules_target_proxy_rule_id_idx": {
+          "name": "pipeline_schedules_target_proxy_rule_id_idx",
+          "columns": [
+            {
+              "expression": "target_proxy_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_schedules_enabled_next_run_idx": {
+          "name": "pipeline_schedules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schedules_project_id_projects_id_fk": {
+          "name": "pipeline_schedules_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schedules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pipeline_schedules_target_proxy_rule_id_proxy_rules_id_fk": {
+          "name": "pipeline_schedules_target_proxy_rule_id_proxy_rules_id_fk",
+          "tableFrom": "pipeline_schedules",
+          "tableTo": "proxy_rules",
+          "columnsFrom": [
+            "target_proxy_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_schemas": {
+      "name": "pipeline_schemas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_schemas_project_id_idx": {
+          "name": "pipeline_schemas_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_schemas_project_id_projects_id_fk": {
+          "name": "pipeline_schemas_project_id_projects_id_fk",
+          "tableFrom": "pipeline_schemas",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pipeline_schemas_project_name_unique": {
+          "name": "pipeline_schemas_project_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.primary_content": {
+      "name": "primary_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "www_enabled": {
+          "name": "www_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "www_behavior": {
+          "name": "www_behavior",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'redirect-to-www'"
+        },
+        "is_spa": {
+          "name": "is_spa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "primary_content_project_id_projects_id_fk": {
+          "name": "primary_content_project_id_projects_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "primary_content_configured_by_users_id_fk": {
+          "name": "primary_content_configured_by_users_id_fk",
+          "tableFrom": "primary_content",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_default_proxy_rule_sets": {
+      "name": "project_default_proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_rule_set_id": {
+          "name": "proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_default_proxy_rule_sets_project_ruleset_unique": {
+          "name": "project_default_proxy_rule_sets_project_ruleset_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_project_id_idx": {
+          "name": "project_default_proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_default_proxy_rule_sets_rule_set_id_idx": {
+          "name": "project_default_proxy_rule_sets_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "proxy_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_default_proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "project_default_proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "project_default_proxy_rule_sets_proxy_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "project_default_proxy_rule_sets",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "proxy_rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invite_links": {
+      "name": "project_invite_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guest'"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invite_links_project_id_idx": {
+          "name": "project_invite_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_token_idx": {
+          "name": "project_invite_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_invite_links_is_active_idx": {
+          "name": "project_invite_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invite_links_project_id_projects_id_fk": {
+          "name": "project_invite_links_project_id_projects_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_invite_links_created_by_users_id_fk": {
+          "name": "project_invite_links_created_by_users_id_fk",
+          "tableFrom": "project_invite_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_invite_links_token_unique": {
+          "name": "project_invite_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_group_permissions": {
+      "name": "project_group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_group_permissions_project_idx": {
+          "name": "project_group_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_permissions_group_idx": {
+          "name": "project_group_permissions_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_permissions_project_id_projects_id_fk": {
+          "name": "project_group_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_group_id_user_groups_id_fk": {
+          "name": "project_group_permissions_group_id_user_groups_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_permissions_granted_by_users_id_fk": {
+          "name": "project_group_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_group_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_group_permissions_unique": {
+          "name": "project_group_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "group_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_permissions": {
+      "name": "project_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_permissions_project_idx": {
+          "name": "project_permissions_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_permissions_user_idx": {
+          "name": "project_permissions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_permissions_project_id_projects_id_fk": {
+          "name": "project_permissions_project_id_projects_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_user_id_users_id_fk": {
+          "name": "project_permissions_user_id_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_permissions_granted_by_users_id_fk": {
+          "name": "project_permissions_granted_by_users_id_fk",
+          "tableFrom": "project_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_permissions_unique": {
+          "name": "project_permissions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_secrets": {
+      "name": "project_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_secrets_project_name_unique": {
+          "name": "project_secrets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_secrets_project_id_idx": {
+          "name": "project_secrets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_secrets_project_id_projects_id_fk": {
+          "name": "project_secrets_project_id_projects_id_fk",
+          "tableFrom": "project_secrets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "unauthorized_behavior": {
+          "name": "unauthorized_behavior",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_found'"
+        },
+        "required_role": {
+          "name": "required_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authenticated'"
+        },
+        "allow_public_signup": {
+          "name": "allow_public_signup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_providers": {
+          "name": "ai_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_services": {
+          "name": "ai_services",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_proxy_rule_set_id": {
+          "name": "default_proxy_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_created_by_idx": {
+          "name": "projects_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_owner_idx": {
+          "name": "projects_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_owner_name_unique": {
+          "name": "projects_owner_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_set_revisions": {
+      "name": "proxy_rule_set_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_set_revisions_set_created_idx": {
+          "name": "proxy_rule_set_revisions_set_created_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_set_revisions_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rule_set_revisions_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rule_set_revisions",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rule_sets": {
+      "name": "proxy_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rule_sets_project_name_unique": {
+          "name": "proxy_rule_sets_project_name_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_project_id_idx": {
+          "name": "proxy_rule_sets_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rule_sets_environment_idx": {
+          "name": "proxy_rule_sets_environment_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rule_sets_project_id_projects_id_fk": {
+          "name": "proxy_rule_sets_project_id_projects_id_fk",
+          "tableFrom": "proxy_rule_sets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_rules": {
+      "name": "proxy_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_set_id": {
+          "name": "rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "methods": {
+          "name": "methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strip_prefix": {
+          "name": "strip_prefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "preserve_host": {
+          "name": "preserve_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forward_cookies": {
+          "name": "forward_cookies",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "header_config": {
+          "name": "header_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_transform": {
+          "name": "auth_transform",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_rewrite": {
+          "name": "internal_rewrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proxy_type": {
+          "name": "proxy_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'external_proxy'"
+        },
+        "email_handler_config": {
+          "name": "email_handler_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "debug_enabled": {
+          "name": "debug_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bypass_visibility": {
+          "name": "bypass_visibility",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proxy_rules_rule_set_path_method_unique": {
+          "name": "proxy_rules_rule_set_path_method_unique",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_id_idx": {
+          "name": "proxy_rules_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_rule_set_order_idx": {
+          "name": "proxy_rules_rule_set_order_idx",
+          "columns": [
+            {
+              "expression": "rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proxy_rules_proxy_type_idx": {
+          "name": "proxy_rules_proxy_type_idx",
+          "columns": [
+            {
+              "expression": "proxy_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proxy_rules_rule_set_id_proxy_rule_sets_id_fk": {
+          "name": "proxy_rules_rule_set_id_proxy_rule_sets_id_fk",
+          "tableFrom": "proxy_rules",
+          "tableTo": "proxy_rule_sets",
+          "columnsFrom": [
+            "rule_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_connections": {
+      "name": "remote_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google_id_token'"
+        },
+        "credential_encrypted": {
+          "name": "credential_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_inflight": {
+          "name": "max_inflight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "health_path": {
+          "name": "health_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/health'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "remote_connections_name_unique": {
+          "name": "remote_connections_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_header_rules": {
+      "name": "response_header_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_policy": {
+          "name": "frame_policy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sameorigin'"
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_header_rules_project_pattern_unique": {
+          "name": "response_header_rules_project_pattern_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_id_idx": {
+          "name": "response_header_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_header_rules_project_priority_idx": {
+          "name": "response_header_rules_project_priority_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "response_header_rules_project_id_projects_id_fk": {
+          "name": "response_header_rules_project_id_projects_id_fk",
+          "tableFrom": "response_header_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_logs": {
+      "name": "retention_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_count": {
+          "name": "asset_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "freed_bytes": {
+          "name": "freed_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_partial": {
+          "name": "is_partial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_logs_project_id_idx": {
+          "name": "retention_logs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_rule_id_idx": {
+          "name": "retention_logs_rule_id_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_deleted_at_idx": {
+          "name": "retention_logs_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_logs_project_deleted_at_idx": {
+          "name": "retention_logs_project_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_logs_project_id_projects_id_fk": {
+          "name": "retention_logs_project_id_projects_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retention_logs_rule_id_retention_rules_id_fk": {
+          "name": "retention_logs_rule_id_retention_rules_id_fk",
+          "tableFrom": "retention_logs",
+          "tableTo": "retention_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retention_rules": {
+      "name": "retention_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_pattern": {
+          "name": "branch_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_branches": {
+          "name": "exclude_branches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keep_with_alias": {
+          "name": "keep_with_alias",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "keep_minimum": {
+          "name": "keep_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "path_patterns": {
+          "name": "path_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_mode": {
+          "name": "path_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_summary": {
+          "name": "last_run_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retention_rules_project_id_idx": {
+          "name": "retention_rules_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_next_run_idx": {
+          "name": "retention_rules_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retention_rules_enabled_next_run_idx": {
+          "name": "retention_rules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retention_rules_project_id_projects_id_fk": {
+          "name": "retention_rules_project_id_projects_id_fk",
+          "tableFrom": "retention_rules",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_mapping_id": {
+          "name": "domain_mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "share_links_project_id_idx": {
+          "name": "share_links_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_domain_mapping_id_idx": {
+          "name": "share_links_domain_mapping_id_idx",
+          "columns": [
+            {
+              "expression": "domain_mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_token_idx": {
+          "name": "share_links_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_is_active_idx": {
+          "name": "share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_project_id_projects_id_fk": {
+          "name": "share_links_project_id_projects_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_domain_mapping_id_domain_mappings_id_fk": {
+          "name": "share_links_domain_mapping_id_domain_mappings_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_created_by_users_id_fk": {
+          "name": "share_links_created_by_users_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "share_links_token_unique": {
+          "name": "share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_challenges": {
+      "name": "ssl_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "base_domain": {
+          "name": "base_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_type": {
+          "name": "challenge_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_name": {
+          "name": "record_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_value": {
+          "name": "record_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_data": {
+          "name": "order_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authz_data": {
+          "name": "authz_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_authorization": {
+          "name": "key_authorization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_challenges_base_domain_idx": {
+          "name": "ssl_challenges_base_domain_idx",
+          "columns": [
+            {
+              "expression": "base_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_challenges_status_idx": {
+          "name": "ssl_challenges_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ssl_challenges_base_domain_unique": {
+          "name": "ssl_challenges_base_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "base_domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_renewal_history": {
+      "name": "ssl_renewal_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_type": {
+          "name": "certificate_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_expires_at": {
+          "name": "new_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssl_renewal_history_domain_id_idx": {
+          "name": "ssl_renewal_history_domain_id_idx",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssl_renewal_history_created_at_idx": {
+          "name": "ssl_renewal_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssl_renewal_history_domain_id_domain_mappings_id_fk": {
+          "name": "ssl_renewal_history_domain_id_domain_mappings_id_fk",
+          "tableFrom": "ssl_renewal_history",
+          "tableTo": "domain_mappings",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssl_settings": {
+      "name": "ssl_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_config": {
+      "name": "system_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_setup_complete": {
+          "name": "is_setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_config": {
+          "name": "storage_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_provider": {
+          "name": "email_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_config": {
+          "name": "email_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_configured": {
+          "name": "email_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "smtp_config": {
+          "name": "smtp_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtp_configured": {
+          "name": "smtp_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_config": {
+          "name": "cache_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwt_secret": {
+          "name": "jwt_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_salt": {
+          "name": "api_key_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_public_signups": {
+          "name": "allow_public_signups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "telemetry_enabled": {
+          "name": "telemetry_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "telemetry_last_sent": {
+          "name": "telemetry_last_sent",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branding_config": {
+          "name": "branding_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_ip_rollups": {
+      "name": "traffic_ip_rollups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_paths": {
+          "name": "sample_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "sample_user_agents": {
+          "name": "sample_user_agents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_ip_rollups_ip_unique": {
+          "name": "traffic_ip_rollups_ip_unique",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_request_count_idx": {
+          "name": "traffic_ip_rollups_request_count_idx",
+          "columns": [
+            {
+              "expression": "request_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_ip_rollups_last_seen_idx": {
+          "name": "traffic_ip_rollups_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traffic_requests": {
+      "name": "traffic_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_version": {
+          "name": "http_version",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referer": {
+          "name": "referer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traffic_requests_timestamp_idx": {
+          "name": "traffic_requests_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_ip_idx": {
+          "name": "traffic_requests_ip_idx",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_status_idx": {
+          "name": "traffic_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traffic_requests_classification_idx": {
+          "name": "traffic_requests_classification_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_group_members": {
+      "name": "user_group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_group_members_group_idx": {
+          "name": "user_group_members_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_group_members_user_idx": {
+          "name": "user_group_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_group_members_group_id_user_groups_id_fk": {
+          "name": "user_group_members_group_id_user_groups_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_user_id_users_id_fk": {
+          "name": "user_group_members_user_id_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_members_added_by_users_id_fk": {
+          "name": "user_group_members_added_by_users_id_fk",
+          "tableFrom": "user_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_group_members_unique": {
+          "name": "user_group_members_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_groups_created_by_idx": {
+          "name": "user_groups_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_created_by_users_id_fk": {
+          "name": "user_groups_created_by_users_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_verified_at": {
+          "name": "oidc_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitations": {
+      "name": "workspace_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_invitations_email": {
+          "name": "idx_workspace_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_invitations_token": {
+          "name": "idx_workspace_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invitations_invited_by_users_id_fk": {
+          "name": "workspace_invitations_invited_by_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_invitations_accepted_user_id_users_id_fk": {
+          "name": "workspace_invitations_accepted_user_id_users_id_fk",
+          "tableFrom": "workspace_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitations_token_unique": {
+          "name": "workspace_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1788432634156,
       "tag": "0047_volatile_robbie_robertson",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1788435174314,
+      "tag": "0048_confused_violations",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { ApiKeysModule } from './api-keys/api-keys.module';
 import { AppTokensModule } from './app-tokens/app-tokens.module';
+import { OAuthModule } from './oauth/oauth.module';
 import { StorageModule, StorageModuleConfig } from './storage/storage.module';
 import { CacheModule } from './storage/cache/cache.module';
 import { CacheConfig } from './storage/cache/cache.interface';
@@ -147,6 +148,7 @@ import { AppCatalogModule } from './app-catalog/app-catalog.module';
     UsersModule,
     ApiKeysModule,
     AppTokensModule,
+    OAuthModule,
     AssetsModule,
     DeploymentsModule,
     RepoBrowserModule,

--- a/apps/backend/src/db/schema/index.ts
+++ b/apps/backend/src/db/schema/index.ts
@@ -3,6 +3,9 @@ export * from './users.schema';
 export * from './assets.schema';
 export * from './api-keys.schema';
 export * from './app-tokens.schema';
+export * from './oauth-clients.schema';
+export * from './oauth-authorization-codes.schema';
+export * from './oauth-refresh-tokens.schema';
 export * from './system-config.schema';
 export * from './proxy-rule-sets.schema'; // Must be before deployment-aliases and projects
 export * from './deployment-aliases.schema';

--- a/apps/backend/src/db/schema/oauth-authorization-codes.schema.ts
+++ b/apps/backend/src/db/schema/oauth-authorization-codes.schema.ts
@@ -1,0 +1,27 @@
+import { pgTable, uuid, varchar, timestamp, jsonb, text } from 'drizzle-orm/pg-core';
+import { oauthClients } from './oauth-clients.schema';
+import { users } from './users.schema';
+import { projects } from './projects.schema';
+
+/** Authorization codes (10 minutes, single use, PKCE S256 only). Stored hashed. */
+export const oauthAuthorizationCodes = pgTable('oauth_authorization_codes', {
+  codeHash: varchar('code_hash', { length: 64 }).primaryKey(),
+  clientId: uuid('client_id')
+    .references(() => oauthClients.clientId)
+    .notNull(),
+  userId: uuid('user_id')
+    .references(() => users.id)
+    .notNull(),
+  projectId: uuid('project_id')
+    .references(() => projects.id)
+    .notNull(),
+  scopes: jsonb('scopes').$type<string[]>().notNull(),
+  codeChallenge: varchar('code_challenge', { length: 128 }).notNull(),
+  redirectUri: text('redirect_uri').notNull(),
+  resource: text('resource').notNull(),
+  expiresAt: timestamp('expires_at').notNull(),
+  usedAt: timestamp('used_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export type OAuthAuthorizationCode = typeof oauthAuthorizationCodes.$inferSelect;

--- a/apps/backend/src/db/schema/oauth-authorization-codes.schema.ts
+++ b/apps/backend/src/db/schema/oauth-authorization-codes.schema.ts
@@ -7,13 +7,13 @@ import { projects } from './projects.schema';
 export const oauthAuthorizationCodes = pgTable('oauth_authorization_codes', {
   codeHash: varchar('code_hash', { length: 64 }).primaryKey(),
   clientId: uuid('client_id')
-    .references(() => oauthClients.clientId)
+    .references(() => oauthClients.clientId, { onDelete: 'cascade' })
     .notNull(),
   userId: uuid('user_id')
-    .references(() => users.id)
+    .references(() => users.id, { onDelete: 'cascade' })
     .notNull(),
   projectId: uuid('project_id')
-    .references(() => projects.id)
+    .references(() => projects.id, { onDelete: 'cascade' })
     .notNull(),
   scopes: jsonb('scopes').$type<string[]>().notNull(),
   codeChallenge: varchar('code_challenge', { length: 128 }).notNull(),

--- a/apps/backend/src/db/schema/oauth-clients.schema.ts
+++ b/apps/backend/src/db/schema/oauth-clients.schema.ts
@@ -1,0 +1,17 @@
+import { pgTable, uuid, varchar, timestamp, jsonb } from 'drizzle-orm/pg-core';
+
+/** OAuth 2.1 clients registered dynamically (RFC 7591) — public clients only, no secret. */
+export const oauthClients = pgTable('oauth_clients', {
+  clientId: uuid('client_id').primaryKey().defaultRandom(),
+  clientName: varchar('client_name', { length: 255 }).notNull(),
+  redirectUris: jsonb('redirect_uris').$type<string[]>().notNull(),
+  grantTypes: jsonb('grant_types')
+    .$type<string[]>()
+    .notNull()
+    .default(['authorization_code', 'refresh_token']),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  lastUsedAt: timestamp('last_used_at'),
+});
+
+export type OAuthClient = typeof oauthClients.$inferSelect;
+export type NewOAuthClient = typeof oauthClients.$inferInsert;

--- a/apps/backend/src/db/schema/oauth-refresh-tokens.schema.ts
+++ b/apps/backend/src/db/schema/oauth-refresh-tokens.schema.ts
@@ -14,17 +14,17 @@ export const oauthRefreshTokens = pgTable(
     tokenHash: varchar('token_hash', { length: 64 }).primaryKey(),
     familyId: uuid('family_id').notNull(),
     clientId: uuid('client_id')
-      .references(() => oauthClients.clientId)
+      .references(() => oauthClients.clientId, { onDelete: 'cascade' })
       .notNull(),
     userId: uuid('user_id')
-      .references(() => users.id)
+      .references(() => users.id, { onDelete: 'cascade' })
       .notNull(),
     projectId: uuid('project_id')
-      .references(() => projects.id)
+      .references(() => projects.id, { onDelete: 'cascade' })
       .notNull(),
     scopes: jsonb('scopes').$type<string[]>().notNull(),
     /** The access token (an app token) this refresh token last issued. */
-    appTokenId: uuid('app_token_id').references(() => appTokens.id),
+    appTokenId: uuid('app_token_id').references(() => appTokens.id, { onDelete: 'set null' }),
     expiresAt: timestamp('expires_at').notNull(),
     rotatedAt: timestamp('rotated_at'),
     createdAt: timestamp('created_at').defaultNow().notNull(),

--- a/apps/backend/src/db/schema/oauth-refresh-tokens.schema.ts
+++ b/apps/backend/src/db/schema/oauth-refresh-tokens.schema.ts
@@ -1,0 +1,35 @@
+import { pgTable, uuid, varchar, timestamp, jsonb, index } from 'drizzle-orm/pg-core';
+import { oauthClients } from './oauth-clients.schema';
+import { users } from './users.schema';
+import { projects } from './projects.schema';
+import { appTokens } from './app-tokens.schema';
+
+/**
+ * Refresh tokens (30 days), rotated on every use (OAuth 2.1 §4.3.1): a rotated
+ * token presented again revokes its whole family. Stored hashed.
+ */
+export const oauthRefreshTokens = pgTable(
+  'oauth_refresh_tokens',
+  {
+    tokenHash: varchar('token_hash', { length: 64 }).primaryKey(),
+    familyId: uuid('family_id').notNull(),
+    clientId: uuid('client_id')
+      .references(() => oauthClients.clientId)
+      .notNull(),
+    userId: uuid('user_id')
+      .references(() => users.id)
+      .notNull(),
+    projectId: uuid('project_id')
+      .references(() => projects.id)
+      .notNull(),
+    scopes: jsonb('scopes').$type<string[]>().notNull(),
+    /** The access token (an app token) this refresh token last issued. */
+    appTokenId: uuid('app_token_id').references(() => appTokens.id),
+    expiresAt: timestamp('expires_at').notNull(),
+    rotatedAt: timestamp('rotated_at'),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (t) => [index('oauth_refresh_tokens_family_idx').on(t.familyId)],
+);
+
+export type OAuthRefreshToken = typeof oauthRefreshTokens.$inferSelect;

--- a/apps/backend/src/db/schema/oauth.schemas.spec.ts
+++ b/apps/backend/src/db/schema/oauth.schemas.spec.ts
@@ -1,0 +1,33 @@
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import { oauthAuthorizationCodes } from './oauth-authorization-codes.schema';
+import { oauthRefreshTokens } from './oauth-refresh-tokens.schema';
+
+/** Same rule as app_tokens (ce#730 review): no NO ACTION FK to projects/users/clients. */
+function onDeleteOf(
+  table: Parameters<typeof getTableConfig>[0],
+): Record<string, string | undefined> {
+  return Object.fromEntries(
+    getTableConfig(table).foreignKeys.map((fk) => {
+      const ref = fk.reference();
+      return [ref.columns[0].name, fk.onDelete];
+    }),
+  );
+}
+
+describe('OAuth tables cascade with what they reference', () => {
+  it('authorization codes', () => {
+    expect(onDeleteOf(oauthAuthorizationCodes)).toEqual({
+      client_id: 'cascade',
+      user_id: 'cascade',
+      project_id: 'cascade',
+    });
+  });
+  it('refresh tokens (the issued access token may go first: set null)', () => {
+    expect(onDeleteOf(oauthRefreshTokens)).toEqual({
+      client_id: 'cascade',
+      user_id: 'cascade',
+      project_id: 'cascade',
+      app_token_id: 'set null',
+    });
+  });
+});

--- a/apps/backend/src/oauth/oauth-metadata.controller.ts
+++ b/apps/backend/src/oauth/oauth-metadata.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Header } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { PublicProjectAccess } from '../auth/decorators/public-project-access.decorator';
+import { OAuthService } from './oauth.service';
+
+/** RFC 8414 — served at the issuer's root; the admin nginx vhost routes this one path to the backend. */
+@ApiTags('OAuth')
+@Controller('.well-known')
+@PublicProjectAccess()
+export class OAuthMetadataController {
+  constructor(private readonly oauth: OAuthService) {}
+
+  @Get('oauth-authorization-server')
+  @Header('Cache-Control', 'public, max-age=3600')
+  @ApiOperation({ summary: 'OAuth 2.1 authorization-server metadata (RFC 8414)' })
+  metadata() {
+    return this.oauth.metadata();
+  }
+}

--- a/apps/backend/src/oauth/oauth.controller.spec.ts
+++ b/apps/backend/src/oauth/oauth.controller.spec.ts
@@ -13,7 +13,7 @@ function make() {
     metadata: jest.fn().mockReturnValue({ issuer: 'https://admin.example' }),
     registerClient: jest.fn().mockResolvedValue({ client_id: 'c1' }),
     beginAuthorization: jest.fn().mockResolvedValue({ request: 'signed', pending: {} }),
-    readPending: jest.fn().mockReturnValue({
+    pendingFor: jest.fn().mockResolvedValue({
       clientName: 'Claude',
       scopes: ['a:b'],
       projectId: 'p1',
@@ -112,7 +112,7 @@ describe('OAuth controllers', () => {
 
   it('consent GET shapes the pending request; POST delegates the decision', async () => {
     const { controller, service } = make();
-    expect(controller.pending('signed')).toEqual({
+    await expect(controller.pending({ id: 'u1', role: 'user' }, 'signed')).resolves.toEqual({
       clientName: 'Claude',
       scopes: ['a:b'],
       project: { id: 'p1', slug: 'o/r', name: 'R' },
@@ -122,7 +122,8 @@ describe('OAuth controllers', () => {
     await expect(
       controller.decide({ id: 'u1' }, { request: 'signed', approve: true, scopes: ['a:b'] }),
     ).resolves.toEqual({ redirectTo: 'https://claude.ai/cb?code=x' });
-    expect(service.consent).toHaveBeenCalledWith('u1', 'signed', {
+    expect(service.pendingFor).toHaveBeenCalledWith('u1', 'user', 'signed');
+    expect(service.consent).toHaveBeenCalledWith('u1', undefined, 'signed', {
       approve: true,
       scopes: ['a:b'],
     });

--- a/apps/backend/src/oauth/oauth.controller.spec.ts
+++ b/apps/backend/src/oauth/oauth.controller.spec.ts
@@ -1,0 +1,146 @@
+import 'reflect-metadata';
+import { Request, Response } from 'express';
+import { OAuthController } from './oauth.controller';
+import { OAuthMetadataController } from './oauth-metadata.controller';
+import { OAuthError } from './oauth.errors';
+import { PUBLIC_PROJECT_ACCESS_KEY } from '../auth/decorators/public-project-access.decorator';
+
+jest.mock('supertokens-node/recipe/session', () => ({ getSession: jest.fn() }));
+const { getSession: mockGetSession } = jest.requireMock('supertokens-node/recipe/session');
+
+function make() {
+  const service = {
+    metadata: jest.fn().mockReturnValue({ issuer: 'https://admin.example' }),
+    registerClient: jest.fn().mockResolvedValue({ client_id: 'c1' }),
+    beginAuthorization: jest.fn().mockResolvedValue({ request: 'signed', pending: {} }),
+    readPending: jest.fn().mockReturnValue({
+      clientName: 'Claude',
+      scopes: ['a:b'],
+      projectId: 'p1',
+      projectSlug: 'o/r',
+      projectName: 'R',
+      redirectUri: 'https://claude.ai/cb',
+      exp: 1700000000,
+    }),
+    consent: jest.fn().mockResolvedValue({ redirectTo: 'https://claude.ai/cb?code=x' }),
+    token: jest.fn().mockResolvedValue({ access_token: 'bfat_x' }),
+    revoke: jest.fn().mockResolvedValue(undefined),
+  };
+  return {
+    controller: new OAuthController(service as never),
+    metadata: new OAuthMetadataController(service as never),
+    service,
+  };
+}
+const res = () => ({ redirect: jest.fn(), set: jest.fn() }) as unknown as Response;
+
+describe('OAuth controllers', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('opt out of project-membership scoping; only the consent routes carry SessionAuthGuard', () => {
+    expect(Reflect.getMetadata(PUBLIC_PROJECT_ACCESS_KEY, OAuthController)).toBe(true);
+    expect(Reflect.getMetadata(PUBLIC_PROJECT_ACCESS_KEY, OAuthMetadataController)).toBe(true);
+    const guards = (method: string) =>
+      (
+        Reflect.getMetadata(
+          '__guards__',
+          OAuthController.prototype[method as keyof OAuthController],
+        ) ?? []
+      ).map((g: { name: string }) => g.name);
+    expect(guards('pending')).toEqual(['SessionAuthGuard']);
+    expect(guards('decide')).toEqual(['SessionAuthGuard']);
+    expect(guards('token')).toEqual([]);
+    expect(guards('register')).toEqual([]);
+    expect(guards('authorize')).toEqual([]);
+  });
+
+  it('serves RFC 8414 metadata', () => {
+    const { metadata, service } = make();
+    expect(metadata.metadata()).toEqual({ issuer: 'https://admin.example' });
+    expect(service.metadata).toHaveBeenCalled();
+  });
+
+  it('authorize: no session → the login with the full authorize URL to return to', async () => {
+    const { controller } = make();
+    mockGetSession.mockResolvedValueOnce(undefined);
+    const r = res();
+    await controller.authorize(
+      { originalUrl: '/api/oauth/authorize?client_id=c1&state=s' } as Request,
+      r,
+      { client_id: 'c1', state: 's' },
+    );
+    expect(r.redirect).toHaveBeenCalledWith(
+      302,
+      '/login?redirect=%2Fapi%2Foauth%2Fauthorize%3Fclient_id%3Dc1%26state%3Ds&tryRefresh=true',
+    );
+  });
+
+  it('authorize: a session → the consent page with the signed request', async () => {
+    const { controller } = make();
+    mockGetSession.mockResolvedValueOnce({ getUserId: () => 'u1' });
+    const r = res();
+    await controller.authorize({ originalUrl: '/x' } as Request, r, { client_id: 'c1' });
+    expect(r.redirect).toHaveBeenCalledWith(302, '/oauth/consent?request=signed');
+  });
+
+  it('authorize: an error after the redirect_uri was trusted is redirected with error= and state; invalid_client is thrown', async () => {
+    const { controller, service } = make();
+    mockGetSession.mockResolvedValue({ getUserId: () => 'u1' });
+    service.beginAuthorization.mockRejectedValueOnce(
+      new OAuthError('invalid_target', 'no resource'),
+    );
+    const r = res();
+    await controller.authorize({ originalUrl: '/x' } as Request, r, {
+      client_id: 'c1',
+      redirect_uri: 'https://claude.ai/cb',
+      state: 'xyz',
+    });
+    expect(r.redirect).toHaveBeenCalledWith(
+      302,
+      'https://claude.ai/cb?error=invalid_target&error_description=no+resource&state=xyz',
+    );
+    service.beginAuthorization.mockRejectedValueOnce(
+      new OAuthError('invalid_client', 'unknown', 401),
+    );
+    await expect(
+      controller.authorize({ originalUrl: '/x' } as Request, res(), {
+        client_id: 'nope',
+        redirect_uri: 'https://claude.ai/cb',
+      }),
+    ).rejects.toMatchObject({ error: 'invalid_client' });
+  });
+
+  it('consent GET shapes the pending request; POST delegates the decision', async () => {
+    const { controller, service } = make();
+    expect(controller.pending('signed')).toEqual({
+      clientName: 'Claude',
+      scopes: ['a:b'],
+      project: { id: 'p1', slug: 'o/r', name: 'R' },
+      redirectHost: 'claude.ai',
+      expiresAt: '2023-11-14T22:13:20.000Z',
+    });
+    await expect(
+      controller.decide({ id: 'u1' }, { request: 'signed', approve: true, scopes: ['a:b'] }),
+    ).resolves.toEqual({ redirectTo: 'https://claude.ai/cb?code=x' });
+    expect(service.consent).toHaveBeenCalledWith('u1', 'signed', {
+      approve: true,
+      scopes: ['a:b'],
+    });
+  });
+
+  it('token and revoke read form or JSON bodies and set no-store; revoke never fails', async () => {
+    const { controller, service } = make();
+    const r = res();
+    await expect(
+      controller.token({ body: { grant_type: 'authorization_code' } } as unknown as Request, r),
+    ).resolves.toEqual({ access_token: 'bfat_x' });
+    expect(r.set).toHaveBeenCalledWith({ 'Cache-Control': 'no-store', Pragma: 'no-cache' });
+    expect(service.token).toHaveBeenCalledWith({ grant_type: 'authorization_code' });
+    service.revoke.mockRejectedValueOnce(new Error('db down'));
+    await expect(
+      controller.revoke({ body: { token: 'bfat_x' } } as unknown as Request, res()),
+    ).resolves.toEqual({});
+    await expect(controller.revoke({ body: {} } as unknown as Request, res())).resolves.toEqual({});
+    expect(service.revoke).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/oauth/oauth.controller.ts
+++ b/apps/backend/src/oauth/oauth.controller.ts
@@ -83,8 +83,8 @@ export class OAuthController {
   @Get('consent')
   @UseGuards(SessionAuthGuard)
   @ApiOperation({ summary: 'What the consent page shows for a pending request' })
-  pending(@Query('request') request: string) {
-    const p = this.oauth.readPending(request ?? '');
+  async pending(@CurrentUser() user: CurrentUserData, @Query('request') request: string) {
+    const p = await this.oauth.pendingFor(user.id, user.role, request ?? '');
     return {
       clientName: p.clientName,
       scopes: p.scopes,
@@ -99,7 +99,10 @@ export class OAuthController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'The member approves (possibly narrowing the scopes) or denies' })
   decide(@CurrentUser() user: CurrentUserData, @Body() dto: ConsentDecisionDto) {
-    return this.oauth.consent(user.id, dto.request, { approve: dto.approve, scopes: dto.scopes });
+    return this.oauth.consent(user.id, user.role, dto.request, {
+      approve: dto.approve,
+      scopes: dto.scopes,
+    });
   }
 
   @Post('token')

--- a/apps/backend/src/oauth/oauth.controller.ts
+++ b/apps/backend/src/oauth/oauth.controller.ts
@@ -1,0 +1,130 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Query,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Request, Response } from 'express';
+import { getSession } from 'supertokens-node/recipe/session';
+import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
+import { PublicProjectAccess } from '../auth/decorators/public-project-access.decorator';
+import { OAuthService } from './oauth.service';
+import { OAuthError } from './oauth.errors';
+import { ConsentDecisionDto, RegisterClientDto } from './oauth.dto';
+
+const NO_STORE = { 'Cache-Control': 'no-store', Pragma: 'no-cache' };
+
+/**
+ * CE's OAuth 2.1 authorization server on the admin host (ADR-0005). The
+ * authorize step needs a member's SuperTokens session (the consent page is the
+ * admin SPA); register/token/revoke are the client's, unauthenticated by design.
+ */
+@ApiTags('OAuth')
+@Controller('api/oauth')
+@PublicProjectAccess()
+export class OAuthController {
+  constructor(private readonly oauth: OAuthService) {}
+
+  @Post('register')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Dynamic client registration (RFC 7591) — public clients' })
+  async register(@Body() dto: RegisterClientDto, @Res({ passthrough: true }) res: Response) {
+    res.set(NO_STORE);
+    return this.oauth.registerClient(dto);
+  }
+
+  @Get('authorize')
+  @ApiOperation({
+    summary: 'Authorization endpoint (code + PKCE S256, RFC 8707 resource)',
+    description:
+      'Without a session: redirects to the admin login, which returns here. With one: redirects to the consent page.',
+  })
+  async authorize(
+    @Req() req: Request,
+    @Res() res: Response,
+    @Query() query: Record<string, string>,
+  ) {
+    const session = await getSession(req, res, { sessionRequired: false }).catch(() => undefined);
+    if (!session) {
+      const back = req.originalUrl || req.url;
+      res.redirect(302, `/login?redirect=${encodeURIComponent(back)}&tryRefresh=true`);
+      return;
+    }
+    try {
+      const { request } = await this.oauth.beginAuthorization(query);
+      res.redirect(302, `/oauth/consent?request=${encodeURIComponent(request)}`);
+    } catch (error) {
+      if (
+        error instanceof OAuthError &&
+        query.redirect_uri &&
+        error.error !== 'invalid_client' &&
+        error.error !== 'invalid_request'
+      ) {
+        // The redirect_uri was validated before any of these can throw (OAuth 2.1 §4.1.2.1).
+        const url = new URL(query.redirect_uri);
+        url.searchParams.set('error', error.error);
+        url.searchParams.set('error_description', error.description);
+        if (query.state) url.searchParams.set('state', query.state);
+        res.redirect(302, url.toString());
+        return;
+      }
+      throw error;
+    }
+  }
+
+  @Get('consent')
+  @UseGuards(SessionAuthGuard)
+  @ApiOperation({ summary: 'What the consent page shows for a pending request' })
+  pending(@Query('request') request: string) {
+    const p = this.oauth.readPending(request ?? '');
+    return {
+      clientName: p.clientName,
+      scopes: p.scopes,
+      project: { id: p.projectId, slug: p.projectSlug, name: p.projectName },
+      redirectHost: new URL(p.redirectUri).host,
+      expiresAt: new Date(p.exp * 1000).toISOString(),
+    };
+  }
+
+  @Post('consent')
+  @UseGuards(SessionAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'The member approves (possibly narrowing the scopes) or denies' })
+  decide(@CurrentUser() user: CurrentUserData, @Body() dto: ConsentDecisionDto) {
+    return this.oauth.consent(user.id, dto.request, { approve: dto.approve, scopes: dto.scopes });
+  }
+
+  @Post('token')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Token endpoint — authorization_code (PKCE) and refresh_token (rotating)',
+  })
+  async token(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    res.set(NO_STORE);
+    return this.oauth.token(bodyOf(req));
+  }
+
+  @Post('revoke')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Revocation (RFC 7009) — always 200' })
+  async revoke(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    res.set(NO_STORE);
+    const token = String(bodyOf(req).token ?? '');
+    if (token) await this.oauth.revoke(token).catch(() => undefined);
+    return {};
+  }
+}
+
+/** `application/x-www-form-urlencoded` (what RFC 6749 clients send) and JSON alike. */
+function bodyOf(req: Request): Record<string, unknown> {
+  const body = (req as Request & { body?: unknown }).body;
+  return body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+}

--- a/apps/backend/src/oauth/oauth.dto.ts
+++ b/apps/backend/src/oauth/oauth.dto.ts
@@ -1,0 +1,106 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+} from 'class-validator';
+
+/** RFC 7591 §2 — the subset CE accepts: public clients only. */
+export class RegisterClientDto {
+  @ApiProperty({ type: [String] })
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsString({ each: true })
+  redirect_uris: string[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  client_name?: string;
+
+  @ApiPropertyOptional({ default: 'none' })
+  @IsOptional()
+  @IsIn(['none'])
+  token_endpoint_auth_method?: 'none';
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsIn(['authorization_code', 'refresh_token'], { each: true })
+  grant_types?: string[];
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsIn(['code'], { each: true })
+  response_types?: string[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  scope?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUrl({ require_tld: false })
+  client_uri?: string;
+}
+
+export class ConsentDecisionDto {
+  @ApiProperty({ description: 'The pending request (a signed token from /api/oauth/authorize)' })
+  @IsString()
+  request: string;
+
+  @ApiProperty()
+  @IsBoolean()
+  approve: boolean;
+
+  @ApiPropertyOptional({ type: [String], description: 'A subset of the requested scopes to grant' })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  scopes?: string[];
+}
+
+export interface AuthorizationServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint: string;
+  revocation_endpoint: string;
+  response_types_supported: string[];
+  grant_types_supported: string[];
+  code_challenge_methods_supported: string[];
+  token_endpoint_auth_methods_supported: string[];
+  scopes_supported: string[];
+  resource_indicators_supported: boolean;
+}
+
+export interface TokenResponse {
+  access_token: string;
+  token_type: 'Bearer';
+  expires_in: number;
+  refresh_token: string;
+  scope: string;
+}
+
+export interface PendingRequest {
+  clientId: string;
+  clientName: string;
+  redirectUri: string;
+  codeChallenge: string;
+  state?: string;
+  scopes: string[];
+  resource: string;
+  projectId: string;
+  projectSlug: string;
+  projectName: string;
+  iat: number;
+  exp: number;
+}

--- a/apps/backend/src/oauth/oauth.errors.ts
+++ b/apps/backend/src/oauth/oauth.errors.ts
@@ -1,0 +1,24 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+/** RFC 6749 §5.2 / §4.1.2.1, RFC 7591 §3.2.2, RFC 8707 §2: `{ error, error_description }`. */
+export type OAuthErrorCode =
+  | 'invalid_request'
+  | 'invalid_client'
+  | 'invalid_grant'
+  | 'unauthorized_client'
+  | 'unsupported_grant_type'
+  | 'invalid_scope'
+  | 'invalid_target'
+  | 'invalid_client_metadata'
+  | 'invalid_redirect_uri'
+  | 'access_denied';
+
+export class OAuthError extends HttpException {
+  constructor(
+    public readonly error: OAuthErrorCode,
+    public readonly description: string,
+    status: HttpStatus = HttpStatus.BAD_REQUEST,
+  ) {
+    super({ error, error_description: description }, status);
+  }
+}

--- a/apps/backend/src/oauth/oauth.module.ts
+++ b/apps/backend/src/oauth/oauth.module.ts
@@ -3,9 +3,10 @@ import { OAuthController } from './oauth.controller';
 import { OAuthMetadataController } from './oauth-metadata.controller';
 import { OAuthService } from './oauth.service';
 import { AppTokensModule } from '../app-tokens/app-tokens.module';
+import { PermissionsModule } from '../permissions/permissions.module';
 
 @Module({
-  imports: [AppTokensModule],
+  imports: [AppTokensModule, PermissionsModule],
   controllers: [OAuthController, OAuthMetadataController],
   providers: [OAuthService],
   exports: [OAuthService],

--- a/apps/backend/src/oauth/oauth.module.ts
+++ b/apps/backend/src/oauth/oauth.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { OAuthController } from './oauth.controller';
+import { OAuthMetadataController } from './oauth-metadata.controller';
+import { OAuthService } from './oauth.service';
+import { AppTokensModule } from '../app-tokens/app-tokens.module';
+
+@Module({
+  imports: [AppTokensModule],
+  controllers: [OAuthController, OAuthMetadataController],
+  providers: [OAuthService],
+  exports: [OAuthService],
+})
+export class OAuthModule {}

--- a/apps/backend/src/oauth/oauth.service.spec.ts
+++ b/apps/backend/src/oauth/oauth.service.spec.ts
@@ -1,0 +1,422 @@
+import * as jwt from 'jsonwebtoken';
+import { OAuthService, familyOfCode } from './oauth.service';
+import { OAuthError } from './oauth.errors';
+import { challengeOf } from './pkce.util';
+import { hashToken } from '../auth/app-token.util';
+
+jest.mock('../db/client', () => {
+  const chain: Record<string, jest.Mock> = {};
+  for (const m of [
+    'select',
+    'from',
+    'where',
+    'limit',
+    'insert',
+    'values',
+    'returning',
+    'update',
+    'set',
+  ])
+    chain[m] = jest.fn();
+  return { db: chain };
+});
+const mockDb = jest.requireMock('../db/client').db as Record<string, jest.Mock>;
+
+const client = {
+  clientId: 'c1',
+  clientName: 'Claude',
+  redirectUris: ['https://claude.ai/cb'],
+  grantTypes: ['authorization_code', 'refresh_token'],
+  createdAt: new Date('2026-09-03T00:00:00Z'),
+  lastUsedAt: null,
+};
+const mapping = {
+  id: 'm1',
+  domain: 'workflow.j5s.dev',
+  projectId: 'p1',
+  alias: 'workflow',
+  path: '/dist',
+  isActive: true,
+  domainType: 'subdomain',
+};
+const project = { id: 'p1', owner: 'bffless', name: 'workflow', displayName: 'Workflow' };
+const user = { id: 'u1', email: 'm@example.com', role: 'user', disabled: false };
+const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+const prm = async () => ({
+  status: 200,
+  json: async () => ({
+    resource: 'https://workflow.j5s.dev/api/workflow/mcp',
+    scopes_supported: ['workflow:read', 'workflow:run', 'workflow:files'],
+  }),
+});
+
+function make() {
+  const config = {
+    get: (k: string) => ({ JWT_SECRET: 'test-secret', FRONTEND_URL: 'https://admin.j5s.dev/' })[k],
+  };
+  const appTokens = {
+    create: jest.fn().mockResolvedValue({ view: { id: 'tok-1' }, raw: 'bfat_raw' }),
+  };
+  return { service: new OAuthService(config as never, appTokens as never), appTokens };
+}
+
+const authorizeParams = (over: Record<string, unknown> = {}) => ({
+  response_type: 'code',
+  client_id: 'c1',
+  redirect_uri: 'https://claude.ai/cb',
+  code_challenge: challengeOf(verifier),
+  code_challenge_method: 'S256',
+  state: 'xyz',
+  resource: 'https://workflow.j5s.dev/api/workflow/mcp',
+  ...over,
+});
+
+describe('OAuthService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const m of Object.keys(mockDb)) mockDb[m].mockReturnValue(mockDb);
+  });
+
+  it('publishes RFC 8414 metadata on the issuer', () => {
+    const { service } = make();
+    const m = service.metadata();
+    expect(m.issuer).toBe('https://admin.j5s.dev');
+    expect(m.authorization_endpoint).toBe('https://admin.j5s.dev/api/oauth/authorize');
+    expect(m.registration_endpoint).toBe('https://admin.j5s.dev/api/oauth/register');
+    expect(m.code_challenge_methods_supported).toEqual(['S256']);
+    expect(m.token_endpoint_auth_methods_supported).toEqual(['none']);
+    expect(m.resource_indicators_supported).toBe(true);
+  });
+
+  describe('registerClient', () => {
+    it('registers a public client with https or localhost redirects and echoes the metadata', async () => {
+      const { service } = make();
+      mockDb.returning.mockResolvedValueOnce([client]);
+      const out = await service.registerClient({
+        redirect_uris: ['https://claude.ai/cb', 'http://localhost:8080/cb'],
+        client_name: 'Claude',
+      });
+      expect(out).toMatchObject({
+        client_id: 'c1',
+        client_name: 'Claude',
+        token_endpoint_auth_method: 'none',
+        response_types: ['code'],
+      });
+      expect(out).not.toHaveProperty('client_secret');
+      expect(mockDb.values.mock.calls[0][0]).toMatchObject({
+        redirectUris: ['https://claude.ai/cb', 'http://localhost:8080/cb'],
+      });
+    });
+    it('refuses a plain-http remote redirect and a confidential client', async () => {
+      const { service } = make();
+      await expect(
+        service.registerClient({ redirect_uris: ['http://evil.example/cb'] }),
+      ).rejects.toThrow(OAuthError);
+      await expect(
+        service.registerClient({
+          redirect_uris: ['https://x/cb'],
+          token_endpoint_auth_method: 'client_secret_basic' as never,
+        }),
+      ).rejects.toMatchObject({ error: 'invalid_client_metadata' });
+    });
+  });
+
+  describe('beginAuthorization / readPending', () => {
+    it('resolves the resource to its project and scopes, and signs a 10-minute pending request', async () => {
+      const { service } = make();
+      mockDb.limit
+        .mockResolvedValueOnce([client])
+        .mockResolvedValueOnce([mapping])
+        .mockResolvedValueOnce([project]);
+      const fetchImpl = jest.fn(prm);
+      const { request, pending } = await service.beginAuthorization(authorizeParams(), fetchImpl);
+      expect(fetchImpl).toHaveBeenCalledWith(
+        'http://localhost:3000/public/bffless/workflow/alias/workflow/dist/.well-known/oauth-protected-resource',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'x-forwarded-host': 'workflow.j5s.dev',
+            'x-original-uri': '/.well-known/oauth-protected-resource',
+          }),
+        }),
+      );
+      expect(pending).toMatchObject({
+        clientId: 'c1',
+        projectId: 'p1',
+        projectSlug: 'bffless/workflow',
+        scopes: ['workflow:read', 'workflow:run', 'workflow:files'],
+        state: 'xyz',
+      });
+      expect(pending.exp - pending.iat).toBe(600);
+      expect(service.readPending(request)).toMatchObject({ clientId: 'c1', projectId: 'p1' });
+    });
+    it('narrows to the requested scopes and refuses an unknown one', async () => {
+      const { service } = make();
+      mockDb.limit
+        .mockResolvedValueOnce([client])
+        .mockResolvedValueOnce([mapping])
+        .mockResolvedValueOnce([project]);
+      const { pending } = await service.beginAuthorization(
+        authorizeParams({ scope: 'workflow:read' }),
+        prm,
+      );
+      expect(pending.scopes).toEqual(['workflow:read']);
+      mockDb.limit
+        .mockResolvedValueOnce([client])
+        .mockResolvedValueOnce([mapping])
+        .mockResolvedValueOnce([project]);
+      await expect(
+        service.beginAuthorization(authorizeParams({ scope: 'workflow:admin' }), prm),
+      ).rejects.toMatchObject({ error: 'invalid_scope' });
+    });
+    it('refuses before trusting the redirect: unknown client, unregistered redirect_uri; then invalid_target, missing PKCE', async () => {
+      const { service } = make();
+      mockDb.limit.mockResolvedValueOnce([]);
+      await expect(service.beginAuthorization(authorizeParams(), prm)).rejects.toMatchObject({
+        error: 'invalid_client',
+      });
+      mockDb.limit.mockResolvedValueOnce([client]);
+      await expect(
+        service.beginAuthorization(authorizeParams({ redirect_uri: 'https://other/cb' }), prm),
+      ).rejects.toMatchObject({ error: 'invalid_request' });
+      mockDb.limit.mockResolvedValueOnce([client]);
+      await expect(
+        service.beginAuthorization(authorizeParams({ resource: undefined }), prm),
+      ).rejects.toMatchObject({ error: 'invalid_target' });
+      mockDb.limit.mockResolvedValueOnce([client]).mockResolvedValueOnce([]);
+      await expect(service.beginAuthorization(authorizeParams(), prm)).rejects.toMatchObject({
+        error: 'invalid_target',
+      });
+      mockDb.limit
+        .mockResolvedValueOnce([client])
+        .mockResolvedValueOnce([mapping])
+        .mockResolvedValueOnce([project]);
+      await expect(
+        service.beginAuthorization(authorizeParams(), async () => ({
+          status: 404,
+          json: async () => ({}),
+        })),
+      ).rejects.toMatchObject({ error: 'invalid_target' });
+      mockDb.limit.mockResolvedValueOnce([client]);
+      await expect(
+        service.beginAuthorization(authorizeParams({ code_challenge_method: 'plain' }), prm),
+      ).rejects.toMatchObject({ error: 'invalid_request' });
+    });
+    it('rejects a tampered or expired pending request', () => {
+      const { service } = make();
+      expect(() => service.readPending('nope')).toThrow(OAuthError);
+      const expired = jwt.sign(
+        { kind: 'oauth_pending', exp: Math.floor(Date.now() / 1000) - 5 },
+        'test-secret',
+      );
+      expect(() => service.readPending(expired)).toThrow(OAuthError);
+      const other = jwt.sign({ kind: 'other' }, 'test-secret');
+      expect(() => service.readPending(other)).toThrow(OAuthError);
+    });
+  });
+
+  describe('consent', () => {
+    const pendingFor = (service: OAuthService, scopes = ['workflow:read', 'workflow:run']) =>
+      jwt.sign(
+        {
+          kind: 'oauth_pending',
+          clientId: 'c1',
+          clientName: 'Claude',
+          redirectUri: 'https://claude.ai/cb',
+          codeChallenge: challengeOf(verifier),
+          state: 'xyz',
+          scopes,
+          resource: 'https://workflow.j5s.dev/api/workflow/mcp',
+          projectId: 'p1',
+          projectSlug: 'bffless/workflow',
+          projectName: 'Workflow',
+          iat: 1,
+          exp: Math.floor(Date.now() / 1000) + 600,
+        },
+        'test-secret',
+      );
+
+    it('denial redirects with access_denied and the state; approval stores a hashed code with the granted subset', async () => {
+      const { service } = make();
+      const denied = await service.consent('u1', pendingFor(service), { approve: false });
+      expect(denied.redirectTo).toBe(
+        'https://claude.ai/cb?state=xyz&error=access_denied&error_description=the+member+declined',
+      );
+      mockDb.values.mockReturnValueOnce(Promise.resolve());
+      const ok = await service.consent('u1', pendingFor(service), {
+        approve: true,
+        scopes: ['workflow:read', 'workflow:admin'],
+      });
+      const url = new URL(ok.redirectTo);
+      expect(url.searchParams.get('state')).toBe('xyz');
+      const code = url.searchParams.get('code')!;
+      expect(code.length).toBeGreaterThan(30);
+      const stored = mockDb.values.mock.calls[0][0];
+      expect(stored.codeHash).toBe(hashToken(code));
+      expect(stored.scopes).toEqual(['workflow:read']);
+      expect(stored.userId).toBe('u1');
+      expect(stored.codeChallenge).toBe(challengeOf(verifier));
+    });
+    it('refuses an empty grant', async () => {
+      const { service } = make();
+      await expect(
+        service.consent('u1', pendingFor(service), { approve: true, scopes: [] }),
+      ).rejects.toMatchObject({ error: 'invalid_scope' });
+    });
+  });
+
+  describe('token: authorization_code', () => {
+    const codeRow = (over: Record<string, unknown> = {}) => ({
+      codeHash: hashToken('the-code'),
+      clientId: 'c1',
+      userId: 'u1',
+      projectId: 'p1',
+      scopes: ['workflow:read'],
+      codeChallenge: challengeOf(verifier),
+      redirectUri: 'https://claude.ai/cb',
+      resource: 'https://workflow.j5s.dev/api/workflow/mcp',
+      expiresAt: new Date(Date.now() + 60_000),
+      usedAt: null,
+      ...over,
+    });
+    const body = (over: Record<string, unknown> = {}) => ({
+      grant_type: 'authorization_code',
+      code: 'the-code',
+      client_id: 'c1',
+      redirect_uri: 'https://claude.ai/cb',
+      code_verifier: verifier,
+      ...over,
+    });
+
+    it('mints an app token (kind oauth, 1 h) and a refresh token in a family derived from the code', async () => {
+      const { service, appTokens } = make();
+      mockDb.limit
+        .mockResolvedValueOnce([codeRow()])
+        .mockResolvedValueOnce([project])
+        .mockResolvedValueOnce([client])
+        .mockResolvedValueOnce([user]);
+      mockDb.where.mockReturnValue(mockDb);
+      const out = await service.token(body());
+      expect(out).toMatchObject({
+        access_token: 'bfat_raw',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'workflow:read',
+      });
+      expect(out.refresh_token).toMatch(/^bfrt_[0-9a-f]{64}$/);
+      expect(appTokens.create).toHaveBeenCalledWith(
+        'u1',
+        'user',
+        { name: 'OAuth: Claude', project: 'bffless/workflow', scopes: ['workflow:read'] },
+        expect.objectContaining({ kind: 'oauth', clientId: 'c1', expiresAt: expect.any(Date) }),
+      );
+      const refreshRow = mockDb.values.mock.calls.find((c) => c[0].familyId)![0];
+      expect(refreshRow.familyId).toBe(familyOfCode(hashToken('the-code')));
+      expect(refreshRow.appTokenId).toBe('tok-1');
+      expect(refreshRow.tokenHash).toBe(hashToken(out.refresh_token));
+    });
+    it('refuses a wrong verifier, a mismatched redirect_uri, a used code (and revokes its family), an expired code', async () => {
+      const { service } = make();
+      mockDb.limit.mockResolvedValueOnce([codeRow()]);
+      await expect(service.token(body({ code_verifier: 'x'.repeat(43) }))).rejects.toMatchObject({
+        error: 'invalid_grant',
+      });
+      mockDb.limit.mockResolvedValueOnce([codeRow()]);
+      await expect(
+        service.token(body({ redirect_uri: 'https://claude.ai/other' })),
+      ).rejects.toMatchObject({ error: 'invalid_grant' });
+      mockDb.limit.mockResolvedValueOnce([codeRow({ usedAt: new Date() })]);
+      mockDb.where.mockReturnValueOnce(mockDb).mockResolvedValueOnce([]);
+      await expect(service.token(body())).rejects.toMatchObject({ error: 'invalid_grant' });
+      mockDb.limit.mockResolvedValueOnce([codeRow({ expiresAt: new Date(Date.now() - 1) })]);
+      await expect(service.token(body())).rejects.toMatchObject({ error: 'invalid_grant' });
+      mockDb.limit.mockResolvedValueOnce([]);
+      await expect(service.token(body())).rejects.toMatchObject({ error: 'invalid_grant' });
+      await expect(service.token({ grant_type: 'password' })).rejects.toMatchObject({
+        error: 'unsupported_grant_type',
+      });
+    });
+  });
+
+  describe('token: refresh_token', () => {
+    const refreshRow = (over: Record<string, unknown> = {}) => ({
+      tokenHash: hashToken('bfrt_old'),
+      familyId: 'fam-1',
+      clientId: 'c1',
+      userId: 'u1',
+      projectId: 'p1',
+      scopes: ['workflow:read', 'workflow:run'],
+      appTokenId: 'tok-old',
+      expiresAt: new Date(Date.now() + 60_000),
+      rotatedAt: null,
+      ...over,
+    });
+
+    it('rotates: marks the old token, revokes the old access token, issues a new pair in the same family', async () => {
+      const { service } = make();
+      mockDb.limit
+        .mockResolvedValueOnce([refreshRow()])
+        .mockResolvedValueOnce([project])
+        .mockResolvedValueOnce([client])
+        .mockResolvedValueOnce([user]);
+      mockDb.where.mockReturnValue(mockDb);
+      const out = await service.token({
+        grant_type: 'refresh_token',
+        refresh_token: 'bfrt_old',
+        client_id: 'c1',
+      });
+      expect(out.refresh_token).not.toBe('bfrt_old');
+      expect(mockDb.set).toHaveBeenCalledWith({ rotatedAt: expect.any(Date) });
+      expect(mockDb.set).toHaveBeenCalledWith({ revokedAt: expect.any(Date) });
+      const newRow = mockDb.values.mock.calls.find((c) => c[0].familyId)![0];
+      expect(newRow.familyId).toBe('fam-1');
+    });
+    it('a rotated token presented again revokes the family', async () => {
+      const { service } = make();
+      mockDb.limit.mockResolvedValueOnce([refreshRow({ rotatedAt: new Date() })]);
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce([
+          refreshRow({ rotatedAt: new Date() }),
+          refreshRow({ tokenHash: 'h2', appTokenId: 'tok-2' }),
+        ]);
+      await expect(
+        service.token({ grant_type: 'refresh_token', refresh_token: 'bfrt_old' }),
+      ).rejects.toMatchObject({ error: 'invalid_grant' });
+      // both access tokens revoked, whole family closed
+      expect(mockDb.set).toHaveBeenCalledWith({ revokedAt: expect.any(Date) });
+      expect(mockDb.set).toHaveBeenCalledWith({
+        rotatedAt: expect.any(Date),
+        expiresAt: expect.any(Date),
+      });
+    });
+    it('refuses an unknown or expired refresh token', async () => {
+      const { service } = make();
+      mockDb.limit.mockResolvedValueOnce([]);
+      await expect(
+        service.token({ grant_type: 'refresh_token', refresh_token: 'bfrt_nope' }),
+      ).rejects.toMatchObject({ error: 'invalid_grant' });
+      await expect(
+        service.token({ grant_type: 'refresh_token', refresh_token: 'not-a-refresh' }),
+      ).rejects.toMatchObject({ error: 'invalid_grant' });
+      mockDb.limit.mockResolvedValueOnce([refreshRow({ expiresAt: new Date(Date.now() - 1) })]);
+      await expect(
+        service.token({ grant_type: 'refresh_token', refresh_token: 'bfrt_old' }),
+      ).rejects.toMatchObject({ error: 'invalid_grant' });
+    });
+  });
+
+  describe('revoke', () => {
+    it('revokes an access token by hash and a refresh token by family, never throwing', async () => {
+      const { service } = make();
+      mockDb.where.mockResolvedValueOnce(undefined);
+      await expect(service.revoke('bfat_x')).resolves.toBeUndefined();
+      expect(mockDb.set).toHaveBeenCalledWith({ revokedAt: expect.any(Date) });
+      mockDb.limit.mockResolvedValueOnce([{ familyId: 'fam-9' }]);
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce([])
+        .mockResolvedValue(undefined);
+      await expect(service.revoke('bfrt_x')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/apps/backend/src/oauth/oauth.service.spec.ts
+++ b/apps/backend/src/oauth/oauth.service.spec.ts
@@ -1,5 +1,5 @@
 import * as jwt from 'jsonwebtoken';
-import { OAuthService, familyOfCode } from './oauth.service';
+import { OAuthService, resourceHosts, familyOfCode } from './oauth.service';
 import { OAuthError } from './oauth.errors';
 import { challengeOf } from './pkce.util';
 import { hashToken } from '../auth/app-token.util';
@@ -57,7 +57,12 @@ function make() {
   const appTokens = {
     create: jest.fn().mockResolvedValue({ view: { id: 'tok-1' }, raw: 'bfat_raw' }),
   };
-  return { service: new OAuthService(config as never, appTokens as never), appTokens };
+  const permissions = { getUserProjectRole: jest.fn().mockResolvedValue('contributor') };
+  return {
+    service: new OAuthService(config as never, appTokens as never, permissions as never),
+    appTokens,
+    permissions,
+  };
 }
 
 const authorizeParams = (over: Record<string, unknown> = {}) => ({
@@ -149,6 +154,27 @@ describe('OAuthService', () => {
       expect(pending.exp - pending.iat).toBe(600);
       expect(service.readPending(request)).toMatchObject({ clientId: 'c1', projectId: 'p1' });
     });
+    it('resolves the www/non-www alternate of the resource host, like every other domain lookup', async () => {
+      const { service } = make();
+      expect(resourceHosts('www.Example.com')).toEqual(['www.example.com', 'example.com']);
+      expect(resourceHosts('example.com')).toEqual(['example.com', 'www.example.com']);
+      mockDb.limit
+        .mockResolvedValueOnce([client])
+        .mockResolvedValueOnce([mapping])
+        .mockResolvedValueOnce([project]);
+      const fetchImpl = jest.fn(prm);
+      const { pending } = await service.beginAuthorization(
+        authorizeParams({ resource: 'https://www.workflow.j5s.dev/api/workflow/mcp' }),
+        fetchImpl,
+      );
+      expect(pending.projectId).toBe('p1');
+      expect(fetchImpl).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'x-forwarded-host': 'www.workflow.j5s.dev' }),
+        }),
+      );
+    });
     it('narrows to the requested scopes and refuses an unknown one', async () => {
       const { service } = make();
       mockDb.limit
@@ -237,12 +263,12 @@ describe('OAuthService', () => {
 
     it('denial redirects with access_denied and the state; approval stores a hashed code with the granted subset', async () => {
       const { service } = make();
-      const denied = await service.consent('u1', pendingFor(service), { approve: false });
+      const denied = await service.consent('u1', 'user', pendingFor(service), { approve: false });
       expect(denied.redirectTo).toBe(
         'https://claude.ai/cb?state=xyz&error=access_denied&error_description=the+member+declined',
       );
       mockDb.values.mockReturnValueOnce(Promise.resolve());
-      const ok = await service.consent('u1', pendingFor(service), {
+      const ok = await service.consent('u1', 'user', pendingFor(service), {
         approve: true,
         scopes: ['workflow:read', 'workflow:admin'],
       });
@@ -259,8 +285,31 @@ describe('OAuthService', () => {
     it('refuses an empty grant', async () => {
       const { service } = make();
       await expect(
-        service.consent('u1', pendingFor(service), { approve: true, scopes: [] }),
+        service.consent('u1', 'user', pendingFor(service), { approve: true, scopes: [] }),
       ).rejects.toMatchObject({ error: 'invalid_scope' });
+    });
+    it('shows and grants only to a member of the named project; an admin passes without a role row', async () => {
+      const { service, permissions } = make();
+      permissions.getUserProjectRole.mockResolvedValueOnce(null);
+      await expect(service.pendingFor('u2', 'user', pendingFor(service))).rejects.toMatchObject({
+        error: 'access_denied',
+        status: 403,
+      });
+      permissions.getUserProjectRole.mockResolvedValueOnce('guest');
+      await expect(
+        service.consent('u2', 'user', pendingFor(service), { approve: true }),
+      ).rejects.toMatchObject({ error: 'access_denied' });
+      expect(mockDb.insert).not.toHaveBeenCalled();
+      // a non-member's Deny still redirects — nothing about the project is revealed by it
+      const denied = await service.consent('u2', 'user', pendingFor(service), { approve: false });
+      expect(denied.redirectTo).toContain('error=access_denied');
+      permissions.getUserProjectRole.mockClear();
+      await expect(service.pendingFor('root', 'admin', pendingFor(service))).resolves.toMatchObject(
+        {
+          projectId: 'p1',
+        },
+      );
+      expect(permissions.getUserProjectRole).not.toHaveBeenCalled();
     });
   });
 
@@ -295,6 +344,7 @@ describe('OAuthService', () => {
         .mockResolvedValueOnce([client])
         .mockResolvedValueOnce([user]);
       mockDb.where.mockReturnValue(mockDb);
+      mockDb.returning.mockResolvedValueOnce([{ codeHash: hashToken('the-code') }]);
       const out = await service.token(body());
       expect(out).toMatchObject({
         access_token: 'bfat_raw',
@@ -337,6 +387,70 @@ describe('OAuthService', () => {
     });
   });
 
+  describe('token: single use is enforced by the consuming UPDATE, not the earlier read', () => {
+    it('an exchange that finds the code consumed underneath it revokes the family', async () => {
+      const { service, appTokens } = make();
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          codeHash: hashToken('the-code'),
+          clientId: 'c1',
+          userId: 'u1',
+          projectId: 'p1',
+          scopes: ['workflow:read'],
+          codeChallenge: challengeOf(verifier),
+          redirectUri: 'https://claude.ai/cb',
+          resource: 'https://workflow.j5s.dev/api/workflow/mcp',
+          expiresAt: new Date(Date.now() + 60_000),
+          usedAt: null,
+        },
+      ]);
+      mockDb.returning.mockResolvedValueOnce([]); // the other exchange won
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce([]);
+      await expect(
+        service.token({
+          grant_type: 'authorization_code',
+          code: 'the-code',
+          client_id: 'c1',
+          redirect_uri: 'https://claude.ai/cb',
+          code_verifier: verifier,
+        }),
+      ).rejects.toMatchObject({ error: 'invalid_grant', description: 'code already used' });
+      expect(appTokens.create).not.toHaveBeenCalled();
+      expect(mockDb.set).toHaveBeenCalledWith({
+        rotatedAt: expect.any(Date),
+        expiresAt: expect.any(Date),
+      });
+    });
+    it('a rotation that finds the token rotated underneath it revokes the family', async () => {
+      const { service, appTokens } = make();
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          tokenHash: hashToken('bfrt_old'),
+          familyId: 'fam-1',
+          clientId: 'c1',
+          userId: 'u1',
+          projectId: 'p1',
+          scopes: ['workflow:read'],
+          appTokenId: 'tok-1',
+          expiresAt: new Date(Date.now() + 60_000),
+          rotatedAt: null,
+        },
+      ]);
+      mockDb.returning.mockResolvedValueOnce([]);
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce([]);
+      await expect(
+        service.token({ grant_type: 'refresh_token', refresh_token: 'bfrt_old', client_id: 'c1' }),
+      ).rejects.toMatchObject({ error: 'invalid_grant' });
+      expect(appTokens.create).not.toHaveBeenCalled();
+    });
+  });
+
   describe('token: refresh_token', () => {
     const refreshRow = (over: Record<string, unknown> = {}) => ({
       tokenHash: hashToken('bfrt_old'),
@@ -359,6 +473,7 @@ describe('OAuthService', () => {
         .mockResolvedValueOnce([client])
         .mockResolvedValueOnce([user]);
       mockDb.where.mockReturnValue(mockDb);
+      mockDb.returning.mockResolvedValueOnce([{ tokenHash: 'h1' }]);
       const out = await service.token({
         grant_type: 'refresh_token',
         refresh_token: 'bfrt_old',

--- a/apps/backend/src/oauth/oauth.service.ts
+++ b/apps/backend/src/oauth/oauth.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { ForbiddenException, HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull, or } from 'drizzle-orm';
 import * as jwt from 'jsonwebtoken';
 import { randomBytes } from 'crypto';
 import { db } from '../db/client';
@@ -15,6 +15,7 @@ import {
 } from '../db/schema';
 import { hashToken } from '../auth/app-token.util';
 import { AppTokensService } from '../app-tokens/app-tokens.service';
+import { PermissionsService } from '../permissions/permissions.service';
 import { SCOPE_PATTERN } from '../pipelines/types';
 import { OAuthError } from './oauth.errors';
 import { isValidVerifier, verifyS256 } from './pkce.util';
@@ -58,6 +59,7 @@ export class OAuthService {
   constructor(
     private readonly config: ConfigService,
     private readonly appTokens: AppTokensService,
+    private readonly permissions: PermissionsService,
   ) {}
 
   private get jwtSecret(): string {
@@ -209,8 +211,24 @@ export class OAuthService {
   }
 
   /** The member decided. Approve → an authorization code bound to the (possibly narrowed) scopes. */
+  /**
+   * The pending request as the consent page may show it — only to a member of
+   * the project it names. Any other signed-in user gets `access_denied` (403)
+   * and learns nothing about the project or the client.
+   */
+  async pendingFor(
+    userId: string,
+    userRole: string | undefined,
+    request: string,
+  ): Promise<PendingRequest> {
+    const pending = this.readPending(request);
+    await this.assertMember(userId, userRole, pending.projectId);
+    return pending;
+  }
+
   async consent(
     userId: string,
+    userRole: string | undefined,
     request: string,
     decision: { approve: boolean; scopes?: string[] },
   ): Promise<{ redirectTo: string }> {
@@ -222,6 +240,7 @@ export class OAuthService {
       url.searchParams.set('error_description', 'the member declined');
       return { redirectTo: url.toString() };
     }
+    await this.assertMember(userId, userRole, pending.projectId);
     const granted = (decision.scopes ?? pending.scopes).filter((scope) =>
       pending.scopes.includes(scope),
     );
@@ -282,10 +301,22 @@ export class OAuthService {
       throw new OAuthError('invalid_grant', 'redirect_uri mismatch');
     if (!verifyS256(verifier, row.codeChallenge))
       throw new OAuthError('invalid_grant', 'PKCE verification failed');
-    await db
+    // Consume atomically: the UPDATE carries the not-yet-used condition, so of two
+    // concurrent exchanges exactly one gets the row back; the other is a replay.
+    const consumed = await db
       .update(oauthAuthorizationCodes)
       .set({ usedAt: new Date() })
-      .where(eq(oauthAuthorizationCodes.codeHash, row.codeHash));
+      .where(
+        and(
+          eq(oauthAuthorizationCodes.codeHash, row.codeHash),
+          isNull(oauthAuthorizationCodes.usedAt),
+        ),
+      )
+      .returning({ codeHash: oauthAuthorizationCodes.codeHash });
+    if (!Array.isArray(consumed) || consumed.length === 0) {
+      await this.revokeFamilyOfCode(row.codeHash);
+      throw new OAuthError('invalid_grant', 'code already used');
+    }
     return this.issue({
       clientId: row.clientId,
       userId: row.userId,
@@ -317,10 +348,19 @@ export class OAuthService {
     const requested = str(body.scope).split(/\s+/).filter(Boolean);
     const scopes = requested.length ? requested.filter((s) => row.scopes.includes(s)) : row.scopes;
     if (scopes.length === 0) throw new OAuthError('invalid_scope', 'no granted scope requested');
-    await db
+    // Rotate atomically (same shape as the code exchange): a second concurrent
+    // presentation finds no un-rotated row and is treated as the replay it is.
+    const rotated = await db
       .update(oauthRefreshTokens)
       .set({ rotatedAt: new Date() })
-      .where(eq(oauthRefreshTokens.tokenHash, row.tokenHash));
+      .where(
+        and(eq(oauthRefreshTokens.tokenHash, row.tokenHash), isNull(oauthRefreshTokens.rotatedAt)),
+      )
+      .returning({ tokenHash: oauthRefreshTokens.tokenHash });
+    if (!Array.isArray(rotated) || rotated.length === 0) {
+      await this.revokeFamily(row.familyId);
+      throw new OAuthError('invalid_grant', 'refresh_token was already used; the grant is revoked');
+    }
     if (row.appTokenId) {
       await db
         .update(appTokens)
@@ -359,16 +399,25 @@ export class OAuthService {
       throw new OAuthError('invalid_grant', 'the member no longer exists');
     const expiresAt = new Date(Date.now() + ACCESS_TOKEN_TTL_S * 1000);
     // The same mint a member does by hand: the membership check applies (a token never elevates).
-    const { view, raw } = await this.appTokens.create(
-      grant.userId,
-      user.role,
-      {
-        name: `OAuth: ${client?.clientName ?? grant.clientId}`,
-        project: `${project.owner}/${project.name}`,
-        scopes: grant.scopes,
-      },
-      { kind: 'oauth', clientId: grant.clientId, expiresAt },
-    );
+    let minted: Awaited<ReturnType<AppTokensService['create']>>;
+    try {
+      minted = await this.appTokens.create(
+        grant.userId,
+        user.role,
+        {
+          name: `OAuth: ${client?.clientName ?? grant.clientId}`,
+          project: `${project.owner}/${project.name}`,
+          scopes: grant.scopes,
+        },
+        { kind: 'oauth', clientId: grant.clientId, expiresAt },
+      );
+    } catch (error) {
+      if (error instanceof ForbiddenException) {
+        throw new OAuthError('invalid_grant', 'the member no longer belongs to the project');
+      }
+      throw error;
+    }
+    const { view, raw } = minted;
     const refreshRaw = REFRESH_PREFIX + randomBytes(32).toString('hex');
     await db.insert(oauthRefreshTokens).values({
       tokenHash: hashToken(refreshRaw),
@@ -430,6 +479,23 @@ export class OAuthService {
   }
 
   /** A replayed code revokes everything its first exchange issued: the family id is derived from the code. */
+  /** The same membership rule `AppTokensService.create` applies at mint time, RFC-shaped. */
+  private async assertMember(
+    userId: string,
+    userRole: string | undefined,
+    projectId: string,
+  ): Promise<void> {
+    if (userRole === 'admin') return;
+    const role = await this.permissions.getUserProjectRole(userId, projectId);
+    if (!role || role === 'guest') {
+      throw new OAuthError(
+        'access_denied',
+        'you are not a member of this project',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+
   private async revokeFamilyOfCode(codeHash: string): Promise<void> {
     await this.revokeFamily(familyOfCode(codeHash));
   }
@@ -446,10 +512,11 @@ export class OAuthService {
       throw new OAuthError('invalid_target', 'resource must be an absolute URL');
     }
     const host = url.hostname;
+    const [primary, alternate] = resourceHosts(host);
     const [mapping] = await db
       .select()
       .from(domainMappings)
-      .where(eq(domainMappings.domain, host))
+      .where(or(eq(domainMappings.domain, primary), eq(domainMappings.domain, alternate)))
       .limit(1);
     if (!mapping || !mapping.isActive || !mapping.projectId || mapping.domainType === 'redirect') {
       throw new OAuthError('invalid_target', `no deployment answers ${host}`);
@@ -518,3 +585,13 @@ const defaultFetch: FetchLike = async (url, init) => {
   const res = await fetch(url, { headers: init.headers, signal: AbortSignal.timeout(10_000) });
   return { status: res.status, json: () => res.json() };
 };
+
+/**
+ * A resource's host and its www/non-www alternate — a primary domain with
+ * "redirect to www" stores one variant in `domain_mappings` while clients present
+ * the other (the same rule `VisibilityService` and `TrafficRoutingService` apply).
+ */
+export function resourceHosts(host: string): [string, string] {
+  const normalized = host.toLowerCase();
+  return [normalized, normalized.startsWith('www.') ? normalized.slice(4) : `www.${normalized}`];
+}

--- a/apps/backend/src/oauth/oauth.service.ts
+++ b/apps/backend/src/oauth/oauth.service.ts
@@ -1,0 +1,520 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { and, eq } from 'drizzle-orm';
+import * as jwt from 'jsonwebtoken';
+import { randomBytes } from 'crypto';
+import { db } from '../db/client';
+import {
+  appTokens,
+  domainMappings,
+  oauthAuthorizationCodes,
+  oauthClients,
+  oauthRefreshTokens,
+  projects,
+  users,
+} from '../db/schema';
+import { hashToken } from '../auth/app-token.util';
+import { AppTokensService } from '../app-tokens/app-tokens.service';
+import { SCOPE_PATTERN } from '../pipelines/types';
+import { OAuthError } from './oauth.errors';
+import { isValidVerifier, verifyS256 } from './pkce.util';
+import {
+  AuthorizationServerMetadata,
+  PendingRequest,
+  RegisterClientDto,
+  TokenResponse,
+} from './oauth.dto';
+
+export const ACCESS_TOKEN_TTL_S = 3600;
+export const REFRESH_TOKEN_TTL_MS = 30 * 24 * 3600_000;
+export const CODE_TTL_MS = 10 * 60_000;
+export const PENDING_REQUEST_TTL_S = 10 * 60;
+const REFRESH_PREFIX = 'bfrt_';
+
+/** What a fetch of the resource's protected-resource document must do (injected for tests). */
+export type FetchLike = (
+  url: string,
+  init: { headers: Record<string, string> },
+) => Promise<{ status: number; json(): Promise<unknown> }>;
+
+interface ResolvedResource {
+  projectId: string;
+  projectSlug: string;
+  projectName: string;
+  scopesSupported: string[];
+}
+
+/**
+ * CE's built-in OAuth 2.1 authorization server (ADR-0005): dynamic client
+ * registration for public clients, the authorization-code grant with PKCE
+ * `S256`, RFC 8707 `resource` → the CE project the token is bound to, refresh
+ * rotation with family revocation, RFC 7009 revocation. The access token *is*
+ * an app token, minted through `AppTokensService`.
+ */
+@Injectable()
+export class OAuthService {
+  private readonly logger = new Logger(OAuthService.name);
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly appTokens: AppTokensService,
+  ) {}
+
+  private get jwtSecret(): string {
+    const secret = this.config.get<string>('JWT_SECRET');
+    if (!secret) throw new Error('JWT_SECRET is required for the OAuth authorization server');
+    return secret;
+  }
+
+  /** The issuer: the admin host (`FRONTEND_URL`), no trailing slash. */
+  issuer(): string {
+    return (this.config.get<string>('FRONTEND_URL') || 'http://localhost:5173').replace(/\/+$/, '');
+  }
+
+  metadata(): AuthorizationServerMetadata {
+    const issuer = this.issuer();
+    return {
+      issuer,
+      authorization_endpoint: `${issuer}/api/oauth/authorize`,
+      token_endpoint: `${issuer}/api/oauth/token`,
+      registration_endpoint: `${issuer}/api/oauth/register`,
+      revocation_endpoint: `${issuer}/api/oauth/revoke`,
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      code_challenge_methods_supported: ['S256'],
+      token_endpoint_auth_methods_supported: ['none'],
+      scopes_supported: [],
+      resource_indicators_supported: true,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // RFC 7591 — dynamic client registration
+  // ---------------------------------------------------------------------------
+
+  async registerClient(dto: RegisterClientDto): Promise<Record<string, unknown>> {
+    const redirectUris = dto.redirect_uris ?? [];
+    for (const uri of redirectUris) {
+      if (!isAcceptableRedirect(uri)) {
+        throw new OAuthError(
+          'invalid_redirect_uri',
+          `redirect_uri must be https, or http on localhost: ${uri}`,
+        );
+      }
+    }
+    if (dto.token_endpoint_auth_method !== undefined && dto.token_endpoint_auth_method !== 'none') {
+      throw new OAuthError(
+        'invalid_client_metadata',
+        'only public clients (token_endpoint_auth_method: none) are registered',
+      );
+    }
+    const grantTypes = dto.grant_types?.length
+      ? dto.grant_types
+      : ['authorization_code', 'refresh_token'];
+    const [row] = await db
+      .insert(oauthClients)
+      .values({ clientName: dto.client_name?.trim() || 'Unnamed client', redirectUris, grantTypes })
+      .returning();
+    this.logger.log(`OAuth client ${row.clientId} registered (${row.clientName})`);
+    return {
+      client_id: row.clientId,
+      client_id_issued_at: Math.floor(new Date(row.createdAt).getTime() / 1000),
+      client_name: row.clientName,
+      redirect_uris: row.redirectUris,
+      grant_types: row.grantTypes,
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      ...(dto.scope ? { scope: dto.scope } : {}),
+      ...(dto.client_uri ? { client_uri: dto.client_uri } : {}),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Authorization request → consent → code
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Validate an authorize request; resolve `resource` to a project and its
+   * scopes. Errors *before* the redirect_uri is trusted are thrown (400); the
+   * caller redirects the rest with `error=` (OAuth 2.1 §4.1.2.1).
+   */
+  async beginAuthorization(
+    params: Record<string, unknown>,
+    fetchImpl: FetchLike = defaultFetch,
+  ): Promise<{ request: string; pending: PendingRequest }> {
+    const clientId = str(params.client_id);
+    const redirectUri = str(params.redirect_uri);
+    if (!clientId) throw new OAuthError('invalid_request', 'client_id is required');
+    const [client] = await db
+      .select()
+      .from(oauthClients)
+      .where(eq(oauthClients.clientId, clientId))
+      .limit(1);
+    if (!client) throw new OAuthError('invalid_client', 'unknown client_id', 401);
+    if (!redirectUri || !client.redirectUris.includes(redirectUri)) {
+      throw new OAuthError('invalid_request', 'redirect_uri is not registered for this client');
+    }
+    // From here on errors may be redirected — the controller does that; we still throw typed errors.
+    if (str(params.response_type) !== 'code')
+      throw new OAuthError('unsupported_grant_type', 'response_type must be code');
+    const challenge = str(params.code_challenge);
+    if (!challenge) throw new OAuthError('invalid_request', 'code_challenge is required (PKCE)');
+    if (str(params.code_challenge_method) !== 'S256')
+      throw new OAuthError('invalid_request', 'code_challenge_method must be S256');
+    const resource = str(params.resource);
+    if (!resource) throw new OAuthError('invalid_target', 'resource is required (RFC 8707)');
+    const resolved = await this.resolveResource(resource, fetchImpl);
+    const requested = str(params.scope).split(/\s+/).filter(Boolean);
+    const scopes = requested.length ? requested : resolved.scopesSupported;
+    for (const scope of scopes) {
+      if (!SCOPE_PATTERN.test(scope) || !resolved.scopesSupported.includes(scope)) {
+        throw new OAuthError('invalid_scope', `the resource does not offer scope ${scope}`);
+      }
+    }
+    if (scopes.length === 0) throw new OAuthError('invalid_scope', 'the resource offers no scopes');
+    const now = Math.floor(Date.now() / 1000);
+    const pending: PendingRequest = {
+      clientId,
+      clientName: client.clientName,
+      redirectUri,
+      codeChallenge: challenge,
+      ...(str(params.state) ? { state: str(params.state) } : {}),
+      scopes,
+      resource,
+      projectId: resolved.projectId,
+      projectSlug: resolved.projectSlug,
+      projectName: resolved.projectName,
+      iat: now,
+      exp: now + PENDING_REQUEST_TTL_S,
+    };
+    const request = jwt.sign({ ...pending, kind: 'oauth_pending' }, this.jwtSecret, {
+      algorithm: 'HS256',
+    });
+    return { request, pending };
+  }
+
+  readPending(request: string): PendingRequest {
+    try {
+      const decoded = jwt.verify(request, this.jwtSecret, {
+        algorithms: ['HS256'],
+      }) as PendingRequest & { kind?: string };
+      if (decoded.kind !== 'oauth_pending') throw new Error('not a pending request');
+      return decoded;
+    } catch {
+      throw new OAuthError(
+        'invalid_request',
+        'the authorization request is invalid or has expired',
+      );
+    }
+  }
+
+  /** The member decided. Approve → an authorization code bound to the (possibly narrowed) scopes. */
+  async consent(
+    userId: string,
+    request: string,
+    decision: { approve: boolean; scopes?: string[] },
+  ): Promise<{ redirectTo: string }> {
+    const pending = this.readPending(request);
+    const url = new URL(pending.redirectUri);
+    if (pending.state) url.searchParams.set('state', pending.state);
+    if (!decision.approve) {
+      url.searchParams.set('error', 'access_denied');
+      url.searchParams.set('error_description', 'the member declined');
+      return { redirectTo: url.toString() };
+    }
+    const granted = (decision.scopes ?? pending.scopes).filter((scope) =>
+      pending.scopes.includes(scope),
+    );
+    if (granted.length === 0)
+      throw new OAuthError('invalid_scope', 'at least one scope must be granted');
+    const code = randomBytes(32).toString('base64url');
+    await db.insert(oauthAuthorizationCodes).values({
+      codeHash: hashToken(code),
+      clientId: pending.clientId,
+      userId,
+      projectId: pending.projectId,
+      scopes: granted,
+      codeChallenge: pending.codeChallenge,
+      redirectUri: pending.redirectUri,
+      resource: pending.resource,
+      expiresAt: new Date(Date.now() + CODE_TTL_MS),
+    });
+    url.searchParams.set('code', code);
+    return { redirectTo: url.toString() };
+  }
+
+  // ---------------------------------------------------------------------------
+  // The token endpoint
+  // ---------------------------------------------------------------------------
+
+  async token(body: Record<string, unknown>): Promise<TokenResponse> {
+    const grant = str(body.grant_type);
+    if (grant === 'authorization_code') return this.exchangeCode(body);
+    if (grant === 'refresh_token') return this.refresh(body);
+    throw new OAuthError(
+      'unsupported_grant_type',
+      `grant_type ${grant || '(none)'} is not supported`,
+    );
+  }
+
+  private async exchangeCode(body: Record<string, unknown>): Promise<TokenResponse> {
+    const code = str(body.code);
+    const verifier = body.code_verifier;
+    const clientId = str(body.client_id);
+    if (!code || !clientId)
+      throw new OAuthError('invalid_request', 'code and client_id are required');
+    if (!isValidVerifier(verifier))
+      throw new OAuthError('invalid_grant', 'code_verifier is missing or malformed');
+    const [row] = await db
+      .select()
+      .from(oauthAuthorizationCodes)
+      .where(eq(oauthAuthorizationCodes.codeHash, hashToken(code)))
+      .limit(1);
+    if (!row || row.clientId !== clientId) throw new OAuthError('invalid_grant', 'unknown code');
+    if (row.usedAt) {
+      // Replay: revoke what the first exchange issued (OAuth 2.1 §4.1.2 / RFC 6749 §4.1.2).
+      await this.revokeFamilyOfCode(row.codeHash);
+      throw new OAuthError('invalid_grant', 'code already used');
+    }
+    if (new Date(row.expiresAt).getTime() < Date.now())
+      throw new OAuthError('invalid_grant', 'code expired');
+    if (str(body.redirect_uri) !== row.redirectUri)
+      throw new OAuthError('invalid_grant', 'redirect_uri mismatch');
+    if (!verifyS256(verifier, row.codeChallenge))
+      throw new OAuthError('invalid_grant', 'PKCE verification failed');
+    await db
+      .update(oauthAuthorizationCodes)
+      .set({ usedAt: new Date() })
+      .where(eq(oauthAuthorizationCodes.codeHash, row.codeHash));
+    return this.issue({
+      clientId: row.clientId,
+      userId: row.userId,
+      projectId: row.projectId,
+      scopes: row.scopes,
+      familyId: familyOfCode(row.codeHash),
+    });
+  }
+
+  private async refresh(body: Record<string, unknown>): Promise<TokenResponse> {
+    const presented = str(body.refresh_token);
+    if (!presented.startsWith(REFRESH_PREFIX))
+      throw new OAuthError('invalid_grant', 'unknown refresh_token');
+    const [row] = await db
+      .select()
+      .from(oauthRefreshTokens)
+      .where(eq(oauthRefreshTokens.tokenHash, hashToken(presented)))
+      .limit(1);
+    if (!row) throw new OAuthError('invalid_grant', 'unknown refresh_token');
+    if (str(body.client_id) && str(body.client_id) !== row.clientId)
+      throw new OAuthError('invalid_grant', 'client mismatch');
+    if (row.rotatedAt) {
+      // A rotated token presented again: the family is compromised — revoke it all (OAuth 2.1 §4.3.1).
+      await this.revokeFamily(row.familyId);
+      throw new OAuthError('invalid_grant', 'refresh_token was already used; the grant is revoked');
+    }
+    if (new Date(row.expiresAt).getTime() < Date.now())
+      throw new OAuthError('invalid_grant', 'refresh_token expired');
+    const requested = str(body.scope).split(/\s+/).filter(Boolean);
+    const scopes = requested.length ? requested.filter((s) => row.scopes.includes(s)) : row.scopes;
+    if (scopes.length === 0) throw new OAuthError('invalid_scope', 'no granted scope requested');
+    await db
+      .update(oauthRefreshTokens)
+      .set({ rotatedAt: new Date() })
+      .where(eq(oauthRefreshTokens.tokenHash, row.tokenHash));
+    if (row.appTokenId) {
+      await db
+        .update(appTokens)
+        .set({ revokedAt: new Date() })
+        .where(and(eq(appTokens.id, row.appTokenId)));
+    }
+    return this.issue({
+      clientId: row.clientId,
+      userId: row.userId,
+      projectId: row.projectId,
+      scopes,
+      familyId: row.familyId,
+    });
+  }
+
+  private async issue(grant: {
+    clientId: string;
+    userId: string;
+    projectId: string;
+    scopes: string[];
+    familyId: string;
+  }): Promise<TokenResponse> {
+    const [project] = await db
+      .select()
+      .from(projects)
+      .where(eq(projects.id, grant.projectId))
+      .limit(1);
+    if (!project) throw new OAuthError('invalid_grant', 'the project no longer exists');
+    const [client] = await db
+      .select()
+      .from(oauthClients)
+      .where(eq(oauthClients.clientId, grant.clientId))
+      .limit(1);
+    const [user] = await db.select().from(users).where(eq(users.id, grant.userId)).limit(1);
+    if (!user || user.disabled)
+      throw new OAuthError('invalid_grant', 'the member no longer exists');
+    const expiresAt = new Date(Date.now() + ACCESS_TOKEN_TTL_S * 1000);
+    // The same mint a member does by hand: the membership check applies (a token never elevates).
+    const { view, raw } = await this.appTokens.create(
+      grant.userId,
+      user.role,
+      {
+        name: `OAuth: ${client?.clientName ?? grant.clientId}`,
+        project: `${project.owner}/${project.name}`,
+        scopes: grant.scopes,
+      },
+      { kind: 'oauth', clientId: grant.clientId, expiresAt },
+    );
+    const refreshRaw = REFRESH_PREFIX + randomBytes(32).toString('hex');
+    await db.insert(oauthRefreshTokens).values({
+      tokenHash: hashToken(refreshRaw),
+      familyId: grant.familyId,
+      clientId: grant.clientId,
+      userId: grant.userId,
+      projectId: grant.projectId,
+      scopes: grant.scopes,
+      appTokenId: view.id,
+      expiresAt: new Date(Date.now() + REFRESH_TOKEN_TTL_MS),
+    });
+    await db
+      .update(oauthClients)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(oauthClients.clientId, grant.clientId));
+    return {
+      access_token: raw,
+      token_type: 'Bearer',
+      expires_in: ACCESS_TOKEN_TTL_S,
+      refresh_token: refreshRaw,
+      scope: grant.scopes.join(' '),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // RFC 7009 — revocation (always 200 to the caller)
+  // ---------------------------------------------------------------------------
+
+  async revoke(token: string): Promise<void> {
+    if (token.startsWith(REFRESH_PREFIX)) {
+      const [row] = await db
+        .select()
+        .from(oauthRefreshTokens)
+        .where(eq(oauthRefreshTokens.tokenHash, hashToken(token)))
+        .limit(1);
+      if (row) await this.revokeFamily(row.familyId);
+      return;
+    }
+    await db
+      .update(appTokens)
+      .set({ revokedAt: new Date() })
+      .where(and(eq(appTokens.tokenHash, hashToken(token)), eq(appTokens.kind, 'oauth')));
+  }
+
+  private async revokeFamily(familyId: string): Promise<void> {
+    const rows = await db
+      .select()
+      .from(oauthRefreshTokens)
+      .where(eq(oauthRefreshTokens.familyId, familyId));
+    const now = new Date();
+    for (const row of rows) {
+      if (row.appTokenId)
+        await db.update(appTokens).set({ revokedAt: now }).where(eq(appTokens.id, row.appTokenId));
+    }
+    await db
+      .update(oauthRefreshTokens)
+      .set({ rotatedAt: now, expiresAt: now })
+      .where(eq(oauthRefreshTokens.familyId, familyId));
+  }
+
+  /** A replayed code revokes everything its first exchange issued: the family id is derived from the code. */
+  private async revokeFamilyOfCode(codeHash: string): Promise<void> {
+    await this.revokeFamily(familyOfCode(codeHash));
+  }
+
+  // ---------------------------------------------------------------------------
+  // RFC 8707 — resource → project (+ the resource's own scope vocabulary)
+  // ---------------------------------------------------------------------------
+
+  private async resolveResource(resource: string, fetchImpl: FetchLike): Promise<ResolvedResource> {
+    let url: URL;
+    try {
+      url = new URL(resource);
+    } catch {
+      throw new OAuthError('invalid_target', 'resource must be an absolute URL');
+    }
+    const host = url.hostname;
+    const [mapping] = await db
+      .select()
+      .from(domainMappings)
+      .where(eq(domainMappings.domain, host))
+      .limit(1);
+    if (!mapping || !mapping.isActive || !mapping.projectId || mapping.domainType === 'redirect') {
+      throw new OAuthError('invalid_target', `no deployment answers ${host}`);
+    }
+    const [project] = await db
+      .select()
+      .from(projects)
+      .where(eq(projects.id, mapping.projectId))
+      .limit(1);
+    if (!project) throw new OAuthError('invalid_target', `no deployment answers ${host}`);
+    const alias = mapping.alias || 'production';
+    const base = `${(mapping.path || '').replace(/\/+$/, '')}`;
+    const prmPath = '/.well-known/oauth-protected-resource';
+    const inProcess = `http://localhost:3000/public/${project.owner}/${project.name}/alias/${alias}${base}${prmPath}`;
+    let scopesSupported: string[] = [];
+    try {
+      const res = await fetchImpl(inProcess, {
+        headers: {
+          'x-forwarded-host': host,
+          'x-original-uri': prmPath,
+          accept: 'application/json',
+        },
+      });
+      if (res.status !== 200) throw new Error(`status ${res.status}`);
+      const doc = (await res.json()) as { resource?: unknown; scopes_supported?: unknown };
+      scopesSupported = Array.isArray(doc.scopes_supported)
+        ? doc.scopes_supported.filter((s): s is string => typeof s === 'string')
+        : [];
+    } catch (error) {
+      this.logger.debug(`protected-resource document for ${host}: ${String(error)}`);
+      throw new OAuthError('invalid_target', `${host} publishes no protected-resource document`);
+    }
+    return {
+      projectId: project.id,
+      projectSlug: `${project.owner}/${project.name}`,
+      projectName: project.displayName || project.name,
+      scopesSupported,
+    };
+  }
+}
+
+/** The refresh-token family a code's exchange starts — a UUID carved from the code's hash, so a replay can find it. */
+export function familyOfCode(codeHash: string): string {
+  const h = codeHash.padEnd(32, '0').slice(0, 32);
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-4${h.slice(13, 16)}-8${h.slice(17, 20)}-${h.slice(20, 32)}`;
+}
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function isAcceptableRedirect(uri: string): boolean {
+  try {
+    const u = new URL(uri);
+    if (u.protocol === 'https:') return true;
+    return (
+      u.protocol === 'http:' &&
+      (u.hostname === 'localhost' || u.hostname === '127.0.0.1' || u.hostname === '[::1]')
+    );
+  } catch {
+    return false;
+  }
+}
+
+const defaultFetch: FetchLike = async (url, init) => {
+  const res = await fetch(url, { headers: init.headers, signal: AbortSignal.timeout(10_000) });
+  return { status: res.status, json: () => res.json() };
+};

--- a/apps/backend/src/oauth/pkce.util.spec.ts
+++ b/apps/backend/src/oauth/pkce.util.spec.ts
@@ -1,0 +1,22 @@
+import { challengeOf, isValidVerifier, verifyS256 } from './pkce.util';
+
+describe('pkce', () => {
+  // RFC 7636 appendix B
+  const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+  const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+  it('matches the RFC example and refuses plain', () => {
+    expect(challengeOf(verifier)).toBe(challenge);
+    expect(verifyS256(verifier, challenge)).toBe(true);
+    expect(verifyS256(verifier, verifier)).toBe(false);
+    expect(verifyS256('x'.repeat(43), challenge)).toBe(false);
+  });
+
+  it('validates verifier shape', () => {
+    expect(isValidVerifier(verifier)).toBe(true);
+    expect(isValidVerifier('x'.repeat(42))).toBe(false);
+    expect(isValidVerifier('x'.repeat(129))).toBe(false);
+    expect(isValidVerifier('has space'.padEnd(43, 'x'))).toBe(false);
+    expect(isValidVerifier(42)).toBe(false);
+  });
+});

--- a/apps/backend/src/oauth/pkce.util.ts
+++ b/apps/backend/src/oauth/pkce.util.ts
@@ -1,0 +1,20 @@
+import { createHash, timingSafeEqual } from 'crypto';
+
+/** RFC 7636 §4.1: 43–128 unreserved characters. */
+const VERIFIER = /^[A-Za-z0-9\-._~]{43,128}$/;
+
+export function isValidVerifier(verifier: unknown): verifier is string {
+  return typeof verifier === 'string' && VERIFIER.test(verifier);
+}
+
+/** base64url(sha256(verifier)) — the only method OAuth 2.1 allows. */
+export function challengeOf(verifier: string): string {
+  return createHash('sha256').update(verifier).digest('base64url');
+}
+
+/** Timing-safe `challengeOf(verifier) === challenge`. */
+export function verifyS256(verifier: string, challenge: string): boolean {
+  const expected = Buffer.from(challengeOf(verifier), 'utf8');
+  const given = Buffer.from(String(challenge), 'utf8');
+  return expected.length === given.length && timingSafeEqual(expected, given);
+}

--- a/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
@@ -630,6 +630,41 @@ describe('ProxyMiddleware', () => {
       expect((res as any).redirect).not.toHaveBeenCalled();
     });
 
+    it('points an anonymous API caller at the resource metadata (RFC 9728) when the request came through a domain host', async () => {
+      makePrivate();
+      (mockVisibilityService as any).resolveAccessControlByDomain = jest
+        .fn()
+        .mockResolvedValue(null);
+      const req = createMockRequest('/api/works', {
+        accept: 'application/json',
+        'x-forwarded-host': 'workflow.j5s.dev',
+      });
+      const res = createMockResponse();
+      (res as any).setHeader = jest.fn();
+      await (middleware as any).checkVisibilityAndAuth(
+        req,
+        res,
+        project,
+        'studio',
+        createMockRule({ pathPattern: '/api/*', proxyType: 'pipeline' }),
+      );
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect((res as any).setHeader).toHaveBeenCalledWith(
+        'WWW-Authenticate',
+        'Bearer resource_metadata="https://workflow.j5s.dev/.well-known/oauth-protected-resource"',
+      );
+      const bare = createMockResponse();
+      (bare as any).setHeader = jest.fn();
+      await (middleware as any).checkVisibilityAndAuth(
+        createMockRequest('/api/works', { accept: 'application/json' }),
+        bare,
+        project,
+        'studio',
+        createMockRule({ pathPattern: '/api/*', proxyType: 'pipeline' }),
+      );
+      expect((bare as any).setHeader).not.toHaveBeenCalled();
+    });
+
     it('does not exempt a non-proxy rule served from an auth path', async () => {
       makePrivate();
       const req = expiredTokenRequest('/api/auth/session/refresh');

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -647,6 +647,9 @@ export class ProxyMiddleware implements NestMiddleware {
       this.logger.debug(`Proxy blocked: not authenticated for private ${aliasName || 'project'}`);
 
       if (this.isApiRequest(req)) {
+        // RFC 9728 §5.1: tell a bearer client where the resource's OAuth metadata is
+        // (an app-shipped /.well-known rule), so a connector can start its flow.
+        this.setResourceMetadataHint(req, res);
         // Check if token was expired (set by AuthMiddleware)
         // If so, the response was already sent by AuthMiddleware
         // This is a fallback for cases where AuthMiddleware didn't catch it
@@ -705,6 +708,21 @@ export class ProxyMiddleware implements NestMiddleware {
 
     // User has access
     return 'allowed';
+  }
+
+  /**
+   * `WWW-Authenticate: Bearer resource_metadata="https://<host>/.well-known/oauth-protected-resource"`
+   * (RFC 9728 §5.1) on a 401 that reached CE through a domain host. The document itself is
+   * the app's to ship (a rule served despite visibility); CE only points at where it would be.
+   */
+  private setResourceMetadataHint(req: Request, res: Response): void {
+    const forwardedHost = req.headers['x-forwarded-host'];
+    const host = Array.isArray(forwardedHost) ? forwardedHost[0] : forwardedHost;
+    if (!host) return;
+    res.setHeader(
+      'WWW-Authenticate',
+      `Bearer resource_metadata="https://${host.split(',')[0].trim()}/.well-known/oauth-protected-resource"`,
+    );
   }
 
   /**
@@ -1206,6 +1224,7 @@ export class ProxyMiddleware implements NestMiddleware {
         // Pipeline failed - map error codes to appropriate HTTP status codes
         // (pipeline-from-rule.ts, shared with the in-process invoker)
         const statusCode = statusForPipelineError(result.error?.code);
+        if (statusCode === 401) this.setResourceMetadataHint(req, res);
         // RFC 6750 §3.1: a token that lacks the rule's scope is told which one.
         const scopeHeader = insufficientScopeHeader(result.error);
         if (scopeHeader) {

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import { UserGroupsPage } from '@/pages/UserGroupsPage';
 import { GroupDetailPage } from '@/pages/GroupDetailPage';
 import { UsersPage } from '@/pages/UsersPage';
 import { UserSettingsPage } from '@/pages/UserSettingsPage';
+import { OAuthConsentPage } from '@/pages/OAuthConsentPage';
 import { AdminSettingsPage } from '@/pages/AdminSettingsPage';
 import { GeneralTab } from '@/pages/admin-settings/GeneralTab';
 import { AuthTab } from '@/pages/admin-settings/AuthTab';
@@ -100,6 +101,18 @@ function App() {
               element={
                 <ProtectedRoute>
                   <UserSettingsPage />
+                </ProtectedRoute>
+              }
+            />
+
+            {/* OAuth 2.1 consent (ADR-0005): the authorize endpoint sends a signed-in
+              member here with a signed pending request; a signed-out one goes through
+              the login first (ProtectedRoute). */}
+            <Route
+              path="/oauth/consent"
+              element={
+                <ProtectedRoute>
+                  <OAuthConsentPage />
                 </ProtectedRoute>
               }
             />

--- a/apps/frontend/src/pages/OAuthConsentPage.tsx
+++ b/apps/frontend/src/pages/OAuthConsentPage.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useDecideConsentMutation, useGetPendingConsentQuery } from '@/services/oauthApi';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Skeleton } from '@/components/ui/skeleton';
+import { AlertCircle, KeyRound } from 'lucide-react';
+
+/**
+ * OAuth consent — `/oauth/consent?request=<signed pending request>` (ADR-0005).
+ * The member sees who asks, for which project, and one checkbox per requested
+ * scope (all ticked; unticking narrows the grant — a `workflow:read`-only
+ * consent yields a token that cannot start a run). Requires the admin session
+ * (ProtectedRoute); the authorize endpoint sends a signed-out member through
+ * the login first.
+ */
+export function OAuthConsentPage() {
+  const [params] = useSearchParams();
+  const request = params.get('request') ?? '';
+  const { data, isLoading, error } = useGetPendingConsentQuery(request, { skip: request === '' });
+  const [decide, { isLoading: deciding }] = useDecideConsentMutation();
+  const [unticked, setUnticked] = useState<Set<string>>(new Set());
+  const [failure, setFailure] = useState<string | null>(null);
+
+  const granted = (data?.scopes ?? []).filter((s) => !unticked.has(s));
+
+  const submit = async (approve: boolean) => {
+    setFailure(null);
+    try {
+      const { redirectTo } = await decide({
+        request,
+        approve,
+        ...(approve ? { scopes: granted } : {}),
+      }).unwrap();
+      window.location.assign(redirectTo);
+    } catch (err: unknown) {
+      const message = (err as { data?: { error_description?: string; message?: string } })?.data;
+      setFailure(
+        message?.error_description || message?.message || 'The decision could not be recorded',
+      );
+    }
+  };
+
+  if (request === '' || error) {
+    return (
+      <div className="max-w-lg mx-auto p-6">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            {request === ''
+              ? 'This page needs an authorization request to show.'
+              : (error as { data?: { error_description?: string } })?.data?.error_description ||
+                'The authorization request is invalid or has expired. Start again from the app that asked.'}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  if (isLoading || !data) {
+    return (
+      <div className="max-w-lg mx-auto p-6">
+        <Skeleton className="h-40" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-lg mx-auto p-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <KeyRound className="h-5 w-5" />
+            Allow access?
+          </CardTitle>
+          <CardDescription>
+            <strong>{data.clientName}</strong> wants to act as you on{' '}
+            <strong>{data.project.slug}</strong>
+            {data.project.name !== data.project.slug ? ` (${data.project.name})` : ''}.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <div className="text-sm font-medium">It asks for</div>
+            {data.scopes.map((scope) => (
+              <div key={scope} className="flex items-center gap-2">
+                <Checkbox
+                  id={`scope-${scope}`}
+                  checked={!unticked.has(scope)}
+                  onCheckedChange={(checked) =>
+                    setUnticked((prev) => {
+                      const next = new Set(prev);
+                      if (checked) next.delete(scope);
+                      else next.add(scope);
+                      return next;
+                    })
+                  }
+                />
+                <Label htmlFor={`scope-${scope}`} className="font-mono text-sm">
+                  {scope}
+                </Label>
+              </div>
+            ))}
+            <p className="text-xs text-muted-foreground">
+              The app defines what each scope allows. Untick one to grant less; the token can never
+              do more than you can.
+            </p>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            You will be sent back to {data.redirectHost}.
+          </p>
+          {failure && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{failure}</AlertDescription>
+            </Alert>
+          )}
+        </CardContent>
+        <CardFooter className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => submit(false)} disabled={deciding}>
+            Deny
+          </Button>
+          <Button onClick={() => submit(true)} disabled={deciding || granted.length === 0}>
+            {deciding ? 'Working…' : 'Allow'}
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/__tests__/OAuthConsentPage.test.tsx
+++ b/apps/frontend/src/pages/__tests__/OAuthConsentPage.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import { OAuthConsentPage } from '../OAuthConsentPage';
+
+const decide = vi.fn();
+let pending: { data?: unknown; isLoading: boolean; error?: unknown } = { isLoading: false };
+
+vi.mock('@/services/oauthApi', () => ({
+  useGetPendingConsentQuery: () => pending,
+  useDecideConsentMutation: () => [decide, { isLoading: false }],
+}));
+
+const consent = {
+  clientName: 'Claude',
+  scopes: ['workflow:read', 'workflow:run', 'workflow:files'],
+  project: { id: 'p1', slug: 'bffless/workflow', name: 'Workflow' },
+  redirectHost: 'claude.ai',
+  expiresAt: '2026-09-03T00:10:00.000Z',
+};
+
+function renderAt(query: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/oauth/consent${query}`]}>
+      <OAuthConsentPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('OAuthConsentPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pending = { data: consent, isLoading: false };
+    Object.defineProperty(window, 'location', { value: { assign: vi.fn() }, writable: true });
+  });
+
+  it('renders the client, the project and one checkbox per scope, all ticked', () => {
+    renderAt('?request=abc');
+    expect(screen.getByText('Claude')).toBeInTheDocument();
+    expect(screen.getByText('bffless/workflow')).toBeInTheDocument();
+    const boxes = screen.getAllByRole('checkbox');
+    expect(boxes).toHaveLength(3);
+    for (const box of boxes) expect(box).toHaveAttribute('data-state', 'checked');
+    expect(screen.getByText(/sent back to claude.ai/)).toBeInTheDocument();
+  });
+
+  it('unticking narrows the grant; Allow posts the subset and follows the redirect', async () => {
+    decide.mockReturnValue({
+      unwrap: () => Promise.resolve({ redirectTo: 'https://claude.ai/cb?code=x' }),
+    });
+    renderAt('?request=abc');
+    fireEvent.click(screen.getByLabelText('workflow:run'));
+    fireEvent.click(screen.getByRole('button', { name: /allow/i }));
+    await waitFor(() =>
+      expect(decide).toHaveBeenCalledWith({
+        request: 'abc',
+        approve: true,
+        scopes: ['workflow:read', 'workflow:files'],
+      }),
+    );
+    await waitFor(() =>
+      expect(window.location.assign).toHaveBeenCalledWith('https://claude.ai/cb?code=x'),
+    );
+  });
+
+  it('Deny posts approve: false', async () => {
+    decide.mockReturnValue({
+      unwrap: () => Promise.resolve({ redirectTo: 'https://claude.ai/cb?error=access_denied' }),
+    });
+    renderAt('?request=abc');
+    fireEvent.click(screen.getByRole('button', { name: /deny/i }));
+    await waitFor(() => expect(decide).toHaveBeenCalledWith({ request: 'abc', approve: false }));
+  });
+
+  it('shows the error and no buttons for an invalid request', () => {
+    pending = {
+      isLoading: false,
+      error: { data: { error_description: 'the authorization request is invalid or has expired' } },
+    };
+    renderAt('?request=bad');
+    expect(screen.getByText(/invalid or has expired/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /allow/i })).toBeNull();
+  });
+});

--- a/apps/frontend/src/services/oauthApi.ts
+++ b/apps/frontend/src/services/oauthApi.ts
@@ -1,0 +1,26 @@
+import { api } from './api';
+
+/** What `GET /api/oauth/consent?request=` answers — the consent page's content. */
+export interface PendingConsent {
+  clientName: string;
+  scopes: string[];
+  project: { id: string; slug: string; name: string };
+  redirectHost: string;
+  expiresAt: string;
+}
+
+export const oauthApi = api.injectEndpoints({
+  endpoints: (builder) => ({
+    getPendingConsent: builder.query<PendingConsent, string>({
+      query: (request) => `/api/oauth/consent?request=${encodeURIComponent(request)}`,
+    }),
+    decideConsent: builder.mutation<
+      { redirectTo: string },
+      { request: string; approve: boolean; scopes?: string[] }
+    >({
+      query: (body) => ({ url: '/api/oauth/consent', method: 'POST', body }),
+    }),
+  }),
+});
+
+export const { useGetPendingConsentQuery, useDecideConsentMutation } = oauthApi;

--- a/docker/nginx-ssl.conf
+++ b/docker/nginx-ssl.conf
@@ -137,6 +137,17 @@ server {
     }
 
     # Proxy API requests to backend
+    # RFC 8414: CE's OAuth 2.1 authorization-server metadata (OAuthModule). Declared
+    # before `location /`, whose SPA catch-all would otherwise answer index.html here.
+    location = /.well-known/oauth-authorization-server {
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location /api {
         proxy_pass http://backend:3000;
         proxy_http_version 1.1;

--- a/docker/nginx/render-main-conf.test.sh
+++ b/docker/nginx/render-main-conf.test.sh
@@ -56,6 +56,7 @@ REALIP_RANGES="151.101.0.0/16 2a04:4e40::/32"'
 run_render
 assert_contains "$ETC/sites-available/main.conf" 'return 301 https://$host$request_uri;' 'proxy: port 80 redirects'
 assert_contains "$ETC/sites-available/main.conf" '/.well-known/acme-challenge/'          'proxy: ACME location present'
+assert_contains "$ETC/sites-available/main.conf" 'location = /.well-known/oauth-authorization-server'          'proxy: OAuth AS metadata location present'
 assert_contains "$ETC/cloudflare-realip.conf"    'set_real_ip_from 151.101.0.0/16;'      'proxy: custom range 1'
 assert_contains "$ETC/cloudflare-realip.conf"    'set_real_ip_from 2a04:4e40::/32;'      'proxy: custom range 2'
 assert_contains "$ETC/cloudflare-realip.conf"    'real_ip_header True-Client-IP;'        'proxy: custom header'
@@ -80,6 +81,7 @@ PORT80=redirect
 REALIP_MODE=off'
 run_render
 assert_contains     "$ETC/sites-available/main.conf" '/.well-known/acme-challenge/' 'direct: ACME location present'
+assert_contains     "$ETC/sites-available/main.conf" 'location = /.well-known/oauth-authorization-server' 'direct: OAuth AS metadata location present'
 assert_not_contains "$ETC/cloudflare-realip.conf"    'set_real_ip_from'             'direct: realip inactive'
 assert_contains     "$ETC/sites-available/main.conf" "ssl_certificate $ETC/ssl/fullchain.pem;" 'direct: admin vhost uses fullchain.pem by default'
 

--- a/docker/nginx/sites-available/main.conf.template
+++ b/docker/nginx/sites-available/main.conf.template
@@ -212,6 +212,17 @@ server {
         client_max_body_size 200M;
     }
 
+    # RFC 8414: CE's OAuth 2.1 authorization-server metadata (OAuthModule). Declared
+    # before `location /`, whose SPA catch-all would otherwise answer index.html here.
+    location = /.well-known/oauth-authorization-server {
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Proxy API requests to backend
     location /api {
         proxy_pass http://backend:3000;

--- a/docs/adr/0005-built-in-oauth-authorization-server.md
+++ b/docs/adr/0005-built-in-oauth-authorization-server.md
@@ -1,0 +1,50 @@
+---
+status: accepted
+date: 2026-09-03
+---
+# A built-in OAuth 2.1 authorization server, not SuperTokens' OAuth2Provider recipe
+
+**Context.** The Workflow harness's MCP endpoint (bffless/apps#554, spec 10, auth ladder
+rung 3) must let claude.ai's one-click connector flow complete against a private deployment:
+RFC 9728 protected-resource discovery → dynamic client registration (RFC 7591) → an
+authorization-code grant with PKCE → tokens, where the access token *is* an app token
+(a member-bound, project-bound, scoped bearer — CE #727) so that `auth_required`,
+`requiredScopes` and the visibility gate need no second credential type. SuperTokens is
+CE's identity provider, and its OAuth2Provider recipe ("unified login") exists; the story
+required a spike to decide between adopting it and building the small server CE needs.
+
+**Decision.** Build it in: a `OAuthModule` on the admin host — `GET
+/.well-known/oauth-authorization-server` (RFC 8414), `POST /api/oauth/register` (RFC 7591,
+public clients only), `GET /api/oauth/authorize` (PKCE `S256` required, RFC 8707 `resource`
+required), a consent page in the admin SPA with per-scope checkboxes, `POST
+/api/oauth/consent`, `POST /api/oauth/token` (authorization_code + refresh_token with
+rotation and family revocation), `POST /api/oauth/revoke` (RFC 7009). Access tokens are
+minted through the app-tokens service (`kind: 'oauth'`, 1 h) bound to the project the
+`resource` resolves to. State: `oauth_clients`, `oauth_authorization_codes`,
+`oauth_refresh_tokens`; pending authorization requests ride as signed JWTs (10 min), no table.
+
+**Considered — SuperTokens OAuth2Provider (rejected, four criteria, spike 2026-09-03).**
+1. *Dynamic client registration for public clients with no admin step* — **no.** The recipe's
+   API surface (`lib/ts/recipe/oauth2provider/api/`: `auth`, `token`, `login`, `loginInfo`,
+   `logout`, `endSession`, `introspectToken`, `revokeToken`, `userInfo`) has no `register`
+   endpoint; clients are created by the authenticated SDK function `createOAuth2Client`.
+   claude.ai registers itself, so an operator-created client would not work.
+2. *Works with CE's `supertokens-node` ^17 and core 12.0.10* — **no.** The recipe shipped in
+   `supertokens-node` **21.0.0** (2024-10-07, "Added OAuth2Provider recipe", core ≥ 9.3, CDI
+   5.2): a four-major upgrade of the SDK, on top of the core-12 migration pain recorded in #695.
+3. *RFC 8707 resource indicators honoured and reflected into the token* — **not as such.**
+   The recipe reasons in OAuth2 *audiences* (`requirements.audience` on token validation),
+   not resource indicators mapped to a CE project.
+4. *The access token can be an app token* — **no.** The recipe issues its own JWTs; CE would
+   have to exchange them for app tokens at every gate, or teach three guards a second bearer.
+
+Any one failure was to decide it; all four did. Also considered: an external authorization
+server (Hydra, Keycloak) — rejected for the same operational reason ADR-0005 in the apps repo
+gives for a standalone Node service: an unowned unit every self-hoster would have to run.
+
+**Consequences.** CE owns a small, standards-shaped authorization server and its three
+tables; the admin nginx vhost gains one `location` for the RFC 8414 document (the SPA's
+catch-all served `index.html` there); the app ships its protected-resource document as a
+rule (`bypassVisibility`), so CE never grows an app-aware discovery endpoint. OIDC discovery,
+token introspection (RFC 7662) and client garbage collection are deferred. If SuperTokens'
+recipe later gains DCR and CE has crossed the SDK-21 line, revisiting is a one-ADR decision.

--- a/docs/adr/0005-built-in-oauth-authorization-server.md
+++ b/docs/adr/0005-built-in-oauth-authorization-server.md
@@ -2,12 +2,13 @@
 status: accepted
 date: 2026-09-03
 ---
+
 # A built-in OAuth 2.1 authorization server, not SuperTokens' OAuth2Provider recipe
 
 **Context.** The Workflow harness's MCP endpoint (bffless/apps#554, spec 10, auth ladder
 rung 3) must let claude.ai's one-click connector flow complete against a private deployment:
 RFC 9728 protected-resource discovery → dynamic client registration (RFC 7591) → an
-authorization-code grant with PKCE → tokens, where the access token *is* an app token
+authorization-code grant with PKCE → tokens, where the access token _is_ an app token
 (a member-bound, project-bound, scoped bearer — CE #727) so that `auth_required`,
 `requiredScopes` and the visibility gate need no second credential type. SuperTokens is
 CE's identity provider, and its OAuth2Provider recipe ("unified login") exists; the story
@@ -24,18 +25,19 @@ minted through the app-tokens service (`kind: 'oauth'`, 1 h) bound to the projec
 `oauth_refresh_tokens`; pending authorization requests ride as signed JWTs (10 min), no table.
 
 **Considered — SuperTokens OAuth2Provider (rejected, four criteria, spike 2026-09-03).**
-1. *Dynamic client registration for public clients with no admin step* — **no.** The recipe's
+
+1. _Dynamic client registration for public clients with no admin step_ — **no.** The recipe's
    API surface (`lib/ts/recipe/oauth2provider/api/`: `auth`, `token`, `login`, `loginInfo`,
    `logout`, `endSession`, `introspectToken`, `revokeToken`, `userInfo`) has no `register`
    endpoint; clients are created by the authenticated SDK function `createOAuth2Client`.
    claude.ai registers itself, so an operator-created client would not work.
-2. *Works with CE's `supertokens-node` ^17 and core 12.0.10* — **no.** The recipe shipped in
+2. _Works with CE's `supertokens-node` ^17 and core 12.0.10_ — **no.** The recipe shipped in
    `supertokens-node` **21.0.0** (2024-10-07, "Added OAuth2Provider recipe", core ≥ 9.3, CDI
    5.2): a four-major upgrade of the SDK, on top of the core-12 migration pain recorded in #695.
-3. *RFC 8707 resource indicators honoured and reflected into the token* — **not as such.**
-   The recipe reasons in OAuth2 *audiences* (`requirements.audience` on token validation),
+3. _RFC 8707 resource indicators honoured and reflected into the token_ — **not as such.**
+   The recipe reasons in OAuth2 _audiences_ (`requirements.audience` on token validation),
    not resource indicators mapped to a CE project.
-4. *The access token can be an app token* — **no.** The recipe issues its own JWTs; CE would
+4. _The access token can be an app token_ — **no.** The recipe issues its own JWTs; CE would
    have to exchange them for app tokens at every gate, or teach three guards a second bearer.
 
 Any one failure was to decide it; all four did. Also considered: an external authorization


### PR DESCRIPTION
Closes #729 — story 9 of the Workflow M5 agent-embedding epic (bffless/apps#554); plan `docs/superpowers/plans/2026-09-03-workflow-m5-phase3-ce-auth.md` on the apps epic branch (Phase C, Tasks 15–22, Decisions 19–23). Rebased onto `main` (#730 and #731 landed); this diff stands on its own.


## The flow

claude.ai's one-click connector, end to end. The **access token is an app token** — the resource (the app's MCP rule, behind `auth_required`) never learns OAuth exists.

```mermaid
sequenceDiagram
    participant Host as MCP host (claude.ai)
    participant App as workflow.<domain><br/>(the app's rules)
    participant AS as admin.<domain><br/>OAuthModule
    participant Member as member's browser

    Host->>App: POST /api/workflow/mcp (no credential)
    App-->>Host: 401 · WWW-Authenticate Bearer resource_metadata="…/.well-known/oauth-protected-resource"
    Host->>App: GET /.well-known/oauth-protected-resource (bypassVisibility rule)
    App-->>Host: authorization_servers [admin.<domain>] · scopes_supported
    Host->>AS: GET /.well-known/oauth-authorization-server (RFC 8414)
    Host->>AS: POST /api/oauth/register (RFC 7591, public client)
    AS-->>Host: client_id
    Host->>Member: open /api/oauth/authorize?resource=…&scope=…&code_challenge=… (PKCE S256)
    Member->>AS: authorize — resource → domain_mappings → project · scopes ⊆ the resource's PRM
    AS-->>Member: 302 /oauth/consent?request=<signed JWT, 10 min>
    Member->>AS: GET /api/oauth/consent (session · must be a member of that project)
    Member->>AS: POST /api/oauth/consent {approve, scopes} (may narrow)
    AS-->>Member: 302 redirect_uri?code=…&state=…
    Member->>Host: code
    Host->>AS: POST /api/oauth/token (code + code_verifier)
    AS->>AS: consume code atomically → AppTokensService.create (kind oauth, 1 h) + refresh token (family)
    AS-->>Host: access_token bfat_… · refresh_token bfrt_…
    Host->>App: POST /api/workflow/mcp · Authorization Bearer bfat_…
    App-->>Host: runs as the member (startedBy = member id) · scopes = the consent
```

## What is new, by file

```text
apps/backend/src/
├── oauth/
│   ├── oauth-metadata.controller.ts   # GET /.well-known/oauth-authorization-server (RFC 8414)
│   ├── oauth.controller.ts            # register · authorize · consent (session) · token · revoke
│   ├── oauth.service.ts               # DCR, pending-request JWT, resource → project, PKCE, grants, rotation
│   ├── pkce.util.ts                   # S256 verify, verifier shape
│   └── oauth.errors.ts                # {error, error_description} — RFC-shaped everywhere
├── db/schema/
│   ├── oauth-clients.schema.ts
│   ├── oauth-authorization-codes.schema.ts   # hashed, single use, 10 min
│   └── oauth-refresh-tokens.schema.ts        # hashed, 30 d, family_id, app_token_id (set null)
└── proxy-rules/proxy.middleware.ts    # + WWW-Authenticate resource_metadata hint on API 401s
apps/backend/drizzle/0048_confused_violations.sql
apps/frontend/src/pages/OAuthConsentPage.tsx   # /oauth/consent — one checkbox per scope
docker/nginx/…/main.conf.template, docker/nginx-ssl.conf   # the .well-known location on the admin vhost
docs/adr/0005-built-in-oauth-authorization-server.md      # the spike: SuperTokens OAuth2Provider rejected
```

## Single use, enforced by the write (review finding 3)

```diff
 exchangeCode(code)
   row = SELECT … WHERE code_hash = ?
   if row.usedAt → revoke family, invalid_grant
   verify client · expiry · redirect_uri · PKCE
-  UPDATE codes SET used_at = now() WHERE code_hash = ?
+  consumed = UPDATE codes SET used_at = now()
+             WHERE code_hash = ? AND used_at IS NULL RETURNING code_hash
+  if consumed is empty → revoke family, invalid_grant   # the other exchange won
   issue(app token + refresh token)
```

The same shape for `refresh` on `rotated_at`. Two concurrent redemptions of one code can no longer both mint.

## The spike, first — `docs/adr/0005-built-in-oauth-authorization-server.md`
SuperTokens' OAuth2Provider recipe was checked against the four criteria the plan set and failed all four: no RFC 7591 registration endpoint (its API surface is `auth`/`token`/`login`/`loginInfo`/`logout`/`endSession`/`introspectToken`/`revokeToken`/`userInfo`; clients come from the authenticated `createOAuth2Client`), it shipped in `supertokens-node` 21.0.0 against CE's ^17 (core ≥ 9.3; CE runs core 12 with #695's migration pain already recorded), it reasons in audiences rather than RFC 8707 resource → project, and it issues its own JWTs where CE needs the access token to *be* an app token. So: built in.

## What
**`OAuthModule` on the admin host** — `GET /.well-known/oauth-authorization-server` (RFC 8414; one nginx `location` on the admin vhost in `main.conf.template` + `nginx-ssl.conf`, asserted by `render-main-conf.test.sh` in both render modes — the SPA catch-all served `index.html` there), `POST /api/oauth/register` (RFC 7591, public clients only: https or localhost redirects, `token_endpoint_auth_method: none`), `GET /api/oauth/authorize` (PKCE `S256` required; RFC 8707 `resource` required and resolved through `domain_mappings` to the project, with the requested scopes checked against the resource's own `/.well-known/oauth-protected-resource` fetched in-process; no session → the login round-trips back; session → the consent page; post-redirect-uri errors are redirected with `error=`), `GET/POST /api/oauth/consent` (`SessionAuthGuard`; the member may narrow the scopes), `POST /api/oauth/token` (`authorization_code` with PKCE, single use, exact `redirect_uri`, a replayed code revokes its family; `refresh_token` with rotation, reuse revokes the family — OAuth 2.1 §4.3.1), `POST /api/oauth/revoke` (RFC 7009, always 200). Pending authorization requests are signed JWTs (`JWT_SECRET`, 10 min) — no table. **The access token is an app token** (`AppTokensService.create`, `kind: 'oauth'`, 1 h, the member's own membership check applies — a token never elevates).

**RFC 9728 hints** — API-shaped 401s from the visibility gate and from a pipeline's `auth_required` carry `WWW-Authenticate: Bearer resource_metadata="https://<host>/.well-known/oauth-protected-resource"` when the request came through a domain host. The document itself is the app's to ship (a `bypassVisibility` rule, #730).

**Consent page** — `/oauth/consent` in the admin SPA (`OAuthConsentPage`): client, project, one checkbox per scope (all ticked; unticking narrows), Deny/Allow, then the redirect.

**Schemas** — `oauth_clients`, `oauth_authorization_codes` (hashed, 10 min, single use), `oauth_refresh_tokens` (hashed, 30 d, `family_id`, the access token it issued). Glossary: *Authorization server*, *Protected-resource document*.

## Backwards compatibility
Three additive tables (migration to be generated with `pnpm db:generate` — maintainer's step); one nginx location on the admin vhost (ships in the frontend image; the k8s workspace ConfigMap is a platform follow-up); the `WWW-Authenticate` header rides on 401s that already were 401s. No change to sessions, API keys, or any existing route.

## Verification
| Suite | Result |
| --- | --- |
| backend `jest` | 3676 passed, 47 skipped (218 suites) |
| frontend `vitest` | 964 passed (91 files) |
| `docker/nginx/render-main-conf.test.sh` | all render tests passed (both modes) |
| eslint + prettier on the branch's files | clean (the repo-wide `lint` / `format:check` failures are pre-existing on `main`: `setupApi.ts`, `visual-plans/`, …) |

**Migration status:** draft until the maintainer runs `pnpm db:generate` in `apps/backend` (after #731 lands, so it follows 0047).
**Live proof pending:** the apps `oauth` walk (DCR → consent → tokens → `workflow.status` as the member → rotation → narrowed consent refused → revocation) on both j5s hosts, and claude.ai's connector flow against `workflow.j5s.dev` with screenshots — the Phase-3 gate.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sd1UdizNNZjGLZxyy8FY11
