### PR TITLE
fix(proxy-rules): invoker parses a sibling's passthrough JSON string body

### DIFF
--- a/apps/backend/src/proxy-rules/rule-invoker.service.spec.ts
+++ b/apps/backend/src/proxy-rules/rule-invoker.service.spec.ts
@@ -3,6 +3,7 @@ import {
   buildTargetUrl,
   publicPrefixOf,
   MAX_INVOKE_DEPTH,
+  structuredBody,
 } from './rule-invoker.service';
 import { Request } from 'express';
 
@@ -288,6 +289,28 @@ describe('RuleInvokerService', () => {
     ]);
     expect(await service.invoke(base)).toEqual({ ok: false, failure: { kind: 'recursion' } });
     expect(execution.executePipelineWithDebug).not.toHaveBeenCalled();
+  });
+
+  it("parses a pipeline sibling's JSON answer the response handler passed through as a string (large bodies, #418)", async () => {
+    const { service, execution } = make([rule()]);
+    const big = JSON.stringify({
+      content: [{ type: 'text', text: 'x'.repeat(300 * 1024) }],
+      structuredContent: { html: '<div>' },
+    });
+    execution.executePipelineWithDebug.mockResolvedValueOnce({
+      success: true,
+      response: { status: 200, body: big, headers: { 'Content-Type': 'application/json' } },
+    });
+    const result = await service.invoke(base);
+    expect(result.ok).toBe(true);
+    const body = (
+      result as { answer: { body: { content: unknown[]; structuredContent: unknown } } }
+    ).answer.body;
+    expect(Array.isArray(body.content)).toBe(true);
+    expect(body.structuredContent).toEqual({ html: '<div>' });
+    // not JSON, or not a JSON content type: the string stays a string
+    expect(structuredBody('<html>', 'text/html')).toBe('<html>');
+    expect(structuredBody('{not json', 'application/json')).toBe('{not json');
   });
 
   it("caches the alias's rules for a short window", async () => {

--- a/apps/backend/src/proxy-rules/rule-invoker.service.ts
+++ b/apps/backend/src/proxy-rules/rule-invoker.service.ts
@@ -150,13 +150,14 @@ export class RuleInvokerService {
 
     if (result.success && result.response) {
       const headers = { ...(result.response.headers ?? {}) };
+      const contentType = headers['Content-Type'] ?? headers['content-type'] ?? 'application/json';
       return {
         ok: true,
         answer: {
           status: result.response.status,
-          body: result.response.body,
+          body: structuredBody(result.response.body, contentType),
           headers,
-          contentType: headers['Content-Type'] ?? headers['content-type'] ?? 'application/json',
+          contentType,
         },
       };
     }
@@ -337,4 +338,21 @@ function stripMatchedPrefix(pattern: string, path: string): string {
     return '';
   }
   return path;
+}
+
+/**
+ * A sibling's JSON answer as a value. The response handler sends a rendered
+ * JSON body of 256 KiB or more verbatim as a string rather than materialising
+ * it (#418, a heap concern on the way out to Express) — in-process there is no
+ * Express, and a caller such as the MCP handler reads the body's shape
+ * (`content[]`), so the string is parsed here; anything that is not JSON stays
+ * a string.
+ */
+export function structuredBody(body: unknown, contentType: string): unknown {
+  if (typeof body !== 'string' || !contentType.toLowerCase().includes('json')) return body;
+  try {
+    return JSON.parse(body);
+  } catch {
+    return body;
+  }
 }


### PR DESCRIPTION
Follow-up to #731, found by the Workflow `mcp` live walk against the scratch project on v0.4.44 (25/26).

## What
`ResponseHandler.formatBody` sends a rendered JSON body of **256 KiB or more** verbatim as a string instead of materialising it (#418 — a heap concern on the way out to Express). In-process there is no Express: `RuleInvokerService.invokePipeline` handed that string on as the sibling's `answer.body`, and `results.ts`'s "already a CallToolResult" check (`isPlainObject(body) && Array.isArray(body.content)`) saw a string, so the MCP handler wrapped the whole serialized result as `content[0].text` — `structuredContent` gone. Every tool with a small answer passed; `workflow.stepView`, which carries a 323 KB island, did not.

Fix: `structuredBody(body, contentType)` in the invoker — a string body under a JSON content type is parsed once; anything that is not JSON, or not JSON-typed, stays a string. Test: a pipeline sibling answering a 300 KB `content[]` string comes back as the object; the two non-JSON cases stay strings.

```diff
 invokePipeline(rule, req)
   result = executePipelineWithDebug(pipeline, synthetic, user)
-  answer.body = result.response.body          # a string when ≥ 256 KiB (#418)
+  answer.body = structuredBody(result.response.body, contentType)
+                                               # parsed once in-process; non-JSON stays a string
```

## Also seen, not fixed here
An in-process sibling call runs with `captureDebug: false` and never reaches the middleware's log persistence, so a rule's **debug toggle records nothing for in-process invocations** (I enabled it on the tool rule and re-ran: zero logs). Worth its own issue — an operator debugging an MCP tool has no pipeline log to read.

## Verification
`rule-invoker.service.spec.ts` + `mcp.handler.spec.ts`: 20 passed; `tsc --noEmit`, eslint clean. Live proof: the `mcp` walk on `workflow-mcp.j5s.dev` once this is on j5s (currently 25/26, `spec10.stepViewMounts` the one failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sd1UdizNNZjGLZxyy8FY11