### PR TITLE
fix(auth): OAuth issuer is the admin host (ADMIN_DOMAIN / OAUTH_ISSUER), not FRONTEND_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -250,6 +250,13 @@ FRONTEND_URL=http://localhost
 # Usually you don't need to set this - it's derived from PRIMARY_DOMAIN.
 # ADMIN_DOMAIN=admin.yourdomain.com
 
+# OAuth issuer [OPTIONAL] - defaults to https://{ADMIN_DOMAIN}
+# The URL MCP hosts and other OAuth 2.1 clients are told to register, authorize
+# and exchange tokens at (RFC 8414 metadata at {issuer}/.well-known/oauth-authorization-server).
+# It must be the admin host: the public site's /api/* belongs to a project's proxy rules.
+# Set it only when the admin panel is reached at a URL ADMIN_DOMAIN does not describe.
+# OAUTH_ISSUER=https://admin.yourdomain.com
+
 
 # ============================================================================
 # 5. COOKIE & SESSION SETTINGS [REQUIRED]

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,7 +46,7 @@ A per-rule opt-out of the deployment visibility gate (`bypassVisibility: true` i
 _Avoid_: "public rule" (deployment visibility is a different setting)
 
 **Authorization server**:
-CE's built-in OAuth 2.1 server on the admin host (`/api/oauth/*`; RFC 8414 metadata at `/.well-known/oauth-authorization-server`). Clients register themselves (RFC 7591, public clients only); a member consents per project and per scope on `/oauth/consent`; the access token _is_ an App token, bound to the project the RFC 8707 `resource` named. Not SuperTokens' OAuth2Provider recipe (ADR-0005).
+CE's built-in OAuth 2.1 server on the admin host — the issuer is `https://<ADMIN_DOMAIN>` (or `OAUTH_ISSUER`), never `FRONTEND_URL`, which is the public site (`/api/oauth/*`; RFC 8414 metadata at `/.well-known/oauth-authorization-server`). Clients register themselves (RFC 7591, public clients only); a member consents per project and per scope on `/oauth/consent`; the access token _is_ an App token, bound to the project the RFC 8707 `resource` named. Not SuperTokens' OAuth2Provider recipe (ADR-0005).
 _Avoid_: "SuperTokens OAuth", "SSO" (that is the member's own login, the other direction)
 
 **Protected-resource document**:

--- a/apps/backend/src/oauth/oauth.service.spec.ts
+++ b/apps/backend/src/oauth/oauth.service.spec.ts
@@ -50,9 +50,15 @@ const prm = async () => ({
   }),
 });
 
-function make() {
+function make(configOverrides: Record<string, string | undefined> = {}) {
   const config = {
-    get: (k: string) => ({ JWT_SECRET: 'test-secret', FRONTEND_URL: 'https://admin.j5s.dev/' })[k],
+    get: (k: string) =>
+      ({
+        JWT_SECRET: 'test-secret',
+        FRONTEND_URL: 'https://www.j5s.dev',
+        ADMIN_DOMAIN: 'admin.j5s.dev',
+        ...configOverrides,
+      })[k],
   };
   const appTokens = {
     create: jest.fn().mockResolvedValue({ view: { id: 'tok-1' }, raw: 'bfat_raw' }),
@@ -82,10 +88,34 @@ describe('OAuthService', () => {
     for (const m of Object.keys(mockDb)) mockDb[m].mockReturnValue(mockDb);
   });
 
-  it('publishes RFC 8414 metadata on the issuer', () => {
+  it('publishes RFC 8414 metadata on the issuer — the admin host, never the public site', () => {
     const { service } = make();
     const m = service.metadata();
     expect(m.issuer).toBe('https://admin.j5s.dev');
+    // an installed instance: FRONTEND_URL is www.<domain> (a project's rules answer its /api/*), ADMIN_DOMAIN the admin host
+    expect(
+      make({
+        FRONTEND_URL: 'https://www.example.com',
+        ADMIN_DOMAIN: 'admin.example.com',
+      }).service.issuer(),
+    ).toBe('https://admin.example.com');
+    // an explicit issuer wins; a scheme on ADMIN_DOMAIN is kept
+    expect(make({ OAUTH_ISSUER: 'https://auth.example.com/' }).service.issuer()).toBe(
+      'https://auth.example.com',
+    );
+    expect(make({ ADMIN_DOMAIN: 'http://admin.example.com/' }).service.issuer()).toBe(
+      'http://admin.example.com',
+    );
+    // local dev: admin.localhost is not a host a client can reach — the frontend URL serves both
+    expect(
+      make({
+        FRONTEND_URL: 'http://localhost:5173/',
+        ADMIN_DOMAIN: 'admin.localhost',
+      }).service.issuer(),
+    ).toBe('http://localhost:5173');
+    expect(
+      make({ FRONTEND_URL: 'http://localhost:3000', ADMIN_DOMAIN: undefined }).service.issuer(),
+    ).toBe('http://localhost:3000');
     expect(m.authorization_endpoint).toBe('https://admin.j5s.dev/api/oauth/authorize');
     expect(m.registration_endpoint).toBe('https://admin.j5s.dev/api/oauth/register');
     expect(m.code_challenge_methods_supported).toEqual(['S256']);

--- a/apps/backend/src/oauth/oauth.service.ts
+++ b/apps/backend/src/oauth/oauth.service.ts
@@ -68,9 +68,23 @@ export class OAuthService {
     return secret;
   }
 
-  /** The issuer: the admin host (`FRONTEND_URL`), no trailing slash. */
+  /**
+   * The issuer (RFC 8414): the admin host, where `/api/oauth/*` and the
+   * consent page live. `OAUTH_ISSUER` when set; else `https://<ADMIN_DOMAIN>`
+   * (`admin.<PRIMARY_DOMAIN>` on an installed instance — never `FRONTEND_URL`,
+   * which is the public site `www.<domain>` whose `/api/*` is a project's
+   * proxy rules); else `FRONTEND_URL` for a local dev instance, where the
+   * admin SPA and the API share it.
+   */
   issuer(): string {
-    return (this.config.get<string>('FRONTEND_URL') || 'http://localhost:5173').replace(/\/+$/, '');
+    const trim = (url: string) => url.replace(/\/+$/, '');
+    const explicit = this.config.get<string>('OAUTH_ISSUER');
+    if (explicit) return trim(explicit);
+    const adminDomain = (this.config.get<string>('ADMIN_DOMAIN') || '').trim();
+    if (adminDomain && !/^(admin\.)?(localhost|127\.0\.0\.1)(:\d+)?$/i.test(adminDomain)) {
+      return /^https?:\/\//i.test(adminDomain) ? trim(adminDomain) : `https://${adminDomain}`;
+    }
+    return trim(this.config.get<string>('FRONTEND_URL') || 'http://localhost:5173');
   }
 
   metadata(): AuthorizationServerMetadata {


### PR DESCRIPTION
Follow-up to #734, found the moment v0.4.45 was on j5s.dev:

```
GET https://admin.j5s.dev/.well-known/oauth-authorization-server
→ { "issuer": "https://www.j5s.dev", "token_endpoint": "https://www.j5s.dev/api/oauth/token", … }
POST https://www.j5s.dev/api/oauth/register → 404
```

`OAuthService.issuer()` read `FRONTEND_URL`, and on an installed instance the bootstrap sets that to `https://www.<domain>` — the public site, whose `/api/*` belongs to a project's proxy rules — while the admin panel and `/api/oauth/*` live on `ADMIN_DOMAIN` (`admin.<domain>`). The spec had baked in the wrong assumption (`FRONTEND_URL: 'https://admin.j5s.dev/'`).

## What
```diff
 issuer()
-  FRONTEND_URL                                   # www.<domain> on an installed instance
+  OAUTH_ISSUER                 if set            # explicit override
+  https://<ADMIN_DOMAIN>       if not localhost  # admin.<domain> — where /api/oauth/* and /oauth/consent are
+  FRONTEND_URL                 otherwise         # local dev: the admin SPA and the API share it
```

- `.env.example`: `OAUTH_ISSUER` documented next to `ADMIN_DOMAIN`.
- `CONTEXT.md` glossary (*Authorization server*) states the rule.
- The app-side protected-resource document already names `https://admin.<domain>` (bffless/apps#585), so the two now agree.

## Tests
`oauth.service.spec.ts`: the metadata test now runs with an installed-instance config (`FRONTEND_URL` = www, `ADMIN_DOMAIN` = admin) and pins the four derivations: admin host; explicit `OAUTH_ISSUER`; a scheme on `ADMIN_DOMAIN` kept; local dev falling back to `FRONTEND_URL`. 28 passed; `tsc`, eslint clean.

## Backwards compatibility
Only the OAuth metadata document and the URLs it publishes change; no existing route, session or token path is touched. Needs the next release + j5s bump before the story-9 live walk can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sd1UdizNNZjGLZxyy8FY11