### PR TITLE
fix(auth): lenient OAuth client registration (RFC 7591) — claude.ai's DCR was refused

### DIFF
--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -238,6 +238,22 @@ checklist itself, it is the one file the review process treats as ground truth.
 **Learned from:** PR #734, 2026-09-03 — a `>>>>>>> 02d3564 (…)` trailer was left in this file,
 reformatted into a nested blockquote by prettier, and shipped through three review passes.
 
+### A parameter or route pipe cannot relax the app-wide `ValidationPipe`
+
+**Surface:** any route in `apps/backend/src/**` adding `@Body(new ValidationPipe(…))` or
+`@UsePipes()` to _loosen_ validation (accept unknown properties, skip a check) while
+`main.ts` keeps `useGlobalPipes(new ValidationPipe({ forbidNonWhitelisted: true, … }))`.
+**Check:** Nest chains pipes global → controller → method → parameter on the same value and
+the first to throw wins, so a local pipe can only add strictness. To relax, take the
+parameter untyped (the global pipe skips plain `Object` metatypes) and validate in the
+handler — and prove it with a supertest spec that installs the same global pipe as
+`main.ts` (`oauth-register-http.spec.ts` is the pattern). Only DTO decorator changes
+(`@IsIn` → `@IsString`) are shared between global and local pipes.
+**Why:** The fix silently no-ops for exactly the case it targets, and a unit test that calls
+the local pipe's `.transform()` directly gives false confidence.
+**Learned from:** PR #742, 2026-09-03 — `@Body(registerBodyPipe())` was meant to accept
+claude.ai's RFC 7591 metadata; the global pipe would still have 400'd first.
+
 ---
 
 ## Entry template

--- a/apps/backend/src/oauth/oauth-register-http.spec.ts
+++ b/apps/backend/src/oauth/oauth-register-http.spec.ts
@@ -1,0 +1,94 @@
+import 'reflect-metadata';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { OAuthController } from './oauth.controller';
+import { OAuthService } from './oauth.service';
+import { SessionAuthGuard } from '../auth/session-auth.guard';
+
+/**
+ * The one scenario #742 exists for, end to end: claude.ai's registration body
+ * through an app carrying the SAME global ValidationPipe as main.ts
+ * (`forbidNonWhitelisted: true`). A parameter pipe cannot relax a global one —
+ * Nest runs global pipes first — so the route takes its body untyped and
+ * validates it itself; this proves the global pipe no longer 400s.
+ */
+describe('POST /api/oauth/register behind the app-wide ValidationPipe', () => {
+  let app: INestApplication;
+  const registerClient = jest.fn(async (dto: Record<string, unknown>) => ({
+    client_id: 'c1',
+    client_name: dto.client_name,
+    redirect_uris: dto.redirect_uris,
+    token_endpoint_auth_method: 'none',
+  }));
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [OAuthController],
+      providers: [{ provide: OAuthService, useValue: { registerClient } }],
+    })
+      .overrideGuard(SessionAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    app = moduleRef.createNestApplication();
+    // Exactly main.ts's pipe.
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("registers claude.ai's body — unmodelled RFC 7591 fields stripped, a confidential method downgraded", async () => {
+    const res = await request(app.getHttpServer())
+      .post('/api/oauth/register')
+      .send({
+        client_name: 'Claude',
+        client_uri: 'https://claude.ai',
+        redirect_uris: [
+          'https://claude.ai/api/mcp/auth_callback',
+          'https://claude.com/api/mcp/auth_callback',
+        ],
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'client_secret_post',
+        logo_uri: 'https://claude.ai/logo.png',
+        contacts: ['support@anthropic.com'],
+        software_id: 'claude',
+        software_version: '1',
+        tos_uri: 'https://claude.ai/tos',
+        policy_uri: 'https://claude.ai/privacy',
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.client_id).toBe('c1');
+    expect(res.headers['cache-control']).toBe('no-store');
+    const dto = registerClient.mock.calls[0][0];
+    expect(dto).toMatchObject({
+      client_name: 'Claude',
+      token_endpoint_auth_method: 'client_secret_post',
+    });
+    for (const stripped of [
+      'logo_uri',
+      'contacts',
+      'software_id',
+      'software_version',
+      'tos_uri',
+      'policy_uri',
+    ]) {
+      expect(dto).not.toHaveProperty(stripped);
+    }
+  });
+
+  it("answers invalid metadata in the RFC shape, not Nest's", async () => {
+    const res = await request(app.getHttpServer())
+      .post('/api/oauth/register')
+      .send({ client_name: 42 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_client_metadata');
+    expect(typeof res.body.error_description).toBe('string');
+    expect(res.body).not.toHaveProperty('statusCode');
+  });
+});

--- a/apps/backend/src/oauth/oauth.controller.spec.ts
+++ b/apps/backend/src/oauth/oauth.controller.spec.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import { Request, Response } from 'express';
-import { OAuthController } from './oauth.controller';
+import { OAuthController, registerBodyPipe } from './oauth.controller';
+import { RegisterClientDto } from './oauth.dto';
 import { OAuthMetadataController } from './oauth-metadata.controller';
 import { OAuthError } from './oauth.errors';
 import { PUBLIC_PROJECT_ACCESS_KEY } from '../auth/decorators/public-project-access.decorator';
@@ -33,6 +34,35 @@ function make() {
   };
 }
 const res = () => ({ redirect: jest.fn(), set: jest.fn() }) as unknown as Response;
+
+describe('registerBodyPipe (RFC 7591 leniency)', () => {
+  const meta = { type: 'body' as const, metatype: RegisterClientDto };
+  it('strips metadata CE does not model instead of refusing it — what claude.ai sends', async () => {
+    const dto = (await registerBodyPipe().transform(
+      {
+        client_name: 'Claude',
+        client_uri: 'https://claude.ai',
+        redirect_uris: ['https://claude.ai/api/mcp/auth_callback'],
+        logo_uri: 'https://claude.ai/logo.png',
+        contacts: ['support@anthropic.com'],
+        software_id: 'claude',
+        token_endpoint_auth_method: 'client_secret_post',
+      },
+      meta,
+    )) as Record<string, unknown>;
+    expect(dto).toMatchObject({
+      client_name: 'Claude',
+      token_endpoint_auth_method: 'client_secret_post',
+    });
+    expect(dto).not.toHaveProperty('logo_uri');
+    expect(dto).not.toHaveProperty('contacts');
+  });
+  it('answers what fails validation in the RFC error shape', async () => {
+    await expect(registerBodyPipe().transform({ client_name: 42 }, meta)).rejects.toMatchObject({
+      error: 'invalid_client_metadata',
+    });
+  });
+});
 
 describe('OAuth controllers', () => {
   beforeEach(() => jest.clearAllMocks());

--- a/apps/backend/src/oauth/oauth.controller.ts
+++ b/apps/backend/src/oauth/oauth.controller.ts
@@ -26,8 +26,10 @@ const NO_STORE = { 'Cache-Control': 'no-store', Pragma: 'no-cache' };
 /**
  * RFC 7591 registration bodies carry metadata CE does not model (`logo_uri`,
  * `contacts`, `software_id`, …) — the global pipe's `forbidNonWhitelisted`
- * would 400 on every one of them (claude.ai's registration did). Unknown
- * fields are stripped, and what fails validation is answered in the RFC's
+ * would 400 on every one of them (claude.ai's registration did). Applied by
+ * the route itself to its untyped body (a parameter pipe cannot override a
+ * global one — Nest runs global pipes first): unknown fields are stripped,
+ * and what fails validation is answered in the RFC's
  * `{ error: invalid_client_metadata, error_description }` shape.
  */
 export function registerBodyPipe(): ValidationPipe {
@@ -59,10 +61,17 @@ export class OAuthController {
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: 'Dynamic client registration (RFC 7591) — public clients' })
   async register(
-    @Body(registerBodyPipe()) dto: RegisterClientDto,
+    // Untyped on purpose: the app-wide ValidationPipe (`forbidNonWhitelisted`) skips a
+    // plain-object parameter, and global pipes run before any parameter pipe could
+    // relax them — so the lenient validation happens here, on the raw body.
+    @Body() body: unknown,
     @Res({ passthrough: true }) res: Response,
   ) {
     res.set(NO_STORE);
+    const dto = (await registerBodyPipe().transform(body, {
+      type: 'body',
+      metatype: RegisterClientDto,
+    })) as RegisterClientDto;
     return this.oauth.registerClient(dto);
   }
 

--- a/apps/backend/src/oauth/oauth.controller.ts
+++ b/apps/backend/src/oauth/oauth.controller.ts
@@ -9,6 +9,7 @@ import {
   Req,
   Res,
   UseGuards,
+  ValidationPipe,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
@@ -21,6 +22,27 @@ import { OAuthError } from './oauth.errors';
 import { ConsentDecisionDto, RegisterClientDto } from './oauth.dto';
 
 const NO_STORE = { 'Cache-Control': 'no-store', Pragma: 'no-cache' };
+
+/**
+ * RFC 7591 registration bodies carry metadata CE does not model (`logo_uri`,
+ * `contacts`, `software_id`, …) — the global pipe's `forbidNonWhitelisted`
+ * would 400 on every one of them (claude.ai's registration did). Unknown
+ * fields are stripped, and what fails validation is answered in the RFC's
+ * `{ error: invalid_client_metadata, error_description }` shape.
+ */
+export function registerBodyPipe(): ValidationPipe {
+  return new ValidationPipe({
+    whitelist: true,
+    forbidNonWhitelisted: false,
+    transform: true,
+    exceptionFactory: (errors) =>
+      new OAuthError(
+        'invalid_client_metadata',
+        errors.flatMap((e) => Object.values(e.constraints ?? {})).join('; ') ||
+          'invalid client metadata',
+      ),
+  });
+}
 
 /**
  * CE's OAuth 2.1 authorization server on the admin host (ADR-0005). The
@@ -36,7 +58,10 @@ export class OAuthController {
   @Post('register')
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: 'Dynamic client registration (RFC 7591) — public clients' })
-  async register(@Body() dto: RegisterClientDto, @Res({ passthrough: true }) res: Response) {
+  async register(
+    @Body(registerBodyPipe()) dto: RegisterClientDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
     res.set(NO_STORE);
     return this.oauth.registerClient(dto);
   }

--- a/apps/backend/src/oauth/oauth.dto.ts
+++ b/apps/backend/src/oauth/oauth.dto.ts
@@ -3,7 +3,6 @@ import {
   ArrayMinSize,
   IsArray,
   IsBoolean,
-  IsIn,
   IsOptional,
   IsString,
   IsUrl,
@@ -24,21 +23,23 @@ export class RegisterClientDto {
   @MaxLength(255)
   client_name?: string;
 
+  /** Whatever the client asks for, it is registered as a public client (`none`) — RFC 7591 §3.2.1 lets the server substitute and the response says so. */
   @ApiPropertyOptional({ default: 'none' })
   @IsOptional()
-  @IsIn(['none'])
-  token_endpoint_auth_method?: 'none';
+  @IsString()
+  token_endpoint_auth_method?: string;
 
+  /** The supported subset is registered; unsupported entries are dropped, not refused. */
   @ApiPropertyOptional({ type: [String] })
   @IsOptional()
   @IsArray()
-  @IsIn(['authorization_code', 'refresh_token'], { each: true })
+  @IsString({ each: true })
   grant_types?: string[];
 
   @ApiPropertyOptional({ type: [String] })
   @IsOptional()
   @IsArray()
-  @IsIn(['code'], { each: true })
+  @IsString({ each: true })
   response_types?: string[];
 
   @ApiPropertyOptional()

--- a/apps/backend/src/oauth/oauth.service.spec.ts
+++ b/apps/backend/src/oauth/oauth.service.spec.ts
@@ -142,17 +142,29 @@ describe('OAuthService', () => {
         redirectUris: ['https://claude.ai/cb', 'http://localhost:8080/cb'],
       });
     });
-    it('refuses a plain-http remote redirect and a confidential client', async () => {
+    it('refuses a plain-http remote redirect', async () => {
       const { service } = make();
       await expect(
         service.registerClient({ redirect_uris: ['http://evil.example/cb'] }),
       ).rejects.toThrow(OAuthError);
-      await expect(
-        service.registerClient({
-          redirect_uris: ['https://x/cb'],
-          token_endpoint_auth_method: 'client_secret_basic' as never,
-        }),
-      ).rejects.toMatchObject({ error: 'invalid_client_metadata' });
+    });
+    it('registers a client that asked for a secret as a public client and says so (RFC 7591 §3.2.1); drops unsupported grant types', async () => {
+      const { service } = make();
+      mockDb.returning.mockResolvedValueOnce([
+        {
+          ...client,
+          redirectUris: ['https://x/cb'],
+          grantTypes: ['authorization_code'],
+          createdAt: new Date(),
+        },
+      ]);
+      const out = await service.registerClient({
+        redirect_uris: ['https://x/cb'],
+        token_endpoint_auth_method: 'client_secret_basic',
+        grant_types: ['authorization_code', 'implicit'],
+      });
+      expect(out.token_endpoint_auth_method).toBe('none');
+      expect(mockDb.values.mock.calls[0][0]).toMatchObject({ grantTypes: ['authorization_code'] });
     });
   });
 

--- a/apps/backend/src/oauth/oauth.service.ts
+++ b/apps/backend/src/oauth/oauth.service.ts
@@ -30,6 +30,7 @@ export const ACCESS_TOKEN_TTL_S = 3600;
 export const REFRESH_TOKEN_TTL_MS = 30 * 24 * 3600_000;
 export const CODE_TTL_MS = 10 * 60_000;
 export const PENDING_REQUEST_TTL_S = 10 * 60;
+const SUPPORTED_GRANT_TYPES = ['authorization_code', 'refresh_token'];
 const REFRESH_PREFIX = 'bfrt_';
 
 /** What a fetch of the resource's protected-resource document must do (injected for tests). */
@@ -118,15 +119,19 @@ export class OAuthService {
         );
       }
     }
-    if (dto.token_endpoint_auth_method !== undefined && dto.token_endpoint_auth_method !== 'none') {
-      throw new OAuthError(
-        'invalid_client_metadata',
-        'only public clients (token_endpoint_auth_method: none) are registered',
+    // RFC 7591 §3.2.1: the server may register different values than requested and
+    // MUST return the ones it registered. Every client is a public client here —
+    // there is no secret to issue — and a client that asked for another method
+    // is told `none` in the response (claude.ai and the MCP SDKs honour it).
+    if (dto.token_endpoint_auth_method && dto.token_endpoint_auth_method !== 'none') {
+      this.logger.log(
+        `OAuth client registration asked for ${dto.token_endpoint_auth_method}; registered as a public client (none)`,
       );
     }
-    const grantTypes = dto.grant_types?.length
-      ? dto.grant_types
-      : ['authorization_code', 'refresh_token'];
+    const requestedGrants = (dto.grant_types ?? []).filter((g) =>
+      SUPPORTED_GRANT_TYPES.includes(g),
+    );
+    const grantTypes = requestedGrants.length ? requestedGrants : [...SUPPORTED_GRANT_TYPES];
     const [row] = await db
       .insert(oauthClients)
       .values({ clientName: dto.client_name?.trim() || 'Unnamed client', redirectUris, grantTypes })


### PR DESCRIPTION
Found at the Phase-3 gate (bffless/apps#554, apps#585): claude.ai's connector dialog detects OAuth on `workflow.j5s.dev`, picks dynamic registration, and fails with *"Couldn't register with workflow's sign-in service"* (their API: `mcp_registration_failed`). Our own walk registers fine, so the difference is the request body: CE's global `ValidationPipe` has `forbidNonWhitelisted: true`, and a registration carrying any RFC 7591 metadata CE does not model gets a Nest-shaped 400:

```
POST /api/oauth/register {"redirect_uris":[…],"logo_uri":…,"contacts":[…],"software_id":…}
→ 400 {"message":["property logo_uri should not exist","property contacts should not exist",…]}
POST /api/oauth/register {…,"token_endpoint_auth_method":"client_secret_post"}
→ 400 {"message":["token_endpoint_auth_method must be one of the following values: none"]}
```

## What
```diff
 POST /api/oauth/register
-  global pipe: whitelist + forbidNonWhitelisted → 400 on logo_uri / contacts / software_id / …
-  token_endpoint_auth_method must be none      → 400 otherwise
-  grant_types must be ⊆ supported              → 400 otherwise
+  body taken untyped (the global pipe skips a plain object — a parameter pipe cannot relax it, global pipes run first)
+  registerBodyPipe() applied in the handler: whitelist, unknown fields stripped; failures → { error: invalid_client_metadata, error_description }
+  any token_endpoint_auth_method accepted; the client is registered as public and the response says `none` (RFC 7591 §3.2.1)
+  grant_types: the supported subset is registered (default both)
```
`redirect_uris` stay strict (https, or http on localhost). No other route changes.

## Tests
- **`oauth-register-http.spec.ts`** (supertest): the controller behind `main.ts`'s exact global `ValidationPipe`; claude.ai's body → 201 with `logo_uri`/`contacts`/`software_id`/… stripped and the confidential method downgraded; invalid metadata → 400 in the RFC shape. The one scenario this PR is for, end to end.
- `registerBodyPipe`: a claude.ai-shaped body with `logo_uri`/`contacts`/`software_id`/`client_secret_post` passes with the unknown fields stripped; an invalid body answers in the RFC shape.
- `registerClient`: a confidential-method request is registered as `none`; `implicit` is dropped from `grant_types`.
- OAuth suites 33 passed; `tsc`, eslint clean.

Follow-up filed: #741 (CIMD — claude.ai's *recommended* mode). Needs release + j5s bump, then the connector flow is retried for the gate screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sd1UdizNNZjGLZxyy8FY11
