### PR TITLE
fix(frontend): config panel for mcp_handler steps (was "Unknown handler type")

### DIFF
--- a/apps/frontend/src/components/pipelines/handlers/HandlerConfigWrapper.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/HandlerConfigWrapper.tsx
@@ -30,6 +30,7 @@ import { XmlFeedParseConfig } from './XmlFeedParseConfig';
 import { DataUpsertManyConfig } from './DataUpsertManyConfig';
 import { DelayHandlerConfig } from './DelayHandlerConfig';
 import { FfmpegHandlerConfig } from './FfmpegHandlerConfig';
+import { McpHandlerConfig } from './McpHandlerConfig';
 import { AvailableVariables, type PreviousStep } from './AvailableVariables';
 import type { HandlerConfig } from './types';
 
@@ -427,6 +428,10 @@ export function HandlerConfigWrapper({
           />
         </>
       );
+
+    case 'mcp_handler':
+      // No expressions panel: the config is a declaration, not a step over prior outputs.
+      return <McpHandlerConfig config={config} onChange={handleChange} />;
 
     default:
       return (

--- a/apps/frontend/src/components/pipelines/handlers/McpHandlerConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/McpHandlerConfig.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { McpHandlerConfig } from './McpHandlerConfig';
+import { summarizeMcpConfig } from './mcp-config-summary';
+
+const config = {
+  serverInfo: { name: 'bffless-workflow', version: '1.0.0' },
+  tools: [
+    { name: 'workflow.list', rule: { path: '/api/workflow/mcp-tools/list', method: 'POST' } },
+    { name: 'workflow.status', rule: { path: '/api/workflow/mcp-tools/status', method: 'POST' } },
+  ],
+  resources: {
+    static: [
+      {
+        uri: 'ui://bffless/workflow/step.html',
+        rule: { path: '/api/workflow/mcp-resources/step-view' },
+      },
+    ],
+    templates: [
+      { uriTemplate: 'ui://bffless/{impl}/{path+}', rule: { path: '/w/{impl}/{path+}' } },
+    ],
+  },
+};
+
+describe('McpHandlerConfig', () => {
+  it('summarizes what the config declares', () => {
+    expect(summarizeMcpConfig(config)).toEqual({
+      server: 'bffless-workflow',
+      tools: ['workflow.list', 'workflow.status'],
+      staticResources: 1,
+      templates: 1,
+    });
+    render(<McpHandlerConfig config={config} onChange={() => {}} />);
+    expect(screen.getByText(/MCP server: bffless-workflow/)).toBeInTheDocument();
+    expect(screen.getByTestId('mcp-summary').textContent).toContain(
+      '2 tools (workflow.list, workflow.status)',
+    );
+    expect(screen.getByTestId('mcp-summary').textContent).toContain('1 static resource');
+  });
+
+  it('applies a parsed edit on blur and reports one that does not parse without sending it', () => {
+    const onChange = vi.fn();
+    render(<McpHandlerConfig config={config} onChange={onChange} />);
+    const editor = screen.getByLabelText('Configuration (JSON)') as HTMLTextAreaElement;
+    expect(editor.value).toContain('"workflow.list"');
+
+    fireEvent.change(editor, { target: { value: '{"serverInfo":{"name":"x"},"tools":[]}' } });
+    fireEvent.blur(editor);
+    expect(onChange).toHaveBeenCalledWith({ serverInfo: { name: 'x' }, tools: [] });
+
+    fireEvent.change(editor, { target: { value: '{"tools": [' } });
+    fireEvent.blur(editor);
+    expect(screen.getByRole('alert').textContent).toMatch(/Not saved/);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(editor, { target: { value: '[1,2]' } });
+    fireEvent.blur(editor);
+    expect(screen.getByRole('alert').textContent).toMatch(/must be a JSON object/);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an empty config without blowing up', () => {
+    render(<McpHandlerConfig config={{}} onChange={() => {}} />);
+    expect(screen.getByTestId('mcp-summary').textContent).toContain('0 tools');
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/McpHandlerConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/McpHandlerConfig.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { isRecord, summarizeMcpConfig } from './mcp-config-summary';
+
+interface Props {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+}
+
+/**
+ * `mcp_handler` is authored as code (a rule set's YAML, or an app rendering it
+ * from its tool catalog), not as a form: the config is the MCP server — its
+ * tools, each mapped to a sibling rule, and its `ui://` resources. The panel
+ * shows what the config declares and lets an operator edit the JSON directly;
+ * a body that does not parse is reported and never sent.
+ */
+export function McpHandlerConfig({ config, onChange }: Props) {
+  const [text, setText] = useState(() => JSON.stringify(config ?? {}, null, 2));
+  const [error, setError] = useState<string | null>(null);
+
+  // A config replaced from outside (another step selected, a reload) resets the editor.
+  useEffect(() => {
+    setText(JSON.stringify(config ?? {}, null, 2));
+    setError(null);
+  }, [config]);
+
+  const summary = useMemo(() => summarizeMcpConfig(config ?? {}), [config]);
+
+  const commit = () => {
+    try {
+      const parsed: unknown = JSON.parse(text);
+      if (!isRecord(parsed)) throw new Error('the config must be a JSON object');
+      setError(null);
+      onChange(parsed);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border bg-muted/30 p-3 space-y-1.5 text-xs">
+        <p className="font-medium text-muted-foreground">
+          MCP server{summary.server ? `: ${summary.server}` : ''}
+        </p>
+        <p className="text-muted-foreground" data-testid="mcp-summary">
+          {summary.tools.length} tool{summary.tools.length === 1 ? '' : 's'}
+          {summary.tools.length ? ` (${summary.tools.join(', ')})` : ''} · {summary.staticResources}{' '}
+          static resource{summary.staticResources === 1 ? '' : 's'} · {summary.templates} resource
+          template{summary.templates === 1 ? '' : 's'}
+        </p>
+        <p className="text-muted-foreground">
+          Each tool names a sibling rule of this alias (<code>rule.path</code>) that answers it
+          in-process as the caller; resources map <code>ui://</code> URIs to sibling paths. This
+          step is usually rendered from the app&apos;s own code and synced with{' '}
+          <code>bffless rules push</code>.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="mcp-config-json">Configuration (JSON)</Label>
+        <Textarea
+          id="mcp-config-json"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onBlur={commit}
+          spellCheck={false}
+          className="font-mono text-xs min-h-[320px]"
+        />
+        {error ? (
+          <p className="text-xs text-destructive" role="alert">
+            Not saved — {error}
+          </p>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            <code>serverInfo</code>, <code>instructions</code>, <code>tools[]</code> (
+            <code>name</code>, <code>description</code>, <code>inputSchema</code>,{' '}
+            <code>rule: {'{ path, method }'}</code>, optional <code>visibility</code>,{' '}
+            <code>_meta</code>), <code>resources</code> (<code>static[]</code>,{' '}
+            <code>templates[]</code>, <code>list.rule</code>, <code>csp</code>). Edits apply when
+            the field loses focus.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/pipelines/handlers/mcp-config-summary.ts
+++ b/apps/frontend/src/components/pipelines/handlers/mcp-config-summary.ts
@@ -1,0 +1,25 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** What an `mcp_handler` config declares, for the summary line: server name, tools, resources. */
+export function summarizeMcpConfig(config: Record<string, unknown>): {
+  server: string;
+  tools: string[];
+  staticResources: number;
+  templates: number;
+} {
+  const serverInfo = isRecord(config.serverInfo) ? config.serverInfo : {};
+  const tools = Array.isArray(config.tools)
+    ? config.tools
+        .map((t: unknown) => (isRecord(t) && typeof t.name === 'string' ? t.name : ''))
+        .filter((n: string) => n !== '')
+    : [];
+  const resources = isRecord(config.resources) ? config.resources : {};
+  return {
+    server: typeof serverInfo.name === 'string' ? serverInfo.name : '',
+    tools,
+    staticResources: Array.isArray(resources.static) ? resources.static.length : 0,
+    templates: Array.isArray(resources.templates) ? resources.templates.length : 0,
+  };
+}


### PR DESCRIPTION
Seen on `admin.j5s.dev` opening the Workflow harness's `POST /api/workflow/mcp` rule after #731: the handler picker shows *MCP Server…*, the panel below it says **Unknown handler type: mcp_handler**. #731 added the label and description but no case in `HandlerConfigWrapper`'s switch, so the default branch rendered.

## What
`McpHandlerConfig` — the step is authored as code (a rule set's YAML, or the app rendering it from its tool catalog), so the panel is a summary plus a JSON editor rather than a form:
- a summary of what the config declares: server name, the tools (each naming a sibling rule), static resources and resource templates;
- the configuration as JSON, applied on blur; a body that does not parse, or is not an object, is reported ("Not saved — …") and never sent;
- the key shape (`serverInfo`, `instructions`, `tools[]`, `resources`) in the helper text.

`summarizeMcpConfig` lives in `mcp-config-summary.ts` (react-refresh wants component files to export only components). No expressions panel: this config is a declaration, not a step over prior outputs.

## Tests
`McpHandlerConfig.test.tsx`: the summary; a parsed edit reaches `onChange`; a non-parsing and a non-object body are reported and not sent; an empty config renders. `tsc`, eslint (0 warnings on the new files) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sd1UdizNNZjGLZxyy8FY11