### PR TITLE
fix(deployments): wildcard subdomain handler serves a mapped host from its domain mapping

### DIFF
--- a/apps/backend/src/deployments/public.controller.spec.ts
+++ b/apps/backend/src/deployments/public.controller.spec.ts
@@ -607,6 +607,87 @@ describe('PublicController', () => {
     });
   });
 
+  describe('serveSubdomainAlias (nginx wildcard catch-all)', () => {
+    const setupDbMock = (results: any[]) => {
+      let callIndex = 0;
+      mockDb.then.mockImplementation((resolve: any) => {
+        const result = results[callIndex] || [];
+        callIndex++;
+        return resolve(result);
+      });
+    };
+    const requestFor = (host: string) =>
+      ({
+        headers: { 'x-forwarded-host': host },
+        path: `/public/subdomain-alias/${host.split('.')[0]}/index.html`,
+        cookies: {},
+        query: {},
+      }) as unknown as Request;
+
+    it("serves a mapped host from its domain mapping — project, alias and path prefix — even though an alias of the subdomain's name exists elsewhere", async () => {
+      // The host's own server block was not loaded (a restart mid-regeneration), so the
+      // wildcard vhost sent the request here as subdomain-alias/workflow. Two projects
+      // hold an alias named "workflow"; the mapping says which one, and where its files are.
+      const mapping = {
+        id: 'map-1',
+        domain: 'workflow.example.com',
+        isActive: true,
+        projectId: mockPublicProject.id,
+        alias: 'workflow',
+        path: '/apps/workflow/dist',
+        domainType: 'subdomain',
+        wwwBehavior: null,
+      };
+      setupDbMock([[mapping]]);
+      (mockProjectsService as any).getProjectById = jest.fn().mockResolvedValue(mockPublicProject);
+      const getAsset = jest.fn().mockResolvedValue(mockAsset);
+      (controller as any).getAssetWithCache = getAsset;
+      const res = createMockResponse();
+
+      await controller.serveSubdomainAlias(
+        'workflow',
+        'index.html',
+        requestFor('workflow.example.com'),
+        res,
+      );
+
+      expect(mockDeploymentsService.resolveAlias).toHaveBeenCalledWith(mockRepository, 'workflow');
+      expect(getAsset).toHaveBeenCalledWith(
+        mockPublicProject.id,
+        mockCommitSha,
+        'apps/workflow/dist/index.html',
+      );
+      // the mapping answered; the alias-name lookup (a second SELECT) never ran
+      expect(mockDb.then).toHaveBeenCalledTimes(1);
+    });
+
+    it('serves a host with no mapping by alias name — the auto-preview subdomain case', async () => {
+      const aliasRecord = {
+        id: 'alias-1',
+        projectId: mockPublicProject.id,
+        alias: 'abc123-preview',
+        commitSha: mockCommitSha,
+        isAutoPreview: true,
+        basePath: null,
+      };
+      // no mapping for the host, no www variant, then the alias row
+      setupDbMock([[], [], [aliasRecord]]);
+      (mockProjectsService as any).getProjectById = jest.fn().mockResolvedValue(mockPublicProject);
+      const getAsset = jest.fn().mockResolvedValue(mockAsset);
+      (controller as any).getAssetWithCache = getAsset;
+      const res = createMockResponse();
+
+      await controller.serveSubdomainAlias(
+        'abc123-preview',
+        'index.html',
+        requestFor('abc123-preview.example.com'),
+        res,
+      );
+
+      expect(getAsset).toHaveBeenCalledWith(mockPublicProject.id, mockCommitSha, 'index.html');
+    });
+  });
+
   describe('MIME type detection', () => {
     const setupDbMock = (results: any[]) => {
       let callIndex = 0;

--- a/apps/backend/src/deployments/public.controller.ts
+++ b/apps/backend/src/deployments/public.controller.ts
@@ -106,6 +106,20 @@ export class PublicController {
       `[serveSubdomainAlias] Request: aliasName=${aliasName}, filePath=${filePath}`,
     );
 
+    // A host that has a domain mapping is that mapping's — its project, its
+    // alias, its path prefix, its access control — even when nginx's wildcard
+    // catch-all intercepted the request because the host's own server block is
+    // not loaded (not written yet after a restart, or a reload that did not
+    // take). The alias-name lookup below is for hosts with no mapping: the
+    // auto-generated preview subdomains. Consulting it first for a mapped host
+    // served files from an alias that merely shares the subdomain's name — in
+    // whichever project holds one — without the mapping's path prefix.
+    const forwardedHost = req.headers['x-forwarded-host'] as string | undefined;
+    if (forwardedHost) {
+      const served = await this.serveDomainMappingFallback(forwardedHost, filePath, req, res);
+      if (served) return;
+    }
+
     // Look up alias by name across all projects
     const [aliasRecord] = await db
       .select()
@@ -114,19 +128,9 @@ export class PublicController {
       .limit(1);
 
     if (!aliasRecord) {
-      // Fallback: check if the original host matches a domain mapping.
-      // This handles the case where nginx's wildcard catch-all intercepts requests
-      // that should have gone to domain-specific server blocks (e.g., when the
-      // domain config hasn't been loaded by nginx yet, or after a restart).
       this.logger.debug(
-        `[serveSubdomainAlias] Alias '${aliasName}' not found, checking domain mapping fallback`,
+        `[serveSubdomainAlias] Alias '${aliasName}' not found and no domain mapping for the host`,
       );
-      const forwardedHost = req.headers['x-forwarded-host'] as string | undefined;
-      if (forwardedHost) {
-        const served = await this.serveDomainMappingFallback(forwardedHost, filePath, req, res);
-        if (served) return;
-      }
-
       return this.serve404Page(res);
     }
 


### PR DESCRIPTION
Found on j5s.dev after the v0.4.47 restart: `workflow.j5s.dev` and `hello.j5s.dev` (both mappings of `bffless/workflow`, paths `/apps/workflow/dist` and `/dist`) answered 404 on every file with a valid session, while the raw stored path (`/apps/workflow/dist/step.html`) served — the mapping's path prefix was not being applied. The backend log shows all 17 domain configs regenerated with 0 errors, so the requests were reaching the **wildcard `*.<domain>` vhost** rather than the host's own server block, and its handler served them wrong.

## The bug
`PublicController.serveSubdomainAlias` (what the wildcard vhost rewrites to, `/public/subdomain-alias/<sub>/…`) looked the subdomain up **as an alias name across all projects** first and, when one existed, served that alias directly — "no domain mapping path prefix", in whichever project happened to hold an alias of that name. The host's **domain mapping** was consulted only when no alias of that name existed anywhere. Its own comment names the scenario it meant to cover ("when the domain config hasn't been loaded by nginx yet, or after a restart") — but for any mapped host whose subdomain equals an alias name (the normal case: `workflow.j5s.dev` → alias `workflow`), the fallback never ran.

```diff
 serveSubdomainAlias(aliasName, filePath, req, res)
-  alias = SELECT … FROM deployment_aliases WHERE alias = aliasName   # any project
-  if alias → serve it directly (no mapping path prefix)
-  else if x-forwarded-host has a mapping → serveDomainMappingFallback
+  if x-forwarded-host has a mapping → serveDomainMappingFallback   # project, alias, path, access control
+  else alias = SELECT … WHERE alias = aliasName → serve it (auto-preview subdomains)
```

`serveDomainMappingFallback` already does everything right (mapping → project → traffic variant → alias → path prefix → `serveAssetInternal` with the domain's access control); it just never got the chance.

## Tests
`public.controller.spec.ts`: a mapped host whose subdomain matches an alias name elsewhere is served from the mapping with the prefixed path (`apps/workflow/dist/index.html`) and the alias-name lookup never runs; a host with no mapping is served by alias name. 24 passed; `tsc` clean.

## Not in this PR
Why nginx on j5s ended up without those two server blocks after a clean regeneration (the write order puts them 15th/16th of 17; a container coming up mid-write and a reload that did not take would explain it) — the operator is checking `nginx -t`. Whatever that turns out to be, with this fix a mapped host keeps serving correctly from the wildcard vhost in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sd1UdizNNZjGLZxyy8FY11