### PR TITLE
fix(nginx): coalesce config-write bursts into one reload; atomic writes; in-place startup regeneration

### DIFF
--- a/.github/workflows/shell-checks.yml
+++ b/.github/workflows/shell-checks.yml
@@ -6,6 +6,7 @@ on:
       - '*.sh'
       - 'scripts/**'
       - 'marketplace/**'
+      - 'docker/nginx/**'
       - '.github/workflows/shell-checks.yml'
 
 permissions:
@@ -33,6 +34,7 @@ jobs:
             marketplace/digitalocean/scripts/030-bffless.sh \
             marketplace/digitalocean/files/first-login.sh \
             marketplace/digitalocean/files/first-login.test.sh \
+            docker/nginx/nginx-reload-watcher.sh docker/nginx/nginx-reload-watcher.test.sh \
             marketplace/digitalocean/files/etc/update-motd.d/99-bffless-readme \
             marketplace/digitalocean/files/var/lib/cloud/scripts/per-instance/001-swap \
             marketplace/digitalocean/files/var/lib/cloud/scripts/per-instance/002-bffless-first-boot
@@ -44,6 +46,7 @@ jobs:
           bash scripts/lifecycle.test.sh
           bash scripts/channel.test.sh
           bash marketplace/digitalocean/files/first-login.test.sh
+          sh docker/nginx/nginx-reload-watcher.test.sh
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/shell-checks.yml
+++ b/.github/workflows/shell-checks.yml
@@ -35,6 +35,7 @@ jobs:
             marketplace/digitalocean/files/first-login.sh \
             marketplace/digitalocean/files/first-login.test.sh \
             docker/nginx/nginx-reload-watcher.sh docker/nginx/nginx-reload-watcher.test.sh \
+            docker/nginx/nginx-boot-guard.sh docker/nginx/nginx-boot-guard.test.sh \
             marketplace/digitalocean/files/etc/update-motd.d/99-bffless-readme \
             marketplace/digitalocean/files/var/lib/cloud/scripts/per-instance/001-swap \
             marketplace/digitalocean/files/var/lib/cloud/scripts/per-instance/002-bffless-first-boot
@@ -47,6 +48,7 @@ jobs:
           bash scripts/channel.test.sh
           bash marketplace/digitalocean/files/first-login.test.sh
           sh docker/nginx/nginx-reload-watcher.test.sh
+          sh docker/nginx/nginx-boot-guard.test.sh
 
       - uses: actions/setup-node@v4
         with:

--- a/apps/backend/src/domains/nginx-config.service.spec.ts
+++ b/apps/backend/src/domains/nginx-config.service.spec.ts
@@ -837,13 +837,16 @@ server {
       const config = 'server { listen 80; }';
       const result = await service.writeConfigFile('domain-1', config);
 
+      // The temp file sits beside its target (dot-prefixed, outside nginx's
+      // `*.conf` include) so the move into place is an atomic rename.
       expect(mockWriteFile).toHaveBeenCalledWith(
-        expect.stringContaining('/tmp/domain-domain-1.conf'),
+        expect.stringContaining('/.domain-domain-1.conf.tmp'),
         config,
         'utf-8',
       );
-      expect(result.tempPath).toContain('/tmp/domain-domain-1.conf');
-      expect(result.finalPath).toContain('domain-domain-1.conf');
+      expect(result.tempPath).toContain('/.domain-domain-1.conf.tmp');
+      expect(result.tempPath.replace(/[^/]*$/, '')).toBe(result.finalPath.replace(/[^/]*$/, ''));
+      expect(result.finalPath).toMatch(/\/domain-domain-1\.conf$/);
     });
   });
 

--- a/apps/backend/src/domains/nginx-config.service.ts
+++ b/apps/backend/src/domains/nginx-config.service.ts
@@ -888,12 +888,7 @@ ${spaFallback}
   ): Promise<{ tempPath: string; finalPath: string }> {
     const filename = `domain-${domainMappingId}.conf`;
     const finalPath = join(this.getNginxSitesPath(), filename);
-    // The temp file lives beside its target so the move into place is an
-    // atomic rename on the same filesystem (nginx and its watcher never see a
-    // half-written file). The dot prefix keeps it out of nginx's
-    // `include sites-enabled/*.conf` and out of the watcher's reload until it
-    // is renamed — inotify reports that rename as moved_to.
-    const tempPath = join(this.getNginxSitesPath(), `.${filename}.tmp`);
+    const tempPath = this.stagingPathFor(filename);
 
     // Write to temp file
     await writeFile(tempPath, config, 'utf-8');
@@ -910,6 +905,18 @@ ${spaFallback}
     } catch {
       this.logger.warn(`Config file not found: ${nginxConfigPath}`);
     }
+  }
+
+  /**
+   * Where a rendered config is staged before it is renamed into place: beside
+   * its target, dot-prefixed and `.tmp`-suffixed — same filesystem (so the
+   * move is one atomic rename and nginx never sees a half-written file), and
+   * outside nginx's `include sites-enabled/*.conf` until renamed. Every
+   * writer in this service stages here; `/tmp` is another filesystem in the
+   * container and would force a copy.
+   */
+  stagingPathFor(filename: string): string {
+    return join(this.getNginxSitesPath(), `.${filename}.tmp`);
   }
 
   getConfigFilePath(domainMappingId: string): string {
@@ -1179,7 +1186,7 @@ ${httpServerBlock}${httpsServerBlock}
     const baseDomain = this.getBaseDomain();
     // Use domain mapping ID in filename for consistency with other domain mappings
     const filename = `domain-${config.id}.conf`;
-    const tempPath = join('/tmp', filename);
+    const tempPath = this.stagingPathFor(filename);
     const finalPath = join(this.getNginxSitesPath(), filename);
 
     // Check if nginx should handle SSL directly
@@ -1586,7 +1593,7 @@ ${proxyRulesComment}${serverBlocks}`;
   async generateWelcomePageConfig(): Promise<{ tempPath: string; finalPath: string }> {
     const baseDomain = this.getBaseDomain();
     const filename = 'primary-content.conf';
-    const tempPath = join('/tmp', filename);
+    const tempPath = this.stagingPathFor(filename);
     const finalPath = join(this.getNginxSitesPath(), filename);
 
     const nginxConfig = this.generateWelcomePageNginxConfig(baseDomain);
@@ -1877,7 +1884,7 @@ ${this.buildEdgeBlocklistRules('444')}
     config: string,
   ): Promise<{ tempPath: string; finalPath: string }> {
     const filename = `redirect-${redirectId}.conf`;
-    const tempPath = join('/tmp', filename);
+    const tempPath = this.stagingPathFor(filename);
     const finalPath = join(this.getNginxSitesPath(), filename);
 
     await writeFile(tempPath, config, 'utf-8');

--- a/apps/backend/src/domains/nginx-config.service.ts
+++ b/apps/backend/src/domains/nginx-config.service.ts
@@ -887,8 +887,13 @@ ${spaFallback}
     config: string,
   ): Promise<{ tempPath: string; finalPath: string }> {
     const filename = `domain-${domainMappingId}.conf`;
-    const tempPath = join('/tmp', filename);
     const finalPath = join(this.getNginxSitesPath(), filename);
+    // The temp file lives beside its target so the move into place is an
+    // atomic rename on the same filesystem (nginx and its watcher never see a
+    // half-written file). The dot prefix keeps it out of nginx's
+    // `include sites-enabled/*.conf` and out of the watcher's reload until it
+    // is renamed — inotify reports that rename as moved_to.
+    const tempPath = join(this.getNginxSitesPath(), `.${filename}.tmp`);
 
     // Write to temp file
     await writeFile(tempPath, config, 'utf-8');

--- a/apps/backend/src/domains/nginx-reload.service.spec.ts
+++ b/apps/backend/src/domains/nginx-reload.service.spec.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs/promises';
 // Mock fs/promises
 jest.mock('fs/promises', () => ({
   copyFile: jest.fn(),
+  rename: jest.fn(),
   unlink: jest.fn(),
   access: jest.fn(),
 }));
@@ -12,6 +13,7 @@ jest.mock('fs/promises', () => ({
 describe('NginxReloadService', () => {
   let service: NginxReloadService;
   let mockCopyFile: jest.MockedFunction<typeof fs.copyFile>;
+  let mockRename: jest.MockedFunction<typeof fs.rename>;
   let mockUnlink: jest.MockedFunction<typeof fs.unlink>;
   let mockAccess: jest.MockedFunction<typeof fs.access>;
 
@@ -20,11 +22,13 @@ describe('NginxReloadService', () => {
     process.env.NGINX_RELOAD_WAIT_MS = '100'; // Reduce wait time for tests
 
     mockCopyFile = fs.copyFile as jest.MockedFunction<typeof fs.copyFile>;
+    mockRename = fs.rename as jest.MockedFunction<typeof fs.rename>;
     mockUnlink = fs.unlink as jest.MockedFunction<typeof fs.unlink>;
     mockAccess = fs.access as jest.MockedFunction<typeof fs.access>;
 
     // Default mock implementations
     mockCopyFile.mockResolvedValue(undefined);
+    mockRename.mockResolvedValue(undefined);
     mockUnlink.mockResolvedValue(undefined);
     mockAccess.mockResolvedValue(undefined);
 
@@ -45,23 +49,35 @@ describe('NginxReloadService', () => {
   });
 
   describe('validateAndReload', () => {
-    it('should copy config file, delete temp, and return success', async () => {
+    it('renames the temp file into place (atomic on one filesystem) and returns success', async () => {
+      const tempPath = '/etc/nginx/sites-enabled/.domain-1.conf.tmp';
+      const finalPath = '/etc/nginx/sites-enabled/domain-1.conf';
+
+      const result = await service.validateAndReload(tempPath, finalPath);
+
+      expect(mockRename).toHaveBeenCalledWith(tempPath, finalPath);
+      expect(mockCopyFile).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('falls back to copy + unlink when the temp file is on another filesystem (EXDEV)', async () => {
       const tempPath = '/tmp/domain-1.conf';
       const finalPath = '/etc/nginx/sites-enabled/domain-1.conf';
+      mockRename.mockRejectedValueOnce(Object.assign(new Error('cross-device'), { code: 'EXDEV' }));
 
       const result = await service.validateAndReload(tempPath, finalPath);
 
       expect(mockCopyFile).toHaveBeenCalledWith(tempPath, finalPath);
       expect(mockUnlink).toHaveBeenCalledWith(tempPath);
       expect(result.success).toBe(true);
-      expect(result.error).toBeUndefined();
     });
 
-    it('should return failure on copyFile error', async () => {
+    it('should return failure on a write error', async () => {
       const tempPath = '/tmp/domain-1.conf';
       const finalPath = '/etc/nginx/sites-enabled/domain-1.conf';
 
-      mockCopyFile.mockRejectedValue(new Error('Permission denied'));
+      mockRename.mockRejectedValue(new Error('Permission denied'));
 
       const result = await service.validateAndReload(tempPath, finalPath);
 
@@ -84,16 +100,15 @@ describe('NginxReloadService', () => {
   });
 
   describe('writeConfigOnly', () => {
-    it('copies the temp file to final, deletes temp, and does NOT wait for nginx', async () => {
-      const tempPath = '/tmp/domain-bulk.conf';
+    it('renames the temp file into place and does NOT wait for nginx', async () => {
+      const tempPath = '/etc/nginx/sites-enabled/.domain-bulk.conf.tmp';
       const finalPath = '/etc/nginx/sites-enabled/domain-bulk.conf';
 
       const startTime = Date.now();
       const result = await service.writeConfigOnly(tempPath, finalPath);
       const elapsed = Date.now() - startTime;
 
-      expect(mockCopyFile).toHaveBeenCalledWith(tempPath, finalPath);
-      expect(mockUnlink).toHaveBeenCalledWith(tempPath);
+      expect(mockRename).toHaveBeenCalledWith(tempPath, finalPath);
       expect(result.success).toBe(true);
       expect(result.error).toBeUndefined();
       // Must return well before NGINX_RELOAD_WAIT_MS (100ms in test) — otherwise
@@ -101,14 +116,14 @@ describe('NginxReloadService', () => {
       expect(elapsed).toBeLessThan(50);
     });
 
-    it('returns failure on copyFile error without throwing', async () => {
-      mockCopyFile.mockRejectedValueOnce(new Error('disk full'));
+    it('returns failure on a write error without throwing', async () => {
+      mockRename.mockRejectedValueOnce(new Error('disk full'));
 
-      const result = await service.writeConfigOnly('/tmp/x.conf', '/etc/nginx/x.conf');
+      const result = await service.writeConfigOnly('/etc/nginx/.x.conf.tmp', '/etc/nginx/x.conf');
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('disk full');
-      // Temp file should NOT be unlinked when copy failed (would mask the original error)
+      // Temp file should NOT be unlinked when the move failed (would mask the original error)
       expect(mockUnlink).not.toHaveBeenCalled();
     });
   });

--- a/apps/backend/src/domains/nginx-reload.service.ts
+++ b/apps/backend/src/domains/nginx-reload.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { copyFile, unlink, access } from 'fs/promises';
+import { copyFile, rename, unlink, access } from 'fs/promises';
 
 @Injectable()
 export class NginxReloadService {
@@ -19,10 +19,8 @@ export class NginxReloadService {
     finalConfigPath: string,
   ): Promise<{ success: boolean; error?: string }> {
     try {
-      // Copy config to final location (can't use rename across filesystems in Docker)
-      this.logger.log(`Copying config to: ${finalConfigPath}`);
-      await copyFile(tempConfigPath, finalConfigPath);
-      await unlink(tempConfigPath);
+      this.logger.log(`Moving config into place: ${finalConfigPath}`);
+      await this.moveIntoPlace(tempConfigPath, finalConfigPath);
 
       // File watcher will detect change and reload automatically
       this.logger.log('Config written, nginx watcher will reload automatically (2-5s)');
@@ -92,8 +90,7 @@ export class NginxReloadService {
     finalConfigPath: string,
   ): Promise<{ success: boolean; error?: string }> {
     try {
-      await copyFile(tempConfigPath, finalConfigPath);
-      await unlink(tempConfigPath);
+      await this.moveIntoPlace(tempConfigPath, finalConfigPath);
       return { success: true };
     } catch (error) {
       this.logger.error('Failed to write config', error);
@@ -101,6 +98,22 @@ export class NginxReloadService {
         success: false,
         error: error instanceof Error ? error.message : 'Unknown error',
       };
+    }
+  }
+
+  /**
+   * Put a rendered config into place atomically: a rename when the temp file
+   * is on the same filesystem (NginxConfigService writes it beside its target,
+   * so this is the normal case — nginx never sees a half-written file), with a
+   * copy-and-unlink fallback for a temp path on another filesystem.
+   */
+  private async moveIntoPlace(tempConfigPath: string, finalConfigPath: string): Promise<void> {
+    try {
+      await rename(tempConfigPath, finalConfigPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EXDEV') throw error;
+      await copyFile(tempConfigPath, finalConfigPath);
+      await unlink(tempConfigPath);
     }
   }
 

--- a/apps/backend/src/domains/nginx-startup.service.ts
+++ b/apps/backend/src/domains/nginx-startup.service.ts
@@ -29,6 +29,9 @@ const BLOCKLIST_REGEN_DEBOUNCE_MS = 1_500;
  */
 const BLOCKLIST_LOAD_WAIT_MS = 15_000;
 
+/** A `.<name>.conf.tmp` staging file older than this is a failed write's debris. */
+const STALE_STAGING_MS = 10 * 60 * 1000;
+
 /**
  * Service that regenerates all nginx configs on backend startup.
  * This ensures any template changes are applied automatically without
@@ -226,6 +229,24 @@ export class NginxStartupService implements OnModuleInit {
 
     const domainRe = /^domain-([a-f0-9-]+)\.conf$/;
     const redirectRe = /^redirect-([a-f0-9-]+)\.conf$/;
+
+    // Staging files (`.<name>.conf.tmp`) are renamed into place within
+    // milliseconds; one still here after STALE_STAGING_MS is debris from a
+    // failed write and is removed so it cannot pile up on the mount.
+    const stagingRe = /^\..+\.conf\.tmp$/;
+    const { stat } = await import('fs/promises');
+    for (const file of files) {
+      if (!stagingRe.test(file)) continue;
+      try {
+        const info = await stat(join(sitesPath, file));
+        if (Date.now() - info.mtimeMs > STALE_STAGING_MS) {
+          await unlink(join(sitesPath, file));
+          this.logger.warn(`Removed stale nginx staging file: ${file}`);
+        }
+      } catch (error) {
+        this.logger.warn(`Failed to inspect ${file}: ${error}`);
+      }
+    }
 
     const fileEntries: Array<{ file: string; id: string; kind: 'domain' | 'redirect' }> = [];
     for (const file of files) {

--- a/apps/backend/src/domains/nginx-startup.service.ts
+++ b/apps/backend/src/domains/nginx-startup.service.ts
@@ -163,8 +163,11 @@ export class NginxStartupService implements OnModuleInit {
     // so what gets rendered here is never a half-loaded state (#607).
     await this.edgeBlocklistService.sync();
 
-    // 0. Clean up orphaned config files (from previous installs or deleted mappings)
-    await this.cleanupOrphanedConfigs();
+    // Every config is regenerated IN PLACE below (rename-into-place, so a
+    // live site never has a moment without its server block); orphans — files
+    // whose mapping or redirect no longer exists — are pruned afterwards.
+    // Deleting everything first used to open a window in which nginx, coming
+    // up alongside the backend, loaded a partial set of server blocks.
 
     // 0.5. Clean up stale primary domain mapping if PRIMARY_DOMAIN changed
     await this.cleanupStalePrimaryDomainMapping();
@@ -178,7 +181,10 @@ export class NginxStartupService implements OnModuleInit {
     // 3. Regenerate primary content config (write only)
     const primaryCount = await this.regeneratePrimaryContentConfig();
 
-    // 4. Single wait for the nginx watcher to debounce + reload all the writes.
+    // 4. Remove configs whose row is gone (previous installs, deleted mappings).
+    await this.pruneOrphanNginxConfigs();
+
+    // 5. Single wait for the nginx watcher to coalesce + reload all the writes.
     if (domainCount + redirectCount + primaryCount > 0) {
       await this.nginxReloadService.waitForReload();
     }
@@ -187,65 +193,16 @@ export class NginxStartupService implements OnModuleInit {
   }
 
   /**
-   * Cleans up ALL domain and redirect nginx config files before regenerating.
-   *
-   * Why delete ALL configs instead of just orphaned ones?
-   * - Nginx starts before backend finishes startup
-   * - If a stale config has errors (e.g., SSL certs that don't exist), nginx crashes
-   * - By the time backend cleans up orphaned configs, nginx is already in CrashLoopBackOff
-   * - Deleting ALL configs and regenerating ensures a clean slate with current code/templates
-   *
-   * This also handles:
-   * - App reinstalled but nginx volume persists
-   * - Domain mappings deleted but config files weren't removed
-   * - Template changes that need to be applied to all configs
-   */
-  private async cleanupOrphanedConfigs(): Promise<void> {
-    const sitesPath = this.nginxConfigService.getNginxSitesPath();
-
-    try {
-      const { readdir, unlink } = await import('fs/promises');
-      const { join } = await import('path');
-
-      const files = await readdir(sitesPath);
-
-      let cleanedCount = 0;
-
-      for (const file of files) {
-        // Delete ALL domain-*.conf files (will be regenerated from DB)
-        if (file.match(/^domain-[a-f0-9-]+\.conf$/)) {
-          this.logger.debug(`Removing domain config for regeneration: ${file}`);
-          await unlink(join(sitesPath, file));
-          cleanedCount++;
-          continue;
-        }
-
-        // Delete ALL redirect-*.conf files (will be regenerated from DB)
-        if (file.match(/^redirect-[a-f0-9-]+\.conf$/)) {
-          this.logger.debug(`Removing redirect config for regeneration: ${file}`);
-          await unlink(join(sitesPath, file));
-          cleanedCount++;
-        }
-      }
-
-      if (cleanedCount > 0) {
-        this.logger.log(`Cleared ${cleanedCount} nginx config file(s) for regeneration`);
-      }
-    } catch (error) {
-      this.logger.warn(`Failed to cleanup configs: ${error}`);
-    }
-  }
-
-  /**
    * Runtime sweep that prunes orphan nginx config files — files on disk
    * whose UUID has no corresponding row in `domain_mappings` / `domain_redirects`.
    *
-   * Different from `cleanupOrphanedConfigs` (startup): that one nukes every
-   * domain-*.conf because regeneration immediately rewrites them. At runtime
-   * that would 404 every live site for 2-5s, so this sweep is *selective* —
-   * it only removes truly orphaned files. Safe to run on a live cluster.
+   * Selective on purpose — it only removes truly orphaned files, so it is safe
+   * on a live cluster and is what startup runs after regenerating every
+   * config in place (the old startup path deleted every domain-*.conf first,
+   * which could leave nginx on a partial set of server blocks).
    *
    * Triggered by:
+   * - Startup, after regeneration
    * - Hourly cron (defense-in-depth against any future leak)
    * - Manual call from project/domain delete paths once they exist
    */

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -23,6 +23,10 @@ COPY sites-available/bootstrap.conf.template /etc/nginx/sites-available/bootstra
 COPY nginx-reload-watcher.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/nginx-reload-watcher.sh
 
+# Boot guard: quarantines an invalid leftover site config so nginx still starts
+COPY nginx-boot-guard.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/nginx-boot-guard.sh
+
 # Copy main-config renderer (re-runnable: called by entrypoint and by the watcher)
 COPY render-main-conf.sh /usr/local/bin/render-main-conf.sh
 RUN chmod +x /usr/local/bin/render-main-conf.sh

--- a/docker/nginx/docker-entrypoint.sh
+++ b/docker/nginx/docker-entrypoint.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 set -e
 /usr/local/bin/render-main-conf.sh
+
+# Never let one bad per-domain file keep nginx from starting: quarantine it
+# (`<name>.invalid`) and let the backend regenerate it. A failure anywhere
+# else still stops the container — that is a real problem, not a leftover.
+/usr/local/bin/nginx-boot-guard.sh
 exec "$@"

--- a/docker/nginx/nginx-boot-guard.sh
+++ b/docker/nginx/nginx-boot-guard.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Boot guard: never let one bad per-domain file keep nginx from starting.
+#
+# nginx starts alongside the backend and loads whatever is in sites-enabled
+# at that moment. The backend regenerates every config in place after it
+# boots, but an invalid leftover — a rotated or removed certificate path, a
+# file from a template the upgrade changed — fails `nginx -t` as a whole and
+# nginx refuses to start, taking every site down and crash-looping until the
+# backend's rewrite lands (and it cannot land if the backend depends on a
+# healthy proxy). So: validate before starting; when the failing directive is
+# in a sites-enabled file, move that file aside (`<name>.invalid`, outside the
+# `*.conf` include) and validate again. The backend regenerates the real file
+# from the database within seconds of its own start; the `.invalid` copy stays
+# for the operator to inspect. A failure anywhere else (main config, missing
+# module) is not ours to hide: it is reported and the caller decides.
+#
+# Host-testable: nginx-boot-guard.test.sh runs `quarantine_invalid_sites`
+# with a shim nginx on PATH and NGINX_SITES_DIR pointing at a sandbox.
+
+SITES_DIR="${NGINX_SITES_DIR:-/etc/nginx/sites-enabled}"
+MAX_QUARANTINE="${NGINX_BOOT_GUARD_MAX:-20}"
+
+# Prints the sites-enabled file `nginx -t`'s first error names, or nothing.
+# nginx reports the location as `in <path>:<line>`.
+failing_site_file() {
+  nginx -t 2>&1 | sed -n "s#.* in \(${SITES_DIR}/[^:]*\.conf\):[0-9]*.*#\1#p" | head -n1
+}
+
+# Returns 0 when nginx's configuration validates (possibly after quarantining
+# files), 1 when it still fails for a reason outside sites-enabled.
+quarantine_invalid_sites() {
+  n=0
+  while ! nginx -t >/dev/null 2>&1; do
+    bad="$(failing_site_file)"
+    if [ -z "$bad" ] || [ ! -f "$bad" ]; then
+      echo "❌ nginx configuration invalid outside ${SITES_DIR}; not quarantining:" >&2
+      nginx -t 2>&1 | tail -n 3 >&2
+      return 1
+    fi
+    n=$((n + 1))
+    if [ "$n" -gt "$MAX_QUARANTINE" ]; then
+      echo "❌ quarantined ${MAX_QUARANTINE} files and nginx still fails; giving up" >&2
+      return 1
+    fi
+    mv "$bad" "$bad.invalid"
+    echo "⚠️  quarantined invalid site config $(basename "$bad") → $(basename "$bad").invalid (the backend regenerates it from the database)" >&2
+  done
+  return 0
+}
+
+# When executed (not sourced), run the guard.
+case "$0" in
+  *nginx-boot-guard.sh) quarantine_invalid_sites ;;
+esac

--- a/docker/nginx/nginx-boot-guard.test.sh
+++ b/docker/nginx/nginx-boot-guard.test.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Host-runnable harness for nginx-boot-guard.sh: a shim nginx whose `-t`
+# fails while any file listed in $WATCH_TEST_BAD exists in the sites dir.
+# Run: sh docker/nginx/nginx-boot-guard.test.sh
+set -e
+HERE="$(cd "$(dirname "$0")" && pwd)"
+FAILURES=0
+assert_eq() { # actual expected label
+  if [ "$1" = "$2" ]; then echo "ok: $3"; else echo "FAIL: $3 (got '$1', want '$2')"; FAILURES=$((FAILURES+1)); fi
+}
+
+setup() {
+  SANDBOX="$(mktemp -d)"
+  mkdir -p "$SANDBOX/sites" "$SANDBOX/bin"
+  cat > "$SANDBOX/bin/nginx" <<'EOF'
+#!/bin/sh
+# `nginx -t` fails on the first still-present bad file; else succeeds.
+case "$*" in
+  *-t*)
+    for f in $WATCH_TEST_BAD; do
+      if [ -f "$WATCH_TEST_SITES/$f" ]; then
+        echo "nginx: [emerg] cannot load certificate \"/etc/nginx/ssl/gone.crt\" in $WATCH_TEST_SITES/$f:12" >&2
+        echo "nginx: configuration file /etc/nginx/nginx.conf test failed" >&2
+        exit 1
+      fi
+    done
+    if [ -n "$WATCH_TEST_MAIN_BROKEN" ]; then
+      echo "nginx: [emerg] unknown directive \"bogus\" in /etc/nginx/nginx.conf:5" >&2
+      exit 1
+    fi
+    echo "nginx: configuration file /etc/nginx/nginx.conf test is successful" >&2 ;;
+esac
+EOF
+  chmod +x "$SANDBOX/bin/nginx"
+  export WATCH_TEST_SITES="$SANDBOX/sites"
+}
+
+run_guard() {
+  PATH="$SANDBOX/bin:$PATH" NGINX_SITES_DIR="$SANDBOX/sites" sh "$HERE/nginx-boot-guard.sh" > "$SANDBOX/log" 2>&1
+}
+
+echo "--- two invalid site files are moved aside and nginx validates"
+setup
+for f in domain-good.conf domain-bad1.conf domain-bad2.conf; do echo "server {}" > "$SANDBOX/sites/$f"; done
+WATCH_TEST_BAD="domain-bad1.conf domain-bad2.conf" run_guard; rc=$?
+assert_eq "$rc" "0" "guard exits 0 once the config validates"
+# shellcheck disable=SC2012 # sandbox names are ours
+assert_eq "$(ls "$SANDBOX/sites" | sort | tr '\n' ' ')" "domain-bad1.conf.invalid domain-bad2.conf.invalid domain-good.conf " "the bad files are renamed .invalid, the good one untouched"
+assert_eq "$(grep -c quarantined "$SANDBOX/log")" "2" "each quarantine is logged"
+
+echo "--- a valid tree is left alone"
+setup
+echo "server {}" > "$SANDBOX/sites/domain-a.conf"
+WATCH_TEST_BAD="" run_guard; rc=$?
+assert_eq "$rc" "0" "exit 0"
+assert_eq "$(ls "$SANDBOX/sites")" "domain-a.conf" "nothing renamed"
+
+echo "--- a failure outside sites-enabled is reported, not hidden"
+setup
+echo "server {}" > "$SANDBOX/sites/domain-a.conf"
+set +e
+WATCH_TEST_BAD="" WATCH_TEST_MAIN_BROKEN=1 run_guard; rc=$?
+set -e
+assert_eq "$rc" "1" "exit 1 when the main config is the problem"
+assert_eq "$(ls "$SANDBOX/sites")" "domain-a.conf" "no site file quarantined for someone else's error"
+assert_eq "$(grep -c 'not quarantining' "$SANDBOX/log")" "1" "the reason is logged"
+
+if [ "$FAILURES" -eq 0 ]; then echo "ALL BOOT GUARD TESTS PASSED"; else echo "$FAILURES FAILURE(S)"; exit 1; fi

--- a/docker/nginx/nginx-reload-watcher.sh
+++ b/docker/nginx/nginx-reload-watcher.sh
@@ -1,80 +1,96 @@
 #!/bin/sh
-echo "🔄 Starting nginx config watcher..."
+# Reloads nginx when the backend writes per-domain configs, certificates or the
+# bootstrap marker. Host-testable: nginx-reload-watcher.test.sh runs it with
+# shim inotifywait/nginx/render binaries on PATH and NGINX_WATCH_* overrides.
 
-while true; do
-  # /etc/nginx/bootstrap/ is a bind mount added by a later task (the backend's
-  # apply step writes instance.env there) and may not exist yet on an older
-  # install or before that mount is wired up. inotifywait fails immediately on
-  # a missing path; since stderr is discarded below, that failure would
-  # otherwise be silent, and — without the guard on the inotifywait exit
-  # status further down — the loop would hot-spin (re-arm the watch every
-  # iteration with no delay). mkdir -p makes the directory's existence a
-  # guaranteed invariant instead of an assumption, so the watch call itself
-  # never has a reason to fail on this path.
-  mkdir -p /etc/nginx/bootstrap
+WATCHED_PATHS="${NGINX_WATCH_PATHS:-/etc/nginx/sites-enabled/ /etc/nginx/ssl/ /etc/nginx/bootstrap/}"
+# How long the watched paths must stay quiet before a burst of writes is
+# treated as complete. The backend's startup regeneration rewrites every
+# domain config within a couple of seconds; reloading in the middle of that
+# burst loads a partial set of server blocks and — with the old one-event
+# design — nothing reloaded again afterwards (#747).
+QUIET_SECONDS="${NGINX_WATCH_QUIET_SECONDS:-2}"
+RENDER="${NGINX_WATCH_RENDER:-/usr/local/bin/render-main-conf.sh}"
+# Set by the test harness to stop after N reload cycles; unset = forever.
+MAX_CYCLES="${NGINX_WATCH_MAX_CYCLES:-}"
 
-  # Wait for file changes in sites-enabled (dynamic per-domain configs),
-  # ssl (certificates), or bootstrap (instance.env written by the backend on
-  # apply). moved_to is required, not optional: both the backend
-  # (writeInstanceConfig) and render-main-conf.sh write via rename-into-place
-  # for atomicity, which inotify reports as moved_to rather than
-  # create/modify on the final filename.
-  if ! inotifywait -e create,modify,delete,moved_to -q \
-    /etc/nginx/sites-enabled/ /etc/nginx/ssl/ /etc/nginx/bootstrap/ 2>/dev/null; then
-    # inotifywait couldn't watch one of the paths (e.g. still missing despite
-    # mkdir -p, or some other transient error). Back off before retrying so
-    # this can never become a tight, CPU-burning spin loop.
-    #
-    # Log it: a PERMANENT fault (broken bind mount, bad permissions) retries
-    # here forever, and inotifywait's own stderr is discarded above. Without
-    # this line the watcher would fail silently and invisibly — the old
-    # hot-spin was at least diagnosable from high CPU.
-    echo "⚠️  inotifywait failed (watched path missing or unreadable), retrying in 2s..." >&2
-    sleep 2
-    continue
-  fi
+# A digest of every watched file's name, size and mtime. Compared before and
+# after a reload cycle: any write that landed while this script was busy
+# rendering/validating/reloading (no inotifywait armed) shows up as a
+# different digest and gets its own cycle instead of being lost.
+fingerprint() {
+  # shellcheck disable=SC2086 # WATCHED_PATHS is a space-separated list on purpose
+  find $WATCHED_PATHS -maxdepth 1 -type f 2>/dev/null | sort | while IFS= read -r f; do
+    stat -c '%n %s %Y' "$f" 2>/dev/null
+  done | md5sum | cut -d' ' -f1
+}
 
-  echo "📝 Config/certificate/bootstrap change detected, waiting for write to complete..."
-  sleep 1
+# Keep re-arming the watch until the paths have been quiet for QUIET_SECONDS.
+# inotifywait exits 0 on an event (keep draining), 2 on timeout (quiet), 1 on
+# error (stop draining and let the cycle proceed rather than spin).
+drain_burst() {
+  # shellcheck disable=SC2086
+  while inotifywait -t "$QUIET_SECONDS" -e create,modify,delete,moved_to -q $WATCHED_PATHS 2>/dev/null; do :; done
+}
 
-  # Re-render main config first. This picks up bootstrap→applied transitions
-  # (new instance.env) and newly-written certs, and decides bootstrap vs.
-  # normal mode itself. A render failure must never fall through to
-  # validate/reload — that would risk reloading nginx onto a half-written or
-  # stale sites-available/main.conf. This script has no `set -e`, so a
-  # non-zero return here only trips the `if`, it can't abort the loop.
-  #
-  # Feedback-loop check: render-main-conf.sh writes sites-available/*.conf
-  # and /etc/nginx/cloudflare-realip.conf, neither of which is a watched
-  # path, so those writes cannot re-trigger this watcher. Its writes into a
-  # watched directory (ssl/) are all guarded by `[ ! -f ... ]` existence
-  # checks — the bootstrap self-signed cert (idempotent after the first run,
-  # which normally already happened via docker-entrypoint.sh before this
-  # watcher even starts) AND, in SSL_MODE=selfsigned, the fullchain.pem/
-  # privkey.pem materialization (guarded so it never overwrites a staged
-  # pasted cert already sitting there). So a render triggered by this watcher
-  # cannot itself produce another watched-path change: no infinite loop.
+# One render → validate → reload pass. Returns 0 when nginx was reloaded.
+reload_cycle() {
   echo "🔧 Re-rendering nginx config..."
-  if ! /usr/local/bin/render-main-conf.sh; then
-    # No backoff needed: the next statement after `continue` is another
-    # blocking inotifywait, so there is no spin to prevent here — unlike the
-    # inotifywait-failure branch above, which returns instantly.
+  # A render failure must never fall through to validate/reload — that would
+  # risk reloading nginx onto a half-written or stale sites-available/main.conf.
+  # render-main-conf.sh writes only unwatched paths (sites-available/, the
+  # realip include) plus existence-guarded certs, so it cannot re-trigger us.
+  if ! "$RENDER"; then
     echo "❌ Render failed, skipping reload"
-    continue
+    return 1
   fi
-
   echo "🔍 Validating nginx configuration..."
-
-  # Validate config before reloading
   if nginx -t 2>&1 | grep -q "successful"; then
     echo "✅ Config valid, reloading nginx..."
     nginx -s reload
     echo "🔄 Nginx reloaded successfully at $(date)"
-  else
-    echo "❌ Config invalid, skipping reload"
-    nginx -t
+    return 0
   fi
+  echo "❌ Config invalid, skipping reload"
+  nginx -t
+  return 1
+}
 
-  # Debounce - wait before watching again
-  sleep 2
+echo "🔄 Starting nginx config watcher..."
+cycles=0
+while true; do
+  # /etc/nginx/bootstrap/ is a bind mount the backend's apply step writes
+  # instance.env into; it may not exist yet on an older install. inotifywait
+  # fails immediately on a missing path, so make its existence an invariant.
+  mkdir -p /etc/nginx/bootstrap 2>/dev/null
+
+  # moved_to is required: the backend and render-main-conf.sh write via
+  # rename-into-place, which inotify reports as moved_to on the final name.
+  # shellcheck disable=SC2086
+  if ! inotifywait -e create,modify,delete,moved_to -q $WATCHED_PATHS 2>/dev/null; then
+    # A watched path is missing or unreadable. Back off so this can never
+    # become a CPU-burning spin, and say so — inotifywait's stderr is discarded.
+    echo "⚠️  inotifywait failed (watched path missing or unreadable), retrying in 2s..." >&2
+    sleep 2
+    continue
+  fi
+  echo "📝 Config/certificate/bootstrap change detected, waiting for the burst to settle..."
+
+  # Reload once per burst, and once more for anything that landed while we
+  # were busy — never leave nginx on a partial set of server blocks.
+  while :; do
+    drain_burst
+    before="$(fingerprint)"
+    reload_cycle
+    cycles=$((cycles + 1))
+    if [ "$(fingerprint)" = "$before" ]; then
+      break
+    fi
+    echo "📝 More changes landed during the reload, going again..."
+  done
+
+  if [ -n "$MAX_CYCLES" ] && [ "$cycles" -ge "$MAX_CYCLES" ]; then
+    echo "test harness: $cycles cycle(s) done, exiting"
+    exit 0
+  fi
 done

--- a/docker/nginx/nginx-reload-watcher.test.sh
+++ b/docker/nginx/nginx-reload-watcher.test.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# Host-runnable harness for nginx-reload-watcher.sh: shim inotifywait, nginx,
+# the renderer and a scripted event queue, then assert how many reloads a
+# burst of writes produces. Run: sh docker/nginx/nginx-reload-watcher.test.sh
+set -e
+HERE="$(cd "$(dirname "$0")" && pwd)"
+FAILURES=0
+assert_eq() { # actual expected label
+  if [ "$1" = "$2" ]; then echo "ok: $3"; else echo "FAIL: $3 (got '$1', want '$2')"; FAILURES=$((FAILURES+1)); fi
+}
+
+# One sandbox per scenario: a watched dir, a shim bin dir, an event queue.
+# The inotifywait shim pops one line from the queue per call:
+#   "event"        → exit 0 (an event arrived)
+#   "quiet"        → exit 2 (timeout: nothing for QUIET_SECONDS)
+#   "event:<file>" → write that file into the watched dir, then exit 0
+# An empty queue means "no more events ever": the shim blocks briefly and,
+# because MAX_CYCLES is set, the watcher has already exited by then.
+setup() {
+  SANDBOX="$(mktemp -d)"
+  mkdir -p "$SANDBOX/sites" "$SANDBOX/bin"
+  QUEUE="$SANDBOX/queue"; : > "$QUEUE"
+  cat > "$SANDBOX/bin/inotifywait" <<'EOF'
+#!/bin/sh
+line="$(head -n1 "$WATCH_TEST_QUEUE")"
+if [ -z "$line" ]; then sleep 5; exit 1; fi
+tail -n +2 "$WATCH_TEST_QUEUE" > "$WATCH_TEST_QUEUE.next" && mv "$WATCH_TEST_QUEUE.next" "$WATCH_TEST_QUEUE"
+case "$line" in
+  quiet) exit 2 ;;
+  event:*) f="${line#event:}"; echo "server {}" > "$WATCH_TEST_SITES/$f"; exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+  cat > "$SANDBOX/bin/nginx" <<'EOF'
+#!/bin/sh
+case "$*" in
+  *-t*) echo "nginx: configuration file /etc/nginx/nginx.conf test is successful" ;;
+  *reload*) echo reload >> "$WATCH_TEST_RELOADS"; ls "$WATCH_TEST_SITES" | sort | tr '\n' ' ' >> "$WATCH_TEST_RELOADS"; echo >> "$WATCH_TEST_RELOADS" ;;
+esac
+EOF
+  cat > "$SANDBOX/bin/render" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+  chmod +x "$SANDBOX/bin/"*
+  RELOADS="$SANDBOX/reloads"; : > "$RELOADS"
+  export WATCH_TEST_QUEUE="$QUEUE" WATCH_TEST_SITES="$SANDBOX/sites" WATCH_TEST_RELOADS="$RELOADS"
+}
+
+run_watcher() { # max cycles
+  PATH="$SANDBOX/bin:$PATH" \
+  NGINX_WATCH_PATHS="$SANDBOX/sites/" NGINX_WATCH_QUIET_SECONDS=1 \
+  NGINX_WATCH_RENDER="$SANDBOX/bin/render" NGINX_WATCH_MAX_CYCLES="$1" \
+    sh "$HERE/nginx-reload-watcher.sh" > "$SANDBOX/log" 2>&1
+}
+
+echo "--- a burst of writes reloads once, after the last write"
+setup
+# first event wakes the watcher; three more writes arrive while it drains; then quiet
+printf 'event:domain-a.conf\nevent:domain-b.conf\nevent:domain-c.conf\nevent:domain-d.conf\nquiet\n' > "$QUEUE"
+run_watcher 1
+assert_eq "$(grep -c '^reload$' "$RELOADS")" "1" "one reload for a four-file burst"
+assert_eq "$(sed -n '2p' "$RELOADS" | tr -s ' ')" "domain-a.conf domain-b.conf domain-c.conf domain-d.conf " "nginx saw every file of the burst at reload time"
+
+echo "--- a write that lands during the reload gets its own cycle"
+setup
+# The nginx shim's reload writes nothing; simulate a late write by making the
+# render shim drop a file into the watched dir (the watcher is busy, no watch armed).
+cat > "$SANDBOX/bin/render" <<'EOF'
+#!/bin/sh
+if [ ! -f "$WATCH_TEST_SITES/late.conf" ] && [ -f "$WATCH_TEST_SITES/domain-a.conf" ]; then echo "server {}" > "$WATCH_TEST_SITES/late.conf"; fi
+exit 0
+EOF
+chmod +x "$SANDBOX/bin/render"
+printf 'event:domain-a.conf\nquiet\nquiet\n' > "$QUEUE"
+run_watcher 2
+assert_eq "$(grep -c '^reload$' "$RELOADS")" "2" "the late write triggered a second reload"
+assert_eq "$(grep -c 'going again' "$SANDBOX/log")" "1" "the watcher noticed the fingerprint change"
+
+echo "--- an invalid config is not reloaded"
+setup
+cat > "$SANDBOX/bin/nginx" <<'EOF'
+#!/bin/sh
+case "$*" in *-t*) echo "nginx: [emerg] unexpected end of file" ;; *reload*) echo reload >> "$WATCH_TEST_RELOADS" ;; esac
+EOF
+chmod +x "$SANDBOX/bin/nginx"
+printf 'event:domain-a.conf\nquiet\n' > "$QUEUE"
+run_watcher 1
+assert_eq "$(grep -c '^reload$' "$RELOADS")" "0" "no reload on an invalid config"
+assert_eq "$(grep -c 'Config invalid' "$SANDBOX/log")" "1" "the failure is logged"
+
+if [ "$FAILURES" -eq 0 ]; then echo "ALL WATCHER TESTS PASSED"; else echo "$FAILURES FAILURE(S)"; exit 1; fi


### PR DESCRIPTION
Companion to #746. The j5s.dev outage after the v0.4.47 restart, from the backend log the operator pulled:

```
22:36:10  Regenerating all nginx configs on startup...
22:36:10  Cleared 17 nginx config file(s) for regeneration
22:36:11  Wrote … domain-802bc041 (workflow-mcp.j5s.dev)          ← 4th
22:36:12  Wrote … domain-7276258f (workflow.j5s.dev)              ← 15th
22:36:12  Wrote … domain-240c0ccb (hello.j5s.dev)                 ← 16th
22:36:12  Regenerated 17 domain mapping configs (0 errors)
```

Generation was clean. nginx, though, kept serving `workflow-mcp` and not `workflow`/`hello`, and a backend restart an hour later changed nothing.

## The bug
`nginx-reload-watcher.sh` waited for **one** inotify event, slept 1 s, ran `nginx -t` + `nginx -s reload`, slept 2 s, and only then re-armed `inotifywait`. Every file event during those seconds was lost. The startup regeneration deletes every `domain-*.conf` and rewrites all 17 within two seconds, so the watcher woke on the first delete, reloaded at ~22:36:11 on a half-rewritten directory (the first few files present), and — the remaining writes having finished before it re-armed — never reloaded again. Which vhosts survive is a matter of write order and timing: v0.4.46's restart got lucky, v0.4.47's did not, and every restart is a new roll.

```diff
 watcher
-  inotifywait (one event) → sleep 1 → render → nginx -t → reload → sleep 2 → loop
+  inotifywait (one event)
+  → drain: re-arm with -t QUIET_SECONDS until the paths are quiet     # a burst = one reload, after its last write
+  → fingerprint watched files → render → nginx -t → reload
+  → fingerprint again; different? something landed while busy → drain + reload again
+  → loop
 backend
-  every writer: temp in /tmp; copyFile → sites-enabled (a half-written file is visible)
+  every writer (domain, redirect, primary, welcome): stagingPathFor() = `.<name>.conf.tmp` beside the target; rename into place (moved_to; never half-written)
 startup
-  delete every domain-*.conf, then regenerate each                    # a window with no server block
+  regenerate each in place (rename over), then prune orphans (rows that no longer exist) and stale `.tmp` debris (> 10 min)
 nginx image boot (docker-entrypoint.sh)
+  nginx-boot-guard.sh: `nginx -t`; a failing sites-enabled file → `<name>.invalid` (outside the include), validate again;
+  a failure outside sites-enabled is reported and still stops the container
```

## Tests
- `docker/nginx/nginx-boot-guard.test.sh` (shim nginx): two invalid site files quarantined and nginx validates; a valid tree untouched; a main-config error reported, exit 1, nothing quarantined.
- `docker/nginx/nginx-reload-watcher.test.sh` (host-runnable, shim `inotifywait`/`nginx`/render): a four-file burst → **one** reload that saw all four files; a write landing during the reload → a second cycle; an invalid config → no reload, logged. Wired into `shell-checks.yml` (with shellcheck on both scripts).
- `nginx-reload.service.spec.ts`: rename into place; EXDEV falls back to copy + unlink; write errors reported. `nginx-config.service.spec.ts`: the temp file sits beside its target. 129 passed across the nginx + domains suites; `tsc`, eslint clean.

## The startup-wipe trade-off (review finding 2)
The old wipe existed so a stale, invalid leftover could not keep nginx from booting. That protection now lives where it belongs — in the nginx image, before nginx starts — instead of in a backend step that races nginx's boot and, in exchange, left every site without a server block for the duration of the rewrite. The `.invalid` file stays for the operator; the backend regenerates the real one from the database seconds later.

## Backwards compatibility
Same files, same names, same watcher semantics from nginx's point of view — just no lost events and no half-written files. `NGINX_WATCH_QUIET_SECONDS` (default 2) tunes the burst window. The nginx image must be rebuilt for the watcher change (it ships in the image); the backend half is effective on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sd1UdizNNZjGLZxyy8FY11
