### PR TITLE
feat(frontend): a form editor for mcp_handler steps

### DIFF
--- a/apps/frontend/src/components/pipelines/handlers/HandlerConfigWrapper.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/HandlerConfigWrapper.tsx
@@ -510,7 +510,7 @@ export function getHandlerDescription(type: HandlerType): string {
     remote_request:
       'Call an admin-configured remote connection (Cloud Run etc.) with the platform identity',
     mcp_handler:
-      'Answer as a stateless MCP server from this step’s config: tools and ui:// resources mapped to sibling rules, run as the caller. Authored as code (rules-as-code); no form editor',
+      'Answer as a stateless MCP server: tools and ui:// resources mapped to sibling rules of this alias, run as the caller',
     stripe_checkout: 'Create a Stripe Checkout Session and return the payment URL',
     stripe_webhook: 'Verify Stripe webhook signature and parse the event',
     signed_url: 'Generate a time-limited presigned URL for a file in storage',

--- a/apps/frontend/src/components/pipelines/handlers/McpHandlerConfig.stories.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/McpHandlerConfig.stories.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { http, HttpResponse } from 'msw';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { configureStore } from '@reduxjs/toolkit';
+import { api } from '@/services/api';
+import { McpHandlerConfig } from './McpHandlerConfig';
+import workflow from './mcp/__fixtures__/workflow.json';
+
+const createStore = () =>
+  configureStore({
+    reducer: { [api.reducerPath]: api.reducer },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+  });
+
+const siblingRules = {
+  rules: [
+    {
+      id: 'self',
+      pathPattern: '/api/workflow/mcp',
+      method: null,
+      methods: ['GET', 'POST', 'DELETE'],
+      isEnabled: true,
+    },
+    ...[
+      'list',
+      'describe',
+      'start',
+      'status',
+      'await',
+      'runs',
+      'submitStep',
+      'outputs',
+      'sign',
+      'cancel',
+      'resume',
+      'submit',
+      'annotate',
+      'pipeline',
+      'stepView',
+    ].map((n) => ({
+      id: `t-${n}`,
+      pathPattern: `/api/workflow/mcp-tools/${n}`,
+      method: null,
+      methods: ['POST'],
+      isEnabled: true,
+    })),
+    {
+      id: 'res',
+      pathPattern: '/api/workflow/mcp-resources',
+      method: 'GET',
+      methods: null,
+      isEnabled: true,
+    },
+    {
+      id: 'sv',
+      pathPattern: '/api/workflow/mcp-resources/step-view',
+      method: 'GET',
+      methods: null,
+      isEnabled: true,
+    },
+    { id: 'w', pathPattern: '/w/*', method: 'GET', methods: null, isEnabled: true },
+  ],
+};
+
+function Stateful({ initial }: { initial: Record<string, unknown> }) {
+  const [config, setConfig] = useState(initial);
+  return (
+    <div className="max-w-4xl p-4">
+      <McpHandlerConfig config={config} onChange={setConfig} />
+    </div>
+  );
+}
+
+const meta: Meta<typeof Stateful> = {
+  title: 'Pipelines/Handlers/McpHandlerConfig',
+  component: Stateful,
+  parameters: {
+    layout: 'fullscreen',
+    msw: {
+      handlers: [
+        http.get('*/api/proxy-rule-sets/:id/rules', () => HttpResponse.json(siblingRules)),
+      ],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Provider store={createStore()}>
+        <MemoryRouter initialEntries={['/repo/bffless/workflow/proxy-rules/set-1/self']}>
+          <Routes>
+            <Route path="/repo/:owner/:repo/proxy-rules/:ruleSetId/:ruleId" element={<Story />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof Stateful>;
+
+export const WorkflowServer: Story = { args: { initial: workflow } };
+export const Empty: Story = { args: { initial: {} } };
+export const WithProblems: Story = {
+  args: {
+    initial: {
+      serverInfo: { name: 'demo', version: '' },
+      tools: [
+        { name: 'a', description: '', inputSchema: { type: 'object' }, rule: { path: 'relative' } },
+        { name: 'a', description: '', inputSchema: { type: 'object' }, rule: { path: '/ok' } },
+      ],
+      resources: { templates: [{ uriTemplate: 'ui://plain', name: 'p', rule: { path: '/p' } }] },
+    },
+  },
+};

--- a/apps/frontend/src/components/pipelines/handlers/McpHandlerConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/McpHandlerConfig.test.tsx
@@ -1,23 +1,52 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { McpHandlerConfig } from './McpHandlerConfig';
-import { summarizeMcpConfig } from './mcp-config-summary';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ ruleSetId: 'set-1', ruleId: 'rule-1' }),
+}));
+const rulesQuery = vi.fn();
+vi.mock('@/services/proxyRulesApi', () => ({
+  useGetRuleSetRulesQuery: (id: string, opts?: { skip?: boolean }) => {
+    rulesQuery(id, opts);
+    return { data: { rules: [] }, isLoading: false };
+  },
+}));
+
+const { McpHandlerConfig } = await import('./McpHandlerConfig');
+const { summarizeMcpConfig } = await import('./mcp-config-summary');
+const workflow = (await import('./mcp/__fixtures__/workflow.json')).default;
 
 const config = {
   serverInfo: { name: 'bffless-workflow', version: '1.0.0' },
   tools: [
-    { name: 'workflow.list', rule: { path: '/api/workflow/mcp-tools/list', method: 'POST' } },
-    { name: 'workflow.status', rule: { path: '/api/workflow/mcp-tools/status', method: 'POST' } },
+    {
+      name: 'workflow.list',
+      description: 'List',
+      inputSchema: { type: 'object' },
+      rule: { path: '/api/workflow/mcp-tools/list', method: 'POST' },
+    },
+    {
+      name: 'workflow.status',
+      description: 'Status',
+      inputSchema: { type: 'object' },
+      rule: { path: '/api/workflow/mcp-tools/status', method: 'POST' },
+    },
   ],
   resources: {
     static: [
       {
         uri: 'ui://bffless/workflow/step.html',
+        name: 'Step',
         rule: { path: '/api/workflow/mcp-resources/step-view' },
       },
     ],
     templates: [
-      { uriTemplate: 'ui://bffless/{impl}/{path+}', rule: { path: '/w/{impl}/{path+}' } },
+      {
+        uriTemplate: 'ui://bffless/{impl}/{path+}',
+        name: 'island',
+        rule: { path: '/w/{impl}/{path+}' },
+      },
     ],
   },
 };
@@ -38,29 +67,71 @@ describe('McpHandlerConfig', () => {
     expect(screen.getByTestId('mcp-summary').textContent).toContain('1 static resource');
   });
 
-  it('applies a parsed edit on blur and reports one that does not parse without sending it', () => {
+  it('edits the server name through the form and emits the serialized config', () => {
     const onChange = vi.fn();
     render(<McpHandlerConfig config={config} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText(/server name/i), { target: { value: 'renamed' } });
+    expect(onChange).toHaveBeenCalledWith({
+      ...config,
+      serverInfo: { name: 'renamed', version: '1.0.0' },
+    });
+  });
+
+  it('opens the Tools tab with one card per tool and passes the rule set to the pickers', async () => {
+    render(<McpHandlerConfig config={config} onChange={() => {}} />);
+    await userEvent.click(screen.getByRole('tab', { name: /tools/i }));
+    expect(screen.getAllByTestId(/mcp-tool-\d+/)).toHaveLength(2);
+    await userEvent.click(screen.getByRole('button', { name: /expand workflow\.list/i }));
+    expect(rulesQuery).toHaveBeenCalledWith('set-1', { skip: false });
+  });
+
+  it('applies a parsed JSON edit on blur and reports one that does not parse without sending it', async () => {
+    const onChange = vi.fn();
+    render(<McpHandlerConfig config={config} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('tab', { name: /json/i }));
     const editor = screen.getByLabelText('Configuration (JSON)') as HTMLTextAreaElement;
     expect(editor.value).toContain('"workflow.list"');
 
-    fireEvent.change(editor, { target: { value: '{"serverInfo":{"name":"x"},"tools":[]}' } });
+    fireEvent.change(editor, {
+      target: { value: '{"serverInfo":{"name":"x","version":"2"},"tools":[]}' },
+    });
     fireEvent.blur(editor);
-    expect(onChange).toHaveBeenCalledWith({ serverInfo: { name: 'x' }, tools: [] });
+    expect(onChange).toHaveBeenCalledWith({ serverInfo: { name: 'x', version: '2' }, tools: [] });
 
     fireEvent.change(editor, { target: { value: '{"tools": [' } });
     fireEvent.blur(editor);
     expect(screen.getByRole('alert').textContent).toMatch(/Not saved/);
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
 
-    fireEvent.change(editor, { target: { value: '[1,2]' } });
-    fireEvent.blur(editor);
-    expect(screen.getByRole('alert').textContent).toMatch(/must be a JSON object/);
-    expect(onChange).toHaveBeenCalledTimes(1);
+  it('lists what the run would refuse, whichever tab is open', () => {
+    render(
+      <McpHandlerConfig
+        config={{
+          tools: [
+            { name: 'a', rule: { path: 'relative' } },
+            { name: 'a', rule: { path: '/ok' } },
+          ],
+        }}
+        onChange={() => {}}
+      />,
+    );
+    const summary = screen.getByTestId('mcp-problems');
+    expect(summary.textContent).toContain(
+      'serverInfo.name and serverInfo.version are required strings',
+    );
+    expect(summary.textContent).toContain('tool a: rule.path must start with /');
+    expect(summary.textContent).toContain('duplicate tool name: a');
   });
 
   it('renders an empty config without blowing up', () => {
     render(<McpHandlerConfig config={{}} onChange={() => {}} />);
     expect(screen.getByTestId('mcp-summary').textContent).toContain('0 tools');
+  });
+
+  it('renders the shipped workflow server', () => {
+    render(<McpHandlerConfig config={workflow} onChange={() => {}} />);
+    expect(screen.getByTestId('mcp-summary').textContent).toContain('15 tools');
+    expect(screen.queryByTestId('mcp-problems')).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/pipelines/handlers/McpHandlerConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/McpHandlerConfig.tsx
@@ -1,42 +1,53 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { isRecord, summarizeMcpConfig } from './mcp-config-summary';
+import { useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { AlertCircle } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { summarizeMcpConfig } from './mcp-config-summary';
+import { JsonField } from './mcp/JsonField';
+import { McpServerSection } from './mcp/McpServerSection';
+import { McpToolList } from './mcp/McpToolList';
+import { McpResourcesSection } from './mcp/McpResourcesSection';
+import { normalize, serialize, validate, type McpConfig } from './mcp/model';
 
 interface Props {
   config: Record<string, unknown>;
   onChange: (config: Record<string, unknown>) => void;
+  /** The rule set whose rules answer the tools; defaults to the route's `:ruleSetId`. */
+  ruleSetId?: string;
+  /** The rule being edited; defaults to the route's `:ruleId`. */
+  ruleId?: string;
 }
 
+type TabKey = 'server' | 'tools' | 'resources' | 'json';
+
 /**
- * `mcp_handler` is authored as code (a rule set's YAML, or an app rendering it
- * from its tool catalog), not as a form: the config is the MCP server — its
- * tools, each mapped to a sibling rule, and its `ui://` resources. The panel
- * shows what the config declares and lets an operator edit the JSON directly;
- * a body that does not parse is reported and never sent.
+ * `mcp_handler`: the step *is* the MCP server. Its config declares the server
+ * (`serverInfo`, `instructions`), the tools — each answered by a sibling rule
+ * of the same alias, run in-process as the caller — and the `ui://` resources
+ * an MCP App host can read. Edited as a form (Server / Tools / Resources) or,
+ * for copying into rules-as-code, as JSON. The form writes the same shape the
+ * backend validates; keys it does not model are carried through untouched.
  */
-export function McpHandlerConfig({ config, onChange }: Props) {
-  const [text, setText] = useState(() => JSON.stringify(config ?? {}, null, 2));
-  const [error, setError] = useState<string | null>(null);
+export function McpHandlerConfig({ config, onChange, ruleSetId, ruleId }: Props) {
+  const params = useParams<{ ruleSetId?: string; ruleId?: string }>();
+  const setId = ruleSetId ?? params.ruleSetId;
+  const excludeRuleId = ruleId ?? params.ruleId;
 
-  // A config replaced from outside (another step selected, a reload) resets the editor.
-  useEffect(() => {
-    setText(JSON.stringify(config ?? {}, null, 2));
-    setError(null);
-  }, [config]);
+  const [tab, setTab] = useState<TabKey>('server');
 
-  const summary = useMemo(() => summarizeMcpConfig(config ?? {}), [config]);
+  const model = useMemo(() => normalize(config ?? {}), [config]);
+  const serialized = useMemo(() => serialize(model), [model]);
+  const problems = useMemo(() => validate(model), [model]);
+  const summary = useMemo(() => summarizeMcpConfig(serialized), [serialized]);
 
-  const commit = () => {
-    try {
-      const parsed: unknown = JSON.parse(text);
-      if (!isRecord(parsed)) throw new Error('the config must be a JSON object');
-      setError(null);
-      onChange(parsed);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    }
-  };
+  const emit = (next: McpConfig) => onChange(serialize(next));
+  const patch = (p: Partial<McpConfig>) => emit({ ...model, ...p });
+
+  const serverInfoError = problems.find((p) => p.path[0] === 'serverInfo')?.message;
+  const staticResourceUris = model.resources.static.map((r) => r.uri).filter(Boolean);
+  const toolProblems = problems.filter((p) => p.path[0] === 'tools').length;
+  const resourceProblems = problems.filter((p) => p.path[0] === 'resources').length;
 
   return (
     <div className="space-y-4">
@@ -51,38 +62,112 @@ export function McpHandlerConfig({ config, onChange }: Props) {
           template{summary.templates === 1 ? '' : 's'}
         </p>
         <p className="text-muted-foreground">
-          Each tool names a sibling rule of this alias (<code>rule.path</code>) that answers it
-          in-process as the caller; resources map <code>ui://</code> URIs to sibling paths. This
-          step is usually rendered from the app&apos;s own code and synced with{' '}
-          <code>bffless rules push</code>.
+          This step answers as a stateless MCP server. Each tool names a sibling rule of this alias
+          (its path and method) that runs it in-process as the caller, with that rule&apos;s own
+          auth; resources map <code>ui://</code> URIs to sibling paths. The JSON tab holds the same
+          config for <code>bffless rules push</code>.
         </p>
       </div>
 
-      <div className="space-y-2">
-        <Label htmlFor="mcp-config-json">Configuration (JSON)</Label>
-        <Textarea
-          id="mcp-config-json"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          onBlur={commit}
-          spellCheck={false}
-          className="font-mono text-xs min-h-[320px]"
-        />
-        {error ? (
-          <p className="text-xs text-destructive" role="alert">
-            Not saved — {error}
-          </p>
-        ) : (
-          <p className="text-xs text-muted-foreground">
-            <code>serverInfo</code>, <code>instructions</code>, <code>tools[]</code> (
-            <code>name</code>, <code>description</code>, <code>inputSchema</code>,{' '}
-            <code>rule: {'{ path, method }'}</code>, optional <code>visibility</code>,{' '}
-            <code>_meta</code>), <code>resources</code> (<code>static[]</code>,{' '}
-            <code>templates[]</code>, <code>list.rule</code>, <code>csp</code>). Edits apply when
-            the field loses focus.
-          </p>
-        )}
-      </div>
+      {problems.length > 0 && (
+        <Alert variant="destructive" data-testid="mcp-problems">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>
+            {problems.length === 1 ? 'One thing' : `${problems.length} things`} the server would
+            refuse at run time
+          </AlertTitle>
+          <AlertDescription>
+            <ul className="list-disc pl-4 space-y-0.5 text-xs">
+              {problems.map((p, i) => (
+                <li key={i}>
+                  <button
+                    type="button"
+                    className="text-left underline-offset-2 hover:underline"
+                    onClick={() =>
+                      setTab(
+                        p.path[0] === 'tools'
+                          ? 'tools'
+                          : p.path[0] === 'resources'
+                            ? 'resources'
+                            : 'server',
+                      )
+                    }
+                  >
+                    {p.message}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <Tabs value={tab} onValueChange={(v) => setTab(v as TabKey)}>
+        <TabsList className="grid w-full grid-cols-4">
+          <TabsTrigger value="server">
+            Server
+            {serverInfoError && <ProblemDot count={1} />}
+          </TabsTrigger>
+          <TabsTrigger value="tools">
+            Tools
+            <span className="ml-1 text-xs text-muted-foreground">{model.tools.length}</span>
+            {toolProblems > 0 && <ProblemDot count={toolProblems} />}
+          </TabsTrigger>
+          <TabsTrigger value="resources">
+            Resources
+            <span className="ml-1 text-xs text-muted-foreground">
+              {model.resources.static.length + model.resources.templates.length}
+            </span>
+            {resourceProblems > 0 && <ProblemDot count={resourceProblems} />}
+          </TabsTrigger>
+          <TabsTrigger value="json">JSON</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="server" className="pt-2">
+          <McpServerSection config={model} onChange={patch} serverInfoError={serverInfoError} />
+        </TabsContent>
+
+        <TabsContent value="tools" className="pt-2">
+          <McpToolList
+            tools={model.tools}
+            onChange={(tools) => patch({ tools })}
+            staticResourceUris={staticResourceUris}
+            problems={problems}
+            ruleSetId={setId}
+            excludeRuleId={excludeRuleId}
+          />
+        </TabsContent>
+
+        <TabsContent value="resources" className="pt-2">
+          <McpResourcesSection
+            resources={model.resources}
+            onChange={(resources) => patch({ resources })}
+            problems={problems}
+            ruleSetId={setId}
+            excludeRuleId={excludeRuleId}
+          />
+        </TabsContent>
+
+        <TabsContent value="json" className="pt-2">
+          <JsonField
+            label="Configuration (JSON)"
+            value={serialized}
+            onChange={onChange}
+            minHeightClass="min-h-[420px]"
+            help="The whole step config — what rules-as-code carries under the step's `config`. Edits apply when the field loses focus."
+          />
+        </TabsContent>
+      </Tabs>
     </div>
+  );
+}
+
+function ProblemDot({ count }: { count: number }) {
+  return (
+    <span
+      role="img"
+      aria-label={`${count} problem${count === 1 ? '' : 's'}`}
+      className="ml-1.5 inline-block h-2 w-2 rounded-full bg-destructive"
+    />
   );
 }

--- a/apps/frontend/src/components/pipelines/handlers/mcp/InputSchemaEditor.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/InputSchemaEditor.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InputSchemaEditor } from './InputSchemaEditor';
+
+const flat = {
+  type: 'object',
+  required: ['impl'],
+  properties: { impl: { type: 'string', description: 'The alias' } },
+  additionalProperties: false,
+};
+
+describe('InputSchemaEditor', () => {
+  it('lists the properties of a flat schema and adds one', () => {
+    const onChange = vi.fn();
+    render(<InputSchemaEditor value={flat} onChange={onChange} />);
+    expect(screen.getByDisplayValue('impl')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'impl required' })).toBeChecked();
+
+    fireEvent.click(screen.getByRole('button', { name: /add property/i }));
+    const names = screen.getAllByPlaceholderText('name');
+    fireEvent.change(names[1], { target: { value: 'limit' } });
+    expect(onChange).toHaveBeenLastCalledWith({
+      type: 'object',
+      required: ['impl'],
+      properties: { impl: { type: 'string', description: 'The alias' }, limit: { type: 'string' } },
+      additionalProperties: false,
+    });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'limit required' }));
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ required: ['impl', 'limit'] }),
+    );
+  });
+
+  it('removes a property', () => {
+    const onChange = vi.fn();
+    render(<InputSchemaEditor value={flat} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Remove impl' }));
+    expect(onChange).toHaveBeenLastCalledWith({
+      type: 'object',
+      required: [],
+      properties: {},
+      additionalProperties: false,
+    });
+  });
+
+  it('toggles whether extra arguments are allowed', () => {
+    const onChange = vi.fn();
+    render(<InputSchemaEditor value={flat} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('switch', { name: /allow extra arguments/i }));
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ additionalProperties: true }),
+    );
+  });
+
+  it('falls back to JSON for a schema the builder cannot show', () => {
+    const rich = { type: 'object', properties: { a: { oneOf: [{ type: 'string' }] } } };
+    render(<InputSchemaEditor value={rich} onChange={() => {}} />);
+    expect(screen.getByText(/builder can.t show/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('Input schema (JSON)')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /add property/i })).not.toBeInTheDocument();
+  });
+
+  it('can switch a flat schema to JSON and back', () => {
+    render(<InputSchemaEditor value={flat} onChange={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /edit as json/i }));
+    expect(screen.getByLabelText('Input schema (JSON)')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /edit as table/i }));
+    expect(screen.getByDisplayValue('impl')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/mcp/InputSchemaEditor.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/InputSchemaEditor.tsx
@@ -1,0 +1,277 @@
+import { useEffect, useRef, useState } from 'react';
+import { Plus, Trash2, Settings2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { JsonField } from './JsonField';
+import { StringListInput } from './StringListInput';
+import {
+  PROP_TYPES,
+  emptyRow,
+  isFlatObjectSchema,
+  rowsToSchema,
+  schemaToRows,
+  type FlatSchema,
+  type PropType,
+  type PropertyRow,
+} from './input-schema';
+
+interface InputSchemaEditorProps {
+  value: Record<string, unknown>;
+  onChange: (schema: Record<string, unknown>) => void;
+}
+
+/**
+ * A tool's `inputSchema` as a property table — one row per argument — with a
+ * JSON view for anything the table can't show.
+ */
+export function InputSchemaEditor({ value, onChange }: InputSchemaEditorProps) {
+  const flatAble = isFlatObjectSchema(value);
+  const [jsonMode, setJsonMode] = useState(!flatAble);
+  const [flat, setFlat] = useState<FlatSchema>(() =>
+    flatAble ? schemaToRows(value) : { rows: [], additionalProperties: false },
+  );
+  // What we last emitted; an incoming value equal to it is our own echo, and
+  // must not rebuild the rows (that would drop a half-typed row).
+  const lastEmitted = useRef<string>(JSON.stringify(value));
+
+  useEffect(() => {
+    const incoming = JSON.stringify(value);
+    if (incoming === lastEmitted.current) return;
+    lastEmitted.current = incoming;
+    const ok = isFlatObjectSchema(value);
+    if (ok) setFlat(schemaToRows(value));
+    setJsonMode(!ok);
+  }, [value]);
+
+  const emit = (next: FlatSchema) => {
+    setFlat(next);
+    const schema = rowsToSchema(next);
+    lastEmitted.current = JSON.stringify(schema);
+    onChange(schema);
+  };
+
+  const updateRow = (i: number, patch: Partial<PropertyRow>) =>
+    emit({ ...flat, rows: flat.rows.map((r, j) => (j === i ? { ...r, ...patch } : r)) });
+
+  if (jsonMode) {
+    return (
+      <div className="space-y-2">
+        <JsonField
+          label="Input schema (JSON)"
+          value={value}
+          onChange={(v) => {
+            lastEmitted.current = JSON.stringify(v);
+            onChange(v);
+            if (isFlatObjectSchema(v)) setFlat(schemaToRows(v));
+          }}
+          help="A JSON Schema object describing the tool's arguments."
+        />
+        {flatAble ? (
+          <Button type="button" variant="ghost" size="sm" onClick={() => setJsonMode(false)}>
+            Edit as table
+          </Button>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            This schema uses features the table builder can&apos;t show (nested objects,{' '}
+            <code>oneOf</code>, <code>$ref</code>, patterns…), so it is edited as JSON.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <Label>Arguments</Label>
+        <div className="flex gap-1">
+          <Button type="button" variant="ghost" size="sm" onClick={() => setJsonMode(true)}>
+            Edit as JSON
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => emit({ ...flat, rows: [...flat.rows, emptyRow()] })}
+          >
+            <Plus className="h-3 w-3 mr-1" />
+            Add property
+          </Button>
+        </div>
+      </div>
+
+      {flat.rows.length === 0 && (
+        <p className="text-xs text-muted-foreground">
+          No arguments — the tool is called with {'{}'}.
+        </p>
+      )}
+
+      {flat.rows.map((row, i) => (
+        <div key={i} className="flex flex-wrap items-center gap-2 sm:flex-nowrap">
+          <Input
+            value={row.name}
+            placeholder="name"
+            aria-label={`Property ${i + 1} name`}
+            onChange={(e) => updateRow(i, { name: e.target.value })}
+            className="w-full font-mono text-sm sm:w-40"
+          />
+          <Select value={row.type} onValueChange={(t) => updateRow(i, { type: t as PropType })}>
+            <SelectTrigger className="w-full sm:w-28" aria-label={`${row.name || 'property'} type`}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PROP_TYPES.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {t}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
+            value={row.description ?? ''}
+            placeholder="description"
+            aria-label={`${row.name || 'property'} description`}
+            onChange={(e) => updateRow(i, { description: e.target.value || undefined })}
+            className="min-w-0 flex-1 text-sm"
+          />
+          <label className="flex items-center gap-1.5 text-xs whitespace-nowrap">
+            <Checkbox
+              checked={row.required}
+              aria-label={`${row.name || 'property'} required`}
+              onCheckedChange={(c) => updateRow(i, { required: c === true })}
+            />
+            required
+          </label>
+          <RowExtras row={row} onChange={(patch) => updateRow(i, patch)} />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            aria-label={`Remove ${row.name || 'property'}`}
+            onClick={() => emit({ ...flat, rows: flat.rows.filter((_, j) => j !== i) })}
+          >
+            <Trash2 className="h-4 w-4 text-muted-foreground" />
+          </Button>
+        </div>
+      ))}
+
+      <label className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Switch
+          checked={flat.additionalProperties}
+          aria-label="Allow extra arguments"
+          onCheckedChange={(c) => emit({ ...flat, additionalProperties: c })}
+        />
+        Allow extra arguments not listed above
+      </label>
+    </div>
+  );
+}
+
+const numberOrUndefined = (s: string) => (s.trim() === '' ? undefined : Number(s));
+
+/** Per-type constraints behind a gear: enum, min/max, item type, open object. */
+function RowExtras({
+  row,
+  onChange,
+}: {
+  row: PropertyRow;
+  onChange: (patch: Partial<PropertyRow>) => void;
+}) {
+  const numeric = row.type === 'integer' || row.type === 'number';
+  const hasExtras =
+    (row.enum && row.enum.length > 0) ||
+    row.minimum !== undefined ||
+    row.maximum !== undefined ||
+    row.items !== undefined ||
+    row.additionalProperties !== undefined;
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant={hasExtras ? 'secondary' : 'ghost'}
+          size="icon"
+          className="h-8 w-8"
+          aria-label={`${row.name || 'property'} constraints`}
+        >
+          <Settings2 className="h-4 w-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-72 space-y-3" align="end">
+        {row.type === 'string' && (
+          <StringListInput
+            label="Allowed values (enum)"
+            value={row.enum ?? []}
+            onChange={(v) => onChange({ enum: v.length ? v : undefined })}
+            placeholder="value, Enter"
+          />
+        )}
+        {numeric && (
+          <div className="grid grid-cols-2 gap-2">
+            <div className="space-y-1">
+              <Label className="text-xs">Minimum</Label>
+              <Input
+                type="number"
+                value={row.minimum ?? ''}
+                onChange={(e) => onChange({ minimum: numberOrUndefined(e.target.value) })}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Maximum</Label>
+              <Input
+                type="number"
+                value={row.maximum ?? ''}
+                onChange={(e) => onChange({ maximum: numberOrUndefined(e.target.value) })}
+              />
+            </div>
+          </div>
+        )}
+        {row.type === 'object' && (
+          <label className="flex items-center gap-2 text-xs">
+            <Switch
+              checked={row.additionalProperties !== false}
+              onCheckedChange={(c) => onChange({ additionalProperties: c ? true : false })}
+            />
+            Any keys allowed (open object)
+          </label>
+        )}
+        {row.type === 'array' && (
+          <div className="space-y-1">
+            <Label className="text-xs">Item type</Label>
+            <Select
+              value={row.items?.type ?? 'string'}
+              onValueChange={(t) => onChange({ items: { ...row.items, type: t as PropType } })}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PROP_TYPES.map((t) => (
+                  <SelectItem key={t} value={t}>
+                    {t}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+        {(row.type === 'boolean' ||
+          (!numeric && row.type !== 'string' && row.type !== 'object' && row.type !== 'array')) && (
+          <p className="text-xs text-muted-foreground">No constraints for this type.</p>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/frontend/src/components/pipelines/handlers/mcp/JsonField.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/JsonField.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { JsonField } from './JsonField';
+
+describe('JsonField', () => {
+  it('applies a parsed object on blur and reports one that does not parse without applying it', () => {
+    const onChange = vi.fn();
+    render(<JsonField label="Schema" value={{ a: 1 }} onChange={onChange} />);
+    const editor = screen.getByLabelText('Schema') as HTMLTextAreaElement;
+    expect(editor.value).toContain('"a": 1');
+
+    fireEvent.change(editor, { target: { value: '{"b":2}' } });
+    fireEvent.blur(editor);
+    expect(onChange).toHaveBeenCalledWith({ b: 2 });
+
+    fireEvent.change(editor, { target: { value: '{"b":' } });
+    fireEvent.blur(editor);
+    expect(screen.getByRole('alert').textContent).toMatch(/Not saved/);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(editor, { target: { value: '[1]' } });
+    fireEvent.blur(editor);
+    expect(screen.getByRole('alert').textContent).toMatch(/must be a JSON object/);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-seeds the text when the value is replaced from outside', () => {
+    const { rerender } = render(<JsonField label="Schema" value={{ a: 1 }} onChange={() => {}} />);
+    rerender(<JsonField label="Schema" value={{ z: 9 }} onChange={() => {}} />);
+    expect((screen.getByLabelText('Schema') as HTMLTextAreaElement).value).toContain('"z": 9');
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/mcp/JsonField.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/JsonField.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useId, useState } from 'react';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { isRecord } from './model';
+
+interface JsonFieldProps {
+  label: string;
+  value: Record<string, unknown>;
+  onChange: (value: Record<string, unknown>) => void;
+  help?: string;
+  minHeightClass?: string;
+}
+
+/**
+ * A JSON object edited as text. Applied when the field loses focus; a body
+ * that does not parse (or is not an object) is reported and never applied.
+ */
+export function JsonField({
+  label,
+  value,
+  onChange,
+  help,
+  minHeightClass = 'min-h-[200px]',
+}: JsonFieldProps) {
+  const id = useId();
+  const [text, setText] = useState(() => JSON.stringify(value, null, 2));
+  const [error, setError] = useState<string | null>(null);
+
+  // A value replaced from outside (another tab's edit, a reload) re-seeds the text.
+  useEffect(() => {
+    setText(JSON.stringify(value, null, 2));
+    setError(null);
+  }, [value]);
+
+  const commit = () => {
+    try {
+      const parsed: unknown = JSON.parse(text);
+      if (!isRecord(parsed)) throw new Error('the value must be a JSON object');
+      setError(null);
+      onChange(parsed);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Textarea
+        id={id}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onBlur={commit}
+        spellCheck={false}
+        className={`font-mono text-xs ${minHeightClass}`}
+      />
+      {error ? (
+        <p className="text-xs text-destructive" role="alert">
+          Not saved — {error}
+        </p>
+      ) : (
+        help && <p className="text-xs text-muted-foreground">{help}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/pipelines/handlers/mcp/McpResourcesSection.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/McpResourcesSection.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+
+vi.mock('@/services/proxyRulesApi', () => ({
+  useGetRuleSetRulesQuery: () => ({ data: undefined, isLoading: false }),
+}));
+
+const { McpResourcesSection } = await import('./McpResourcesSection');
+const { normalize } = await import('./model');
+const workflow = (await import('./__fixtures__/workflow.json')).default;
+type Resources = ReturnType<typeof normalize>['resources'];
+
+function Harness({ initial, spy }: { initial: Resources; spy: (r: Resources) => void }) {
+  const [resources, setResources] = useState(initial);
+  return (
+    <McpResourcesSection
+      resources={resources}
+      problems={[]}
+      onChange={(r) => {
+        setResources(r);
+        spy(r);
+      }}
+    />
+  );
+}
+
+describe('McpResourcesSection', () => {
+  it('shows the shipped static resource, template, list rule and csp', () => {
+    render(<Harness initial={normalize(workflow).resources} spy={() => {}} />);
+    expect(
+      screen.getByDisplayValue('ui://bffless/workflow/step-view.e2235b30.html'),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue('ui://bffless/{impl}/{path+}')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /enumerate resources/i })).toBeChecked();
+    expect(screen.getByDisplayValue('/api/workflow/mcp-resources')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Remove $storage' })).toHaveLength(2);
+  });
+
+  it('adds a static resource and edits it', () => {
+    const spy = vi.fn();
+    render(<Harness initial={normalize({}).resources} spy={spy} />);
+    fireEvent.click(screen.getByRole('button', { name: /add static resource/i }));
+    const card = screen.getByTestId('mcp-static-0');
+    fireEvent.change(within(card).getByLabelText('URI'), { target: { value: 'ui://a/b.html' } });
+    fireEvent.change(within(card).getByLabelText('Name'), { target: { value: 'B' } });
+    fireEvent.change(within(card).getByLabelText('Answered by rule'), {
+      target: { value: '/api/b' },
+    });
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        static: [{ uri: 'ui://a/b.html', name: 'B', rule: { path: '/api/b' } }],
+      }),
+    );
+  });
+
+  it('adds a template and lists the variables it declares', () => {
+    const spy = vi.fn();
+    render(<Harness initial={normalize({}).resources} spy={spy} />);
+    fireEvent.click(screen.getByRole('button', { name: /add template/i }));
+    const card = screen.getByTestId('mcp-template-0');
+    fireEvent.change(within(card).getByLabelText('URI template'), {
+      target: { value: 'ui://x/{impl}/{path+}' },
+    });
+    fireEvent.change(within(card).getByLabelText('Answered by rule'), {
+      target: { value: '/w/{impl}/{other}' },
+    });
+    expect(within(card).getByText(/variables: impl, path/i)).toBeInTheDocument();
+    expect(within(card).getByText(/other.*not declared/i)).toBeInTheDocument();
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        templates: [
+          { uriTemplate: 'ui://x/{impl}/{path+}', name: '', rule: { path: '/w/{impl}/{other}' } },
+        ],
+      }),
+    );
+  });
+
+  it('toggles the list rule and edits csp chips', () => {
+    const spy = vi.fn();
+    render(<Harness initial={normalize({}).resources} spy={spy} />);
+    fireEvent.click(screen.getByRole('checkbox', { name: /enumerate resources/i }));
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ list: { rule: { path: '', method: 'GET' } } }),
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: /enumerate resources/i }));
+    expect(spy).toHaveBeenLastCalledWith(expect.objectContaining({ list: undefined }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add $app' })[0]);
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ csp: { connectDomains: ['$app'], resourceDomains: [] } }),
+    );
+  });
+
+  it('removes a resource', () => {
+    const spy = vi.fn();
+    render(<Harness initial={normalize(workflow).resources} spy={spy} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Workflow step view' }));
+    expect(spy).toHaveBeenLastCalledWith(expect.objectContaining({ static: [] }));
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/mcp/McpResourcesSection.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/McpResourcesSection.tsx
@@ -1,0 +1,366 @@
+import { useId } from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { SiblingRulePicker } from './SiblingRulePicker';
+import { StringListInput } from './StringListInput';
+import {
+  emptyStaticResource,
+  emptyTemplate,
+  templateVariables,
+  type McpResourceTemplate,
+  type McpResources,
+  type McpStaticResource,
+  type Problem,
+} from './model';
+
+const MIME_SUGGESTIONS = [
+  'text/html;profile=mcp-app',
+  'text/html',
+  'application/json',
+  'text/plain',
+  'text/markdown',
+  'image/png',
+];
+
+const CSP_TOKENS = [
+  { value: '$app', hint: "this deployment's origin" },
+  { value: '$storage', hint: "the storage backend's origin" },
+];
+
+interface McpResourcesSectionProps {
+  resources: McpResources;
+  onChange: (resources: McpResources) => void;
+  problems: Problem[];
+  ruleSetId?: string;
+  excludeRuleId?: string;
+}
+
+/**
+ * `resources`: static `ui://` resources, URI templates, the optional list
+ * rule and the CSP every resource is stamped with.
+ */
+export function McpResourcesSection({
+  resources,
+  onChange,
+  problems,
+  ruleSetId,
+  excludeRuleId,
+}: McpResourcesSectionProps) {
+  const id = useId();
+  const patch = (p: Partial<McpResources>) => onChange({ ...resources, ...p });
+
+  const replaceStatic = (i: number, r: McpStaticResource) =>
+    patch({ static: resources.static.map((x, j) => (j === i ? r : x)) });
+  const replaceTemplate = (i: number, t: McpResourceTemplate) =>
+    patch({ templates: resources.templates.map((x, j) => (j === i ? t : x)) });
+
+  const problemAt = (kind: 'static' | 'templates', i: number) =>
+    problems.find((p) => p.path[0] === 'resources' && p.path[1] === kind && p.path[2] === i)
+      ?.message;
+  const listProblem = problems.find(
+    (p) => p.path[0] === 'resources' && p.path[1] === 'list',
+  )?.message;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <Label>Static resources</Label>
+            <p className="text-xs text-muted-foreground">
+              Fixed <code>ui://</code> URIs a host can read — an MCP App&apos;s HTML, for one.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => patch({ static: [...resources.static, emptyStaticResource()] })}
+          >
+            <Plus className="h-3 w-3 mr-1" />
+            Add static resource
+          </Button>
+        </div>
+        {resources.static.map((r, i) => (
+          <ResourceCard
+            key={i}
+            testId={`mcp-static-${i}`}
+            title={r.name || r.uri || `resource ${i + 1}`}
+            error={problemAt('static', i)}
+            onRemove={() => patch({ static: resources.static.filter((_, j) => j !== i) })}
+          >
+            <div className="grid gap-3 sm:grid-cols-2">
+              <Field label="URI" id={`${id}-s${i}-uri`}>
+                <Input
+                  id={`${id}-s${i}-uri`}
+                  value={r.uri}
+                  placeholder="ui://my-app/view.html"
+                  onChange={(e) => replaceStatic(i, { ...r, uri: e.target.value })}
+                  className="font-mono text-sm"
+                />
+              </Field>
+              <Field label="Name" id={`${id}-s${i}-name`}>
+                <Input
+                  id={`${id}-s${i}-name`}
+                  value={r.name}
+                  placeholder="Human-readable name"
+                  onChange={(e) => replaceStatic(i, { ...r, name: e.target.value })}
+                />
+              </Field>
+            </div>
+            <SiblingRulePicker
+              label="Answered by rule"
+              value={r.rule.path}
+              method="GET"
+              ruleSetId={ruleSetId}
+              excludeRuleId={excludeRuleId}
+              onChange={(path) => replaceStatic(i, { ...r, rule: { ...r.rule, path } })}
+              help="Read with GET; its body becomes the resource's content."
+            />
+            <div className="grid gap-3 sm:grid-cols-2">
+              <Field label="Description" id={`${id}-s${i}-desc`}>
+                <Input
+                  id={`${id}-s${i}-desc`}
+                  value={r.description ?? ''}
+                  onChange={(e) =>
+                    replaceStatic(i, { ...r, description: e.target.value || undefined })
+                  }
+                />
+              </Field>
+              <MimeField
+                id={`${id}-s${i}-mime`}
+                value={r.mimeType ?? ''}
+                onChange={(v) => replaceStatic(i, { ...r, mimeType: v || undefined })}
+              />
+            </div>
+          </ResourceCard>
+        ))}
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <Label>Resource templates</Label>
+            <p className="text-xs text-muted-foreground">
+              A URI pattern with <code>{'{var}'}</code> (one segment) or <code>{'{var+}'}</code> (a
+              tail) that maps onto a sibling path with the same variables.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => patch({ templates: [...resources.templates, emptyTemplate()] })}
+          >
+            <Plus className="h-3 w-3 mr-1" />
+            Add template
+          </Button>
+        </div>
+        {resources.templates.map((t, i) => {
+          const declared = templateVariables(t.uriTemplate);
+          const undeclared = templateVariables(t.rule.path).filter((v) => !declared.includes(v));
+          return (
+            <ResourceCard
+              key={i}
+              testId={`mcp-template-${i}`}
+              title={t.name || t.uriTemplate || `template ${i + 1}`}
+              error={problemAt('templates', i)}
+              onRemove={() => patch({ templates: resources.templates.filter((_, j) => j !== i) })}
+            >
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Field label="URI template" id={`${id}-t${i}-uri`}>
+                  <Input
+                    id={`${id}-t${i}-uri`}
+                    value={t.uriTemplate}
+                    placeholder="ui://my-app/{impl}/{path+}"
+                    onChange={(e) => replaceTemplate(i, { ...t, uriTemplate: e.target.value })}
+                    className="font-mono text-sm"
+                  />
+                  {declared.length > 0 && (
+                    <p className="text-xs text-muted-foreground">
+                      Variables: {declared.join(', ')}
+                    </p>
+                  )}
+                </Field>
+                <Field label="Name" id={`${id}-t${i}-name`}>
+                  <Input
+                    id={`${id}-t${i}-name`}
+                    value={t.name}
+                    onChange={(e) => replaceTemplate(i, { ...t, name: e.target.value })}
+                  />
+                </Field>
+              </div>
+              <SiblingRulePicker
+                label="Answered by rule"
+                value={t.rule.path}
+                method="GET"
+                template
+                ruleSetId={ruleSetId}
+                excludeRuleId={excludeRuleId}
+                placeholder="/w/{impl}/{path+}"
+                onChange={(path) => replaceTemplate(i, { ...t, rule: { ...t.rule, path } })}
+                help="The same variables, expanded into the sibling's path."
+              />
+              {undeclared.length > 0 && (
+                <p className="text-xs text-destructive">
+                  {undeclared.join(', ')} used in the rule path but not declared by the template.
+                </p>
+              )}
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Field label="Description" id={`${id}-t${i}-desc`}>
+                  <Input
+                    id={`${id}-t${i}-desc`}
+                    value={t.description ?? ''}
+                    onChange={(e) =>
+                      replaceTemplate(i, { ...t, description: e.target.value || undefined })
+                    }
+                  />
+                </Field>
+                <MimeField
+                  id={`${id}-t${i}-mime`}
+                  value={t.mimeType ?? ''}
+                  onChange={(v) => replaceTemplate(i, { ...t, mimeType: v || undefined })}
+                />
+              </div>
+            </ResourceCard>
+          );
+        })}
+      </div>
+
+      <div className="space-y-3">
+        <label className="flex items-start gap-2 text-sm">
+          <Checkbox
+            className="mt-0.5"
+            checked={resources.list !== undefined}
+            aria-label="Enumerate resources from a sibling rule"
+            onCheckedChange={(c) =>
+              patch({ list: c === true ? { rule: { path: '', method: 'GET' } } : undefined })
+            }
+          />
+          <span>
+            <span className="block font-medium">Enumerate resources from a sibling rule</span>
+            <span className="block text-xs text-muted-foreground">
+              For resources that vary at run time: a GET rule whose JSON answer is the list (an
+              array, or <code>{'{ resources }'}</code>), merged into <code>resources/list</code>.
+            </span>
+          </span>
+        </label>
+        {resources.list && (
+          <div className="pl-6">
+            <SiblingRulePicker
+              label="List rule"
+              value={resources.list.rule.path}
+              method="GET"
+              ruleSetId={ruleSetId}
+              excludeRuleId={excludeRuleId}
+              onChange={(path) => patch({ list: { rule: { ...resources.list!.rule, path } } })}
+            />
+            {listProblem && <p className="text-xs text-destructive">{listProblem}</p>}
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <Label>Content security policy</Label>
+          <p className="text-xs text-muted-foreground">
+            Origins a host lets every resource reach (<code>_meta.ui.csp</code>). <code>$app</code>{' '}
+            and <code>$storage</code> resolve per request.
+          </p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <StringListInput
+            label="Connect domains"
+            value={resources.csp.connectDomains}
+            onChange={(connectDomains) => patch({ csp: { ...resources.csp, connectDomains } })}
+            suggestions={CSP_TOKENS}
+            placeholder="https://api.example.com"
+            help="fetch / XHR / WebSocket targets."
+          />
+          <StringListInput
+            label="Resource domains"
+            value={resources.csp.resourceDomains}
+            onChange={(resourceDomains) => patch({ csp: { ...resources.csp, resourceDomains } })}
+            suggestions={CSP_TOKENS}
+            placeholder="https://cdn.example.com"
+            help="Images, media, scripts and styles."
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, id, children }: { label: string; id: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      {children}
+    </div>
+  );
+}
+
+function MimeField({
+  id,
+  value,
+  onChange,
+}: {
+  id: string;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <Field label="MIME type" id={id}>
+      <Input
+        id={id}
+        list={`${id}-options`}
+        value={value}
+        placeholder="text/html;profile=mcp-app"
+        onChange={(e) => onChange(e.target.value)}
+        className="font-mono text-sm"
+      />
+      <datalist id={`${id}-options`}>
+        {MIME_SUGGESTIONS.map((m) => (
+          <option key={m} value={m} />
+        ))}
+      </datalist>
+    </Field>
+  );
+}
+
+function ResourceCard({
+  testId,
+  title,
+  error,
+  onRemove,
+  children,
+}: {
+  testId: string;
+  title: string;
+  error?: string;
+  onRemove: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div data-testid={testId} className="rounded-md border p-3 space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="min-w-0 truncate font-mono text-sm">{title}</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0"
+          aria-label={`Remove ${title}`}
+          onClick={onRemove}
+        >
+          <Trash2 className="h-4 w-4 text-muted-foreground" />
+        </Button>
+      </div>
+      {children}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/pipelines/handlers/mcp/McpServerSection.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/McpServerSection.tsx
@@ -1,0 +1,108 @@
+import { useId, useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { StringListInput } from './StringListInput';
+import { PROTOCOL_VERSION_DEFAULTS, type McpConfig } from './model';
+
+interface McpServerSectionProps {
+  config: McpConfig;
+  onChange: (patch: Partial<McpConfig>) => void;
+  serverInfoError?: string;
+}
+
+/** `serverInfo`, `instructions` and (behind Advanced) `protocolVersions`. */
+export function McpServerSection({ config, onChange, serverInfoError }: McpServerSectionProps) {
+  const id = useId();
+  const [advanced, setAdvanced] = useState(config.protocolVersions.length > 0);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-[1fr_10rem]">
+        <div className="space-y-2">
+          <Label htmlFor={`${id}-name`}>
+            Server name <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            id={`${id}-name`}
+            value={config.serverInfo.name}
+            placeholder="my-app"
+            onChange={(e) =>
+              onChange({ serverInfo: { ...config.serverInfo, name: e.target.value } })
+            }
+            className="font-mono text-sm"
+            aria-invalid={serverInfoError ? true : undefined}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`${id}-version`}>
+            Version <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            id={`${id}-version`}
+            value={config.serverInfo.version}
+            placeholder="1.0.0"
+            onChange={(e) =>
+              onChange({ serverInfo: { ...config.serverInfo, version: e.target.value } })
+            }
+            className="font-mono text-sm"
+            aria-invalid={serverInfoError ? true : undefined}
+          />
+        </div>
+      </div>
+      {serverInfoError ? (
+        <p className="text-xs text-destructive">{serverInfoError}</p>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          What <code>initialize</code> reports as <code>serverInfo</code>. Clients show the name;
+          bump the version when tools change.
+        </p>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor={`${id}-instructions`}>Instructions</Label>
+        <Textarea
+          id={`${id}-instructions`}
+          value={config.instructions}
+          placeholder="How a model should use this server: what the tools are for, what to pass, what to avoid."
+          onChange={(e) => onChange({ instructions: e.target.value })}
+          className="min-h-[80px] text-sm"
+        />
+        <p className="text-xs text-muted-foreground">
+          Sent once at <code>initialize</code>; most hosts put it in the model&apos;s system prompt.
+        </p>
+      </div>
+
+      <div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="px-1 text-muted-foreground"
+          aria-expanded={advanced}
+          onClick={() => setAdvanced((v) => !v)}
+        >
+          {advanced ? (
+            <ChevronDown className="h-4 w-4 mr-1" />
+          ) : (
+            <ChevronRight className="h-4 w-4 mr-1" />
+          )}
+          Advanced
+        </Button>
+        {advanced && (
+          <div className="mt-2 pl-1">
+            <StringListInput
+              label="Protocol versions"
+              value={config.protocolVersions}
+              onChange={(protocolVersions) => onChange({ protocolVersions })}
+              placeholder={PROTOCOL_VERSION_DEFAULTS.join(', ')}
+              help={`Newest first. Leave empty for the defaults (${PROTOCOL_VERSION_DEFAULTS.join(', ')}).`}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/pipelines/handlers/mcp/McpToolForm.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/McpToolForm.tsx
@@ -1,0 +1,224 @@
+import { useId } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { InputSchemaEditor } from './InputSchemaEditor';
+import { SiblingRulePicker } from './SiblingRulePicker';
+import { isRecord, type McpMethod, type McpTool } from './model';
+
+/** The MCP tool annotations (spec "ToolAnnotations") a client uses to decide how carefully to call. */
+const HINTS: { key: string; label: string; help: string }[] = [
+  { key: 'readOnlyHint', label: 'Read-only', help: 'The tool changes nothing.' },
+  {
+    key: 'destructiveHint',
+    label: 'Destructive',
+    help: 'It may delete or irreversibly change data.',
+  },
+  {
+    key: 'idempotentHint',
+    label: 'Idempotent',
+    help: 'Calling it again with the same arguments changes nothing more.',
+  },
+  {
+    key: 'openWorldHint',
+    label: 'Open world',
+    help: 'It reaches outside this server (the web, third parties).',
+  },
+];
+
+interface McpToolFormProps {
+  tool: McpTool;
+  onChange: (tool: McpTool) => void;
+  /** Declared `resources.static[].uri` values, offered for `_meta.ui.resourceUri`. */
+  staticResourceUris: string[];
+  ruleSetId?: string;
+  excludeRuleId?: string;
+  nameError?: string;
+}
+
+export function McpToolForm({
+  tool,
+  onChange,
+  staticResourceUris,
+  ruleSetId,
+  excludeRuleId,
+  nameError,
+}: McpToolFormProps) {
+  const id = useId();
+  const patch = (p: Partial<McpTool>) => onChange({ ...tool, ...p });
+
+  const setHint = (key: string, on: boolean) => {
+    const annotations = { ...tool.annotations };
+    if (on) annotations[key] = true;
+    else delete annotations[key];
+    patch({ annotations });
+  };
+
+  const ui = isRecord(tool._meta.ui) ? tool._meta.ui : {};
+  const resourceUri = typeof ui.resourceUri === 'string' ? ui.resourceUri : '';
+  const setResourceUri = (value: string) => {
+    const nextUi = { ...ui };
+    if (value) nextUi.resourceUri = value;
+    else delete nextUi.resourceUri;
+    const meta = { ...tool._meta };
+    if (Object.keys(nextUi).length) meta.ui = nextUi;
+    else delete meta.ui;
+    patch({ _meta: meta });
+  };
+
+  const appOnly = tool.visibility.includes('app');
+
+  return (
+    <div className="space-y-5">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor={`${id}-name`}>Tool name</Label>
+          <Input
+            id={`${id}-name`}
+            value={tool.name}
+            placeholder="workflow.list"
+            onChange={(e) => patch({ name: e.target.value })}
+            className="font-mono text-sm"
+            aria-invalid={nameError ? true : undefined}
+          />
+          {nameError ? (
+            <p className="text-xs text-destructive">{nameError}</p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              What the client calls. Dots group tools (<code>workflow.list</code>).
+            </p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`${id}-title`}>Title</Label>
+          <Input
+            id={`${id}-title`}
+            value={typeof tool.annotations.title === 'string' ? tool.annotations.title : ''}
+            placeholder="Optional human-readable title"
+            onChange={(e) => {
+              const annotations = { ...tool.annotations };
+              if (e.target.value) annotations.title = e.target.value;
+              else delete annotations.title;
+              patch({ annotations });
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`${id}-description`}>Description</Label>
+        <Textarea
+          id={`${id}-description`}
+          value={tool.description}
+          placeholder="What the tool does and when a model should call it."
+          onChange={(e) => patch({ description: e.target.value })}
+          className="min-h-[72px] text-sm"
+        />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-[1fr_8rem]">
+        <SiblingRulePicker
+          label="Answered by rule"
+          value={tool.rule.path}
+          method={tool.rule.method ?? 'POST'}
+          ruleSetId={ruleSetId}
+          excludeRuleId={excludeRuleId}
+          onChange={(path) => patch({ rule: { ...tool.rule, path } })}
+          help="The sibling rule of this alias that runs the tool, in-process as the caller. Its own auth validators apply."
+        />
+        <div className="space-y-2">
+          <Label htmlFor={`${id}-method`}>Method</Label>
+          <Select
+            value={tool.rule.method ?? 'POST'}
+            onValueChange={(m) => patch({ rule: { ...tool.rule, method: m as McpMethod } })}
+          >
+            <SelectTrigger id={`${id}-method`}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="POST">POST</SelectItem>
+              <SelectItem value="GET">GET</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Arguments go as the JSON body (POST) or the query (GET).
+          </p>
+        </div>
+      </div>
+
+      <InputSchemaEditor
+        value={tool.inputSchema}
+        onChange={(inputSchema) => patch({ inputSchema })}
+      />
+
+      <div className="space-y-2">
+        <Label>Hints for the client</Label>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {HINTS.map((h) => (
+            <label key={h.key} className="flex items-start gap-2 rounded-md border p-2 text-sm">
+              <Switch
+                checked={tool.annotations[h.key] === true}
+                onCheckedChange={(on) => setHint(h.key, on)}
+                aria-label={`${h.label} (${h.key})`}
+              />
+              <span className="min-w-0">
+                <span className="block font-medium">{h.label}</span>
+                <span className="block text-xs text-muted-foreground">{h.help}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor={`${id}-visibility`}>Visible to</Label>
+          <Select
+            value={appOnly ? 'app' : 'model'}
+            onValueChange={(v) => patch({ visibility: v === 'app' ? ['app'] : [] })}
+          >
+            <SelectTrigger id={`${id}-visibility`}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="model">Model (default)</SelectItem>
+              <SelectItem value="app">App only</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            App-only tools are listed with <code>_meta.ui.visibility</code> for an MCP App&apos;s
+            own UI to call; a model does not see them.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`${id}-ui`}>UI resource</Label>
+          <Input
+            id={`${id}-ui`}
+            list={`${id}-ui-options`}
+            value={resourceUri}
+            placeholder="ui://… (optional)"
+            onChange={(e) => setResourceUri(e.target.value)}
+            className="font-mono text-sm"
+          />
+          <datalist id={`${id}-ui-options`}>
+            {staticResourceUris.map((u) => (
+              <option key={u} value={u} />
+            ))}
+          </datalist>
+          <p className="text-xs text-muted-foreground">
+            <code>_meta.ui.resourceUri</code>: the static resource a host renders for this tool (MCP
+            Apps).
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/pipelines/handlers/mcp/McpToolList.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/McpToolList.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+
+vi.mock('@/services/proxyRulesApi', () => ({
+  useGetRuleSetRulesQuery: () => ({ data: undefined, isLoading: false }),
+}));
+
+const { McpToolList } = await import('./McpToolList');
+const { emptyTool, normalize } = await import('./model');
+const workflow = (await import('./__fixtures__/workflow.json')).default;
+type McpTool = ReturnType<typeof emptyTool>;
+
+/** Holds the tools in state so sequential edits accumulate, as they do under the real parent. */
+function Harness({
+  initial,
+  spy,
+  uris = [],
+}: {
+  initial: McpTool[];
+  spy: (t: McpTool[]) => void;
+  uris?: string[];
+}) {
+  const [tools, setTools] = useState(initial);
+  return (
+    <McpToolList
+      tools={tools}
+      staticResourceUris={uris}
+      problems={[]}
+      onChange={(t) => {
+        setTools(t);
+        spy(t);
+      }}
+    />
+  );
+}
+
+const twoTools = normalize({
+  serverInfo: { name: 's', version: '1' },
+  tools: [
+    {
+      name: 'workflow.list',
+      description: 'List',
+      inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+      annotations: { readOnlyHint: true },
+      rule: { path: '/api/list', method: 'POST' },
+    },
+    {
+      name: 'workflow.submitStep',
+      description: 'Submit',
+      inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+      visibility: ['app'],
+      _meta: { ui: { resourceUri: 'ui://x/step.html' } },
+      rule: { path: '/api/submit', method: 'POST' },
+    },
+  ],
+}).tools;
+
+describe('McpToolList', () => {
+  it('shows one collapsed card per tool with its method, path and badges', () => {
+    render(
+      <McpToolList tools={twoTools} staticResourceUris={[]} onChange={() => {}} problems={[]} />,
+    );
+    const first = screen.getByTestId('mcp-tool-0');
+    expect(within(first).getByText('workflow.list')).toBeInTheDocument();
+    expect(within(first).getByText('POST /api/list')).toBeInTheDocument();
+    expect(within(first).getByText('read-only')).toBeInTheDocument();
+    const second = screen.getByTestId('mcp-tool-1');
+    expect(within(second).getByText('app-only')).toBeInTheDocument();
+    expect(within(second).getByText('UI')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Tool name')).not.toBeInTheDocument();
+  });
+
+  it('adds a tool expanded with the empty defaults', () => {
+    const onChange = vi.fn();
+    render(
+      <McpToolList tools={twoTools} staticResourceUris={[]} onChange={onChange} problems={[]} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /add tool/i }));
+    expect(onChange).toHaveBeenCalledWith([...twoTools, emptyTool()]);
+  });
+
+  it('expands a card and edits the tool name, description, path and hints', () => {
+    const onChange = vi.fn();
+    render(<Harness initial={twoTools} spy={onChange} uris={['ui://x/step.html']} />);
+    fireEvent.click(
+      within(screen.getByTestId('mcp-tool-0')).getByRole('button', {
+        name: /^expand workflow\.list/i,
+      }),
+    );
+    fireEvent.change(screen.getByLabelText('Tool name'), { target: { value: 'workflow.ls' } });
+    expect(onChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({ name: 'workflow.ls' }),
+      twoTools[1],
+    ]);
+    fireEvent.click(screen.getByRole('switch', { name: /destructive/i }));
+    expect(onChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        name: 'workflow.ls',
+        annotations: { readOnlyHint: true, destructiveHint: true },
+      }),
+      twoTools[1],
+    ]);
+    fireEvent.click(screen.getByRole('switch', { name: /read-only/i }));
+    expect(onChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({ annotations: { destructiveHint: true } }),
+      twoTools[1],
+    ]);
+    fireEvent.change(screen.getByLabelText('UI resource'), {
+      target: { value: 'ui://x/step.html' },
+    });
+    expect(onChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({ _meta: { ui: { resourceUri: 'ui://x/step.html' } } }),
+      twoTools[1],
+    ]);
+    fireEvent.change(screen.getByLabelText('UI resource'), { target: { value: '' } });
+    expect(onChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({ _meta: {} }),
+      twoTools[1],
+    ]);
+  });
+
+  it('duplicates, reorders and deletes tools', () => {
+    const onChange = vi.fn();
+    render(
+      <McpToolList tools={twoTools} staticResourceUris={[]} onChange={onChange} problems={[]} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate workflow.list' }));
+    expect(onChange).toHaveBeenLastCalledWith([
+      twoTools[0],
+      { ...twoTools[0], name: 'workflow.list-copy' },
+      twoTools[1],
+    ]);
+    fireEvent.click(screen.getByRole('button', { name: 'Move workflow.submitStep up' }));
+    expect(onChange).toHaveBeenLastCalledWith([twoTools[1], twoTools[0]]);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete workflow.list' }));
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+    expect(onChange).toHaveBeenLastCalledWith([twoTools[1]]);
+  });
+
+  it('flags a card that has a problem', () => {
+    render(
+      <McpToolList
+        tools={twoTools}
+        staticResourceUris={[]}
+        onChange={() => {}}
+        problems={[
+          {
+            path: ['tools', 1, 'rule', 'path'],
+            message: 'tool workflow.submitStep: rule.path must start with /',
+          },
+        ]}
+      />,
+    );
+    expect(
+      within(screen.getByTestId('mcp-tool-1')).getByLabelText(/1 problem/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the shipped workflow server without blowing up', () => {
+    render(
+      <McpToolList
+        tools={normalize(workflow).tools}
+        staticResourceUris={[]}
+        onChange={() => {}}
+        problems={[]}
+      />,
+    );
+    expect(screen.getAllByTestId(/mcp-tool-\d+/)).toHaveLength(15);
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/mcp/McpToolList.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/McpToolList.tsx
@@ -1,0 +1,258 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, ChevronUp, Copy, Plus, Trash2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { McpToolForm } from './McpToolForm';
+import { emptyTool, isRecord, type McpTool, type Problem } from './model';
+
+interface McpToolListProps {
+  tools: McpTool[];
+  onChange: (tools: McpTool[]) => void;
+  staticResourceUris: string[];
+  problems: Problem[];
+  ruleSetId?: string;
+  excludeRuleId?: string;
+}
+
+const hasContent = (t: McpTool) =>
+  t.description !== '' ||
+  (isRecord(t.inputSchema.properties) && Object.keys(t.inputSchema.properties).length > 0);
+
+const hasUi = (t: McpTool) => isRecord(t._meta.ui) && typeof t._meta.ui.resourceUri === 'string';
+
+export function McpToolList({
+  tools,
+  onChange,
+  staticResourceUris,
+  problems,
+  ruleSetId,
+  excludeRuleId,
+}: McpToolListProps) {
+  const [expanded, setExpanded] = useState<Set<number>>(() => new Set());
+  const [confirmDelete, setConfirmDelete] = useState<number | null>(null);
+
+  const setExpandedAt = (i: number, on: boolean) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (on) next.add(i);
+      else next.delete(i);
+      return next;
+    });
+
+  const replaceAt = (i: number, tool: McpTool) =>
+    onChange(tools.map((t, j) => (j === i ? tool : t)));
+
+  const remove = (i: number) => {
+    onChange(tools.filter((_, j) => j !== i));
+    setExpanded(
+      (prev) => new Set([...prev].filter((j) => j !== i).map((j) => (j > i ? j - 1 : j))),
+    );
+  };
+
+  const move = (i: number, dir: -1 | 1) => {
+    const j = i + dir;
+    if (j < 0 || j >= tools.length) return;
+    const next = [...tools];
+    [next[i], next[j]] = [next[j], next[i]];
+    onChange(next);
+    setExpanded((prev) => {
+      const s = new Set<number>();
+      prev.forEach((k) => s.add(k === i ? j : k === j ? i : k));
+      return s;
+    });
+  };
+
+  const add = () => {
+    onChange([...tools, emptyTool()]);
+    setExpandedAt(tools.length, true);
+  };
+
+  const duplicate = (i: number) => {
+    const copy: McpTool = { ...tools[i], name: `${tools[i].name}-copy` };
+    onChange([...tools.slice(0, i + 1), copy, ...tools.slice(i + 1)]);
+    setExpandedAt(i + 1, true);
+  };
+
+  const problemsFor = (i: number) =>
+    problems.filter((p) => p.path[0] === 'tools' && p.path[1] === i);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <Label>Tools</Label>
+          <p className="text-xs text-muted-foreground">
+            What <code>tools/list</code> advertises, in this order. Each one runs a sibling rule.
+          </p>
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={add}>
+          <Plus className="h-3 w-3 mr-1" />
+          Add tool
+        </Button>
+      </div>
+
+      {tools.length === 0 && (
+        <p className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground">
+          No tools yet. A server with no tools still answers <code>initialize</code>.
+        </p>
+      )}
+
+      {tools.map((tool, i) => {
+        const isOpen = expanded.has(i);
+        const label = tool.name || `tool ${i + 1}`;
+        const toolProblems = problemsFor(i);
+        const nameProblem = toolProblems.find((p) => p.path[2] === 'name')?.message;
+        return (
+          <Card key={i} data-testid={`mcp-tool-${i}`}>
+            <CardHeader className="py-2 px-3">
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${label}`}
+                  aria-expanded={isOpen}
+                  onClick={() => setExpandedAt(i, !isOpen)}
+                  className="min-w-0 flex-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-left hover:text-primary"
+                >
+                  {isOpen ? (
+                    <ChevronDown className="h-4 w-4 shrink-0" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4 shrink-0" />
+                  )}
+                  <span className="font-mono text-sm font-medium">
+                    {tool.name || <span className="italic text-muted-foreground">unnamed</span>}
+                  </span>
+                  <span className="font-mono text-xs text-muted-foreground truncate">
+                    {tool.rule.method ?? 'POST'} {tool.rule.path || '—'}
+                  </span>
+                  <span className="flex gap-1">
+                    {tool.annotations.readOnlyHint === true && (
+                      <Badge variant="outline" className="text-[10px] px-1 py-0 font-normal">
+                        read-only
+                      </Badge>
+                    )}
+                    {tool.annotations.destructiveHint === true && (
+                      <Badge variant="outline" className="text-[10px] px-1 py-0 font-normal">
+                        destructive
+                      </Badge>
+                    )}
+                    {tool.visibility.includes('app') && (
+                      <Badge variant="secondary" className="text-[10px] px-1 py-0 font-normal">
+                        app-only
+                      </Badge>
+                    )}
+                    {hasUi(tool) && (
+                      <Badge variant="secondary" className="text-[10px] px-1 py-0 font-normal">
+                        UI
+                      </Badge>
+                    )}
+                  </span>
+                  {toolProblems.length > 0 && (
+                    <span
+                      role="img"
+                      aria-label={`${toolProblems.length} problem${toolProblems.length === 1 ? '' : 's'}`}
+                      title={toolProblems.map((p) => p.message).join('\n')}
+                      className="h-2 w-2 rounded-full bg-destructive"
+                    />
+                  )}
+                </button>
+                <div className="flex gap-0.5">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    disabled={i === 0}
+                    aria-label={`Move ${label} up`}
+                    onClick={() => move(i, -1)}
+                  >
+                    <ChevronUp className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    disabled={i === tools.length - 1}
+                    aria-label={`Move ${label} down`}
+                    onClick={() => move(i, 1)}
+                  >
+                    <ChevronDown className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    aria-label={`Duplicate ${label}`}
+                    onClick={() => duplicate(i)}
+                  >
+                    <Copy className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    aria-label={`Delete ${label}`}
+                    onClick={() => (hasContent(tool) ? setConfirmDelete(i) : remove(i))}
+                  >
+                    <Trash2 className="h-4 w-4 text-muted-foreground" />
+                  </Button>
+                </div>
+              </div>
+            </CardHeader>
+            {isOpen && (
+              <CardContent className="pt-0 pb-4 px-3 sm:px-4">
+                <McpToolForm
+                  tool={tool}
+                  onChange={(t) => replaceAt(i, t)}
+                  staticResourceUris={staticResourceUris}
+                  ruleSetId={ruleSetId}
+                  excludeRuleId={excludeRuleId}
+                  nameError={nameProblem}
+                />
+              </CardContent>
+            )}
+          </Card>
+        );
+      })}
+
+      <AlertDialog open={confirmDelete !== null} onOpenChange={(o) => !o && setConfirmDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete {confirmDelete !== null ? tools[confirmDelete]?.name || 'this tool' : ''}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Clients stop seeing the tool once the rule is saved. The sibling rule it pointed at is
+              not touched.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (confirmDelete !== null) remove(confirmDelete);
+                setConfirmDelete(null);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/pipelines/handlers/mcp/SiblingRulePicker.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/SiblingRulePicker.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const rulesQuery = vi.fn();
+vi.mock('@/services/proxyRulesApi', () => ({
+  useGetRuleSetRulesQuery: (id: string, opts?: { skip?: boolean }) => {
+    rulesQuery(id, opts);
+    if (opts?.skip) return { data: undefined, isLoading: false };
+    return {
+      data: {
+        rules: [
+          { id: 'self', pathPattern: '/api/mcp', method: null, methods: null, isEnabled: true },
+          {
+            id: 'r1',
+            pathPattern: '/api/tools/list',
+            method: null,
+            methods: ['POST'],
+            isEnabled: true,
+          },
+          { id: 'r2', pathPattern: '/w/*', method: 'GET', methods: null, isEnabled: true },
+        ],
+      },
+      isLoading: false,
+    };
+  },
+}));
+
+const { SiblingRulePicker } = await import('./SiblingRulePicker');
+
+describe('SiblingRulePicker', () => {
+  it('says which sibling answers the path and method', () => {
+    render(
+      <SiblingRulePicker
+        label="Rule path"
+        value="/api/tools/list"
+        method="POST"
+        ruleSetId="set1"
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText(/answered by/i)).toHaveTextContent('/api/tools/list');
+  });
+
+  it('warns when no sibling in the set matches', () => {
+    render(
+      <SiblingRulePicker
+        label="Rule path"
+        value="/api/tools/list"
+        method="GET"
+        ruleSetId="set1"
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText(/no enabled rule in this set/i)).toBeInTheDocument();
+  });
+
+  it('lists the set’s rules except the one being edited, and picks one', () => {
+    const onChange = vi.fn();
+    render(
+      <SiblingRulePicker
+        label="Rule path"
+        value=""
+        method="POST"
+        ruleSetId="set1"
+        excludeRuleId="self"
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('combobox', { name: /rule path/i }));
+    expect(screen.queryByText('/api/mcp')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('/w/*'));
+    expect(onChange).toHaveBeenCalledWith('/w/*');
+  });
+
+  it('stays a plain text field without a rule set', () => {
+    render(<SiblingRulePicker label="Rule path" value="/x" method="POST" onChange={() => {}} />);
+    expect(rulesQuery).toHaveBeenLastCalledWith('', { skip: true });
+    expect(screen.queryByText(/answered by|no enabled rule/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/mcp/SiblingRulePicker.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/SiblingRulePicker.tsx
@@ -1,0 +1,182 @@
+import { useId, useMemo, useState } from 'react';
+import { Check, ChevronsUpDown, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useGetRuleSetRulesQuery } from '@/services/proxyRulesApi';
+import { cn } from '@/lib/utils';
+import { findSibling, type SiblingRule } from './model';
+
+interface SiblingRulePickerProps {
+  label: string;
+  value: string;
+  onChange: (path: string) => void;
+  /** The method the MCP step will invoke the sibling with (GET for resources). */
+  method?: string;
+  /** The rule set whose rules answer the path; without it the field is plain text. */
+  ruleSetId?: string;
+  /** The rule being edited — it cannot answer its own tools. */
+  excludeRuleId?: string;
+  /** For templates: `{var}` segments are matched as wildcards. */
+  template?: boolean;
+  placeholder?: string;
+  help?: string;
+}
+
+const methodsOf = (r: SiblingRule): string[] =>
+  r.methods && r.methods.length ? r.methods : r.method ? [r.method] : ['ANY'];
+
+/**
+ * A sibling rule's path: a combobox over the rule set's rules (free text
+ * allowed) with a hint saying which enabled rule would answer it — as the
+ * edge resolves it, so a miss is a hint, not an error: another set attached
+ * to the same alias may answer.
+ */
+export function SiblingRulePicker({
+  label,
+  value,
+  onChange,
+  method = 'GET',
+  ruleSetId,
+  excludeRuleId,
+  template = false,
+  placeholder = '/api/...',
+  help,
+}: SiblingRulePickerProps) {
+  const id = useId();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const { data } = useGetRuleSetRulesQuery(ruleSetId ?? '', { skip: !ruleSetId });
+
+  const rules = useMemo<SiblingRule[]>(
+    () => (data?.rules ?? []).filter((r) => r.id !== excludeRuleId),
+    [data, excludeRuleId],
+  );
+
+  const sibling = useMemo(() => {
+    if (!ruleSetId || !value) return undefined;
+    const probe = template ? value.replace(/\{[^}]+\}/g, 'x') : value;
+    return findSibling(rules, probe, method);
+  }, [ruleSetId, value, template, rules, method]);
+
+  if (!ruleSetId) {
+    return (
+      <div className="space-y-2">
+        <Label htmlFor={id}>{label}</Label>
+        <Input
+          id={id}
+          value={value}
+          placeholder={placeholder}
+          onChange={(e) => onChange(e.target.value)}
+          className="font-mono text-sm"
+        />
+        {help && <p className="text-xs text-muted-foreground">{help}</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Popover
+        open={open}
+        onOpenChange={(o) => {
+          setOpen(o);
+          if (o) setSearch('');
+        }}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            id={id}
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="w-full justify-between font-normal font-mono text-sm"
+          >
+            <span className={cn('truncate', !value && 'text-muted-foreground')}>
+              {value || placeholder}
+            </span>
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+          <Command>
+            <CommandInput
+              placeholder="Search rules or type a path..."
+              value={search}
+              onValueChange={(v) => {
+                setSearch(v);
+                onChange(v);
+              }}
+            />
+            <CommandList>
+              <CommandEmpty>
+                <div className="py-2 text-sm text-muted-foreground">
+                  Using <span className="font-mono">{value || '…'}</span>
+                </div>
+              </CommandEmpty>
+              <CommandGroup heading="Rules in this set">
+                {rules.map((r) => (
+                  <CommandItem
+                    key={r.id}
+                    value={r.pathPattern}
+                    className={cn(!r.isEnabled && 'opacity-60')}
+                    onSelect={() => {
+                      onChange(r.pathPattern);
+                      setSearch('');
+                      setOpen(false);
+                    }}
+                  >
+                    <Check
+                      className={cn(
+                        'mr-2 h-4 w-4',
+                        value === r.pathPattern ? 'opacity-100' : 'opacity-0',
+                      )}
+                    />
+                    <span className="font-mono text-sm flex-1 truncate">{r.pathPattern}</span>
+                    <span className="flex gap-1">
+                      {methodsOf(r).map((m) => (
+                        <Badge key={m} variant="outline" className="text-[10px] px-1 py-0">
+                          {m}
+                        </Badge>
+                      ))}
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {value &&
+        (sibling ? (
+          <p className="flex items-center gap-1 text-xs text-emerald-700 dark:text-emerald-400">
+            <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+            <span>
+              Answered by <span className="font-mono">{sibling.pathPattern}</span>
+            </span>
+          </p>
+        ) : (
+          <p className="flex items-center gap-1 text-xs text-amber-700 dark:text-amber-400">
+            <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+            <span>
+              No enabled rule in this set answers {method} {value}. Another set on the same alias
+              may — otherwise the tool fails with &quot;no rule answers&quot;.
+            </span>
+          </p>
+        ))}
+      {help && <p className="text-xs text-muted-foreground">{help}</p>}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/pipelines/handlers/mcp/StringListInput.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/StringListInput.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StringListInput } from './StringListInput';
+
+describe('StringListInput', () => {
+  it('shows each value as a removable chip', () => {
+    const onChange = vi.fn();
+    render(
+      <StringListInput label="Domains" value={['$app', 'https://x.test']} onChange={onChange} />,
+    );
+    expect(screen.getByText('$app')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Remove $app' }));
+    expect(onChange).toHaveBeenCalledWith(['https://x.test']);
+  });
+
+  it('adds a typed value on Enter and ignores blanks and duplicates', () => {
+    const onChange = vi.fn();
+    render(<StringListInput label="Domains" value={['a']} onChange={onChange} />);
+    const input = screen.getByLabelText('Domains');
+    fireEvent.change(input, { target: { value: ' b ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenLastCalledWith(['a', 'b']);
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers suggestion chips that add on click', () => {
+    const onChange = vi.fn();
+    render(
+      <StringListInput
+        label="Domains"
+        value={[]}
+        onChange={onChange}
+        suggestions={[{ value: '$app', hint: 'this origin' }]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add $app' }));
+    expect(onChange).toHaveBeenCalledWith(['$app']);
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/mcp/StringListInput.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/StringListInput.tsx
@@ -1,0 +1,104 @@
+import { useId, useState } from 'react';
+import { X } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+export interface StringListSuggestion {
+  value: string;
+  hint?: string;
+}
+
+interface StringListInputProps {
+  label: string;
+  value: string[];
+  onChange: (value: string[]) => void;
+  placeholder?: string;
+  /** Quick-add chips shown under the input (hidden once present in the list). */
+  suggestions?: StringListSuggestion[];
+  help?: string;
+}
+
+/** A list of strings edited as chips: type + Enter (or comma) to add, × to remove. */
+export function StringListInput({
+  label,
+  value,
+  onChange,
+  placeholder,
+  suggestions = [],
+  help,
+}: StringListInputProps) {
+  const id = useId();
+  const [draft, setDraft] = useState('');
+
+  const add = (raw: string) => {
+    const v = raw.trim();
+    if (!v || value.includes(v)) return;
+    onChange([...value, v]);
+  };
+
+  const commitDraft = () => {
+    add(draft);
+    setDraft('');
+  };
+
+  const pending = suggestions.filter((s) => !value.includes(s.value));
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {value.map((v) => (
+            <Badge key={v} variant="secondary" className="font-mono font-normal gap-1 pr-1">
+              {v}
+              <button
+                type="button"
+                aria-label={`Remove ${v}`}
+                className="rounded-sm hover:bg-muted-foreground/20"
+                onClick={() => onChange(value.filter((x) => x !== v))}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+      <Input
+        id={id}
+        value={draft}
+        placeholder={placeholder}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => draft.trim() && commitDraft()}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ',') {
+            e.preventDefault();
+            commitDraft();
+          }
+        }}
+        className="font-mono text-sm"
+      />
+      {pending.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {pending.map((s) => (
+            <Button
+              key={s.value}
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-6 px-2 text-xs font-normal"
+              aria-label={`Add ${s.value}`}
+              title={s.hint}
+              onClick={() => add(s.value)}
+            >
+              + <span className="font-mono ml-1">{s.value}</span>
+              {s.hint && <span className="ml-1 text-muted-foreground">{s.hint}</span>}
+            </Button>
+          ))}
+        </div>
+      )}
+      {help && <p className="text-xs text-muted-foreground">{help}</p>}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/pipelines/handlers/mcp/__fixtures__/workflow.json
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/__fixtures__/workflow.json
@@ -1,0 +1,248 @@
+{
+  "tools": [
+    {
+      "name": "workflow.list",
+      "rule": { "path": "/api/workflow/mcp-tools/list", "method": "POST" },
+      "annotations": { "readOnlyHint": true },
+      "description": "List the implementations published to this harness and their workflows, each with its `headlessSafe` mark (whether every interactive step declares what to do without a person).",
+      "inputSchema": {
+        "type": "object",
+        "required": [],
+        "properties": { "impl": { "type": "string", "description": "Only this implementation." } },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "workflow.describe",
+      "rule": { "path": "/api/workflow/mcp-tools/describe", "method": "POST" },
+      "annotations": { "readOnlyHint": true },
+      "description": "Describe one workflow before deciding a run can complete without a person: its inputs (types, required, defaults), its outputs, the job/step graph in dependency order, and each interactive step’s `headless` declaration.",
+      "inputSchema": {
+        "type": "object",
+        "required": ["impl", "workflow"],
+        "properties": {
+          "impl": { "type": "string", "description": "The implementation alias, e.g. `hello`." },
+          "workflow": { "type": "string", "description": "The workflow id — the file base name minus `.workflow.yaml`, e.g. `interactive`." }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "workflow.start",
+      "rule": { "path": "/api/workflow/mcp-tools/start", "method": "POST" },
+      "annotations": { "readOnlyHint": false },
+      "description": "Start a run of a workflow with the given inputs. Validated exactly as the kickoff form validates a person’s values; a refusal names each bad input. Returns the run id and its first snapshot, and moves the page to the run.",
+      "inputSchema": {
+        "type": "object",
+        "required": ["impl", "workflow", "inputs"],
+        "properties": {
+          "impl": { "type": "string", "description": "The implementation alias, e.g. `hello`." },
+          "inputs": { "type": "object", "description": "Values for `on.manual.inputs`, keyed by input name. An omitted input takes its declared default; a `file` input is a whole File ref (`{ path, name, contentType, size, url }`), never a bare path or a URL. Pass `{}` for a workflow with no inputs.", "additionalProperties": true },
+          "workflow": { "type": "string", "description": "The workflow id — the file base name minus `.workflow.yaml`, e.g. `interactive`." }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "workflow.status",
+      "rule": { "path": "/api/workflow/mcp-tools/status", "method": "POST" },
+      "annotations": { "readOnlyHint": true },
+      "description": "The run snapshot: status, the steps in flight, every reached step’s status, the outputs so far, and `waitingOn` — for each waiting step what would satisfy it (its kind, its evaluated inputs, an island’s declared outputs and src).",
+      "inputSchema": {
+        "type": "object",
+        "required": [],
+        "properties": { "runId": { "type": "string", "description": "The run to act on. Optional where a current run exists (the harness page); required over the MCP endpoint." } },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "workflow.await",
+      "rule": { "path": "/api/workflow/mcp-tools/await", "method": "POST" },
+      "annotations": { "readOnlyHint": true },
+      "description": "Wait until the run needs input (`until: \"waiting\"`) or ends (`until: \"terminal\"`), then return its snapshot. The polite alternative to polling `workflow.status`.",
+      "inputSchema": {
+        "type": "object",
+        "required": ["until"],
+        "properties": {
+          "runId": { "type": "string", "description": "The run to act on. Optional where a current run exists (the harness page); required over the MCP endpoint." },
+          "until": { "enum": ["waiting", "terminal"], "type": "string", "description": "`waiting`: resolve as soon as the run needs input (a step is `waiting`) or ends; `terminal`: resolve only when the run ends." },
+          "timeoutMs": { "type": "integer", "maximum": 600000, "minimum": 1, "description": "How long to wait before answering with the current snapshot and `timedOut: true` (default 120000)." }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "workflow.runs",
+      "rule": { "path": "/api/workflow/mcp-tools/runs", "method": "POST" },
+      "annotations": { "readOnlyHint": true },
+      "description": "Past runs of one workflow, newest first: id, status, when it started and ended, and which steps it is waiting on.",
+      "inputSchema": {
+        "type": "object",
+        "required": [],
+        "properties": {
+          "impl": { "type": "string", "description": "The implementation alias; defaults to the current run’s (or the page’s) on the harness page." },
+          "limit": { "type": "integer", "maximum": 50, "minimum": 1, "description": "At most this many runs, newest first (default 20)." },
+          "status": { "enum": ["running", "succeeded", "failed", "cancelled"], "type": "string", "description": "Only runs in this status." },
+          "workflow": { "type": "string", "description": "The workflow id; defaults to the current run’s (or the page’s) on the harness page." }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "workflow.submitStep",
+      "rule": { "path": "/api/workflow/mcp-tools/submitStep", "method": "POST" },
+      "_meta": { "ui": { "resourceUri": "ui://bffless/workflow/step-view.e2235b30.html" } },
+      "annotations": { "readOnlyHint": false },
+      "description": "Complete a waiting interactive step, or open it for the person. A `form` step takes a value per field; an `island` step takes its declared outputs. Validated by the same checks a person’s submit runs; a refusal names each bad value. In an agent host that renders this tool’s UI, call it with `values: {}` for an island or form step: the step’s own UI is shown and the person completes it there — do not invent values for them.",
+      "inputSchema": {
+        "type": "object",
+        "required": ["step", "values"],
+        "properties": {
+          "step": { "type": "string", "description": "The waiting step’s key, `<job>/<index>/<step>` — as listed in the snapshot’s `waitingOn`." },
+          "runId": { "type": "string", "description": "The run to act on. Optional where a current run exists (the harness page); required over the MCP endpoint." },
+          "values": { "type": "object", "description": "For a `form` step: a value per field, keyed by field name (a `choice` over File refs takes the ref’s `path`). For an `island` step: the step’s declared outputs, keyed by output name.", "additionalProperties": true }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "workflow.outputs",
+      "rule": { "path": "/api/workflow/mcp-tools/outputs", "method": "POST" },
+      "annotations": { "readOnlyHint": true },
+      "description": "The run’s outputs — File refs (`{ path, name, contentType, size, url }`), never bytes.",
+      "inputSchema": {
+        "type": "object",
+        "required": [],
+        "properties": { "runId": { "type": "string", "description": "The run to act on. Optional where a current run exists (the harness page); required over the MCP endpoint." } },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "workflow.sign",
+      "rule": { "path": "/api/workflow/mcp-tools/sign", "method": "POST" },
+      "annotations": { "readOnlyHint": false },
+      "description": "Exchange a File ref’s `path` for a short-lived presigned GET URL (`{ url, expiresIn }`), the same one islands get to show media.",
+      "inputSchema": {
+        "type": "object",
+        "required": ["path"],
+        "properties": {
+          "path": { "type": "string", "description": "A File ref’s `path` — an uploads-relative key under `workflows/`. Nothing else is signable." },
+          "runId": { "type": "string", "description": "The run to act on. Optional where a current run exists (the harness page); required over the MCP endpoint." }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "workflow.cancel",
+      "rule": { "path": "/api/workflow/mcp-tools/cancel", "method": "POST" },
+      "annotations": { "readOnlyHint": false },
+      "description": "Cancel the run. Server-side pipeline jobs already enqueued keep running.",
+      "inputSchema": {
+        "type": "object",
+        "required": [],
+        "properties": { "runId": { "type": "string", "description": "The run to act on. Optional where a current run exists (the harness page); required over the MCP endpoint." } },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "workflow.resume",
+      "rule": { "path": "/api/workflow/mcp-tools/resume", "method": "POST" },
+      "annotations": { "readOnlyHint": false },
+      "description": "Take over a `running` run whose driver went away (an expired lease) so this surface drives it from here — how an agent adopts a run another tab or host abandoned.",
+      "inputSchema": {
+        "type": "object",
+        "required": ["runId"],
+        "properties": { "runId": { "type": "string", "description": "The `running` run to take over." } },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "workflow.submit",
+      "rule": { "path": "/api/workflow/mcp-tools/submit", "method": "POST" },
+      "visibility": ["app"],
+      "description": "Complete the waiting island step of a run with its declared outputs — the island's own `workflow.submit` (spec 04), answered server-side: validated against the step's declared output map exactly as the harness page validates it, then written to the step row. Refused while a harness tab still drives the run.",
+      "inputSchema": {
+        "type": "object",
+        "required": ["runId", "step", "outputs"],
+        "properties": {
+          "step": { "type": "string", "description": "The step key, `<job>/<index>/<step>`, of the waiting island step." },
+          "runId": { "type": "string", "description": "The run the island belongs to." },
+          "outputs": { "type": "object", "description": "The values for the step’s declared outputs.", "additionalProperties": true }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "workflow.annotate",
+      "rule": { "path": "/api/workflow/mcp-tools/annotate", "method": "POST" },
+      "visibility": ["app"],
+      "description": "Record annotations and/or a summary on the waiting island step — the island's own `workflow.annotate` (spec 04), budgeted per step exactly as on the harness page.",
+      "inputSchema": {
+        "type": "object",
+        "required": ["runId", "step"],
+        "properties": {
+          "step": { "type": "string", "description": "The step key, `<job>/<index>/<step>`, of the waiting island step." },
+          "runId": { "type": "string", "description": "The run the island belongs to." },
+          "summary": { "type": "string" },
+          "annotations": { "type": "array", "items": { "type": "object", "additionalProperties": true }, "description": "Entries of `{ level: notice|warning|error, message, title? }`." }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "workflow.pipeline",
+      "rule": { "path": "/api/workflow/mcp-tools/pipeline", "method": "POST" },
+      "visibility": ["app"],
+      "description": "Call one of the run's own implementation's pipelines on the island's behalf — a tool name resolves to `/api/<impl>/<path>` (dots as slashes) and is fenced to that implementation exactly as on the harness page (spec 04).",
+      "inputSchema": {
+        "type": "object",
+        "required": ["runId", "step", "name"],
+        "properties": {
+          "name": { "type": "string", "description": "The pipeline’s tool name, e.g. `echo` or `video.slice`." },
+          "step": { "type": "string", "description": "The step key, `<job>/<index>/<step>`, of the waiting island step." },
+          "runId": { "type": "string", "description": "The run the island belongs to." },
+          "method": { "enum": ["GET", "POST"], "type": "string", "description": "Defaults to POST." },
+          "arguments": { "type": "object", "description": "The JSON body (POST) or query (GET).", "additionalProperties": true }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "workflow.stepView",
+      "rule": { "path": "/api/workflow/mcp-tools/stepView", "method": "POST" },
+      "visibility": ["app"],
+      "description": "What the step view needs to mount a waiting interactive step. An island: its HTML (unchanged, fetched from the implementation's bundle), the step's persisted inputs (its tool-input arguments) and its declared outputs. A form: the fields the harness evaluated when the step started waiting, their initial values, the title and the submit label.",
+      "inputSchema": {
+        "type": "object",
+        "required": ["runId", "step"],
+        "properties": {
+          "step": { "type": "string", "description": "The step key, `<job>/<index>/<step>`, of the waiting island step." },
+          "runId": { "type": "string", "description": "The run the island belongs to." }
+        },
+        "additionalProperties": false
+      }
+    }
+  ],
+  "resources": {
+    "csp": { "connectDomains": ["$app", "$storage"], "resourceDomains": ["$storage"] },
+    "list": { "rule": { "path": "/api/workflow/mcp-resources", "method": "GET" } },
+    "static": [
+      {
+        "uri": "ui://bffless/workflow/step-view.e2235b30.html",
+        "name": "Workflow step view",
+        "rule": { "path": "/api/workflow/mcp-resources/step-view" },
+        "description": "Mounts a waiting island or form step of a run (spec 10)."
+      }
+    ],
+    "templates": [
+      {
+        "name": "island",
+        "rule": { "path": "/w/{impl}/{path+}" },
+        "description": "An island of an implementation, served unchanged from its bundle (spec 04).",
+        "uriTemplate": "ui://bffless/{impl}/{path+}"
+      }
+    ]
+  },
+  "serverInfo": { "name": "bffless-workflow", "version": "1.0.0" },
+  "instructions": "The BFFless Workflow harness: 11 workflow.* tools to list, describe and watch runs and complete a waiting interactive step (island or form). Pass runId to every run-scoped tool."
+}

--- a/apps/frontend/src/components/pipelines/handlers/mcp/input-schema.test.ts
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/input-schema.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import workflow from './__fixtures__/workflow.json';
+import { isFlatObjectSchema, schemaToRows, rowsToSchema, emptyFlatSchema } from './input-schema';
+
+const tools = (workflow as { tools: { name: string; inputSchema: Record<string, unknown> }[] })
+  .tools;
+
+describe('isFlatObjectSchema', () => {
+  it('accepts every tool schema the workflow server ships', () => {
+    for (const t of tools) expect(isFlatObjectSchema(t.inputSchema), t.name).toBe(true);
+  });
+
+  it('accepts an empty schema', () => {
+    expect(isFlatObjectSchema({})).toBe(true);
+    expect(isFlatObjectSchema({ type: 'object' })).toBe(true);
+  });
+
+  it('refuses what the builder cannot show', () => {
+    expect(isFlatObjectSchema({ type: 'string' })).toBe(false);
+    expect(
+      isFlatObjectSchema({
+        type: 'object',
+        properties: { a: { type: 'object', properties: { b: { type: 'string' } } } },
+      }),
+    ).toBe(false);
+    expect(
+      isFlatObjectSchema({ type: 'object', properties: { a: { oneOf: [{ type: 'string' }] } } }),
+    ).toBe(false);
+    expect(
+      isFlatObjectSchema({ type: 'object', properties: { a: { type: ['string', 'null'] } } }),
+    ).toBe(false);
+    expect(
+      isFlatObjectSchema({ type: 'object', properties: { a: { type: 'string', pattern: '^x' } } }),
+    ).toBe(false);
+    expect(
+      isFlatObjectSchema({
+        type: 'object',
+        properties: { a: { type: 'string' } },
+        required: ['b'],
+      }),
+    ).toBe(false);
+    expect(
+      isFlatObjectSchema({
+        type: 'object',
+        properties: { a: { type: 'array', items: { type: 'string', enum: ['x'] } } },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('schemaToRows / rowsToSchema', () => {
+  it('round-trips every shipped tool schema (required compared as a set)', () => {
+    const sortRequired = (s: Record<string, unknown>) => ({
+      ...s,
+      required: [...((s.required as string[] | undefined) ?? [])].sort(),
+    });
+    for (const t of tools)
+      expect(sortRequired(rowsToSchema(schemaToRows(t.inputSchema))), t.name).toEqual(
+        sortRequired(t.inputSchema),
+      );
+  });
+
+  it('keeps property order and marks required rows', () => {
+    const flat = schemaToRows({
+      type: 'object',
+      required: ['b'],
+      properties: {
+        a: { type: 'integer', minimum: 1, maximum: 5, description: 'A' },
+        b: { type: 'string', enum: ['x', 'y'] },
+        c: { type: 'array', items: { type: 'object', additionalProperties: true } },
+      },
+      additionalProperties: false,
+    });
+    expect(flat.additionalProperties).toBe(false);
+    expect(flat.rows.map((r) => r.name)).toEqual(['a', 'b', 'c']);
+    expect(flat.rows[0]).toEqual({
+      name: 'a',
+      type: 'integer',
+      required: false,
+      minimum: 1,
+      maximum: 5,
+      description: 'A',
+    });
+    expect(flat.rows[1]).toEqual({ name: 'b', type: 'string', required: true, enum: ['x', 'y'] });
+    expect(flat.rows[2]).toEqual({
+      name: 'c',
+      type: 'array',
+      required: false,
+      items: { type: 'object', additionalProperties: true },
+    });
+  });
+
+  it('writes required in row order and omits blank rows', () => {
+    const schema = rowsToSchema({
+      additionalProperties: true,
+      rows: [
+        { name: 'z', type: 'string', required: true },
+        { name: '', type: 'string', required: true },
+        { name: 'y', type: 'boolean', required: true, description: '' },
+      ],
+    });
+    expect(schema).toEqual({
+      type: 'object',
+      required: ['z', 'y'],
+      properties: { z: { type: 'string' }, y: { type: 'boolean' } },
+      additionalProperties: true,
+    });
+  });
+
+  it('emptyFlatSchema is a closed object with no rows', () => {
+    expect(rowsToSchema(emptyFlatSchema())).toEqual({
+      type: 'object',
+      required: [],
+      properties: {},
+      additionalProperties: false,
+    });
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/mcp/input-schema.ts
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/input-schema.ts
@@ -1,0 +1,141 @@
+/**
+ * A tool's `inputSchema` as the property table edits it: a flat JSON-Schema
+ * object whose properties are scalars, or opaque objects/arrays. Anything
+ * richer (nested properties, `oneOf`, `$ref`, `pattern`, ...) fails
+ * `isFlatObjectSchema` and is edited as JSON instead.
+ */
+
+export const PROP_TYPES = ['string', 'integer', 'number', 'boolean', 'object', 'array'] as const;
+export type PropType = (typeof PROP_TYPES)[number];
+
+export interface ItemsSpec {
+  type: PropType;
+  additionalProperties?: boolean;
+}
+
+export interface PropertyRow {
+  name: string;
+  type: PropType;
+  required: boolean;
+  description?: string;
+  enum?: string[];
+  minimum?: number;
+  maximum?: number;
+  default?: unknown;
+  additionalProperties?: boolean;
+  items?: ItemsSpec;
+}
+
+export interface FlatSchema {
+  rows: PropertyRow[];
+  additionalProperties: boolean;
+}
+
+const TOP_KEYS = new Set(['type', 'required', 'properties', 'additionalProperties']);
+const PROP_KEYS = new Set([
+  'type',
+  'description',
+  'enum',
+  'minimum',
+  'maximum',
+  'default',
+  'additionalProperties',
+  'items',
+]);
+const ITEMS_KEYS = new Set(['type', 'additionalProperties']);
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  v !== null && typeof v === 'object' && !Array.isArray(v);
+const isPropType = (v: unknown): v is PropType => PROP_TYPES.includes(v as PropType);
+const keysWithin = (obj: Record<string, unknown>, allowed: Set<string>) =>
+  Object.keys(obj).every((k) => allowed.has(k));
+
+function isFlatProperty(p: unknown): boolean {
+  if (!isRecord(p) || !keysWithin(p, PROP_KEYS) || !isPropType(p.type)) return false;
+  if (p.description !== undefined && typeof p.description !== 'string') return false;
+  if (
+    p.enum !== undefined &&
+    !(Array.isArray(p.enum) && p.enum.every((e) => typeof e === 'string'))
+  )
+    return false;
+  if (p.minimum !== undefined && typeof p.minimum !== 'number') return false;
+  if (p.maximum !== undefined && typeof p.maximum !== 'number') return false;
+  if (p.additionalProperties !== undefined && typeof p.additionalProperties !== 'boolean')
+    return false;
+  if (p.items !== undefined) {
+    if (!isRecord(p.items) || !keysWithin(p.items, ITEMS_KEYS) || !isPropType(p.items.type))
+      return false;
+    if (
+      p.items.additionalProperties !== undefined &&
+      typeof p.items.additionalProperties !== 'boolean'
+    )
+      return false;
+  }
+  return true;
+}
+
+export function isFlatObjectSchema(schema: unknown): boolean {
+  if (!isRecord(schema) || !keysWithin(schema, TOP_KEYS)) return false;
+  if (schema.type !== undefined && schema.type !== 'object') return false;
+  if (schema.additionalProperties !== undefined && typeof schema.additionalProperties !== 'boolean')
+    return false;
+  const properties = schema.properties ?? {};
+  if (!isRecord(properties)) return false;
+  if (!Object.values(properties).every(isFlatProperty)) return false;
+  const required = schema.required ?? [];
+  if (!Array.isArray(required)) return false;
+  return required.every((r) => typeof r === 'string' && r in properties);
+}
+
+export function emptyFlatSchema(): FlatSchema {
+  return { rows: [], additionalProperties: false };
+}
+
+export function emptyRow(): PropertyRow {
+  return { name: '', type: 'string', required: false };
+}
+
+/** Assumes `isFlatObjectSchema(schema)`. */
+export function schemaToRows(schema: Record<string, unknown>): FlatSchema {
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  const required = new Set(Array.isArray(schema.required) ? (schema.required as string[]) : []);
+  const rows: PropertyRow[] = Object.entries(properties).map(([name, raw]) => {
+    const p = raw as Record<string, unknown>;
+    const row: PropertyRow = { name, type: p.type as PropType, required: required.has(name) };
+    if (p.description !== undefined) row.description = p.description as string;
+    if (p.enum !== undefined) row.enum = p.enum as string[];
+    if (p.minimum !== undefined) row.minimum = p.minimum as number;
+    if (p.maximum !== undefined) row.maximum = p.maximum as number;
+    if (p.default !== undefined) row.default = p.default;
+    if (p.additionalProperties !== undefined)
+      row.additionalProperties = p.additionalProperties as boolean;
+    if (p.items !== undefined) row.items = { ...(p.items as ItemsSpec) };
+    return row;
+  });
+  return {
+    rows,
+    additionalProperties:
+      typeof schema.additionalProperties === 'boolean' ? schema.additionalProperties : false,
+  };
+}
+
+/** Writes the key layout the shipped servers use: `type, required, properties, additionalProperties`. */
+export function rowsToSchema(flat: FlatSchema): Record<string, unknown> {
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+  for (const row of flat.rows) {
+    const name = row.name.trim();
+    if (!name) continue;
+    const p: Record<string, unknown> = { type: row.type };
+    if (row.description) p.description = row.description;
+    if (row.enum && row.enum.length) p.enum = row.enum;
+    if (row.minimum !== undefined) p.minimum = row.minimum;
+    if (row.maximum !== undefined) p.maximum = row.maximum;
+    if (row.default !== undefined) p.default = row.default;
+    if (row.additionalProperties !== undefined) p.additionalProperties = row.additionalProperties;
+    if (row.items) p.items = { ...row.items };
+    properties[name] = p;
+    if (row.required) required.push(name);
+  }
+  return { type: 'object', required, properties, additionalProperties: flat.additionalProperties };
+}

--- a/apps/frontend/src/components/pipelines/handlers/mcp/model.test.ts
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/model.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest';
+import workflow from './__fixtures__/workflow.json';
+import {
+  normalize,
+  serialize,
+  validate,
+  matchesPattern,
+  findSibling,
+  emptyTool,
+  type McpConfig,
+} from './model';
+
+describe('normalize + serialize', () => {
+  it('keeps every tool, resource, annotation, _meta and csp entry of the shipped workflow config', () => {
+    const model = normalize(workflow as Record<string, unknown>);
+    expect(model.tools).toHaveLength(15);
+    expect(serialize(model)).toEqual(workflow);
+  });
+
+  it('normalizes an empty config into a form-ready model', () => {
+    const model = normalize({});
+    expect(model.serverInfo).toEqual({ name: '', version: '' });
+    expect(model.tools).toEqual([]);
+    expect(model.resources).toEqual({
+      static: [],
+      templates: [],
+      csp: { connectDomains: [], resourceDomains: [] },
+    });
+    expect(model.instructions).toBe('');
+    expect(model.protocolVersions).toEqual([]);
+  });
+
+  it('omits empty optionals and the default visibility on write', () => {
+    const model = normalize({
+      serverInfo: { name: 'x', version: '1' },
+      tools: [
+        {
+          name: 't',
+          description: '',
+          inputSchema: { type: 'object' },
+          rule: { path: '/a', method: 'POST' },
+          annotations: {},
+          visibility: ['model'],
+          _meta: { ui: {} },
+        },
+      ],
+    });
+    expect(serialize(model)).toEqual({
+      serverInfo: { name: 'x', version: '1' },
+      tools: [
+        {
+          name: 't',
+          description: '',
+          inputSchema: { type: 'object' },
+          rule: { path: '/a', method: 'POST' },
+        },
+      ],
+    });
+  });
+
+  it('carries unknown keys through on the config, a tool and a resource', () => {
+    const raw = {
+      serverInfo: { name: 'x', version: '1' },
+      future: { flag: true },
+      tools: [
+        {
+          name: 't',
+          description: 'd',
+          inputSchema: { type: 'object' },
+          rule: { path: '/a' },
+          title: 'Tool T',
+          _meta: { ui: { resourceUri: 'ui://x' }, vendor: 1 },
+          annotations: { readOnlyHint: true, custom: 'y' },
+        },
+      ],
+      resources: { static: [{ uri: 'ui://x', name: 'X', rule: { path: '/x' }, extra: 2 }] },
+    };
+    expect(serialize(normalize(raw))).toEqual(raw);
+  });
+
+  it('emptyTool is a POST tool with an empty closed object schema', () => {
+    expect(emptyTool()).toEqual({
+      name: '',
+      description: '',
+      inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+      annotations: {},
+      visibility: [],
+      _meta: {},
+      rule: { path: '', method: 'POST' },
+    });
+  });
+});
+
+describe('validate', () => {
+  const base = (): McpConfig => normalize({ serverInfo: { name: 's', version: '1' }, tools: [] });
+
+  it('accepts the shipped workflow config', () => {
+    expect(validate(normalize(workflow as Record<string, unknown>))).toEqual([]);
+  });
+
+  it('requires serverInfo name and version', () => {
+    const problems = validate(normalize({}));
+    expect(problems).toContainEqual({
+      path: ['serverInfo'],
+      message: 'serverInfo.name and serverInfo.version are required strings',
+    });
+  });
+
+  it('names each tool problem by its index', () => {
+    const c = base();
+    c.tools.push(
+      { ...emptyTool(), name: 'a', rule: { path: 'nope', method: 'POST' } },
+      { ...emptyTool(), name: 'a', rule: { path: '/ok', method: 'POST' } },
+      { ...emptyTool(), name: '', rule: { path: '/ok', method: 'POST' } },
+    );
+    const problems = validate(c);
+    expect(problems).toContainEqual({
+      path: ['tools', 0, 'rule', 'path'],
+      message: 'tool a: rule.path must start with /',
+    });
+    expect(problems).toContainEqual({
+      path: ['tools', 1, 'name'],
+      message: 'duplicate tool name: a',
+    });
+    expect(problems).toContainEqual({
+      path: ['tools', 2, 'name'],
+      message: 'each tool needs a name',
+    });
+  });
+
+  it('checks a template declares a variable and a list rule has a path', () => {
+    const c = base();
+    c.resources.templates.push({ uriTemplate: 'ui://plain', name: 'p', rule: { path: '/p' } });
+    c.resources.list = { rule: { path: '' } };
+    const problems = validate(c);
+    expect(problems).toContainEqual({
+      path: ['resources', 'templates', 0, 'uriTemplate'],
+      message: 'resource template ui://plain declares no {variable}',
+    });
+    expect(problems).toContainEqual({
+      path: ['resources', 'list', 'rule', 'path'],
+      message: 'resources.list.rule.path is required',
+    });
+  });
+
+  it('checks a static resource has uri, name and rule.path', () => {
+    const c = base();
+    c.resources.static.push({ uri: '', name: 'x', rule: { path: '/x' } });
+    expect(validate(c)).toContainEqual({
+      path: ['resources', 'static', 0],
+      message: 'each static resource needs uri, name and rule.path',
+    });
+  });
+});
+
+describe('matchesPattern + findSibling', () => {
+  it('matches exactly or by * glob like the backend resolver', () => {
+    expect(matchesPattern('/api/a', '/api/a')).toBe(true);
+    expect(matchesPattern('/api/*', '/api/a/b')).toBe(true);
+    expect(matchesPattern('/api/*', '/api')).toBe(false);
+    expect(matchesPattern('/w/*', '/w/{impl}/{path+}')).toBe(true);
+  });
+
+  it('finds the first enabled sibling whose pattern and method match', () => {
+    const rules = [
+      { id: '1', pathPattern: '/api/x', method: 'GET', methods: null, isEnabled: true },
+      { id: '2', pathPattern: '/api/x', method: null, methods: ['POST'], isEnabled: true },
+      { id: '3', pathPattern: '/api/*', method: null, methods: null, isEnabled: false },
+      { id: '4', pathPattern: '/api/*', method: null, methods: null, isEnabled: true },
+    ];
+    expect(findSibling(rules, '/api/x', 'POST')?.id).toBe('2');
+    expect(findSibling(rules, '/api/x', 'GET')?.id).toBe('1');
+    expect(findSibling(rules, '/api/y', 'GET')?.id).toBe('4');
+    expect(findSibling(rules, '/other', 'GET')).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/mcp/model.ts
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/model.ts
@@ -1,0 +1,334 @@
+/**
+ * The form model behind the `mcp_handler` editor.
+ *
+ * `normalize` turns whatever the step holds into a shape every control can
+ * bind to (every optional present, every list an array); `serialize` writes
+ * it back as the config the backend validates (`McpHandler.validateConfig`),
+ * dropping empty optionals and the default visibility. Keys the form does not
+ * model are carried through untouched on the config, each tool and each
+ * resource, so a code-authored rule saved from the dashboard loses nothing.
+ */
+
+export type McpMethod = 'GET' | 'POST';
+export type McpVisibility = 'model' | 'app';
+
+export interface McpToolRule {
+  path: string;
+  method?: McpMethod;
+}
+
+export interface McpTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations: Record<string, unknown>;
+  visibility: McpVisibility[];
+  _meta: Record<string, unknown>;
+  rule: McpToolRule;
+  [extra: string]: unknown;
+}
+
+export interface McpStaticResource {
+  uri: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+  rule: { path: string; method?: 'GET' };
+  [extra: string]: unknown;
+}
+
+export interface McpResourceTemplate {
+  uriTemplate: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+  rule: { path: string };
+  [extra: string]: unknown;
+}
+
+export interface McpCsp {
+  connectDomains: string[];
+  resourceDomains: string[];
+}
+
+export interface McpResources {
+  static: McpStaticResource[];
+  templates: McpResourceTemplate[];
+  list?: { rule: { path: string; method?: 'GET' } };
+  csp: McpCsp;
+  [extra: string]: unknown;
+}
+
+export interface McpConfig {
+  serverInfo: { name: string; version: string };
+  instructions: string;
+  protocolVersions: string[];
+  tools: McpTool[];
+  resources: McpResources;
+  [extra: string]: unknown;
+}
+
+export interface Problem {
+  path: (string | number)[];
+  message: string;
+}
+
+export const PROTOCOL_VERSION_DEFAULTS = ['2025-06-18', '2025-03-26', '2024-11-05'];
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+const rec = (v: unknown): Record<string, unknown> => (isRecord(v) ? v : {});
+const strList = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+
+export function emptyTool(): McpTool {
+  return {
+    name: '',
+    description: '',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    annotations: {},
+    visibility: [],
+    _meta: {},
+    rule: { path: '', method: 'POST' },
+  };
+}
+
+export function emptyStaticResource(): McpStaticResource {
+  return { uri: '', name: '', rule: { path: '' } };
+}
+
+export function emptyTemplate(): McpResourceTemplate {
+  return { uriTemplate: '', name: '', rule: { path: '' } };
+}
+
+function normalizeTool(raw: unknown): McpTool {
+  const t = rec(raw);
+  const rule = rec(t.rule);
+  const method = rule.method === 'GET' || rule.method === 'POST' ? rule.method : undefined;
+  return {
+    ...t,
+    name: str(t.name),
+    description: str(t.description),
+    inputSchema: isRecord(t.inputSchema) ? t.inputSchema : {},
+    annotations: rec(t.annotations),
+    visibility: strList(t.visibility).filter(
+      (v): v is McpVisibility => v === 'model' || v === 'app',
+    ),
+    _meta: rec(t._meta),
+    rule: { ...rule, path: str(rule.path), method },
+  };
+}
+
+function normalizeStatic(raw: unknown): McpStaticResource {
+  const r = rec(raw);
+  const rule = rec(r.rule);
+  return {
+    ...r,
+    uri: str(r.uri),
+    name: str(r.name),
+    description: typeof r.description === 'string' ? r.description : undefined,
+    mimeType: typeof r.mimeType === 'string' ? r.mimeType : undefined,
+    rule: { ...rule, path: str(rule.path), method: rule.method === 'GET' ? 'GET' : undefined },
+  };
+}
+
+function normalizeTemplate(raw: unknown): McpResourceTemplate {
+  const r = rec(raw);
+  const rule = rec(r.rule);
+  return {
+    ...r,
+    uriTemplate: str(r.uriTemplate),
+    name: str(r.name),
+    description: typeof r.description === 'string' ? r.description : undefined,
+    mimeType: typeof r.mimeType === 'string' ? r.mimeType : undefined,
+    rule: { ...rule, path: str(rule.path) },
+  };
+}
+
+export function normalize(raw: Record<string, unknown>): McpConfig {
+  const serverInfo = rec(raw.serverInfo);
+  const resources = rec(raw.resources);
+  const csp = rec(resources.csp);
+  const list = isRecord(resources.list) ? rec(resources.list.rule) : undefined;
+  return {
+    ...raw,
+    serverInfo: { name: str(serverInfo.name), version: str(serverInfo.version) },
+    instructions: str(raw.instructions),
+    protocolVersions: strList(raw.protocolVersions),
+    tools: Array.isArray(raw.tools) ? raw.tools.map(normalizeTool) : [],
+    resources: {
+      ...resources,
+      static: Array.isArray(resources.static) ? resources.static.map(normalizeStatic) : [],
+      templates: Array.isArray(resources.templates)
+        ? resources.templates.map(normalizeTemplate)
+        : [],
+      list: list
+        ? {
+            rule: {
+              ...list,
+              path: str(list.path),
+              method: list.method === 'GET' ? 'GET' : undefined,
+            },
+          }
+        : undefined,
+      csp: {
+        ...csp,
+        connectDomains: strList(csp.connectDomains),
+        resourceDomains: strList(csp.resourceDomains),
+      },
+    },
+  };
+}
+
+/** Drop keys whose value is `undefined`, and (when asked) empty objects. */
+function compact(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) if (v !== undefined) out[k] = v;
+  return out;
+}
+
+const isEmptyObject = (v: unknown) => isRecord(v) && Object.keys(v).length === 0;
+
+/** `_meta` with empty sub-objects (`{ ui: {} }`) pruned; undefined when nothing is left. */
+function pruneMeta(meta: Record<string, unknown>): Record<string, unknown> | undefined {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(meta)) {
+    if (isRecord(v)) {
+      const inner = pruneMeta(v);
+      if (inner) out[k] = inner;
+    } else if (v !== undefined) {
+      out[k] = v;
+    }
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+function serializeTool(t: McpTool): Record<string, unknown> {
+  const { annotations, visibility, _meta, rule, ...rest } = t;
+  return compact({
+    ...rest,
+    annotations: isEmptyObject(annotations) ? undefined : annotations,
+    visibility: visibility.includes('app') ? visibility : undefined,
+    _meta: pruneMeta(_meta),
+    rule: compact({ ...rule }),
+  });
+}
+
+function serializeResource(r: McpStaticResource | McpResourceTemplate): Record<string, unknown> {
+  const { description, mimeType, rule, ...rest } = r;
+  return compact({
+    ...rest,
+    description: description || undefined,
+    mimeType: mimeType || undefined,
+    rule: compact({ ...rule }),
+  });
+}
+
+export function serialize(model: McpConfig): Record<string, unknown> {
+  const { serverInfo, instructions, protocolVersions, tools, resources, ...rest } = model;
+  const { static: statics, templates, list, csp, ...resourcesRest } = resources;
+  const cspOut =
+    csp.connectDomains.length || csp.resourceDomains.length
+      ? compact({
+          ...csp,
+          connectDomains: csp.connectDomains.length ? csp.connectDomains : undefined,
+          resourceDomains: csp.resourceDomains.length ? csp.resourceDomains : undefined,
+        })
+      : undefined;
+  const resourcesOut = compact({
+    ...resourcesRest,
+    static: statics.length ? statics.map(serializeResource) : undefined,
+    templates: templates.length ? templates.map(serializeResource) : undefined,
+    list: list ? { rule: compact({ ...list.rule }) } : undefined,
+    csp: cspOut,
+  });
+  return compact({
+    ...rest,
+    serverInfo: { ...serverInfo },
+    instructions: instructions || undefined,
+    protocolVersions: protocolVersions.length ? protocolVersions : undefined,
+    tools: tools.map(serializeTool),
+    resources: Object.keys(resourcesOut).length ? resourcesOut : undefined,
+  });
+}
+
+const TEMPLATE_VAR = /\{[a-zA-Z_][a-zA-Z0-9_]*\+?\}/;
+
+/** Mirrors `McpHandler.validateConfig` so the form can show what the run would refuse. */
+export function validate(model: McpConfig): Problem[] {
+  const problems: Problem[] = [];
+  const fail = (path: Problem['path'], message: string) => problems.push({ path, message });
+
+  if (!model.serverInfo.name || !model.serverInfo.version) {
+    fail(['serverInfo'], 'serverInfo.name and serverInfo.version are required strings');
+  }
+
+  const names = new Set<string>();
+  model.tools.forEach((tool, i) => {
+    const label = tool.name || `#${i + 1}`;
+    if (!tool.name) fail(['tools', i, 'name'], 'each tool needs a name');
+    else if (names.has(tool.name)) fail(['tools', i, 'name'], `duplicate tool name: ${tool.name}`);
+    names.add(tool.name);
+    if (!isRecord(tool.inputSchema))
+      fail(['tools', i, 'inputSchema'], `tool ${label}: inputSchema must be an object`);
+    if (!tool.rule.path.startsWith('/'))
+      fail(['tools', i, 'rule', 'path'], `tool ${label}: rule.path must start with /`);
+  });
+
+  model.resources.static.forEach((r, i) => {
+    if (!r.uri || !r.name || !r.rule.path)
+      fail(['resources', 'static', i], 'each static resource needs uri, name and rule.path');
+  });
+  model.resources.templates.forEach((t, i) => {
+    if (!t.uriTemplate || !t.rule.path)
+      fail(['resources', 'templates', i], 'each resource template needs uriTemplate and rule.path');
+    else if (!TEMPLATE_VAR.test(t.uriTemplate))
+      fail(
+        ['resources', 'templates', i, 'uriTemplate'],
+        `resource template ${t.uriTemplate} declares no {variable}`,
+      );
+  });
+  if (model.resources.list && !model.resources.list.rule.path)
+    fail(['resources', 'list', 'rule', 'path'], 'resources.list.rule.path is required');
+
+  return problems;
+}
+
+/** The variables a template declares, in order (`{impl}`, `{path+}` → `impl`, `path`). */
+export function templateVariables(template: string): string[] {
+  return Array.from(template.matchAll(/\{([a-zA-Z_][a-zA-Z0-9_]*)\+?\}/g), (m) => m[1]);
+}
+
+/** Same semantics as the backend's `rule-resolution.ts` `matchesPattern`: exact or `*` glob. */
+export function matchesPattern(pattern: string, path: string): boolean {
+  if (pattern === path) return true;
+  if (!pattern.includes('*')) return false;
+  const source = '^' + pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$';
+  return new RegExp(source).test(path);
+}
+
+export interface SiblingRule {
+  id: string;
+  pathPattern: string;
+  method: string | null;
+  methods?: string[] | null;
+  isEnabled: boolean;
+}
+
+/** The first enabled rule of a set that would answer `path` with `method`, as the edge resolves it. */
+export function findSibling<R extends SiblingRule>(
+  rules: R[],
+  path: string,
+  method: string = 'GET',
+): R | undefined {
+  const m = method.toUpperCase();
+  return rules.find((rule) => {
+    if (!rule.isEnabled || !matchesPattern(rule.pathPattern, path)) return false;
+    if (rule.methods && rule.methods.length) return rule.methods.some((x) => x.toUpperCase() === m);
+    if (rule.method) return rule.method.toUpperCase() === m;
+    return true;
+  });
+}

--- a/apps/frontend/src/components/pipelines/handlers/types.ts
+++ b/apps/frontend/src/components/pipelines/handlers/types.ts
@@ -413,7 +413,8 @@ export type HandlerConfig =
   | XmlFeedParseHandlerConfig
   | DataUpsertManyHandlerConfig
   | DelayHandlerConfig
-  | FfmpegHandlerConfig;
+  | FfmpegHandlerConfig
+  | McpHandlerConfig;
 
 export interface SignedUrlHandlerConfig extends BaseHandlerConfig {
   /** Storage key / path (supports expressions, e.g. "steps.upload.storage_path") */
@@ -605,4 +606,42 @@ export interface StripeCheckoutHandlerConfig extends BaseHandlerConfig {
 export interface StripeWebhookHandlerConfig extends BaseHandlerConfig {
   allowedEventTypes?: string[];
   environment?: 'sandbox' | 'production';
+}
+
+/**
+ * `mcp_handler` — the step answers as a stateless MCP server: tools and
+ * `ui://` resources mapped to sibling rules of the same alias. The form
+ * editor lives in `./mcp/`; see `mcp/model.ts` for the normalized shape.
+ */
+export interface McpHandlerConfig extends BaseHandlerConfig {
+  serverInfo: { name: string; version: string };
+  instructions?: string;
+  protocolVersions?: string[];
+  tools: {
+    name: string;
+    description: string;
+    inputSchema: Record<string, unknown>;
+    annotations?: Record<string, unknown>;
+    visibility?: Array<'model' | 'app'>;
+    _meta?: Record<string, unknown>;
+    rule: { path: string; method?: 'GET' | 'POST' };
+  }[];
+  resources?: {
+    static?: {
+      uri: string;
+      name: string;
+      description?: string;
+      mimeType?: string;
+      rule: { path: string; method?: 'GET' };
+    }[];
+    templates?: {
+      uriTemplate: string;
+      name: string;
+      description?: string;
+      mimeType?: string;
+      rule: { path: string };
+    }[];
+    list?: { rule: { path: string; method?: 'GET' } };
+    csp?: { connectDomains?: string[]; resourceDomains?: string[] };
+  };
 }


### PR DESCRIPTION
## What changes for the user

The MCP Server step was a summary line over one raw JSON textarea (#744). It is now a form: a user can add a tool, point it at a sibling rule, mark it read-only or app-only, attach a `ui://` resource and shape its input schema without editing JSON. The JSON stays one tab away for copying into rules-as-code.

```diff
 <McpHandlerConfig>                       apps/frontend/src/components/pipelines/handlers/
   summary card ("15 tools · 1 static resource · 1 template")
-  <Textarea>  whole config as JSON, applied on blur
+  <Alert> problems the run would refuse (mirrors McpHandler.validateConfig), each links to its tab
+  <Tabs>
+    Server     <McpServerSection>     serverInfo · instructions · protocolVersions (Advanced)
+    Tools 15   <McpToolList>          one collapsible card per tool: add / duplicate / reorder / delete
+                 <McpToolForm>        name · title · description
+                   <SiblingRulePicker>  rule.path over the set's rules + GET/POST
+                   <InputSchemaEditor>  property table ⇄ JSON fallback
+                   hints: readOnly · destructive · idempotent · openWorld
+                   visibility: model | app · _meta.ui.resourceUri
+    Resources  <McpResourcesSection>  static[] · templates[] · list rule · CSP chips ($app / $storage)
+    JSON       <JsonField>            the whole config, editable; parse errors reported, not applied
```

## How an edit flows

Every control edits a normalized model; every emit serializes it back to the exact config shape the backend validates. Nothing in the backend or CLI changes.

```mermaid
flowchart LR
    S[step.config JSON] -->|normalize| M[McpConfig model<br/>every optional present]
    M --> F[Form tabs]
    F -->|patch| M
    M -->|serialize<br/>drop empty optionals<br/>keep unknown keys| S
    M -->|validate| P[Problems panel]
    S -.->|save rule| B[(McpHandler.validateConfig<br/>at run time)]
    R[(rule set's rules<br/>useGetRuleSetRulesQuery)] --> K[SiblingRulePicker<br/>exact or * glob, like rule-resolution.ts]
    K -->|"answered by /api/… · no rule answers"| F
```

The sibling hint is a hint, not an error: another set attached to the same alias may answer, so saving is never blocked.

## The two surfaces

```text
dashboard form  ──save──▶  step.config  ◀──bffless rules push──  any.rule.yaml (rules-as-code)
      getting-started surface                         power-user surface; a push overwrites dashboard edits by design
```

Same **shape**, not same **bytes**: the form writes what `validateConfig` accepts and carries unknown keys through on the config, each tool and each resource. `visibility: ['model']` (the default) is never written. Byte-identical YAML is not a goal.

## Input schema: table or JSON

```text
isFlatObjectSchema(schema)
  type is object (or absent)
  every property is string | integer | number | boolean | object | array
    with only type · description · enum · min · max · default · additionalProperties · items{type}
  required ⊆ property names
  yes → property table (name · type · description · required · constraints ⚙)
  no  → JSON editor with a notice; "Edit as JSON" is always one click away either way
```

All 15 shipped `bffless-workflow` tool schemas pass the guard and round-trip through the table.

## Files

```text
handlers/
├── McpHandlerConfig.tsx            entry: model ↔ config, tabs, problems panel
├── McpHandlerConfig.test.tsx
├── McpHandlerConfig.stories.tsx    MSW-mocked sibling rules — backend-free screenshots
├── HandlerConfigWrapper.tsx        one description string
├── types.ts                        McpHandlerConfig in the HandlerConfig union
└── mcp/
    ├── model.ts / .test.ts         normalize · serialize · validate · matchesPattern · findSibling
    ├── input-schema.ts / .test.ts  flat schema ⇄ rows, isFlatObjectSchema guard
    ├── InputSchemaEditor.tsx       property table + JSON fallback
    ├── SiblingRulePicker.tsx       combobox over the set's rules + "answered by" hint
    ├── McpToolList.tsx / McpToolForm.tsx
    ├── McpServerSection.tsx / McpResourcesSection.tsx
    ├── StringListInput.tsx / JsonField.tsx
    └── __fixtures__/workflow.json  the live bffless-workflow server config
```

## Verification

| Check | Result |
| --- | --- |
| `tsc --noEmit`, eslint (new files), prettier | clean |
| Frontend suite | 1015 / 1015, 58 new tests in 8 files |
| Shipped `bffless-workflow` config (15 tools, resources, CSP) | loads, serializes back semantically equal, zero problems |
| Each `validateConfig` failure | reproduced client-side with the same message |
| Storybook story, headless Chromium, all four tabs | renders, zero console errors |
| Live walk on a scratch rule set (form-only server, `curl` `tools/list`) | **not done** — needs this frontend deployed |

## Left out on purpose

Monaco for the JSON tab, a live `tools/list` inspector, a "create sibling rule" shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZNibcaVqtcPmVcniBqYxZ
