### PR TITLE
feat(auth): exchange an app token for a session (POST /api/auth/session/from-app-token)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,11 +34,11 @@ An `X-API-Key` credential scoped to one project, authenticating the data layer (
 _Avoid_: "the project key", "access key"
 
 **App token**:
-A member-bound, project-bound, scoped bearer credential (`Authorization: Bearer bfat_…`) the member mints in _Settings → App Tokens_, or an OAuth client obtains on the member's behalf. Wherever a session is accepted for content or pipelines — the deployment visibility gate, `auth_required` — the token _is_ the member, narrowed by its scopes: effective permission is what the member may do ∩ what the token was granted, so a token never elevates. On the admin API it behaves as a project-scoped API key does (project-fenced, role pinned). Not an API key: an API key is pinned to role `user` and bound to no person.
+A member-bound, project-bound, scoped bearer credential (`Authorization: Bearer bfat_…`) the member mints in _Settings → App Tokens_, or an OAuth client obtains on the member's behalf. Wherever a session is accepted for content or pipelines — the deployment visibility gate, `auth_required` — the token _is_ the member, narrowed by its scopes: effective permission is what the member may do ∩ what the token was granted, so a token never elevates. On the admin API it behaves as a project-scoped API key does (project-fenced, role pinned). Carrying `auth:session`, it can be exchanged for a session (`POST /api/auth/session/from-app-token`, no body) — the session then has SuperTokens' normal lifetime, is not shortened to the token's expiry, and is not ended by revoking the token. Not an API key: an API key is pinned to role `user` and bound to no person.
 _Avoid_: "personal access token", "PAT", "bearer" alone (a SuperTokens JWT is also a bearer)
 
 **Scope**:
-A `namespace:verb` string an app declares on its own rules (`auth_required` → `requiredScopes`) and an App token carries. CE only compares strings; the vocabulary is the app's (`workflow:read`, `workflow:run`, …). Sessions, custom-domain cookies and API keys are never scope-checked — a person acting as themselves is not a delegation.
+A `namespace:verb` string an app declares on its own rules (`auth_required` → `requiredScopes`) and an App token carries. CE only compares strings; the vocabulary is the app's (`workflow:read`, `workflow:run`, …) — except the `auth:` namespace, which CE reserves for scopes it interprets itself. `auth:session` is the first: the opt-in that lets an App token be exchanged for a session. Sessions, custom-domain cookies and API keys are never scope-checked — a person acting as themselves is not a delegation.
 _Avoid_: "permission" (that is the member's project role), "role"
 
 **Bypass visibility**:

--- a/apps/backend/src/app-tokens/app-tokens.dto.ts
+++ b/apps/backend/src/app-tokens/app-tokens.dto.ts
@@ -37,8 +37,9 @@ export class CreateAppTokenDto {
   project: string;
 
   @ApiProperty({
-    description: 'Scopes the token is delegated (the app’s own vocabulary, namespace:verb)',
-    example: ['workflow:read', 'workflow:run'],
+    description:
+      'Scopes the token is delegated (the app’s own vocabulary, namespace:verb). The `auth:` namespace is CE’s: `auth:session` lets the token be exchanged for a session via POST /api/auth/session/from-app-token.',
+    example: ['workflow:read', 'workflow:run', 'auth:session'],
     type: [String],
   })
   @IsArray()

--- a/apps/backend/src/auth/README.md
+++ b/apps/backend/src/auth/README.md
@@ -227,6 +227,24 @@ Sign in a user.
 
 Session cookies are set automatically.
 
+### POST /api/auth/session/from-app-token
+
+Exchange an app token for a session — for a client that holds only a token (a headless browser, a CI job) and needs cookie-authenticated pages without a member's password.
+
+**Request:** no body. `Authorization: Bearer bfat_…`. The token must carry the `auth:session` scope (mint it with `POST /api/app-tokens` or in _Settings → App Tokens_; `auth:` is the one scope namespace CE interprets itself).
+
+**Response:** the same body as `POST /api/auth/signin`; session cookies are set automatically (so `COOKIE_DOMAIN` makes them valid on project subdomains). The access token carries `via: "app_token"` and `appTokenId`, which `GET /api/auth/session` surfaces as `session.via`.
+
+| Status | `code`                   | When                                                                                   |
+| ------ | ------------------------ | -------------------------------------------------------------------------------------- |
+| 401    | `unauthorized`           | No `bfat_` bearer, or the token is unknown, expired or revoked, or its user is disabled |
+| 403    | `insufficient_scope`     | The token lacks `auth:session` (`missingScopes` names it)                              |
+| 403    | `token_project_mismatch` | The request host resolves to a project the token is not bound to                       |
+| 401    | `unauthorized`           | `REQUIRE_PROJECT_MEMBERSHIP` is on and the member has no role on the resolved project  |
+| 409    | `user_not_exchangeable`  | SuperTokens does not know the user's id (the row predates the unified-ID invariant)    |
+
+The session has SuperTokens' normal lifetime: it is not shortened to the token's expiry, and revoking the token does not end sessions already minted from it.
+
 ### POST /api/auth/signout
 
 Sign out current user (revokes session).

--- a/apps/backend/src/auth/app-token.util.ts
+++ b/apps/backend/src/auth/app-token.util.ts
@@ -20,6 +20,16 @@ export const APP_TOKEN_BYTES = 32;
 /** `last_used_at` is written at most once per token per interval — an MCP host's burst must not become a write per call. */
 export const LAST_USED_WRITE_INTERVAL_MS = 60_000;
 
+/**
+ * The one scope CE interprets itself. Scope vocabulary is otherwise the app's
+ * (`workflow:read`, …) and CE only compares strings — but the `auth:` namespace
+ * is reserved for CE-owned scopes, and `auth:session` is the first: a token
+ * carrying it may be exchanged for a SuperTokens session
+ * (`POST /api/auth/session/from-app-token`). The explicit opt-in exists because
+ * a session is broader than any scope list — it is the member, unnarrowed.
+ */
+export const SESSION_EXCHANGE_SCOPE = 'auth:session';
+
 export interface ResolvedAppToken {
   user: { id: string; email: string; role: string };
   token: { id: string; projectId: string; scopes: string[]; kind: string; clientId: string | null };

--- a/apps/backend/src/auth/auth.controller.spec.ts
+++ b/apps/backend/src/auth/auth.controller.spec.ts
@@ -1,15 +1,22 @@
 import { Request } from 'express';
 import { UnauthorizedException } from '@nestjs/common';
 
-// Mock the database client used for the pending-invitation lookup branch.
+// Mock the database client used for the pending-invitation lookup branch and,
+// through the real `resolveAppToken`, the app-token → session exchange (two
+// `select … limit(1)` reads — token row, then user row — and the advisory
+// `update … set({ lastUsedAt })` touch, whose `where` is terminal).
 jest.mock('../db/client', () => ({
   db: {
     select: jest.fn().mockReturnThis(),
     from: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     limit: jest.fn().mockResolvedValue([]),
+    update: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
   },
 }));
+
+const mockDb = jest.requireMock('../db/client').db;
 
 // Mock the supertokens-node top-level imports used by getSession.
 jest.mock('supertokens-node', () => ({
@@ -42,7 +49,10 @@ jest.mock('supertokens-node/recipe/session', () => ({
 
 import EmailPassword from 'supertokens-node/recipe/emailpassword';
 import Session from 'supertokens-node/recipe/session';
+import { ConflictException, ForbiddenException } from '@nestjs/common';
+import { Response } from 'express';
 import { AuthController } from './auth.controller';
+import { resetLastUsedThrottle, SESSION_EXCHANGE_SCOPE } from './app-token.util';
 import { AuthService } from './auth.service';
 import { SetupService } from '../setup/setup.service';
 import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
@@ -55,12 +65,15 @@ import { PermissionsService } from '../permissions/permissions.service';
 const SESSION_USER_ID = 'user-1';
 const SESSION_HANDLE = 'session-handle-1';
 
-const reqWithSession = (): Request & { session: any } =>
+const reqWithSession = (
+  accessTokenPayload: Record<string, unknown> = {},
+): Request & { session: any } =>
   ({
     headers: { host: 'foo.sites.bffless.app' },
     session: {
       getUserId: () => SESSION_USER_ID,
       getHandle: () => SESSION_HANDLE,
+      getAccessTokenPayload: () => accessTokenPayload,
     },
   }) as unknown as Request & { session: any };
 
@@ -220,6 +233,185 @@ describe('AuthController.getSession (project-membership gate, Phase B)', () => {
 
       expect(result.message).toBe('Signed in successfully');
       expect(result.user).toEqual({ id: dbUser.id, email: dbUser.email, role: dbUser.role });
+    });
+  });
+
+  it('getSession surfaces `via` when the session was minted from an app token', async () => {
+    const result: any = await controller.getSession(
+      reqWithSession({ role: 'member', via: 'app_token', appTokenId: 'tok-1' }),
+    );
+
+    expect(result.session).toEqual({
+      userId: SESSION_USER_ID,
+      handle: SESSION_HANDLE,
+      via: 'app_token',
+    });
+  });
+
+  describe('sessionFromAppToken (app token → session exchange)', () => {
+    const createNewSessionMock = Session.createNewSession as jest.Mock;
+    const limitMock = mockDb.limit as jest.Mock;
+    const RAW_TOKEN = 'bfat_' + 'a'.repeat(64);
+    const res = {} as Response;
+
+    const tokenRow = (over: Partial<Record<string, unknown>> = {}) => ({
+      id: 'tok-1',
+      userId: SESSION_USER_ID,
+      projectId: 'proj-1',
+      scopes: ['workflow:read', SESSION_EXCHANGE_SCOPE],
+      kind: 'personal',
+      clientId: null,
+      expiresAt: null,
+      revokedAt: null,
+      ...over,
+    });
+    const userRow = { id: SESSION_USER_ID, email: dbUser.email, role: 'member', disabled: false };
+
+    /** The resolver reads the token row, then its user row. */
+    const storedToken = (row: ReturnType<typeof tokenRow>) => {
+      limitMock.mockResolvedValueOnce([row]).mockResolvedValueOnce([userRow]);
+    };
+    const bearerReq = (
+      host = 'admin.bffless.app',
+      authorization: string | null = `Bearer ${RAW_TOKEN}`,
+    ) => ({ headers: { host, ...(authorization ? { authorization } : {}) } }) as unknown as Request;
+    const rejection = async (req: Request) =>
+      controller.sessionFromAppToken(req, res).then(
+        () => {
+          throw new Error('expected the exchange to be refused');
+        },
+        (e) => e,
+      );
+
+    beforeEach(() => {
+      resetLastUsedThrottle();
+      limitMock.mockReset().mockResolvedValue([]);
+      featureFlags.isEnabled.mockResolvedValue(false);
+      projectResolver.resolveProjectFromRequest.mockResolvedValue(null);
+      createNewSessionMock.mockResolvedValue({
+        getUserId: () => SESSION_USER_ID,
+        getHandle: () => SESSION_HANDLE,
+      });
+    });
+
+    it('401 without a bfat_ bearer (no header, or a non-app-token bearer)', async () => {
+      const noHeader = await rejection(bearerReq('admin.bffless.app', null));
+      expect(noHeader).toBeInstanceOf(UnauthorizedException);
+      expect(noHeader.getResponse()).toMatchObject({ code: 'unauthorized' });
+
+      const jwtBearer = await rejection(bearerReq('admin.bffless.app', 'Bearer eyJhbGciOi'));
+      expect(jwtBearer).toBeInstanceOf(UnauthorizedException);
+      expect(limitMock).not.toHaveBeenCalled();
+      expect(createNewSessionMock).not.toHaveBeenCalled();
+    });
+
+    it('401 for an unknown token', async () => {
+      const err = await rejection(bearerReq());
+      expect(err).toBeInstanceOf(UnauthorizedException);
+      expect(err.getResponse()).toMatchObject({ code: 'unauthorized' });
+      expect(createNewSessionMock).not.toHaveBeenCalled();
+    });
+
+    it('401 for a revoked token', async () => {
+      storedToken(tokenRow({ revokedAt: new Date() }));
+      const err = await rejection(bearerReq());
+      expect(err).toBeInstanceOf(UnauthorizedException);
+      expect(createNewSessionMock).not.toHaveBeenCalled();
+    });
+
+    it('401 for an expired token', async () => {
+      storedToken(tokenRow({ expiresAt: new Date(Date.now() - 1000) }));
+      const err = await rejection(bearerReq());
+      expect(err).toBeInstanceOf(UnauthorizedException);
+      expect(createNewSessionMock).not.toHaveBeenCalled();
+    });
+
+    it('403 insufficient_scope naming auth:session when the token lacks it', async () => {
+      storedToken(tokenRow({ scopes: ['workflow:read', 'workflow:run'] }));
+      const err = await rejection(bearerReq());
+      expect(err).toBeInstanceOf(ForbiddenException);
+      expect(err.getResponse()).toMatchObject({
+        code: 'insufficient_scope',
+        missingScopes: ['auth:session'],
+      });
+      expect(createNewSessionMock).not.toHaveBeenCalled();
+    });
+
+    it('403 token_project_mismatch when the request host resolves to another project', async () => {
+      storedToken(tokenRow({ projectId: 'proj-1' }));
+      projectResolver.resolveProjectFromRequest.mockResolvedValue({ id: 'proj-2' } as any);
+      const err = await rejection(bearerReq('other.sites.bffless.app'));
+      expect(err).toBeInstanceOf(ForbiddenException);
+      expect(err.getResponse()).toMatchObject({ code: 'token_project_mismatch' });
+      expect(createNewSessionMock).not.toHaveBeenCalled();
+    });
+
+    it('401 when REQUIRE_PROJECT_MEMBERSHIP is on and the member has no role on the project', async () => {
+      storedToken(tokenRow({ projectId: 'proj-1' }));
+      featureFlags.isEnabled.mockImplementation(
+        async (flag: string) => flag === 'REQUIRE_PROJECT_MEMBERSHIP',
+      );
+      projectResolver.resolveProjectFromRequest.mockResolvedValue({ id: 'proj-1' } as any);
+      permissions.getUserProjectRole.mockResolvedValue(null);
+
+      const err = await rejection(bearerReq('foo.sites.bffless.app'));
+      expect(err).toBeInstanceOf(UnauthorizedException);
+      expect(err.getResponse()).toMatchObject({ code: 'unauthorized' });
+      expect(permissions.getUserProjectRole).toHaveBeenCalledWith(SESSION_USER_ID, 'proj-1');
+      expect(createNewSessionMock).not.toHaveBeenCalled();
+    });
+
+    it('409 user_not_exchangeable when SuperTokens does not know the user id', async () => {
+      storedToken(tokenRow());
+      createNewSessionMock.mockRejectedValueOnce(
+        new Error(
+          "SuperTokens core threw an error for a POST request to path: '/public/recipe/session' with status code: 400 and message: UNKNOWN_USER_ID",
+        ),
+      );
+      const err = await rejection(bearerReq());
+      expect(err).toBeInstanceOf(ConflictException);
+      expect(err.getResponse()).toMatchObject({ code: 'user_not_exchangeable' });
+    });
+
+    it('mints the session for the token’s user with the via/appTokenId claims and answers like signin', async () => {
+      storedToken(tokenRow());
+      const req = bearerReq();
+
+      const result: any = await controller.sessionFromAppToken(req, res);
+
+      expect(result).toEqual({
+        message: 'Signed in successfully',
+        user: { id: SESSION_USER_ID, email: dbUser.email, role: 'member' },
+      });
+      expect(createNewSessionMock).toHaveBeenCalledTimes(1);
+      const [calledReq, calledRes, tenantId, recipeUserId, payload] =
+        createNewSessionMock.mock.calls[0];
+      expect(calledReq).toBe(req);
+      expect(calledRes).toBe(res);
+      expect(tenantId).toBe('public');
+      expect(recipeUserId.getAsString()).toBe(SESSION_USER_ID);
+      expect(payload).toEqual({ role: 'member', via: 'app_token', appTokenId: 'tok-1' });
+      // resolveAppToken's advisory last_used_at touch ran.
+      expect(mockDb.update).toHaveBeenCalledTimes(1);
+      expect(mockDb.set).toHaveBeenCalledWith({ lastUsedAt: expect.any(Date) });
+    });
+
+    it('lets an OAuth-issued token exchange too — the scope is the gate, not the kind', async () => {
+      storedToken(tokenRow({ kind: 'oauth', clientId: 'client-1' }));
+      const result: any = await controller.sessionFromAppToken(bearerReq(), res);
+      expect(result.user.id).toBe(SESSION_USER_ID);
+      expect(createNewSessionMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('exchanges on a project host when the token is bound to that project', async () => {
+      storedToken(tokenRow({ projectId: 'proj-1' }));
+      projectResolver.resolveProjectFromRequest.mockResolvedValue({ id: 'proj-1' } as any);
+      const result: any = await controller.sessionFromAppToken(
+        bearerReq('foo.sites.bffless.app'),
+        res,
+      );
+      expect(result.user.id).toBe(SESSION_USER_ID);
+      expect(createNewSessionMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -10,11 +10,19 @@ import {
   HttpCode,
   HttpStatus,
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   UnauthorizedException,
   UseGuards,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBody, ApiQuery } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBody,
+  ApiQuery,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { AuthService } from './auth.service';
 import { SessionAuthGuard } from './session-auth.guard';
@@ -25,6 +33,7 @@ import { OnboardingExecutorService } from '../onboarding-rules/onboarding-execut
 import { DomainTokenService } from './domain-token.service';
 import { ProjectInviteLinksService } from '../project-invite-links/project-invite-links.service';
 import { ProjectResolverService } from './project-resolver.service';
+import { resolveAppToken, SESSION_EXCHANGE_SCOPE } from './app-token.util';
 import { PermissionsService } from '../permissions/permissions.service';
 import { OidcProvidersService } from '../settings/oidc-providers.service';
 import { PublicProjectAccess } from './decorators/public-project-access.decorator';
@@ -633,6 +642,10 @@ export class AuthController {
 
       const userId = req.session.getUserId();
       const sessionHandle = req.session.getHandle();
+      // `via` is set only on sessions minted from an app token
+      // (POST session/from-app-token); a password/OIDC session has no claim.
+      const via = req.session.getAccessTokenPayload()?.via as string | undefined;
+      const sessionInfo = { userId, handle: sessionHandle, ...(via ? { via } : {}) };
 
       // Project-membership gate (REQUIRE_PROJECT_MEMBERSHIP master switch).
       // Closes the parent-domain cookie bleed across *.bffless.app: a user with
@@ -650,7 +663,7 @@ export class AuthController {
           const role = await this.permissions.getUserProjectRole(userId, project.id);
           if (!role) {
             return {
-              session: { userId, handle: sessionHandle },
+              session: sessionInfo,
               user: null,
               emailVerified: false,
               emailVerificationRequired: false,
@@ -692,10 +705,7 @@ export class AuthController {
         if (pendingInvitation) {
           // Return session with user info from SuperTokens (not from DB)
           return {
-            session: {
-              userId,
-              handle: sessionHandle,
-            },
+            session: sessionInfo,
             user: {
               id: userId,
               email: stUserEmail,
@@ -725,10 +735,7 @@ export class AuthController {
       }
 
       return {
-        session: {
-          userId,
-          handle: sessionHandle,
-        },
+        session: sessionInfo,
         user: user
           ? {
               id: user.id,
@@ -774,6 +781,118 @@ export class AuthController {
   async refreshToken() {
     // SuperTokens middleware handles this automatically
     return { status: 'OK' };
+  }
+
+  @Post('session/from-app-token')
+  @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Exchange an app token for a session',
+    description:
+      'Mints a SuperTokens session for the member an app token stands for, so a client that ' +
+      'holds only the token (a headless browser, a CI job) can drive cookie-authenticated pages ' +
+      'without a password. No body — `Authorization: Bearer bfat_…`. The token must carry the ' +
+      '`auth:session` scope, the explicit opt-in for "this token may become a session". On a ' +
+      'project host the token must be bound to that project, and the REQUIRE_PROJECT_MEMBERSHIP ' +
+      'gate applies exactly as it does to sign-in. The session has SuperTokens’ normal lifetime: ' +
+      'it is not shortened to the token’s expiry, and revoking the token does not end sessions ' +
+      'already minted from it. The access token carries `via: "app_token"` and `appTokenId`. ' +
+      'Responds with the same body as POST /api/auth/signin; the session cookies ride on the response.',
+  })
+  @ApiResponse({ status: 200, description: 'Session created (same body as POST /api/auth/signin)' })
+  @ApiResponse({
+    status: 401,
+    description: 'No, unknown, expired or revoked app token (`code: unauthorized`)',
+  })
+  @ApiResponse({
+    status: 403,
+    description:
+      '`code: insufficient_scope` (the token lacks `auth:session`; `missingScopes` names it) or ' +
+      '`code: token_project_mismatch` (the token is bound to another project than the request host)',
+  })
+  @ApiResponse({
+    status: 409,
+    description:
+      '`code: user_not_exchangeable` — the user row predates the unified-ID invariant and SuperTokens does not know its id',
+  })
+  async sessionFromAppToken(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    const resolved = await resolveAppToken(req.headers.authorization);
+    if (!resolved) {
+      throw new UnauthorizedException({
+        code: 'unauthorized',
+        message: 'A valid app token is required (Authorization: Bearer bfat_…)',
+      });
+    }
+    const { user, token } = resolved;
+
+    // The scope is the gate, not the token kind: an OAuth-issued token that was
+    // consented `auth:session` may exchange too.
+    if (!token.scopes.includes(SESSION_EXCHANGE_SCOPE)) {
+      throw new ForbiddenException({
+        code: 'insufficient_scope',
+        missingScopes: [SESSION_EXCHANGE_SCOPE],
+        message: `insufficient_scope: missing ${SESSION_EXCHANGE_SCOPE}`,
+      });
+    }
+
+    // On the admin host nothing resolves; on a project subdomain the token must
+    // be the one bound to that project (mirrors auth_required's check).
+    const project = await this.projectResolver.resolveProjectFromRequest(req);
+    if (project && project.id !== token.projectId) {
+      throw new ForbiddenException({
+        code: 'token_project_mismatch',
+        message: 'This token is bound to another project',
+      });
+    }
+
+    // Same membership gate as sign-in (a no-op unless REQUIRE_PROJECT_MEMBERSHIP
+    // is on). Sign-in's opaque "Invalid email or password" exists so a sister
+    // site cannot probe which accounts exist; the caller here already holds the
+    // member's own token, so the reason can be stated.
+    try {
+      await this.enforceProjectMembership(req, user.id);
+    } catch (error) {
+      if (error instanceof UnauthorizedException) {
+        throw new UnauthorizedException({
+          code: 'unauthorized',
+          message: 'Not a member of this project',
+        });
+      }
+      throw error;
+    }
+
+    // Mint exactly as sign-in does. `dbUser.id === recipeUserId` is the
+    // unified-ID invariant (see completeOAuthSignIn); the claims at creation
+    // time save a second core round-trip and let GET /api/auth/session and
+    // logs tell an exchanged session from a password one.
+    try {
+      await Session.createNewSession(req, res, this.getTenantId(), new RecipeUserId(user.id), {
+        role: user.role,
+        via: 'app_token',
+        appTokenId: token.id,
+      });
+    } catch (error) {
+      if (error instanceof Error && /UNKNOWN_USER_ID/.test(error.message)) {
+        throw new ConflictException({
+          code: 'user_not_exchangeable',
+          message:
+            'This user cannot be exchanged for a session: SuperTokens does not know its id. ' +
+            'The account predates the unified-ID invariant and must be re-linked by an ' +
+            'administrator (its id must match its SuperTokens user id) before it can exchange.',
+        });
+      }
+      this.logger.error('[Session from app token] Failed to create session:', error);
+      throw error;
+    }
+
+    return {
+      message: 'Signed in successfully',
+      user: {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+      },
+    };
   }
 
   @Post('forgot-password')

--- a/apps/backend/src/auth/session-from-app-token-http.spec.ts
+++ b/apps/backend/src/auth/session-from-app-token-http.spec.ts
@@ -1,0 +1,165 @@
+import 'reflect-metadata';
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+
+// The real `resolveAppToken` runs against this: two `select … limit(1)` reads
+// (token row, then user row) and the advisory `update … set({ lastUsedAt })`
+// touch, whose `where` is terminal.
+jest.mock('../db/client', () => ({
+  db: {
+    select: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockResolvedValue([]),
+    update: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+  },
+}));
+jest.mock('supertokens-node', () => ({
+  __esModule: true,
+  getUser: jest.fn(),
+  listUsersByAccountInfo: jest.fn(),
+  RecipeUserId: jest.fn().mockImplementation((id: string) => ({ getAsString: () => id })),
+}));
+jest.mock('supertokens-node/recipe/emailverification', () => ({
+  __esModule: true,
+  default: { isEmailVerified: jest.fn().mockResolvedValue(true) },
+}));
+jest.mock('supertokens-node/recipe/emailpassword', () => ({
+  __esModule: true,
+  default: { signIn: jest.fn() },
+}));
+jest.mock('supertokens-node/recipe/session', () => ({
+  __esModule: true,
+  default: { createNewSession: jest.fn() },
+}));
+
+import Session from 'supertokens-node/recipe/session';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { SessionAuthGuard } from './session-auth.guard';
+import { DomainTokenService } from './domain-token.service';
+import { ProjectResolverService } from './project-resolver.service';
+import { resetLastUsedThrottle } from './app-token.util';
+import { SetupService } from '../setup/setup.service';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import { OnboardingExecutorService } from '../onboarding-rules/onboarding-executor.service';
+import { ProjectInviteLinksService } from '../project-invite-links/project-invite-links.service';
+import { PermissionsService } from '../permissions/permissions.service';
+import { OidcProvidersService } from '../settings/oidc-providers.service';
+import { GlobalExceptionFilter } from '../common/filters';
+
+const mockDb = jest.requireMock('../db/client').db;
+const limitMock = mockDb.limit as jest.Mock;
+const createNewSessionMock = Session.createNewSession as jest.Mock;
+
+const RAW_TOKEN = 'bfat_' + 'b'.repeat(64);
+const userRow = { id: 'user-1', email: 'm@example.com', role: 'member', disabled: false };
+const tokenRow = (scopes: string[]) => ({
+  id: 'tok-1',
+  userId: 'user-1',
+  projectId: 'proj-1',
+  scopes,
+  kind: 'personal',
+  clientId: null,
+  expiresAt: null,
+  revokedAt: null,
+});
+
+/**
+ * The endpoint's error contract on the wire — through the same
+ * `GlobalExceptionFilter` main.ts installs, which rebuilds every error body.
+ * A unit test that inspects `exception.getResponse()` never proves that
+ * `code` / `missingScopes` survive it; this does.
+ */
+describe('POST /api/auth/session/from-app-token over HTTP (GlobalExceptionFilter installed)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        { provide: AuthService, useValue: {} },
+        { provide: SetupService, useValue: {} },
+        {
+          provide: FeatureFlagsService,
+          useValue: { isEnabled: jest.fn().mockResolvedValue(false) },
+        },
+        { provide: OnboardingExecutorService, useValue: {} },
+        { provide: DomainTokenService, useValue: {} },
+        { provide: ProjectInviteLinksService, useValue: {} },
+        {
+          provide: ProjectResolverService,
+          useValue: { resolveProjectFromRequest: jest.fn().mockResolvedValue(null) },
+        },
+        { provide: PermissionsService, useValue: {} },
+        { provide: OidcProvidersService, useValue: {} },
+      ],
+    })
+      .overrideGuard(SessionAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    app = moduleRef.createNestApplication();
+    app.useGlobalFilters(new GlobalExceptionFilter());
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetLastUsedThrottle();
+    limitMock.mockReset().mockResolvedValue([]);
+    createNewSessionMock.mockResolvedValue({});
+  });
+
+  it('401 with `code: unauthorized` on the wire when no app token is presented', async () => {
+    const res = await request(app.getHttpServer()).post('/api/auth/session/from-app-token');
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({
+      statusCode: 401,
+      error: 'Unauthorized',
+      code: 'unauthorized',
+      message: expect.stringContaining('app token'),
+    });
+    expect(createNewSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('403 with `code: insufficient_scope` and `missingScopes` on the wire when the token lacks auth:session', async () => {
+    limitMock.mockResolvedValueOnce([tokenRow(['workflow:read'])]).mockResolvedValueOnce([userRow]);
+    const res = await request(app.getHttpServer())
+      .post('/api/auth/session/from-app-token')
+      .set('Authorization', `Bearer ${RAW_TOKEN}`);
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({
+      statusCode: 403,
+      error: 'Forbidden',
+      code: 'insufficient_scope',
+      missingScopes: ['auth:session'],
+    });
+    expect(createNewSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('200 with the sign-in body when the token carries auth:session', async () => {
+    limitMock
+      .mockResolvedValueOnce([tokenRow(['workflow:read', 'auth:session'])])
+      .mockResolvedValueOnce([userRow]);
+    const res = await request(app.getHttpServer())
+      .post('/api/auth/session/from-app-token')
+      .set('Authorization', `Bearer ${RAW_TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      message: 'Signed in successfully',
+      user: { id: 'user-1', email: 'm@example.com', role: 'member' },
+    });
+    expect(createNewSessionMock).toHaveBeenCalledTimes(1);
+    expect(createNewSessionMock.mock.calls[0][4]).toEqual({
+      role: 'member',
+      via: 'app_token',
+      appTokenId: 'tok-1',
+    });
+  });
+});

--- a/apps/backend/src/common/filters/http-exception.filter.spec.ts
+++ b/apps/backend/src/common/filters/http-exception.filter.spec.ts
@@ -1,0 +1,96 @@
+import {
+  ArgumentsHost,
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { GlobalExceptionFilter } from './http-exception.filter';
+
+/**
+ * The filter rebuilds every error body. The contract under test: a handler's
+ * structured details (`code`, `missingScopes`, `errors`, …) reach the client,
+ * while the keys the filter owns cannot be overridden by the exception body.
+ */
+describe('GlobalExceptionFilter', () => {
+  const run = (exception: unknown) => {
+    const response = {
+      headersSent: false,
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+      setHeader: jest.fn(),
+    };
+    const request = { url: '/api/auth/session/from-app-token', method: 'POST', ip: '10.0.0.1' };
+    const host = {
+      switchToHttp: () => ({ getResponse: () => response, getRequest: () => request }),
+    } as unknown as ArgumentsHost;
+    new GlobalExceptionFilter().catch(exception, host);
+    expect(response.status).toHaveBeenCalledTimes(1);
+    expect(response.json).toHaveBeenCalledTimes(1);
+    return {
+      status: response.status.mock.calls[0][0] as number,
+      body: response.json.mock.calls[0][0],
+    };
+  };
+
+  it('passes structured details on the exception body through to the client', () => {
+    const { status, body } = run(
+      new ForbiddenException({
+        code: 'insufficient_scope',
+        missingScopes: ['auth:session'],
+        message: 'insufficient_scope: missing auth:session',
+      }),
+    );
+    expect(status).toBe(403);
+    expect(body).toMatchObject({
+      statusCode: 403,
+      error: 'Forbidden',
+      message: 'insufficient_scope: missing auth:session',
+      code: 'insufficient_scope',
+      missingScopes: ['auth:session'],
+      path: '/api/auth/session/from-app-token',
+    });
+  });
+
+  it('never lets the exception body override the keys the filter owns', () => {
+    const { status, body } = run(
+      new BadRequestException({
+        message: 'nope',
+        statusCode: 999,
+        path: '/elsewhere',
+        timestamp: 'yesterday',
+        stack: 'forged',
+        error: 'custom_error',
+        detail: 'kept',
+      }),
+    );
+    expect(status).toBe(400);
+    expect(body.statusCode).toBe(400);
+    expect(body.path).toBe('/api/auth/session/from-app-token');
+    expect(body.timestamp).not.toBe('yesterday');
+    expect(body.stack).not.toBe('forged');
+    // `error` is a documented override (email-verification.guard relies on it).
+    expect(body.error).toBe('custom_error');
+    expect(body.detail).toBe('kept');
+  });
+
+  it("leaves Nest's default bodies and string bodies exactly as before", () => {
+    const fromDefault = run(new NotFoundException('nothing here'));
+    expect(fromDefault.status).toBe(404);
+    expect(fromDefault.body).toMatchObject({
+      statusCode: 404,
+      error: 'Not Found',
+      message: 'nothing here',
+    });
+    const fromString = run(new BadRequestException('plain'));
+    expect(fromString.body).toMatchObject({
+      statusCode: 400,
+      error: 'Bad Request',
+      message: 'plain',
+    });
+    for (const { body } of [fromDefault, fromString]) {
+      expect(Object.keys(body).sort()).toEqual(
+        ['error', 'message', 'path', 'stack', 'statusCode', 'timestamp'].sort(),
+      );
+    }
+  });
+});

--- a/apps/backend/src/common/filters/http-exception.filter.ts
+++ b/apps/backend/src/common/filters/http-exception.filter.ts
@@ -17,7 +17,18 @@ interface ErrorResponse {
   path: string;
   // Only included in non-production environments
   stack?: string;
+  // Structured details a handler put on the exception (`code`, `missingScopes`, `errors`, …)
+  [detail: string]: unknown;
 }
+
+/**
+ * Keys the filter owns. A handler's exception body cannot override them — the
+ * status, the canonical error name, the request path and the timestamp are
+ * always the filter's — but every other key on the body rides through to the
+ * client, so `throw new ForbiddenException({ code: 'insufficient_scope',
+ * missingScopes: [...] })` is a real wire contract, not just a unit-test one.
+ */
+const RESERVED_KEYS = new Set(['statusCode', 'error', 'message', 'timestamp', 'path', 'stack']);
 
 /**
  * Global exception filter that:
@@ -50,6 +61,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     let status = HttpStatus.INTERNAL_SERVER_ERROR;
     let message: string | string[] = 'Internal server error';
     let error = 'Internal Server Error';
+    let details: Record<string, unknown> = {};
 
     if (exception instanceof HttpException) {
       status = exception.getStatus();
@@ -61,6 +73,9 @@ export class GlobalExceptionFilter implements ExceptionFilter {
         const responseObj = exceptionResponse as Record<string, unknown>;
         message = (responseObj.message as string | string[]) || exception.message;
         error = (responseObj.error as string) || this.getErrorName(status);
+        details = Object.fromEntries(
+          Object.entries(responseObj).filter(([key]) => !RESERVED_KEYS.has(key)),
+        );
       }
 
       // Handle rate limiting - add Retry-After header
@@ -91,6 +106,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
 
     // Build error response
     const errorResponse: ErrorResponse = {
+      ...details,
       statusCode: status,
       error,
       message,

--- a/apps/frontend/src/components/settings/AppTokensTab.tsx
+++ b/apps/frontend/src/components/settings/AppTokensTab.tsx
@@ -289,7 +289,8 @@ export function AppTokensTab() {
                     />
                     <p className="text-xs text-muted-foreground">
                       The app’s own vocabulary, space-separated (namespace:verb) — e.g.
-                      workflow:read workflow:run workflow:files.
+                      workflow:read workflow:run workflow:files. Add auth:session to let the token
+                      be exchanged for a browser session (headless runs).
                     </p>
                     {scopes.length > 0 && (
                       <div className="flex flex-wrap gap-1" data-testid="scope-chips">


### PR DESCRIPTION
Closes #751

## Summary
A CI job or headless browser that already holds an app token for a member still had to keep that member's email and password as secrets, because the only way to get the SuperTokens session cookie the admin pages rely on was the password relay login. This PR adds `POST /api/auth/session/from-app-token`: send the token as `Authorization: Bearer bfat_…` (no body) and get back the same response and session cookies `POST /api/auth/signin` gives. It only works for tokens that carry the new `auth:session` scope, so a token has to be minted for this on purpose. After this, `workflow-headless` (bffless/apps#588) can drop `WORKFLOW_EMAIL`/`WORKFLOW_PASSWORD` and use `WORKFLOW_APP_TOKEN` alone.

## Behaviour changes
All additive; nothing existing changes shape or meaning.

- **New endpoint** `POST /api/auth/session/from-app-token` — before: did not exist → after: mints a session for the token's member. Responses: 200 (sign-in body + cookies); 401 `{ code: 'unauthorized' }` for no `bfat_` bearer / unknown / expired / revoked token / disabled user; 403 `{ code: 'insufficient_scope', missingScopes: ['auth:session'] }`; 403 `{ code: 'token_project_mismatch' }` when the request host resolves to a project the token is not bound to; 401 when `REQUIRE_PROJECT_MEMBERSHIP` is on and the member has no role on the resolved project (same gate as sign-in); 409 `{ code: 'user_not_exchangeable' }` instead of a 500 when SuperTokens answers `UNKNOWN_USER_ID`.
- **New CE-owned scope** `auth:session` — before: every scope string was the app's vocabulary → after: the `auth:` namespace is reserved for scopes CE interprets itself; `auth:session` is the first. It already passes `SCOPE_PATTERN`, so `POST /api/app-tokens` and the App Tokens tab accept it with no change. `kind: 'oauth'` tokens may exchange too if consented the scope — the scope is the gate, not the kind.
- **Session claims** — an exchanged session's access token carries `via: 'app_token'` and `appTokenId` (plus `role`, as sign-in sets). `GET /api/auth/session` now includes `session.via` **only** when that claim is present; password/OIDC sessions return exactly what they did before.
- **Error bodies keep structured details** (from the CI review, second commit) — before: the global exception filter rebuilt every error body as `{ statusCode, error, message, timestamp, path }` and silently dropped any other key a handler put on the exception → after: non-reserved keys ride through (the five canonical keys still always win and cannot be overridden by an exception body). This is what makes `code` / `missingScopes` above a real wire contract. It also, additively, surfaces details three existing handlers already attach but that never reached clients: `errors` (blocklist pattern validation), `missingFiles`/`totalMissing` (deployment finalize), `aliases` (commit delete blocked by manual aliases). No existing key is removed or renamed.
- Decisions carried from the issue, documented in the endpoint's Swagger description and CONTEXT.md: the session has SuperTokens' normal lifetime (not shortened to the token's expiry), and revoking the token does not end sessions already minted from it.

## Why
CE already mints sessions without a password check on the OAuth callback, and the unified-ID invariant it relies on (`dbUser.id === recipeUserId`) is exactly what a token exchange needs. Reusing the shared `resolveAppToken` resolver, the existing membership gate and the existing `Session.createNewSession` path keeps this one endpoint with no new table, migration, env var or guard. The explicit `auth:session` opt-in exists because a session is broader than any scope list — it is the member, unnarrowed — so a token minted for `workflow:read` must not silently become one. Design and status codes follow the issue (#751) as written. The filter change was the review's finding #1: the alternative (encode the discriminator in `error`) cannot carry `missingScopes`, so the filter was made to pass details through instead.

## What changed
- **backend** — `apps/backend/src/auth/auth.controller.ts` (new `sessionFromAppToken` handler; `getSession` surfaces `via`), `apps/backend/src/auth/app-token.util.ts` (`SESSION_EXCHANGE_SCOPE` constant + rationale), `apps/backend/src/app-tokens/app-tokens.dto.ts` (Swagger text for the scope), `apps/backend/src/common/filters/http-exception.filter.ts` (non-reserved exception-body keys pass through).
- **frontend** — `apps/frontend/src/components/settings/AppTokensTab.tsx`: one helper-text sentence telling members what `auth:session` unlocks.
- **docs** — `CONTEXT.md` (*Scope*: reserved `auth:` namespace; *App token*: exchange + lifetime/revocation semantics), `apps/backend/src/auth/README.md` (endpoint reference with the status/code table).
- **tests** — `apps/backend/src/auth/auth.controller.spec.ts` (11 handler cases driving the real `resolveAppToken` through the db mock), `apps/backend/src/auth/session-from-app-token-http.spec.ts` (supertest through the real `GlobalExceptionFilter`: 401 `code`, 403 `code` + `missingScopes`, 200 body), `apps/backend/src/common/filters/http-exception.filter.spec.ts` (details pass through; reserved keys not overridable; Nest default/string bodies unchanged).

## Compatibility
- **DB migrations:** none — no schema change.
- **API / CLI contract:** additive only. New route; `GET /api/auth/session` gains an optional `session.via` field that is absent for every existing session type. Error bodies keep every existing key (`statusCode`, `error`, `message`, `timestamp`, `path`, dev-only `stack`) and gain keys only where a handler already attached them. `packages/cli` unaffected — it reads `message`/`statusCode`, which are unchanged.
- **`POST /api/deployments/zip` / GitHub Actions:** the endpoint is untouched; its finalize-step 400 (`missingFiles`) now carries the detail it always intended, alongside the unchanged `message`.
- **Pipeline / proxy-rule semantics:** untouched — `auth_required`, `requiredScopes` and the visibility gate are not changed; a stored rule set behaves identically. Pipeline errors go through their own response path, not this filter.
- **Env vars:** none added or renamed. `REQUIRE_PROJECT_MEMBERSHIP` is read through the existing gate only.
- **nginx generation / storage layout / app catalog:** untouched.
- **Guards:** the route sits on the `@PublicProjectAccess()` controller like sign-in; no `ApiKeyGuard` by-id lookup is introduced. The access-token claims are additive to the multi-tenant `createNewSession` override, which spreads the input payload.

## Verification
Run in the worktree on `origin/main` @ `809444a`, after both commits:

- `pnpm --filter backend exec tsc --noEmit` — exit 0
- `pnpm --filter frontend exec tsc --noEmit` — exit 0
- `pnpm --filter backend format:check` / `pnpm --filter frontend format:check` — both "All matched files use Prettier code style!"
- `cd apps/backend && pnpm test -- http-exception.filter.spec session-from-app-token-http.spec auth.controller.spec` — 5 suites, 50 tests passed
- `cd apps/backend && pnpm test` (full suite) — Test Suites: 221 passed, 2 skipped; Tests: 3712 passed, 47 skipped (pre-existing skips)
- `cd apps/frontend && pnpm test -- AppTokensTab` — AppTokensTab.test.tsx 5/5; the run covered all 100 frontend test files, all passed

Not verified here: an end-to-end exchange against a running SuperTokens core (no local DB/core on this VPS). The `UNKNOWN_USER_ID` detection matches the substring in the querier's `Error` message, which is how the OAuth callback comment describes the failure surfacing; it could not be reproduced live.

## Out of scope / follow-ups
- bffless/apps#588 — switch `workflow-headless` and the `workflow-drive.yml` template to `WORKFLOW_APP_TOKEN` + this endpoint once a CE release carries it; tokens minted for that purpose add `auth:session` to `workflow:read workflow:run workflow:files`.
- The review proposed a checklist entry ("a structured `code`/details error object must survive `GlobalExceptionFilter`"); with the filter now passing details through, the durable lesson is "prove an error contract with a supertest spec that installs the real filter" — worth adding to `.claude/ce-pr-review-checklist.md` in a separate docs PR.
- `enforceProjectMembership` resolves the project a second time when `REQUIRE_PROJECT_MEMBERSHIP` is on (the handler already resolved it for the mismatch check). Harmless; left as-is to keep the gate shared verbatim with sign-in.
- Public docs (`docs-public`, separate repo) do not yet document app tokens or this endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SL7nkpVJbzWd1vTnNnrqr
