### PR TITLE
feat(app-tokens): allow minting a token that never expires (neverExpires)

### DIFF
--- a/apps/backend/src/app-tokens/app-tokens.dto.ts
+++ b/apps/backend/src/app-tokens/app-tokens.dto.ts
@@ -3,6 +3,7 @@ import {
   ArrayMaxSize,
   ArrayMinSize,
   IsArray,
+  IsBoolean,
   IsDateString,
   IsOptional,
   IsString,
@@ -49,11 +50,20 @@ export class CreateAppTokenDto {
   scopes: string[];
 
   @ApiPropertyOptional({
-    description: `Expiry (ISO-8601). Defaults to ${APP_TOKEN_DEFAULT_TTL_DAYS} days; at most ${APP_TOKEN_MAX_TTL_DAYS} days ahead.`,
+    description: `Expiry (ISO-8601). Defaults to ${APP_TOKEN_DEFAULT_TTL_DAYS} days; at most ${APP_TOKEN_MAX_TTL_DAYS} days ahead. Mutually exclusive with \`neverExpires\`.`,
   })
   @IsOptional()
   @IsDateString()
   expiresAt?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Mint a token that never expires (`expiresAt` is null in the response). For long-lived automation — CI members, MCP connectors, headless drivers — where a forced renewal is a scheduled outage. Off by default so the safe path stays the default; mutually exclusive with `expiresAt`. The token is still refused once revoked.',
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  neverExpires?: boolean;
 }
 
 export interface AppTokenView {

--- a/apps/backend/src/app-tokens/app-tokens.service.spec.ts
+++ b/apps/backend/src/app-tokens/app-tokens.service.spec.ts
@@ -115,6 +115,29 @@ describe('AppTokensService', () => {
       expect(mockDb.values.mock.calls[0][0].expiresAt.getTime()).toBe(soon.getTime());
     });
 
+    it('mints a never-expiring token on neverExpires (expiresAt null, reported as null)', async () => {
+      mockDb.returning.mockResolvedValueOnce([{ ...inserted, expiresAt: null }]);
+      const { view } = await service.create('user-1', 'user', { ...dto, neverExpires: true });
+      expect(mockDb.values.mock.calls[0][0].expiresAt).toBeNull();
+      expect(view.expiresAt).toBeNull();
+    });
+
+    it('keeps the 90-day default when neverExpires is false or absent', async () => {
+      mockDb.returning.mockResolvedValueOnce([inserted]);
+      await service.create('user-1', 'user', { ...dto, neverExpires: false });
+      const ttl = mockDb.values.mock.calls[0][0].expiresAt.getTime() - Date.now();
+      expect(ttl).toBeGreaterThan(89 * 86400000);
+      expect(ttl).toBeLessThanOrEqual(90 * 86400000);
+    });
+
+    it('refuses neverExpires together with an expiresAt', async () => {
+      const soon = new Date(Date.now() + 86400000).toISOString();
+      await expect(
+        service.create('user-1', 'user', { ...dto, neverExpires: true, expiresAt: soon }),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
     it('lets an OAuth caller set kind, clientId and its own expiry', async () => {
       mockDb.returning.mockResolvedValueOnce([{ ...inserted, kind: 'oauth', clientId: 'c1' }]);
       const at = new Date(Date.now() + 3600_000);

--- a/apps/backend/src/app-tokens/app-tokens.service.ts
+++ b/apps/backend/src/app-tokens/app-tokens.service.ts
@@ -58,7 +58,7 @@ export class AppTokensService {
       }
     }
 
-    const expiresAt = opts.expiresAt ?? this.resolveExpiry(dto.expiresAt);
+    const expiresAt = opts.expiresAt ?? this.resolveExpiry(dto);
     const minted = mintToken();
     const [row] = await db
       .insert(appTokens)
@@ -108,7 +108,22 @@ export class AppTokensService {
     this.logger.log(`App token ${id} revoked by user ${userId}`);
   }
 
-  private resolveExpiry(requested: string | undefined): Date {
+  /**
+   * The expiry a personal mint asked for: `neverExpires` → null (the schema's
+   * `expires_at` is nullable and every resolver — `resolveAppToken`, hence the
+   * guards, the proxy middleware and the session exchange — already reads a
+   * null as "not expired"); omitted → the default TTL; a date → clamped.
+   * `neverExpires` and `expiresAt` together is a contradiction, refused
+   * rather than silently picking one (ce#755).
+   */
+  private resolveExpiry(dto: Pick<CreateAppTokenDto, 'expiresAt' | 'neverExpires'>): Date | null {
+    const requested = dto.expiresAt;
+    if (dto.neverExpires === true) {
+      if (requested) {
+        throw new BadRequestException('expiresAt and neverExpires are mutually exclusive');
+      }
+      return null;
+    }
     const now = Date.now();
     if (!requested) return new Date(now + APP_TOKEN_DEFAULT_TTL_DAYS * DAY_MS);
     const at = new Date(requested).getTime();

--- a/apps/backend/src/auth/app-token.util.spec.ts
+++ b/apps/backend/src/auth/app-token.util.spec.ts
@@ -105,6 +105,15 @@ describe('app-token.util', () => {
       expect(await resolveAppToken('Bearer bfat_x')).toBeNull();
     });
 
+    it('resolves a never-expiring token (expiresAt null) — the guards, the proxy and the session exchange all go through here', async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([tokenRow({ expiresAt: null })])
+        .mockResolvedValueOnce([userRow()]);
+      const resolved = await resolveAppToken('Bearer bfat_never');
+      expect(resolved?.token.id).toBe('tok-1');
+      expect(resolved?.user.id).toBe('user-1');
+    });
+
     it('returns null for a revoked token', async () => {
       mockDb.limit.mockResolvedValueOnce([tokenRow({ revokedAt: new Date() })]);
       expect(await resolveAppToken('Bearer bfat_x')).toBeNull();

--- a/apps/frontend/src/components/settings/AppTokensTab.test.tsx
+++ b/apps/frontend/src/components/settings/AppTokensTab.test.tsx
@@ -94,6 +94,62 @@ describe('AppTokensTab', () => {
     expect(screen.queryByDisplayValue('bfat_rawrawraw')).toBeNull();
   });
 
+  it('sends the dated form by default, and neverExpires (without expiresAt) when ticked', async () => {
+    createTrigger.mockReturnValue({
+      unwrap: () => Promise.resolve({ data: { ...token, expiresAt: null }, token: 'bfat_never' }),
+    });
+    render(<AppTokensTab />);
+    fireEvent.click(screen.getByRole('button', { name: /mint token/i }));
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'workflow-ci' } });
+    fireEvent.change(screen.getByLabelText('Scopes'), { target: { value: 'workflow:run' } });
+
+    const expires = screen.getByLabelText('Expires') as HTMLInputElement;
+    expect(expires).not.toBeDisabled();
+    expect(expires.value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(screen.queryByTestId('never-expires-note')).toBeNull();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /never expires/i }));
+    expect(expires).toBeDisabled();
+    expect(screen.getByTestId('never-expires-note')).toHaveTextContent('until you revoke it');
+
+    fireEvent.click(screen.getAllByRole('button', { name: /mint token/i }).at(-1)!);
+    await waitFor(() => expect(createTrigger).toHaveBeenCalledTimes(1));
+    const body = createTrigger.mock.calls[0][0];
+    expect(body).toMatchObject({ name: 'workflow-ci', neverExpires: true });
+    expect(body).not.toHaveProperty('expiresAt');
+    await screen.findByTestId('minted-token');
+  });
+
+  it('omits neverExpires from the body when the box is left unticked', async () => {
+    createTrigger.mockReturnValue({
+      unwrap: () => Promise.resolve({ data: token, token: 'bfat_dated' }),
+    });
+    render(<AppTokensTab />);
+    fireEvent.click(screen.getByRole('button', { name: /mint token/i }));
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'dated' } });
+    fireEvent.change(screen.getByLabelText('Scopes'), { target: { value: 'workflow:run' } });
+    fireEvent.click(screen.getAllByRole('button', { name: /mint token/i }).at(-1)!);
+    await waitFor(() => expect(createTrigger).toHaveBeenCalledTimes(1));
+    const body = createTrigger.mock.calls[0][0];
+    expect(body).not.toHaveProperty('neverExpires');
+    expect(typeof body.expiresAt).toBe('string');
+  });
+
+  it('shows "Never" in the Expires column for a token without an expiry', () => {
+    // Column order: Name, Project, Scopes, Kind, Expires, Last used, Actions.
+    listResult = { data: [{ ...token, expiresAt: null }], isLoading: false };
+    const { unmount } = render(<AppTokensTab />);
+    let cells = screen.getByText('Claude — workflow').closest('tr')!.querySelectorAll('td');
+    expect(cells[4]).toHaveTextContent('Never');
+    unmount();
+
+    listResult = { data: [token], isLoading: false };
+    render(<AppTokensTab />);
+    cells = screen.getByText('Claude — workflow').closest('tr')!.querySelectorAll('td');
+    expect(cells[4]).not.toHaveTextContent('Never');
+    expect(cells[4]).not.toHaveTextContent('—');
+  });
+
   it('calls the revoke mutation with the id', async () => {
     revokeTrigger.mockReturnValue({ unwrap: () => Promise.resolve() });
     render(<AppTokensTab />);

--- a/apps/frontend/src/components/settings/AppTokensTab.tsx
+++ b/apps/frontend/src/components/settings/AppTokensTab.tsx
@@ -44,6 +44,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -87,6 +88,7 @@ export function AppTokensTab() {
   const [project, setProject] = useState('');
   const [scopesInput, setScopesInput] = useState('');
   const [expiresAt, setExpiresAt] = useState(defaultExpiryDate);
+  const [neverExpires, setNeverExpires] = useState(false);
 
   const { data: tokens, isLoading, error } = useListAppTokensQuery();
   const { data: projects } = useListMyProjectsQuery();
@@ -103,6 +105,7 @@ export function AppTokensTab() {
     setProject('');
     setScopesInput('');
     setExpiresAt(defaultExpiryDate());
+    setNeverExpires(false);
   };
 
   const handleMint = async () => {
@@ -119,7 +122,13 @@ export function AppTokensTab() {
         name: name.trim(),
         project: effectiveProject,
         scopes,
-        expiresAt: expiresAt ? new Date(`${expiresAt}T23:59:59Z`).toISOString() : undefined,
+        // Only the chosen shape is sent: an older server (no `neverExpires` in
+        // its DTO) still accepts the dated/default form from this UI.
+        ...(neverExpires
+          ? { neverExpires: true }
+          : {
+              expiresAt: expiresAt ? new Date(`${expiresAt}T23:59:59Z`).toISOString() : undefined,
+            }),
       }).unwrap();
       setMinted(response);
       resetForm();
@@ -312,7 +321,24 @@ export function AppTokensTab() {
                       type="date"
                       value={expiresAt}
                       onChange={(e) => setExpiresAt(e.target.value)}
+                      disabled={neverExpires}
                     />
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="app-token-never-expires"
+                        checked={neverExpires}
+                        onCheckedChange={(checked) => setNeverExpires(checked === true)}
+                      />
+                      <Label htmlFor="app-token-never-expires" className="font-normal">
+                        Never expires
+                      </Label>
+                    </div>
+                    {neverExpires && (
+                      <p className="text-xs text-muted-foreground" data-testid="never-expires-note">
+                        For long-lived automation (CI, MCP connectors, headless drivers). The token
+                        stays valid until you revoke it — treat it like a password.
+                      </p>
+                    )}
                   </div>
                 </div>
               )}
@@ -389,7 +415,7 @@ export function AppTokensTab() {
                       : 'Personal'}
                   </TableCell>
                   <TableCell className="text-sm text-muted-foreground">
-                    {fmt(t.expiresAt)}
+                    {t.expiresAt ? fmt(t.expiresAt) : 'Never'}
                   </TableCell>
                   <TableCell className="text-sm text-muted-foreground">
                     {t.lastUsedAt ? fmt(t.lastUsedAt) : 'Never'}

--- a/apps/frontend/src/services/appTokensApi.ts
+++ b/apps/frontend/src/services/appTokensApi.ts
@@ -19,7 +19,10 @@ export interface CreateAppTokenDto {
   name: string;
   project: string; // owner/repo
   scopes: string[];
+  /** ISO-8601; omitted → the server's 90-day default. Mutually exclusive with `neverExpires`. */
   expiresAt?: string;
+  /** Mint a token that never expires (`expiresAt` comes back null). Omit rather than send `false`. */
+  neverExpires?: boolean;
 }
 
 export interface CreateAppTokenResponse {


### PR DESCRIPTION
Closes #755

## Summary
App tokens could only be minted with an expiry of at most 365 days (90 by default), so every long-lived automation — a CI member, an MCP connector, a headless driver — was on a forced renewal schedule that nobody remembers until the token starts answering 401. Per the maintainer decision on the issue, a member can now mint a token that never expires: tick "Never expires" in the mint dialog (or send `neverExpires: true` to the API). Nothing changes for anyone who does not opt in — the 90-day default and the 365-day cap for dated tokens stay exactly as they were. Such a token remains revocable and is refused the moment it is revoked.

## Behaviour changes
- `POST /api/app-tokens`: new optional body field `neverExpires: boolean` (additive). `true` → the token is stored with no expiry and comes back with `expiresAt: null`. Omitted / `false` → unchanged (90-day default, or the caller's `expiresAt` clamped to 365 days).
- `POST /api/app-tokens` with both `neverExpires: true` and an `expiresAt` → `400 expiresAt and neverExpires are mutually exclusive` (before: `neverExpires` was rejected as an unknown property by the global `forbidNonWhitelisted` pipe, so no existing client could have been sending it).
- Settings → App Tokens: the mint dialog gains a "Never expires" checkbox (unticked by default) that disables the date picker and shows a short warning; the Expires column shows "Never" instead of "—" for a token without an expiry.
- Token validation (guards, proxy middleware, `POST /api/auth/session/from-app-token` from #752): no change — they all go through `resolveAppToken`, which already treated a null `expires_at` as "not expired". This PR adds a named test pinning that.

## Why
The 365-day cap was never a documented security decision, and the issue's maintainer comment settled the open question as "allow never expire" — not admin-gated and not merely a higher cap. A dedicated boolean was chosen over the `expiresAt: null` sentinel because `null` already passes `@IsOptional()` today and falls through to the 90-day default; repurposing it would silently turn an existing (if unlikely) request shape into an unbounded credential. An explicit flag is additive and cannot be sent by accident.

## What changed
- **backend**: `apps/backend/src/app-tokens/app-tokens.dto.ts` (`neverExpires?: boolean`, Swagger text), `apps/backend/src/app-tokens/app-tokens.service.ts` (`resolveExpiry` returns `Date | null`, mutual-exclusion 400).
- **frontend**: `apps/frontend/src/services/appTokensApi.ts` (DTO mirror), `apps/frontend/src/components/settings/AppTokensTab.tsx` (checkbox + warning in the mint dialog, "Never" in the list; the body only carries `neverExpires` when ticked so the dated form still works against an older server).
- **tests**: `app-tokens.service.spec.ts` (+3: never-expiring mint, default kept when false, mutual exclusion), `auth/app-token.util.spec.ts` (+1: null expiry resolves), `AppTokensTab.test.tsx` (+3: body shape ticked/unticked, "Never" in the Expires cell).

## Compatibility
- **Migrations**: none — `app_tokens.expires_at` is already nullable (`apps/backend/src/db/schema/app-tokens.schema.ts`), and `AppTokenView.expiresAt` was already typed `string | null`.
- **API / CLI contract**: additive only. `packages/cli` has no app-token surface. Old clients that omit `neverExpires` get identical behaviour. The OAuth mint path (`opts.expiresAt`) is untouched.
- **Env vars, nginx generation, storage layout, pipeline semantics**: not touched.
- Sibling PR for #754 (list pagination / hide-expired) touches the same files; this diff keeps the list rendering change to one line in the Expires cell to rebase cleanly.

## Verification
- `pnpm --filter backend exec tsc --noEmit` → exit 0
- `pnpm --filter frontend exec tsc --noEmit` → exit 0
- `pnpm --filter backend format:check` / `pnpm --filter frontend format:check` → exit 0 / 0
- `cd apps/backend && pnpm test -- "app-tokens|app-token.util|session-from-app-token"` → Test Suites: 5 passed, Tests: 33 passed
- `cd apps/frontend && npx vitest run AppTokensTab` → Test Files 1 passed, Tests 8 passed (the full frontend suite also ran green while narrowing the filter)

## Out of scope / follow-ups
- The 365-day cap on *dated* tokens is kept as-is; if a bounded-but-longer token (e.g. 2 years) is wanted, that is a separate one-line change to `APP_TOKEN_MAX_TTL_DAYS`.
- The public docs (`docs-public`) and the `bffless/skills` authentication skill do not yet mention `neverExpires`; worth a line once this ships.
- #754 (cursor pagination + hide-expired filter on the same list) is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaBmRQuNt8d4Msp8d45JDf
