### PR TITLE
feat(app-tokens): paginate GET /api/app-tokens and hide revoked/expired tokens by default

### DIFF
--- a/apps/backend/src/app-tokens/app-tokens-http.spec.ts
+++ b/apps/backend/src/app-tokens/app-tokens-http.spec.ts
@@ -1,0 +1,71 @@
+import 'reflect-metadata';
+import { ExecutionContext, INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AppTokensController } from './app-tokens.controller';
+import { AppTokensService } from './app-tokens.service';
+import { SessionAuthGuard } from '../auth/session-auth.guard';
+
+/**
+ * `GET /api/app-tokens` query parsing on the wire — through the same global
+ * `ValidationPipe` main.ts installs (`whitelist`, `transform`,
+ * `forbidNonWhitelisted`). Query strings arrive as strings, so the DTO's
+ * coercions (`includeInactive=true`, `limit=10`) and its rejections (an unknown
+ * key, an out-of-range page size, a non-uuid cursor) only mean anything here.
+ */
+describe('GET /api/app-tokens over HTTP (global ValidationPipe installed)', () => {
+  let app: INestApplication;
+  const listMine = jest.fn();
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AppTokensController],
+      providers: [{ provide: AppTokensService, useValue: { listMine } }],
+    })
+      .overrideGuard(SessionAuthGuard)
+      .useValue({
+        canActivate: (ctx: ExecutionContext) => {
+          ctx.switchToHttp().getRequest().user = { id: 'user-1', role: 'user' };
+          return true;
+        },
+      })
+      .compile();
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    listMine.mockReset().mockResolvedValue({ items: [{ id: 'tok-1' }], nextCursor: null });
+  });
+
+  it('a bare GET (a pinned client) still answers `data`, now with `nextCursor` beside it', async () => {
+    const res = await request(app.getHttpServer()).get('/api/app-tokens');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ data: [{ id: 'tok-1' }], nextCursor: null });
+    expect(listMine).toHaveBeenCalledWith('user-1', {});
+  });
+
+  it('coerces the query string into the typed options the service reads', async () => {
+    const cursor = '11111111-1111-4111-8111-111111111111';
+    const res = await request(app.getHttpServer()).get(
+      `/api/app-tokens?includeInactive=true&limit=10&cursor=${cursor}`,
+    );
+    expect(res.status).toBe(200);
+    expect(listMine).toHaveBeenCalledWith('user-1', { includeInactive: true, limit: 10, cursor });
+  });
+
+  it('400s an unknown parameter, an out-of-range limit and a malformed cursor', async () => {
+    for (const qs of ['offset=10', 'limit=0', 'limit=201', 'limit=abc', 'cursor=not-a-uuid']) {
+      const res = await request(app.getHttpServer()).get(`/api/app-tokens?${qs}`);
+      expect([qs, res.status]).toEqual([qs, 400]);
+    }
+    expect(listMine).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/app-tokens/app-tokens.controller.spec.ts
+++ b/apps/backend/src/app-tokens/app-tokens.controller.spec.ts
@@ -16,7 +16,7 @@ describe('AppTokensController', () => {
   it('delegates to the service and shapes the responses', async () => {
     const service = {
       create: jest.fn().mockResolvedValue({ view: { id: 't' }, raw: 'bfat_x' }),
-      listMine: jest.fn().mockResolvedValue([{ id: 't' }]),
+      listMine: jest.fn().mockResolvedValue({ items: [{ id: 't' }], nextCursor: 'c' }),
       revoke: jest.fn().mockResolvedValue(undefined),
     };
     const controller = new AppTokensController(service as never);
@@ -29,7 +29,11 @@ describe('AppTokensController', () => {
       project: 'o/r',
       scopes: ['a:b'],
     });
-    await expect(controller.list(user)).resolves.toEqual({ data: [{ id: 't' }] });
+    await expect(controller.list(user, { includeInactive: true, limit: 10 })).resolves.toEqual({
+      data: [{ id: 't' }],
+      nextCursor: 'c',
+    });
+    expect(service.listMine).toHaveBeenCalledWith('u', { includeInactive: true, limit: 10 });
     await expect(controller.revoke(user, 't')).resolves.toBeUndefined();
     expect(service.revoke).toHaveBeenCalledWith('t', 'u');
   });

--- a/apps/backend/src/app-tokens/app-tokens.controller.ts
+++ b/apps/backend/src/app-tokens/app-tokens.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   ParseUUIDPipe,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -15,7 +16,12 @@ import { SessionAuthGuard } from '../auth/session-auth.guard';
 import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
 import { PublicProjectAccess } from '../auth/decorators/public-project-access.decorator';
 import { AppTokensService } from './app-tokens.service';
-import { CreateAppTokenDto, CreateAppTokenResponse, ListAppTokensResponse } from './app-tokens.dto';
+import {
+  CreateAppTokenDto,
+  CreateAppTokenResponse,
+  ListAppTokensQueryDto,
+  ListAppTokensResponse,
+} from './app-tokens.dto';
 
 /**
  * A member's app tokens. Session-only on purpose: a credential cannot beget
@@ -49,9 +55,17 @@ export class AppTokensController {
   }
 
   @Get()
-  @ApiOperation({ summary: 'List my app tokens' })
-  async list(@CurrentUser() user: CurrentUserData): Promise<ListAppTokensResponse> {
-    return { data: await this.appTokens.listMine(user.id) };
+  @ApiOperation({
+    summary: 'List my app tokens',
+    description:
+      'Newest first, one page per call: follow `nextCursor` (as `?cursor=`) until it is null. Revoked and expired tokens are omitted unless `includeInactive=true`.',
+  })
+  async list(
+    @CurrentUser() user: CurrentUserData,
+    @Query() query: ListAppTokensQueryDto,
+  ): Promise<ListAppTokensResponse> {
+    const { items, nextCursor } = await this.appTokens.listMine(user.id, query);
+    return { data: items, nextCursor };
   }
 
   @Delete(':id')

--- a/apps/backend/src/app-tokens/app-tokens.dto.ts
+++ b/apps/backend/src/app-tokens/app-tokens.dto.ts
@@ -1,19 +1,27 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import {
   ArrayMaxSize,
   ArrayMinSize,
   IsArray,
+  IsBoolean,
   IsDateString,
+  IsInt,
   IsOptional,
   IsString,
+  IsUUID,
   Matches,
+  Max,
   MaxLength,
+  Min,
   MinLength,
 } from 'class-validator';
 import { SCOPE_PATTERN } from '../pipelines/types';
 
 export const APP_TOKEN_DEFAULT_TTL_DAYS = 90;
 export const APP_TOKEN_MAX_TTL_DAYS = 365;
+export const APP_TOKEN_LIST_DEFAULT_LIMIT = 50;
+export const APP_TOKEN_LIST_MAX_LIMIT = 200;
 
 export class CreateAppTokenDto {
   @ApiProperty({
@@ -56,6 +64,41 @@ export class CreateAppTokenDto {
   expiresAt?: string;
 }
 
+/** Query for `GET /api/app-tokens`. Every parameter is optional: a bare GET lists the first page of active tokens. */
+export class ListAppTokensQueryDto {
+  @ApiPropertyOptional({
+    description:
+      'Also list revoked and expired tokens. Off by default: only tokens that can still authenticate are returned.',
+    default: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  @IsBoolean()
+  includeInactive?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Page size.',
+    default: APP_TOKEN_LIST_DEFAULT_LIMIT,
+    minimum: 1,
+    maximum: APP_TOKEN_LIST_MAX_LIMIT,
+  })
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value, 10))
+  @IsInt()
+  @Min(1)
+  @Max(APP_TOKEN_LIST_MAX_LIMIT)
+  limit?: number;
+
+  @ApiPropertyOptional({
+    description:
+      'The `nextCursor` of the previous page (the id of its last token). Pages are newest-first.',
+    format: 'uuid',
+  })
+  @IsOptional()
+  @IsUUID()
+  cursor?: string;
+}
+
 export interface AppTokenView {
   id: string;
   name: string;
@@ -78,4 +121,6 @@ export interface CreateAppTokenResponse {
 
 export interface ListAppTokensResponse {
   data: AppTokenView[];
+  /** Pass as `?cursor=` to fetch the next page; `null` on the last page. */
+  nextCursor: string | null;
 }

--- a/apps/backend/src/app-tokens/app-tokens.service.spec.ts
+++ b/apps/backend/src/app-tokens/app-tokens.service.spec.ts
@@ -1,4 +1,6 @@
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { AppTokensService } from './app-tokens.service';
 
 jest.mock('../db/client', () => {
@@ -21,6 +23,12 @@ jest.mock('../db/client', () => {
   return { db: chain };
 });
 const mockDb = jest.requireMock('../db/client').db as Record<string, jest.Mock>;
+
+/** The SQL text + params of the last `where(...)` the service built. */
+function lastWhere(): { sql: string; params: unknown[] } {
+  const calls = mockDb.where.mock.calls;
+  return new PgDialect().sqlToQuery(calls[calls.length - 1][0] as SQL);
+}
 
 const project = { id: 'proj-1', owner: 'bffless', name: 'workflow' };
 const inserted = {
@@ -128,12 +136,74 @@ describe('AppTokensService', () => {
   });
 
   describe('listMine', () => {
+    const CURSOR = '11111111-1111-4111-8111-111111111111';
+    const rowsOf = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        token: { ...inserted, id: `tok-${i + 1}` },
+        project,
+      }));
+
     it('lists the caller’s tokens joined with their project, without hashes', async () => {
-      mockDb.orderBy.mockResolvedValueOnce([{ token: inserted, project }]);
-      const list = await service.listMine('user-1');
-      expect(list).toHaveLength(1);
-      expect(list[0].project).toEqual(project);
-      expect(list[0]).not.toHaveProperty('tokenHash');
+      mockDb.limit.mockResolvedValueOnce([{ token: inserted, project }]);
+      const { items, nextCursor } = await service.listMine('user-1');
+      expect(items).toHaveLength(1);
+      expect(items[0].project).toEqual(project);
+      expect(items[0]).not.toHaveProperty('tokenHash');
+      expect(nextCursor).toBeNull();
+    });
+
+    it('hides revoked and expired tokens by default, and lists them with includeInactive', async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+      await service.listMine('user-1');
+      const { sql, params } = lastWhere();
+      expect(sql).toContain('"app_tokens"."user_id" = $1');
+      expect(sql).toContain('"app_tokens"."revoked_at" is null');
+      expect(sql).toMatch(/"app_tokens"\."expires_at" is null or "app_tokens"\."expires_at" > \$2/);
+      expect(params[0]).toBe('user-1');
+      // "now", as the timestamp column's driver value.
+      expect(Math.abs(Date.now() - new Date(String(params[1])).getTime())).toBeLessThan(5000);
+
+      mockDb.limit.mockResolvedValueOnce([]);
+      await service.listMine('user-1', { includeInactive: true });
+      const all = lastWhere();
+      expect(all.sql).toContain('"app_tokens"."user_id" = $1');
+      expect(all.sql).not.toContain('revoked_at');
+      expect(all.sql).not.toContain('expires_at');
+    });
+
+    it('orders newest first with the id as tie-break and over-fetches one row to detect a next page', async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+      await service.listMine('user-1', { limit: 20 });
+      expect(mockDb.limit).toHaveBeenCalledWith(21);
+      const [createdAt, id] = mockDb.orderBy.mock.calls[0];
+      expect(new PgDialect().sqlToQuery(createdAt).sql).toBe('"app_tokens"."created_at" desc');
+      expect(new PgDialect().sqlToQuery(id).sql).toBe('"app_tokens"."id" desc');
+
+      mockDb.limit.mockResolvedValueOnce([]);
+      await service.listMine('user-1');
+      expect(mockDb.limit).toHaveBeenLastCalledWith(51); // APP_TOKEN_LIST_DEFAULT_LIMIT + 1
+    });
+
+    it('returns exactly `limit` items and the last one’s id as the cursor when more follow', async () => {
+      mockDb.limit.mockResolvedValueOnce(rowsOf(3));
+      const page = await service.listMine('user-1', { limit: 2 });
+      expect(page.items.map((t) => t.id)).toEqual(['tok-1', 'tok-2']);
+      expect(page.nextCursor).toBe('tok-2');
+
+      mockDb.limit.mockResolvedValueOnce(rowsOf(2));
+      const last = await service.listMine('user-1', { limit: 2 });
+      expect(last.items).toHaveLength(2);
+      expect(last.nextCursor).toBeNull();
+    });
+
+    it('resumes after the cursor row by keyset, reading its key in SQL and scoping it to the caller', async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+      await service.listMine('user-1', { cursor: CURSOR, includeInactive: true });
+      const { sql, params } = lastWhere();
+      expect(sql).toContain(
+        '("app_tokens"."created_at", "app_tokens"."id") < (select "cursor_row"."created_at", "cursor_row"."id" from "app_tokens" "cursor_row" where "cursor_row"."id" = $2 and "cursor_row"."user_id" = $3)',
+      );
+      expect(params).toEqual(['user-1', CURSOR, 'user-1']);
     });
   });
 

--- a/apps/backend/src/app-tokens/app-tokens.service.ts
+++ b/apps/backend/src/app-tokens/app-tokens.service.ts
@@ -5,7 +5,8 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { and, desc, eq, isNull } from 'drizzle-orm';
+import { SQL, and, desc, eq, gt, isNull, or, sql } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 import { db } from '../db/client';
 import { appTokens, projects } from '../db/schema';
 import { mintToken } from '../auth/app-token.util';
@@ -13,12 +14,20 @@ import { ProjectsService } from '../projects/projects.service';
 import { PermissionsService } from '../permissions/permissions.service';
 import {
   APP_TOKEN_DEFAULT_TTL_DAYS,
+  APP_TOKEN_LIST_DEFAULT_LIMIT,
   APP_TOKEN_MAX_TTL_DAYS,
   AppTokenView,
   CreateAppTokenDto,
+  ListAppTokensQueryDto,
 } from './app-tokens.dto';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface AppTokenPage {
+  items: AppTokenView[];
+  /** The id of the last item when another page follows; `null` on the last page. */
+  nextCursor: string | null;
+}
 
 /**
  * Mint, list and revoke app tokens. A token never elevates, so any member of
@@ -79,7 +88,31 @@ export class AppTokensService {
     return { view: this.toView(row, project), raw: minted.raw };
   }
 
-  async listMine(userId: string): Promise<AppTokenView[]> {
+  /**
+   * The caller's tokens, newest first, one page at a time. Revoked and expired
+   * tokens are omitted unless `includeInactive` — automation mints a token per
+   * run, so the dead ones outnumber the live ones within days.
+   */
+  async listMine(userId: string, query: ListAppTokensQueryDto = {}): Promise<AppTokenPage> {
+    const limit = query.limit ?? APP_TOKEN_LIST_DEFAULT_LIMIT;
+    const conditions: SQL[] = [eq(appTokens.userId, userId)];
+    if (!query.includeInactive) {
+      conditions.push(
+        isNull(appTokens.revokedAt),
+        or(isNull(appTokens.expiresAt), gt(appTokens.expiresAt, new Date()))!,
+      );
+    }
+    if (query.cursor) {
+      // Keyset on (created_at, id): everything strictly after the cursor row in
+      // list order. The cursor row's key is read in SQL rather than round-tripped
+      // through a JS Date, which would truncate created_at's microseconds and
+      // skip same-millisecond neighbours. A cursor that is not one of the
+      // caller's tokens compares against NULL and yields an empty page.
+      const c = alias(appTokens, 'cursor_row');
+      conditions.push(
+        sql`(${appTokens.createdAt}, ${appTokens.id}) < (select ${c.createdAt}, ${c.id} from ${appTokens} ${c} where ${c.id} = ${query.cursor} and ${c.userId} = ${userId})`,
+      );
+    }
     const rows = await db
       .select({
         token: appTokens,
@@ -87,9 +120,15 @@ export class AppTokensService {
       })
       .from(appTokens)
       .innerJoin(projects, eq(appTokens.projectId, projects.id))
-      .where(eq(appTokens.userId, userId))
-      .orderBy(desc(appTokens.createdAt));
-    return rows.map((r) => this.toView(r.token, r.project));
+      .where(and(...conditions))
+      .orderBy(desc(appTokens.createdAt), desc(appTokens.id))
+      .limit(limit + 1);
+    const hasMore = rows.length > limit;
+    const page = hasMore ? rows.slice(0, limit) : rows;
+    return {
+      items: page.map((r) => this.toView(r.token, r.project)),
+      nextCursor: hasMore ? page[page.length - 1].token.id : null,
+    };
   }
 
   /** Soft revoke; 404 unless the token is the caller's; idempotent on an already-revoked token. */

--- a/apps/frontend/src/components/settings/AppTokensTab.test.tsx
+++ b/apps/frontend/src/components/settings/AppTokensTab.test.tsx
@@ -1,17 +1,29 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
-import { AppTokensTab, parseScopes } from './AppTokensTab';
-import type { AppToken } from '@/services/appTokensApi';
+import { AppTokensTab, isExpired, parseScopes } from './AppTokensTab';
+import type { AppToken, ListAppTokensPage } from '@/services/appTokensApi';
 
 const createTrigger = vi.fn();
 const revokeTrigger = vi.fn();
-let listResult: { data?: AppToken[]; isLoading: boolean; error?: unknown } = {
-  data: [],
-  isLoading: false,
+const fetchNextPage = vi.fn();
+const listQuery = vi.fn();
+let listResult: {
+  data?: { pages: ListAppTokensPage[]; pageParams: (string | null)[] };
+  isLoading: boolean;
+  error?: unknown;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
 };
+const pagesOf = (...pages: AppToken[][]) => ({
+  pages: pages.map((data, i) => ({ data, nextCursor: i < pages.length - 1 ? `c${i}` : null })),
+  pageParams: pages.map((_, i) => (i === 0 ? null : `c${i - 1}`)),
+});
 
 vi.mock('@/services/appTokensApi', () => ({
-  useListAppTokensQuery: () => listResult,
+  useListAppTokensInfiniteQuery: (args: unknown) => {
+    listQuery(args);
+    return { fetchNextPage, hasNextPage: false, isFetchingNextPage: false, ...listResult };
+  },
   useCreateAppTokenMutation: () => [createTrigger, { isLoading: false }],
   useRevokeAppTokenMutation: () => [revokeTrigger, { isLoading: false }],
 }));
@@ -46,10 +58,21 @@ describe('parseScopes', () => {
   });
 });
 
+describe('isExpired', () => {
+  it('is true only for a past expiry on a token that is not revoked', () => {
+    expect(isExpired({ expiresAt: '2020-01-01T00:00:00.000Z', revokedAt: null })).toBe(true);
+    expect(isExpired({ expiresAt: '2999-01-01T00:00:00.000Z', revokedAt: null })).toBe(false);
+    expect(isExpired({ expiresAt: null, revokedAt: null })).toBe(false);
+    expect(
+      isExpired({ expiresAt: '2020-01-01T00:00:00.000Z', revokedAt: '2020-01-02T00:00:00.000Z' }),
+    ).toBe(false);
+  });
+});
+
 describe('AppTokensTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    listResult = { data: [token], isLoading: false };
+    listResult = { data: pagesOf([token]), isLoading: false };
   });
 
   it('renders the rows with project and scope badges', () => {
@@ -103,9 +126,60 @@ describe('AppTokensTab', () => {
   });
 
   it('strikes through a revoked token and hides its revoke action', () => {
-    listResult = { data: [{ ...token, revokedAt: '2026-09-04T00:00:00.000Z' }], isLoading: false };
+    listResult = {
+      data: pagesOf([{ ...token, revokedAt: '2026-09-04T00:00:00.000Z' }]),
+      isLoading: false,
+    };
     render(<AppTokensTab />);
     expect(screen.getByText(/Revoked/)).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /revoke claude/i })).toBeNull();
+  });
+
+  it('labels an expired token, keeping its revoke action', () => {
+    listResult = {
+      data: pagesOf([{ ...token, expiresAt: '2020-01-01T00:00:00.000Z' }]),
+      isLoading: false,
+    };
+    render(<AppTokensTab />);
+    expect(screen.getByText(/^Expired/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /revoke claude/i })).toBeInTheDocument();
+  });
+
+  it('asks the server for active tokens only until "Show expired and revoked" is switched on', () => {
+    listResult = { data: pagesOf([]), isLoading: false };
+    render(<AppTokensTab />);
+    expect(listQuery).toHaveBeenLastCalledWith({ includeInactive: false });
+    expect(screen.getByText('No active app tokens')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('switch', { name: /show expired and revoked/i }));
+    expect(listQuery).toHaveBeenLastCalledWith({ includeInactive: true });
+    expect(screen.getByText('No app tokens yet')).toBeInTheDocument();
+  });
+
+  it('renders every loaded page and offers "Load more" only while a next page exists', () => {
+    const second: AppToken = { ...token, id: 'tok-2', name: 'Older token' };
+    listResult = { data: pagesOf([token], [second]), isLoading: false, hasNextPage: true };
+    render(<AppTokensTab />);
+    expect(screen.getByText('Claude — workflow')).toBeInTheDocument();
+    expect(screen.getByText('Older token')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /load more/i }));
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides "Load more" on the last page and disables it while a page is loading', () => {
+    listResult = { data: pagesOf([token]), isLoading: false, hasNextPage: false };
+    const { unmount } = render(<AppTokensTab />);
+    expect(screen.queryByRole('button', { name: /load more/i })).toBeNull();
+    unmount();
+
+    listResult = {
+      data: pagesOf([token]),
+      isLoading: false,
+      hasNextPage: true,
+      isFetchingNextPage: true,
+    };
+    render(<AppTokensTab />);
+    expect(screen.getByRole('button', { name: /loading/i })).toBeDisabled();
   });
 });

--- a/apps/frontend/src/components/settings/AppTokensTab.tsx
+++ b/apps/frontend/src/components/settings/AppTokensTab.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from 'react';
 import {
-  useListAppTokensQuery,
+  useListAppTokensInfiniteQuery,
   useCreateAppTokenMutation,
   useRevokeAppTokenMutation,
+  type AppToken,
   type CreateAppTokenResponse,
 } from '@/services/appTokensApi';
 import { useListMyProjectsQuery } from '@/services/meApi';
@@ -46,6 +47,7 @@ import {
 } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/hooks/use-toast';
@@ -71,6 +73,11 @@ function defaultExpiryDate(): string {
   return d.toISOString().slice(0, 10);
 }
 
+/** Expired but not revoked — it answers 401 all the same, and is listed only with the toggle on. */
+export function isExpired(token: Pick<AppToken, 'expiresAt' | 'revokedAt'>): boolean {
+  return !token.revokedAt && !!token.expiresAt && new Date(token.expiresAt).getTime() < Date.now();
+}
+
 /**
  * App tokens — scoped, project-bound bearers a member mints for an agent or a
  * script (or an OAuth client obtained on their behalf). Every member gets this
@@ -82,13 +89,16 @@ export function AppTokensTab() {
   const [revoking, setRevoking] = useState<string | null>(null);
   const [minted, setMinted] = useState<CreateAppTokenResponse | null>(null);
   const [copied, setCopied] = useState(false);
+  const [includeInactive, setIncludeInactive] = useState(false);
 
   const [name, setName] = useState('');
   const [project, setProject] = useState('');
   const [scopesInput, setScopesInput] = useState('');
   const [expiresAt, setExpiresAt] = useState(defaultExpiryDate);
 
-  const { data: tokens, isLoading, error } = useListAppTokensQuery();
+  const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useListAppTokensInfiniteQuery({ includeInactive });
+  const tokens = useMemo(() => data?.pages.flatMap((page) => page.data) ?? [], [data]);
   const { data: projects } = useListMyProjectsQuery();
   const [createToken, { isLoading: isCreating }] = useCreateAppTokenMutation();
   const [revokeToken, { isLoading: isRevoking }] = useRevokeAppTokenMutation();
@@ -336,10 +346,22 @@ export function AppTokensTab() {
         </div>
       </CardHeader>
       <CardContent>
-        {!tokens || tokens.length === 0 ? (
+        <div className="flex items-center gap-2 mb-4">
+          <Switch
+            id="app-tokens-include-inactive"
+            checked={includeInactive}
+            onCheckedChange={setIncludeInactive}
+          />
+          <Label htmlFor="app-tokens-include-inactive" className="font-normal">
+            Show expired and revoked
+          </Label>
+        </div>
+        {tokens.length === 0 ? (
           <div className="text-center py-12">
             <KeyRound className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-semibold mb-2">No app tokens yet</h3>
+            <h3 className="text-lg font-semibold mb-2">
+              {includeInactive ? 'No app tokens yet' : 'No active app tokens'}
+            </h3>
             <p className="text-muted-foreground">
               Mint one to let an agent or a script act as you on a project.
             </p>
@@ -359,14 +381,23 @@ export function AppTokensTab() {
             </TableHeader>
             <TableBody>
               {tokens.map((t) => (
-                <TableRow key={t.id} className={t.revokedAt ? 'opacity-60' : undefined}>
+                <TableRow
+                  key={t.id}
+                  className={t.revokedAt || isExpired(t) ? 'opacity-60' : undefined}
+                >
                   <TableCell className="font-medium">
                     <span className={t.revokedAt ? 'line-through' : undefined}>{t.name}</span>
                     <div className="font-mono text-xs text-muted-foreground">{t.tokenPrefix}…</div>
-                    {t.revokedAt && (
+                    {t.revokedAt ? (
                       <div className="text-xs text-muted-foreground">
                         Revoked {fmt(t.revokedAt)}
                       </div>
+                    ) : (
+                      isExpired(t) && (
+                        <div className="text-xs text-muted-foreground">
+                          Expired {fmt(t.expiresAt)}
+                        </div>
+                      )
                     )}
                   </TableCell>
                   <TableCell>
@@ -438,6 +469,18 @@ export function AppTokensTab() {
               ))}
             </TableBody>
           </Table>
+        )}
+        {hasNextPage && (
+          <div className="flex justify-center mt-4">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => fetchNextPage()}
+              disabled={isFetchingNextPage}
+            >
+              {isFetchingNextPage ? 'Loading…' : 'Load more'}
+            </Button>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/apps/frontend/src/services/appTokensApi.ts
+++ b/apps/frontend/src/services/appTokensApi.ts
@@ -27,11 +27,33 @@ export interface CreateAppTokenResponse {
   token: string; // shown once
 }
 
+export interface ListAppTokensArgs {
+  /** Also list revoked and expired tokens; the server omits them by default. */
+  includeInactive?: boolean;
+}
+
+/** One page of `GET /api/app-tokens`; `nextCursor` is null on the last page. */
+export interface ListAppTokensPage {
+  data: AppToken[];
+  nextCursor: string | null;
+}
+
 export const appTokensApi = api.injectEndpoints({
   endpoints: (builder) => ({
-    listAppTokens: builder.query<AppToken[], void>({
-      query: () => '/api/app-tokens',
-      transformResponse: (response: { data: AppToken[] }) => response.data,
+    // Cursor-paged: each page is fetched with the previous page's `nextCursor`;
+    // a mint or revoke invalidates the whole list and every loaded page refetches.
+    listAppTokens: builder.infiniteQuery<ListAppTokensPage, ListAppTokensArgs, string | null>({
+      infiniteQueryOptions: {
+        initialPageParam: null,
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+      },
+      query: ({ queryArg, pageParam }) => {
+        const params = new URLSearchParams();
+        if (queryArg.includeInactive) params.set('includeInactive', 'true');
+        if (pageParam) params.set('cursor', pageParam);
+        const qs = params.toString();
+        return `/api/app-tokens${qs ? `?${qs}` : ''}`;
+      },
       providesTags: [{ type: 'AppToken' as const, id: 'LIST' }],
     }),
     createAppToken: builder.mutation<CreateAppTokenResponse, CreateAppTokenDto>({
@@ -45,5 +67,8 @@ export const appTokensApi = api.injectEndpoints({
   }),
 });
 
-export const { useListAppTokensQuery, useCreateAppTokenMutation, useRevokeAppTokenMutation } =
-  appTokensApi;
+export const {
+  useListAppTokensInfiniteQuery,
+  useCreateAppTokenMutation,
+  useRevokeAppTokenMutation,
+} = appTokensApi;


### PR DESCRIPTION
Closes #754

## Summary
Settings → App Tokens listed every token a member had ever minted in one unbounded table, and because automation mints a fresh token per run (one per driven `workflow-live` walk, one per OAuth connector session) the list grew by several rows a day, most of them revoked. The list endpoint now returns one page at a time and, by default, only tokens that can still authenticate; the tab shows the live tokens first, with a "Show expired and revoked" switch and a "Load more" button for the rest. Members with dozens of dead tokens will open the tab and see just the ones that matter.

## Behaviour changes
- `GET /api/app-tokens` (default, no parameters): before → every token, newest first, in one response; after → the newest **50 active** tokens (not revoked, not expired), plus a `nextCursor` field (`null` on the last page). **The default-filter change is deliberate — it is what the maintainer asked for in #754.** The response still carries `data` as before, so a client that reads only `data` keeps working, and one that wants the old "everything" view passes `?includeInactive=true` and follows `nextCursor`.
- New optional query parameters (additive): `includeInactive=true` (also list revoked and expired), `limit` (1–200, default 50), `cursor` (the previous page's `nextCursor`). An unknown parameter, an out-of-range `limit` or a non-UUID `cursor` is a 400, as everywhere else under the global `ValidationPipe`.
- Settings → App Tokens: a "Show expired and revoked" switch (off by default), a "Load more" button while more pages exist, and an "Expired <date>" label on tokens that lapsed without being revoked (shown only with the switch on). Empty state reads "No active app tokens" when filtered.

## Why
The issue offered three fixes (client-side hide, server pagination, retention deletes); the maintainer chose a combination of backend cursor pagination and a backend filter that defaults to hiding dead tokens, which this implements. Retention/hard-delete of revoked rows is not part of this change. Pagination is keyset on `(created_at desc, id desc)` rather than offset so revoking rows between page loads cannot skip or repeat entries; the cursor is the id of the last row and its sort key is read back in SQL so `created_at`'s microsecond precision is compared exactly (a JS `Date` round-trip would truncate it and could skip same-millisecond neighbours — which a burst of automation mints can produce).

## What changed
- **backend** — `apps/backend/src/app-tokens/app-tokens.dto.ts` (`ListAppTokensQueryDto`, `nextCursor` on the response), `app-tokens.service.ts` (`listMine` takes the query, filters, keyset-pages), `app-tokens.controller.ts` (`@Query()` + Swagger description).
- **frontend** — `apps/frontend/src/services/appTokensApi.ts` (`listAppTokens` is now an RTK `infiniteQuery`; hook renamed to `useListAppTokensInfiniteQuery`, its only consumer is the tab), `apps/frontend/src/components/settings/AppTokensTab.tsx` (switch, load-more, expired label).
- **tests** — `app-tokens.service.spec.ts` (filter SQL, ordering, over-fetch, cursor subquery rendered through `PgDialect`), `app-tokens.controller.spec.ts`, new `app-tokens-http.spec.ts` (query coercion and rejection through the same global `ValidationPipe` `main.ts` installs), `AppTokensTab.test.tsx` (toggle, pages, load-more, expired).

## Compatibility
- **Migrations:** none — no schema change; the existing `app_tokens_user_id_idx` serves the per-user scan.
- **API contract:** additive. `data` keeps its shape; `nextCursor` is a new field; all new query params are optional. `packages/cli` and the GitHub Actions do not call this endpoint (the only client is the admin UI). The default-filter and default-page-size change is the one visible difference for an unparameterised caller and is called out under Behaviour changes.
- **Env vars, nginx generation, storage layout, pipeline/proxy-rule semantics:** untouched.
- **#755 (never-expiring tokens, in flight in parallel):** the "active" filter already treats `expires_at IS NULL` as live, so it composes with that change; this PR does not touch `create`, `resolveExpiry` or `CreateAppTokenDto`.

## Verification
```
pnpm --filter backend exec tsc --noEmit        → clean (exit 0)
pnpm --filter frontend exec tsc --noEmit       → clean (exit 0)
apps/backend: jest src/app-tokens              → 3 suites, 17 tests passed
apps/backend: jest src/auth/app-token.util.spec.ts src/auth/session-from-app-token-http.spec.ts src/db/schema/app-tokens.schema.spec.ts
                                               → 3 suites, 19 tests passed
apps/frontend: vitest src/components/settings/AppTokensTab.test.tsx
                                               → 1 file, 10 tests passed
pnpm --filter backend format:check / --filter frontend format:check → both clean
```
The service spec caught one real bug during development: `from ${aliasedTable}` renders as `from "cursor_row"` with no base table; fixed to `from "app_tokens" "cursor_row"` and the rendered SQL is now asserted verbatim.

## Out of scope / follow-ups
- Hard-deleting revoked rows after N days (suggestion 3 in #754) is a data-retention decision left for a maintainer.
- The public docs (`docs-public`) have no page for `GET /api/app-tokens` yet; Swagger is the only reference and is updated here.
- `pnpm test -- <pattern>` in `apps/backend` does not filter (the script is `jest --coverage` and the pattern is not forwarded), and the full coverage run exhausts the default node heap on this VPS; `pnpm exec jest <path>` was used instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaBmRQuNt8d4Msp8d45JDf
