### PR TITLE
fix(frontend): mock paged app-token list in the never-expires test

### DIFF
--- a/apps/frontend/src/components/settings/AppTokensTab.test.tsx
+++ b/apps/frontend/src/components/settings/AppTokensTab.test.tsx
@@ -160,13 +160,13 @@ describe('AppTokensTab', () => {
 
   it('shows "Never" in the Expires column for a token without an expiry', () => {
     // Column order: Name, Project, Scopes, Kind, Expires, Last used, Actions.
-    listResult = { data: [{ ...token, expiresAt: null }], isLoading: false };
+    listResult = { data: pagesOf([{ ...token, expiresAt: null }]), isLoading: false };
     const { unmount } = render(<AppTokensTab />);
     let cells = screen.getByText('Claude — workflow').closest('tr')!.querySelectorAll('td');
     expect(cells[4]).toHaveTextContent('Never');
     unmount();
 
-    listResult = { data: [token], isLoading: false };
+    listResult = { data: pagesOf([token]), isLoading: false };
     render(<AppTokensTab />);
     cells = screen.getByText('Claude — workflow').closest('tr')!.querySelectorAll('td');
     expect(cells[4]).not.toHaveTextContent('Never');


### PR DESCRIPTION
## Summary

`main` fails the frontend build after #756 and #757 merged back to back. Each passed CI on its own, but #756 added a test in `AppTokensTab.test.tsx` that mocks the list query as a flat `AppToken[]`, while #757 changed `useListAppTokensInfiniteQuery` to return `{ pages, pageParams }`. The combination no longer type-checks:

```
src/components/settings/AppTokensTab.test.tsx(163,20): error TS2739: Type '...[]' is missing the following properties from type '{ pages: ListAppTokensPage[]; pageParams: (string | null)[]; }': pages, pageParams
```

This is why `Test & Build` is red on the release PR #758.

## Change

Wrap the two mocked lists in the `pagesOf` helper the rest of the file already uses. Test-only change, no runtime code touched.

## Verification

- `pnpm --filter frontend exec tsc --noEmit` passes
- `vitest run src/components/settings/AppTokensTab.test.tsx`: 13 tests pass
- `pnpm --filter frontend format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaBmRQuNt8d4Msp8d45JDf
