### PR TITLE
feat(pipelines): oauth_protected_resource handler serves the RFC 9728 document (#760)

### DIFF
--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -267,6 +267,20 @@ for the new key; the action's release is a person's step in another repo and is 
 **Learned from:** PR #730 (`bypassVisibility`), 2026-09-03 — `bffless` 0.3.6 shipped with the CE
 release, `deploy-proxy-rules` needed a separate bump (its v1.3.1) before apps#585's rule set could deploy.
 
+### A step type that implies `bypassVisibility` must gate on the step being the rule's whole answer
+**Surface:** `apps/backend/src/pipelines/mcp/protected-resource.ts` (`servesProtectedResourceDocument`),
+`apps/backend/src/proxy-rules/proxy.middleware.ts` (`checkVisibilityAndAuth`) — any future handler type
+that widens the visibility gate by its presence rather than by the rule's `bypassVisibility` flag.
+**Check:** Does the "implies bypass" check require the rule's own `pathPattern` to match the convention
+(`/.well-known/…`) **and** the step to be the pipeline's first enabled step (its whole answer), or does it
+fire on step-type presence anywhere in `steps`/`postSteps`?
+**Why:** `checkVisibilityAndAuth` runs before the pipeline; on mere presence, a rule that does work before
+the "public" step — a `data_query` on a private deployment, say — has that work served unauthenticated,
+with no `bypassVisibility` ever toggled to signal the intent. Not a new trust boundary (the rule's author
+controls `bypassVisibility` already), but a silent widening.
+**Learned from:** PR #761, 2026-09-06 — the first cut scanned all steps for `oauth_protected_resource`;
+narrowed in the same PR to well-known rules whose first enabled step is the handler.
+
 ---
 
 ## Entry template

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,8 +50,8 @@ CE's built-in OAuth 2.1 server on the admin host — the issuer is `https://<ADM
 _Avoid_: "SuperTokens OAuth", "SSO" (that is the member's own login, the other direction)
 
 **Protected-resource document**:
-An app-shipped `/.well-known/oauth-protected-resource` rule (served despite visibility — Bypass visibility) naming the resource, the Authorization server and the app's scopes (RFC 9728). How a client finds the server from the app; CE points at it in `WWW-Authenticate` on API 401s.
-_Avoid_: "discovery endpoint" (CE has none for apps)
+The `/.well-known/oauth-protected-resource` rule of an alias (served despite visibility) naming the resource, the Authorization server and the app's scopes (RFC 9728). How a client finds the server from the app; CE points at it in `WWW-Authenticate` on API 401s. Written either as the `oauth_protected_resource` step — which derives every URL from the request and CE's own issuer, and `scopes_supported` from the MCP handler's Sibling rules unless declared, and implies Bypass visibility (#760) — or, in older apps, as a hand-written `function_handler` + `response_handler` pair.
+_Avoid_: "discovery endpoint" (it is a rule of the alias, not a CE endpoint)
 
 **Owner session**:
 A browser session authenticated as the project owner, which login-gated SPA routes accept. The thing an automated client holding a Project API key currently cannot obtain.

--- a/apps/backend/src/mcp/tools/proxy-rules.tools.ts
+++ b/apps/backend/src/mcp/tools/proxy-rules.tools.ts
@@ -34,6 +34,7 @@ export const pipelineStepSchema = z.object({
       'http_request',
       'remote_request',
       'mcp_handler',
+      'oauth_protected_resource',
       'stripe_checkout',
       'stripe_webhook',
       'signed_url',

--- a/apps/backend/src/oauth/oauth.module.ts
+++ b/apps/backend/src/oauth/oauth.module.ts
@@ -1,12 +1,16 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { OAuthController } from './oauth.controller';
 import { OAuthMetadataController } from './oauth-metadata.controller';
 import { OAuthService } from './oauth.service';
 import { AppTokensModule } from '../app-tokens/app-tokens.module';
 import { PermissionsModule } from '../permissions/permissions.module';
+import { ProxyRulesModule } from '../proxy-rules/proxy-rules.module';
 
 @Module({
-  imports: [AppTokensModule, PermissionsModule],
+  // forwardRef: ProxyRulesModule → PipelinesModule → OAuthModule (the
+  // oauth_protected_resource step names the issuer); RFC 8707 `resource`
+  // resolution reads that step's config through RuleInvokerService.
+  imports: [AppTokensModule, PermissionsModule, forwardRef(() => ProxyRulesModule)],
   controllers: [OAuthController, OAuthMetadataController],
   providers: [OAuthService],
   exports: [OAuthService],

--- a/apps/backend/src/oauth/oauth.service.spec.ts
+++ b/apps/backend/src/oauth/oauth.service.spec.ts
@@ -64,10 +64,18 @@ function make(configOverrides: Record<string, string | undefined> = {}) {
     create: jest.fn().mockResolvedValue({ view: { id: 'tok-1' }, raw: 'bfat_raw' }),
   };
   const permissions = { getUserProjectRole: jest.fn().mockResolvedValue('contributor') };
+  // The alias's effective rules; empty means "no oauth_protected_resource step" → the fetch path.
+  const rules = { effectiveRules: jest.fn().mockResolvedValue([]) };
   return {
-    service: new OAuthService(config as never, appTokens as never, permissions as never),
+    service: new OAuthService(
+      config as never,
+      appTokens as never,
+      permissions as never,
+      rules as never,
+    ),
     appTokens,
     permissions,
+    rules,
   };
 }
 
@@ -216,6 +224,92 @@ describe('OAuthService', () => {
           headers: expect.objectContaining({ 'x-forwarded-host': 'www.workflow.j5s.dev' }),
         }),
       );
+    });
+    it('reads scopes_supported straight from an oauth_protected_resource step on the alias instead of fetching (#760)', async () => {
+      const { service, rules } = make();
+      const prmRule = {
+        id: 'prm',
+        pathPattern: '/.well-known/oauth-protected-resource*',
+        method: 'GET',
+        methods: null,
+        isEnabled: true,
+        pipelineConfig: {
+          name: 'prm',
+          steps: [
+            {
+              name: 'prm',
+              handlerType: 'oauth_protected_resource',
+              config: { resource: '/api/workflow/mcp' },
+            },
+          ],
+        },
+      };
+      const mcpRule = {
+        id: 'mcp',
+        pathPattern: '/api/workflow/mcp',
+        method: null,
+        methods: null,
+        isEnabled: true,
+        pipelineConfig: {
+          name: 'mcp',
+          steps: [
+            {
+              name: 'server',
+              handlerType: 'mcp_handler',
+              config: {
+                serverInfo: { name: 'Workflow', version: '1' },
+                tools: [{ name: 'list', rule: { path: '/api/workflow/tools/list' } }],
+              },
+            },
+          ],
+        },
+      };
+      const sibling = {
+        id: 'list',
+        pathPattern: '/api/workflow/tools/list',
+        method: 'POST',
+        methods: null,
+        isEnabled: true,
+        pipelineConfig: {
+          name: 'list',
+          validators: [{ type: 'auth_required', config: { requiredScopes: ['workflow:read'] } }],
+          steps: [],
+        },
+      };
+      rules.effectiveRules.mockResolvedValue([prmRule, mcpRule, sibling]);
+      mockDb.limit
+        .mockResolvedValueOnce([client])
+        .mockResolvedValueOnce([mapping])
+        .mockResolvedValueOnce([project]);
+      const fetchImpl = jest.fn(prm);
+      const { pending } = await service.beginAuthorization(authorizeParams(), fetchImpl);
+      expect(rules.effectiveRules).toHaveBeenCalledWith('p1', 'workflow');
+      expect(fetchImpl).not.toHaveBeenCalled();
+      expect(pending).toMatchObject({ projectId: 'p1', scopes: ['workflow:read'] });
+    });
+    it('keeps fetching the document for an app-shipped /.well-known rule', async () => {
+      const { service, rules } = make();
+      rules.effectiveRules.mockResolvedValue([
+        {
+          id: 'shipped',
+          pathPattern: '/.well-known/oauth-protected-resource*',
+          method: null,
+          methods: null,
+          isEnabled: true,
+          pipelineConfig: {
+            name: 'shipped',
+            steps: [{ name: 'doc', handlerType: 'function_handler', config: {} }],
+          },
+        },
+      ]);
+      mockDb.limit
+        .mockResolvedValueOnce([client])
+        .mockResolvedValueOnce([mapping])
+        .mockResolvedValueOnce([project]);
+      const fetchImpl = jest.fn(prm);
+      const { pending } = await service.beginAuthorization(authorizeParams(), fetchImpl);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(pending.scopes).toEqual(['workflow:read', 'workflow:run', 'workflow:files']);
     });
     it('narrows to the requested scopes and refuses an unknown one', async () => {
       const { service } = make();

--- a/apps/backend/src/oauth/oauth.service.spec.ts
+++ b/apps/backend/src/oauth/oauth.service.spec.ts
@@ -287,6 +287,36 @@ describe('OAuthService', () => {
       expect(fetchImpl).not.toHaveBeenCalled();
       expect(pending).toMatchObject({ projectId: 'p1', scopes: ['workflow:read'] });
     });
+    it('falls back to the fetch when the step on the bare well-known rule publishes another resource', async () => {
+      const { service, rules } = make();
+      rules.effectiveRules.mockResolvedValue([
+        {
+          id: 'prm',
+          pathPattern: '/.well-known/oauth-protected-resource*',
+          method: 'GET',
+          methods: null,
+          isEnabled: true,
+          pipelineConfig: {
+            name: 'prm',
+            steps: [
+              {
+                name: 'prm',
+                handlerType: 'oauth_protected_resource',
+                config: { resource: '/api/other/mcp', scopes: ['other:read'] },
+              },
+            ],
+          },
+        },
+      ]);
+      mockDb.limit
+        .mockResolvedValueOnce([client])
+        .mockResolvedValueOnce([mapping])
+        .mockResolvedValueOnce([project]);
+      const fetchImpl = jest.fn(prm);
+      const { pending } = await service.beginAuthorization(authorizeParams(), fetchImpl);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(pending.scopes).not.toContain('other:read');
+    });
     it('keeps fetching the document for an app-shipped /.well-known rule', async () => {
       const { service, rules } = make();
       rules.effectiveRules.mockResolvedValue([

--- a/apps/backend/src/oauth/oauth.service.ts
+++ b/apps/backend/src/oauth/oauth.service.ts
@@ -1,4 +1,11 @@
-import { ForbiddenException, HttpStatus, Injectable, Logger } from '@nestjs/common';
+import {
+  ForbiddenException,
+  HttpStatus,
+  Inject,
+  Injectable,
+  Logger,
+  forwardRef,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { and, eq, isNull, or } from 'drizzle-orm';
 import * as jwt from 'jsonwebtoken';
@@ -16,6 +23,12 @@ import {
 import { hashToken } from '../auth/app-token.util';
 import { AppTokensService } from '../app-tokens/app-tokens.service';
 import { PermissionsService } from '../permissions/permissions.service';
+import { RuleInvokerService } from '../proxy-rules/rule-invoker.service';
+import {
+  PROTECTED_RESOURCE_PATH,
+  findProtectedResourceConfig,
+  scopesSupportedFor,
+} from '../pipelines/mcp/protected-resource';
 import { SCOPE_PATTERN } from '../pipelines/types';
 import { OAuthError } from './oauth.errors';
 import { isValidVerifier, verifyS256 } from './pkce.util';
@@ -61,6 +74,8 @@ export class OAuthService {
     private readonly config: ConfigService,
     private readonly appTokens: AppTokensService,
     private readonly permissions: PermissionsService,
+    @Inject(forwardRef(() => RuleInvokerService))
+    private readonly rules: RuleInvokerService,
   ) {}
 
   private get jwtSecret(): string {
@@ -547,8 +562,23 @@ export class OAuthService {
       .limit(1);
     if (!project) throw new OAuthError('invalid_target', `no deployment answers ${host}`);
     const alias = mapping.alias || 'production';
+    const resolved = {
+      projectId: project.id,
+      projectSlug: `${project.owner}/${project.name}`,
+      projectName: project.displayName || project.name,
+    };
+
+    // When the alias serves its document through the `oauth_protected_resource`
+    // step, read that step's config directly — the same derivation the edge
+    // would run — instead of fetching a document this process would itself
+    // produce. The fetch below stays for app-shipped (function_handler) documents.
+    const direct = await this.protectedResourceConfigOf(project.id, alias, url.pathname);
+    if (direct) {
+      return { ...resolved, scopesSupported: direct };
+    }
+
     const base = `${(mapping.path || '').replace(/\/+$/, '')}`;
-    const prmPath = '/.well-known/oauth-protected-resource';
+    const prmPath = PROTECTED_RESOURCE_PATH;
     const inProcess = `http://localhost:3000/public/${project.owner}/${project.name}/alias/${alias}${base}${prmPath}`;
     let scopesSupported: string[] = [];
     try {
@@ -568,12 +598,28 @@ export class OAuthService {
       this.logger.debug(`protected-resource document for ${host}: ${String(error)}`);
       throw new OAuthError('invalid_target', `${host} publishes no protected-resource document`);
     }
-    return {
-      projectId: project.id,
-      projectSlug: `${project.owner}/${project.name}`,
-      projectName: project.displayName || project.name,
-      scopesSupported,
-    };
+    return { ...resolved, scopesSupported };
+  }
+
+  /**
+   * `scopes_supported` straight from the alias's `oauth_protected_resource` step
+   * (declared, or derived from the `mcp_handler` at the resource's path), or
+   * undefined when the alias's matched `/.well-known` rule is not that handler.
+   * Never throws: a resolution failure falls back to the fetch.
+   */
+  private async protectedResourceConfigOf(
+    projectId: string,
+    alias: string,
+    resourcePath: string,
+  ): Promise<string[] | undefined> {
+    try {
+      const rules = await this.rules.effectiveRules(projectId, alias);
+      const config = findProtectedResourceConfig(rules, resourcePath);
+      return config ? scopesSupportedFor(config, rules) : undefined;
+    } catch (error) {
+      this.logger.debug(`protected-resource step for ${alias}: ${String(error)}`);
+      return undefined;
+    }
   }
 }
 

--- a/apps/backend/src/pipelines/execution/step-handler.interface.ts
+++ b/apps/backend/src/pipelines/execution/step-handler.interface.ts
@@ -1194,3 +1194,27 @@ export interface McpHandlerConfig extends BaseHandlerConfig {
     csp?: { connectDomains?: string[]; resourceDomains?: string[] };
   };
 }
+
+/**
+ * `oauth_protected_resource` — the RFC 9728 protected-resource document for an
+ * `mcp_handler` on this host, so an app writes no discovery code. Every URL is
+ * derived from the request and the instance: `resource` is
+ * `https://<host><resource>`, `authorization_servers` is CE's own issuer
+ * (`OAuthService.issuer()`). A rule carrying this step is served regardless of
+ * deployment visibility — the handler implies `bypassVisibility` (#760).
+ */
+export interface OAuthProtectedResourceConfig extends BaseHandlerConfig {
+  /** The MCP endpoint's path on this host, e.g. `/api/mcp`. */
+  resource: string;
+  /**
+   * `scopes_supported`, verbatim. Omitted: the union of `requiredScopes` on the
+   * `auth_required` validators of the sibling rules the `mcp_handler` at
+   * `resource` maps its tools to. This list is the authorize flow's allowlist,
+   * so declare it when a sibling's scope must not be offered over OAuth.
+   */
+  scopes?: string[];
+  /** `resource_name`; defaults to the `mcp_handler`'s `serverInfo.name`. */
+  resourceName?: string;
+  /** `resource_documentation`, a URL. */
+  resourceDocumentation?: string;
+}

--- a/apps/backend/src/pipelines/handlers/index.ts
+++ b/apps/backend/src/pipelines/handlers/index.ts
@@ -29,3 +29,4 @@ export * from './delay.handler';
 export * from './ffmpeg.handler';
 export * from './remote-request.handler';
 export * from './mcp.handler';
+export * from './oauth-protected-resource.handler';

--- a/apps/backend/src/pipelines/handlers/oauth-protected-resource.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/oauth-protected-resource.handler.spec.ts
@@ -1,0 +1,290 @@
+import { OAuthProtectedResourceHandler } from './oauth-protected-resource.handler';
+import { StepHandlerRegistry } from '../execution/step-handler.registry';
+import { PipelineContext } from '../execution/pipeline-context.interface';
+import { PipelineStep } from '../types';
+import { ConfigurationError } from '../errors';
+import { OAuthProtectedResourceConfig } from '../execution/step-handler.interface';
+import { ProxyRule } from '../../db/schema/proxy-rules.schema';
+
+const rule = (over: Partial<ProxyRule>): ProxyRule =>
+  ({
+    id: 'r',
+    ruleSetId: 'set-1',
+    pathPattern: '/api/x',
+    method: null,
+    methods: null,
+    targetUrl: 'pipeline',
+    stripPrefix: false,
+    order: 0,
+    timeout: 30000,
+    preserveHost: false,
+    forwardCookies: false,
+    headerConfig: null,
+    authTransform: null,
+    internalRewrite: false,
+    proxyType: 'pipeline',
+    emailHandlerConfig: null,
+    pipelineConfig: null,
+    isEnabled: true,
+    description: null,
+    debugEnabled: false,
+    bypassVisibility: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...over,
+  }) as ProxyRule;
+
+const authRequired = (requiredScopes: string[]) => ({
+  type: 'auth_required' as const,
+  config: { requiredScopes },
+});
+
+/** The workflow-shaped alias: an mcp_handler at /api/mcp whose tools map to scoped siblings. */
+const siblings: ProxyRule[] = [
+  rule({
+    id: 'mcp',
+    pathPattern: '/api/mcp',
+    methods: ['GET', 'POST', 'DELETE'],
+    pipelineConfig: {
+      name: 'mcp',
+      steps: [
+        {
+          name: 'server',
+          handlerType: 'mcp_handler',
+          config: {
+            serverInfo: { name: 'BFFless Workflow', version: '1' },
+            tools: [
+              { name: 'list', rule: { path: '/api/tools/list', method: 'POST' } },
+              { name: 'start', rule: { path: '/api/tools/start' } },
+              { name: 'sign', rule: { path: '/api/tools/sign', method: 'GET' } },
+              { name: 'orphan', rule: { path: '/api/tools/nowhere' } },
+            ],
+          },
+        },
+      ],
+    },
+  }),
+  rule({
+    id: 'list',
+    pathPattern: '/api/tools/list',
+    method: 'POST',
+    pipelineConfig: { name: 'l', validators: [authRequired(['workflow:read'])], steps: [] },
+  }),
+  rule({
+    id: 'start',
+    pathPattern: '/api/tools/start',
+    method: 'POST',
+    pipelineConfig: {
+      name: 's',
+      validators: [authRequired(['workflow:run', 'workflow:read'])],
+      steps: [],
+    },
+  }),
+  rule({
+    id: 'sign',
+    pathPattern: '/api/tools/*',
+    method: 'GET',
+    pipelineConfig: { name: 'g', validators: [authRequired(['workflow:files'])], steps: [] },
+  }),
+  rule({
+    id: 'admin',
+    pathPattern: '/api/admin',
+    pipelineConfig: { name: 'a', validators: [authRequired(['workflow:admin'])], steps: [] },
+  }),
+];
+
+function make(rules: ProxyRule[] = siblings, issuer = 'https://admin.j5s.dev') {
+  const registry = { register: jest.fn() } as unknown as StepHandlerRegistry;
+  const invoker = { effectiveRules: jest.fn().mockResolvedValue(rules) };
+  const oauth = { issuer: jest.fn().mockReturnValue(issuer) };
+  const handler = new OAuthProtectedResourceHandler(registry, invoker as never, oauth as never);
+  return { handler, invoker, oauth, registry };
+}
+
+function ctx(
+  headers: Record<string, string | string[] | undefined>,
+  over: Partial<PipelineContext['metadata']> = {},
+): PipelineContext {
+  return {
+    request: { headers, cookies: {} } as never,
+    user: undefined,
+    stepOutputs: {},
+    projectId: 'proj-1',
+    pipelineId: 'pipe-1',
+    deployment: { owner: 'o', repo: 'r', commitSha: 'c', alias: 'workflow' },
+    metadata: {
+      path: '/public/o/r/alias/workflow/.well-known/oauth-protected-resource',
+      method: 'GET',
+      headers,
+      query: {},
+      body: {},
+      ...over,
+    },
+  };
+}
+
+const step = (config: OAuthProtectedResourceConfig): PipelineStep =>
+  ({ id: 'prm', name: 'prm', handlerType: 'oauth_protected_resource', config }) as PipelineStep;
+
+const out = (result: { output?: unknown }) => {
+  const o = result.output as { status: number; body: string; headers: Record<string, string> };
+  return { status: o.status, headers: o.headers, body: JSON.parse(o.body) };
+};
+
+describe('OAuthProtectedResourceHandler', () => {
+  it('registers as oauth_protected_resource', () => {
+    const { registry, handler } = make();
+    expect(handler.type).toBe('oauth_protected_resource');
+    expect(registry.register).toHaveBeenCalledWith(handler);
+  });
+
+  describe('validateConfig', () => {
+    it('needs a literal path on this host; scopes are namespace:verb; documentation is a URL', () => {
+      const { handler } = make();
+      expect(() => handler.validateConfig({ resource: '/api/mcp' })).not.toThrow();
+      expect(() =>
+        handler.validateConfig({
+          resource: '/api/mcp',
+          scopes: ['workflow:read'],
+          resourceName: 'x',
+          resourceDocumentation: 'https://docs.example/mcp',
+        }),
+      ).not.toThrow();
+      expect(() => handler.validateConfig({} as never)).toThrow(ConfigurationError);
+      expect(() => handler.validateConfig({ resource: 'api/mcp' })).toThrow(/starting with \//);
+      expect(() => handler.validateConfig({ resource: '/api/*' })).toThrow(/literal path/);
+      expect(() => handler.validateConfig({ resource: '/api/mcp?x=1' })).toThrow(/literal path/);
+      expect(() =>
+        handler.validateConfig({ resource: '/api/mcp', scopes: 'workflow:read' as never }),
+      ).toThrow(/array/);
+      expect(() =>
+        handler.validateConfig({ resource: '/api/mcp', scopes: ['Workflow Read'] }),
+      ).toThrow(/namespace:verb/);
+      expect(() =>
+        handler.validateConfig({ resource: '/api/mcp', resourceDocumentation: 'not a url' }),
+      ).toThrow(/URL/);
+    });
+  });
+
+  describe('execute', () => {
+    it('emits the RFC 9728 document with explicit scopes verbatim, the issuer from OAuthService and a 5-minute public cache', async () => {
+      const { handler, invoker, oauth } = make();
+      const result = await handler.execute(
+        ctx({ 'x-forwarded-host': 'workflow.j5s.dev, 10.0.0.1', host: 'localhost:3000' }),
+        step({
+          resource: '/api/mcp',
+          scopes: ['workflow:read', 'workflow:run'],
+          resourceName: 'Workflow',
+          resourceDocumentation: 'https://docs.example/mcp',
+        }),
+      );
+      expect(result.success).toBe(true);
+      expect(result.terminates).toBe(true);
+      const { status, headers, body } = out(result);
+      expect(status).toBe(200);
+      expect(headers).toEqual({
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, max-age=300',
+      });
+      expect(body).toEqual({
+        resource: 'https://workflow.j5s.dev/api/mcp',
+        authorization_servers: ['https://admin.j5s.dev'],
+        scopes_supported: ['workflow:read', 'workflow:run'],
+        bearer_methods_supported: ['header'],
+        resource_name: 'Workflow',
+        resource_documentation: 'https://docs.example/mcp',
+      });
+      expect(oauth.issuer).toHaveBeenCalled();
+      // Everything was declared: the siblings were not consulted.
+      expect(invoker.effectiveRules).not.toHaveBeenCalled();
+    });
+
+    it('derives scopes_supported from the siblings the mcp_handler at `resource` maps its tools to, and resource_name from serverInfo.name', async () => {
+      const { handler, invoker } = make();
+      const result = await handler.execute(
+        ctx({ 'x-forwarded-host': 'workflow.j5s.dev' }),
+        step({ resource: '/api/mcp' }),
+      );
+      const { body } = out(result);
+      expect(invoker.effectiveRules).toHaveBeenCalledWith('proj-1', 'workflow');
+      // Union in first-appearance order; the GET sibling resolves with the tool's method;
+      // a tool with no sibling contributes nothing; an unrelated scoped rule is not offered.
+      expect(body.scopes_supported).toEqual(['workflow:read', 'workflow:run', 'workflow:files']);
+      expect(body.resource_name).toBe('BFFless Workflow');
+      expect(body.resource).toBe('https://workflow.j5s.dev/api/mcp');
+      expect(body).not.toHaveProperty('resource_documentation');
+    });
+
+    it('answers an empty scopes_supported and no resource_name when no mcp_handler answers `resource`', async () => {
+      const { handler } = make([]);
+      const result = await handler.execute(
+        ctx({ host: 'h.example' }),
+        step({ resource: '/api/elsewhere' }),
+      );
+      const { body } = out(result);
+      expect(body.scopes_supported).toEqual([]);
+      expect(body).not.toHaveProperty('resource_name');
+      expect(body.resource).toBe('https://h.example/api/elsewhere');
+    });
+
+    it('serves the same document at the path-suffixed form when the suffix is `resource`, and 404s another suffix', async () => {
+      const { handler } = make();
+      const headers = {
+        'x-forwarded-host': 'workflow.j5s.dev',
+        'x-original-uri': '/.well-known/oauth-protected-resource/api/mcp?x=1',
+      };
+      const same = out(
+        await handler.execute(
+          ctx(headers, {
+            path: '/public/o/r/alias/workflow/.well-known/oauth-protected-resource/api/mcp',
+          }),
+          step({ resource: '/api/mcp', scopes: [] }),
+        ),
+      );
+      expect(same.status).toBe(200);
+      expect(same.body.resource).toBe('https://workflow.j5s.dev/api/mcp');
+
+      const other = out(
+        await handler.execute(
+          ctx({
+            'x-forwarded-host': 'workflow.j5s.dev',
+            'x-original-uri': '/.well-known/oauth-protected-resource/api/other',
+          }),
+          step({ resource: '/api/mcp', scopes: [] }),
+        ),
+      );
+      expect(other.status).toBe(404);
+      expect(other.body.error).toBe('not_found');
+      expect(other.headers['Content-Type']).toBe('application/json');
+    });
+
+    it('falls back to the request path for the suffix when x-original-uri is absent', async () => {
+      const { handler } = make();
+      const result = out(
+        await handler.execute(
+          ctx(
+            { 'x-forwarded-host': 'workflow.j5s.dev' },
+            { path: '/public/o/r/alias/workflow/.well-known/oauth-protected-resource/api/nope' },
+          ),
+          step({ resource: '/api/mcp', scopes: [] }),
+        ),
+      );
+      expect(result.status).toBe(404);
+    });
+
+    it('uses `host` when x-forwarded-host is absent and refuses a request that names no host', async () => {
+      const { handler } = make();
+      const viaHost = out(
+        await handler.execute(
+          ctx({ host: 'h.example' }),
+          step({ resource: '/api/mcp', scopes: [] }),
+        ),
+      );
+      expect(viaHost.body.resource).toBe('https://h.example/api/mcp');
+
+      const none = out(await handler.execute(ctx({}), step({ resource: '/api/mcp', scopes: [] })));
+      expect(none.status).toBe(400);
+      expect(none.body.error).toBe('no_host');
+    });
+  });
+});

--- a/apps/backend/src/pipelines/handlers/oauth-protected-resource.handler.ts
+++ b/apps/backend/src/pipelines/handlers/oauth-protected-resource.handler.ts
@@ -1,0 +1,122 @@
+import { Inject, Injectable, forwardRef } from '@nestjs/common';
+import { StepHandler, OAuthProtectedResourceConfig } from '../execution/step-handler.interface';
+import { StepHandlerRegistry } from '../execution/step-handler.registry';
+import { PipelineContext, StepResult } from '../execution/pipeline-context.interface';
+import { PipelineStep, SCOPE_PATTERN } from '../types';
+import { ConfigurationError } from '../errors';
+import { RuleInvokerService } from '../../proxy-rules/rule-invoker.service';
+import { OAuthService } from '../../oauth/oauth.service';
+import {
+  PROTECTED_RESOURCE_HANDLER,
+  protectedResourceDocument,
+  protectedResourceSuffix,
+  suffixNamesResource,
+} from '../mcp/protected-resource';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+const CACHE_CONTROL = 'public, max-age=300';
+
+/**
+ * OAuth protected-resource handler (RFC 9728)
+ *
+ * One step that answers `GET /.well-known/oauth-protected-resource*` with the
+ * discovery document for the `mcp_handler` at `resource`, so an app ships no
+ * discovery code: `resource` is `https://<host><resource>` from the request,
+ * `authorization_servers` is this instance's real issuer (`OAuthService`, never
+ * a guess at `admin.<parent>`), `scopes_supported` is declared or derived from
+ * the MCP rule's siblings. The document is read before a client has any
+ * credential, so a rule carrying this step is served regardless of deployment
+ * visibility — the middleware treats it as `bypassVisibility` (#760).
+ */
+@Injectable()
+export class OAuthProtectedResourceHandler implements StepHandler<OAuthProtectedResourceConfig> {
+  readonly type = PROTECTED_RESOURCE_HANDLER;
+
+  constructor(
+    private readonly registry: StepHandlerRegistry,
+    @Inject(forwardRef(() => RuleInvokerService))
+    private readonly invoker: RuleInvokerService,
+    @Inject(forwardRef(() => OAuthService))
+    private readonly oauth: OAuthService,
+  ) {
+    this.registry.register(this);
+  }
+
+  validateConfig(config: OAuthProtectedResourceConfig): void {
+    const fail = (message: string): never => {
+      throw new ConfigurationError(message, PROTECTED_RESOURCE_HANDLER);
+    };
+    if (typeof config.resource !== 'string' || !config.resource.startsWith('/'))
+      fail('resource must be a path on this host starting with /, e.g. /api/mcp');
+    if (config.resource.includes('*') || /[?#\s]/.test(config.resource))
+      fail('resource must be a literal path: no wildcard, query or fragment');
+    if (config.scopes !== undefined) {
+      if (!Array.isArray(config.scopes)) fail('scopes must be an array of strings');
+      for (const scope of config.scopes) {
+        if (typeof scope !== 'string' || !SCOPE_PATTERN.test(scope))
+          fail(`scope ${JSON.stringify(scope)} must be namespace:verb`);
+      }
+    }
+    if (config.resourceName !== undefined && typeof config.resourceName !== 'string')
+      fail('resourceName must be a string');
+    if (config.resourceDocumentation !== undefined) {
+      if (typeof config.resourceDocumentation !== 'string')
+        fail('resourceDocumentation must be a URL');
+      try {
+        new URL(config.resourceDocumentation);
+      } catch {
+        fail('resourceDocumentation must be a URL');
+      }
+    }
+  }
+
+  async execute(context: PipelineContext, step: PipelineStep): Promise<StepResult> {
+    const config = step.config as OAuthProtectedResourceConfig;
+    const headers = context.metadata.headers;
+    const host = firstHeader(headers['x-forwarded-host']) ?? firstHeader(headers.host);
+    if (!host) {
+      return terminal(400, { error: 'no_host', message: 'the request names no host' });
+    }
+
+    // RFC 9728 §3: a client looks the resource up at the path-suffixed form first;
+    // a suffix that names another path is not this document.
+    const requestPath = firstHeader(headers['x-original-uri']) ?? context.metadata.path ?? '';
+    const suffix = protectedResourceSuffix(requestPath);
+    if (!suffixNamesResource(suffix, config.resource)) {
+      return terminal(404, {
+        error: 'not_found',
+        message: `no protected resource at ${suffix}; this host publishes ${config.resource}`,
+      });
+    }
+
+    // The alias's effective rules are only needed for what the config leaves out.
+    const rules =
+      Array.isArray(config.scopes) && config.resourceName
+        ? []
+        : await this.invoker.effectiveRules(context.projectId, context.deployment?.alias);
+
+    const doc = protectedResourceDocument({ host, issuer: this.oauth.issuer(), config, rules });
+    return {
+      success: true,
+      terminates: true,
+      output: {
+        status: 200,
+        body: JSON.stringify(doc),
+        headers: { ...JSON_HEADERS, 'Cache-Control': CACHE_CONTROL },
+      },
+    };
+  }
+}
+
+function terminal(status: number, body: Record<string, unknown>): StepResult {
+  return {
+    success: true,
+    terminates: true,
+    output: { status, body: JSON.stringify(body), headers: { ...JSON_HEADERS } },
+  };
+}
+
+function firstHeader(value: string | string[] | undefined): string | undefined {
+  const first = Array.isArray(value) ? value[0] : value;
+  return typeof first === 'string' && first !== '' ? first.split(',')[0].trim() : undefined;
+}

--- a/apps/backend/src/pipelines/mcp/protected-resource.spec.ts
+++ b/apps/backend/src/pipelines/mcp/protected-resource.spec.ts
@@ -1,0 +1,124 @@
+import {
+  PROTECTED_RESOURCE_PATH,
+  findProtectedResourceConfig,
+  protectedResourceSuffix,
+  servesProtectedResourceDocument,
+  suffixNamesResource,
+} from './protected-resource';
+import { ProxyRule } from '../../db/schema/proxy-rules.schema';
+
+const rule = (over: Partial<ProxyRule>): ProxyRule =>
+  ({
+    id: 'r',
+    ruleSetId: 's',
+    pathPattern: '/x',
+    method: null,
+    methods: null,
+    targetUrl: 'pipeline',
+    proxyType: 'pipeline',
+    pipelineConfig: null,
+    isEnabled: true,
+    order: 0,
+    bypassVisibility: false,
+    ...over,
+  }) as ProxyRule;
+
+const prmStep = (config: Record<string, unknown>, isEnabled?: boolean) => ({
+  name: 'prm',
+  handlerType: 'oauth_protected_resource',
+  config,
+  ...(isEnabled === undefined ? {} : { isEnabled }),
+});
+
+describe('protected-resource helpers', () => {
+  describe('servesProtectedResourceDocument', () => {
+    it('is true only for a pipeline rule with an enabled oauth_protected_resource step', () => {
+      expect(servesProtectedResourceDocument(undefined)).toBe(false);
+      expect(servesProtectedResourceDocument(rule({ proxyType: 'external_proxy' }))).toBe(false);
+      expect(
+        servesProtectedResourceDocument(
+          rule({
+            pipelineConfig: {
+              name: 'app-shipped',
+              steps: [
+                { name: 'doc', handlerType: 'function_handler', config: {} },
+                { name: 'respond', handlerType: 'response_handler', config: {} },
+              ],
+            },
+          }),
+        ),
+      ).toBe(false);
+      expect(
+        servesProtectedResourceDocument(
+          rule({ pipelineConfig: { name: 'p', steps: [prmStep({ resource: '/api/mcp' })] } }),
+        ),
+      ).toBe(true);
+      expect(
+        servesProtectedResourceDocument(
+          rule({
+            pipelineConfig: { name: 'p', steps: [prmStep({ resource: '/api/mcp' }, false)] },
+          }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('findProtectedResourceConfig', () => {
+    const a = rule({
+      id: 'a',
+      pathPattern: `${PROTECTED_RESOURCE_PATH}/api/a`,
+      method: 'GET',
+      pipelineConfig: { name: 'a', steps: [prmStep({ resource: '/api/a', scopes: ['a:read'] })] },
+    });
+    const bare = rule({
+      id: 'bare',
+      pathPattern: `${PROTECTED_RESOURCE_PATH}*`,
+      method: 'GET',
+      pipelineConfig: { name: 'b', steps: [prmStep({ resource: '/api/b' })] },
+    });
+
+    it('prefers the rule at the path-suffixed form, then the bare path', () => {
+      expect(findProtectedResourceConfig([a, bare], '/api/a')).toMatchObject({
+        resource: '/api/a',
+      });
+      expect(findProtectedResourceConfig([a, bare], '/api/b')).toMatchObject({
+        resource: '/api/b',
+      });
+      expect(findProtectedResourceConfig([a, bare], '/api/zzz')).toMatchObject({
+        resource: '/api/b',
+      });
+    });
+
+    it('is undefined when the matched /.well-known rule is an app-shipped function, or absent', () => {
+      const shipped = rule({
+        pathPattern: `${PROTECTED_RESOURCE_PATH}*`,
+        pipelineConfig: {
+          name: 'shipped',
+          steps: [{ name: 'doc', handlerType: 'function_handler', config: {} }],
+        },
+      });
+      expect(findProtectedResourceConfig([shipped], '/api/mcp')).toBeUndefined();
+      expect(findProtectedResourceConfig([], '/api/mcp')).toBeUndefined();
+    });
+  });
+
+  describe('suffix', () => {
+    it('reads what follows the well-known path, ignoring a query and a trailing slash', () => {
+      expect(protectedResourceSuffix(PROTECTED_RESOURCE_PATH)).toBe('');
+      expect(protectedResourceSuffix(`${PROTECTED_RESOURCE_PATH}/`)).toBe('');
+      expect(protectedResourceSuffix(`${PROTECTED_RESOURCE_PATH}/api/mcp?x=1`)).toBe('/api/mcp');
+      expect(
+        protectedResourceSuffix(`/public/o/r/alias/a/dist${PROTECTED_RESOURCE_PATH}/api/mcp/`),
+      ).toBe('/api/mcp');
+      expect(protectedResourceSuffix('/api/mcp')).toBeUndefined();
+    });
+
+    it('accepts the bare path or an exact match of the resource', () => {
+      expect(suffixNamesResource('', '/api/mcp')).toBe(true);
+      expect(suffixNamesResource(undefined, '/api/mcp')).toBe(true);
+      expect(suffixNamesResource('/api/mcp', '/api/mcp/')).toBe(true);
+      expect(suffixNamesResource('/api/other', '/api/mcp')).toBe(false);
+      expect(suffixNamesResource('/api/mcp/deeper', '/api/mcp')).toBe(false);
+    });
+  });
+});

--- a/apps/backend/src/pipelines/mcp/protected-resource.spec.ts
+++ b/apps/backend/src/pipelines/mcp/protected-resource.spec.ts
@@ -32,12 +32,66 @@ const prmStep = (config: Record<string, unknown>, isEnabled?: boolean) => ({
 
 describe('protected-resource helpers', () => {
   describe('servesProtectedResourceDocument', () => {
-    it('is true only for a pipeline rule with an enabled oauth_protected_resource step', () => {
+    it('is true only for a well-known rule whose first enabled step is oauth_protected_resource', () => {
       expect(servesProtectedResourceDocument(undefined)).toBe(false);
       expect(servesProtectedResourceDocument(rule({ proxyType: 'external_proxy' }))).toBe(false);
+      // The step somewhere in an unrelated rule's pipeline widens nothing (PR #761 review).
       expect(
         servesProtectedResourceDocument(
           rule({
+            pathPattern: '/api/reports*',
+            pipelineConfig: {
+              name: 'reports',
+              steps: [
+                { name: 'q', handlerType: 'data_query', config: {} },
+                prmStep({ resource: '/api/mcp' }),
+              ],
+            },
+          }),
+        ),
+      ).toBe(false);
+      expect(
+        servesProtectedResourceDocument(
+          rule({
+            pathPattern: '/api/reports*',
+            pipelineConfig: { name: 'reports', steps: [prmStep({ resource: '/api/mcp' })] },
+          }),
+        ),
+      ).toBe(false);
+      // Nor does a step that runs after another one on the well-known path.
+      expect(
+        servesProtectedResourceDocument(
+          rule({
+            pathPattern: `${PROTECTED_RESOURCE_PATH}*`,
+            pipelineConfig: {
+              name: 'p',
+              steps: [
+                { name: 'q', handlerType: 'data_query', config: {} },
+                prmStep({ resource: '/api/mcp' }),
+              ],
+            },
+          }),
+        ),
+      ).toBe(false);
+      // A disabled step ahead of it does not count as "before".
+      expect(
+        servesProtectedResourceDocument(
+          rule({
+            pathPattern: `${PROTECTED_RESOURCE_PATH}*`,
+            pipelineConfig: {
+              name: 'p',
+              steps: [
+                { name: 'q', handlerType: 'data_query', config: {}, isEnabled: false },
+                prmStep({ resource: '/api/mcp' }),
+              ],
+            },
+          }),
+        ),
+      ).toBe(true);
+      expect(
+        servesProtectedResourceDocument(
+          rule({
+            pathPattern: `${PROTECTED_RESOURCE_PATH}*`,
             pipelineConfig: {
               name: 'app-shipped',
               steps: [
@@ -50,12 +104,16 @@ describe('protected-resource helpers', () => {
       ).toBe(false);
       expect(
         servesProtectedResourceDocument(
-          rule({ pipelineConfig: { name: 'p', steps: [prmStep({ resource: '/api/mcp' })] } }),
+          rule({
+            pathPattern: `${PROTECTED_RESOURCE_PATH}*`,
+            pipelineConfig: { name: 'p', steps: [prmStep({ resource: '/api/mcp' })] },
+          }),
         ),
       ).toBe(true);
       expect(
         servesProtectedResourceDocument(
           rule({
+            pathPattern: `${PROTECTED_RESOURCE_PATH}*`,
             pipelineConfig: { name: 'p', steps: [prmStep({ resource: '/api/mcp' }, false)] },
           }),
         ),
@@ -77,16 +135,16 @@ describe('protected-resource helpers', () => {
       pipelineConfig: { name: 'b', steps: [prmStep({ resource: '/api/b' })] },
     });
 
-    it('prefers the rule at the path-suffixed form, then the bare path', () => {
+    it('prefers the rule at the path-suffixed form, then the bare path — and only a step naming that resource', () => {
       expect(findProtectedResourceConfig([a, bare], '/api/a')).toMatchObject({
         resource: '/api/a',
       });
-      expect(findProtectedResourceConfig([a, bare], '/api/b')).toMatchObject({
+      expect(findProtectedResourceConfig([a, bare], '/api/b/')).toMatchObject({
         resource: '/api/b',
       });
-      expect(findProtectedResourceConfig([a, bare], '/api/zzz')).toMatchObject({
-        resource: '/api/b',
-      });
+      // The bare rule publishes /api/b; a client naming another resource gets nothing here
+      // (and falls back to the fetch), not /api/b's scopes.
+      expect(findProtectedResourceConfig([a, bare], '/api/zzz')).toBeUndefined();
     });
 
     it('is undefined when the matched /.well-known rule is an app-shipped function, or absent', () => {

--- a/apps/backend/src/pipelines/mcp/protected-resource.ts
+++ b/apps/backend/src/pipelines/mcp/protected-resource.ts
@@ -35,7 +35,7 @@ export function pipelineStepsOf(
   return [...(config.steps ?? []), ...(config.postSteps ?? [])];
 }
 
-/** Whether a rule's pipeline carries a step of the given handler type. */
+/** Whether a rule's pipeline carries an enabled step of the given handler type, anywhere. */
 export function pipelineHasHandler(
   rule: Pick<ProxyRule, 'pipelineConfig'> | null | undefined,
   handlerType: string,
@@ -45,42 +45,65 @@ export function pipelineHasHandler(
   );
 }
 
-/**
- * Whether a matched rule serves the protected-resource document through the
- * dedicated handler — the case the visibility gate lets through without the
- * rule saying `bypassVisibility` (the handler implies it).
- */
-export function servesProtectedResourceDocument(
-  rule: Pick<ProxyRule, 'pipelineConfig'> | null | undefined,
-): boolean {
-  return pipelineHasHandler(rule, PROTECTED_RESOURCE_HANDLER);
+/** Whether a rule's pattern answers the well-known path — bare (`…/oauth-protected-resource*`) or suffixed. */
+export function answersWellKnownPath(rule: Pick<ProxyRule, 'pathPattern'>): boolean {
+  return (
+    matchesPattern(rule.pathPattern, PROTECTED_RESOURCE_PATH) ||
+    rule.pathPattern.startsWith(PROTECTED_RESOURCE_PATH)
+  );
 }
 
-/** The first enabled `oauth_protected_resource` step of a rule, with its config; undefined when none. */
+/**
+ * The `oauth_protected_resource` step that *is* a rule's answer: the first
+ * enabled main step (the handler always terminates, so nothing after it runs
+ * and nothing before it may). Undefined when the step is absent, disabled, or
+ * preceded by another step — a pipeline that does work before publishing the
+ * document is not "just the document".
+ */
 export function protectedResourceStepOf(
   rule: Pick<ProxyRule, 'pipelineConfig'> | null | undefined,
 ): OAuthProtectedResourceConfig | undefined {
-  const step = pipelineStepsOf(rule).find(
-    (s) => s.handlerType === PROTECTED_RESOURCE_HANDLER && s.isEnabled !== false,
-  );
-  return step ? (step.config as unknown as OAuthProtectedResourceConfig) : undefined;
+  const config = rule?.pipelineConfig as PipelineConfig | null | undefined;
+  const first = (config?.steps ?? []).find((s) => s.isEnabled !== false);
+  if (!first || first.handlerType !== PROTECTED_RESOURCE_HANDLER) return undefined;
+  return first.config as unknown as OAuthProtectedResourceConfig;
+}
+
+/**
+ * Whether a matched rule serves the protected-resource document through the
+ * dedicated handler — the case the visibility gate lets through without the
+ * rule saying `bypassVisibility` (the handler implies it). Deliberately
+ * narrow: the rule must answer the well-known path and the step must be its
+ * whole answer, so the implication cannot widen an unrelated rule that merely
+ * carries the step somewhere in its pipeline.
+ */
+export function servesProtectedResourceDocument(
+  rule: Pick<ProxyRule, 'pipelineConfig' | 'pathPattern'> | null | undefined,
+): boolean {
+  return !!rule && answersWellKnownPath(rule) && protectedResourceStepOf(rule) !== undefined;
 }
 
 /**
  * The `oauth_protected_resource` config that answers discovery for `resourcePath`
  * on an alias, as a client would find it: the path-suffixed form first
  * (`/.well-known/oauth-protected-resource/api/mcp`, RFC 9728 §3), then the bare
- * path. Undefined when the alias's matched rule is not this handler (an
- * app-shipped `function_handler` document, or nothing at all).
+ * path — and only when that step's own `resource` is `resourcePath`, so the
+ * scopes read are the resource's, not another server's on the same alias.
+ * Undefined when the alias's matched rule is not this handler (an app-shipped
+ * `function_handler` document, or nothing at all).
  */
 export function findProtectedResourceConfig(
   rules: ProxyRule[],
   resourcePath: string,
 ): OAuthProtectedResourceConfig | undefined {
+  const wanted = resourcePath.replace(/\/+$/, '');
+  const names = (config: OAuthProtectedResourceConfig | undefined) =>
+    config && config.resource.replace(/\/+$/, '') === wanted ? config : undefined;
   const suffixed = findMatchingRule(rules, `${PROTECTED_RESOURCE_PATH}${resourcePath}`, 'GET');
-  const fromSuffixed = protectedResourceStepOf(suffixed);
-  if (fromSuffixed) return fromSuffixed;
-  return protectedResourceStepOf(findMatchingRule(rules, PROTECTED_RESOURCE_PATH, 'GET'));
+  return (
+    names(protectedResourceStepOf(suffixed)) ??
+    names(protectedResourceStepOf(findMatchingRule(rules, PROTECTED_RESOURCE_PATH, 'GET')))
+  );
 }
 
 /**

--- a/apps/backend/src/pipelines/mcp/protected-resource.ts
+++ b/apps/backend/src/pipelines/mcp/protected-resource.ts
@@ -1,0 +1,187 @@
+import { PipelineConfig, ProxyRule } from '../../db/schema/proxy-rules.schema';
+import { findMatchingRule, matchesPattern } from '../../proxy-rules/rule-resolution';
+import {
+  McpHandlerConfig,
+  OAuthProtectedResourceConfig,
+} from '../execution/step-handler.interface';
+import { AuthRequiredConfig } from '../types';
+
+/**
+ * The RFC 9728 protected-resource document for an `mcp_handler`, as pure
+ * functions over the alias's effective rules — shared by the
+ * `oauth_protected_resource` step (the edge) and `OAuthService`'s RFC 8707
+ * `resource` resolution (which reads the same config in-process instead of
+ * fetching the document it would itself serve). One derivation, two callers.
+ */
+
+export const PROTECTED_RESOURCE_HANDLER = 'oauth_protected_resource';
+export const PROTECTED_RESOURCE_PATH = '/.well-known/oauth-protected-resource';
+
+export interface ProtectedResourceDocument {
+  resource: string;
+  authorization_servers: string[];
+  scopes_supported: string[];
+  bearer_methods_supported: ['header'];
+  resource_name?: string;
+  resource_documentation?: string;
+}
+
+/** Every step of a rule's pipeline (main and post), or none for a non-pipeline rule. */
+export function pipelineStepsOf(
+  rule: Pick<ProxyRule, 'pipelineConfig'> | null | undefined,
+): PipelineConfig['steps'] {
+  const config = rule?.pipelineConfig as PipelineConfig | null | undefined;
+  if (!config) return [];
+  return [...(config.steps ?? []), ...(config.postSteps ?? [])];
+}
+
+/** Whether a rule's pipeline carries a step of the given handler type. */
+export function pipelineHasHandler(
+  rule: Pick<ProxyRule, 'pipelineConfig'> | null | undefined,
+  handlerType: string,
+): boolean {
+  return pipelineStepsOf(rule).some(
+    (step) => step.handlerType === handlerType && step.isEnabled !== false,
+  );
+}
+
+/**
+ * Whether a matched rule serves the protected-resource document through the
+ * dedicated handler — the case the visibility gate lets through without the
+ * rule saying `bypassVisibility` (the handler implies it).
+ */
+export function servesProtectedResourceDocument(
+  rule: Pick<ProxyRule, 'pipelineConfig'> | null | undefined,
+): boolean {
+  return pipelineHasHandler(rule, PROTECTED_RESOURCE_HANDLER);
+}
+
+/** The first enabled `oauth_protected_resource` step of a rule, with its config; undefined when none. */
+export function protectedResourceStepOf(
+  rule: Pick<ProxyRule, 'pipelineConfig'> | null | undefined,
+): OAuthProtectedResourceConfig | undefined {
+  const step = pipelineStepsOf(rule).find(
+    (s) => s.handlerType === PROTECTED_RESOURCE_HANDLER && s.isEnabled !== false,
+  );
+  return step ? (step.config as unknown as OAuthProtectedResourceConfig) : undefined;
+}
+
+/**
+ * The `oauth_protected_resource` config that answers discovery for `resourcePath`
+ * on an alias, as a client would find it: the path-suffixed form first
+ * (`/.well-known/oauth-protected-resource/api/mcp`, RFC 9728 §3), then the bare
+ * path. Undefined when the alias's matched rule is not this handler (an
+ * app-shipped `function_handler` document, or nothing at all).
+ */
+export function findProtectedResourceConfig(
+  rules: ProxyRule[],
+  resourcePath: string,
+): OAuthProtectedResourceConfig | undefined {
+  const suffixed = findMatchingRule(rules, `${PROTECTED_RESOURCE_PATH}${resourcePath}`, 'GET');
+  const fromSuffixed = protectedResourceStepOf(suffixed);
+  if (fromSuffixed) return fromSuffixed;
+  return protectedResourceStepOf(findMatchingRule(rules, PROTECTED_RESOURCE_PATH, 'GET'));
+}
+
+/**
+ * The `mcp_handler` rule at `resource`: the first enabled rule whose pipeline
+ * carries an `mcp_handler` step and whose pattern matches the path.
+ */
+export function findMcpRule(
+  rules: ProxyRule[],
+  resource: string,
+): { rule: ProxyRule; config: McpHandlerConfig } | undefined {
+  for (const rule of rules) {
+    if (!rule.isEnabled || !matchesPattern(rule.pathPattern, resource)) continue;
+    const step = pipelineStepsOf(rule).find(
+      (s) => s.handlerType === 'mcp_handler' && s.isEnabled !== false,
+    );
+    if (step) return { rule, config: step.config as unknown as McpHandlerConfig };
+  }
+  return undefined;
+}
+
+/**
+ * The scopes an `mcp_handler`'s tools need, as the union (first appearance
+ * order) of `requiredScopes` on the `auth_required` validators of the sibling
+ * rules its tools map to — each sibling resolved as the edge resolves it
+ * (`findMatchingRule`, the tool's method, POST by default).
+ */
+export function deriveScopes(rules: ProxyRule[], mcp: McpHandlerConfig): string[] {
+  const scopes: string[] = [];
+  for (const tool of mcp.tools ?? []) {
+    if (!tool?.rule?.path) continue;
+    const sibling = findMatchingRule(rules, tool.rule.path, tool.rule.method ?? 'POST');
+    if (!sibling) continue;
+    const validators = (sibling.pipelineConfig as PipelineConfig | null)?.validators ?? [];
+    for (const validator of validators) {
+      if (validator.type !== 'auth_required') continue;
+      const required = (validator.config as AuthRequiredConfig | undefined)?.requiredScopes ?? [];
+      for (const scope of required) {
+        if (typeof scope === 'string' && scope !== '' && !scopes.includes(scope)) {
+          scopes.push(scope);
+        }
+      }
+    }
+  }
+  return scopes;
+}
+
+/**
+ * `scopes_supported` for a handler config: declared verbatim, else derived from
+ * the `mcp_handler` at `resource` (empty when there is none).
+ */
+export function scopesSupportedFor(
+  config: OAuthProtectedResourceConfig,
+  rules: ProxyRule[],
+): string[] {
+  if (Array.isArray(config.scopes)) return [...config.scopes];
+  const mcp = findMcpRule(rules, config.resource);
+  return mcp ? deriveScopes(rules, mcp.config) : [];
+}
+
+/** The document itself. `rules` is only consulted for what the config leaves out. */
+export function protectedResourceDocument(input: {
+  host: string;
+  issuer: string;
+  config: OAuthProtectedResourceConfig;
+  rules: ProxyRule[];
+}): ProtectedResourceDocument {
+  const { host, issuer, config, rules } = input;
+  const needsMcp = !Array.isArray(config.scopes) || !config.resourceName;
+  const mcp = needsMcp ? findMcpRule(rules, config.resource) : undefined;
+  const scopes = Array.isArray(config.scopes)
+    ? [...config.scopes]
+    : mcp
+      ? deriveScopes(rules, mcp.config)
+      : [];
+  const name = config.resourceName || mcp?.config.serverInfo?.name;
+  const doc: ProtectedResourceDocument = {
+    resource: `https://${host}${config.resource}`,
+    authorization_servers: [issuer],
+    scopes_supported: scopes,
+    bearer_methods_supported: ['header'],
+  };
+  if (name) doc.resource_name = name;
+  if (config.resourceDocumentation) doc.resource_documentation = config.resourceDocumentation;
+  return doc;
+}
+
+/**
+ * The path a client appended to the well-known path (RFC 9728 §3: a resource
+ * `https://h/api/mcp` is looked up at `/.well-known/oauth-protected-resource/api/mcp`),
+ * from the public-relative request path; `''` for the bare path, undefined when
+ * the path does not contain the well-known prefix at all.
+ */
+export function protectedResourceSuffix(requestPath: string): string | undefined {
+  const path = requestPath.split('?')[0];
+  const at = path.indexOf(PROTECTED_RESOURCE_PATH);
+  if (at < 0) return undefined;
+  return path.slice(at + PROTECTED_RESOURCE_PATH.length).replace(/\/+$/, '');
+}
+
+/** Whether a suffix names this handler's resource: empty (the bare path) or equal to it. */
+export function suffixNamesResource(suffix: string | undefined, resource: string): boolean {
+  if (suffix === undefined || suffix === '') return true;
+  return suffix === resource.replace(/\/+$/, '');
+}

--- a/apps/backend/src/pipelines/pipelines.module.ts
+++ b/apps/backend/src/pipelines/pipelines.module.ts
@@ -56,6 +56,7 @@ import {
   DelayHandler,
   FfmpegHandler,
   McpHandler,
+  OAuthProtectedResourceHandler,
 } from './handlers';
 import { FfmpegCapabilityService } from './ffmpeg/ffmpeg-capability.service';
 import { FfmpegRunnerService } from './ffmpeg/ffmpeg-runner.service';
@@ -68,6 +69,7 @@ import { FfmpegExecutorSettingsController } from './ffmpeg/ffmpeg-executor-setti
 import { FFMPEG_CONFIG_PROVIDERS } from './ffmpeg/executor/ffmpeg-config.providers';
 import { FeedParserService } from './feed-parser.service';
 import { IntegrationsModule } from '../integrations/integrations.module';
+import { OAuthModule } from '../oauth/oauth.module';
 // Embeddings service
 import { PipelineEmbeddingsService } from './pipeline-embeddings.service';
 // Execution logging
@@ -111,6 +113,10 @@ import {
     // Server-side video ops (Task 5/6): REMOTE_CONNECTIONS is the lazy port the
     // ffmpeg remote executor resolves connections through.
     RemoteConnectionsModule,
+    // forwardRef: the oauth_protected_resource handler names CE's own issuer
+    // (OAuthService.issuer()); OAuthModule reaches back through ProxyRulesModule
+    // → PipelinesModule for the same rule resolution, so both edges defer.
+    forwardRef(() => OAuthModule),
   ],
   controllers: [
     PipelineSchemasController,
@@ -180,6 +186,7 @@ import {
     DelayHandler,
     FfmpegHandler,
     McpHandler,
+    OAuthProtectedResourceHandler,
     // Server-side video ops (Task 2/4/5) — consumed by FfmpegHandler, not otherwise registered
     FfmpegCapabilityService,
     FfmpegRunnerService,

--- a/apps/backend/src/pipelines/types.ts
+++ b/apps/backend/src/pipelines/types.ts
@@ -97,7 +97,8 @@ export type HandlerType =
   | 'delay'
   | 'ffmpeg_handler'
   | 'remote_request'
-  | 'mcp_handler';
+  | 'mcp_handler'
+  | 'oauth_protected_resource';
 
 /**
  * Pipeline step definition for execution.

--- a/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
@@ -585,6 +585,38 @@ describe('ProxyMiddleware', () => {
       expect(res.status).not.toHaveBeenCalled();
     });
 
+    it('does not let the step imply the bypass for an unrelated rule that merely carries it', async () => {
+      makePrivate();
+      const req = createMockRequest('/api/reports', { accept: 'application/json' });
+      const res = createMockResponse();
+
+      const result = await (middleware as any).checkVisibilityAndAuth(
+        req,
+        res,
+        project,
+        'studio',
+        createMockRule({
+          pathPattern: '/api/reports*',
+          proxyType: 'pipeline',
+          bypassVisibility: false,
+          pipelineConfig: {
+            name: 'reports',
+            steps: [
+              { name: 'q', handlerType: 'data_query', config: {} },
+              {
+                name: 'prm',
+                handlerType: 'oauth_protected_resource',
+                config: { resource: '/api/mcp' },
+              },
+            ],
+          },
+        }),
+      );
+
+      expect(result).toBe('blocked');
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+
     it('still gates an app-shipped /.well-known pipeline that did not opt out', async () => {
       makePrivate();
       const req = createMockRequest('/.well-known/oauth-protected-resource', {

--- a/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
@@ -552,6 +552,69 @@ describe('ProxyMiddleware', () => {
       expect(res.status).not.toHaveBeenCalled();
     });
 
+    it('lets a rule whose pipeline serves the RFC 9728 document (oauth_protected_resource) through anonymously without bypassVisibility (#760)', async () => {
+      makePrivate();
+      const req = createMockRequest('/.well-known/oauth-protected-resource', {
+        accept: 'application/json',
+      });
+      const res = createMockResponse();
+
+      const result = await (middleware as any).checkVisibilityAndAuth(
+        req,
+        res,
+        project,
+        'studio',
+        createMockRule({
+          pathPattern: '/.well-known/oauth-protected-resource*',
+          proxyType: 'pipeline',
+          bypassVisibility: false,
+          pipelineConfig: {
+            name: 'prm',
+            steps: [
+              {
+                name: 'prm',
+                handlerType: 'oauth_protected_resource',
+                config: { resource: '/api/mcp' },
+              },
+            ],
+          },
+        }),
+      );
+
+      expect(result).toBe('allowed');
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('still gates an app-shipped /.well-known pipeline that did not opt out', async () => {
+      makePrivate();
+      const req = createMockRequest('/.well-known/oauth-protected-resource', {
+        accept: 'application/json',
+      });
+      const res = createMockResponse();
+
+      const result = await (middleware as any).checkVisibilityAndAuth(
+        req,
+        res,
+        project,
+        'studio',
+        createMockRule({
+          pathPattern: '/.well-known/oauth-protected-resource*',
+          proxyType: 'pipeline',
+          bypassVisibility: false,
+          pipelineConfig: {
+            name: 'shipped',
+            steps: [
+              { name: 'doc', handlerType: 'function_handler', config: { code: '' } },
+              { name: 'respond', handlerType: 'response_handler', config: {} },
+            ],
+          },
+        }),
+      );
+
+      expect(result).toBe('blocked');
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+
     it('admits a Bearer app token on a private deployment as the member', async () => {
       makePrivate();
       mockResolveAppToken.mockResolvedValueOnce({

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -47,6 +47,7 @@ import {
   resolveProjectDefaultRuleSetIds as resolveProjectDefaultRuleSetIdsShared,
   resolveRuleSetIdsForAlias as resolveRuleSetIdsForAliasShared,
 } from './rule-resolution';
+import { servesProtectedResourceDocument } from '../pipelines/mcp/protected-resource';
 
 interface ParsedPublicPath {
   owner: string;
@@ -594,7 +595,10 @@ export class ProxyMiddleware implements NestMiddleware {
 
     // A rule that opted out of the gate serves pre-credential callers (OAuth
     // discovery under /.well-known, a webhook receiver). Its own validators still run.
-    if (matchedRule?.bypassVisibility) {
+    // A rule whose pipeline serves the RFC 9728 document through the dedicated
+    // `oauth_protected_resource` step is such a caller's by definition, so the
+    // handler implies the opt-out — an author never sets `bypassVisibility` for it (#760).
+    if (matchedRule?.bypassVisibility || servesProtectedResourceDocument(matchedRule)) {
       return 'allowed';
     }
 
@@ -648,7 +652,8 @@ export class ProxyMiddleware implements NestMiddleware {
 
       if (this.isApiRequest(req)) {
         // RFC 9728 §5.1: tell a bearer client where the resource's OAuth metadata is
-        // (an app-shipped /.well-known rule), so a connector can start its flow.
+        // (a /.well-known rule — an `oauth_protected_resource` step or an app-shipped
+        // document), so a connector can start its flow.
         this.setResourceMetadataHint(req, res);
         // Check if token was expired (set by AuthMiddleware)
         // If so, the response was already sent by AuthMiddleware
@@ -712,8 +717,10 @@ export class ProxyMiddleware implements NestMiddleware {
 
   /**
    * `WWW-Authenticate: Bearer resource_metadata="https://<host>/.well-known/oauth-protected-resource"`
-   * (RFC 9728 §5.1) on a 401 that reached CE through a domain host. The document itself is
-   * the app's to ship (a rule served despite visibility); CE only points at where it would be.
+   * (RFC 9728 §5.1) on a 401 that reached CE through a domain host. The document is a
+   * rule of the alias, served despite visibility: either the `oauth_protected_resource`
+   * step, which derives it from the `mcp_handler` and CE's own issuer (#760), or an
+   * app-shipped function. CE points at where it is; whether it exists is the rule set's.
    */
   private setResourceMetadataHint(req: Request, res: Response): void {
     const forwardedHost = req.headers['x-forwarded-host'];

--- a/apps/backend/src/proxy-rules/rule-invoker.service.ts
+++ b/apps/backend/src/proxy-rules/rule-invoker.service.ts
@@ -96,19 +96,27 @@ export class RuleInvokerService {
   }
 
   private async resolveRule(req: InvokeRequest): Promise<ProxyRule | null> {
-    const [project] = await db
-      .select()
-      .from(projects)
-      .where(eq(projects.id, req.projectId))
-      .limit(1);
-    if (!project) return null;
+    const rules = await this.effectiveRules(req.projectId, req.alias);
+    return findMatchingRule(rules, req.path, req.method);
+  }
+
+  /**
+   * The effective rules of (project, alias) in priority order — the alias's
+   * sets, else the project's defaults — exactly as the edge resolves them;
+   * cached briefly. Empty when the project or its sets are missing. Public so
+   * a handler that reads its siblings' config (the `oauth_protected_resource`
+   * document's derived scopes) and `OAuthService` see the same list.
+   */
+  async effectiveRules(projectId: string, aliasName: string | undefined): Promise<ProxyRule[]> {
+    const [project] = await db.select().from(projects).where(eq(projects.id, projectId)).limit(1);
+    if (!project) return [];
     let alias: { id: string; proxyRuleSetId: string | null } | null = null;
-    if (req.alias) {
+    if (aliasName) {
       const [row] = await db
         .select()
         .from(deploymentAliases)
         .where(
-          and(eq(deploymentAliases.projectId, project.id), eq(deploymentAliases.alias, req.alias)),
+          and(eq(deploymentAliases.projectId, project.id), eq(deploymentAliases.alias, aliasName)),
         )
         .limit(1);
       if (row) alias = { id: row.id, proxyRuleSetId: row.proxyRuleSetId };
@@ -117,9 +125,8 @@ export class RuleInvokerService {
       { id: project.id, defaultProxyRuleSetId: project.defaultProxyRuleSetId },
       alias,
     );
-    if (ids.length === 0) return null;
-    const rules = await this.cachedRules(ids);
-    return findMatchingRule(rules, req.path, req.method);
+    if (ids.length === 0) return [];
+    return this.cachedRules(ids);
   }
 
   private async cachedRules(ids: string[]): Promise<ProxyRule[]> {

--- a/apps/frontend/src/components/pipelines/PipelineConfig.tsx
+++ b/apps/frontend/src/components/pipelines/PipelineConfig.tsx
@@ -113,6 +113,7 @@ const HANDLER_GROUPS: { label: string; types: HandlerType[] }[] = [
       'xml_feed_parse',
       'delay',
       'mcp_handler',
+      'oauth_protected_resource',
     ],
   },
 ];

--- a/apps/frontend/src/components/pipelines/handlers/HandlerConfigWrapper.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/HandlerConfigWrapper.tsx
@@ -31,6 +31,7 @@ import { DataUpsertManyConfig } from './DataUpsertManyConfig';
 import { DelayHandlerConfig } from './DelayHandlerConfig';
 import { FfmpegHandlerConfig } from './FfmpegHandlerConfig';
 import { McpHandlerConfig } from './McpHandlerConfig';
+import { OAuthProtectedResourceConfig } from './OAuthProtectedResourceConfig';
 import { AvailableVariables, type PreviousStep } from './AvailableVariables';
 import type { HandlerConfig } from './types';
 
@@ -433,6 +434,10 @@ export function HandlerConfigWrapper({
       // No expressions panel: the config is a declaration, not a step over prior outputs.
       return <McpHandlerConfig config={config} onChange={handleChange} />;
 
+    case 'oauth_protected_resource':
+      // A declaration too: the document is derived from the request and the rule set.
+      return <OAuthProtectedResourceConfig config={config} onChange={handleChange} />;
+
     default:
       return (
         <div className="text-sm text-destructive p-4 bg-destructive/10 rounded-md">
@@ -468,6 +473,7 @@ export function getHandlerDisplayName(type: HandlerType): string {
     http_request: 'HTTP Request',
     remote_request: 'Remote Request',
     mcp_handler: 'MCP Server',
+    oauth_protected_resource: 'OAuth Discovery (MCP)',
     stripe_checkout: 'Stripe Checkout',
     stripe_webhook: 'Stripe Webhook',
     signed_url: 'Signed URL',
@@ -511,6 +517,8 @@ export function getHandlerDescription(type: HandlerType): string {
       'Call an admin-configured remote connection (Cloud Run etc.) with the platform identity',
     mcp_handler:
       'Answer as a stateless MCP server: tools and ui:// resources mapped to sibling rules of this alias, run as the caller',
+    oauth_protected_resource:
+      'Serve the RFC 9728 protected-resource document for an MCP server on this host (served regardless of visibility)',
     stripe_checkout: 'Create a Stripe Checkout Session and return the payment URL',
     stripe_webhook: 'Verify Stripe webhook signature and parse the event',
     signed_url: 'Generate a time-limited presigned URL for a file in storage',

--- a/apps/frontend/src/components/pipelines/handlers/McpHandlerConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/McpHandlerConfig.test.tsx
@@ -6,10 +6,11 @@ vi.mock('react-router-dom', () => ({
   useParams: () => ({ ruleSetId: 'set-1', ruleId: 'rule-1' }),
 }));
 const rulesQuery = vi.fn();
+let rulesData: { rules: unknown[] } = { rules: [] };
 vi.mock('@/services/proxyRulesApi', () => ({
   useGetRuleSetRulesQuery: (id: string, opts?: { skip?: boolean }) => {
     rulesQuery(id, opts);
-    return { data: { rules: [] }, isLoading: false };
+    return { data: rulesData, isLoading: false };
   },
 }));
 
@@ -122,6 +123,77 @@ describe('McpHandlerConfig', () => {
     );
     expect(summary.textContent).toContain('tool a: rule.path must start with /');
     expect(summary.textContent).toContain('duplicate tool name: a');
+  });
+
+  describe('Server tab: where OAuth discovery comes from (#760)', () => {
+    const prmRule = (config: Record<string, unknown>) => ({
+      id: 'prm',
+      pathPattern: '/.well-known/oauth-protected-resource*',
+      method: 'GET',
+      methods: null,
+      isEnabled: true,
+      pipelineConfig: { steps: [{ handlerType: 'oauth_protected_resource', config }] },
+    });
+    const self = {
+      id: 'rule-1',
+      pathPattern: '/api/workflow/mcp',
+      method: null,
+      methods: ['GET', 'POST'],
+      isEnabled: true,
+      pipelineConfig: null,
+    };
+    const list = {
+      id: 'list',
+      pathPattern: '/api/workflow/mcp-tools/list',
+      method: 'POST',
+      methods: null,
+      isEnabled: true,
+      pipelineConfig: {
+        validators: [{ type: 'auth_required', config: { requiredScopes: ['workflow:read'] } }],
+        steps: [],
+      },
+    };
+
+    it('says nothing serves it when the set has no well-known rule', () => {
+      rulesData = { rules: [self, list] };
+      render(<McpHandlerConfig config={config} onChange={() => {}} />);
+      expect(screen.getByTestId('mcp-discovery').textContent).toMatch(
+        /No \/\.well-known\/oauth-protected-resource rule in this set/,
+      );
+    });
+
+    it('shows the derived scopes_supported from the tools’ sibling rules', () => {
+      rulesData = { rules: [self, list, prmRule({ resource: '/api/workflow/mcp' })] };
+      render(<McpHandlerConfig config={config} onChange={() => {}} />);
+      const note = screen.getByTestId('mcp-discovery').textContent ?? '';
+      expect(note).toContain('Served by the oauth_protected_resource step');
+      expect(note).toContain('scopes_supported — derived: workflow:read');
+    });
+
+    it('shows a declared list verbatim', () => {
+      rulesData = {
+        rules: [self, prmRule({ resource: '/api/workflow/mcp', scopes: ['workflow:run'] })],
+      };
+      render(<McpHandlerConfig config={config} onChange={() => {}} />);
+      expect(screen.getByTestId('mcp-discovery').textContent).toContain(
+        'scopes_supported — declared: workflow:run',
+      );
+    });
+
+    it('names an app-shipped custom rule', () => {
+      rulesData = {
+        rules: [
+          self,
+          {
+            ...prmRule({}),
+            pipelineConfig: { steps: [{ handlerType: 'function_handler', config: {} }] },
+          },
+        ],
+      };
+      render(<McpHandlerConfig config={config} onChange={() => {}} />);
+      expect(screen.getByTestId('mcp-discovery').textContent).toContain('Served by a custom rule');
+      rulesData = { rules: [] };
+    });
   });
 
   it('renders an empty config without blowing up', () => {

--- a/apps/frontend/src/components/pipelines/handlers/McpHandlerConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/McpHandlerConfig.tsx
@@ -9,6 +9,8 @@ import { McpServerSection } from './mcp/McpServerSection';
 import { McpToolList } from './mcp/McpToolList';
 import { McpResourcesSection } from './mcp/McpResourcesSection';
 import { normalize, serialize, validate, type McpConfig } from './mcp/model';
+import { discoveryFor, type DiscoveryRule } from './mcp/discovery';
+import { useGetRuleSetRulesQuery } from '@/services/proxyRulesApi';
 
 interface Props {
   config: Record<string, unknown>;
@@ -40,6 +42,20 @@ export function McpHandlerConfig({ config, onChange, ruleSetId, ruleId }: Props)
   const serialized = useMemo(() => serialize(model), [model]);
   const problems = useMemo(() => validate(model), [model]);
   const summary = useMemo(() => summarizeMcpConfig(serialized), [serialized]);
+
+  // Where OAuth discovery for this server comes from, read off the set the way the
+  // backend reads it — live against the edited tools, so a scope change shows at once.
+  const { data: siblings } = useGetRuleSetRulesQuery(setId ?? '', { skip: !setId });
+  const discovery = useMemo(
+    () =>
+      siblings
+        ? discoveryFor(siblings.rules as unknown as DiscoveryRule[], {
+            ruleId: excludeRuleId,
+            tools: model.tools,
+          })
+        : undefined,
+    [siblings, excludeRuleId, model.tools],
+  );
 
   const emit = (next: McpConfig) => onChange(serialize(next));
   const patch = (p: Partial<McpConfig>) => emit({ ...model, ...p });
@@ -124,7 +140,12 @@ export function McpHandlerConfig({ config, onChange, ruleSetId, ruleId }: Props)
         </TabsList>
 
         <TabsContent value="server" className="pt-2">
-          <McpServerSection config={model} onChange={patch} serverInfoError={serverInfoError} />
+          <McpServerSection
+            config={model}
+            onChange={patch}
+            serverInfoError={serverInfoError}
+            discovery={discovery}
+          />
         </TabsContent>
 
         <TabsContent value="tools" className="pt-2">

--- a/apps/frontend/src/components/pipelines/handlers/OAuthProtectedResourceConfig.test.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/OAuthProtectedResourceConfig.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ ruleSetId: 'set-1', ruleId: 'prm' }),
+}));
+let rulesData: { rules: unknown[] } = { rules: [] };
+vi.mock('@/services/proxyRulesApi', () => ({
+  useGetRuleSetRulesQuery: () => ({ data: rulesData, isLoading: false }),
+}));
+
+const { OAuthProtectedResourceConfig } = await import('./OAuthProtectedResourceConfig');
+
+const rules = [
+  {
+    id: 'prm',
+    pathPattern: '/.well-known/oauth-protected-resource*',
+    method: 'GET',
+    methods: null,
+    isEnabled: true,
+    pipelineConfig: {
+      steps: [{ handlerType: 'oauth_protected_resource', config: { resource: '/api/mcp' } }],
+    },
+  },
+  {
+    id: 'mcp',
+    pathPattern: '/api/mcp',
+    method: null,
+    methods: ['GET', 'POST'],
+    isEnabled: true,
+    pipelineConfig: {
+      steps: [
+        {
+          handlerType: 'mcp_handler',
+          config: {
+            serverInfo: { name: 'Workflow', version: '1' },
+            tools: [{ name: 'list', rule: { path: '/api/tools/list' } }],
+          },
+        },
+      ],
+    },
+  },
+  {
+    id: 'list',
+    pathPattern: '/api/tools/list',
+    method: 'POST',
+    methods: null,
+    isEnabled: true,
+    pipelineConfig: {
+      validators: [{ type: 'auth_required', config: { requiredScopes: ['workflow:read'] } }],
+      steps: [],
+    },
+  },
+];
+
+describe('OAuthProtectedResourceConfig', () => {
+  it('shows the MCP rule it found and the scopes it will derive, and emits a declared list on switch', () => {
+    rulesData = { rules };
+    const onChange = vi.fn();
+    render(<OAuthProtectedResourceConfig config={{ resource: '/api/mcp' }} onChange={onChange} />);
+    expect(screen.getByTestId('prm-mcp-hint').textContent).toContain(
+      'Found in this set: /api/mcp (Workflow)',
+    );
+    expect(screen.getByTestId('prm-derived').textContent).toContain('derived: workflow:read');
+    expect(screen.queryByTestId('prm-path-warning')).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/resource name/i)).toHaveAttribute('placeholder', 'Workflow');
+
+    fireEvent.click(screen.getByLabelText(/^declare$/i));
+    expect(onChange).toHaveBeenCalledWith({ resource: '/api/mcp', scopes: ['workflow:read'] });
+  });
+
+  it('warns when no mcp_handler answers the resource, and drops `scopes` when switching back to derived', () => {
+    rulesData = { rules: rules.filter((r) => r.id !== 'mcp') };
+    const onChange = vi.fn();
+    render(
+      <OAuthProtectedResourceConfig
+        config={{ resource: '/api/mcp', scopes: ['a:b'], resourceName: 'X' }}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByTestId('prm-mcp-hint').textContent).toContain('No mcp_handler rule');
+    expect(screen.getByLabelText(/^scopes$/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/derive from the mcp server/i));
+    expect(onChange).toHaveBeenCalledWith({ resource: '/api/mcp', resourceName: 'X' });
+  });
+
+  it('flags a rule whose own path is not the well-known one', () => {
+    rulesData = {
+      rules: [{ ...rules[0], pathPattern: '/api/discovery' }, ...rules.slice(1)],
+    };
+    render(<OAuthProtectedResourceConfig config={{ resource: '/api/mcp' }} onChange={() => {}} />);
+    expect(screen.getByTestId('prm-path-warning').textContent).toContain('/api/discovery');
+  });
+
+  it('edits the resource path', () => {
+    rulesData = { rules: [] };
+    const onChange = vi.fn();
+    render(<OAuthProtectedResourceConfig config={{}} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText(/resource path/i), { target: { value: '/api/x' } });
+    expect(onChange).toHaveBeenCalledWith({ resource: '/api/x' });
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/OAuthProtectedResourceConfig.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/OAuthProtectedResourceConfig.tsx
@@ -1,0 +1,169 @@
+import { useId, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { AlertCircle } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useGetRuleSetRulesQuery } from '@/services/proxyRulesApi';
+import { StringListInput } from './mcp/StringListInput';
+import {
+  PROTECTED_RESOURCE_PATH,
+  answersWellKnown,
+  deriveScopes,
+  findMcpRule,
+  type DiscoveryRule,
+} from './mcp/discovery';
+
+interface Props {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+  /** The rule set the MCP rule lives in; defaults to the route's `:ruleSetId`. */
+  ruleSetId?: string;
+  /** The rule being edited; defaults to the route's `:ruleId`. */
+  ruleId?: string;
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+const strList = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+
+/**
+ * `oauth_protected_resource`: the RFC 9728 document for the `mcp_handler` at
+ * `resource`, derived at request time — `resource` from the host,
+ * `authorization_servers` from this instance's issuer, `scopes_supported` from
+ * the MCP rule's siblings unless declared here. The form shows what the
+ * document will say, read off the rule set as the backend reads it.
+ */
+export function OAuthProtectedResourceConfig({ config, onChange, ruleSetId, ruleId }: Props) {
+  const id = useId();
+  const params = useParams<{ ruleSetId?: string; ruleId?: string }>();
+  const setId = ruleSetId ?? params.ruleSetId;
+  const ownRuleId = ruleId ?? params.ruleId;
+  const { data } = useGetRuleSetRulesQuery(setId ?? '', { skip: !setId });
+  const rules = (data?.rules ?? []) as unknown as DiscoveryRule[];
+
+  const resource = str(config.resource);
+  const declared = Array.isArray(config.scopes);
+  const scopes = strList(config.scopes);
+
+  const mcp = useMemo(() => findMcpRule(rules, resource), [rules, resource]);
+  const derived = useMemo(() => (mcp ? deriveScopes(rules, mcp.tools) : []), [rules, mcp]);
+  const ownRule = rules.find((r) => r.id === ownRuleId);
+  const pathWarning = ownRule && !answersWellKnown(ownRule);
+
+  const patch = (p: Record<string, unknown>) => {
+    const next: Record<string, unknown> = { ...config, ...p };
+    for (const key of Object.keys(p)) if (p[key] === undefined) delete next[key];
+    onChange(next);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border bg-muted/30 p-3 space-y-1.5 text-xs text-muted-foreground">
+        <p className="font-medium">OAuth discovery for an MCP server (RFC 9728)</p>
+        <p>
+          Answers <code>GET {PROTECTED_RESOURCE_PATH}</code> (and the path-suffixed form) with the
+          document an OAuth client reads before it has any credential — so this rule is served
+          regardless of deployment visibility. <code>resource</code> is{' '}
+          <code>https://&lt;host&gt;{resource || '/…'}</code>; <code>authorization_servers</code> is
+          this instance&apos;s issuer. Nothing is baked in.
+        </p>
+      </div>
+
+      {pathWarning && (
+        <Alert variant="destructive" data-testid="prm-path-warning">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription className="text-xs">
+            This rule&apos;s path is <code>{ownRule.pathPattern}</code>; clients look for the
+            document at <code>{PROTECTED_RESOURCE_PATH}*</code> (GET).
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor={`${id}-resource`}>
+          Resource path <span className="text-destructive">*</span>
+        </Label>
+        <Input
+          id={`${id}-resource`}
+          value={resource}
+          placeholder="/api/mcp"
+          onChange={(e) => patch({ resource: e.target.value })}
+          className="font-mono text-sm"
+        />
+        <p className="text-xs text-muted-foreground" data-testid="prm-mcp-hint">
+          The <code>mcp_handler</code> rule&apos;s path on this host.{' '}
+          {!resource
+            ? ''
+            : mcp
+              ? `Found in this set: ${mcp.rule.pathPattern}${mcp.serverName ? ` (${mcp.serverName})` : ''}.`
+              : 'No mcp_handler rule at this path in this set — another set attached to the alias may hold it; otherwise scopes_supported will be empty unless declared.'}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label>scopes_supported</Label>
+        <div className="flex flex-wrap gap-4 text-sm" role="radiogroup" aria-label="scopes mode">
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name={`${id}-scopes-mode`}
+              checked={!declared}
+              onChange={() => patch({ scopes: undefined })}
+            />
+            Derive from the MCP server&apos;s tools
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name={`${id}-scopes-mode`}
+              checked={declared}
+              onChange={() => patch({ scopes: derived })}
+            />
+            Declare
+          </label>
+        </div>
+        {declared ? (
+          <StringListInput
+            label="Scopes"
+            value={scopes}
+            onChange={(next) => patch({ scopes: next })}
+            placeholder="namespace:verb"
+            suggestions={derived.filter((s) => !scopes.includes(s)).map((value) => ({ value }))}
+            help="Published verbatim. This list is the authorize flow's allowlist: a scope not here cannot be granted over OAuth."
+          />
+        ) : (
+          <p className="text-xs text-muted-foreground" data-testid="prm-derived">
+            derived: {derived.length ? derived.map((s) => <code key={s}>{s} </code>) : 'none'} — the
+            union of <code>requiredScopes</code> on the <code>auth_required</code> validators of the
+            sibling rules the MCP server&apos;s tools map to. Declare instead when a sibling&apos;s
+            scope must not be offered over OAuth.
+          </p>
+        )}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor={`${id}-name`}>Resource name</Label>
+          <Input
+            id={`${id}-name`}
+            value={str(config.resourceName)}
+            placeholder={mcp?.serverName || 'defaults to the MCP server name'}
+            onChange={(e) => patch({ resourceName: e.target.value || undefined })}
+            className="text-sm"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`${id}-docs`}>Documentation URL</Label>
+          <Input
+            id={`${id}-docs`}
+            value={str(config.resourceDocumentation)}
+            placeholder="https://…"
+            onChange={(e) => patch({ resourceDocumentation: e.target.value || undefined })}
+            className="font-mono text-sm"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/pipelines/handlers/mcp/McpServerSection.tsx
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/McpServerSection.tsx
@@ -6,15 +6,23 @@ import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { StringListInput } from './StringListInput';
 import { PROTOCOL_VERSION_DEFAULTS, type McpConfig } from './model';
+import { PROTECTED_RESOURCE_PATH, type DiscoverySummary } from './discovery';
 
 interface McpServerSectionProps {
   config: McpConfig;
   onChange: (patch: Partial<McpConfig>) => void;
   serverInfoError?: string;
+  /** Where the RFC 9728 discovery document comes from, read off the rule set; omitted when unknown. */
+  discovery?: DiscoverySummary;
 }
 
-/** `serverInfo`, `instructions` and (behind Advanced) `protocolVersions`. */
-export function McpServerSection({ config, onChange, serverInfoError }: McpServerSectionProps) {
+/** `serverInfo`, `instructions`, where OAuth discovery comes from, and (behind Advanced) `protocolVersions`. */
+export function McpServerSection({
+  config,
+  onChange,
+  serverInfoError,
+  discovery,
+}: McpServerSectionProps) {
   const id = useId();
   const [advanced, setAdvanced] = useState(config.protocolVersions.length > 0);
 
@@ -75,6 +83,8 @@ export function McpServerSection({ config, onChange, serverInfoError }: McpServe
         </p>
       </div>
 
+      {discovery && <DiscoveryNote discovery={discovery} />}
+
       <div>
         <Button
           type="button"
@@ -103,6 +113,72 @@ export function McpServerSection({ config, onChange, serverInfoError }: McpServe
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * The OAuth discovery contract, taught where the server is edited: a client
+ * reads `/.well-known/oauth-protected-resource` before it has a credential, and
+ * `scopes_supported` there is what it may be granted. Says which rule answers
+ * and what the list will be — declared, or derived from the tools' siblings.
+ */
+function DiscoveryNote({ discovery }: { discovery: DiscoverySummary }) {
+  const scopesLine = (scopes: { mode: 'declared' | 'derived'; values: string[] }) => (
+    <>
+      <code>scopes_supported</code> — {scopes.mode}:{' '}
+      {scopes.values.length ? (
+        scopes.values.map((s) => (
+          <code key={s} className="mr-1">
+            {s}
+          </code>
+        ))
+      ) : (
+        <span>none</span>
+      )}
+      {scopes.mode === 'derived' && (
+        <>
+          {' '}
+          (the union of <code>requiredScopes</code> on the tools&apos; sibling rules; declare{' '}
+          <code>scopes</code> on that step to publish a different list)
+        </>
+      )}
+    </>
+  );
+
+  return (
+    <div
+      className="rounded-md border bg-muted/30 p-3 space-y-1 text-xs text-muted-foreground"
+      data-testid="mcp-discovery"
+    >
+      <p className="font-medium">OAuth discovery (RFC 9728)</p>
+      {discovery.kind === 'handler' && (
+        <>
+          <p>
+            Served by the <code>oauth_protected_resource</code> step on{' '}
+            <code>{discovery.rulePath}</code>; <code>authorization_servers</code> is this
+            instance&apos;s issuer.
+          </p>
+          <p>{scopesLine(discovery.scopes)}</p>
+        </>
+      )}
+      {discovery.kind === 'custom' && (
+        <p>
+          Served by a custom rule at <code>{discovery.rulePath}</code>; its{' '}
+          <code>scopes_supported</code> is whatever that rule emits. Replace it with an{' '}
+          <code>oauth_protected_resource</code> step to derive the list from this server&apos;s
+          tools and take <code>authorization_servers</code> from this instance.
+        </p>
+      )}
+      {discovery.kind === 'none' && (
+        <p>
+          No <code>{PROTECTED_RESOURCE_PATH}</code> rule in this set. An OAuth client (claude.ai,
+          Claude Code) cannot start without one: add a GET rule at{' '}
+          <code>{PROTECTED_RESOURCE_PATH}*</code> with an <code>oauth_protected_resource</code> step
+          whose <code>resource</code> is this rule&apos;s path. Another set attached to the same
+          alias may already carry it.
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/components/pipelines/handlers/mcp/discovery.test.ts
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/discovery.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PROTECTED_RESOURCE_PATH,
+  deriveScopes,
+  discoveryFor,
+  findMcpRule,
+  type DiscoveryRule,
+} from './discovery';
+
+const rule = (over: Partial<DiscoveryRule> & { id: string; pathPattern: string }): DiscoveryRule =>
+  ({
+    method: null,
+    methods: null,
+    isEnabled: true,
+    pipelineConfig: null,
+    ...over,
+  }) as DiscoveryRule;
+
+const authRequired = (requiredScopes: string[]) => ({
+  type: 'auth_required',
+  config: { requiredScopes },
+});
+
+const mcp = rule({
+  id: 'mcp',
+  pathPattern: '/api/mcp',
+  methods: ['GET', 'POST'],
+  pipelineConfig: {
+    steps: [
+      {
+        handlerType: 'mcp_handler',
+        config: {
+          serverInfo: { name: 'Workflow', version: '1' },
+          tools: [
+            { name: 'list', rule: { path: '/api/tools/list', method: 'POST' } },
+            { name: 'sign', rule: { path: '/api/tools/sign', method: 'GET' } },
+            { name: 'lost', rule: { path: '/api/tools/nowhere' } },
+          ],
+        },
+      },
+    ],
+  },
+});
+const list = rule({
+  id: 'list',
+  pathPattern: '/api/tools/list',
+  method: 'POST',
+  pipelineConfig: { validators: [authRequired(['workflow:read'])], steps: [] },
+});
+const sign = rule({
+  id: 'sign',
+  pathPattern: '/api/tools/*',
+  method: 'GET',
+  pipelineConfig: {
+    validators: [authRequired(['workflow:files', 'workflow:read'])],
+    steps: [],
+  },
+});
+const prm = (config: Record<string, unknown>) =>
+  rule({
+    id: 'prm',
+    pathPattern: `${PROTECTED_RESOURCE_PATH}*`,
+    method: 'GET',
+    pipelineConfig: { steps: [{ handlerType: 'oauth_protected_resource', config }] },
+  });
+const shipped = rule({
+  id: 'shipped',
+  pathPattern: `${PROTECTED_RESOURCE_PATH}*`,
+  method: 'GET',
+  pipelineConfig: {
+    steps: [
+      { handlerType: 'function_handler', config: {} },
+      { handlerType: 'response_handler', config: {} },
+    ],
+  },
+});
+const tools = findMcpRule([mcp], '/api/mcp')!.tools;
+
+describe('discovery', () => {
+  it('finds the mcp_handler rule at a path and reads its server name and tool refs', () => {
+    const found = findMcpRule([list, mcp], '/api/mcp');
+    expect(found?.rule.id).toBe('mcp');
+    expect(found?.serverName).toBe('Workflow');
+    expect(found?.tools.map((t) => t.rule.path)).toEqual([
+      '/api/tools/list',
+      '/api/tools/sign',
+      '/api/tools/nowhere',
+    ]);
+    expect(findMcpRule([list], '/api/mcp')).toBeUndefined();
+    expect(findMcpRule([mcp], '')).toBeUndefined();
+  });
+
+  it('derives the union of sibling requiredScopes in first-appearance order, resolving each sibling with the tool method', () => {
+    expect(deriveScopes([mcp, list, sign], tools)).toEqual(['workflow:read', 'workflow:files']);
+    expect(deriveScopes([mcp], tools)).toEqual([]);
+  });
+
+  it('reports the handler rule that names this MCP rule, with declared or derived scopes', () => {
+    expect(
+      discoveryFor([mcp, list, sign, prm({ resource: '/api/mcp', scopes: ['workflow:read'] })], {
+        ruleId: 'mcp',
+        tools,
+      }),
+    ).toEqual({
+      kind: 'handler',
+      rulePath: `${PROTECTED_RESOURCE_PATH}*`,
+      scopes: { mode: 'declared', values: ['workflow:read'] },
+    });
+    expect(
+      discoveryFor([mcp, list, sign, prm({ resource: '/api/mcp' })], { ruleId: 'mcp', tools }),
+    ).toEqual({
+      kind: 'handler',
+      rulePath: `${PROTECTED_RESOURCE_PATH}*`,
+      scopes: { mode: 'derived', values: ['workflow:read', 'workflow:files'] },
+    });
+  });
+
+  it('ignores a handler rule that names another resource, unless the edited rule is unsaved', () => {
+    const other = prm({ resource: '/api/other' });
+    expect(discoveryFor([mcp, other], { ruleId: 'mcp', tools })).toEqual({
+      kind: 'custom',
+      rulePath: `${PROTECTED_RESOURCE_PATH}*`,
+    });
+    expect(discoveryFor([mcp, other], { ruleId: undefined, tools })).toMatchObject({
+      kind: 'handler',
+    });
+  });
+
+  it('reports an app-shipped well-known rule as custom, and nothing as none', () => {
+    expect(discoveryFor([mcp, shipped], { ruleId: 'mcp', tools })).toEqual({
+      kind: 'custom',
+      rulePath: `${PROTECTED_RESOURCE_PATH}*`,
+    });
+    expect(discoveryFor([mcp, list], { ruleId: 'mcp', tools })).toEqual({ kind: 'none' });
+  });
+});

--- a/apps/frontend/src/components/pipelines/handlers/mcp/discovery.test.ts
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/discovery.test.ts
@@ -126,6 +126,31 @@ describe('discovery', () => {
     });
   });
 
+  it('only counts a handler step that is the whole answer of a well-known rule', () => {
+    const elsewhere = rule({
+      id: 'elsewhere',
+      pathPattern: '/api/reports*',
+      pipelineConfig: {
+        steps: [{ handlerType: 'oauth_protected_resource', config: { resource: '/api/mcp' } }],
+      },
+    });
+    expect(discoveryFor([mcp, elsewhere], { ruleId: 'mcp', tools })).toEqual({ kind: 'none' });
+    const preceded = rule({
+      id: 'preceded',
+      pathPattern: `${PROTECTED_RESOURCE_PATH}*`,
+      pipelineConfig: {
+        steps: [
+          { handlerType: 'data_query', config: {} },
+          { handlerType: 'oauth_protected_resource', config: { resource: '/api/mcp' } },
+        ],
+      },
+    });
+    expect(discoveryFor([mcp, preceded], { ruleId: 'mcp', tools })).toEqual({
+      kind: 'custom',
+      rulePath: `${PROTECTED_RESOURCE_PATH}*`,
+    });
+  });
+
   it('reports an app-shipped well-known rule as custom, and nothing as none', () => {
     expect(discoveryFor([mcp, shipped], { ruleId: 'mcp', tools })).toEqual({
       kind: 'custom',

--- a/apps/frontend/src/components/pipelines/handlers/mcp/discovery.ts
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/discovery.ts
@@ -1,0 +1,174 @@
+import { findSibling, isRecord, matchesPattern, type SiblingRule } from './model';
+
+/**
+ * Where an `mcp_handler`'s OAuth discovery document (RFC 9728) comes from, read
+ * off the rule set the way the backend's `pipelines/mcp/protected-resource.ts`
+ * reads it — so the Server tab can say what `scopes_supported` a client will
+ * see before anything is saved. A miss is a hint, not an error: another set
+ * attached to the same alias may carry the rule.
+ */
+
+export const PROTECTED_RESOURCE_PATH = '/.well-known/oauth-protected-resource';
+export const PROTECTED_RESOURCE_HANDLER = 'oauth_protected_resource';
+
+interface StepLike {
+  handlerType: string;
+  config: Record<string, unknown>;
+  isEnabled?: boolean;
+}
+
+interface ValidatorLike {
+  type: string;
+  config?: Record<string, unknown>;
+}
+
+export interface DiscoveryRule extends SiblingRule {
+  pipelineConfig?: {
+    steps?: StepLike[];
+    postSteps?: StepLike[];
+    validators?: ValidatorLike[];
+  } | null;
+}
+
+export interface ProtectedResourceConfig {
+  resource: string;
+  scopes?: string[];
+  resourceName?: string;
+  resourceDocumentation?: string;
+}
+
+export interface ToolRef {
+  rule: { path: string; method?: string };
+}
+
+export interface McpRuleInfo {
+  rule: DiscoveryRule;
+  serverName: string;
+  tools: ToolRef[];
+}
+
+export type DiscoverySummary =
+  | {
+      kind: 'handler';
+      rulePath: string;
+      scopes: { mode: 'declared' | 'derived'; values: string[] };
+    }
+  | { kind: 'custom'; rulePath: string }
+  | { kind: 'none' };
+
+const strList = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+
+/** Every enabled step of a rule's pipeline (main and post). */
+export function stepsOf(rule: DiscoveryRule | undefined): StepLike[] {
+  const config = rule?.pipelineConfig;
+  if (!config) return [];
+  return [...(config.steps ?? []), ...(config.postSteps ?? [])].filter(
+    (s) => s.isEnabled !== false,
+  );
+}
+
+/** The `oauth_protected_resource` step's config on a rule, when it has one. */
+export function protectedResourceConfigOf(
+  rule: DiscoveryRule | undefined,
+): ProtectedResourceConfig | undefined {
+  const step = stepsOf(rule).find((s) => s.handlerType === PROTECTED_RESOURCE_HANDLER);
+  if (!step) return undefined;
+  const c = isRecord(step.config) ? step.config : {};
+  return {
+    resource: typeof c.resource === 'string' ? c.resource : '',
+    scopes: Array.isArray(c.scopes) ? strList(c.scopes) : undefined,
+    resourceName: typeof c.resourceName === 'string' ? c.resourceName : undefined,
+    resourceDocumentation:
+      typeof c.resourceDocumentation === 'string' ? c.resourceDocumentation : undefined,
+  };
+}
+
+/** The first enabled rule whose pattern matches `resource` and whose pipeline is an `mcp_handler`. */
+export function findMcpRule(rules: DiscoveryRule[], resource: string): McpRuleInfo | undefined {
+  if (!resource) return undefined;
+  for (const rule of rules) {
+    if (!rule.isEnabled || !matchesPattern(rule.pathPattern, resource)) continue;
+    const step = stepsOf(rule).find((s) => s.handlerType === 'mcp_handler');
+    if (!step) continue;
+    const c = isRecord(step.config) ? step.config : {};
+    const serverInfo = isRecord(c.serverInfo) ? c.serverInfo : {};
+    const tools: ToolRef[] = Array.isArray(c.tools)
+      ? c.tools.flatMap((t: unknown) => {
+          if (!isRecord(t) || !isRecord(t.rule) || typeof t.rule.path !== 'string') return [];
+          return [
+            {
+              rule: {
+                path: t.rule.path,
+                method: typeof t.rule.method === 'string' ? t.rule.method : undefined,
+              },
+            },
+          ];
+        })
+      : [];
+    return {
+      rule,
+      serverName: typeof serverInfo.name === 'string' ? serverInfo.name : '',
+      tools,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * The union (first-appearance order) of `requiredScopes` on the `auth_required`
+ * validators of the sibling rules the tools map to — the backend's derivation.
+ */
+export function deriveScopes(rules: DiscoveryRule[], tools: ToolRef[]): string[] {
+  const scopes: string[] = [];
+  for (const tool of tools) {
+    if (!tool.rule.path) continue;
+    const sibling = findSibling(rules, tool.rule.path, tool.rule.method ?? 'POST');
+    for (const validator of sibling?.pipelineConfig?.validators ?? []) {
+      if (validator.type !== 'auth_required') continue;
+      for (const scope of strList(validator.config?.requiredScopes)) {
+        if (scope && !scopes.includes(scope)) scopes.push(scope);
+      }
+    }
+  }
+  return scopes;
+}
+
+/** Whether a rule answers the well-known path (bare or suffixed). */
+export function answersWellKnown(rule: DiscoveryRule): boolean {
+  return (
+    rule.isEnabled &&
+    (matchesPattern(rule.pathPattern, PROTECTED_RESOURCE_PATH) ||
+      rule.pathPattern.startsWith(PROTECTED_RESOURCE_PATH))
+  );
+}
+
+/**
+ * Where discovery for the `mcp_handler` rule `ruleId` (with the given tools —
+ * the edited ones, so the answer is live) comes from within this set.
+ */
+export function discoveryFor(
+  rules: DiscoveryRule[],
+  input: { ruleId?: string; tools: ToolRef[] },
+): DiscoverySummary {
+  const ownPath = rules.find((r) => r.id === input.ruleId)?.pathPattern;
+  const handlerRules = rules
+    .filter((r) => r.isEnabled)
+    .map((rule) => ({ rule, config: protectedResourceConfigOf(rule) }))
+    .filter((x): x is { rule: DiscoveryRule; config: ProtectedResourceConfig } => !!x.config);
+  const own = ownPath
+    ? handlerRules.find((x) => matchesPattern(ownPath, x.config.resource))
+    : handlerRules[0];
+  if (own) {
+    return {
+      kind: 'handler',
+      rulePath: own.rule.pathPattern,
+      scopes: own.config.scopes
+        ? { mode: 'declared', values: own.config.scopes }
+        : { mode: 'derived', values: deriveScopes(rules, input.tools) },
+    };
+  }
+  const custom = rules.find(answersWellKnown);
+  if (custom) return { kind: 'custom', rulePath: custom.pathPattern };
+  return { kind: 'none' };
+}

--- a/apps/frontend/src/components/pipelines/handlers/mcp/discovery.ts
+++ b/apps/frontend/src/components/pipelines/handlers/mcp/discovery.ts
@@ -68,12 +68,16 @@ export function stepsOf(rule: DiscoveryRule | undefined): StepLike[] {
   );
 }
 
-/** The `oauth_protected_resource` step's config on a rule, when it has one. */
+/**
+ * The `oauth_protected_resource` step that is a rule's whole answer — its first
+ * enabled main step, as the backend requires before the step implies the
+ * visibility bypass; undefined otherwise.
+ */
 export function protectedResourceConfigOf(
   rule: DiscoveryRule | undefined,
 ): ProtectedResourceConfig | undefined {
-  const step = stepsOf(rule).find((s) => s.handlerType === PROTECTED_RESOURCE_HANDLER);
-  if (!step) return undefined;
+  const step = (rule?.pipelineConfig?.steps ?? []).find((s) => s.isEnabled !== false);
+  if (!step || step.handlerType !== PROTECTED_RESOURCE_HANDLER) return undefined;
   const c = isRecord(step.config) ? step.config : {};
   return {
     resource: typeof c.resource === 'string' ? c.resource : '',
@@ -153,7 +157,7 @@ export function discoveryFor(
 ): DiscoverySummary {
   const ownPath = rules.find((r) => r.id === input.ruleId)?.pathPattern;
   const handlerRules = rules
-    .filter((r) => r.isEnabled)
+    .filter(answersWellKnown)
     .map((rule) => ({ rule, config: protectedResourceConfigOf(rule) }))
     .filter((x): x is { rule: DiscoveryRule; config: ProtectedResourceConfig } => !!x.config);
   const own = ownPath

--- a/apps/frontend/src/components/pipelines/handlers/types.ts
+++ b/apps/frontend/src/components/pipelines/handlers/types.ts
@@ -414,7 +414,8 @@ export type HandlerConfig =
   | DataUpsertManyHandlerConfig
   | DelayHandlerConfig
   | FfmpegHandlerConfig
-  | McpHandlerConfig;
+  | McpHandlerConfig
+  | OAuthProtectedResourceHandlerConfig;
 
 export interface SignedUrlHandlerConfig extends BaseHandlerConfig {
   /** Storage key / path (supports expressions, e.g. "steps.upload.storage_path") */
@@ -644,4 +645,20 @@ export interface McpHandlerConfig extends BaseHandlerConfig {
     list?: { rule: { path: string; method?: 'GET' } };
     csp?: { connectDomains?: string[]; resourceDomains?: string[] };
   };
+}
+
+/**
+ * `oauth_protected_resource` — the RFC 9728 discovery document for the
+ * `mcp_handler` at `resource`. Every URL comes from the request and the
+ * instance; a rule carrying it is served regardless of deployment visibility.
+ */
+export interface OAuthProtectedResourceHandlerConfig extends BaseHandlerConfig {
+  /** The MCP endpoint's path on this host, e.g. `/api/mcp`. */
+  resource: string;
+  /** `scopes_supported` verbatim; omitted = derived from the MCP rule's sibling `requiredScopes`. */
+  scopes?: string[];
+  /** `resource_name`; defaults to the MCP server's `serverInfo.name`. */
+  resourceName?: string;
+  /** `resource_documentation`, a URL. */
+  resourceDocumentation?: string;
 }

--- a/apps/frontend/src/services/pipelinesApi.ts
+++ b/apps/frontend/src/services/pipelinesApi.ts
@@ -8,6 +8,8 @@ export type ValidatorType = 'auth_required' | 'rate_limit';
 export interface AuthRequiredConfig {
   roles?: string[];
   allowApiKey?: boolean;
+  /** Scopes an app token must carry (`namespace:verb`); the MCP discovery document derives `scopes_supported` from these. */
+  requiredScopes?: string[];
 }
 
 export interface RateLimitConfig {
@@ -51,6 +53,7 @@ export type HandlerType =
   | 'http_request'
   | 'remote_request'
   | 'mcp_handler'
+  | 'oauth_protected_resource'
   | 'stripe_checkout'
   | 'stripe_webhook'
   | 'signed_url'

--- a/docs/adr/0005-built-in-oauth-authorization-server.md
+++ b/docs/adr/0005-built-in-oauth-authorization-server.md
@@ -50,3 +50,16 @@ catch-all served `index.html` there); the app ships its protected-resource docum
 rule (`bypassVisibility`), so CE never grows an app-aware discovery endpoint. OIDC discovery,
 token introspection (RFC 7662) and client garbage collection are deferred. If SuperTokens'
 recipe later gains DCR and CE has crossed the SDK-21 line, revisiting is a one-ADR decision.
+
+**Amended 2026-09-06 (#760).** The document stays a rule of the alias — still no CE endpoint
+that knows about apps — but CE now ships a declared step for it, `oauth_protected_resource`,
+after two apps had copied the same ~50-line function (and both guessed the issuer as
+`admin.<parent>`, wrong for any instance whose admin host is not `admin.*`). The step derives
+`resource` from the request host, `authorization_servers` from `OAuthService.issuer()`, and
+`scopes_supported` from the `mcp_handler`'s sibling `requiredScopes` unless declared; a rule
+carrying it is served regardless of visibility without `bypassVisibility`. The fully-derived
+alternative (answer `/.well-known` on a rule miss from whatever `mcp_handler` the alias has)
+was rejected: `scopes_supported` is the authorize flow's allowlist, and an emergent list that
+an unrelated rule edit can change is not something to publish implicitly. Hand-written
+documents keep working; `OAuthService` reads the step's config directly and fetches only for
+those.


### PR DESCRIPTION
Closes #760

## Summary

Every app that ships an MCP server on `mcp_handler` has had to hand-write the RFC 9728 protected-resource document as a `function_handler` + `response_handler` rule with `bypassVisibility: true` — about 50 lines of JavaScript that two apps had already copied byte-for-byte, and that guessed the authorization server as `admin.<parent domain>` (wrong for any instance whose admin host is not `admin.*`). This PR adds a dedicated pipeline step, `oauth_protected_resource`, that serves the document from the rule set and the instance: one YAML step with a `resource` path replaces the JavaScript, and the URLs it emits are always right for the host and instance it runs on. An author sees in the MCP step editor where discovery comes from and exactly which scopes an OAuth client will be offered.

## Behaviour changes

All additive; nothing an existing rule set does changes.

- **New step type `oauth_protected_resource`** (config: `resource` required; `scopes`, `resourceName`, `resourceDocumentation` optional). Before → after: no way to emit the RFC 9728 document without custom code → a rule at `GET /.well-known/oauth-protected-resource*` with this step answers it, deriving `resource` from the request host (`x-forwarded-host`, else `host`), `authorization_servers` from `OAuthService.issuer()`, `scopes_supported` verbatim from `scopes` or — when omitted — the union of `requiredScopes` on the `auth_required` validators of the sibling rules the `mcp_handler` at `resource` maps its tools to, `resource_name` from `resourceName` or the MCP `serverInfo.name`, plus `bearer_methods_supported: ["header"]` and `Cache-Control: public, max-age=300`. The path-suffixed form (`…/oauth-protected-resource/api/mcp`) answers the same document when the suffix is `resource`; another suffix is a 404. A request naming no host is a 400.
- **Visibility gate:** a rule whose path answers `/.well-known/oauth-protected-resource*` and whose first enabled step is this handler is served on a private deployment without `bypassVisibility` — the handler implies it. The implication is deliberately that narrow (tightened after the first CI review): a rule at another path, or one that runs any step before the handler, gets no bypass and needs the explicit flag like anything else. Rules without the step behave exactly as before (an app-shipped `/.well-known` pipeline that never set `bypassVisibility` is still gated).
- **OAuth authorize flow (RFC 8707 `resource`):** when the alias's matched `/.well-known` rule (path-suffixed form first, then bare) is this handler *and* that step's `resource` is the requested path, `OAuthService` reads `scopes_supported` from the step config directly instead of fetching the document from itself. Anything else — an app-shipped rule, or a step publishing a different resource — keeps the in-process fetch unchanged.
- **Admin UI:** the step is selectable in the pipeline editor (group "Other", label "OAuth Discovery (MCP)") with a form for its four fields that shows which `mcp_handler` rule it found and the scopes it will derive. The `mcp_handler` editor's Server tab gains an "OAuth discovery (RFC 9728)" note: served by the handler step on rule X with `scopes_supported — declared: […]` / `derived: […]`, served by a custom rule, or no rule in this set.
- **Docs:** `CONTEXT.md` glossary entry for the protected-resource document updated; ADR-0005 gains an amendment paragraph recording this decision.

## Why

The maintainer's decision on #760 (option B): a declared step rather than a derive-on-miss fallback, because `scopes_supported` is the authorize flow's scope allowlist — whatever produces it decides what an OAuth client can be granted — so it belongs in a greppable, versioned rule with an explicit `scopes` escape hatch, not in an emergent branch invisible to `rules diff`. The one thing the hand-written copies got wrong (the issuer) is fixed by reusing the resolver CE already has (`OAUTH_ISSUER` → `ADMIN_DOMAIN` → `FRONTEND_URL`).

## What changed

- **Backend / pipelines:** `pipelines/mcp/protected-resource.ts` (pure derivation shared by the edge and OAuth: document, scope union, suffix matching, "does this rule serve the document"); `pipelines/handlers/oauth-protected-resource.handler.ts` (the step; injects `OAuthService` for the issuer and `RuleInvokerService` for the alias's rules); `HandlerType` + `OAuthProtectedResourceConfig` in `types.ts` / `step-handler.interface.ts`; registered in `pipelines.module.ts` (imports `OAuthModule` via `forwardRef`) and in the MCP-tools handler enum.
- **Backend / proxy-rules:** `proxy.middleware.ts` bypass check extended with `servesProtectedResourceDocument(matchedRule)`; the `WWW-Authenticate: Bearer resource_metadata=…` comments updated. `rule-invoker.service.ts` gains a public `effectiveRules(projectId, alias)` (its existing private resolution, lifted).
- **Backend / oauth:** `oauth.service.ts` `resolveResource` short-circuit through the step config (`RuleInvokerService` injected via `forwardRef`); `oauth.module.ts` imports `ProxyRulesModule` via `forwardRef`.
- **Frontend:** `handlers/OAuthProtectedResourceConfig.tsx` (new form), `handlers/mcp/discovery.ts` (pure mirror of the backend derivation), `mcp/McpServerSection.tsx` discovery note, `McpHandlerConfig.tsx` wiring; `HandlerType` + config type + wrapper/name/description + handler group entries; `AuthRequiredConfig.requiredScopes` type added.
- **Tests:** backend `oauth-protected-resource.handler.spec.ts`, `protected-resource.spec.ts`, two cases in `proxy.middleware.spec.ts`, two in `oauth.service.spec.ts`; frontend `OAuthProtectedResourceConfig.test.tsx`, `mcp/discovery.test.ts`, four cases in `McpHandlerConfig.test.tsx`.
- **Docs:** `CONTEXT.md`, `docs/adr/0005-built-in-oauth-authorization-server.md`; `.claude/ce-pr-review-checklist.md` gains the entry the CI review proposed (a step that implies `bypassVisibility` must gate on being the rule's whole answer).

## Compatibility

- **Migrations:** none — no schema change.
- **Pipeline / proxy-rule semantics:** opt-in only. A stored rule set behaves differently only if it contains a step of the new type, which none can today. The visibility-gate widening is keyed on the presence of that step, so existing `/.well-known` rules (with or without `bypassVisibility`) are gated exactly as before. The `OAuthService` short-circuit is taken only when the alias's matched rule is the new handler; every existing app-shipped document still goes through the fetch.
- **API / CLI contract:** additive. The CLI manifest's `handler` is `z.string()`, so `bffless rules push` accepts the new step with no CLI or `deploy-proxy-rules` release (unlike the `bypassVisibility` key in #730, this is a handler type, not a manifest key). Frontend `AuthRequiredConfig.requiredScopes` is a type-only addition mirroring what the backend already stores.
- **Env vars, nginx generation, storage layout, upload endpoint:** untouched.
- **Module graph:** two new `forwardRef` edges (`PipelinesModule → OAuthModule`, `OAuthModule → ProxyRulesModule`) on a graph that already resolves `ProxyRulesModule ↔ PipelinesModule` the same way. `OAuthService` gains a fourth constructor dependency (`RuleInvokerService`).

## Verification

Run in the worktree:

- `pnpm --filter backend exec tsc --noEmit` — clean
- `pnpm --filter frontend exec tsc --noEmit` — clean
- `pnpm --filter backend format:check` / `pnpm --filter frontend format:check` — "All matched files use Prettier code style!"
- Backend targeted: `pnpm test -- oauth-protected-resource protected-resource.spec proxy.middleware.spec oauth.service.spec rule-invoker.service.spec mcp.handler.spec` — 7 suites, 109 tests passed
- Backend full: `pnpm test` — 224 suites passed (2 skipped, pre-existing), 3740 tests passed (47 skipped, pre-existing)
- Frontend targeted: `vitest run OAuthProtectedResourceConfig discovery McpHandlerConfig McpToolList PipelineConfig.terminalBranches` — 5 files, 36 tests passed
- Frontend full: `vitest run` — 102 files passed, 1036 tests passed
- After the review tightening (second commit; touched only the two pure helpers, their specs, the middleware/OAuth specs and the checklist): backend `pnpm test -- oauth-protected-resource protected-resource.spec proxy.middleware.spec oauth.service.spec rule-invoker.service.spec` — 6 suites, 104 tests passed; frontend `vitest run OAuthProtectedResourceConfig discovery McpHandlerConfig` — 3 files, 21 tests passed; both `tsc --noEmit` and both `format:check` clean. CI re-runs the full suites.

## Out of scope / follow-ups

- The two app-shipped copies (`bffless/apps` workflow, `bffless/presentations` images) keep working unchanged; swapping them for the step is an apps-repo change once this ships (`resource: /api/workflow/mcp`, `scopes` declared or derived).
- `bffless/docs#75` (Build an MCP Server page) and `bffless/skills#62` (`mcp_handler` in the skills) should mention the new step; not touched here.
- The middleware's hand-rolled `findMatchingRule`/`matchesPattern` still wrap the shared `rule-resolution.ts` versions under aliased names — pre-existing, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ee7y8uVqxLtEtxpXUNgfF
