### PR TITLE
fix(pipelines): persist execution logs for in-process sibling invocations

### DIFF
--- a/apps/backend/src/db/schema/pipeline-execution-logs.schema.ts
+++ b/apps/backend/src/db/schema/pipeline-execution-logs.schema.ts
@@ -22,6 +22,21 @@ export interface PipelineLogRequestMeta {
   ip?: string;
   userAgent?: string;
   userId?: string;
+  /**
+   * Present when the run was not an edge request but an in-process sibling
+   * invocation (`RuleInvokerService`, e.g. an `mcp_handler` tool call): the
+   * rule that invoked it and the nesting depth (#738). Absent for edge runs.
+   */
+  invocation?: PipelineLogInvocationMeta;
+}
+
+/** How an in-process pipeline run was reached — stored in `requestMeta.invocation`. */
+export interface PipelineLogInvocationMeta {
+  source: 'in_process';
+  /** The calling rule's id (its pipeline id), when known. */
+  parentRuleId?: string;
+  /** The invocation depth: 1 for a sibling called directly by an edge-run rule. */
+  depth: number;
 }
 
 /**

--- a/apps/backend/src/pipelines/handlers/mcp.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/mcp.handler.spec.ts
@@ -146,6 +146,7 @@ describe('McpHandler', () => {
           body: { a: 1 },
           user: c.user,
           parent: c.request,
+          parentRuleId: c.pipelineId,
           depth: 1,
         }),
       );

--- a/apps/backend/src/pipelines/handlers/mcp.handler.ts
+++ b/apps/backend/src/pipelines/handlers/mcp.handler.ts
@@ -143,6 +143,7 @@ export class McpHandler implements StepHandler<McpHandlerConfig> {
             body: method === 'POST' ? args : undefined,
             user: context.user,
             parent: context.request,
+            parentRuleId: context.pipelineId,
             depth: parentDepth + 1,
           }),
         origins: async () => ({

--- a/apps/backend/src/proxy-rules/pipeline-from-rule.ts
+++ b/apps/backend/src/proxy-rules/pipeline-from-rule.ts
@@ -1,5 +1,6 @@
 import { PipelineConfig, ProxyRule } from '../db/schema/proxy-rules.schema';
 import { Pipeline, PipelineStep } from '../pipelines/types';
+import type { PipelineResult } from '../pipelines/execution/pipeline-context.interface';
 
 /**
  * A `Pipeline` from a pipeline proxy rule's stored config — shared by the edge
@@ -54,6 +55,27 @@ export function statusForPipelineError(code: string | undefined): number {
     default:
       return 500;
   }
+}
+
+/**
+ * Pipeline error codes that map to a 4xx response (`statusForPipelineError`):
+ * validator outcomes an anonymous caller can trigger on any public rule. These
+ * stay debug-gated for execution-log persistence; everything else in a failed
+ * result is treated as an execution failure and is always logged (#724).
+ * Expressed as an exclusion list so a future unmapped error code defaults to
+ * "persist" (fail-visible), matching its 500 response. Shared by the edge and
+ * the in-process invoker so a sibling is logged under the same rule (#738).
+ */
+export const CLIENT_FAULT_ERROR_CODES: ReadonlySet<string> = new Set([
+  'VALIDATION_ERROR', // 400
+  'AUTH_REQUIRED', // 401
+  'AUTHORIZATION_ERROR', // 403
+  'RATE_LIMIT_EXCEEDED', // 429
+]);
+
+/** A failed result that is not one of the client-fault validator outcomes — the always-logged bucket. */
+export function isExecutionFailure(result: Pick<PipelineResult, 'success' | 'error'>): boolean {
+  return !result.success && !CLIENT_FAULT_ERROR_CODES.has(result.error?.code ?? '');
 }
 
 /** `WWW-Authenticate` for a scope refusal (RFC 6750 §3.1), or undefined. */

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -30,6 +30,7 @@ import {
 } from '../pipelines/execution/pipeline-context.interface';
 import {
   insufficientScopeHeader,
+  isExecutionFailure,
   pipelineFromRule,
   statusForPipelineError,
 } from './pipeline-from-rule';
@@ -60,21 +61,6 @@ interface CacheEntry {
   rules: ProxyRule[];
   expiry: number;
 }
-
-/**
- * Pipeline error codes that map to a 4xx response (see the status mapping in
- * handlePipelineExecution): validator outcomes an anonymous caller can trigger
- * on any public rule. These stay debug-gated for execution-log persistence;
- * everything else in a failed result is treated as an execution failure and is
- * always logged (#724). Expressed as an exclusion list so a future unmapped
- * error code defaults to "persist" (fail-visible), matching its 500 response.
- */
-const CLIENT_FAULT_ERROR_CODES: ReadonlySet<string> = new Set([
-  'VALIDATION_ERROR', // 400
-  'AUTH_REQUIRED', // 401
-  'AUTHORIZATION_ERROR', // 403
-  'RATE_LIMIT_EXCEEDED', // 429
-]);
 
 @Injectable()
 export class ProxyMiddleware implements NestMiddleware {
@@ -1206,9 +1192,7 @@ export class ProxyMiddleware implements NestMiddleware {
       // load exactly under rate-limit/bot pressure and crowd the small
       // per-rule retention window with 4xx noise. An unmapped error code
       // defaults to "persist" (fail-visible).
-      const isExecutionFailure =
-        !result.success && !CLIENT_FAULT_ERROR_CODES.has(result.error?.code ?? '');
-      const shouldPersistLog = rule.debugEnabled || isExecutionFailure;
+      const shouldPersistLog = rule.debugEnabled || isExecutionFailure(result);
       const logId = shouldPersistLog ? randomUUID() : undefined;
 
       if (result.success && result.response) {

--- a/apps/backend/src/proxy-rules/rule-invoker.service.spec.ts
+++ b/apps/backend/src/proxy-rules/rule-invoker.service.spec.ts
@@ -82,9 +82,17 @@ function make(rules: unknown[]) {
       },
     }),
   };
-  const service = new RuleInvokerService(proxyRulesService as never, execution as never);
-  return { service, proxyRulesService, execution };
+  const executionLog = { log: jest.fn().mockResolvedValue('log-1') };
+  const service = new RuleInvokerService(
+    proxyRulesService as never,
+    execution as never,
+    executionLog as never,
+  );
+  return { service, proxyRulesService, execution, executionLog };
 }
+
+/** Let the fire-and-forget persistence chain settle. */
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
 
 const base = {
   projectId: 'proj-1',
@@ -95,6 +103,7 @@ const base = {
   body: { a: 1 },
   user: { id: 'u', credential: 'app_token' as const, scopes: ['app:read'] },
   parent,
+  parentRuleId: 'rule-mcp',
   depth: 1,
 };
 
@@ -313,6 +322,132 @@ describe('RuleInvokerService', () => {
     expect(structuredBody('{not json', 'application/json')).toBe('{not json');
   });
 
+  describe('execution logs (#738): a sibling is logged the way the edge logs the rule', () => {
+    const debugInfo = {
+      validators: [],
+      steps: [{ name: 'respond', handlerType: 'response_handler', success: true }],
+      totalDurationMs: 3,
+      startTime: 's',
+      endTime: 'e',
+    };
+
+    it('a debugEnabled sibling captures debug and persists one row tagged as an in-process invocation', async () => {
+      const { service, execution, executionLog } = make([rule({ debugEnabled: true })]);
+      execution.executePipelineWithDebug.mockResolvedValueOnce({
+        success: true,
+        response: { status: 200, body: { ok: true }, headers: {} },
+        debug: debugInfo,
+      });
+      const result = await service.invoke(base);
+      expect(result).toMatchObject({ ok: true, answer: { status: 200 } });
+      expect(execution.executePipelineWithDebug.mock.calls[0][3]).toEqual({
+        deployment: base.deployment,
+        captureDebug: true,
+      });
+      await flush();
+      expect(executionLog.log).toHaveBeenCalledTimes(1);
+      const [ruleId, projectId, logged, meta, method, path] = executionLog.log.mock.calls[0];
+      expect(ruleId).toBe('rule-1');
+      expect(projectId).toBe('proj-1');
+      expect(logged.debug).toBe(debugInfo);
+      expect(meta).toEqual({
+        ip: '1.2.3.4',
+        userAgent: 'ua',
+        userId: 'u',
+        invocation: { source: 'in_process', parentRuleId: 'rule-mcp', depth: 1 },
+      });
+      expect(method).toBe('POST');
+      expect(path).toBe('/api/app/read');
+    });
+
+    it('a sibling with debug off persists nothing on success or on a client-fault outcome', async () => {
+      const { service, execution, executionLog } = make([rule({ debugEnabled: false })]);
+      await service.invoke(base);
+      expect(execution.executePipelineWithDebug.mock.calls[0][3]).toEqual({
+        deployment: base.deployment,
+        captureDebug: false,
+      });
+      for (const code of [
+        'VALIDATION_ERROR',
+        'AUTH_REQUIRED',
+        'AUTHORIZATION_ERROR',
+        'RATE_LIMIT_EXCEEDED',
+      ]) {
+        execution.executePipelineWithDebug.mockResolvedValueOnce({
+          success: false,
+          error: { code, message: 'no' },
+        });
+        mockDb.limit.mockResolvedValueOnce([project]).mockResolvedValueOnce([aliasRow]);
+        await service.invoke(base);
+      }
+      await flush();
+      expect(executionLog.log).not.toHaveBeenCalled();
+    });
+
+    it('an execution failure is always persisted, debug off (#724 parity), under its 500 status', async () => {
+      const { service, execution, executionLog } = make([rule({ debugEnabled: false })]);
+      execution.executePipelineWithDebug.mockResolvedValueOnce({
+        success: false,
+        error: { code: 'HANDLER_ERROR', message: 'boom', step: 'respond' },
+      });
+      expect(await service.invoke(base)).toMatchObject({ ok: true, answer: { status: 500 } });
+      await flush();
+      expect(executionLog.log).toHaveBeenCalledTimes(1);
+      expect(executionLog.log.mock.calls[0][2]).toEqual({
+        success: false,
+        error: { code: 'HANDLER_ERROR', message: 'boom', step: 'respond' },
+      });
+      expect(executionLog.log.mock.calls[0][3].invocation).toEqual({
+        source: 'in_process',
+        parentRuleId: 'rule-mcp',
+        depth: 1,
+      });
+    });
+
+    it('a thrown execution is answered as an error failure and still persisted', async () => {
+      const { service, execution, executionLog } = make([rule({ debugEnabled: false })]);
+      execution.executePipelineWithDebug.mockRejectedValueOnce(new Error('kaboom'));
+      expect(await service.invoke(base)).toEqual({
+        ok: false,
+        failure: { kind: 'error', message: 'kaboom' },
+      });
+      await flush();
+      expect(executionLog.log).toHaveBeenCalledTimes(1);
+      expect(executionLog.log.mock.calls[0][2]).toEqual({
+        success: false,
+        error: { code: 'PIPELINE_EXECUTION_ERROR', message: 'kaboom' },
+      });
+    });
+
+    it('waits for post-steps so their debug info lands in the row, and omits parentRuleId when unknown', async () => {
+      const { service, execution, executionLog } = make([rule({ debugEnabled: true })]);
+      const postSteps = [{ name: 'after', handlerType: 'webhook', success: true }];
+      const debug = { ...debugInfo };
+      execution.executePipelineWithDebug.mockResolvedValueOnce({
+        success: true,
+        response: { status: 200, body: {}, headers: {} },
+        debug,
+        postStepsPromise: Promise.resolve(postSteps),
+      });
+      await service.invoke({ ...base, parentRuleId: undefined });
+      await flush();
+      expect(executionLog.log).toHaveBeenCalledTimes(1);
+      expect(executionLog.log.mock.calls[0][2].debug.postSteps).toBe(postSteps);
+      expect(executionLog.log.mock.calls[0][3].invocation).toEqual({
+        source: 'in_process',
+        depth: 1,
+      });
+    });
+
+    it('a failing insert never reaches the caller', async () => {
+      const { service, executionLog } = make([rule({ debugEnabled: true })]);
+      executionLog.log.mockRejectedValueOnce(new Error('db down'));
+      expect(await service.invoke(base)).toMatchObject({ ok: true, answer: { status: 200 } });
+      await flush();
+      expect(executionLog.log).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("caches the alias's rules for a short window", async () => {
     const { service, proxyRulesService } = make([rule()]);
     await service.invoke(base);
@@ -377,7 +512,11 @@ describe('publicPrefixOf', () => {
         .fn()
         .mockResolvedValue({ success: true, response: { status: 200, body: {} } }),
     };
-    const service = new RuleInvokerService(proxyRulesService as never, execution as never);
+    const service = new RuleInvokerService(
+      proxyRulesService as never,
+      execution as never,
+      { log: jest.fn().mockResolvedValue('log-1') } as never,
+    );
     mockDb.limit.mockReset();
     mockDb.limit.mockResolvedValueOnce([project]).mockResolvedValueOnce([aliasRow]);
     const parentEdge = {

--- a/apps/backend/src/proxy-rules/rule-invoker.service.ts
+++ b/apps/backend/src/proxy-rules/rule-invoker.service.ts
@@ -5,10 +5,16 @@ import { db } from '../db/client';
 import { deploymentAliases, projects } from '../db/schema';
 import { ProxyRule } from '../db/schema/proxy-rules.schema';
 import { PipelineExecutionService } from '../pipelines/execution';
-import { PipelineContext, PipelineUser } from '../pipelines/execution/pipeline-context.interface';
+import {
+  PipelineContext,
+  PipelineDebugResult,
+  PipelineUser,
+} from '../pipelines/execution/pipeline-context.interface';
+import { PipelineExecutionLogService } from '../pipelines/pipeline-execution-log.service';
 import { ProxyRulesService } from './proxy-rules.service';
 import {
   insufficientScopeHeader,
+  isExecutionFailure,
   pipelineFromRule,
   statusForPipelineError,
 } from './pipeline-from-rule';
@@ -29,6 +35,8 @@ export interface InvokeRequest {
   user: PipelineUser | undefined;
   /** The parent request: headers, cookies, ip, user-agent are copied onto the synthetic one. */
   parent: Request;
+  /** The calling rule's id (its pipeline id) — recorded on the sibling's execution log (#738). */
+  parentRuleId?: string;
   /** The parent's depth + 1; beyond MAX_INVOKE_DEPTH is refused. */
   depth: number;
 }
@@ -75,6 +83,8 @@ export class RuleInvokerService {
     private readonly proxyRulesService: ProxyRulesService,
     @Inject(forwardRef(() => PipelineExecutionService))
     private readonly pipelineExecutionService: PipelineExecutionService,
+    @Inject(forwardRef(() => PipelineExecutionLogService))
+    private readonly executionLogService: PipelineExecutionLogService,
   ) {}
 
   async invoke(req: InvokeRequest): Promise<InvokeResult> {
@@ -148,12 +158,35 @@ export class RuleInvokerService {
     }
 
     const synthetic = this.syntheticRequest(req);
-    const result = await this.pipelineExecutionService.executePipelineWithDebug(
-      pipeline,
-      synthetic,
-      req.user,
-      { deployment: req.deployment, captureDebug: false },
-    );
+    let result: PipelineDebugResult;
+    try {
+      result = await this.pipelineExecutionService.executePipelineWithDebug(
+        pipeline,
+        synthetic,
+        req.user,
+        // Only retain in-memory debug snapshots when this rule persists them —
+        // the edge's rule (handlePipelineExecution), not a blanket `false`.
+        { deployment: req.deployment, captureDebug: rule.debugEnabled },
+      );
+    } catch (error) {
+      // A thrown error is an execution failure: always leave a row (#724),
+      // as the edge does, so an mcp_handler tool that blew up is visible.
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Sibling pipeline ${rule.id} failed: ${message}`);
+      this.persistLog(
+        rule,
+        req,
+        synthetic,
+        { success: false, error: { code: 'PIPELINE_EXECUTION_ERROR', message } },
+        true,
+      );
+      return { ok: false, failure: { kind: 'error', message } };
+    }
+
+    // Same persistence gate as the edge: debug-enabled rules log every run;
+    // execution failures (the 500 bucket) always log; client-fault validator
+    // outcomes (400/401/403/429) stay debug-gated.
+    this.persistLog(rule, req, synthetic, result, rule.debugEnabled || isExecutionFailure(result));
 
     if (result.success && result.response) {
       const headers = { ...(result.response.headers ?? {}) };
@@ -181,6 +214,56 @@ export class RuleInvokerService {
         contentType: 'application/json',
       },
     };
+  }
+
+  /**
+   * Fire-and-forget: persist the sibling's execution log the way the edge does
+   * for a rule it runs itself, tagged as an in-process invocation
+   * (`requestMeta.invocation`: the calling rule and the depth) so an operator
+   * reading the rule's logs can tell a tool call from an edge request (#738).
+   * Post-steps are awaited first so their debug info is included. Never
+   * throws and never delays the answer.
+   */
+  private persistLog(
+    rule: ProxyRule,
+    req: InvokeRequest,
+    synthetic: Request,
+    result: PipelineDebugResult,
+    shouldPersist: boolean,
+  ): void {
+    if (!shouldPersist) return;
+    const persist = async () => {
+      if (result.postStepsPromise) {
+        try {
+          const postStepsDebug = await result.postStepsPromise;
+          if (result.debug && postStepsDebug.length > 0) {
+            result.debug.postSteps = postStepsDebug;
+          }
+        } catch (err) {
+          this.logger.error('Failed to capture post-steps debug info', err);
+        }
+      }
+      await this.executionLogService.log(
+        rule.id,
+        req.projectId,
+        result,
+        {
+          ip: synthetic.ip,
+          userAgent: first(synthetic.headers['user-agent']),
+          userId: req.user?.id,
+          invocation: {
+            source: 'in_process',
+            ...(req.parentRuleId ? { parentRuleId: req.parentRuleId } : {}),
+            depth: req.depth,
+          },
+        },
+        req.method,
+        synthetic.path,
+      );
+    };
+    persist().catch((err) =>
+      this.logger.error('Failed to persist pipeline execution log for sibling invocation', err),
+    );
   }
 
   /**


### PR DESCRIPTION
Closes #738

## Summary
When an `mcp_handler` rule called a sibling tool rule in-process, that sibling's run left no pipeline execution log — even with the sibling's debug toggle switched on. An operator debugging an MCP tool (where the host only shows a wrapped result) had nothing to read. The in-process invoker now honours the sibling rule's `debugEnabled` and persists the run exactly the way the edge does for a directly-hit rule, so the rule's log list in the admin UI (and `list_pipeline_logs`) shows tool calls too. Each such row is tagged as an in-process invocation with the calling rule's id and depth.

## Behaviour changes
- Sibling pipeline invoked via `mcp_handler`, sibling rule has debug **on**: before → no log row; after → one `pipeline_execution_logs` row per call, with full step debug, under the sibling rule (additive).
- Sibling rule has debug **off**, run hits an execution failure (500 bucket, or a thrown error): before → nothing; after → one row (the same always-log-failures rule the edge applies since #724). Client-fault validator outcomes (400/401/403/429) stay debug-gated, as at the edge — no new write load from routine rejections.
- Sibling rule has debug **off**, run succeeds: unchanged — nothing persisted, no debug snapshots retained in memory.
- Log rows produced this way carry `requestMeta.invocation = { source: 'in_process', parentRuleId, depth }`; edge rows are unchanged (field absent).
- A sibling pipeline that **throws** used to propagate out of the invoker and fail the whole MCP request (the parent's edge run logged a `PIPELINE_EXECUTION_ERROR` against the *parent* rule). It is now caught, logged against the *sibling* rule, and returned to the MCP protocol as an `isError` tool result — the same `{ kind: 'error' }` path an `external_proxy` sibling already takes on a fetch failure, and the MCP-idiomatic way for the host model to see the failure.

## Why
`RuleInvokerService.invokePipeline` passed `captureDebug: false` and returned without touching `PipelineExecutionLogService`, while `ProxyMiddleware.handlePipelineExecution` (edge) and `OnboardingExecutorService.executeRunPipeline` (system trigger) both persist. This mirrors the onboarding precedent and reuses the edge's exact persistence gate rather than inventing a third one — the client-fault code set is lifted into the shared `pipeline-from-rule.ts` module (already the home of the edge/invoker parity helpers) so both call sites read one definition.

## What changed
- **backend / proxy-rules:** `rule-invoker.service.ts` — injects `PipelineExecutionLogService`, `captureDebug: rule.debugEnabled`, try/catch around execution, fire-and-forget `persistLog()` (awaits post-steps first, like the edge); new optional `InvokeRequest.parentRuleId`. `pipeline-from-rule.ts` — exports `CLIENT_FAULT_ERROR_CODES` + `isExecutionFailure()`; `proxy.middleware.ts` now imports them instead of its private copy (no logic change).
- **backend / schema (TS only):** `pipeline-execution-logs.schema.ts` — optional `PipelineLogRequestMeta.invocation` (`PipelineLogInvocationMeta`). JSONB column, no migration.
- **backend / pipelines:** `mcp.handler.ts` — passes `context.pipelineId` (its own rule id) as `parentRuleId`.
- **tests:** `rule-invoker.service.spec.ts` — six new cases (debug-on logs + captures, debug-off logs nothing on success or any client-fault code, execution failure always logged, thrown error logged + answered as error, post-steps awaited + `parentRuleId` omitted when unknown, failing insert never reaches the caller). `mcp.handler.spec.ts` — pins `parentRuleId`.

## Compatibility
- **Migrations:** none. `requestMeta` is free-form JSONB; the new key is a TS interface field, absent on all existing rows.
- **API / CLI contract:** additive only — `GET /api/pipeline-logs/:id` may now return `requestMeta.invocation`; no field removed or renamed. `packages/cli` untouched.
- **Pipeline semantics:** no change to what any stored rule set answers. Persistence for sibling runs is opt-in via the sibling rule's existing `debugEnabled` toggle, plus the same failure-only fallback the edge already has. Retention (50/rule) and redaction unchanged. The one observable behaviour change (a throwing sibling now yields a tool error result instead of a 500 on the MCP request) is called out above.
- **Env vars / nginx / storage layout:** untouched.

## Verification
```
pnpm --filter backend exec tsc --noEmit    → exit 0
pnpm --filter frontend exec tsc --noEmit   → exit 0
apps/backend: pnpm test -- "rule-invoker|mcp.handler|proxy.middleware"
  → Test Suites: 3 passed, 3 total; Tests: 68 passed, 68 total
apps/backend: pnpm test (full)
  → Test Suites: 224 passed, 2 skipped, 224 of 226; Tests: 3748 passed, 47 skipped, 3795 total; exit 0
pnpm --filter backend format:check         → All matched files use Prettier code style!
```

## Out of scope / follow-ups
- **#616** — scheduled/cron pipeline runs still hardcode `captureDebug: false` and skip persistence for a different reason (different call site). Not touched here; when it is fixed, `isExecutionFailure()` from `pipeline-from-rule.ts` is the gate to reuse and `requestMeta.invocation` (with a different `source`) the tag to reuse.
- The invoker does not surface the new row's id to the MCP host (the edge sets `X-Pipeline-Log-Id`; there is no equivalent slot in a tool result). Easy to add to `InvokeAnswer` later if the Workflow harness wants to link straight to a log.
- The admin UI's log detail view does not yet render `requestMeta.invocation` specially; it appears in the raw request metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JztpRG45wFyxZyy56PeNLp
