### PR TITLE
feat(oauth): accept Client ID Metadata Document URLs as client_id (CIMD)

### DIFF
--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -281,6 +281,20 @@ controls `bypassVisibility` already), but a silent widening.
 **Learned from:** PR #761, 2026-09-06 — the first cut scanned all steps for `oauth_protected_resource`;
 narrowed in the same PR to well-known rules whose first enabled step is the handler.
 
+### A fetch of a caller-supplied URL needs the whole SSRF guard, not a hostname regex
+**Surface:** any new server-side fetch whose URL comes from a request — `apps/backend/src/oauth/client-metadata.service.ts`
+(Client ID Metadata Documents), `proxy-rules.service.ts` `validateTargetUrl` (rule targets), future webhook /
+import-by-URL features.
+**Check:** Does the guard (1) require https and a domain name (never an IP literal, never a local /
+`.internal` / `.svc` / `.cluster.local` suffix), (2) resolve the name and refuse if *any* address is
+non-public — including IPv6 forms that embed an IPv4 (`::ffff:`, NAT64, 6to4), (3) pin the connection to the
+vetted addresses so the name is not resolved again between check and connect, (4) refuse redirects, and
+(5) bound the read with a timeout and a byte cap? A hostname/regex check alone (the `validateTargetUrl`
+TODO) is bypassed by a public name that resolves to `169.254.169.254`.
+**Why:** The backend runs next to the metadata endpoint, the database, MinIO and the other pods; one
+missed step turns "fetch my client metadata" into "read the instance credentials".
+**Learned from:** #741, 2026-09-07 — the triage comment flagged it before the code was written.
+
 ---
 
 ## Entry template

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,7 +46,7 @@ A per-rule opt-out of the deployment visibility gate (`bypassVisibility: true` i
 _Avoid_: "public rule" (deployment visibility is a different setting)
 
 **Authorization server**:
-CE's built-in OAuth 2.1 server on the admin host — the issuer is `https://<ADMIN_DOMAIN>` (or `OAUTH_ISSUER`), never `FRONTEND_URL`, which is the public site (`/api/oauth/*`; RFC 8414 metadata at `/.well-known/oauth-authorization-server`). Clients register themselves (RFC 7591, public clients only); a member consents per project and per scope on `/oauth/consent`; the access token _is_ an App token, bound to the project the RFC 8707 `resource` named. Not SuperTokens' OAuth2Provider recipe (ADR-0005).
+CE's built-in OAuth 2.1 server on the admin host — the issuer is `https://<ADMIN_DOMAIN>` (or `OAUTH_ISSUER`), never `FRONTEND_URL`, which is the public site (`/api/oauth/*`; RFC 8414 metadata at `/.well-known/oauth-authorization-server`). Clients register themselves (RFC 7591, public clients only) or present an `https://` URL as `client_id` — a Client ID Metadata Document CE fetches through an SSRF guard and caches (claude.ai's recommended connector mode; advertised as `client_id_metadata_document_supported`); a member consents per project and per scope on `/oauth/consent`; the access token _is_ an App token, bound to the project the RFC 8707 `resource` named. Not SuperTokens' OAuth2Provider recipe (ADR-0005).
 _Avoid_: "SuperTokens OAuth", "SSO" (that is the member's own login, the other direction)
 
 **Protected-resource document**:

--- a/apps/backend/src/oauth/client-metadata.service.spec.ts
+++ b/apps/backend/src/oauth/client-metadata.service.spec.ts
@@ -1,0 +1,325 @@
+import {
+  CIMD_CLIENT_NAMESPACE,
+  CIMD_DEFAULT_TTL_MS,
+  CIMD_MAX_TTL_MS,
+  ClientMetadataService,
+  ClientMetadataTransport,
+  assertClientIdUrl,
+  isPublicAddress,
+  parseClientMetadataDocument,
+  pinnedLookup,
+  readCapped,
+  ttlFrom,
+} from './client-metadata.service';
+import { OAuthError } from './oauth.errors';
+import { Test } from '@nestjs/testing';
+
+const URL_ = 'https://claude.ai/.well-known/oauth-client-metadata';
+const doc = (over: Record<string, unknown> = {}) => ({
+  client_id: URL_,
+  client_name: 'Claude',
+  client_uri: 'https://claude.ai',
+  redirect_uris: ['https://claude.ai/api/mcp/auth_callback'],
+  grant_types: ['authorization_code', 'refresh_token'],
+  response_types: ['code'],
+  token_endpoint_auth_method: 'none',
+  logo_uri: 'https://claude.ai/logo.png',
+  ...over,
+});
+const PUBLIC = [{ address: '104.18.1.1', family: 4 as const }];
+
+function make(over: Partial<ClientMetadataTransport> = {}) {
+  const transport = {
+    lookup: jest.fn().mockResolvedValue(PUBLIC),
+    fetch: jest.fn().mockResolvedValue({
+      status: 200,
+      headers: { get: () => null },
+      text: JSON.stringify(doc()),
+    }),
+    ...over,
+  };
+  return { service: new ClientMetadataService(transport as never), transport };
+}
+
+describe('ClientMetadataService — Client ID Metadata Documents (#741)', () => {
+  it('is constructible by Nest with no transport bound (the network is the default)', async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [ClientMetadataService],
+    }).compile();
+    const service = moduleRef.get(ClientMetadataService);
+    expect(service.isClientIdUrl(URL_)).toBe(true);
+    await expect(service.resolve('https://localhost/metadata')).rejects.toMatchObject({
+      error: 'invalid_client',
+    });
+  });
+
+  it('maps a URL to the same uuid every time, under a namespace that must never change', () => {
+    const { service } = make();
+    expect(service.isClientIdUrl(URL_)).toBe(true);
+    expect(service.isClientIdUrl('http://x.example/m')).toBe(true);
+    expect(service.isClientIdUrl('4a3c9d5e-0000-4000-8000-000000000000')).toBe(false);
+    const id = service.clientIdFor(URL_);
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    expect(service.clientIdFor(URL_)).toBe(id);
+    expect(service.clientIdFor('https://other.example/m')).not.toBe(id);
+    expect(service.normalizeClientId(URL_)).toBe(id);
+    expect(service.normalizeClientId('c1')).toBe('c1');
+    // pinned: issued codes and refresh tokens reference the uuid this namespace produces
+    expect(CIMD_CLIENT_NAMESPACE).toBe('5b7d4a3e-9c21-4f6e-8d0a-1e2f3c4b5a69');
+    expect(service.clientIdFor('https://example.com/client')).toBe(
+      '4a1038f8-a30c-5c55-904e-6259b04636e7',
+    );
+  });
+
+  describe('resolve', () => {
+    it('vets the host, fetches with the vetted addresses, reads the RFC 7591 fields, and caches', async () => {
+      const { service, transport } = make();
+      const out = await service.resolve(URL_);
+      expect(transport.lookup).toHaveBeenCalledWith('claude.ai');
+      expect(transport.fetch).toHaveBeenCalledWith(
+        URL_,
+        expect.objectContaining({ addresses: PUBLIC, signal: expect.any(AbortSignal) }),
+      );
+      expect(out).toEqual({
+        clientId: URL_,
+        clientName: 'Claude',
+        clientUri: 'https://claude.ai',
+        redirectUris: ['https://claude.ai/api/mcp/auth_callback'],
+        grantTypes: ['authorization_code', 'refresh_token'],
+        tokenEndpointAuthMethod: 'none',
+      });
+      await service.resolve(URL_);
+      expect(transport.fetch).toHaveBeenCalledTimes(1);
+      service.clearCache();
+      await service.resolve(URL_);
+      expect(transport.fetch).toHaveBeenCalledTimes(2);
+    });
+    it('does not cache a document that says no-store, and re-fetches after max-age', async () => {
+      const { service, transport } = make({
+        fetch: jest.fn().mockResolvedValue({
+          status: 200,
+          headers: { get: () => 'no-store' },
+          text: JSON.stringify(doc()),
+        }),
+      });
+      await service.resolve(URL_);
+      await service.resolve(URL_);
+      expect(transport.fetch).toHaveBeenCalledTimes(2);
+      expect(ttlFrom(null)).toBe(CIMD_DEFAULT_TTL_MS);
+      expect(ttlFrom('public, max-age=60')).toBe(60_000);
+      expect(ttlFrom('max-age=0')).toBe(0);
+      expect(ttlFrom('max-age=999999999')).toBe(CIMD_MAX_TTL_MS);
+      expect(ttlFrom('no-cache')).toBe(CIMD_DEFAULT_TTL_MS);
+    });
+    it('refuses a host that resolves to any non-public address, without fetching', async () => {
+      const { service, transport } = make({
+        lookup: jest.fn().mockResolvedValue([
+          { address: '104.18.1.1', family: 4 },
+          { address: '10.0.0.5', family: 4 },
+        ]),
+      });
+      await expect(service.resolve(URL_)).rejects.toMatchObject({
+        error: 'invalid_client',
+        status: 401,
+      });
+      expect(transport.fetch).not.toHaveBeenCalled();
+      const unresolved = make({ lookup: jest.fn().mockRejectedValue(new Error('ENOTFOUND')) });
+      await expect(unresolved.service.resolve(URL_)).rejects.toMatchObject({
+        error: 'invalid_client',
+      });
+      const empty = make({ lookup: jest.fn().mockResolvedValue([]) });
+      await expect(empty.service.resolve(URL_)).rejects.toMatchObject({ error: 'invalid_client' });
+    });
+    it('a fetch failure, a redirect, a non-JSON body, or a document naming another client_id is invalid_client', async () => {
+      const failing = make({ fetch: jest.fn().mockRejectedValue(new Error('timeout')) });
+      await expect(failing.service.resolve(URL_)).rejects.toMatchObject({
+        error: 'invalid_client',
+        description: 'the client metadata document could not be fetched',
+      });
+      const redirect = make({
+        fetch: jest.fn().mockResolvedValue({ status: 302, headers: { get: () => null }, text: '' }),
+      });
+      await expect(redirect.service.resolve(URL_)).rejects.toMatchObject({
+        description: 'the client metadata document answered 302',
+      });
+      const html = make({
+        fetch: jest
+          .fn()
+          .mockResolvedValue({ status: 200, headers: { get: () => null }, text: '<html>' }),
+      });
+      await expect(html.service.resolve(URL_)).rejects.toMatchObject({
+        description: 'the client metadata document is not JSON',
+      });
+      const other = make({
+        fetch: jest.fn().mockResolvedValue({
+          status: 200,
+          headers: { get: () => null },
+          text: JSON.stringify(doc({ client_id: 'https://claude.ai/other' })),
+        }),
+      });
+      await expect(other.service.resolve(URL_)).rejects.toMatchObject({ error: 'invalid_client' });
+      // none of those are cached
+      expect(other.transport.fetch).toHaveBeenCalledTimes(1);
+      await expect(other.service.resolve(URL_)).rejects.toThrow(OAuthError);
+      expect(other.transport.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('assertClientIdUrl', () => {
+    it('accepts an https URL naming a public domain (a port and a query are fine)', () => {
+      expect(assertClientIdUrl(URL_).hostname).toBe('claude.ai');
+      expect(assertClientIdUrl('https://example.com:8443/client?v=2').port).toBe('8443');
+    });
+    it.each([
+      ['not a url', 'not-a-url'],
+      ['http', 'http://claude.ai/metadata'],
+      ['credentials', 'https://user:pw@claude.ai/metadata'],
+      ['fragment', 'https://claude.ai/metadata#frag'],
+      ['dot segment', 'https://claude.ai/a/../metadata'],
+      ['single dot', 'https://claude.ai/./metadata'],
+      ['ipv4 literal', 'https://169.254.169.254/latest/meta-data'],
+      ['ipv6 literal', 'https://[::1]/metadata'],
+      ['localhost', 'https://localhost/metadata'],
+      ['single label', 'https://intranet/metadata'],
+      ['.internal', 'https://metadata.google.internal/computeMetadata'],
+      ['.svc', 'https://backend.default.svc/metadata'],
+      ['.cluster.local', 'https://backend.default.svc.cluster.local/metadata'],
+      ['.localhost', 'https://app.localhost/metadata'],
+    ])('refuses %s', (_name, url) => {
+      expect(() => assertClientIdUrl(url)).toThrow(OAuthError);
+      try {
+        assertClientIdUrl(url);
+      } catch (error) {
+        expect((error as OAuthError).error).toBe('invalid_client');
+        expect((error as OAuthError).getStatus()).toBe(401);
+      }
+    });
+  });
+
+  describe('parseClientMetadataDocument', () => {
+    it('reads the fields the way registration validates them; falls back to the hostname as a name', () => {
+      expect(parseClientMetadataDocument(doc({ client_name: '  ' }), URL_).clientName).toBe(
+        'claude.ai',
+      );
+      expect(
+        parseClientMetadataDocument(doc({ grant_types: ['implicit'] }), URL_).grantTypes,
+      ).toEqual(['authorization_code', 'refresh_token']);
+      expect(
+        parseClientMetadataDocument(doc({ grant_types: ['authorization_code'] }), URL_).grantTypes,
+      ).toEqual(['authorization_code']);
+      expect(
+        parseClientMetadataDocument(doc({ token_endpoint_auth_method: 'private_key_jwt' }), URL_)
+          .tokenEndpointAuthMethod,
+      ).toBe('private_key_jwt');
+      expect(parseClientMetadataDocument(doc({ client_uri: 7 }), URL_)).not.toHaveProperty(
+        'clientUri',
+      );
+    });
+    it.each([
+      ['an array', []],
+      ['a string', 'x'],
+      ['no client_id', doc({ client_id: undefined })],
+      ['another client_id', doc({ client_id: 'https://claude.ai/other' })],
+      ['no redirect_uris', doc({ redirect_uris: undefined })],
+      ['empty redirect_uris', doc({ redirect_uris: [] })],
+      ['non-string redirect_uris', doc({ redirect_uris: [1] })],
+      ['a plain-http remote redirect', doc({ redirect_uris: ['http://evil.example/cb'] })],
+    ])('refuses %s', (_name, raw) => {
+      expect(() => parseClientMetadataDocument(raw, URL_)).toThrow(OAuthError);
+    });
+    it('allows http on localhost as a redirect, like registration does', () => {
+      expect(
+        parseClientMetadataDocument(doc({ redirect_uris: ['http://localhost:8080/cb'] }), URL_)
+          .redirectUris,
+      ).toEqual(['http://localhost:8080/cb']);
+    });
+  });
+
+  describe('isPublicAddress', () => {
+    it.each([
+      '104.18.1.1',
+      '8.8.8.8',
+      '203.0.113.9',
+      '2606:4700::6810:1',
+      '::ffff:8.8.8.8',
+      '64:ff9b::808:808',
+      '2002:808:808::',
+    ])('%s is public', (ip) => expect(isPublicAddress(ip)).toBe(true));
+    it.each([
+      '127.0.0.1',
+      '127.8.8.8',
+      '10.1.2.3',
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.1.1',
+      '169.254.169.254',
+      '100.64.0.1',
+      '0.0.0.0',
+      '192.0.0.8',
+      '198.18.0.1',
+      '224.0.0.1',
+      '255.255.255.255',
+      '::',
+      '::1',
+      '::ffff:127.0.0.1',
+      '::ffff:10.0.0.1',
+      '::ffff:7f00:1',
+      '64:ff9b::a00:1',
+      '2002:a00:1::',
+      'fc00::1',
+      'fd12:3456::1',
+      'fe80::1',
+      'fe80::1%eth0',
+      'ff02::1',
+      '2001:db8::1',
+      'not-an-ip',
+    ])('%s is not', (ip) => expect(isPublicAddress(ip)).toBe(false));
+    it('a public IPv4 is not public when 172.15 / 172.32 style neighbours are mistaken for private', () => {
+      expect(isPublicAddress('172.15.0.1')).toBe(true);
+      expect(isPublicAddress('172.32.0.1')).toBe(true);
+      expect(isPublicAddress('100.63.0.1')).toBe(true);
+      expect(isPublicAddress('100.128.0.1')).toBe(true);
+    });
+  });
+
+  describe('the connection is pinned to the vetted addresses', () => {
+    it('answers net.connect from them, in both callback shapes', () => {
+      const lookup = pinnedLookup([
+        { address: '104.18.1.1', family: 4 },
+        { address: '2606:4700::1', family: 6 },
+      ]);
+      const all = jest.fn();
+      lookup('claude.ai', { all: true }, all);
+      expect(all).toHaveBeenCalledWith(null, [
+        { address: '104.18.1.1', family: 4 },
+        { address: '2606:4700::1', family: 6 },
+      ]);
+      const one = jest.fn();
+      lookup('claude.ai', {}, one);
+      expect(one).toHaveBeenCalledWith(null, '104.18.1.1', 4);
+      const short = jest.fn();
+      lookup('claude.ai', short);
+      expect(short).toHaveBeenCalledWith(null, '104.18.1.1', 4);
+    });
+  });
+
+  describe('readCapped', () => {
+    const stream = (...parts: string[]) =>
+      (async function* () {
+        for (const p of parts) yield Buffer.from(p);
+      })();
+    it('joins chunks under the cap and throws — stopping the read — past it', async () => {
+      await expect(readCapped(stream('{"a":', '1}'), 100)).resolves.toBe('{"a":1}');
+      await expect(readCapped(null, 100)).resolves.toBe('');
+      let pulled = 0;
+      const big = (async function* () {
+        for (;;) {
+          pulled += 1;
+          yield Buffer.alloc(1024);
+        }
+      })();
+      await expect(readCapped(big, 4096)).rejects.toThrow('exceeds 4096 bytes');
+      expect(pulled).toBe(5);
+    });
+  });
+});

--- a/apps/backend/src/oauth/client-metadata.service.spec.ts
+++ b/apps/backend/src/oauth/client-metadata.service.spec.ts
@@ -244,6 +244,10 @@ describe('ClientMetadataService — Client ID Metadata Documents (#741)', () => 
       '::ffff:8.8.8.8',
       '64:ff9b::808:808',
       '2002:808:808::',
+      '2001:3::1',
+      '2001:20::1',
+      '100:1::1',
+      '4000::1',
     ])('%s is public', (ip) => expect(isPublicAddress(ip)).toBe(true));
     it.each([
       '127.0.0.1',
@@ -272,6 +276,12 @@ describe('ClientMetadataService — Client ID Metadata Documents (#741)', () => 
       'fe80::1%eth0',
       'ff02::1',
       '2001:db8::1',
+      '100::1',
+      '2001:2::1',
+      '2001:10::1',
+      '2001:1f::1',
+      '3fff::1',
+      '3fff:ffff::1',
       'not-an-ip',
     ])('%s is not', (ip) => expect(isPublicAddress(ip)).toBe(false));
     it('a public IPv4 is not public when 172.15 / 172.32 style neighbours are mistaken for private', () => {

--- a/apps/backend/src/oauth/client-metadata.service.ts
+++ b/apps/backend/src/oauth/client-metadata.service.ts
@@ -1,0 +1,415 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+import { Agent, fetch as undiciFetch } from 'undici';
+import { v5 as uuidv5 } from 'uuid';
+import { OAuthError } from './oauth.errors';
+import { isAcceptableRedirect } from './redirect-uri.util';
+
+/**
+ * OAuth Client ID Metadata Documents (draft-ietf-oauth-client-id-metadata-document):
+ * a client identifies itself by an `https://` URL it controls, and the
+ * authorization server reads its metadata (RFC 7591 fields) from that URL
+ * instead of a registration. claude.ai's "Recommended" connector mode.
+ *
+ * The URL is caller-supplied and the server fetches it, so this is an SSRF
+ * surface by construction. The guard, in order: the URL's own shape (https,
+ * a domain name — never an IP literal — no credentials, fragment or dot
+ * segments, not a local/internal suffix); every address the name resolves
+ * to must be public; the connection is then pinned to exactly those
+ * addresses (no re-resolution between the check and the connect); redirects
+ * are not followed; the read is bounded by a timeout and a byte cap.
+ */
+
+export const CIMD_FETCH_TIMEOUT_MS = 5_000;
+export const CIMD_MAX_BYTES = 64 * 1024;
+/** Cache lifetime when the document carries no `Cache-Control: max-age`. */
+export const CIMD_DEFAULT_TTL_MS = 5 * 60_000;
+/** The longest a `max-age` may hold a document — a rotated redirect_uri must land within a day. */
+export const CIMD_MAX_TTL_MS = 24 * 3600_000;
+export const CIMD_CACHE_MAX_ENTRIES = 500;
+/**
+ * The uuid v5 namespace an `oauth_clients` row keyed by its metadata URL gets.
+ * `oauth_clients.client_id` (and the codes / refresh tokens that reference it)
+ * is a uuid, so the URL is mapped to one deterministically. NEVER change this:
+ * every issued code and refresh token is bound to the uuid it produced.
+ */
+export const CIMD_CLIENT_NAMESPACE = '5b7d4a3e-9c21-4f6e-8d0a-1e2f3c4b5a69';
+export const CLIENT_METADATA_TRANSPORT = 'CLIENT_METADATA_TRANSPORT';
+
+const SUPPORTED_GRANT_TYPES = ['authorization_code', 'refresh_token'];
+const BLOCKED_HOSTNAMES = new Set(['localhost', 'metadata.google.internal', 'metadata']);
+const BLOCKED_HOST_SUFFIXES = [
+  '.localhost',
+  '.local',
+  '.internal',
+  '.svc',
+  '.cluster.local',
+  '.home.arpa',
+  '.in-addr.arpa',
+  '.ip6.arpa',
+];
+
+export interface ClientMetadataDocument {
+  /** The URL — the draft requires the document's own `client_id` to equal it. */
+  clientId: string;
+  clientName: string;
+  redirectUris: string[];
+  clientUri?: string;
+  /** The supported subset of what the document declares; both when it declares none. */
+  grantTypes: string[];
+  /** What the document declares; CE treats every CIMD client as public regardless. */
+  tokenEndpointAuthMethod: string;
+}
+
+export interface ResolvedAddress {
+  address: string;
+  family: 4 | 6;
+}
+
+export interface ClientMetadataResponse {
+  status: number;
+  headers: { get(name: string): string | null };
+  /** The body, already read under {@link CIMD_MAX_BYTES}. */
+  text: string;
+}
+
+/** The network, injected so the guard and the document handling are testable without it. */
+export interface ClientMetadataTransport {
+  /** Every address the name resolves to (`dns.lookup` with `all: true`). */
+  lookup(hostname: string): Promise<ResolvedAddress[]>;
+  /** GET the document, connecting only to `addresses` — the ones just vetted. */
+  fetch(
+    url: string,
+    opts: { addresses: ResolvedAddress[]; signal: AbortSignal },
+  ): Promise<ClientMetadataResponse>;
+}
+
+@Injectable()
+export class ClientMetadataService {
+  private readonly logger = new Logger(ClientMetadataService.name);
+  private readonly cache = new Map<string, { doc: ClientMetadataDocument; expiresAt: number }>();
+  private readonly transport: ClientMetadataTransport;
+
+  constructor(@Optional() @Inject(CLIENT_METADATA_TRANSPORT) transport?: ClientMetadataTransport) {
+    this.transport = transport ?? defaultTransport;
+  }
+
+  /**
+   * A `client_id` that is a URL names a metadata document; anything else is a
+   * registered client's uuid. `http://` counts as URL-shaped so that it is
+   * refused as a metadata URL (https required) rather than looked up as a uuid.
+   */
+  isClientIdUrl(clientId: string): boolean {
+    return /^https?:\/\//i.test(clientId);
+  }
+
+  /** The `oauth_clients.client_id` a metadata URL maps to — the same uuid every time. */
+  clientIdFor(url: string): string {
+    return uuidv5(url, CIMD_CLIENT_NAMESPACE);
+  }
+
+  /** What to compare a presented `client_id` against a stored row with: URLs become their uuid. */
+  normalizeClientId(clientId: string): string {
+    return this.isClientIdUrl(clientId) ? this.clientIdFor(clientId) : clientId;
+  }
+
+  /**
+   * The document behind `clientId`, from the cache or fetched through the guard.
+   * Every failure is `invalid_client` (401): the client_id names no usable client.
+   */
+  async resolve(clientId: string): Promise<ClientMetadataDocument> {
+    const url = assertClientIdUrl(clientId);
+    const cached = this.cache.get(clientId);
+    if (cached && cached.expiresAt > Date.now()) return cached.doc;
+    this.cache.delete(clientId);
+
+    const addresses = await this.vettedAddresses(url.hostname);
+    let res: ClientMetadataResponse;
+    try {
+      res = await this.transport.fetch(clientId, {
+        addresses,
+        signal: AbortSignal.timeout(CIMD_FETCH_TIMEOUT_MS),
+      });
+    } catch (error) {
+      this.logger.debug(`client metadata document ${clientId}: ${String(error)}`);
+      throw invalidClient('the client metadata document could not be fetched');
+    }
+    if (res.status !== 200) {
+      throw invalidClient(`the client metadata document answered ${res.status}`);
+    }
+    let raw: unknown;
+    try {
+      raw = JSON.parse(res.text);
+    } catch {
+      throw invalidClient('the client metadata document is not JSON');
+    }
+    const doc = parseClientMetadataDocument(raw, clientId);
+    if (doc.tokenEndpointAuthMethod !== 'none') {
+      this.logger.log(
+        `OAuth client ${clientId} declares ${doc.tokenEndpointAuthMethod}; treated as a public client (none)`,
+      );
+    }
+    this.remember(clientId, doc, ttlFrom(res.headers.get('cache-control')));
+    return doc;
+  }
+
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  private async vettedAddresses(hostname: string): Promise<ResolvedAddress[]> {
+    let addresses: ResolvedAddress[];
+    try {
+      addresses = await this.transport.lookup(hostname);
+    } catch (error) {
+      this.logger.debug(`client metadata host ${hostname}: ${String(error)}`);
+      throw invalidClient('the client_id host does not resolve');
+    }
+    if (addresses.length === 0) throw invalidClient('the client_id host does not resolve');
+    if (!addresses.every((a) => isPublicAddress(a.address))) {
+      this.logger.warn(`OAuth client_id ${hostname} resolves to a non-public address; refused`);
+      throw invalidClient('the client_id host is not publicly routable');
+    }
+    return addresses;
+  }
+
+  private remember(clientId: string, doc: ClientMetadataDocument, ttlMs: number): void {
+    if (ttlMs <= 0) return;
+    if (this.cache.size >= CIMD_CACHE_MAX_ENTRIES) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest !== undefined) this.cache.delete(oldest);
+    }
+    this.cache.set(clientId, { doc, expiresAt: Date.now() + ttlMs });
+  }
+}
+
+function invalidClient(description: string): OAuthError {
+  return new OAuthError('invalid_client', description, 401);
+}
+
+/**
+ * The URL constraints of the draft (§3) plus CE's own: https, a domain name with
+ * at least two labels (never an IP literal or a bare host), no userinfo, no
+ * fragment, no `.`/`..` segments, and no local / cluster-internal suffix.
+ */
+export function assertClientIdUrl(clientId: string): URL {
+  let url: URL;
+  try {
+    url = new URL(clientId);
+  } catch {
+    throw invalidClient('client_id is not a valid URL');
+  }
+  if (url.protocol !== 'https:') throw invalidClient('client_id must be an https URL');
+  if (url.username || url.password) throw invalidClient('client_id must not carry credentials');
+  if (url.hash || clientId.includes('#'))
+    throw invalidClient('client_id must not carry a fragment');
+  if (/\/\.\.?(?=[/?#]|$)/.test(clientId)) {
+    throw invalidClient('client_id must not contain dot path segments');
+  }
+  const host = url.hostname.toLowerCase().replace(/\.$/, '');
+  if (!host) throw invalidClient('client_id must name a host');
+  if (isIP(host.replace(/^\[|\]$/g, '')) !== 0) {
+    throw invalidClient('client_id must name a domain, not an IP address');
+  }
+  if (
+    !host.includes('.') ||
+    BLOCKED_HOSTNAMES.has(host) ||
+    BLOCKED_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix))
+  ) {
+    throw invalidClient('client_id must name a public domain');
+  }
+  return url;
+}
+
+/** The RFC 7591 fields CE reads from a document, validated the way `POST /api/oauth/register` validates them. */
+export function parseClientMetadataDocument(raw: unknown, url: string): ClientMetadataDocument {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw invalidClient('the client metadata document must be a JSON object');
+  }
+  const doc = raw as Record<string, unknown>;
+  if (doc.client_id !== url) {
+    throw invalidClient('the client metadata document does not name its own URL as client_id');
+  }
+  const uris = doc.redirect_uris;
+  if (!Array.isArray(uris) || uris.length === 0 || !uris.every((u) => typeof u === 'string')) {
+    throw invalidClient('the client metadata document must list redirect_uris');
+  }
+  for (const uri of uris as string[]) {
+    if (!isAcceptableRedirect(uri)) {
+      throw invalidClient(`redirect_uri must be https, or http on localhost: ${uri}`);
+    }
+  }
+  const name = typeof doc.client_name === 'string' ? doc.client_name.trim().slice(0, 255) : '';
+  const grants = Array.isArray(doc.grant_types)
+    ? doc.grant_types.filter(
+        (g): g is string => typeof g === 'string' && SUPPORTED_GRANT_TYPES.includes(g),
+      )
+    : [];
+  return {
+    clientId: url,
+    clientName: name || new URL(url).hostname,
+    redirectUris: [...(uris as string[])],
+    ...(typeof doc.client_uri === 'string' ? { clientUri: doc.client_uri } : {}),
+    grantTypes: grants.length ? grants : [...SUPPORTED_GRANT_TYPES],
+    tokenEndpointAuthMethod:
+      typeof doc.token_endpoint_auth_method === 'string' ? doc.token_endpoint_auth_method : 'none',
+  };
+}
+
+/** How long to hold a document: its `max-age` (capped), the default when it says nothing, 0 for `no-store`. */
+export function ttlFrom(cacheControl: string | null): number {
+  if (!cacheControl) return CIMD_DEFAULT_TTL_MS;
+  const lower = cacheControl.toLowerCase();
+  if (/\bno-store\b/.test(lower)) return 0;
+  const match = lower.match(/\bmax-age=(\d+)/);
+  if (!match) return CIMD_DEFAULT_TTL_MS;
+  return Math.min(Number(match[1]) * 1000, CIMD_MAX_TTL_MS);
+}
+
+/**
+ * Is this a globally routable unicast address? Loopback, private (RFC 1918),
+ * CGNAT, link-local (incl. the cloud metadata endpoint), unspecified,
+ * multicast, reserved and documentation ranges are not; IPv6 forms that embed
+ * an IPv4 address (mapped, 6to4, NAT64) are judged by the address they embed.
+ */
+export function isPublicAddress(ip: string): boolean {
+  const family = isIP(ip);
+  if (family === 4) return isPublicV4(ip);
+  if (family === 6) return isPublicV6(ip);
+  return false;
+}
+
+function isPublicV4(ip: string): boolean {
+  const [a, b] = ip.split('.').map(Number);
+  if (a === 0 || a === 10 || a === 127) return false;
+  if (a === 100 && b >= 64 && b <= 127) return false;
+  if (a === 169 && b === 254) return false;
+  if (a === 172 && b >= 16 && b <= 31) return false;
+  if (a === 192 && (b === 0 || b === 168)) return false;
+  if (a === 198 && (b === 18 || b === 19)) return false;
+  if (a >= 224) return false;
+  return true;
+}
+
+function isPublicV6(ip: string): boolean {
+  const groups = expandV6(ip.toLowerCase());
+  if (!groups) return false;
+  const first = parseInt(groups[0], 16);
+  const v4Of = (hi: string, lo: string) => {
+    const h = parseInt(hi, 16);
+    const l = parseInt(lo, 16);
+    return `${h >> 8}.${h & 0xff}.${l >> 8}.${l & 0xff}`;
+  };
+  // ::/8 — unspecified, loopback, IPv4-compatible; ::ffff:0:0/96 — IPv4-mapped
+  if (first === 0) {
+    const mapped = groups.slice(0, 5).every((g) => g === '0000') && groups[5] === 'ffff';
+    return mapped ? isPublicV4(v4Of(groups[6], groups[7])) : false;
+  }
+  if (groups[0] === '0064' && groups[1] === 'ff9b') return isPublicV4(v4Of(groups[6], groups[7])); // NAT64
+  if (first === 0x2002) return isPublicV4(v4Of(groups[1], groups[2])); // 6to4
+  if (groups[0] === '2001' && groups[1] === '0db8') return false; // documentation
+  if ((first & 0xfe00) === 0xfc00) return false; // fc00::/7 unique local
+  if ((first & 0xffc0) === 0xfe80) return false; // fe80::/10 link-local
+  if ((first & 0xff00) === 0xff00) return false; // ff00::/8 multicast
+  return true;
+}
+
+/** The eight 4-hex-digit groups of an IPv6 address, or null when it does not parse. */
+function expandV6(ip: string): string[] | null {
+  let s = ip;
+  const zone = s.indexOf('%');
+  if (zone >= 0) s = s.slice(0, zone);
+  const v4 = s.match(/(\d+\.\d+\.\d+\.\d+)$/);
+  if (v4) {
+    const [a, b, c, d] = v4[1].split('.').map(Number);
+    s = `${s.slice(0, -v4[1].length)}${((a << 8) | b).toString(16)}:${((c << 8) | d).toString(16)}`;
+  }
+  const halves = s.split('::');
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(':') : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  const missing = 8 - head.length - tail.length;
+  if (missing < 0 || (halves.length === 1 && missing !== 0)) return null;
+  const groups = [...head, ...(halves.length === 2 ? Array(missing).fill('0') : []), ...tail];
+  if (groups.length !== 8 || groups.some((g) => !/^[0-9a-f]{1,4}$/.test(g))) return null;
+  return groups.map((g) => g.padStart(4, '0'));
+}
+
+/**
+ * Reads a body under a byte cap. Throws — and, by leaving the loop, cancels the
+ * stream — the moment the cap is passed, so an oversized document never buffers.
+ */
+export async function readCapped(
+  body: AsyncIterable<Uint8Array> | null,
+  maxBytes: number,
+): Promise<string> {
+  if (!body) return '';
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of body) {
+    total += chunk.byteLength;
+    if (total > maxBytes) throw new Error(`document exceeds ${maxBytes} bytes`);
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+/**
+ * A `lookup` for the socket that answers from the vetted addresses only — the
+ * name is never resolved again between the check and the connect. Node's
+ * `net.connect` calls it with `{ all: true }` (happy eyeballs) or for one address.
+ */
+export function pinnedLookup(addresses: ResolvedAddress[]) {
+  return (
+    _hostname: string,
+    options: { all?: boolean } | ((...args: unknown[]) => void),
+    callback?: (...args: unknown[]) => void,
+  ) => {
+    const done = (typeof options === 'function' ? options : callback) as (
+      ...args: unknown[]
+    ) => void;
+    const all = typeof options === 'object' && options !== null && options.all === true;
+    if (all)
+      done(
+        null,
+        addresses.map((a) => ({ address: a.address, family: a.family })),
+      );
+    else done(null, addresses[0].address, addresses[0].family);
+  };
+}
+
+const defaultTransport: ClientMetadataTransport = {
+  async lookup(hostname) {
+    const found = await dnsLookup(hostname, { all: true, verbatim: true });
+    return found.map((a) => ({ address: a.address, family: a.family as 4 | 6 }));
+  },
+  async fetch(url, { addresses, signal }) {
+    const agent = new Agent({
+      connect: { lookup: pinnedLookup(addresses) as never },
+      maxRedirections: 0,
+    });
+    try {
+      const res = await undiciFetch(url, {
+        method: 'GET',
+        headers: { accept: 'application/json', 'user-agent': 'bffless-ce/oauth (client-metadata)' },
+        redirect: 'manual',
+        signal,
+        dispatcher: agent,
+      });
+      const declared = Number(res.headers.get('content-length'));
+      if (Number.isFinite(declared) && declared > CIMD_MAX_BYTES) {
+        await res.body?.cancel();
+        throw new Error(`document declares ${declared} bytes, over the ${CIMD_MAX_BYTES} byte cap`);
+      }
+      if (res.status !== 200) {
+        await res.body?.cancel();
+        return { status: res.status, headers: res.headers, text: '' };
+      }
+      const text = await readCapped(res.body, CIMD_MAX_BYTES);
+      return { status: res.status, headers: res.headers, text };
+    } finally {
+      await agent.close();
+    }
+  },
+};

--- a/apps/backend/src/oauth/client-metadata.service.ts
+++ b/apps/backend/src/oauth/client-metadata.service.ts
@@ -308,7 +308,11 @@ function isPublicV6(ip: string): boolean {
   }
   if (groups[0] === '0064' && groups[1] === 'ff9b') return isPublicV4(v4Of(groups[6], groups[7])); // NAT64
   if (first === 0x2002) return isPublicV4(v4Of(groups[1], groups[2])); // 6to4
-  if (groups[0] === '2001' && groups[1] === '0db8') return false; // documentation
+  if (groups[0] === '0100' && groups.slice(1, 4).every((g) => g === '0000')) return false; // 100::/64 discard
+  if (groups[0] === '2001' && groups[1] === '0db8') return false; // 2001:db8::/32 documentation
+  if (groups[0] === '2001' && groups[1] === '0002' && groups[2] === '0000') return false; // 2001:2::/48 benchmarking
+  if (groups[0] === '2001' && (parseInt(groups[1], 16) & 0xfff0) === 0x0010) return false; // 2001:10::/28 ORCHID
+  if ((first & 0xfff0) === 0x3ff0) return false; // 3fff::/20 documentation
   if ((first & 0xfe00) === 0xfc00) return false; // fc00::/7 unique local
   if ((first & 0xffc0) === 0xfe80) return false; // fe80::/10 link-local
   if ((first & 0xff00) === 0xff00) return false; // ff00::/8 multicast

--- a/apps/backend/src/oauth/oauth.dto.ts
+++ b/apps/backend/src/oauth/oauth.dto.ts
@@ -81,6 +81,8 @@ export interface AuthorizationServerMetadata {
   token_endpoint_auth_methods_supported: string[];
   scopes_supported: string[];
   resource_indicators_supported: boolean;
+  /** draft-ietf-oauth-client-id-metadata-document: an `https://` client_id is fetched as the client's metadata. */
+  client_id_metadata_document_supported: boolean;
 }
 
 export interface TokenResponse {

--- a/apps/backend/src/oauth/oauth.module.ts
+++ b/apps/backend/src/oauth/oauth.module.ts
@@ -2,6 +2,7 @@ import { Module, forwardRef } from '@nestjs/common';
 import { OAuthController } from './oauth.controller';
 import { OAuthMetadataController } from './oauth-metadata.controller';
 import { OAuthService } from './oauth.service';
+import { ClientMetadataService } from './client-metadata.service';
 import { AppTokensModule } from '../app-tokens/app-tokens.module';
 import { PermissionsModule } from '../permissions/permissions.module';
 import { ProxyRulesModule } from '../proxy-rules/proxy-rules.module';
@@ -12,7 +13,7 @@ import { ProxyRulesModule } from '../proxy-rules/proxy-rules.module';
   // resolution reads that step's config through RuleInvokerService.
   imports: [AppTokensModule, PermissionsModule, forwardRef(() => ProxyRulesModule)],
   controllers: [OAuthController, OAuthMetadataController],
-  providers: [OAuthService],
+  providers: [OAuthService, ClientMetadataService],
   exports: [OAuthService],
 })
 export class OAuthModule {}

--- a/apps/backend/src/oauth/oauth.service.spec.ts
+++ b/apps/backend/src/oauth/oauth.service.spec.ts
@@ -16,6 +16,7 @@ jest.mock('../db/client', () => {
     'returning',
     'update',
     'set',
+    'onConflictDoUpdate',
   ])
     chain[m] = jest.fn();
   return { db: chain };
@@ -41,6 +42,15 @@ const mapping = {
 };
 const project = { id: 'p1', owner: 'bffless', name: 'workflow', displayName: 'Workflow' };
 const user = { id: 'u1', email: 'm@example.com', role: 'user', disabled: false };
+const CIMD_URL = 'https://claude.ai/.well-known/oauth-client-metadata';
+const CIMD_UUID = '11111111-2222-4333-8444-555555555555';
+const cimdDoc = {
+  clientId: CIMD_URL,
+  clientName: 'Claude (hosted)',
+  redirectUris: ['https://claude.ai/api/mcp/auth_callback'],
+  grantTypes: ['authorization_code', 'refresh_token'],
+  tokenEndpointAuthMethod: 'none',
+};
 const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
 const prm = async () => ({
   status: 200,
@@ -66,16 +76,25 @@ function make(configOverrides: Record<string, string | undefined> = {}) {
   const permissions = { getUserProjectRole: jest.fn().mockResolvedValue('contributor') };
   // The alias's effective rules; empty means "no oauth_protected_resource step" → the fetch path.
   const rules = { effectiveRules: jest.fn().mockResolvedValue([]) };
+  // Client ID Metadata Documents (#741): a URL client_id maps to a fixed uuid; the document is stubbed.
+  const clientMetadata = {
+    isClientIdUrl: (id: string) => /^https?:\/\//i.test(id),
+    clientIdFor: jest.fn().mockReturnValue(CIMD_UUID),
+    normalizeClientId: (id: string) => (/^https?:\/\//i.test(id) ? CIMD_UUID : id),
+    resolve: jest.fn().mockResolvedValue(cimdDoc),
+  };
   return {
     service: new OAuthService(
       config as never,
       appTokens as never,
       permissions as never,
       rules as never,
+      clientMetadata as never,
     ),
     appTokens,
     permissions,
     rules,
+    clientMetadata,
   };
 }
 
@@ -129,6 +148,7 @@ describe('OAuthService', () => {
     expect(m.code_challenge_methods_supported).toEqual(['S256']);
     expect(m.token_endpoint_auth_methods_supported).toEqual(['none']);
     expect(m.resource_indicators_supported).toBe(true);
+    expect(m.client_id_metadata_document_supported).toBe(true);
   });
 
   describe('registerClient', () => {
@@ -403,6 +423,133 @@ describe('OAuthService', () => {
       expect(() => service.readPending(expired)).toThrow(OAuthError);
       const other = jwt.sign({ kind: 'other' }, 'test-secret');
       expect(() => service.readPending(other)).toThrow(OAuthError);
+    });
+  });
+
+  describe('client_id as a Client ID Metadata Document URL (#741)', () => {
+    const cimdParams = (over: Record<string, unknown> = {}) =>
+      authorizeParams({
+        client_id: CIMD_URL,
+        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+        ...over,
+      });
+
+    it('resolves the document, upserts the client under the uuid the URL maps to, and binds the pending request to that uuid', async () => {
+      const { service, clientMetadata } = make();
+      mockDb.limit.mockResolvedValueOnce([mapping]).mockResolvedValueOnce([project]);
+      const { pending } = await service.beginAuthorization(cimdParams(), prm);
+      expect(clientMetadata.resolve).toHaveBeenCalledWith(CIMD_URL);
+      // no oauth_clients SELECT — the document is the client
+      expect(mockDb.select).toHaveBeenCalledTimes(2);
+      expect(mockDb.insert).toHaveBeenCalledTimes(1);
+      expect(mockDb.values).toHaveBeenCalledWith({
+        clientId: CIMD_UUID,
+        clientName: 'Claude (hosted)',
+        redirectUris: ['https://claude.ai/api/mcp/auth_callback'],
+        grantTypes: ['authorization_code', 'refresh_token'],
+      });
+      expect(mockDb.onConflictDoUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          set: expect.objectContaining({ clientName: 'Claude (hosted)' }),
+        }),
+      );
+      expect(pending).toMatchObject({
+        clientId: CIMD_UUID,
+        clientName: 'Claude (hosted)',
+        redirectUri: 'https://claude.ai/api/mcp/auth_callback',
+        projectId: 'p1',
+      });
+    });
+    it('refuses a redirect_uri the document does not list, before anything is redirected', async () => {
+      const { service } = make();
+      await expect(
+        service.beginAuthorization(cimdParams({ redirect_uri: 'https://evil.example/cb' }), prm),
+      ).rejects.toMatchObject({ error: 'invalid_request' });
+      expect(mockDb.select).not.toHaveBeenCalled();
+    });
+    it('a document that fails the guard is an unknown client: nothing is upserted', async () => {
+      const { service, clientMetadata } = make();
+      clientMetadata.resolve.mockRejectedValueOnce(
+        new OAuthError('invalid_client', 'the client_id host is not publicly routable', 401),
+      );
+      await expect(service.beginAuthorization(cimdParams(), prm)).rejects.toMatchObject({
+        error: 'invalid_client',
+        status: 401,
+      });
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+    it('the token endpoint maps the URL to the same uuid the code was issued to — and to nothing else', async () => {
+      const { service, appTokens, clientMetadata } = make();
+      const codeRow = {
+        codeHash: hashToken('the-code'),
+        clientId: CIMD_UUID,
+        userId: 'u1',
+        projectId: 'p1',
+        scopes: ['workflow:read'],
+        codeChallenge: challengeOf(verifier),
+        redirectUri: 'https://claude.ai/api/mcp/auth_callback',
+        resource: 'https://workflow.j5s.dev/api/workflow/mcp',
+        expiresAt: new Date(Date.now() + 60_000),
+        usedAt: null,
+      };
+      mockDb.limit
+        .mockResolvedValueOnce([codeRow])
+        .mockResolvedValueOnce([project])
+        .mockResolvedValueOnce([{ ...client, clientId: CIMD_UUID, clientName: 'Claude (hosted)' }])
+        .mockResolvedValueOnce([user]);
+      mockDb.where.mockReturnValue(mockDb);
+      mockDb.returning.mockResolvedValueOnce([{ codeHash: hashToken('the-code') }]);
+      const body = {
+        grant_type: 'authorization_code',
+        code: 'the-code',
+        client_id: CIMD_URL,
+        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+        code_verifier: verifier,
+      };
+      const out = await service.token(body);
+      expect(out.access_token).toBe('bfat_raw');
+      // no fetch at the token endpoint: the code + verifier is the proof
+      expect(clientMetadata.resolve).not.toHaveBeenCalled();
+      expect(appTokens.create).toHaveBeenCalledWith(
+        'u1',
+        'user',
+        expect.objectContaining({ name: 'OAuth: Claude (hosted)' }),
+        expect.objectContaining({ kind: 'oauth', clientId: CIMD_UUID }),
+      );
+      // another URL maps to another uuid → not this code's client
+      clientMetadata.normalizeClientId = (id: string) => (id === CIMD_URL ? CIMD_UUID : 'other');
+      mockDb.limit.mockResolvedValueOnce([codeRow]);
+      await expect(
+        service.token({ ...body, client_id: 'https://other.example/metadata.json' }),
+      ).rejects.toMatchObject({ error: 'invalid_grant' });
+    });
+    it('a refresh presented with the URL matches the family issued to its uuid', async () => {
+      const { service } = make();
+      mockDb.limit
+        .mockResolvedValueOnce([
+          {
+            tokenHash: hashToken('bfrt_old'),
+            familyId: 'fam-1',
+            clientId: CIMD_UUID,
+            userId: 'u1',
+            projectId: 'p1',
+            scopes: ['workflow:read'],
+            appTokenId: 'tok-old',
+            expiresAt: new Date(Date.now() + 60_000),
+            rotatedAt: null,
+          },
+        ])
+        .mockResolvedValueOnce([project])
+        .mockResolvedValueOnce([{ ...client, clientId: CIMD_UUID }])
+        .mockResolvedValueOnce([user]);
+      mockDb.where.mockReturnValue(mockDb);
+      mockDb.returning.mockResolvedValueOnce([{ tokenHash: 'h1' }]);
+      const out = await service.token({
+        grant_type: 'refresh_token',
+        refresh_token: 'bfrt_old',
+        client_id: CIMD_URL,
+      });
+      expect(out.refresh_token).toMatch(/^bfrt_/);
     });
   });
 

--- a/apps/backend/src/oauth/oauth.service.ts
+++ b/apps/backend/src/oauth/oauth.service.ts
@@ -20,6 +20,7 @@ import {
   projects,
   users,
 } from '../db/schema';
+import type { OAuthClient } from '../db/schema/oauth-clients.schema';
 import { hashToken } from '../auth/app-token.util';
 import { AppTokensService } from '../app-tokens/app-tokens.service';
 import { PermissionsService } from '../permissions/permissions.service';
@@ -32,6 +33,8 @@ import {
 import { SCOPE_PATTERN } from '../pipelines/types';
 import { OAuthError } from './oauth.errors';
 import { isValidVerifier, verifyS256 } from './pkce.util';
+import { isAcceptableRedirect } from './redirect-uri.util';
+import { ClientMetadataService } from './client-metadata.service';
 import {
   AuthorizationServerMetadata,
   PendingRequest,
@@ -61,10 +64,11 @@ interface ResolvedResource {
 
 /**
  * CE's built-in OAuth 2.1 authorization server (ADR-0005): dynamic client
- * registration for public clients, the authorization-code grant with PKCE
- * `S256`, RFC 8707 `resource` → the CE project the token is bound to, refresh
- * rotation with family revocation, RFC 7009 revocation. The access token *is*
- * an app token, minted through `AppTokensService`.
+ * registration for public clients, Client ID Metadata Documents (an `https://`
+ * client_id, #741), the authorization-code grant with PKCE `S256`, RFC 8707
+ * `resource` → the CE project the token is bound to, refresh rotation with
+ * family revocation, RFC 7009 revocation. The access token *is* an app token,
+ * minted through `AppTokensService`.
  */
 @Injectable()
 export class OAuthService {
@@ -76,6 +80,7 @@ export class OAuthService {
     private readonly permissions: PermissionsService,
     @Inject(forwardRef(() => RuleInvokerService))
     private readonly rules: RuleInvokerService,
+    private readonly clientMetadata: ClientMetadataService,
   ) {}
 
   private get jwtSecret(): string {
@@ -117,6 +122,7 @@ export class OAuthService {
       token_endpoint_auth_methods_supported: ['none'],
       scopes_supported: [],
       resource_indicators_supported: true,
+      client_id_metadata_document_supported: true,
     };
   }
 
@@ -181,11 +187,7 @@ export class OAuthService {
     const clientId = str(params.client_id);
     const redirectUri = str(params.redirect_uri);
     if (!clientId) throw new OAuthError('invalid_request', 'client_id is required');
-    const [client] = await db
-      .select()
-      .from(oauthClients)
-      .where(eq(oauthClients.clientId, clientId))
-      .limit(1);
+    const client = await this.clientFor(clientId);
     if (!client) throw new OAuthError('invalid_client', 'unknown client_id', 401);
     if (!redirectUri || !client.redirectUris.includes(redirectUri)) {
       throw new OAuthError('invalid_request', 'redirect_uri is not registered for this client');
@@ -210,7 +212,7 @@ export class OAuthService {
     if (scopes.length === 0) throw new OAuthError('invalid_scope', 'the resource offers no scopes');
     const now = Math.floor(Date.now() / 1000);
     const pending: PendingRequest = {
-      clientId,
+      clientId: client.clientId,
       clientName: client.clientName,
       redirectUri,
       codeChallenge: challenge,
@@ -227,6 +229,47 @@ export class OAuthService {
       algorithm: 'HS256',
     });
     return { request, pending };
+  }
+
+  /**
+   * The client a `client_id` names: a registered row, or — when it is a URL —
+   * the Client ID Metadata Document behind it (fetched through the SSRF guard,
+   * cached), upserted into `oauth_clients` under the uuid derived from the URL
+   * so codes, refresh tokens and the App Tokens page (`OAuth: <client_name>`)
+   * work exactly as for a registered client. A URL that fails the guard or
+   * whose document is invalid throws `invalid_client`, as an unknown uuid does.
+   */
+  private async clientFor(clientId: string): Promise<OAuthClient | undefined> {
+    if (!this.clientMetadata.isClientIdUrl(clientId)) {
+      const [client] = await db
+        .select()
+        .from(oauthClients)
+        .where(eq(oauthClients.clientId, clientId))
+        .limit(1);
+      return client;
+    }
+    const doc = await this.clientMetadata.resolve(clientId);
+    const row = {
+      clientId: this.clientMetadata.clientIdFor(clientId),
+      clientName: doc.clientName,
+      redirectUris: doc.redirectUris,
+      grantTypes: doc.grantTypes,
+    };
+    await db
+      .insert(oauthClients)
+      .values(row)
+      .onConflictDoUpdate({
+        target: oauthClients.clientId,
+        set: {
+          clientName: row.clientName,
+          redirectUris: row.redirectUris,
+          grantTypes: row.grantTypes,
+        },
+      });
+    this.logger.debug(
+      `OAuth client ${clientId} → ${row.clientId} (${row.clientName}) from its metadata document`,
+    );
+    return { ...row, createdAt: new Date(), lastUsedAt: null };
   }
 
   readPending(request: string): PendingRequest {
@@ -313,7 +356,8 @@ export class OAuthService {
   private async exchangeCode(body: Record<string, unknown>): Promise<TokenResponse> {
     const code = str(body.code);
     const verifier = body.code_verifier;
-    const clientId = str(body.client_id);
+    // A metadata-document client presents its URL; the code was issued to the uuid it maps to.
+    const clientId = this.clientMetadata.normalizeClientId(str(body.client_id));
     if (!code || !clientId)
       throw new OAuthError('invalid_request', 'code and client_id are required');
     if (!isValidVerifier(verifier))
@@ -370,7 +414,10 @@ export class OAuthService {
       .where(eq(oauthRefreshTokens.tokenHash, hashToken(presented)))
       .limit(1);
     if (!row) throw new OAuthError('invalid_grant', 'unknown refresh_token');
-    if (str(body.client_id) && str(body.client_id) !== row.clientId)
+    if (
+      str(body.client_id) &&
+      this.clientMetadata.normalizeClientId(str(body.client_id)) !== row.clientId
+    )
       throw new OAuthError('invalid_grant', 'client mismatch');
     if (row.rotatedAt) {
       // A rotated token presented again: the family is compromised — revoke it all (OAuth 2.1 §4.3.1).
@@ -631,19 +678,6 @@ export function familyOfCode(codeHash: string): string {
 
 function str(value: unknown): string {
   return typeof value === 'string' ? value : '';
-}
-
-function isAcceptableRedirect(uri: string): boolean {
-  try {
-    const u = new URL(uri);
-    if (u.protocol === 'https:') return true;
-    return (
-      u.protocol === 'http:' &&
-      (u.hostname === 'localhost' || u.hostname === '127.0.0.1' || u.hostname === '[::1]')
-    );
-  } catch {
-    return false;
-  }
 }
 
 const defaultFetch: FetchLike = async (url, init) => {

--- a/apps/backend/src/oauth/redirect-uri.util.ts
+++ b/apps/backend/src/oauth/redirect-uri.util.ts
@@ -1,0 +1,17 @@
+/**
+ * The redirect URIs CE accepts for a public client, whether registered (RFC 7591)
+ * or declared in a Client ID Metadata Document: https anywhere, or plain http on a
+ * loopback host (a local MCP client, OAuth 2.1 §8.4.2).
+ */
+export function isAcceptableRedirect(uri: string): boolean {
+  try {
+    const u = new URL(uri);
+    if (u.protocol === 'https:') return true;
+    return (
+      u.protocol === 'http:' &&
+      (u.hostname === 'localhost' || u.hostname === '127.0.0.1' || u.hostname === '[::1]')
+    );
+  } catch {
+    return false;
+  }
+}

--- a/docs/adr/0005-built-in-oauth-authorization-server.md
+++ b/docs/adr/0005-built-in-oauth-authorization-server.md
@@ -63,3 +63,18 @@ was rejected: `scopes_supported` is the authorize flow's allowlist, and an emerg
 an unrelated rule edit can change is not something to publish implicitly. Hand-written
 documents keep working; `OAuthService` reads the step's config directly and fetches only for
 those.
+
+**Amended 2026-09-07 (#741).** A client may also identify itself by URL — a _Client ID
+Metadata Document_ (draft-ietf-oauth-client-id-metadata-document), the mode claude.ai's
+connector dialog marks "Recommended": `client_id` is an `https://` URL, CE fetches the
+RFC 7591 metadata from it, requires the document's own `client_id` to equal that URL, and
+proceeds as for a registered public client. No new table: the URL maps deterministically to
+an `oauth_clients` uuid (uuid v5 under a pinned namespace) that is upserted with the
+document's name and redirect URIs, so the uuid foreign keys on codes and refresh tokens hold
+and the App Tokens page shows the client's name. The token endpoint maps the URL to that
+uuid without fetching — the code plus PKCE verifier is the proof. Because the server fetches
+a caller-supplied URL, the fetch is guarded (`ClientMetadataService`): https only, a domain
+name never an IP literal, no local/cluster suffixes, every resolved address must be public
+and the socket is pinned to those addresses, no redirects, 5 s timeout, 64 KiB cap; the
+authorize endpoint (where the fetch happens) already requires a member session. Registration
+stays as the fallback for hosts without hosted metadata.


### PR DESCRIPTION
Closes #741

## Summary
claude.ai's custom-connector dialog marks one OAuth mode "Recommended": the server reads Claude's client details from a metadata document Anthropic hosts, instead of registering a client. CE's authorization server refused that mode — `client_id` had to be a registered uuid — so operators were pushed to the dynamic-registration fallback. After this PR an `https://` URL is accepted as `client_id`: CE fetches the Client ID Metadata Document behind it (guarded against server-side request forgery), checks the document names itself, and runs the normal consent flow. The App Tokens page shows the client by the name the document declares (`OAuth: Claude`), exactly as for a registered client.

## Behaviour changes
- `GET /api/oauth/authorize` with `client_id=https://…`: before → `401 invalid_client` (or a database error for a non-uuid); after → the document at that URL is fetched and validated, and the request proceeds with its `redirect_uris` / `client_name` / `client_uri`. A URL that fails the guard, an unreachable document, a redirect, a non-JSON body, a document whose `client_id` differs from the URL, or a redirect URI it does not list → `401 invalid_client` (or `400 invalid_request` for the redirect mismatch), never a redirect to the client.
- `POST /api/oauth/token` (authorization_code and refresh_token): a URL `client_id` is mapped to the client it identifies with no network call; a different URL is `invalid_grant` as a different uuid would be.
- `GET /.well-known/oauth-authorization-server` gains `client_id_metadata_document_supported: true` (additive).
- `oauth_clients` gains one row per metadata URL seen, upserted on every authorize so a renamed client or a rotated redirect URI is picked up; the row's uuid is derived from the URL (uuid v5, pinned namespace) so it is the same on every instance and never changes.
- Registered (RFC 7591) and pre-registered uuid clients: unchanged. Fully additive.

## Why
The connector's recommended mode is the one operators will try first, and it also removes the "Unnamed client"/duplicate-registration noise DCR leaves behind, since a hosted document identifies the client stably. The triage comment flagged that fetching an attacker-supplied URL is an SSRF vector; the existing `validateTargetUrl` pattern is hostname-regex only (it carries a TODO for DNS resolution), so this PR builds the full guard rather than reusing it as-is: https, a domain name (never an IP literal or a local/`.internal`/`.svc`/`.cluster.local` suffix), every resolved address must be public (IPv4-mapped / NAT64 / 6to4 forms judged by the embedded IPv4), the socket is pinned to the vetted addresses so the name is not resolved a second time, redirects are not followed, 5 s timeout, 64 KiB cap. The fetch only ever happens on the authorize endpoint, which already requires a member session. Keying the client by a uuid derived from the URL keeps the existing uuid foreign keys on codes and refresh tokens intact — no migration.

## What changed
- backend: new `apps/backend/src/oauth/client-metadata.service.ts` (guard, fetch via undici with a pinned lookup, document validation, bounded cache honouring `Cache-Control: max-age`/`no-store`); `oauth.service.ts` resolves URL client_ids and upserts the row, normalises the URL at the token endpoint, advertises the RFC 8414 flag; `oauth.dto.ts`, `oauth.module.ts`; `isAcceptableRedirect` lifted into `redirect-uri.util.ts` so both paths validate redirects identically.
- tests: `client-metadata.service.spec.ts` (guard cases, address classification table, cache TTL, transport failures, pinned lookup, capped read, Nest DI); `oauth.service.spec.ts` gains the CIMD authorize / token / refresh cases.
- docs: `CONTEXT.md` authorization-server entry, ADR-0005 amendment, one new `.claude/ce-pr-review-checklist.md` entry on outbound fetches of caller-supplied URLs.

## Compatibility
- DB migrations: none. The URL → uuid v5 mapping reuses `oauth_clients.client_id` as-is; the namespace is pinned and documented as never-change.
- API/CLI contract: additive only (a new metadata field, a new accepted `client_id` shape). `packages/cli` does not touch these endpoints.
- Env vars: none added or renamed.
- nginx generation, storage layout, pipeline/proxy-rule semantics: untouched.

## Verification
- `pnpm --filter backend exec tsc --noEmit` — exit 0
- `pnpm --filter frontend exec tsc --noEmit` — exit 0
- `pnpm --filter backend format:check` — "All matched files use Prettier code style!"
- `cd apps/backend && pnpm test -- src/oauth` — 5 suites, 109 tests passed
- `cd apps/backend && pnpm test` (full) — Test Suites: 225 passed, 2 skipped (pre-existing), 227 total; Tests: 3815 passed, 47 skipped, 3862 total; exit 0
- Live smoke of the default transport from this host: `https://example.com/` → "not JSON"; `https://claude.ai/.well-known/oauth-client-metadata` → "answered 404"; `httpbin.org/redirect-to` → "answered 302" (not followed); `httpbin.org/json` → "does not name its own URL as client_id"; `https://localtest.me/metadata` (public name → 127.0.0.1) → "not publicly routable", no fetch made.

## Out of scope / follow-ups
- `validateTargetUrl` in `proxy-rules.service.ts` still has no DNS-resolution check (its own TODO); `isPublicAddress` / `assertClientIdUrl` are exported so a follow-up can lift them into `common/` and close that gap.
- A non-uuid, non-URL `client_id` on authorize still reaches Postgres and errors as a 500 (pre-existing).
- The CIMD variant of the `oauth` walk in bffless/apps (cross-repo, per the issue).
- No known live CIMD URL existed to test against (both `claude.ai` and `claude.com` `/.well-known/oauth-client-metadata` answer 404 today); the first real connector attempt will be the end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jYurRQzRczvqkFyVr3e1M

