### PR TITLE
fix(oauth): reject a non-uuid, non-URL client_id on authorize as invalid_client

### DIFF
--- a/apps/backend/src/oauth/oauth.service.spec.ts
+++ b/apps/backend/src/oauth/oauth.service.spec.ts
@@ -23,8 +23,10 @@ jest.mock('../db/client', () => {
 });
 const mockDb = jest.requireMock('../db/client').db as Record<string, jest.Mock>;
 
+// `oauth_clients.client_id` is a uuid column; a registered client is only ever looked up by one (#767).
+const CLIENT_UUID = '0f4c1e6a-7b2d-4c58-9a3e-1d2f3a4b5c6d';
 const client = {
-  clientId: 'c1',
+  clientId: CLIENT_UUID,
   clientName: 'Claude',
   redirectUris: ['https://claude.ai/cb'],
   grantTypes: ['authorization_code', 'refresh_token'],
@@ -100,7 +102,7 @@ function make(configOverrides: Record<string, string | undefined> = {}) {
 
 const authorizeParams = (over: Record<string, unknown> = {}) => ({
   response_type: 'code',
-  client_id: 'c1',
+  client_id: CLIENT_UUID,
   redirect_uri: 'https://claude.ai/cb',
   code_challenge: challengeOf(verifier),
   code_challenge_method: 'S256',
@@ -160,7 +162,7 @@ describe('OAuthService', () => {
         client_name: 'Claude',
       });
       expect(out).toMatchObject({
-        client_id: 'c1',
+        client_id: CLIENT_UUID,
         client_name: 'Claude',
         token_endpoint_auth_method: 'none',
         response_types: ['code'],
@@ -215,14 +217,17 @@ describe('OAuthService', () => {
         }),
       );
       expect(pending).toMatchObject({
-        clientId: 'c1',
+        clientId: CLIENT_UUID,
         projectId: 'p1',
         projectSlug: 'bffless/workflow',
         scopes: ['workflow:read', 'workflow:run', 'workflow:files'],
         state: 'xyz',
       });
       expect(pending.exp - pending.iat).toBe(600);
-      expect(service.readPending(request)).toMatchObject({ clientId: 'c1', projectId: 'p1' });
+      expect(service.readPending(request)).toMatchObject({
+        clientId: CLIENT_UUID,
+        projectId: 'p1',
+      });
     });
     it('resolves the www/non-www alternate of the resource host, like every other domain lookup', async () => {
       const { service } = make();
@@ -413,6 +418,22 @@ describe('OAuthService', () => {
         service.beginAuthorization(authorizeParams({ code_challenge_method: 'plain' }), prm),
       ).rejects.toMatchObject({ error: 'invalid_request' });
     });
+    it('a client_id that is neither a uuid nor a metadata URL is an unknown client, not a query (#767)', async () => {
+      const { service, clientMetadata } = make();
+      // Nothing is ever looked up: the uuid column would reject the value with a
+      // Postgres 22P02 and the request would 500 before invalid_client fired.
+      for (const client_id of ['not-a-client', 'c1', ' ', 'http:/x', CLIENT_UUID + 'x']) {
+        const err = await service.beginAuthorization(authorizeParams({ client_id }), prm).then(
+          () => null,
+          (e: OAuthError) => e,
+        );
+        expect(err).toBeInstanceOf(OAuthError);
+        expect(err).toMatchObject({ error: 'invalid_client', description: 'unknown client_id' });
+        expect(err!.getStatus()).toBe(401);
+      }
+      expect(mockDb.select).not.toHaveBeenCalled();
+      expect(clientMetadata.resolve).not.toHaveBeenCalled();
+    });
     it('rejects a tampered or expired pending request', () => {
       const { service } = make();
       expect(() => service.readPending('nope')).toThrow(OAuthError);
@@ -558,7 +579,7 @@ describe('OAuthService', () => {
       jwt.sign(
         {
           kind: 'oauth_pending',
-          clientId: 'c1',
+          clientId: CLIENT_UUID,
           clientName: 'Claude',
           redirectUri: 'https://claude.ai/cb',
           codeChallenge: challengeOf(verifier),
@@ -629,7 +650,7 @@ describe('OAuthService', () => {
   describe('token: authorization_code', () => {
     const codeRow = (over: Record<string, unknown> = {}) => ({
       codeHash: hashToken('the-code'),
-      clientId: 'c1',
+      clientId: CLIENT_UUID,
       userId: 'u1',
       projectId: 'p1',
       scopes: ['workflow:read'],
@@ -643,7 +664,7 @@ describe('OAuthService', () => {
     const body = (over: Record<string, unknown> = {}) => ({
       grant_type: 'authorization_code',
       code: 'the-code',
-      client_id: 'c1',
+      client_id: CLIENT_UUID,
       redirect_uri: 'https://claude.ai/cb',
       code_verifier: verifier,
       ...over,
@@ -670,7 +691,11 @@ describe('OAuthService', () => {
         'u1',
         'user',
         { name: 'OAuth: Claude', project: 'bffless/workflow', scopes: ['workflow:read'] },
-        expect.objectContaining({ kind: 'oauth', clientId: 'c1', expiresAt: expect.any(Date) }),
+        expect.objectContaining({
+          kind: 'oauth',
+          clientId: CLIENT_UUID,
+          expiresAt: expect.any(Date),
+        }),
       );
       const refreshRow = mockDb.values.mock.calls.find((c) => c[0].familyId)![0];
       expect(refreshRow.familyId).toBe(familyOfCode(hashToken('the-code')));
@@ -706,7 +731,7 @@ describe('OAuthService', () => {
       mockDb.limit.mockResolvedValueOnce([
         {
           codeHash: hashToken('the-code'),
-          clientId: 'c1',
+          clientId: CLIENT_UUID,
           userId: 'u1',
           projectId: 'p1',
           scopes: ['workflow:read'],
@@ -726,7 +751,7 @@ describe('OAuthService', () => {
         service.token({
           grant_type: 'authorization_code',
           code: 'the-code',
-          client_id: 'c1',
+          client_id: CLIENT_UUID,
           redirect_uri: 'https://claude.ai/cb',
           code_verifier: verifier,
         }),
@@ -743,7 +768,7 @@ describe('OAuthService', () => {
         {
           tokenHash: hashToken('bfrt_old'),
           familyId: 'fam-1',
-          clientId: 'c1',
+          clientId: CLIENT_UUID,
           userId: 'u1',
           projectId: 'p1',
           scopes: ['workflow:read'],
@@ -758,7 +783,11 @@ describe('OAuthService', () => {
         .mockReturnValueOnce(mockDb)
         .mockResolvedValueOnce([]);
       await expect(
-        service.token({ grant_type: 'refresh_token', refresh_token: 'bfrt_old', client_id: 'c1' }),
+        service.token({
+          grant_type: 'refresh_token',
+          refresh_token: 'bfrt_old',
+          client_id: CLIENT_UUID,
+        }),
       ).rejects.toMatchObject({ error: 'invalid_grant' });
       expect(appTokens.create).not.toHaveBeenCalled();
     });
@@ -768,7 +797,7 @@ describe('OAuthService', () => {
     const refreshRow = (over: Record<string, unknown> = {}) => ({
       tokenHash: hashToken('bfrt_old'),
       familyId: 'fam-1',
-      clientId: 'c1',
+      clientId: CLIENT_UUID,
       userId: 'u1',
       projectId: 'p1',
       scopes: ['workflow:read', 'workflow:run'],
@@ -790,7 +819,7 @@ describe('OAuthService', () => {
       const out = await service.token({
         grant_type: 'refresh_token',
         refresh_token: 'bfrt_old',
-        client_id: 'c1',
+        client_id: CLIENT_UUID,
       });
       expect(out.refresh_token).not.toBe('bfrt_old');
       expect(mockDb.set).toHaveBeenCalledWith({ rotatedAt: expect.any(Date) });

--- a/apps/backend/src/oauth/oauth.service.ts
+++ b/apps/backend/src/oauth/oauth.service.ts
@@ -48,6 +48,8 @@ export const CODE_TTL_MS = 10 * 60_000;
 export const PENDING_REQUEST_TTL_S = 10 * 60;
 const SUPPORTED_GRANT_TYPES = ['authorization_code', 'refresh_token'];
 const REFRESH_PREFIX = 'bfrt_';
+/** Canonical hyphenated uuid — the shape `oauth_clients.client_id` is issued and stored in. */
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /** What a fetch of the resource's protected-resource document must do (injected for tests). */
 export type FetchLike = (
@@ -238,9 +240,16 @@ export class OAuthService {
    * so codes, refresh tokens and the App Tokens page (`OAuth: <client_name>`)
    * work exactly as for a registered client. A URL that fails the guard or
    * whose document is invalid throws `invalid_client`, as an unknown uuid does.
+   *
+   * A value that is neither is unknown too: `oauth_clients.client_id` is a
+   * `uuid` column, so querying it with anything else makes Postgres raise
+   * `invalid input syntax for type uuid` (22P02) — a 500 where the caller
+   * should see `invalid_client` (#767). Registered ids are issued in canonical
+   * hyphenated form, so that is the only shape worth looking up.
    */
   private async clientFor(clientId: string): Promise<OAuthClient | undefined> {
     if (!this.clientMetadata.isClientIdUrl(clientId)) {
+      if (!UUID_PATTERN.test(clientId)) return undefined;
       const [client] = await db
         .select()
         .from(oauthClients)


### PR DESCRIPTION
Closes #767

## Summary
An OAuth client that started an authorization flow with a malformed `client_id` — anything that is neither a registered client's uuid nor an `https://` Client ID Metadata Document URL — got a 500 from `GET /api/oauth/authorize` instead of the `invalid_client` rejection the spec (and the rest of this endpoint) gives an unknown client. This PR checks the value is a uuid before looking it up, so a garbage `client_id` is now refused as an unknown client with a proper 401 JSON error. Operators stop seeing spurious Postgres errors in the backend log for what is really a client mistake or a scanner.

## Behaviour changes
- `GET /api/oauth/authorize?client_id=not-a-client&…`: before → HTTP 500 (unhandled Postgres `invalid input syntax for type uuid`); after → HTTP 401 `{ "error": "invalid_client", "error_description": "unknown client_id" }`, identical to an unknown-but-well-formed uuid.
- Well-formed uuids and metadata-document URLs are handled exactly as before. `POST /api/oauth/token` is untouched (it resolves the code by hash first, so a malformed `client_id` there already yields `invalid_grant`).
- Additive / non-breaking: only a previously-erroring input changes outcome.

## Why
`oauth_clients.client_id` is a `uuid` column. `clientFor()` branched on "is it a metadata URL?" and sent everything else straight to a Drizzle `eq()` lookup, which Postgres rejects with error 22P02 before `beginAuthorization` can reach its `invalid_client` throw. Pre-existing before #764; CIMD support merely made the branch explicit. Registered ids are issued in canonical hyphenated form (`defaultRandom()`), so a uuid regex is sufficient and avoids a needless round-trip for values that cannot match a row (issue #767's suggested fix).

## What changed
- **backend**: `apps/backend/src/oauth/oauth.service.ts` — `UUID_PATTERN` constant; `clientFor()` returns `undefined` for a non-URL value that is not a canonical uuid, so the existing `invalid_client` / 401 path fires.
- **tests**: `apps/backend/src/oauth/oauth.service.spec.ts` — new case beside the existing unknown-client test: five garbage `client_id` shapes (`not-a-client`, `c1`, whitespace, `http:/x`, uuid with a trailing char) each reject with `invalid_client` / `unknown client_id` / status 401, and neither the DB nor the metadata resolver is touched. The spec's fixture client id changes from `'c1'` to a real uuid constant (`CLIENT_UUID`) so the existing flows keep exercising the lookup path.

## Compatibility
No migration, no schema change, no env vars, no nginx generation, no storage layout, no pipeline/proxy-rule semantics, no CLI or GitHub Action contract. The only API-visible difference is a 500 becoming the documented 401 for malformed input.

## Verification
Run in the worktree on top of `origin/main` (432247a):
- `pnpm --filter backend exec tsc --noEmit` → exit 0
- `pnpm --filter frontend exec tsc --noEmit` → exit 0
- `cd apps/backend && pnpm test -- src/oauth` → Test Suites: 5 passed, 5 total; Tests: 120 passed, 120 total (`oauth.service.spec`, `client-metadata.service.spec`, `oauth.controller.spec`, `oauth-register-http.spec`, `pkce.util.spec`)
- `pnpm --filter backend format:check` → "All matched files use Prettier code style!"

## Out of scope / follow-ups
- The other CIMD follow-ups tracked in #766 are not touched here.
- No local database on this VPS, so the fix was verified via the unit suite (which stubs `db`); the 500 → 401 change is straightforward to confirm live with the reproduce URL from #767.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NK2eaY4ZwmXRxifq22ELsV
