### PR TITLE
feat(oauth): rate-limit and dedupe Client ID Metadata Document fetches

### DIFF
--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -290,10 +290,18 @@ import-by-URL features.
 non-public — including IPv6 forms that embed an IPv4 (`::ffff:`, NAT64, 6to4), (3) pin the connection to the
 vetted addresses so the name is not resolved again between check and connect, (4) refuse redirects, and
 (5) bound the read with a timeout and a byte cap? A hostname/regex check alone (the `validateTargetUrl`
-TODO) is bypassed by a public name that resolves to `169.254.169.254`.
+TODO) is bypassed by a public name that resolves to `169.254.169.254`. And (6) does the route that
+triggers the fetch carry a rate limit tighter than the global default (a `@Throttle` override on the
+handler — the global `ThrottlerGuard` is 100/min per IP), plus, where the target is cacheable, in-flight
+dedupe (one fetch per URL shared by concurrent callers) and a negative cache (a failure is remembered for
+a fixed TTL, not refetched per request)? A cache keyed by the full URL is defeated by a query string the
+caller controls, so the positive cache alone is no ceiling.
 **Why:** The backend runs next to the metadata endpoint, the database, MinIO and the other pods; one
-missed step turns "fetch my client metadata" into "read the instance credentials".
-**Learned from:** #741, 2026-09-07 — the triage comment flagged it before the code was written.
+missed step turns "fetch my client metadata" into "read the instance credentials". Without (6), any
+session holder can make the server perform one guarded outbound fetch per request, for as long as the
+global limit allows.
+**Learned from:** #741, 2026-09-07 — the triage comment flagged it before the code was written;
+(6) from #768, 2026-09-07 — the CIMD fetch shipped (PR #764) with only the global throttle over it.
 
 ---
 

--- a/apps/backend/src/oauth/client-metadata.service.spec.ts
+++ b/apps/backend/src/oauth/client-metadata.service.spec.ts
@@ -1,7 +1,9 @@
 import {
+  CIMD_CACHE_MAX_ENTRIES,
   CIMD_CLIENT_NAMESPACE,
   CIMD_DEFAULT_TTL_MS,
   CIMD_MAX_TTL_MS,
+  CIMD_NEGATIVE_TTL_MS,
   ClientMetadataService,
   ClientMetadataTransport,
   assertClientIdUrl,
@@ -158,10 +160,183 @@ describe('ClientMetadataService — Client ID Metadata Documents (#741)', () => 
         }),
       });
       await expect(other.service.resolve(URL_)).rejects.toMatchObject({ error: 'invalid_client' });
-      // none of those are cached
+      // a failure is remembered (negative cache, #768): the repeat is answered without a fetch
       expect(other.transport.fetch).toHaveBeenCalledTimes(1);
       await expect(other.service.resolve(URL_)).rejects.toThrow(OAuthError);
-      expect(other.transport.fetch).toHaveBeenCalledTimes(2);
+      expect(other.transport.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('resolve — one fetch per URL, failures remembered (#768)', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    it('concurrent calls for the same URL share one lookup and one fetch', async () => {
+      let release!: (r: { status: number; headers: { get(): null }; text: string }) => void;
+      const fetch = jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            release = resolve;
+          }),
+      );
+      const { service, transport } = make({ fetch });
+      const a = service.resolve(URL_);
+      const b = service.resolve(URL_);
+      // let both calls get through the (mocked) lookup to the fetch — microtasks only
+      for (let i = 0; i < 20 && fetch.mock.calls.length === 0; i += 1) await Promise.resolve();
+      expect(transport.lookup).toHaveBeenCalledTimes(1);
+      expect(transport.fetch).toHaveBeenCalledTimes(1);
+      release({ status: 200, headers: { get: () => null }, text: JSON.stringify(doc()) });
+      const [docA, docB] = await Promise.all([a, b]);
+      expect(docA).toBe(docB);
+      expect(docA.clientName).toBe('Claude');
+      // the in-flight slot is released: after the cache is cleared, a new call fetches again
+      service.clearCache();
+      fetch.mockResolvedValue({
+        status: 200,
+        headers: { get: () => null },
+        text: JSON.stringify(doc()),
+      });
+      await service.resolve(URL_);
+      expect(transport.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('concurrent callers all see the one failure, and a different URL is not held up', async () => {
+      const otherUrl = 'https://other.example/client';
+      const fetch = jest.fn().mockImplementation(async (url: string) =>
+        url === URL_
+          ? Promise.reject(new Error('timeout'))
+          : {
+              status: 200,
+              headers: { get: () => null },
+              text: JSON.stringify(doc({ client_id: otherUrl })),
+            },
+      );
+      const { service, transport } = make({ fetch });
+      const results = await Promise.allSettled([
+        service.resolve(URL_),
+        service.resolve(URL_),
+        service.resolve(otherUrl),
+      ]);
+      expect(results.map((r) => r.status)).toEqual(['rejected', 'rejected', 'fulfilled']);
+      expect(transport.fetch).toHaveBeenCalledTimes(2);
+      expect(transport.fetch).toHaveBeenCalledWith(URL_, expect.anything());
+      expect(transport.fetch).toHaveBeenCalledWith(otherUrl, expect.anything());
+    });
+
+    it('a failed fetch is not retried within the negative TTL, and is retried after it', async () => {
+      const now = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+      const fetch = jest.fn().mockRejectedValue(new Error('ECONNRESET'));
+      const { service, transport } = make({ fetch });
+      const failure = {
+        error: 'invalid_client',
+        status: 401,
+        description: 'the client metadata document could not be fetched',
+      };
+      await expect(service.resolve(URL_)).rejects.toMatchObject(failure);
+      await expect(service.resolve(URL_)).rejects.toMatchObject(failure);
+      now.mockReturnValue(1_000_000 + CIMD_NEGATIVE_TTL_MS - 1);
+      await expect(service.resolve(URL_)).rejects.toMatchObject(failure);
+      expect(transport.lookup).toHaveBeenCalledTimes(1);
+      expect(transport.fetch).toHaveBeenCalledTimes(1);
+      // past the TTL the URL is tried again — and the document may be there now
+      now.mockReturnValue(1_000_000 + CIMD_NEGATIVE_TTL_MS);
+      fetch.mockResolvedValueOnce({
+        status: 200,
+        headers: { get: () => null },
+        text: JSON.stringify(doc()),
+      });
+      await expect(service.resolve(URL_)).resolves.toMatchObject({ clientName: 'Claude' });
+      expect(transport.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("a non-200, an invalid document, and an unresolvable host are remembered the same way; the TTL is fixed, not the response's", async () => {
+      const gone = make({
+        fetch: jest.fn().mockResolvedValue({
+          status: 404,
+          headers: { get: () => 'max-age=0' },
+          text: '',
+        }),
+      });
+      await expect(gone.service.resolve(URL_)).rejects.toMatchObject({
+        description: 'the client metadata document answered 404',
+      });
+      await expect(gone.service.resolve(URL_)).rejects.toMatchObject({
+        description: 'the client metadata document answered 404',
+      });
+      expect(gone.transport.fetch).toHaveBeenCalledTimes(1);
+
+      const bad = make({
+        fetch: jest.fn().mockResolvedValue({
+          status: 200,
+          headers: { get: () => 'no-store' },
+          text: JSON.stringify(doc({ redirect_uris: [] })),
+        }),
+      });
+      await expect(bad.service.resolve(URL_)).rejects.toMatchObject({ error: 'invalid_client' });
+      await expect(bad.service.resolve(URL_)).rejects.toMatchObject({ error: 'invalid_client' });
+      expect(bad.transport.fetch).toHaveBeenCalledTimes(1);
+
+      const unresolved = make({ lookup: jest.fn().mockRejectedValue(new Error('ENOTFOUND')) });
+      await expect(unresolved.service.resolve(URL_)).rejects.toMatchObject({
+        description: 'the client_id host does not resolve',
+      });
+      await expect(unresolved.service.resolve(URL_)).rejects.toMatchObject({
+        description: 'the client_id host does not resolve',
+      });
+      expect(unresolved.transport.lookup).toHaveBeenCalledTimes(1);
+    });
+
+    it('a URL refused by shape is not cached — that check costs nothing and does not touch the network', async () => {
+      const { service, transport } = make();
+      await expect(service.resolve('https://localhost/m')).rejects.toThrow(OAuthError);
+      expect(transport.lookup).not.toHaveBeenCalled();
+      expect(transport.fetch).not.toHaveBeenCalled();
+    });
+
+    it('clearCache drops negative entries too', async () => {
+      const fetch = jest.fn().mockRejectedValue(new Error('timeout'));
+      const { service, transport } = make({ fetch });
+      await expect(service.resolve(URL_)).rejects.toThrow(OAuthError);
+      service.clearCache();
+      await expect(service.resolve(URL_)).rejects.toThrow(OAuthError);
+      expect(transport.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('negative entries count toward the cache bound: at the cap the oldest one is evicted', async () => {
+      const failing = (url: string) => `${url}?v=fail`;
+      const fetch = jest.fn().mockImplementation(async (url: string) =>
+        url.endsWith('?v=fail')
+          ? Promise.reject(new Error('timeout'))
+          : {
+              status: 200,
+              headers: { get: () => null },
+              text: JSON.stringify(doc({ client_id: url })),
+            },
+      );
+      const { service, transport } = make({ fetch });
+      const first = failing('https://client-0.example/m');
+      for (let i = 0; i < CIMD_CACHE_MAX_ENTRIES; i += 1) {
+        await expect(service.resolve(failing(`https://client-${i}.example/m`))).rejects.toThrow(
+          OAuthError,
+        );
+      }
+      expect(transport.fetch).toHaveBeenCalledTimes(CIMD_CACHE_MAX_ENTRIES);
+      // full: the first (oldest) negative entry still answers from the cache
+      await expect(service.resolve(first)).rejects.toThrow(OAuthError);
+      expect(transport.fetch).toHaveBeenCalledTimes(CIMD_CACHE_MAX_ENTRIES);
+      // one more entry — a document this time — evicts exactly the oldest
+      await expect(service.resolve('https://client-new.example/m')).resolves.toMatchObject({
+        clientId: 'https://client-new.example/m',
+      });
+      expect(transport.fetch).toHaveBeenCalledTimes(CIMD_CACHE_MAX_ENTRIES + 1);
+      // the second-oldest is still held …
+      await expect(service.resolve(failing('https://client-1.example/m'))).rejects.toThrow(
+        OAuthError,
+      );
+      expect(transport.fetch).toHaveBeenCalledTimes(CIMD_CACHE_MAX_ENTRIES + 1);
+      // … the oldest is gone and is fetched again
+      await expect(service.resolve(first)).rejects.toThrow(OAuthError);
+      expect(transport.fetch).toHaveBeenCalledTimes(CIMD_CACHE_MAX_ENTRIES + 2);
     });
   });
 

--- a/apps/backend/src/oauth/client-metadata.service.ts
+++ b/apps/backend/src/oauth/client-metadata.service.ts
@@ -19,6 +19,13 @@ import { isAcceptableRedirect } from './redirect-uri.util';
  * to must be public; the connection is then pinned to exactly those
  * addresses (no re-resolution between the check and the connect); redirects
  * are not followed; the read is bounded by a timeout and a byte cap.
+ *
+ * The fetch is also a cost a session holder can make the server pay: a
+ * query string is legal in a `client_id`, so a cache-busting query defeats
+ * the positive cache. Three ceilings (#768): the authorize route's own
+ * `@Throttle` override, one in-flight fetch per URL shared by concurrent
+ * callers, and a fixed-TTL negative cache so a failing URL is not refetched
+ * on every request.
  */
 
 export const CIMD_FETCH_TIMEOUT_MS = 5_000;
@@ -27,6 +34,9 @@ export const CIMD_MAX_BYTES = 64 * 1024;
 export const CIMD_DEFAULT_TTL_MS = 5 * 60_000;
 /** The longest a `max-age` may hold a document — a rotated redirect_uri must land within a day. */
 export const CIMD_MAX_TTL_MS = 24 * 3600_000;
+/** How long a failed resolution (unreachable, non-200, invalid document) is remembered — fixed, never from `Cache-Control`. */
+export const CIMD_NEGATIVE_TTL_MS = 60_000;
+/** Positive and negative entries together — a failing URL costs the same slot a document does. */
 export const CIMD_CACHE_MAX_ENTRIES = 500;
 /**
  * The uuid v5 namespace an `oauth_clients` row keyed by its metadata URL gets.
@@ -88,7 +98,9 @@ export interface ClientMetadataTransport {
 @Injectable()
 export class ClientMetadataService {
   private readonly logger = new Logger(ClientMetadataService.name);
-  private readonly cache = new Map<string, { doc: ClientMetadataDocument; expiresAt: number }>();
+  private readonly cache = new Map<string, CacheEntry>();
+  /** One fetch per URL at a time: concurrent callers await the same promise. */
+  private readonly inflight = new Map<string, Promise<ClientMetadataDocument>>();
   private readonly transport: ClientMetadataTransport;
 
   constructor(@Optional() @Inject(CLIENT_METADATA_TRANSPORT) transport?: ClientMetadataTransport) {
@@ -117,45 +129,68 @@ export class ClientMetadataService {
   /**
    * The document behind `clientId`, from the cache or fetched through the guard.
    * Every failure is `invalid_client` (401): the client_id names no usable client.
+   * A failure is remembered for {@link CIMD_NEGATIVE_TTL_MS} and answered from the
+   * cache without another fetch; concurrent calls for one URL share one fetch.
    */
   async resolve(clientId: string): Promise<ClientMetadataDocument> {
     const url = assertClientIdUrl(clientId);
     const cached = this.cache.get(clientId);
-    if (cached && cached.expiresAt > Date.now()) return cached.doc;
+    if (cached && cached.expiresAt > Date.now()) {
+      if ('doc' in cached) return cached.doc;
+      throw invalidClient(cached.description);
+    }
     this.cache.delete(clientId);
 
-    const addresses = await this.vettedAddresses(url.hostname);
-    let res: ClientMetadataResponse;
-    try {
-      res = await this.transport.fetch(clientId, {
-        addresses,
-        signal: AbortSignal.timeout(CIMD_FETCH_TIMEOUT_MS),
-      });
-    } catch (error) {
-      this.logger.debug(`client metadata document ${clientId}: ${String(error)}`);
-      throw invalidClient('the client metadata document could not be fetched');
-    }
-    if (res.status !== 200) {
-      throw invalidClient(`the client metadata document answered ${res.status}`);
-    }
-    let raw: unknown;
-    try {
-      raw = JSON.parse(res.text);
-    } catch {
-      throw invalidClient('the client metadata document is not JSON');
-    }
-    const doc = parseClientMetadataDocument(raw, clientId);
-    if (doc.tokenEndpointAuthMethod !== 'none') {
-      this.logger.log(
-        `OAuth client ${clientId} declares ${doc.tokenEndpointAuthMethod}; treated as a public client (none)`,
-      );
-    }
-    this.remember(clientId, doc, ttlFrom(res.headers.get('cache-control')));
-    return doc;
+    const pending = this.inflight.get(clientId);
+    if (pending) return pending;
+    const fetching = this.fetchDocument(clientId, url).finally(() => {
+      this.inflight.delete(clientId);
+    });
+    this.inflight.set(clientId, fetching);
+    return fetching;
   }
 
   clearCache(): void {
     this.cache.clear();
+  }
+
+  /** The guarded fetch and parse; the outcome — document or failure — goes into the cache. */
+  private async fetchDocument(clientId: string, url: URL): Promise<ClientMetadataDocument> {
+    try {
+      const addresses = await this.vettedAddresses(url.hostname);
+      let res: ClientMetadataResponse;
+      try {
+        res = await this.transport.fetch(clientId, {
+          addresses,
+          signal: AbortSignal.timeout(CIMD_FETCH_TIMEOUT_MS),
+        });
+      } catch (error) {
+        this.logger.debug(`client metadata document ${clientId}: ${String(error)}`);
+        throw invalidClient('the client metadata document could not be fetched');
+      }
+      if (res.status !== 200) {
+        throw invalidClient(`the client metadata document answered ${res.status}`);
+      }
+      let raw: unknown;
+      try {
+        raw = JSON.parse(res.text);
+      } catch {
+        throw invalidClient('the client metadata document is not JSON');
+      }
+      const doc = parseClientMetadataDocument(raw, clientId);
+      if (doc.tokenEndpointAuthMethod !== 'none') {
+        this.logger.log(
+          `OAuth client ${clientId} declares ${doc.tokenEndpointAuthMethod}; treated as a public client (none)`,
+        );
+      }
+      this.remember(clientId, { doc }, ttlFrom(res.headers.get('cache-control')));
+      return doc;
+    } catch (error) {
+      if (error instanceof OAuthError) {
+        this.remember(clientId, { description: error.description }, CIMD_NEGATIVE_TTL_MS);
+      }
+      throw error;
+    }
   }
 
   private async vettedAddresses(hostname: string): Promise<ResolvedAddress[]> {
@@ -174,15 +209,20 @@ export class ClientMetadataService {
     return addresses;
   }
 
-  private remember(clientId: string, doc: ClientMetadataDocument, ttlMs: number): void {
+  /** Insert-ordered and bounded: at the cap the oldest entry, positive or negative, makes room. */
+  private remember(clientId: string, outcome: CacheOutcome, ttlMs: number): void {
     if (ttlMs <= 0) return;
     if (this.cache.size >= CIMD_CACHE_MAX_ENTRIES) {
       const oldest = this.cache.keys().next().value;
       if (oldest !== undefined) this.cache.delete(oldest);
     }
-    this.cache.set(clientId, { doc, expiresAt: Date.now() + ttlMs });
+    this.cache.set(clientId, { ...outcome, expiresAt: Date.now() + ttlMs });
   }
 }
+
+/** A resolved document, or the `invalid_client` description a failed resolution produced. */
+type CacheOutcome = { doc: ClientMetadataDocument } | { description: string };
+type CacheEntry = CacheOutcome & { expiresAt: number };
 
 function invalidClient(description: string): OAuthError {
   return new OAuthError('invalid_client', description, 401);

--- a/apps/backend/src/oauth/oauth.controller.spec.ts
+++ b/apps/backend/src/oauth/oauth.controller.spec.ts
@@ -5,6 +5,8 @@ import { RegisterClientDto } from './oauth.dto';
 import { OAuthMetadataController } from './oauth-metadata.controller';
 import { OAuthError } from './oauth.errors';
 import { PUBLIC_PROJECT_ACCESS_KEY } from '../auth/decorators/public-project-access.decorator';
+// Not re-exported from the package root; these are the keys `ThrottlerGuard` reads through the Reflector.
+import { THROTTLER_LIMIT, THROTTLER_TTL } from '@nestjs/throttler/dist/throttler.constants';
 
 jest.mock('supertokens-node/recipe/session', () => ({ getSession: jest.fn() }));
 const { getSession: mockGetSession } = jest.requireMock('supertokens-node/recipe/session');
@@ -82,6 +84,20 @@ describe('OAuth controllers', () => {
     expect(guards('token')).toEqual([]);
     expect(guards('register')).toEqual([]);
     expect(guards('authorize')).toEqual([]);
+  });
+
+  it('authorize carries its own per-IP throttle, tighter than the global 100/min (#768)', () => {
+    // A URL client_id makes the route fetch a Client ID Metadata Document; the
+    // global ThrottlerGuard applies this override per IP on the authorize handler.
+    const handler = OAuthController.prototype.authorize;
+    expect(Reflect.getMetadata(`${THROTTLER_LIMIT}default`, handler)).toBe(20);
+    expect(Reflect.getMetadata(`${THROTTLER_TTL}default`, handler)).toBe(60_000);
+    // and only there — the other routes keep the global default
+    for (const other of ['register', 'pending', 'decide', 'token', 'revoke'] as const) {
+      expect(
+        Reflect.getMetadata(`${THROTTLER_LIMIT}default`, OAuthController.prototype[other]),
+      ).toBeUndefined();
+    }
   });
 
   it('serves RFC 8414 metadata', () => {

--- a/apps/backend/src/oauth/oauth.controller.ts
+++ b/apps/backend/src/oauth/oauth.controller.ts
@@ -12,6 +12,7 @@ import {
   ValidationPipe,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { Request, Response } from 'express';
 import { getSession } from 'supertokens-node/recipe/session';
 import { SessionAuthGuard } from '../auth/session-auth.guard';
@@ -76,6 +77,10 @@ export class OAuthController {
   }
 
   @Get('authorize')
+  // A URL client_id makes this route fetch a Client ID Metadata Document, and a
+  // query string in the URL defeats the document cache — so the route is held
+  // well under the global 100/min per IP (#768). A browser flow needs one hit.
+  @Throttle({ default: { limit: 20, ttl: 60_000 } })
   @ApiOperation({
     summary: 'Authorization endpoint (code + PKCE S256, RFC 8707 resource)',
     description:


### PR DESCRIPTION
Closes #768

## Summary
When an OAuth client identifies itself by an `https://` URL (Client ID Metadata Document, shipped in #764), `GET /api/oauth/authorize` fetches that URL server-side. The document cache is keyed by the full URL, and a query string is legal in a `client_id`, so a caller could bust the cache on every request and make the server perform one outbound fetch per request — bounded only by the global 100/min per-IP limit. This PR puts three ceilings on that: the authorize route gets its own tighter per-IP rate limit, concurrent requests for the same URL share one fetch, and a URL that fails is remembered for 60 seconds instead of being retried on every request. A real browser flow (one hit on authorize per login) is unaffected.

## Behaviour changes
- `GET /api/oauth/authorize`: before → 100 requests/min per IP (global default); after → 20 requests/min per IP. Over the limit the existing throttler answers 429 as it does elsewhere. No per-user limiter.
- Metadata document resolution: before → every failed resolution (unresolvable host, non-public address, fetch error/timeout, non-200, invalid document) was retried on the next request; after → the same `invalid_client` (401) is answered from a negative cache for 60 s without touching the network, then retried. The TTL is fixed and never taken from the response's `Cache-Control`.
- Concurrent requests for the same `client_id` URL: before → one fetch each; after → one shared fetch; every caller sees the same document or the same failure.
- Successful documents are cached exactly as before (`Cache-Control` `max-age` / default 5 min / `no-store`). Negative entries share the same 500-entry bound, so the cache still cannot grow without limit. `clearCache()` drops negative entries too.
- Additive throughout: no new dependency, schema, env var, or API field.

## Why
Decision recorded on #766 (item 1). The SSRF guard from #741 makes the fetch safe, but not free: any session holder could keep the backend fetching an attacker-chosen public URL. The route-level `@Throttle` override uses the `ThrottlerGuard` already registered globally, so there is no new infrastructure; dedupe and the negative cache reduce the cost of the requests that do get through.

## What changed
- **backend** — `apps/backend/src/oauth/oauth.controller.ts` (`@Throttle({ default: { limit: 20, ttl: 60_000 } })` on `authorize`); `apps/backend/src/oauth/client-metadata.service.ts` (`resolve()` now checks a positive-or-negative cache entry, then an in-flight map, and delegates to a new private `fetchDocument()` whose failure path records a negative entry; new `CIMD_NEGATIVE_TTL_MS = 60_000`).
- **tests** — `client-metadata.service.spec.ts`: concurrent calls share one lookup and one fetch; concurrent callers all see one failure while another URL is not held up; a failed fetch is not retried within the negative TTL and is retried after it; non-200, invalid document and unresolvable host are remembered the same way; shape-refused URLs are not cached; `clearCache()` drops negative entries; negative entries count toward the cache bound (500 failures fill it, the next entry evicts the oldest). The pre-existing "none of those are cached" assertion is updated to the new behaviour. `oauth.controller.spec.ts`: reflector check that `authorize` carries limit 20 / ttl 60 000 and no other route does.
- **docs** — `.claude/ce-pr-review-checklist.md`: the "fetch of a caller-supplied URL" entry gains check (6): the triggering route must carry a rate limit tighter than the global default, plus in-flight dedupe / negative caching where the target is cacheable. Points (1)–(5) unchanged.

## Compatibility
- Migrations: none. Env vars: none. Storage layout, nginx generation, pipeline/proxy-rule semantics: untouched.
- API/CLI contract: additive. Response shapes are unchanged; the only client-visible difference is a 429 past 20 authorize requests/min per IP, which no legitimate browser flow approaches, and a 60 s window in which a just-fixed metadata document is still answered `invalid_client`.
- `oauth.service.ts` is deliberately not touched (a concurrent PR for #767 edits it).

## Verification
Run in the worktree:
- `pnpm --filter backend exec tsc --noEmit` — exit 0
- `pnpm --filter frontend exec tsc --noEmit` — exit 0
- `pnpm --filter backend format:check` — "All matched files use Prettier code style!"
- `cd apps/backend && pnpm test -- src/oauth` — 5 suites, 127 tests passed, 0 failed (`client-metadata.service.spec.ts`, `oauth.service.spec.ts`, `oauth.controller.spec.ts`, `oauth-register-http.spec.ts`, `pkce.util.spec.ts`)

## Out of scope / follow-ups
- Lifting the SSRF guard into `common/` and reusing it for proxy-rule targets (`validateTargetUrl`) is #766 item 2.
- The negative cache also covers DNS/non-public-address refusals (a network cost, same `invalid_client`), which is slightly wider than the three cases the issue lists; called out here so the reviewer can object if that is not wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NK2eaY4ZwmXRxifq22ELsV
