### PR TITLE
feat(backend): shared SSRF guard for proxy-rule targets and app bundle URLs (warn by default)

### DIFF
--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -282,9 +282,12 @@ controls `bypassVisibility` already), but a silent widening.
 narrowed in the same PR to well-known rules whose first enabled step is the handler.
 
 ### A fetch of a caller-supplied URL needs the whole SSRF guard, not a hostname regex
-**Surface:** any new server-side fetch whose URL comes from a request — `apps/backend/src/oauth/client-metadata.service.ts`
-(Client ID Metadata Documents), `proxy-rules.service.ts` `validateTargetUrl` (rule targets), future webhook /
-import-by-URL features.
+**Surface:** any new server-side fetch whose URL comes from a request. The building blocks live in
+`apps/backend/src/common/outbound-url.guard.ts` (`isPublicAddress`, `vetOutboundHost`, `pinnedLookup`, `readCapped`,
+and the `OUTBOUND_URL_GUARD` warn/reject policy for places a hard refusal would break self-hosters); callers are
+`oauth/client-metadata.service.ts` (Client ID Metadata Documents — always refuses), `proxy-rules.service.ts`
+`validateTargetUrl` (rule targets) and `app-catalog/app-bundle.service.ts` (bundle URLs); future webhook /
+import-by-URL features should reuse them rather than re-implement a hostname check.
 **Check:** Does the guard (1) require https and a domain name (never an IP literal, never a local /
 `.internal` / `.svc` / `.cluster.local` suffix), (2) resolve the name and refuse if *any* address is
 non-public — including IPv6 forms that embed an IPv4 (`::ffff:`, NAT64, 6to4), (3) pin the connection to the

--- a/.env.example
+++ b/.env.example
@@ -348,6 +348,20 @@ MINIO_USE_SSL=false
 # Available from CE 0.4.0.
 # APPS_REGISTRY_URL=https://apps.bffless.dev/registry.json
 
+# Outbound URL guard (SSRF defence in depth) for URLs the server fetches on
+# someone's behalf: proxy-rule targets (checked on rule create/update) and app
+# bundle URLs (checked at install preflight). The hostname is resolved and
+# every address must be public. Hosts that are internal by declaration —
+# localhost, 127.0.0.1, *.svc, *.svc.cluster.local — are exempt.
+#   warn   (default) log a warning and allow — split-horizon or private
+#          targets that worked before keep working after upgrade
+#   reject refuse: HTTP 400 on rule create/update, a failed preflight step
+#          on app install. A name that does not resolve is refused too.
+# Any other value is treated as warn (warned about once at startup).
+# Does not apply to OAuth Client ID Metadata Documents, which always refuse
+# non-public hosts.
+# OUTBOUND_URL_GUARD=warn
+
 
 # ============================================================================
 # 7. CACHE CONFIGURATION [OPTIONAL]

--- a/apps/backend/src/app-catalog/app-bundle.service.spec.ts
+++ b/apps/backend/src/app-catalog/app-bundle.service.spec.ts
@@ -1,8 +1,13 @@
 import { zipSync, strToU8 } from 'fflate';
 import { createHash } from 'crypto';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, Logger } from '@nestjs/common';
+import { lookup as dnsLookup } from 'node:dns/promises';
 import { AppBundleService } from './app-bundle.service';
 import { TEST_MANIFEST } from './app-manifest.util.spec';
+
+// fetchBundle vets the bundle host through the outbound URL guard (#770); no real DNS in tests.
+jest.mock('node:dns/promises', () => ({ lookup: jest.fn() }));
+const mockDnsLookup = dnsLookup as unknown as jest.Mock;
 
 function makeBundle(
   manifest: unknown = TEST_MANIFEST,
@@ -49,6 +54,8 @@ describe('AppBundleService', () => {
   beforeEach(() => {
     service = new AppBundleService();
     fetchSpy = jest.spyOn(globalThis, 'fetch');
+    // Default: the registry's bundle host resolves to a public address.
+    mockDnsLookup.mockReset().mockResolvedValue([{ address: '104.18.1.1', family: 4 }]);
   });
 
   afterEach(() => {
@@ -160,6 +167,105 @@ describe('AppBundleService', () => {
       const loaded = await service.loadFromBuffer(buf);
 
       expect(loaded.manifest).toEqual(TEST_MANIFEST);
+    });
+  });
+
+  describe('fetchBundle — bundle host under OUTBOUND_URL_GUARD (#770)', () => {
+    const envBefore = process.env.OUTBOUND_URL_GUARD;
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+      if (envBefore === undefined) delete process.env.OUTBOUND_URL_GUARD;
+      else process.env.OUTBOUND_URL_GUARD = envBefore;
+    });
+
+    it('passes a public bundle URL silently and downloads it', async () => {
+      process.env.OUTBOUND_URL_GUARD = 'reject';
+      const { buf, sha256 } = makeBundle();
+      fetchSpy.mockResolvedValue(fetchResponse(buf));
+
+      const loaded = await service.fetchBundle('https://apps.bffless.dev/handoff.zip', sha256);
+
+      expect(loaded.sha256).toBe(sha256);
+      expect(mockDnsLookup).toHaveBeenCalledWith(
+        'apps.bffless.dev',
+        expect.objectContaining({ all: true }),
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warn (default): a private-resolving bundle host is logged and still downloaded', async () => {
+      delete process.env.OUTBOUND_URL_GUARD;
+      mockDnsLookup.mockResolvedValue([{ address: '10.0.0.9', family: 4 }]);
+      const { buf, sha256 } = makeBundle();
+      fetchSpy.mockResolvedValue(fetchResponse(buf));
+
+      const loaded = await service.fetchBundle('https://registry.corp.example/handoff.zip', sha256);
+
+      expect(loaded.sha256).toBe(sha256);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const line = String(warnSpy.mock.calls[0][0]);
+      expect(line).toContain('app bundle https://registry.corp.example/handoff.zip');
+      expect(line).toContain('10.0.0.9');
+      expect(line).toContain('OUTBOUND_URL_GUARD=warn');
+    });
+
+    it('reject: a private-resolving bundle host fails with a clear error before any download', async () => {
+      process.env.OUTBOUND_URL_GUARD = 'reject';
+      mockDnsLookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+
+      const attempt = service.fetchBundle(
+        'https://registry.corp.example/handoff.zip',
+        'a'.repeat(64),
+      );
+      await expect(attempt).rejects.toThrow(BadRequestException);
+      await expect(attempt).rejects.toThrow(
+        /app bundle https:\/\/registry\.corp\.example\/handoff\.zip.*169\.254\.169\.254.*OUTBOUND_URL_GUARD=reject/,
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      'https://localhost:8443/handoff.zip',
+      'https://127.0.0.1:8443/handoff.zip',
+      'https://registry.apps.svc/handoff.zip',
+      'https://registry.apps.svc.cluster.local/handoff.zip',
+    ])('a local registry at %s is exempt from the lookup, in reject mode too', async (url) => {
+      process.env.OUTBOUND_URL_GUARD = 'reject';
+      const { buf, sha256 } = makeBundle();
+      fetchSpy.mockResolvedValue(fetchResponse(buf));
+
+      await expect(service.fetchBundle(url, sha256)).resolves.toBeDefined();
+      expect(mockDnsLookup).not.toHaveBeenCalled();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not vet (or fetch) when the sha is already cached', async () => {
+      const { buf, sha256 } = makeBundle();
+      fetchSpy.mockResolvedValue(fetchResponse(buf));
+      await service.fetchBundle('https://apps.bffless.dev/handoff.zip', sha256);
+      mockDnsLookup.mockClear();
+      process.env.OUTBOUND_URL_GUARD = 'reject';
+      mockDnsLookup.mockResolvedValue([{ address: '10.0.0.9', family: 4 }]);
+
+      await expect(
+        service.fetchBundle('https://apps.bffless.dev/handoff.zip', sha256),
+      ).resolves.toBeDefined();
+      expect(mockDnsLookup).not.toHaveBeenCalled();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects an unparseable bundle URL as a 400 rather than a fetch TypeError', async () => {
+      await expect(service.fetchBundle('not a url', 'a'.repeat(64))).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/app-catalog/app-bundle.service.ts
+++ b/apps/backend/src/app-catalog/app-bundle.service.ts
@@ -1,6 +1,11 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
+import { Injectable, BadRequestException, Logger } from '@nestjs/common';
 import { unzip } from 'fflate';
 import { createHash } from 'crypto';
+import {
+  guardOutboundHost,
+  isExplicitlyInternalHost,
+  outboundUrlGuardMode,
+} from '../common/outbound-url.guard';
 import { validateAppManifest } from './app-manifest.util';
 import type { AppManifest } from './app-manifest.types';
 
@@ -37,6 +42,7 @@ const COMMIT_PATTERN = /^[0-9a-f]{40}$/i;
  */
 @Injectable()
 export class AppBundleService {
+  private readonly logger = new Logger(AppBundleService.name);
   private readonly MAX_BUNDLE_BYTES = 200 * 1024 * 1024;
   private readonly DOWNLOAD_TIMEOUT_MS = 30_000;
   private readonly MAX_CACHE_ENTRIES = 3;
@@ -51,6 +57,11 @@ export class AppBundleService {
    */
   private readonly MAX_CACHE_BYTES = 8 * 1024 * 1024;
   private readonly cache = new Map<string, LoadedBundle>();
+
+  constructor() {
+    // Read once at startup so an unrecognised OUTBOUND_URL_GUARD value is warned about at boot.
+    outboundUrlGuardMode();
+  }
 
   /** Decompressed size of a bundle's entries — what retaining it actually costs. */
   private bundleBytes(files: Record<string, Uint8Array>): number {
@@ -96,6 +107,8 @@ export class AppBundleService {
       }
     }
 
+    await this.assertBundleHost(url);
+
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.DOWNLOAD_TIMEOUT_MS);
     let res: Response;
@@ -127,6 +140,28 @@ export class AppBundleService {
     }
 
     return this.loadFromBuffer(new Uint8Array(arrayBuffer), expectedSha256);
+  }
+
+  /**
+   * The bundle URL comes from the registry (operator-controlled via
+   * `APPS_REGISTRY_URL`), so this is defence in depth (#770): the host is
+   * resolved and every address must be public, under `OUTBOUND_URL_GUARD` —
+   * `warn` (default) logs and downloads anyway; `reject` fails the install
+   * preflight with a clear step error. The same hosts `validateTargetUrl`
+   * treats as declared-internal are exempt, so a local registry keeps working.
+   */
+  private async assertBundleHost(url: string): Promise<void> {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new BadRequestException(`Bundle URL is not a valid URL: ${url}`);
+    }
+    if (isExplicitlyInternalHost(parsed.hostname)) return;
+    await guardOutboundHost(parsed.hostname, {
+      subject: `app bundle ${url}`,
+      logger: this.logger,
+    });
   }
 
   async loadFromBuffer(buf: Uint8Array, expectedSha256?: string): Promise<LoadedBundle> {

--- a/apps/backend/src/common/outbound-url.guard.spec.ts
+++ b/apps/backend/src/common/outbound-url.guard.spec.ts
@@ -1,0 +1,283 @@
+import { BadRequestException, Logger } from '@nestjs/common';
+import {
+  guardOutboundHost,
+  isExplicitlyInternalHost,
+  isPublicAddress,
+  outboundUrlGuardMode,
+  pinnedLookup,
+  readCapped,
+  vetOutboundHost,
+  type HostLookup,
+} from './outbound-url.guard';
+
+const PUBLIC = [{ address: '104.18.1.1', family: 4 as const }];
+const METADATA = [{ address: '169.254.169.254', family: 4 as const }];
+
+describe('outbound-url.guard (#770)', () => {
+  describe('isPublicAddress', () => {
+    it.each([
+      '104.18.1.1',
+      '8.8.8.8',
+      '203.0.113.9',
+      '2606:4700::6810:1',
+      '::ffff:8.8.8.8',
+      '64:ff9b::808:808',
+      '2002:808:808::',
+      '2001:3::1',
+      '2001:20::1',
+      '100:1::1',
+      '4000::1',
+    ])('%s is public', (ip) => expect(isPublicAddress(ip)).toBe(true));
+    it.each([
+      '127.0.0.1',
+      '127.8.8.8',
+      '10.1.2.3',
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.1.1',
+      '169.254.169.254',
+      '100.64.0.1',
+      '0.0.0.0',
+      '192.0.0.8',
+      '198.18.0.1',
+      '224.0.0.1',
+      '255.255.255.255',
+      '::',
+      '::1',
+      '::ffff:127.0.0.1',
+      '::ffff:10.0.0.1',
+      '::ffff:7f00:1',
+      '64:ff9b::a00:1',
+      '2002:a00:1::',
+      'fc00::1',
+      'fd12:3456::1',
+      'fe80::1',
+      'fe80::1%eth0',
+      'ff02::1',
+      '2001:db8::1',
+      '100::1',
+      '2001:2::1',
+      '2001:10::1',
+      '2001:1f::1',
+      '3fff::1',
+      '3fff:ffff::1',
+      'not-an-ip',
+    ])('%s is not', (ip) => expect(isPublicAddress(ip)).toBe(false));
+    it('does not mistake the neighbours of the private ranges for private', () => {
+      expect(isPublicAddress('172.15.0.1')).toBe(true);
+      expect(isPublicAddress('172.32.0.1')).toBe(true);
+      expect(isPublicAddress('100.63.0.1')).toBe(true);
+      expect(isPublicAddress('100.128.0.1')).toBe(true);
+    });
+  });
+
+  describe('isExplicitlyInternalHost', () => {
+    it.each([
+      'localhost',
+      'LOCALHOST',
+      '127.0.0.1',
+      'backend.default.svc',
+      'backend.default.svc.cluster.local',
+      'backend.default.svc.',
+    ])('%s is declared internal', (host) => expect(isExplicitlyInternalHost(host)).toBe(true));
+    it.each(['api.example.com', 'svc.example.com', 'localhost.example.com', '10.0.0.1', '::1'])(
+      '%s is not',
+      (host) => expect(isExplicitlyInternalHost(host)).toBe(false),
+    );
+  });
+
+  describe('outboundUrlGuardMode', () => {
+    it('defaults to warn when unset or blank', () => {
+      expect(outboundUrlGuardMode(undefined)).toBe('warn');
+      expect(outboundUrlGuardMode('')).toBe('warn');
+      expect(outboundUrlGuardMode('  ')).toBe('warn');
+    });
+    it('reads warn / reject case-insensitively', () => {
+      expect(outboundUrlGuardMode('warn')).toBe('warn');
+      expect(outboundUrlGuardMode('reject')).toBe('reject');
+      expect(outboundUrlGuardMode(' REJECT ')).toBe('reject');
+    });
+    it('treats an unknown value as warn and says so once', () => {
+      const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+      try {
+        expect(outboundUrlGuardMode('strict-please')).toBe('warn');
+        expect(outboundUrlGuardMode('strict-please')).toBe('warn');
+        const calls = warn.mock.calls.filter((c) => String(c[0]).includes('strict-please'));
+        expect(calls).toHaveLength(1);
+        expect(String(calls[0][0])).toContain('OUTBOUND_URL_GUARD');
+        expect(String(calls[0][0])).toContain('using warn');
+      } finally {
+        warn.mockRestore();
+      }
+    });
+    it('reads the process environment by default', () => {
+      const before = process.env.OUTBOUND_URL_GUARD;
+      try {
+        process.env.OUTBOUND_URL_GUARD = 'reject';
+        expect(outboundUrlGuardMode()).toBe('reject');
+        delete process.env.OUTBOUND_URL_GUARD;
+        expect(outboundUrlGuardMode()).toBe('warn');
+      } finally {
+        if (before === undefined) delete process.env.OUTBOUND_URL_GUARD;
+        else process.env.OUTBOUND_URL_GUARD = before;
+      }
+    });
+  });
+
+  describe('vetOutboundHost', () => {
+    it('passes a name whose every address is public', async () => {
+      const lookup: HostLookup = jest
+        .fn()
+        .mockResolvedValue([...PUBLIC, { address: '2606:4700::1', family: 6 }]);
+      await expect(vetOutboundHost('api.example.com', lookup)).resolves.toEqual({
+        ok: true,
+        addresses: [...PUBLIC, { address: '2606:4700::1', family: 6 }],
+      });
+      expect(lookup).toHaveBeenCalledWith('api.example.com');
+    });
+    it('fails when any one address is non-public, naming the offenders', async () => {
+      const lookup: HostLookup = jest.fn().mockResolvedValue([...PUBLIC, ...METADATA]);
+      const verdict = await vetOutboundHost('api.example.com', lookup);
+      expect(verdict.ok).toBe(false);
+      if (verdict.ok) return;
+      expect(verdict.reason).toBe('non-public');
+      expect(verdict.detail).toContain('169.254.169.254');
+      expect(verdict.detail).not.toContain('104.18.1.1');
+    });
+    it('is unresolved when the lookup throws or answers nothing', async () => {
+      const throwing: HostLookup = jest.fn().mockRejectedValue(new Error('ENOTFOUND'));
+      const a = await vetOutboundHost('nope.example.com', throwing);
+      expect(a).toMatchObject({ ok: false, reason: 'unresolved' });
+      if (!a.ok) expect(a.detail).toContain('ENOTFOUND');
+      const empty: HostLookup = jest.fn().mockResolvedValue([]);
+      await expect(vetOutboundHost('nope.example.com', empty)).resolves.toMatchObject({
+        ok: false,
+        reason: 'unresolved',
+      });
+    });
+    it('judges an IP literal as itself without a lookup, brackets and all', async () => {
+      const lookup: HostLookup = jest.fn();
+      await expect(vetOutboundHost('8.8.8.8', lookup)).resolves.toMatchObject({ ok: true });
+      await expect(vetOutboundHost('100.64.0.1', lookup)).resolves.toMatchObject({
+        ok: false,
+        reason: 'non-public',
+      });
+      await expect(vetOutboundHost('[::ffff:10.0.0.1]', lookup)).resolves.toMatchObject({
+        ok: false,
+        reason: 'non-public',
+      });
+      expect(lookup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('guardOutboundHost', () => {
+    const warnLogger = () => ({ warn: jest.fn() });
+
+    it('is silent for a public host in either mode', async () => {
+      const lookup: HostLookup = jest.fn().mockResolvedValue(PUBLIC);
+      for (const mode of ['warn', 'reject'] as const) {
+        const logger = warnLogger();
+        await expect(
+          guardOutboundHost('api.example.com', { subject: 's', mode, lookup, logger }),
+        ).resolves.toMatchObject({ ok: true });
+        expect(logger.warn).not.toHaveBeenCalled();
+      }
+    });
+    it('warn: logs the subject and the verdict, and allows', async () => {
+      const lookup: HostLookup = jest.fn().mockResolvedValue(METADATA);
+      const logger = warnLogger();
+      await expect(
+        guardOutboundHost('api.example.com', {
+          subject: 'proxy rule r1: target https://api.example.com',
+          mode: 'warn',
+          lookup,
+          logger,
+        }),
+      ).resolves.toMatchObject({ ok: false, reason: 'non-public' });
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      const line = String(logger.warn.mock.calls[0][0]);
+      expect(line).toContain('proxy rule r1');
+      expect(line).toContain('169.254.169.254');
+      expect(line).toContain('OUTBOUND_URL_GUARD=warn');
+    });
+    it('reject: throws a BadRequestException naming the env var', async () => {
+      const lookup: HostLookup = jest.fn().mockResolvedValue(METADATA);
+      const logger = warnLogger();
+      const attempt = guardOutboundHost('api.example.com', {
+        subject: 'app bundle https://api.example.com/a.zip',
+        mode: 'reject',
+        lookup,
+        logger,
+      });
+      await expect(attempt).rejects.toThrow(BadRequestException);
+      await expect(attempt).rejects.toThrow(
+        /app bundle .*169\.254\.169\.254.*OUTBOUND_URL_GUARD=reject/,
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+    it('reject: an unresolvable host is refused too', async () => {
+      const lookup: HostLookup = jest.fn().mockRejectedValue(new Error('ENOTFOUND'));
+      await expect(
+        guardOutboundHost('nope.example.com', { subject: 's', mode: 'reject', lookup }),
+      ).rejects.toThrow(/does not resolve/);
+    });
+    it('takes the mode from the environment when none is given', async () => {
+      const before = process.env.OUTBOUND_URL_GUARD;
+      const lookup: HostLookup = jest.fn().mockResolvedValue(METADATA);
+      try {
+        process.env.OUTBOUND_URL_GUARD = 'reject';
+        await expect(
+          guardOutboundHost('api.example.com', { subject: 's', lookup }),
+        ).rejects.toThrow(BadRequestException);
+        delete process.env.OUTBOUND_URL_GUARD;
+        await expect(
+          guardOutboundHost('api.example.com', { subject: 's', lookup, logger: warnLogger() }),
+        ).resolves.toMatchObject({ ok: false });
+      } finally {
+        if (before === undefined) delete process.env.OUTBOUND_URL_GUARD;
+        else process.env.OUTBOUND_URL_GUARD = before;
+      }
+    });
+  });
+
+  describe('pinnedLookup — the connection is pinned to the vetted addresses', () => {
+    it('answers net.connect from them, in both callback shapes', () => {
+      const lookup = pinnedLookup([
+        { address: '104.18.1.1', family: 4 },
+        { address: '2606:4700::1', family: 6 },
+      ]);
+      const all = jest.fn();
+      lookup('claude.ai', { all: true }, all);
+      expect(all).toHaveBeenCalledWith(null, [
+        { address: '104.18.1.1', family: 4 },
+        { address: '2606:4700::1', family: 6 },
+      ]);
+      const one = jest.fn();
+      lookup('claude.ai', {}, one);
+      expect(one).toHaveBeenCalledWith(null, '104.18.1.1', 4);
+      const short = jest.fn();
+      lookup('claude.ai', short);
+      expect(short).toHaveBeenCalledWith(null, '104.18.1.1', 4);
+    });
+  });
+
+  describe('readCapped', () => {
+    const stream = (...parts: string[]) =>
+      (async function* () {
+        for (const p of parts) yield Buffer.from(p);
+      })();
+    it('joins chunks under the cap and throws — stopping the read — past it', async () => {
+      await expect(readCapped(stream('{"a":', '1}'), 100)).resolves.toBe('{"a":1}');
+      await expect(readCapped(null, 100)).resolves.toBe('');
+      let pulled = 0;
+      const big = (async function* () {
+        for (;;) {
+          pulled += 1;
+          yield Buffer.alloc(1024);
+        }
+      })();
+      await expect(readCapped(big, 4096)).rejects.toThrow('exceeds 4096 bytes');
+      expect(pulled).toBe(5);
+    });
+  });
+});

--- a/apps/backend/src/common/outbound-url.guard.ts
+++ b/apps/backend/src/common/outbound-url.guard.ts
@@ -1,0 +1,280 @@
+import { BadRequestException, Logger } from '@nestjs/common';
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+/**
+ * The building blocks of CE's SSRF guard for server-side fetches of URLs a
+ * caller influences — first built for OAuth Client ID Metadata Documents
+ * (`oauth/client-metadata.service.ts`, #741), shared here so proxy-rule
+ * targets and app bundle URLs (#770) vet a hostname the same way.
+ *
+ * The pieces, in the order a full guard uses them:
+ *   1. {@link isPublicAddress} — is one address globally routable?
+ *   2. {@link vetOutboundHost} — resolve a name and judge *every* address.
+ *   3. {@link pinnedLookup} — connect only to the vetted addresses.
+ *   4. {@link readCapped} — bound the body read.
+ *
+ * {@link guardOutboundHost} is 2 wrapped in the `OUTBOUND_URL_GUARD` policy
+ * (`warn`, the default, logs and allows; `reject` throws) for the places
+ * where a hard refusal would break self-hosters whose targets legitimately
+ * resolve to private space (split-horizon DNS, in-cluster services).
+ * The CIMD guard does not use the policy: a client_id is never allowed to
+ * point inward.
+ */
+
+export const OUTBOUND_URL_GUARD_ENV = 'OUTBOUND_URL_GUARD';
+export type OutboundUrlGuardMode = 'warn' | 'reject';
+export const OUTBOUND_URL_GUARD_DEFAULT: OutboundUrlGuardMode = 'warn';
+
+export interface ResolvedAddress {
+  address: string;
+  family: 4 | 6;
+}
+
+/** Every address a name resolves to (`dns.lookup` with `all: true`), or throws. */
+export type HostLookup = (hostname: string) => Promise<ResolvedAddress[]>;
+
+export type OutboundHostVerdict =
+  | { ok: true; addresses: ResolvedAddress[] }
+  | {
+      ok: false;
+      reason: 'unresolved' | 'non-public';
+      addresses: ResolvedAddress[];
+      detail: string;
+    };
+
+const logger = new Logger('OutboundUrlGuard');
+const warnedModes = new Set<string>();
+
+/**
+ * The policy from `OUTBOUND_URL_GUARD`. Anything other than `warn` / `reject`
+ * (case-insensitive, trimmed) is treated as `warn` and warned about once per
+ * value — call it from a service constructor so the warning lands at startup.
+ */
+export function outboundUrlGuardMode(
+  raw: string | undefined = process.env[OUTBOUND_URL_GUARD_ENV],
+): OutboundUrlGuardMode {
+  const value = (raw ?? '').trim().toLowerCase();
+  if (value === '' || value === 'warn') return 'warn';
+  if (value === 'reject') return 'reject';
+  if (!warnedModes.has(value)) {
+    warnedModes.add(value);
+    logger.warn(
+      `${OUTBOUND_URL_GUARD_ENV}=${JSON.stringify(raw)} is not one of warn|reject; using ${OUTBOUND_URL_GUARD_DEFAULT}`,
+    );
+  }
+  return OUTBOUND_URL_GUARD_DEFAULT;
+}
+
+/**
+ * The hosts CE deliberately lets an operator point *inward* at over plain
+ * http: a same-pod sidecar and in-cluster Kubernetes services. They are
+ * internal by declaration, so resolving them proves nothing — callers skip
+ * the public-address check for these and only these.
+ */
+export function isExplicitlyInternalHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/\.$/, '');
+  return (
+    host === 'localhost' ||
+    host === '127.0.0.1' ||
+    host.endsWith('.svc') ||
+    host.endsWith('.svc.cluster.local')
+  );
+}
+
+/** `dns.lookup` with every address, in resolver order; the default {@link HostLookup}. */
+export const lookupAddresses: HostLookup = async (hostname) => {
+  const found = await dnsLookup(hostname, { all: true, verbatim: true });
+  return found.map((a) => ({ address: a.address, family: a.family as 4 | 6 }));
+};
+
+/**
+ * Resolve `hostname` and judge every address it has. An IP literal (with or
+ * without IPv6 brackets) is judged as itself. A name that does not resolve,
+ * or resolves to nothing, is `unresolved`: it cannot be vetted, and the
+ * caller decides whether that is fatal.
+ */
+export async function vetOutboundHost(
+  hostname: string,
+  lookup: HostLookup = lookupAddresses,
+): Promise<OutboundHostVerdict> {
+  const host = hostname.replace(/^\[|\]$/g, '').replace(/\.$/, '');
+  let addresses: ResolvedAddress[];
+  if (isIP(host) !== 0) {
+    addresses = [{ address: host, family: isIP(host) as 4 | 6 }];
+  } else {
+    try {
+      addresses = await lookup(host);
+    } catch (error) {
+      return {
+        ok: false,
+        reason: 'unresolved',
+        addresses: [],
+        detail: `${host} does not resolve (${error instanceof Error ? error.message : String(error)})`,
+      };
+    }
+    if (addresses.length === 0) {
+      return { ok: false, reason: 'unresolved', addresses, detail: `${host} does not resolve` };
+    }
+  }
+  const nonPublic = addresses.filter((a) => !isPublicAddress(a.address)).map((a) => a.address);
+  if (nonPublic.length > 0) {
+    return {
+      ok: false,
+      reason: 'non-public',
+      addresses,
+      detail: `${host} resolves to a non-public address (${nonPublic.join(', ')})`,
+    };
+  }
+  return { ok: true, addresses };
+}
+
+export interface GuardOutboundHostOptions {
+  /** What is being vetted, for the log line / error — e.g. `proxy rule target https://…`. */
+  subject: string;
+  /** Defaults to the process-wide `OUTBOUND_URL_GUARD` setting. */
+  mode?: OutboundUrlGuardMode;
+  lookup?: HostLookup;
+  /** Where the `warn`-mode line goes; defaults to this module's logger. */
+  logger?: Pick<Logger, 'warn'>;
+}
+
+/**
+ * {@link vetOutboundHost} under the `OUTBOUND_URL_GUARD` policy. Public
+ * addresses pass silently. Otherwise `warn` logs the subject and the verdict
+ * and returns; `reject` throws a `BadRequestException` naming the env var so
+ * the operator knows which knob refused it.
+ */
+export async function guardOutboundHost(
+  hostname: string,
+  opts: GuardOutboundHostOptions,
+): Promise<OutboundHostVerdict> {
+  const mode = opts.mode ?? outboundUrlGuardMode();
+  const verdict = await vetOutboundHost(hostname, opts.lookup);
+  if (verdict.ok) return verdict;
+  if (mode === 'reject') {
+    throw new BadRequestException(
+      `${opts.subject}: ${verdict.detail}; refused by ${OUTBOUND_URL_GUARD_ENV}=reject`,
+    );
+  }
+  (opts.logger ?? logger).warn(
+    `${opts.subject}: ${verdict.detail}; allowed because ${OUTBOUND_URL_GUARD_ENV}=${mode}`,
+  );
+  return verdict;
+}
+
+/**
+ * Is this a globally routable unicast address? Loopback, private (RFC 1918),
+ * CGNAT, link-local (incl. the cloud metadata endpoint), unspecified,
+ * multicast, reserved and documentation ranges are not; IPv6 forms that embed
+ * an IPv4 address (mapped, 6to4, NAT64) are judged by the address they embed.
+ */
+export function isPublicAddress(ip: string): boolean {
+  const family = isIP(ip);
+  if (family === 4) return isPublicV4(ip);
+  if (family === 6) return isPublicV6(ip);
+  return false;
+}
+
+function isPublicV4(ip: string): boolean {
+  const [a, b] = ip.split('.').map(Number);
+  if (a === 0 || a === 10 || a === 127) return false;
+  if (a === 100 && b >= 64 && b <= 127) return false;
+  if (a === 169 && b === 254) return false;
+  if (a === 172 && b >= 16 && b <= 31) return false;
+  if (a === 192 && (b === 0 || b === 168)) return false;
+  if (a === 198 && (b === 18 || b === 19)) return false;
+  if (a >= 224) return false;
+  return true;
+}
+
+function isPublicV6(ip: string): boolean {
+  const groups = expandV6(ip.toLowerCase());
+  if (!groups) return false;
+  const first = parseInt(groups[0], 16);
+  const v4Of = (hi: string, lo: string) => {
+    const h = parseInt(hi, 16);
+    const l = parseInt(lo, 16);
+    return `${h >> 8}.${h & 0xff}.${l >> 8}.${l & 0xff}`;
+  };
+  // ::/8 — unspecified, loopback, IPv4-compatible; ::ffff:0:0/96 — IPv4-mapped
+  if (first === 0) {
+    const mapped = groups.slice(0, 5).every((g) => g === '0000') && groups[5] === 'ffff';
+    return mapped ? isPublicV4(v4Of(groups[6], groups[7])) : false;
+  }
+  if (groups[0] === '0064' && groups[1] === 'ff9b') return isPublicV4(v4Of(groups[6], groups[7])); // NAT64
+  if (first === 0x2002) return isPublicV4(v4Of(groups[1], groups[2])); // 6to4
+  if (groups[0] === '0100' && groups.slice(1, 4).every((g) => g === '0000')) return false; // 100::/64 discard
+  if (groups[0] === '2001' && groups[1] === '0db8') return false; // 2001:db8::/32 documentation
+  if (groups[0] === '2001' && groups[1] === '0002' && groups[2] === '0000') return false; // 2001:2::/48 benchmarking
+  if (groups[0] === '2001' && (parseInt(groups[1], 16) & 0xfff0) === 0x0010) return false; // 2001:10::/28 ORCHID
+  if ((first & 0xfff0) === 0x3ff0) return false; // 3fff::/20 documentation
+  if ((first & 0xfe00) === 0xfc00) return false; // fc00::/7 unique local
+  if ((first & 0xffc0) === 0xfe80) return false; // fe80::/10 link-local
+  if ((first & 0xff00) === 0xff00) return false; // ff00::/8 multicast
+  return true;
+}
+
+/** The eight 4-hex-digit groups of an IPv6 address, or null when it does not parse. */
+function expandV6(ip: string): string[] | null {
+  let s = ip;
+  const zone = s.indexOf('%');
+  if (zone >= 0) s = s.slice(0, zone);
+  const v4 = s.match(/(\d+\.\d+\.\d+\.\d+)$/);
+  if (v4) {
+    const [a, b, c, d] = v4[1].split('.').map(Number);
+    s = `${s.slice(0, -v4[1].length)}${((a << 8) | b).toString(16)}:${((c << 8) | d).toString(16)}`;
+  }
+  const halves = s.split('::');
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(':') : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  const missing = 8 - head.length - tail.length;
+  if (missing < 0 || (halves.length === 1 && missing !== 0)) return null;
+  const groups = [...head, ...(halves.length === 2 ? Array(missing).fill('0') : []), ...tail];
+  if (groups.length !== 8 || groups.some((g) => !/^[0-9a-f]{1,4}$/.test(g))) return null;
+  return groups.map((g) => g.padStart(4, '0'));
+}
+
+/**
+ * Reads a body under a byte cap. Throws — and, by leaving the loop, cancels the
+ * stream — the moment the cap is passed, so an oversized document never buffers.
+ */
+export async function readCapped(
+  body: AsyncIterable<Uint8Array> | null,
+  maxBytes: number,
+): Promise<string> {
+  if (!body) return '';
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of body) {
+    total += chunk.byteLength;
+    if (total > maxBytes) throw new Error(`document exceeds ${maxBytes} bytes`);
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+/**
+ * A `lookup` for the socket that answers from the vetted addresses only — the
+ * name is never resolved again between the check and the connect. Node's
+ * `net.connect` calls it with `{ all: true }` (happy eyeballs) or for one address.
+ */
+export function pinnedLookup(addresses: ResolvedAddress[]) {
+  return (
+    _hostname: string,
+    options: { all?: boolean } | ((...args: unknown[]) => void),
+    callback?: (...args: unknown[]) => void,
+  ) => {
+    const done = (typeof options === 'function' ? options : callback) as (
+      ...args: unknown[]
+    ) => void;
+    const all = typeof options === 'object' && options !== null && options.all === true;
+    if (all)
+      done(
+        null,
+        addresses.map((a) => ({ address: a.address, family: a.family })),
+      );
+    else done(null, addresses[0].address, addresses[0].family);
+  };
+}

--- a/apps/backend/src/oauth/client-metadata.service.ts
+++ b/apps/backend/src/oauth/client-metadata.service.ts
@@ -1,10 +1,21 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
-import { lookup as dnsLookup } from 'node:dns/promises';
 import { isIP } from 'node:net';
 import { Agent, fetch as undiciFetch } from 'undici';
 import { v5 as uuidv5 } from 'uuid';
+import {
+  isPublicAddress,
+  lookupAddresses,
+  pinnedLookup,
+  readCapped,
+  type ResolvedAddress,
+} from '../common/outbound-url.guard';
 import { OAuthError } from './oauth.errors';
 import { isAcceptableRedirect } from './redirect-uri.util';
+
+// The guard's building blocks live in common/outbound-url.guard.ts (#770) so
+// proxy-rule targets and app bundle URLs share them; re-exported here so the
+// oauth surface is unchanged.
+export { isPublicAddress, pinnedLookup, readCapped, type ResolvedAddress };
 
 /**
  * OAuth Client ID Metadata Documents (draft-ietf-oauth-client-id-metadata-document):
@@ -60,11 +71,6 @@ export interface ClientMetadataDocument {
   grantTypes: string[];
   /** What the document declares; CE treats every CIMD client as public regardless. */
   tokenEndpointAuthMethod: string;
-}
-
-export interface ResolvedAddress {
-  address: string;
-  family: 4 | 6;
 }
 
 export interface ClientMetadataResponse {
@@ -267,127 +273,8 @@ export function ttlFrom(cacheControl: string | null): number {
   return Math.min(Number(match[1]) * 1000, CIMD_MAX_TTL_MS);
 }
 
-/**
- * Is this a globally routable unicast address? Loopback, private (RFC 1918),
- * CGNAT, link-local (incl. the cloud metadata endpoint), unspecified,
- * multicast, reserved and documentation ranges are not; IPv6 forms that embed
- * an IPv4 address (mapped, 6to4, NAT64) are judged by the address they embed.
- */
-export function isPublicAddress(ip: string): boolean {
-  const family = isIP(ip);
-  if (family === 4) return isPublicV4(ip);
-  if (family === 6) return isPublicV6(ip);
-  return false;
-}
-
-function isPublicV4(ip: string): boolean {
-  const [a, b] = ip.split('.').map(Number);
-  if (a === 0 || a === 10 || a === 127) return false;
-  if (a === 100 && b >= 64 && b <= 127) return false;
-  if (a === 169 && b === 254) return false;
-  if (a === 172 && b >= 16 && b <= 31) return false;
-  if (a === 192 && (b === 0 || b === 168)) return false;
-  if (a === 198 && (b === 18 || b === 19)) return false;
-  if (a >= 224) return false;
-  return true;
-}
-
-function isPublicV6(ip: string): boolean {
-  const groups = expandV6(ip.toLowerCase());
-  if (!groups) return false;
-  const first = parseInt(groups[0], 16);
-  const v4Of = (hi: string, lo: string) => {
-    const h = parseInt(hi, 16);
-    const l = parseInt(lo, 16);
-    return `${h >> 8}.${h & 0xff}.${l >> 8}.${l & 0xff}`;
-  };
-  // ::/8 — unspecified, loopback, IPv4-compatible; ::ffff:0:0/96 — IPv4-mapped
-  if (first === 0) {
-    const mapped = groups.slice(0, 5).every((g) => g === '0000') && groups[5] === 'ffff';
-    return mapped ? isPublicV4(v4Of(groups[6], groups[7])) : false;
-  }
-  if (groups[0] === '0064' && groups[1] === 'ff9b') return isPublicV4(v4Of(groups[6], groups[7])); // NAT64
-  if (first === 0x2002) return isPublicV4(v4Of(groups[1], groups[2])); // 6to4
-  if (groups[0] === '0100' && groups.slice(1, 4).every((g) => g === '0000')) return false; // 100::/64 discard
-  if (groups[0] === '2001' && groups[1] === '0db8') return false; // 2001:db8::/32 documentation
-  if (groups[0] === '2001' && groups[1] === '0002' && groups[2] === '0000') return false; // 2001:2::/48 benchmarking
-  if (groups[0] === '2001' && (parseInt(groups[1], 16) & 0xfff0) === 0x0010) return false; // 2001:10::/28 ORCHID
-  if ((first & 0xfff0) === 0x3ff0) return false; // 3fff::/20 documentation
-  if ((first & 0xfe00) === 0xfc00) return false; // fc00::/7 unique local
-  if ((first & 0xffc0) === 0xfe80) return false; // fe80::/10 link-local
-  if ((first & 0xff00) === 0xff00) return false; // ff00::/8 multicast
-  return true;
-}
-
-/** The eight 4-hex-digit groups of an IPv6 address, or null when it does not parse. */
-function expandV6(ip: string): string[] | null {
-  let s = ip;
-  const zone = s.indexOf('%');
-  if (zone >= 0) s = s.slice(0, zone);
-  const v4 = s.match(/(\d+\.\d+\.\d+\.\d+)$/);
-  if (v4) {
-    const [a, b, c, d] = v4[1].split('.').map(Number);
-    s = `${s.slice(0, -v4[1].length)}${((a << 8) | b).toString(16)}:${((c << 8) | d).toString(16)}`;
-  }
-  const halves = s.split('::');
-  if (halves.length > 2) return null;
-  const head = halves[0] ? halves[0].split(':') : [];
-  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
-  const missing = 8 - head.length - tail.length;
-  if (missing < 0 || (halves.length === 1 && missing !== 0)) return null;
-  const groups = [...head, ...(halves.length === 2 ? Array(missing).fill('0') : []), ...tail];
-  if (groups.length !== 8 || groups.some((g) => !/^[0-9a-f]{1,4}$/.test(g))) return null;
-  return groups.map((g) => g.padStart(4, '0'));
-}
-
-/**
- * Reads a body under a byte cap. Throws — and, by leaving the loop, cancels the
- * stream — the moment the cap is passed, so an oversized document never buffers.
- */
-export async function readCapped(
-  body: AsyncIterable<Uint8Array> | null,
-  maxBytes: number,
-): Promise<string> {
-  if (!body) return '';
-  const chunks: Buffer[] = [];
-  let total = 0;
-  for await (const chunk of body) {
-    total += chunk.byteLength;
-    if (total > maxBytes) throw new Error(`document exceeds ${maxBytes} bytes`);
-    chunks.push(Buffer.from(chunk));
-  }
-  return Buffer.concat(chunks).toString('utf8');
-}
-
-/**
- * A `lookup` for the socket that answers from the vetted addresses only — the
- * name is never resolved again between the check and the connect. Node's
- * `net.connect` calls it with `{ all: true }` (happy eyeballs) or for one address.
- */
-export function pinnedLookup(addresses: ResolvedAddress[]) {
-  return (
-    _hostname: string,
-    options: { all?: boolean } | ((...args: unknown[]) => void),
-    callback?: (...args: unknown[]) => void,
-  ) => {
-    const done = (typeof options === 'function' ? options : callback) as (
-      ...args: unknown[]
-    ) => void;
-    const all = typeof options === 'object' && options !== null && options.all === true;
-    if (all)
-      done(
-        null,
-        addresses.map((a) => ({ address: a.address, family: a.family })),
-      );
-    else done(null, addresses[0].address, addresses[0].family);
-  };
-}
-
 const defaultTransport: ClientMetadataTransport = {
-  async lookup(hostname) {
-    const found = await dnsLookup(hostname, { all: true, verbatim: true });
-    return found.map((a) => ({ address: a.address, family: a.family as 4 | 6 }));
-  },
+  lookup: lookupAddresses,
   async fetch(url, { addresses, signal }) {
     const agent = new Agent({
       connect: { lookup: pinnedLookup(addresses) as never },

--- a/apps/backend/src/proxy-rules/proxy-rules.service.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.service.spec.ts
@@ -4,13 +4,19 @@ import {
   BadRequestException,
   ConflictException,
   ForbiddenException,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
+import { lookup as dnsLookup } from 'node:dns/promises';
 import { ProxyRulesService } from './proxy-rules.service';
 import { PermissionsService } from '../permissions/permissions.service';
 import { NginxRegenerationService } from '../domains/nginx-regeneration.service';
 import { EmailService } from '../email/email.service';
 import { ProxyRuleSetRevisionsService } from './proxy-rule-set-revisions.service';
+
+// The outbound URL guard resolves rule targets (#770); no real DNS in tests.
+jest.mock('node:dns/promises', () => ({ lookup: jest.fn() }));
+const mockDnsLookup = dnsLookup as unknown as jest.Mock;
 
 // Mock the db client - using factory function for hoisting
 jest.mock('../db/client', () => {
@@ -154,6 +160,9 @@ describe('ProxyRulesService', () => {
 
     service = module.get<ProxyRulesService>(ProxyRulesService);
     jest.clearAllMocks();
+    // Default: a public name resolves to a public address, so the existing
+    // https://api.example.com fixtures pass the guard silently.
+    mockDnsLookup.mockResolvedValue([{ address: '104.18.1.1', family: 4 }]);
   });
 
   describe('validateTargetUrl', () => {
@@ -282,6 +291,111 @@ describe('ProxyRulesService', () => {
           'admin',
         ),
       ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('validateTargetUrl — resolve-and-vet under OUTBOUND_URL_GUARD (#770)', () => {
+    const envBefore = process.env.OUTBOUND_URL_GUARD;
+    let warnSpy: jest.SpyInstance;
+
+    // rule set lookup (limit), findRuleByPattern (orderBy), getNextOrder (orderBy);
+    // insert returning falls back to [{ id: 'test-id' }]
+    const successfulCreate = () => mockDb.__setResults([[createMockRuleSet()], [], []]);
+    const createWith = (targetUrl: string) =>
+      service.create(
+        { ruleSetId: 'rule-set-1', pathPattern: '/api/*', targetUrl },
+        'user-id',
+        'admin',
+      );
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+      if (envBefore === undefined) delete process.env.OUTBOUND_URL_GUARD;
+      else process.env.OUTBOUND_URL_GUARD = envBefore;
+    });
+
+    it.each([
+      'http://localhost:3000',
+      'http://127.0.0.1:3000',
+      'http://backend.default.svc:8080',
+      'http://backend.default.svc.cluster.local:8080',
+      'https://backend.default.svc',
+    ])(
+      'does not resolve the declared-internal target %s, in reject mode too',
+      async (targetUrl) => {
+        process.env.OUTBOUND_URL_GUARD = 'reject';
+        successfulCreate();
+
+        await expect(createWith(targetUrl)).resolves.toBeDefined();
+        expect(mockDnsLookup).not.toHaveBeenCalled();
+        expect(warnSpy).not.toHaveBeenCalled();
+      },
+    );
+
+    it('passes a public name that resolves to public addresses silently', async () => {
+      process.env.OUTBOUND_URL_GUARD = 'reject';
+      mockDnsLookup.mockResolvedValue([
+        { address: '104.18.1.1', family: 4 },
+        { address: '2606:4700::6810:1', family: 6 },
+      ]);
+      successfulCreate();
+
+      await expect(createWith('https://api.example.com')).resolves.toBeDefined();
+      expect(mockDnsLookup).toHaveBeenCalledWith(
+        'api.example.com',
+        expect.objectContaining({ all: true }),
+      );
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warn (default): a public name resolving to a private address is logged and allowed', async () => {
+      delete process.env.OUTBOUND_URL_GUARD;
+      mockDnsLookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+      successfulCreate();
+
+      await expect(createWith('https://api.example.com')).resolves.toBeDefined();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const line = String(warnSpy.mock.calls[0][0]);
+      expect(line).toContain('rule set rule-set-1');
+      expect(line).toContain('https://api.example.com');
+      expect(line).toContain('169.254.169.254');
+      expect(line).toContain('OUTBOUND_URL_GUARD=warn');
+    });
+
+    it('reject: a public name resolving to a private address is a 400', async () => {
+      process.env.OUTBOUND_URL_GUARD = 'reject';
+      mockDnsLookup.mockResolvedValue([
+        { address: '104.18.1.1', family: 4 },
+        { address: '10.0.0.5', family: 4 },
+      ]);
+      successfulCreate();
+
+      const attempt = createWith('https://api.example.com');
+      await expect(attempt).rejects.toThrow(BadRequestException);
+      await expect(attempt).rejects.toThrow(/10\.0\.0\.5.*OUTBOUND_URL_GUARD=reject/);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('reject: applies on update when the target changes, naming the rule', async () => {
+      process.env.OUTBOUND_URL_GUARD = 'reject';
+      mockDnsLookup.mockResolvedValue([{ address: '192.168.1.10', family: 4 }]);
+      // findById (limit), rule set lookup (limit)
+      mockDb.__setResults([[createMockRule()], [createMockRuleSet()]]);
+
+      await expect(
+        service.update('rule-1', { targetUrl: 'https://intranet.example.com' }, 'user-id', 'admin'),
+      ).rejects.toThrow(/proxy rule rule-1.*192\.168\.1\.10/);
+    });
+
+    it('the string checks still reject before any lookup', async () => {
+      process.env.OUTBOUND_URL_GUARD = 'warn';
+      mockDb.__setResults([[createMockRuleSet()]]);
+
+      await expect(createWith('https://169.254.169.254')).rejects.toThrow(BadRequestException);
+      expect(mockDnsLookup).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/proxy-rules/proxy-rules.service.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.service.ts
@@ -26,6 +26,11 @@ import type {
 import type { ProxyRuleSet } from '../db/schema/proxy-rule-sets.schema';
 import type { RevisionTrigger } from '../db/schema/proxy-rule-set-revisions.schema';
 import { methodSignature } from './method-match';
+import {
+  guardOutboundHost,
+  isExplicitlyInternalHost,
+  outboundUrlGuardMode,
+} from '../common/outbound-url.guard';
 
 // SSRF protection - blocked hostnames
 const BLOCKED_HOSTS = [
@@ -62,6 +67,9 @@ export class ProxyRulesService {
     private readonly emailService: EmailService,
     private readonly proxyRuleSetRevisionsService: ProxyRuleSetRevisionsService,
   ) {
+    // Read once at startup so an unrecognised OUTBOUND_URL_GUARD value is warned about at boot.
+    outboundUrlGuardMode();
+
     // Get encryption key from environment (same as used for storage credentials)
     const encryptionKey = this.configService.get<string>('ENCRYPTION_KEY');
     if (encryptionKey) {
@@ -234,7 +242,10 @@ export class ProxyRulesService {
       dto.proxyType === 'pipeline' ||
       dto.internalRewrite;
     if (!skipUrlValidation) {
-      this.validateTargetUrl(dto.targetUrl);
+      await this.validateTargetUrl(
+        dto.targetUrl,
+        `proxy rule ${dto.pathPattern} in rule set ${dto.ruleSetId}`,
+      );
     }
 
     // Check for duplicate path pattern + method within the rule set
@@ -384,7 +395,7 @@ export class ProxyRulesService {
       dto.internalRewrite === true ||
       (dto.internalRewrite === undefined && existing.internalRewrite);
     if (dto.targetUrl && dto.targetUrl !== existing.targetUrl && !skipUrlValidation) {
-      this.validateTargetUrl(dto.targetUrl);
+      await this.validateTargetUrl(dto.targetUrl, `proxy rule ${id}`);
     }
 
     // Check for duplicate path pattern + method/methods if changing
@@ -852,9 +863,17 @@ export class ProxyRulesService {
   }
 
   /**
-   * Validate target URL for SSRF protection
+   * Validate target URL for SSRF protection.
+   *
+   * The protocol and hostname-string rules reject outright. A hostname that
+   * is not explicitly internal (localhost / 127.0.0.1 / *.svc /
+   * *.svc.cluster.local, which are allowed as same-pod and in-cluster
+   * targets) is then resolved and every address must be public — under
+   * `OUTBOUND_URL_GUARD` (#770): `warn` (default) logs and allows, so a
+   * self-hoster's split-horizon target keeps working after upgrade; `reject`
+   * refuses with a 400. `subject` names the rule for the log line / error.
    */
-  private validateTargetUrl(url: string): void {
+  private async validateTargetUrl(url: string, subject: string): Promise<void> {
     let parsed: URL;
     try {
       parsed = new URL(url);
@@ -896,8 +915,14 @@ export class ProxyRulesService {
       }
     }
 
-    // TODO: DNS resolution check for additional SSRF protection
-    // This would resolve the hostname and check if it points to internal IPs
+    // Resolve anything not declared internal and vet every address it has. A
+    // public name that resolves to 169.254.169.254 passes every check above.
+    if (!isExplicitlyInternalHost(hostname)) {
+      await guardOutboundHost(hostname, {
+        subject: `${subject}: target ${url}`,
+        logger: this.logger,
+      });
+    }
   }
 
   /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -420,6 +420,10 @@ services:
       # App catalog registry (Admin → Apps) — override for air-gapped or
       # self-published catalogs; see .env.example
       APPS_REGISTRY_URL: ${APPS_REGISTRY_URL:-}
+
+      # Outbound URL guard for proxy-rule targets and app bundle URLs:
+      # warn (default) or reject; see .env.example
+      OUTBOUND_URL_GUARD: ${OUTBOUND_URL_GUARD:-}
     ports:
       - '3000:3000'
     depends_on:


### PR DESCRIPTION
Closes #770

## Summary
CE already had a full SSRF guard for OAuth Client ID Metadata Documents, but two other server-side fetches of caller-influenced URLs only had a hostname/regex check (proxy-rule targets) or none at all (app bundle downloads) — a public name that resolves to `169.254.169.254` sailed through. This PR moves the guard's building blocks into a shared `common/` module and reuses them in both places, so a rule target or bundle host is now resolved and every address vetted. Because self-hosters may legitimately point rules at split-horizon names that resolve to private space, the new check is gated by `OUTBOUND_URL_GUARD` and **defaults to `warn`**: a non-public target is logged and allowed, exactly as before. Operators who want the hard line set `OUTBOUND_URL_GUARD=reject`.

## Behaviour changes
- **Proxy rule create / update** (admin UI, API, MCP tools): a target whose hostname is not declared internal (`localhost`, `127.0.0.1`, `*.svc`, `*.svc.cluster.local`) is now DNS-resolved and every address checked.
  - before: protocol + hostname-string checks only → after, `warn` (default): same outcome plus a warning log line naming the rule, the target and the offending address(es) when any resolves non-public; `reject`: HTTP 400 naming `OUTBOUND_URL_GUARD=reject`. A name that does not resolve is also refused under `reject` (it cannot be vetted).
  - The existing allowances are unchanged: `http://` to `*.svc`, `*.svc.cluster.local`, `localhost`, `127.0.0.1` still passes and is never resolved.
- **App install preflight / update fetch**: the registry's `bundleUrl` host gets the same check before download, with the same internal exemptions so a local registry keeps working.
  - before: plain `fetch(url)` → after, `warn` (default): downloads as before plus a warning; `reject`: the preflight step fails with a clear error naming the bundle URL and address. An unparseable bundle URL is now a 400 instead of a raw fetch `TypeError`.
- **New optional env var** `OUTBOUND_URL_GUARD=warn|reject` (default `warn`; any other value is treated as `warn` and warned about once at startup). Additive — an untouched `.env` boots and behaves as before.
- **OAuth CIMD**: no change. It still always refuses non-public hosts and does not consult the env var.

## Why
Split out of #766 (item 2, decision recorded there). The checklist's "A fetch of a caller-supplied URL needs the whole SSRF guard" entry named `validateTargetUrl`'s own `// TODO: DNS resolution check` as the known gap; `fetchBundle` was the other unguarded fetch (defence in depth — the registry is operator-controlled via `APPS_REGISTRY_URL`). Sharing the helpers instead of copying them keeps one `isPublicAddress` to get right. Warn-by-default is the backwards-compatibility constraint from the issue: existing rules must keep working after upgrade.

## What changed
- **backend / common**: new `apps/backend/src/common/outbound-url.guard.ts` — `isPublicAddress`, `vetOutboundHost`, `guardOutboundHost` (the warn/reject policy), `isExplicitlyInternalHost`, `outboundUrlGuardMode`, `lookupAddresses`, `pinnedLookup`, `readCapped`, `ResolvedAddress`.
- **backend / oauth**: `client-metadata.service.ts` imports the moved helpers and re-exports them; `resolve()`, `vettedAddresses()`, `assertClientIdUrl` and the CIMD URL-shape rules are untouched (kept deliberately so #771 merges as an import/export-only diff).
- **backend / proxy-rules**: `proxy-rules.service.ts` `validateTargetUrl` is now async and calls the guard after the existing checks; both call sites (`create`, `update`) await it; the mode is read once in the constructor so a bad value is warned about at boot.
- **backend / app-catalog**: `app-bundle.service.ts` `fetchBundle` vets the host before `fetch` (cache hits skip it, as no network happens).
- **config**: `.env.example` documents `OUTBOUND_URL_GUARD`; `docker-compose.yml` passes it through to the backend container (it maps env vars explicitly).
- **docs**: `.claude/ce-pr-review-checklist.md` SSRF entry's Surface line now points at the common helper and its three callers. No new entry.
- **tests**: `common/outbound-url.guard.spec.ts` (the `isPublicAddress` matrix, internal-host rules, mode parsing, resolve-and-vet verdicts, warn/reject); `proxy-rules.service.spec.ts` (+6, DNS mocked: internal targets never resolved even under `reject`, public → silent, private → warn/allow vs 400, update path, string checks still first); `app-bundle.service.spec.ts` (+6: public, warn, reject, local-registry exemptions, cache skip, bad URL). `client-metadata.service.spec.ts` passes unchanged.

## Compatibility
- **Env vars**: additive, safe default (`warn`), documented in `.env.example` and passed through `docker-compose.yml`; an unset/blank/unknown value behaves as `warn`.
- **Pipeline / proxy-rule semantics**: no runtime behaviour change for stored rules — the guard runs at rule create/update only, not on the request path (no request-time re-resolution or pinning in `ProxyService`, per the issue). Under the default nothing is rejected that was not rejected before.
- **API / CLI contract**: no fields, endpoints or params change. `reject` mode adds a new 400 reason on rule create/update.
- **Migrations, nginx generation, storage layout**: untouched.
- **Cross-repo**: `docs-public` `configuration/` needs the same `OUTBOUND_URL_GUARD` entry (not in this PR).

## Verification
```
pnpm --filter backend exec tsc --noEmit    → exit 0, no output
pnpm --filter frontend exec tsc --noEmit   → exit 0, no output
cd apps/backend && pnpm test -- "src/(common|oauth|proxy-rules|app-catalog)/"
  Test Suites: 39 passed, 39 total
  Tests:       1076 passed, 1076 total
pnpm --filter backend format:check         → All matched files use Prettier code style!
```

## Out of scope / follow-ups
- **The rules-as-code sync path does not go through `validateTargetUrl`.** `ProxyRuleSetsService.syncRuleSet` (what `bffless rules push` / `deploy-proxy-rules` hit), `importRuleSet` and `copy` insert `proxy_rules` rows directly; the `importRuleSet` doc comment records this as deliberate ("no email-service / SSRF re-validation beyond the DTO validation"). So neither the pre-existing protocol / private-IP-literal checks nor this PR's resolve-and-vet apply to synced rule sets. Extending them there would change what an existing rule-set push accepts (e.g. an `http://` non-internal target that syncs today), so it is left as a maintainer decision rather than folded in here.
- Bundle downloads still use global `fetch` (follows redirects, re-resolves at connect). The issue scoped this PR to the hostname check; pinning/redirect refusal for bundles is a possible follow-up.
- `.claude/ce-pr-review-checklist.md`: #771 also edits the same SSRF entry (adds check (6)); whichever merges second needs a trivial rebase of that block.
- `docs-public` `configuration/` env var entry for `OUTBOUND_URL_GUARD` (cross-repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NK2eaY4ZwmXRxifq22ELsV
