### PR TITLE
fix(backend): break the AppTokensModule import cycle that crashes startup since v0.4.52

### DIFF
--- a/apps/backend/src/app-tokens/app-tokens.module.ts
+++ b/apps/backend/src/app-tokens/app-tokens.module.ts
@@ -1,11 +1,18 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { AppTokensController } from './app-tokens.controller';
 import { AppTokensService } from './app-tokens.service';
 import { ProjectsModule } from '../projects/projects.module';
 import { PermissionsModule } from '../permissions/permissions.module';
 
 @Module({
-  imports: [ProjectsModule, PermissionsModule],
+  // forwardRef: this file is first required *while* projects.module.ts is
+  // still evaluating (app → setup → auth → settings → domains → projects →
+  // pipelines → oauth → app-tokens), so a direct reference to ProjectsModule
+  // is `undefined` at decoration time and Nest refuses to boot ("The module
+  // at index [0] of the AppTokensModule imports array is undefined").
+  // PermissionsModule is deferred the same way so a future re-ordering of
+  // that chain cannot reintroduce the crash.
+  imports: [forwardRef(() => ProjectsModule), forwardRef(() => PermissionsModule)],
   controllers: [AppTokensController],
   providers: [AppTokensService],
   exports: [AppTokensService],

--- a/apps/backend/src/app.module.spec.ts
+++ b/apps/backend/src/app.module.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Regression guard for file-level import cycles between Nest modules.
+ *
+ * Loading `AppModule` requires every module file in production order. When a
+ * module file is required while one of its own imports is still mid-evaluation
+ * (a CommonJS cycle), the decorator sees `undefined` instead of the class and
+ * Nest refuses to boot with "The module at index [n] of the X imports array is
+ * undefined". Unit tests never load the whole graph, so this walks it: every
+ * `@Module({ imports })` entry reachable from `AppModule` must be a class, a
+ * `forwardRef`, or a (possibly async) dynamic module — never `undefined`.
+ */
+import 'reflect-metadata';
+import { AppModule } from './app.module';
+
+type ModuleRef = (new (...args: unknown[]) => unknown) & { name: string };
+type ImportEntry =
+  | ModuleRef
+  | { forwardRef: () => ModuleRef }
+  | { module: ModuleRef }
+  | Promise<{ module: ModuleRef }>
+  | undefined;
+
+async function unwrap(entry: ImportEntry): Promise<ModuleRef | undefined> {
+  if (!entry) return undefined;
+  if (typeof entry === 'function') return entry;
+  if (entry instanceof Promise) return (await entry).module;
+  if ('forwardRef' in entry) return entry.forwardRef();
+  if ('module' in entry) return entry.module;
+  return undefined;
+}
+
+describe('AppModule import graph', () => {
+  it('has no undefined entries in any reachable @Module imports array', async () => {
+    const seen = new Set<ModuleRef>();
+    const problems: string[] = [];
+    const queue: ModuleRef[] = [AppModule as unknown as ModuleRef];
+    while (queue.length) {
+      const mod = queue.shift()!;
+      if (seen.has(mod)) continue;
+      seen.add(mod);
+      const imports = (Reflect.getMetadata('imports', mod) as ImportEntry[] | undefined) ?? [];
+      for (const [index, entry] of imports.entries()) {
+        const target = await unwrap(entry);
+        if (!target) {
+          problems.push(`${mod.name}.imports[${index}] is ${String(entry)}`);
+          continue;
+        }
+        queue.push(target);
+      }
+    }
+    expect(problems).toEqual([]);
+    // Sanity: the walk actually covered the graph and did not stop at AppModule.
+    expect(seen.size).toBeGreaterThan(20);
+  });
+});


### PR DESCRIPTION
## Problem

`ghcr.io/bffless/ce-backend:v0.4.52` and `:v0.4.53` crash-loop on startup:

```
Nest cannot create the AppTokensModule instance.
The module at index [0] of the AppTokensModule "imports" array is undefined.
Scope [AppModule -> AuthModule -> DomainsModule -> ProjectsModule -> ... -> PipelinesModule -> OAuthModule]
```

`v0.4.51` boots. Root cause is a CommonJS import cycle introduced when #761 made `PipelinesModule` import `OAuthModule`: the production require order (`app → setup → auth → settings → domains → projects → pipelines → oauth → app-tokens`) reaches `app-tokens.module.ts` while `projects.module.ts` is still mid-evaluation, so `ProjectsModule` is `undefined` when `@Module` runs. Unit tests never load the whole graph, so CI did not see it.

## Fix

- `app-tokens.module.ts`: wrap both imports in `forwardRef` (standard Nest fix; no runtime change once the graph resolves). Comment records the chain.
- New `app.module.spec.ts`: walks every `@Module({ imports })` array reachable from `AppModule` (classes, `forwardRef`, sync and async dynamic modules) and fails on any `undefined` entry. On the unfixed code it reports exactly `AppTokensModule.imports[0] is undefined`; after the fix it passes. Milliseconds, no database.

## Verification

- `node dist/main.js` with stub env: previously failed in the module scan; now gets past it (stops at the expected `JWT_SECRET` check).
- `tsc --noEmit` clean, `format:check` clean, app-tokens + oauth + new spec: 9 suites / 149 tests pass.

## Compatibility

No migration, API, env var, nginx, storage, or CLI surface touched. Restores boot for self-hosters on `stable` who pulled `:latest` today.

Refs #761.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NK2eaY4ZwmXRxifq22ELsV
