### PR TITLE
fix(auth): stop SessionAuthGuard/ApiKeyGuard double-writing the response on a missing session

### DIFF
--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -322,6 +322,24 @@ then the downstream handler / `EmailVerificationGuard` on the same request objec
 **Learned from:** PR #776, 2026-09-07 — the first push kept `getSession()`'s result local; caught by
 the CI review before merge.
 
+### A guard's "browser or API caller?" heuristic must default to API and match the bundled SPA's real headers
+**Surface:** `apps/backend/src/auth/session-auth.guard.ts` (`isApiRequest`) and any guard or middleware
+that branches response shape (401 JSON vs. redirect) on request headers — `email-verification.guard.ts`,
+`auth.middleware.ts`, `proxy.middleware.ts` carry sibling copies. The admin SPA's single `fetchBaseQuery`
+(`apps/frontend/src/services/api.ts`) sets no `Accept`, so its calls arrive as `Accept: */*`.
+**Check:** Does the "browser" branch require a positive navigation signal (`Sec-Fetch-Mode: navigate`,
+which browsers send only for top-level navigations and `fetch()`/XHR never do, or an `Accept` naming
+`text/html`), with everything else — bare `*/*`, no `Accept`, curl — treated as API? And does a spec
+cover the *default* header profile (no `Accept` at all), not only explicit `application/json` /
+`text/html`? Also: the 401 body texts `unauthorised` / `try refresh token` are a wire contract —
+`baseQueryWithReauth` reads "unauthorised" as "no session, skip refresh" and anything else as "refresh
+and retry". A guard that answers the request itself must keep emitting them.
+**Why:** `fetch()` follows a 302 transparently, so a redirect aimed at browsers turns into `/login`'s
+HTML with status 200 for the SPA: `result.error.status` becomes `PARSING_ERROR`, never `401`, and the
+silent-refresh path is skipped for every expired session. Nothing in `tsc` or a guard-level spec sees it.
+**Learned from:** PR #776, 2026-09-07 — moving the guards off `verifySession()` made a previously dead
+classification branch live; the first cut redirected `Accept: */*` and replaced the body texts.
+
 ---
 
 ## Entry template

--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -306,6 +306,22 @@ global limit allows.
 **Learned from:** #741, 2026-09-07 — the triage comment flagged it before the code was written;
 (6) from #768, 2026-09-07 — the CIMD fetch shipped (PR #764) with only the global throttle over it.
 
+### A guard moved from `verifySession()` to `getSession()` must still set `request.session`
+**Surface:** `apps/backend/src/auth/session-auth.guard.ts`, `apps/backend/src/auth/api-key.guard.ts`,
+and any other guard migrated off the SuperTokens express `verifySession()` middleware onto the
+recipe-level `getSession()`.
+**Check:** The express middleware sets `request.session` as a side effect; `getSession()` returns the
+container and sets nothing. Does the guard assign it back (`request.session = session`)? Grep for
+`req.session` / `request.session` outside the guard: `AuthController.getSession`, `change-password`,
+`login-methods`, `SetupController.adopt-session-user` 401 without it, and the global
+`EmailVerificationGuard` (`APP_GUARD`) treats a missing `request.session` as "unauthenticated, skip",
+silently disabling `ENABLE_EMAIL_VERIFICATION`.
+**Why:** Invisible to `tsc` (the field is typed optional) and to guard-level unit tests that mock
+`getSession` and assert only `request.user`. `session-request-contract.spec.ts` runs the guard and
+then the downstream handler / `EmailVerificationGuard` on the same request object to pin it.
+**Learned from:** PR #776, 2026-09-07 — the first push kept `getSession()`'s result local; caught by
+the CI review before merge.
+
 ---
 
 ## Entry template

--- a/apps/backend/src/auth/api-key.guard.spec.ts
+++ b/apps/backend/src/auth/api-key.guard.spec.ts
@@ -93,9 +93,10 @@ describe('ApiKeyGuard', () => {
 
       // When no API key is provided, the guard falls back to session authentication.
       // With no session it throws its own 401 (never a redirect - this guard is for
-      // programmatic access) and leaves the response untouched for the filter.
+      // programmatic access) and leaves the response untouched for the filter. The
+      // body is the one SuperTokens used to write; the frontend keys on it.
       await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
-        new UnauthorizedException('Authentication required'),
+        new UnauthorizedException('unauthorised'),
       );
       expect(mockGetSession).toHaveBeenCalledWith(mockRequest, mockResponse, {
         sessionRequired: false,
@@ -131,13 +132,13 @@ describe('ApiKeyGuard', () => {
         expect(mockRequest.session).toBe(session);
       });
 
-      it('throws 401 when getSession rejects (present but invalid token)', async () => {
+      it('throws 401 "try refresh token" when getSession rejects with TRY_REFRESH_TOKEN', async () => {
         mockGetSession.mockRejectedValue(
-          Object.assign(new Error('try refresh token'), { type: 'TRY_REFRESH_TOKEN' }),
+          Object.assign(new Error('expired'), { type: 'TRY_REFRESH_TOKEN' }),
         );
 
         await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
-          new UnauthorizedException('Invalid or expired session'),
+          new UnauthorizedException('try refresh token'),
         );
         expect(mockResponse.redirect).not.toHaveBeenCalled();
         expect(mockRequest.user).toBeUndefined();
@@ -251,7 +252,7 @@ describe('ApiKeyGuard', () => {
         mockResolveAppToken.mockResolvedValueOnce(null);
 
         await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
-          new UnauthorizedException('Authentication required'),
+          new UnauthorizedException('unauthorised'),
         );
         expect(mockResolveAppToken).toHaveBeenCalledWith('Bearer eyJhbGciOi.jwt');
       });

--- a/apps/backend/src/auth/api-key.guard.spec.ts
+++ b/apps/backend/src/auth/api-key.guard.spec.ts
@@ -17,6 +17,11 @@ jest.mock('../db/client', () => ({
 
 jest.mock('bcrypt');
 
+// The session fallback must use getSession (never the express verifySession
+// middleware, which writes its own 401 on a missing session - issue #775).
+jest.mock('supertokens-node/recipe/session', () => ({ getSession: jest.fn() }));
+const { getSession: mockGetSession } = jest.requireMock('supertokens-node/recipe/session');
+
 jest.mock('./app-token.util', () => ({
   ...jest.requireActual('./app-token.util'),
   resolveAppToken: jest.fn().mockResolvedValue(null),
@@ -46,6 +51,7 @@ describe('ApiKeyGuard', () => {
     guard = module.get<ApiKeyGuard>(ApiKeyGuard);
     reflector = module.get<Reflector>(Reflector);
     jest.clearAllMocks();
+    mockGetSession.mockResolvedValue(undefined);
   });
 
   it('should be defined', () => {
@@ -62,7 +68,7 @@ describe('ApiKeyGuard', () => {
         headers: {},
       };
 
-      mockResponse = {};
+      mockResponse = { redirect: jest.fn(), headersSent: false };
 
       mockExecutionContext = {
         switchToHttp: jest.fn().mockReturnValue({
@@ -85,11 +91,64 @@ describe('ApiKeyGuard', () => {
     it('should throw error if no API key and no valid session', async () => {
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
 
-      // When no API key is provided, the guard falls back to session authentication
-      // Since there's no valid session, it throws "Invalid or expired session"
+      // When no API key is provided, the guard falls back to session authentication.
+      // With no session it throws its own 401 (never a redirect - this guard is for
+      // programmatic access) and leaves the response untouched for the filter.
       await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
-        new UnauthorizedException('Invalid or expired session'),
+        new UnauthorizedException('Authentication required'),
       );
+      expect(mockGetSession).toHaveBeenCalledWith(mockRequest, mockResponse, {
+        sessionRequired: false,
+      });
+      expect(mockResponse.redirect).not.toHaveBeenCalled();
+    });
+
+    describe('session fallback', () => {
+      beforeEach(() => {
+        jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      });
+
+      it('allows access with a valid session and attaches the user', async () => {
+        mockGetSession.mockResolvedValue({
+          getUserId: () => 'user-123',
+          getHandle: () => 'session-handle',
+        });
+        mockDb.limit = jest
+          .fn()
+          .mockResolvedValue([{ id: 'user-123', email: 'test@example.com', role: 'admin' }]);
+        mockDb.from.mockReturnThis();
+        mockDb.where.mockReturnThis();
+
+        await expect(guard.canActivate(mockExecutionContext)).resolves.toBe(true);
+        expect(mockRequest.user).toEqual({
+          id: 'user-123',
+          sessionHandle: 'session-handle',
+          email: 'test@example.com',
+          role: 'admin',
+        });
+      });
+
+      it('throws 401 when getSession rejects (present but invalid token)', async () => {
+        mockGetSession.mockRejectedValue(
+          Object.assign(new Error('try refresh token'), { type: 'TRY_REFRESH_TOKEN' }),
+        );
+
+        await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+          new UnauthorizedException('Invalid or expired session'),
+        );
+        expect(mockResponse.redirect).not.toHaveBeenCalled();
+        expect(mockRequest.user).toBeUndefined();
+      });
+
+      it('never redirects, even for a browser-style request', async () => {
+        mockRequest.headers = { accept: 'text/html,application/xhtml+xml' };
+        mockGetSession.mockResolvedValue(undefined);
+
+        await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+          UnauthorizedException,
+        );
+        expect(mockResponse.redirect).not.toHaveBeenCalled();
+      });
     });
 
     it('should allow access with valid API key', async () => {
@@ -188,7 +247,7 @@ describe('ApiKeyGuard', () => {
         mockResolveAppToken.mockResolvedValueOnce(null);
 
         await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
-          new UnauthorizedException('Invalid or expired session'),
+          new UnauthorizedException('Authentication required'),
         );
         expect(mockResolveAppToken).toHaveBeenCalledWith('Bearer eyJhbGciOi.jwt');
       });

--- a/apps/backend/src/auth/api-key.guard.spec.ts
+++ b/apps/backend/src/auth/api-key.guard.spec.ts
@@ -109,10 +109,11 @@ describe('ApiKeyGuard', () => {
       });
 
       it('allows access with a valid session and attaches the user', async () => {
-        mockGetSession.mockResolvedValue({
+        const session = {
           getUserId: () => 'user-123',
           getHandle: () => 'session-handle',
-        });
+        };
+        mockGetSession.mockResolvedValue(session);
         mockDb.limit = jest
           .fn()
           .mockResolvedValue([{ id: 'user-123', email: 'test@example.com', role: 'admin' }]);
@@ -126,6 +127,8 @@ describe('ApiKeyGuard', () => {
           email: 'test@example.com',
           role: 'admin',
         });
+        // verifySession() used to set this; handlers and EmailVerificationGuard read it.
+        expect(mockRequest.session).toBe(session);
       });
 
       it('throws 401 when getSession rejects (present but invalid token)', async () => {
@@ -138,6 +141,7 @@ describe('ApiKeyGuard', () => {
         );
         expect(mockResponse.redirect).not.toHaveBeenCalled();
         expect(mockRequest.user).toBeUndefined();
+        expect(mockRequest.session).toBeUndefined();
       });
 
       it('never redirects, even for a browser-style request', async () => {

--- a/apps/backend/src/auth/api-key.guard.ts
+++ b/apps/backend/src/auth/api-key.guard.ts
@@ -5,7 +5,7 @@ import * as bcrypt from 'bcrypt';
 import { getSession, SessionContainer } from 'supertokens-node/recipe/session';
 import { db } from '../db/client';
 import { apiKeys, users } from '../db/schema';
-import { IS_PUBLIC_KEY } from './session-auth.guard';
+import { IS_PUBLIC_KEY, SESSION_401_NO_SESSION, sessionErrorMessage } from './session-auth.guard';
 import { requestUserFromAppToken, resolveAppToken } from './app-token.util';
 
 /**
@@ -95,16 +95,17 @@ export class ApiKeyGuard implements CanActivate {
     // The express verifySession() middleware must NOT be used here: on a missing
     // session it writes SuperTokens' own 401 and never calls back, so the guard's
     // own throw becomes a second write (ERR_HTTP_HEADERS_SENT, issue #775).
+    // The 401 body texts mirror what SuperTokens used to write; the frontend's
+    // silent-refresh flow keys on them (see session-auth.guard.ts).
     let session: SessionContainer | undefined;
     try {
       session = await getSession(request, response, { sessionRequired: false });
-    } catch {
-      // Present-but-invalid token (e.g. TRY_REFRESH_TOKEN): same 401 as no session.
-      throw new UnauthorizedException('Invalid or expired session');
+    } catch (error) {
+      throw new UnauthorizedException(sessionErrorMessage(error));
     }
 
     if (!session) {
-      throw new UnauthorizedException('Authentication required');
+      throw new UnauthorizedException(SESSION_401_NO_SESSION);
     }
 
     // verifySession() used to set request.session as a side effect; getSession()

--- a/apps/backend/src/auth/api-key.guard.ts
+++ b/apps/backend/src/auth/api-key.guard.ts
@@ -107,6 +107,11 @@ export class ApiKeyGuard implements CanActivate {
       throw new UnauthorizedException('Authentication required');
     }
 
+    // verifySession() used to set request.session as a side effect; getSession()
+    // does not. The global EmailVerificationGuard and session handlers still read
+    // request.session, so restore it.
+    request.session = session;
+
     try {
       const userId = session.getUserId();
 

--- a/apps/backend/src/auth/api-key.guard.ts
+++ b/apps/backend/src/auth/api-key.guard.ts
@@ -2,8 +2,7 @@ import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from
 import { Reflector } from '@nestjs/core';
 import { eq } from 'drizzle-orm';
 import * as bcrypt from 'bcrypt';
-import { verifySession } from 'supertokens-node/recipe/session/framework/express';
-import { SessionContainer } from 'supertokens-node/recipe/session';
+import { getSession, SessionContainer } from 'supertokens-node/recipe/session';
 import { db } from '../db/client';
 import { apiKeys, users } from '../db/schema';
 import { IS_PUBLIC_KEY } from './session-auth.guard';
@@ -92,21 +91,23 @@ export class ApiKeyGuard implements CanActivate {
   }
 
   private async validateSession(request: any, response: any): Promise<boolean> {
+    // Read the session with sessionRequired: false (same as OptionalAuthGuard).
+    // The express verifySession() middleware must NOT be used here: on a missing
+    // session it writes SuperTokens' own 401 and never calls back, so the guard's
+    // own throw becomes a second write (ERR_HTTP_HEADERS_SENT, issue #775).
+    let session: SessionContainer | undefined;
     try {
-      // Verify session using SuperTokens
-      await verifySession()(request, response, (err?: any) => {
-        if (err) {
-          throw new UnauthorizedException('Invalid or expired session');
-        }
-      });
+      session = await getSession(request, response, { sessionRequired: false });
+    } catch {
+      // Present-but-invalid token (e.g. TRY_REFRESH_TOKEN): same 401 as no session.
+      throw new UnauthorizedException('Invalid or expired session');
+    }
 
-      // Session is now available on request.session
-      const session: SessionContainer = request.session;
+    if (!session) {
+      throw new UnauthorizedException('Authentication required');
+    }
 
-      if (!session) {
-        throw new UnauthorizedException('No active session');
-      }
-
+    try {
       const userId = session.getUserId();
 
       // Get user from database to include role information

--- a/apps/backend/src/auth/session-auth.guard.spec.ts
+++ b/apps/backend/src/auth/session-auth.guard.spec.ts
@@ -113,6 +113,8 @@ describe('SessionAuthGuard', () => {
       expect(mockGetSession).toHaveBeenCalledWith(mockRequest, mockResponse, {
         sessionRequired: false,
       });
+      // verifySession() used to set this; handlers and EmailVerificationGuard read it.
+      expect(mockRequest.session).toBe(mockSession);
       expect(mockResponse.redirect).not.toHaveBeenCalled();
     });
 
@@ -125,6 +127,8 @@ describe('SessionAuthGuard', () => {
         new UnauthorizedException('Authentication required'),
       );
       expect(mockResponse.redirect).not.toHaveBeenCalled();
+      expect(mockRequest.session).toBeUndefined();
+      expect(mockRequest.user).toBeUndefined();
     });
 
     it('should redirect browser request to login with tryRefresh param', async () => {

--- a/apps/backend/src/auth/session-auth.guard.spec.ts
+++ b/apps/backend/src/auth/session-auth.guard.spec.ts
@@ -10,13 +10,14 @@ jest.mock('../db/client', () => ({
   },
 }));
 
-// Mock SuperTokens
-jest.mock('supertokens-node/recipe/session/framework/express', () => ({
-  verifySession: jest.fn(),
-}));
+// Mock SuperTokens. The guard must use getSession (never the express verifySession
+// middleware, which writes its own 401 on a missing session - issue #775).
+jest.mock('supertokens-node/recipe/session', () => ({ getSession: jest.fn() }));
 
-import { verifySession } from 'supertokens-node/recipe/session/framework/express';
+import { getSession } from 'supertokens-node/recipe/session';
 import { db } from '../db/client';
+
+const mockGetSession = getSession as jest.Mock;
 
 describe('SessionAuthGuard', () => {
   let guard: SessionAuthGuard;
@@ -37,6 +38,7 @@ describe('SessionAuthGuard', () => {
 
     guard = module.get<SessionAuthGuard>(SessionAuthGuard);
     reflector = module.get<Reflector>(Reflector);
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
@@ -58,6 +60,7 @@ describe('SessionAuthGuard', () => {
       };
       mockResponse = {
         redirect: jest.fn(),
+        headersSent: false,
       };
 
       mockExecutionContext = {
@@ -86,13 +89,7 @@ describe('SessionAuthGuard', () => {
         getHandle: jest.fn().mockReturnValue('session-handle'),
       };
 
-      mockRequest.session = mockSession;
-
-      (verifySession as jest.Mock).mockReturnValue(
-        (req: any, res: any, next: (err?: any) => void) => {
-          next();
-        },
-      );
+      mockGetSession.mockResolvedValue(mockSession);
 
       // Mock database query to return user with role
       const mockDbChain = {
@@ -107,21 +104,27 @@ describe('SessionAuthGuard', () => {
       const result = await guard.canActivate(mockExecutionContext);
 
       expect(result).toBe(true);
-      expect(mockRequest.user).toBeDefined();
-      expect(mockRequest.user.id).toBe('user-123');
-      expect(mockRequest.user.role).toBe('admin');
+      expect(mockRequest.user).toEqual({
+        id: 'user-123',
+        sessionHandle: 'session-handle',
+        email: 'test@example.com',
+        role: 'admin',
+      });
+      expect(mockGetSession).toHaveBeenCalledWith(mockRequest, mockResponse, {
+        sessionRequired: false,
+      });
+      expect(mockResponse.redirect).not.toHaveBeenCalled();
     });
 
     it('should deny access without session (API request)', async () => {
       jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
 
-      (verifySession as jest.Mock).mockReturnValue(
-        (req: any, res: any, next: (err?: any) => void) => {
-          next(new Error('No session'));
-        },
-      );
+      mockGetSession.mockResolvedValue(undefined);
 
-      await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(UnauthorizedException);
+      await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+        new UnauthorizedException('Authentication required'),
+      );
+      expect(mockResponse.redirect).not.toHaveBeenCalled();
     });
 
     it('should redirect browser request to login with tryRefresh param', async () => {
@@ -131,18 +134,59 @@ describe('SessionAuthGuard', () => {
       mockRequest.headers = { accept: 'text/html,application/xhtml+xml' };
       mockRequest.originalUrl = '/dashboard';
 
-      (verifySession as jest.Mock).mockReturnValue(
-        (req: any, res: any, next: (err?: any) => void) => {
-          next(new Error('No session'));
-        },
-      );
+      mockGetSession.mockResolvedValue(undefined);
 
       // Should throw after redirect, but redirect should be called first
       await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(UnauthorizedException);
+      expect(mockResponse.redirect).toHaveBeenCalledTimes(1);
       expect(mockResponse.redirect).toHaveBeenCalledWith(
         302,
         '/login?redirect=%2Fdashboard&tryRefresh=true',
       );
+    });
+
+    describe('present-but-invalid session (getSession rejects, e.g. TRY_REFRESH_TOKEN)', () => {
+      const tryRefresh = Object.assign(new Error('try refresh token'), {
+        type: 'TRY_REFRESH_TOKEN',
+      });
+
+      it('returns 401 to an API request without redirecting', async () => {
+        jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+        mockRequest.headers = { accept: 'application/json' };
+        mockGetSession.mockRejectedValue(tryRefresh);
+
+        await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+          new UnauthorizedException('Authentication required'),
+        );
+        expect(mockResponse.redirect).not.toHaveBeenCalled();
+      });
+
+      it('redirects a browser request to /login exactly once, then throws', async () => {
+        jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+        mockRequest.headers = { accept: 'text/html,application/xhtml+xml' };
+        mockRequest.originalUrl = '/dashboard';
+        mockGetSession.mockRejectedValue(tryRefresh);
+
+        await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+          UnauthorizedException,
+        );
+        expect(mockResponse.redirect).toHaveBeenCalledTimes(1);
+        expect(mockResponse.redirect).toHaveBeenCalledWith(
+          302,
+          '/login?redirect=%2Fdashboard&tryRefresh=true',
+        );
+      });
+    });
+
+    it('does not redirect when the response was already sent (no ERR_HTTP_HEADERS_SENT)', async () => {
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      mockRequest.headers = { accept: 'text/html,application/xhtml+xml' };
+      mockRequest.originalUrl = '/dashboard';
+      mockResponse.headersSent = true;
+      mockGetSession.mockResolvedValue(undefined);
+
+      await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(UnauthorizedException);
+      expect(mockResponse.redirect).not.toHaveBeenCalled();
     });
 
     it('should not redirect API requests (return 401 instead)', async () => {
@@ -152,11 +196,7 @@ describe('SessionAuthGuard', () => {
       mockRequest.headers = { accept: 'application/json' };
       mockRequest.originalUrl = '/api/users';
 
-      (verifySession as jest.Mock).mockReturnValue(
-        (req: any, res: any, next: (err?: any) => void) => {
-          next(new Error('No session'));
-        },
-      );
+      mockGetSession.mockResolvedValue(undefined);
 
       // Should throw without redirect (API clients expect 401, not redirect)
       await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(UnauthorizedException);

--- a/apps/backend/src/auth/session-auth.guard.spec.ts
+++ b/apps/backend/src/auth/session-auth.guard.spec.ts
@@ -123,8 +123,10 @@ describe('SessionAuthGuard', () => {
 
       mockGetSession.mockResolvedValue(undefined);
 
+      // "unauthorised" is the body SuperTokens used to write for no session; the
+      // frontend's baseQueryWithReauth reads it as "skip refresh, go to /login".
       await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
-        new UnauthorizedException('Authentication required'),
+        new UnauthorizedException('unauthorised'),
       );
       expect(mockResponse.redirect).not.toHaveBeenCalled();
       expect(mockRequest.session).toBeUndefined();
@@ -154,13 +156,27 @@ describe('SessionAuthGuard', () => {
         type: 'TRY_REFRESH_TOKEN',
       });
 
-      it('returns 401 to an API request without redirecting', async () => {
+      it('returns 401 "try refresh token" to an API request without redirecting', async () => {
         jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
         mockRequest.headers = { accept: 'application/json' };
         mockGetSession.mockRejectedValue(tryRefresh);
 
+        // The body SuperTokens used to write; the frontend attempts a silent refresh on it.
         await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
-          new UnauthorizedException('Authentication required'),
+          new UnauthorizedException('try refresh token'),
+        );
+        expect(mockResponse.redirect).not.toHaveBeenCalled();
+      });
+
+      it('maps any other getSession error to a plain 401 "unauthorised"', async () => {
+        jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+        mockRequest.headers = { accept: 'application/json' };
+        mockGetSession.mockRejectedValue(
+          Object.assign(new Error('token theft'), { type: 'TOKEN_THEFT_DETECTED' }),
+        );
+
+        await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+          new UnauthorizedException('unauthorised'),
         );
         expect(mockResponse.redirect).not.toHaveBeenCalled();
       });
@@ -179,6 +195,71 @@ describe('SessionAuthGuard', () => {
           302,
           '/login?redirect=%2Fdashboard&tryRefresh=true',
         );
+      });
+    });
+
+    describe('browser vs. API classification', () => {
+      beforeEach(() => {
+        jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+        mockGetSession.mockResolvedValue(undefined);
+      });
+
+      it('treats a request with no Accept header at all as an API client (401, no redirect)', async () => {
+        mockRequest.headers = {};
+
+        await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+          new UnauthorizedException('unauthorised'),
+        );
+        expect(mockResponse.redirect).not.toHaveBeenCalled();
+      });
+
+      it("treats the SPA's own fetch() profile (Accept: */*, Sec-Fetch-Mode: cors) as an API client", async () => {
+        // This is what apps/frontend/src/services/api.ts actually sends: it sets no
+        // Accept header. A redirect here would be followed by fetch() to /login's
+        // HTML and the frontend's 401-keyed silent refresh would never run.
+        mockRequest.headers = { accept: '*/*', 'sec-fetch-mode': 'cors' };
+
+        await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+          new UnauthorizedException('unauthorised'),
+        );
+        expect(mockResponse.redirect).not.toHaveBeenCalled();
+      });
+
+      it('treats Sec-Fetch-Mode: navigate as a browser navigation (redirect)', async () => {
+        mockRequest.headers = { accept: '*/*', 'sec-fetch-mode': 'navigate' };
+        mockRequest.originalUrl = '/api/auth/session';
+
+        await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+          UnauthorizedException,
+        );
+        expect(mockResponse.redirect).toHaveBeenCalledTimes(1);
+        expect(mockResponse.redirect).toHaveBeenCalledWith(
+          302,
+          '/login?redirect=%2Fapi%2Fauth%2Fsession&tryRefresh=true',
+        );
+      });
+
+      it('treats curl -H "Accept: text/html" (the issue repro) as a browser navigation', async () => {
+        mockRequest.headers = { accept: 'text/html' };
+        mockRequest.originalUrl = '/api/auth/session';
+
+        await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+          UnauthorizedException,
+        );
+        expect(mockResponse.redirect).toHaveBeenCalledTimes(1);
+      });
+
+      it('still prefers the explicit API signals over navigation hints', async () => {
+        mockRequest.headers = {
+          accept: 'text/html',
+          'sec-fetch-mode': 'navigate',
+          'x-requested-with': 'XMLHttpRequest',
+        };
+
+        await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+          new UnauthorizedException('unauthorised'),
+        );
+        expect(mockResponse.redirect).not.toHaveBeenCalled();
       });
     });
 

--- a/apps/backend/src/auth/session-auth.guard.ts
+++ b/apps/backend/src/auth/session-auth.guard.ts
@@ -9,6 +9,28 @@ import { users } from '../db/schema';
 export const IS_PUBLIC_KEY = 'isPublic';
 
 /**
+ * 401 body texts for a failed session check. These are the exact strings
+ * SuperTokens' own error handler used to write (it answered these requests
+ * itself before issue #775), and the frontend's `baseQueryWithReauth`
+ * (apps/frontend/src/services/api.ts) keys on them: "unauthorised" means no
+ * session at all (skip the refresh attempt, go to /login); anything else on a
+ * 401 triggers a silent POST /api/auth/session/refresh and retry. Keep them.
+ */
+export const SESSION_401_NO_SESSION = 'unauthorised';
+export const SESSION_401_TRY_REFRESH = 'try refresh token';
+
+/**
+ * Map a `getSession()` rejection to the 401 body SuperTokens would have sent.
+ * A present-but-expired access token is `TRY_REFRESH_TOKEN` (the client should
+ * refresh); every other failure (token theft, unparsable token, ...) is a plain
+ * "unauthorised". Compared by string so specs can mock the session module.
+ */
+export function sessionErrorMessage(error: unknown): string {
+  const type = (error as { type?: unknown } | null)?.type;
+  return type === 'TRY_REFRESH_TOKEN' ? SESSION_401_TRY_REFRESH : SESSION_401_NO_SESSION;
+}
+
+/**
  * Session-based authentication guard using SuperTokens
  * Verifies that a valid session exists for the request
  *
@@ -35,27 +57,30 @@ export class SessionAuthGuard implements CanActivate {
     const request = context.switchToHttp().getRequest<Request>();
     const response = context.switchToHttp().getResponse<Response>();
 
+    // Read the session with sessionRequired: false (same as OptionalAuthGuard).
+    // The express verifySession() middleware must NOT be used here: on a missing
+    // session it writes SuperTokens' own 401 and never calls back, so anything the
+    // guard does afterwards is a second write (ERR_HTTP_HEADERS_SENT, issue #775).
+    // getSession resolves undefined when there is no session and rejects for a
+    // present-but-invalid token (TRY_REFRESH_TOKEN) - both take the failure path,
+    // which owns the response (401 JSON or /login redirect).
+    let session: SessionContainer | undefined;
     try {
-      // Read the session with sessionRequired: false (same as OptionalAuthGuard).
-      // The express verifySession() middleware must NOT be used here: on a missing
-      // session it writes SuperTokens' own 401 and never calls back, so anything the
-      // guard does afterwards is a second write (ERR_HTTP_HEADERS_SENT, issue #775).
-      // getSession resolves undefined when there is no session and rejects for a
-      // present-but-invalid token (TRY_REFRESH_TOKEN) - both take the failure path
-      // below, which owns the response (401 JSON or /login redirect).
-      const session: SessionContainer | undefined = await getSession(request, response, {
-        sessionRequired: false,
-      });
+      session = await getSession(request, response, { sessionRequired: false });
+    } catch (error) {
+      return this.handleAuthFailure(request, response, sessionErrorMessage(error));
+    }
 
-      if (!session) {
-        throw new UnauthorizedException('No active session');
-      }
+    if (!session) {
+      return this.handleAuthFailure(request, response, SESSION_401_NO_SESSION);
+    }
 
-      // verifySession() used to set request.session as a side effect; getSession()
-      // does not. Handlers (AuthController.getSession, SetupController) and the
-      // global EmailVerificationGuard still read request.session, so restore it.
-      (request as Request & { session?: SessionContainer }).session = session;
+    // verifySession() used to set request.session as a side effect; getSession()
+    // does not. Handlers (AuthController.getSession, SetupController) and the
+    // global EmailVerificationGuard still read request.session, so restore it.
+    (request as Request & { session?: SessionContainer }).session = session;
 
+    try {
       const userId = session.getUserId();
 
       // Fetch user from database to get role
@@ -75,20 +100,20 @@ export class SessionAuthGuard implements CanActivate {
 
       return true;
     } catch {
-      // Session validation failed - handle based on request type
-      return this.handleAuthFailure(request, response);
+      // User lookup failed - treated as an auth failure, as before
+      return this.handleAuthFailure(request, response, 'Authentication required');
     }
   }
 
   /**
    * Handle authentication failure based on request type
-   * - API requests: throw UnauthorizedException (returns 401 JSON)
-   * - Browser requests: redirect to /login?tryRefresh=true (frontend handles refresh)
+   * - API requests: throw UnauthorizedException (returns 401 JSON with `message`)
+   * - Browser navigations: redirect to /login?tryRefresh=true (frontend handles refresh)
    */
-  private handleAuthFailure(request: Request, response: Response): never {
+  private handleAuthFailure(request: Request, response: Response, message: string): never {
     // API requests should get a 401 JSON response, not a redirect
     if (this.isApiRequest(request)) {
-      throw new UnauthorizedException('Authentication required');
+      throw new UnauthorizedException(message);
     }
 
     // Browser request - redirect to login with tryRefresh param
@@ -109,8 +134,16 @@ export class SessionAuthGuard implements CanActivate {
   }
 
   /**
-   * Determines if this is an API request (expects JSON response)
-   * vs a browser request (can handle redirects)
+   * Determines if this is an API request (expects a 401 JSON body) vs. a
+   * top-level browser navigation (can act on a redirect).
+   *
+   * Only a real navigation may get the redirect. The admin SPA's own fetch()
+   * calls send no Accept header (browser default `*\/*`) and `Sec-Fetch-Mode:
+   * cors`/`same-origin`; if those were redirected, fetch() would follow the 302
+   * to /login's HTML and the frontend's silent-refresh flow (which keys on a
+   * 401) would never run. So the default is API, and "browser" requires a
+   * positive signal: `Sec-Fetch-Mode: navigate` (set by browsers on navigation,
+   * never by fetch/XHR) or an Accept header that asks for text/html.
    */
   private isApiRequest(request: Request): boolean {
     const acceptHeader = request.headers.accept || '';
@@ -136,13 +169,15 @@ export class SessionAuthGuard implements CanActivate {
       return true;
     }
 
-    // Accept header starts with application/* (not text/html) suggests API client
-    // Note: Browsers typically send Accept: text/html,application/xhtml+xml,... first
-    if (acceptHeader.startsWith('application/') && !acceptHeader.includes('text/html')) {
-      return true;
+    // Top-level browser navigation: can act on a redirect
+    if (request.headers['sec-fetch-mode'] === 'navigate') {
+      return false;
+    }
+    if (acceptHeader.includes('text/html')) {
+      return false;
     }
 
-    // Default: treat as browser request (can handle redirects)
-    return false;
+    // Default: API client (fetch()/XHR with Accept: */*, curl, no Accept at all)
+    return true;
   }
 }

--- a/apps/backend/src/auth/session-auth.guard.ts
+++ b/apps/backend/src/auth/session-auth.guard.ts
@@ -1,7 +1,6 @@
 import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { verifySession } from 'supertokens-node/recipe/session/framework/express';
-import { SessionContainer } from 'supertokens-node/recipe/session';
+import { getSession, SessionContainer } from 'supertokens-node/recipe/session';
 import { Request, Response } from 'express';
 import { eq } from 'drizzle-orm';
 import { db } from '../db/client';
@@ -37,15 +36,16 @@ export class SessionAuthGuard implements CanActivate {
     const response = context.switchToHttp().getResponse<Response>();
 
     try {
-      // Verify session using SuperTokens
-      await verifySession()(request, response, (err) => {
-        if (err) {
-          throw new UnauthorizedException('Invalid or expired session');
-        }
+      // Read the session with sessionRequired: false (same as OptionalAuthGuard).
+      // The express verifySession() middleware must NOT be used here: on a missing
+      // session it writes SuperTokens' own 401 and never calls back, so anything the
+      // guard does afterwards is a second write (ERR_HTTP_HEADERS_SENT, issue #775).
+      // getSession resolves undefined when there is no session and rejects for a
+      // present-but-invalid token (TRY_REFRESH_TOKEN) - both take the failure path
+      // below, which owns the response (401 JSON or /login redirect).
+      const session: SessionContainer | undefined = await getSession(request, response, {
+        sessionRequired: false,
       });
-
-      // Session is now available on request.session
-      const session = (request as Request & { session?: SessionContainer }).session;
 
       if (!session) {
         throw new UnauthorizedException('No active session');
@@ -89,9 +89,14 @@ export class SessionAuthGuard implements CanActivate {
     // Browser request - redirect to login with tryRefresh param
     // Server can't reliably check for refresh token cookie due to cookie path restrictions
     // The frontend login page will attempt session refresh before showing the form
-    const originalUrl = request.originalUrl || request.url || '/';
-    const loginUrl = `/login?redirect=${encodeURIComponent(originalUrl)}&tryRefresh=true`;
-    response.redirect(302, loginUrl);
+    // Never write over a response something upstream already sent - that turns an
+    // auth failure into an ERR_HTTP_HEADERS_SENT 500. The exception filter skips
+    // writing when headers are sent, so throwing is always safe.
+    if (!response.headersSent) {
+      const originalUrl = request.originalUrl || request.url || '/';
+      const loginUrl = `/login?redirect=${encodeURIComponent(originalUrl)}&tryRefresh=true`;
+      response.redirect(302, loginUrl);
+    }
 
     // After redirect, throw to prevent further processing
     // This exception will be caught by NestJS but the response is already sent

--- a/apps/backend/src/auth/session-auth.guard.ts
+++ b/apps/backend/src/auth/session-auth.guard.ts
@@ -51,6 +51,11 @@ export class SessionAuthGuard implements CanActivate {
         throw new UnauthorizedException('No active session');
       }
 
+      // verifySession() used to set request.session as a side effect; getSession()
+      // does not. Handlers (AuthController.getSession, SetupController) and the
+      // global EmailVerificationGuard still read request.session, so restore it.
+      (request as Request & { session?: SessionContainer }).session = session;
+
       const userId = session.getUserId();
 
       // Fetch user from database to get role

--- a/apps/backend/src/auth/session-request-contract.spec.ts
+++ b/apps/backend/src/auth/session-request-contract.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Guard → handler contract for `request.session`.
+ *
+ * SuperTokens' express `verifySession()` middleware set `request.session` as a
+ * side effect. `SessionAuthGuard` / `ApiKeyGuard` now read the session with the
+ * recipe-level `getSession()` (issue #775), which sets nothing — so the guards
+ * must write it back themselves. Downstream code still reads it directly:
+ * `AuthController.getSession` (and `change-password`, `login-methods`,
+ * `SetupController.adopt-session-user`) 401 without it, and the global
+ * `EmailVerificationGuard` treats a missing `request.session` as "unauthenticated,
+ * skip" — silently disabling `ENABLE_EMAIL_VERIFICATION`.
+ *
+ * Guard-level unit tests mock `getSession` and assert `request.user`, so they
+ * cannot see this. These tests run a guard and then the consumer on the *same*
+ * request object.
+ */
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+
+jest.mock('../db/client', () => ({
+  db: {
+    select: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockResolvedValue([]),
+    update: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+  },
+}));
+jest.mock('bcrypt', () => ({ compare: jest.fn() }));
+jest.mock('./app-token.util', () => ({
+  ...jest.requireActual('./app-token.util'),
+  resolveAppToken: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('supertokens-node', () => ({
+  __esModule: true,
+  getUser: jest.fn(),
+  listUsersByAccountInfo: jest.fn(),
+  RecipeUserId: jest.fn().mockImplementation((id: string) => ({ getAsString: () => id })),
+}));
+jest.mock('supertokens-node/recipe/emailverification', () => ({
+  __esModule: true,
+  default: { isEmailVerified: jest.fn() },
+}));
+jest.mock('supertokens-node/recipe/emailpassword', () => ({
+  __esModule: true,
+  default: { signIn: jest.fn() },
+}));
+jest.mock('supertokens-node/recipe/session', () => ({
+  __esModule: true,
+  default: { createNewSession: jest.fn() },
+  getSession: jest.fn(),
+}));
+
+import EmailVerification from 'supertokens-node/recipe/emailverification';
+import { AuthController } from './auth.controller';
+import { SessionAuthGuard } from './session-auth.guard';
+import { ApiKeyGuard } from './api-key.guard';
+import { EmailVerificationGuard } from './email-verification.guard';
+import { AuthService } from './auth.service';
+import { SetupService } from '../setup/setup.service';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import { OnboardingExecutorService } from '../onboarding-rules/onboarding-executor.service';
+import { DomainTokenService } from './domain-token.service';
+import { ProjectInviteLinksService } from '../project-invite-links/project-invite-links.service';
+import { ProjectResolverService } from './project-resolver.service';
+import { PermissionsService } from '../permissions/permissions.service';
+
+const mockDb = jest.requireMock('../db/client').db;
+const { getSession: mockGetSession } = jest.requireMock('supertokens-node/recipe/session');
+const mockIsEmailVerified = EmailVerification.isEmailVerified as jest.Mock;
+
+const USER_ID = 'user-1';
+const dbUser = { id: USER_ID, email: 'a@example.com', role: 'member' };
+
+const validSession = () => ({
+  getUserId: () => USER_ID,
+  getHandle: () => 'session-handle-1',
+  getAccessTokenPayload: () => ({}),
+});
+
+/** A request as it arrives at the guard: session cookie, no `session` yet. */
+const freshRequest = (): Request & { session?: any; user?: any } =>
+  ({
+    headers: { accept: 'application/json', host: 'admin.example.com' },
+    cookies: { sAccessToken: 'jwt' },
+    originalUrl: '/api/auth/session',
+  }) as unknown as Request & { session?: any; user?: any };
+
+const contextFor = (request: unknown, response: unknown = { redirect: jest.fn() }) =>
+  ({
+    switchToHttp: () => ({ getRequest: () => request, getResponse: () => response }),
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+  }) as unknown as ExecutionContext;
+
+const reflector = { getAllAndOverride: jest.fn().mockReturnValue(false) } as unknown as Reflector;
+
+describe('request.session contract after SessionAuthGuard / ApiKeyGuard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (reflector.getAllAndOverride as jest.Mock).mockReturnValue(false);
+    mockDb.limit.mockResolvedValue([dbUser]);
+    mockGetSession.mockResolvedValue(validSession());
+    mockIsEmailVerified.mockResolvedValue(true);
+  });
+
+  describe('AuthController.getSession on the request the guard mutated', () => {
+    let controller: AuthController;
+
+    beforeEach(() => {
+      const authService = {
+        getUserById: jest.fn().mockResolvedValue(dbUser),
+        getUserByEmail: jest.fn().mockResolvedValue(null),
+      } as unknown as jest.Mocked<AuthService>;
+      const featureFlags = {
+        isEnabled: jest.fn().mockResolvedValue(false),
+      } as unknown as jest.Mocked<FeatureFlagsService>;
+      controller = new AuthController(
+        authService,
+        {} as SetupService,
+        featureFlags,
+        {} as OnboardingExecutorService,
+        {} as DomainTokenService,
+        {} as ProjectInviteLinksService,
+        {
+          resolveProjectFromRequest: jest.fn().mockResolvedValue(null),
+        } as unknown as ProjectResolverService,
+        { getUserProjectRole: jest.fn().mockResolvedValue(null) } as unknown as PermissionsService,
+        {} as never,
+      );
+    });
+
+    it('returns the session for a logged-in user (GET /api/auth/session)', async () => {
+      const request = freshRequest();
+
+      await expect(new SessionAuthGuard(reflector).canActivate(contextFor(request))).resolves.toBe(
+        true,
+      );
+      expect(request.session).toBeDefined();
+
+      const result: any = await controller.getSession(request);
+      expect(result.session).toEqual({ userId: USER_ID, handle: 'session-handle-1' });
+      expect(result.user).toMatchObject({ id: USER_ID, email: 'a@example.com' });
+    });
+  });
+
+  describe('EmailVerificationGuard (global APP_GUARD) on the request the guard mutated', () => {
+    const emailVerificationGuard = () =>
+      new EmailVerificationGuard(reflector, {
+        isEnabled: jest.fn().mockResolvedValue(true),
+      } as unknown as FeatureFlagsService);
+
+    it('still blocks an unverified user behind SessionAuthGuard', async () => {
+      const request = freshRequest();
+      mockIsEmailVerified.mockResolvedValue(false);
+
+      await expect(new SessionAuthGuard(reflector).canActivate(contextFor(request))).resolves.toBe(
+        true,
+      );
+      await expect(emailVerificationGuard().canActivate(contextFor(request))).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('still blocks an unverified user behind the ApiKeyGuard session fallback', async () => {
+      const request = freshRequest();
+      mockIsEmailVerified.mockResolvedValue(false);
+
+      await expect(new ApiKeyGuard(reflector).canActivate(contextFor(request))).resolves.toBe(true);
+      await expect(emailVerificationGuard().canActivate(contextFor(request))).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('lets a verified user through behind SessionAuthGuard', async () => {
+      const request = freshRequest();
+
+      await expect(new SessionAuthGuard(reflector).canActivate(contextFor(request))).resolves.toBe(
+        true,
+      );
+      await expect(emailVerificationGuard().canActivate(contextFor(request))).resolves.toBe(true);
+      expect(mockIsEmailVerified).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Closes #775

## Summary
Every unauthenticated request to a session-protected route from a client that does not ask for JSON — the admin frontend's first-load probe of `GET /api/auth/session`, or a browser navigating straight to an `/api/*` URL — logged a spurious `500 ERR_HTTP_HEADERS_SENT` in the backend log, on every release. The client still got a 401, so login and refresh worked; the noise came from the guard trying to write a second response over the one SuperTokens had already sent. This PR makes the two session guards read the session without letting SuperTokens write the response, so the guard's own 401 (or, for a real browser navigation, its login redirect) is the only response. Operators will stop seeing the 500 lines; everything the admin SPA and API clients see stays exactly as it was; a browser typing an `/api/*` URL into the address bar now gets the `302 /login?tryRefresh=true` the guard has always documented.

## Behaviour changes
- Backend log: an anonymous non-JSON request to a `SessionAuthGuard` / `ApiKeyGuard` route logged `ERROR [GlobalExceptionFilter] ... 500 ... ERR_HTTP_HEADERS_SENT` → logs a normal 401.
- Anonymous or expired-session call from the admin SPA / `fetch()` / XHR / curl (no `Accept`, `Accept: */*`, `Accept: application/json`, `X-API-Key`, …): `401 {"message":"unauthorised"}` or `401 {"message":"try refresh token"}` (written by SuperTokens) → the **same status and the same `message` text**, now written by the guard through Nest's standard error envelope (`{"statusCode":401,"message":"unauthorised","error":"Unauthorized",…}`). The frontend's `baseQueryWithReauth` keys on exactly those two strings ("unauthorised" = no session, skip refresh; anything else = silent refresh + retry), so its behaviour is unchanged.
- Top-level browser navigation (`Sec-Fetch-Mode: navigate`, or `Accept` naming `text/html`) to a `SessionAuthGuard` route without a session: `401 {"message":"unauthorised"}` → `302 /login?redirect=<originalUrl>&tryRefresh=true`. This is the documented behaviour that never fired before; the login page's `tryRefresh` handling already exists.
- `ApiKeyGuard` never redirects (programmatic access); unchanged, now pinned by a test.
- Authenticated requests: `request.user` and `request.session` are populated exactly as before.
- `ENABLE_EMAIL_VERIFICATION` enforcement (global `EmailVerificationGuard`) unchanged.

## Why
`supertokens-node` 17.x's express `verifySession()` middleware, on a missing/invalid session, runs `supertokens.errorHandler(...)` itself — which writes the 401 — and never calls our `next` callback (verified in `lib/build/recipe/session/framework/express.js` of the installed 17.1.5). Both guards then saw no session, threw, and `SessionAuthGuard.handleAuthFailure` called `response.redirect(302, …)` on an already-sent response. `OptionalAuthGuard` already used the right primitive — `getSession(request, response, { sessionRequired: false })` — which neither throws nor writes when there is no session. This PR brings the other two guards in line with it, and guards the redirect with `!response.headersSent` so a future upstream writer cannot turn an auth failure into a 500 again.

Two things the CI review caught across the first pushes, both consequences of the guard now owning the response for the first time:

1. `verifySession()` also set `request.session` as a side effect and `getSession()` does not. `AuthController.getSession` / `change-password` / `login-methods`, `SetupController.adopt-session-user` and the global `EmailVerificationGuard` read it directly, so without writing it back every logged-in `GET /api/auth/session` would 401 and email-verification enforcement would silently switch off. Both guards assign it; a new spec runs the guard and then the downstream consumer on the same request object.
2. The guard's previously dead "browser vs. API" branch and 401 body became live. Its heuristic defaulted to "browser" for anything without an explicit JSON/XHR/API-key signal — but the admin SPA's `fetchBaseQuery` sets no `Accept`, so its calls arrive as `Accept: */*`; a redirect there is followed by `fetch()` to `/login`'s HTML and the frontend's 401-keyed silent refresh never runs. And the frontend keys on the 401 body text (`unauthorised`), which the issue's proposed "Authentication required" would have broken. The guard now defaults to API (401) unless there is a positive navigation signal, and emits the same two body texts SuperTokens did (`sessionErrorMessage()` maps `TRY_REFRESH_TOKEN` → `try refresh token`, everything else → `unauthorised`; CE runs `EmailVerification` in `OPTIONAL` mode so there are no claim validators and `INVALID_CLAIMS` is not a live path).

## What changed
- backend: `apps/backend/src/auth/session-auth.guard.ts` — `verifySession()` → `getSession(..., { sessionRequired: false })`; `request.session` assigned from the result; `SESSION_401_NO_SESSION` / `SESSION_401_TRY_REFRESH` constants + `sessionErrorMessage()` exported; `handleAuthFailure(request, response, message)` redirects only when `!response.headersSent`; `isApiRequest` defaults to API and treats `Sec-Fetch-Mode: navigate` / `Accept: text/html` as the browser signals. `apps/backend/src/auth/api-key.guard.ts` — same `getSession` swap in `validateSession`, same body texts via the shared helper, `request.session` assigned.
- tests: `session-auth.guard.spec.ts` / `api-key.guard.spec.ts` — mock `getSession`; cases for `undefined` and `TRY_REFRESH_TOKEN` / other rejections (message mapping), browser → exactly one `redirect(302, …)` then throw, `headersSent: true` → no redirect, `request.user` + `request.session` populated, `ApiKeyGuard` never redirecting, and the classification matrix (no `Accept`, the `fetch()` default `*/*` + `Sec-Fetch-Mode: cors`, `Sec-Fetch-Mode: navigate`, the curl repro, explicit API signals winning). New `session-request-contract.spec.ts` — runs each guard then `AuthController.getSession` / `EmailVerificationGuard` on the same mutated request (fails 3/4 without the `request.session` assignment).
- process: `.claude/ce-pr-review-checklist.md` — two entries: "guard moved off `verifySession()` must still set `request.session`" and "browser-or-API heuristic must default to API and match the SPA's real headers / keep the 401 body texts".

## Compatibility
- Migrations / schema: none.
- API / CLI contract: no route, field, status code, or 401 `message` text change for API clients; the body gains Nest's `statusCode`/`error` envelope fields around the same `message`. `packages/cli` and `upload-artifact@v1` authenticate with `X-API-Key` and never reach the session path.
- Frontend: no change needed — `baseQueryWithReauth` receives the same status and `message` it did before (verified against `apps/frontend/src/services/api.ts`).
- Env vars: none. `ENABLE_EMAIL_VERIFICATION` enforcement unchanged (pinned by spec).
- nginx generation / storage layout / pipeline semantics: untouched.

## Verification
- `pnpm --filter backend exec tsc --noEmit` — exit 0, no output.
- `cd apps/backend && pnpm test -- src/auth src/setup` — 27 suites, 416/416 passed.
- Regression proof for finding 1: with the `request.session = session` line removed from `SessionAuthGuard`, `session-request-contract.spec.ts` fails 3 of 4; restored and green.
- `pnpm --filter backend format:check` — "All matched files use Prettier code style!".
- No local database on this VPS. For the deploy to confirm: `curl -si https://<admin-domain>/api/auth/session` (no `Accept`, no cookie) → `401` with `"message":"unauthorised"` and no 500 in the log; `curl -si -H 'Accept: text/html' …` → `302` to `/login?…&tryRefresh=true`; a logged-in `GET /api/auth/session` still returns the session; an expired access token with a live refresh cookie still refreshes silently in the SPA.

## Out of scope / follow-ups
- `apps/backend/src/proxy-rules/email-form-handler.service.ts` `validateSession()` wraps the same `verifySession()` middleware in a `new Promise` that only resolves inside the callback; on a missing session SuperTokens writes the 401 and the callback never runs, so that promise never settles. Same fix applies; deliberately not touched here.
- `EmailVerificationGuard.isApiRequest` (and the sibling copies in `auth.middleware.ts` / `proxy.middleware.ts`) carry the same "default to browser" heuristic this PR corrected in `SessionAuthGuard`. That one is live today: with `ENABLE_EMAIL_VERIFICATION` on, the SPA's `Accept: */*` calls from an unverified user get a `302 /verify-email` that `fetch()` follows, instead of the `403 EMAIL_NOT_VERIFIED` the frontend handles. Pre-existing and independent; worth its own issue.
- (From CI review pass 3) SuperTokens' `verifySession()` error handler also cleared the session cookies before writing its 401 for a revoked/invalid (not merely missing) session; `getSession()` leaves them in place, so such a client keeps sending the stale cookie and keeps getting `401 unauthorised` until it logs in again or the cookie expires. Not a security change (the server-side session is already invalid) and the same trade-off `OptionalAuthGuard` already makes; noted for a possible follow-up that clears cookies on that path.
- The frontend has no unit test for `baseQueryWithReauth`; the backend specs pin the body texts it depends on, but a Vitest around the 401 → refresh → retry path would be a good addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NK2eaY4ZwmXRxifq22ELsV

