### PR TITLE
fix(proxy-rules): email form handler answers a missing session with its own 401 instead of hanging

### DIFF
--- a/apps/backend/src/proxy-rules/email-form-handler.service.spec.ts
+++ b/apps/backend/src/proxy-rules/email-form-handler.service.spec.ts
@@ -1,0 +1,218 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Request, Response } from 'express';
+import { EmailFormHandlerService } from './email-form-handler.service';
+import { EmailService } from '../email/email.service';
+import { ProxyRule } from '../db/schema/proxy-rules.schema';
+
+// Mock the database module
+jest.mock('../db/client', () => ({
+  db: {
+    select: jest.fn(),
+  },
+}));
+
+// Mock SuperTokens. The handler must use getSession (never the express verifySession
+// middleware, which writes its own 401 on a missing session and never calls back,
+// leaving validateSession pending forever - issue #777).
+jest.mock('supertokens-node/recipe/session', () => ({ getSession: jest.fn() }));
+
+import { getSession } from 'supertokens-node/recipe/session';
+import { db } from '../db/client';
+
+const mockGetSession = getSession as jest.Mock;
+
+/** The handler's documented 401 body for a form that requires auth. */
+const UNAUTHORIZED_BODY = {
+  success: false,
+  error: 'Unauthorized',
+  message: 'Authentication required to submit this form',
+};
+
+function makeRule(
+  overrides: Partial<NonNullable<ProxyRule['emailHandlerConfig']>> = {},
+): ProxyRule {
+  return {
+    id: 'rule-1',
+    pathPattern: '/api/contact',
+    proxyType: 'email_form_handler',
+    emailHandlerConfig: {
+      destinationEmail: 'owner@example.com',
+      subject: 'Contact form',
+      requireAuth: true,
+      ...overrides,
+    },
+  } as unknown as ProxyRule;
+}
+
+function makeRequest(overrides: Partial<Request> = {}): Request {
+  return {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: 'https://site.example.com' },
+    body: { name: 'Ada', message: 'hello' },
+    ip: '203.0.113.7',
+    socket: { remoteAddress: '203.0.113.7' },
+    ...overrides,
+  } as unknown as Request;
+}
+
+function makeResponse(): Response & { headersSent: boolean } {
+  const res: any = {
+    headersSent: false,
+    status: jest.fn(),
+    json: jest.fn(),
+    redirect: jest.fn(),
+    setHeader: jest.fn(),
+  };
+  res.status.mockReturnValue(res);
+  res.json.mockImplementation(() => {
+    res.headersSent = true;
+    return res;
+  });
+  return res;
+}
+
+function mockUserLookup(rows: Array<{ id: string; email: string | null }>): void {
+  (db.select as jest.Mock).mockReturnValue({
+    from: jest.fn().mockReturnValue({
+      where: jest.fn().mockReturnValue({
+        limit: jest.fn().mockResolvedValue(rows),
+      }),
+    }),
+  });
+}
+
+describe('EmailFormHandlerService', () => {
+  let service: EmailFormHandlerService;
+  let emailService: { isConfigured: jest.Mock; sendEmail: jest.Mock };
+  let setIntervalSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    // The constructor schedules a rate-limit cache sweep; keep it off the event loop.
+    setIntervalSpy = jest
+      .spyOn(global, 'setInterval')
+      .mockReturnValue(0 as unknown as NodeJS.Timeout);
+
+    emailService = {
+      isConfigured: jest.fn().mockReturnValue(true),
+      sendEmail: jest.fn().mockResolvedValue({ success: true }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EmailFormHandlerService, { provide: EmailService, useValue: emailService }],
+    }).compile();
+
+    service = module.get(EmailFormHandlerService);
+    mockGetSession.mockReset();
+    (db.select as jest.Mock).mockReset();
+  });
+
+  afterEach(() => {
+    setIntervalSpy.mockRestore();
+  });
+
+  describe('handleSubmission with requireAuth', () => {
+    it('answers a missing session with the handler 401 body and stops processing', async () => {
+      mockGetSession.mockResolvedValue(undefined);
+      const rateLimitSpy = jest.spyOn(service as any, 'isRateLimited');
+      const req = makeRequest();
+      const res = makeResponse();
+
+      // Would hang (and time the test out) with the old verifySession() wrapper.
+      await expect(service.handleSubmission(req, res, makeRule())).resolves.toBeUndefined();
+
+      expect(mockGetSession).toHaveBeenCalledWith(req, res, { sessionRequired: false });
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ ...UNAUTHORIZED_BODY, reason: 'unauthorised' });
+      expect(rateLimitSpy).not.toHaveBeenCalled();
+      expect(emailService.isConfigured).not.toHaveBeenCalled();
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('answers an expired access token with the handler 401 body and reason "try refresh token"', async () => {
+      mockGetSession.mockRejectedValue({ type: 'TRY_REFRESH_TOKEN', message: 'try refresh token' });
+      const res = makeResponse();
+
+      await service.handleSubmission(makeRequest(), res, makeRule());
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ ...UNAUTHORIZED_BODY, reason: 'try refresh token' });
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('answers any other getSession rejection with the handler 401 body and reason "unauthorised"', async () => {
+      mockGetSession.mockRejectedValue(new Error('token theft detected'));
+      const res = makeResponse();
+
+      await service.handleSubmission(makeRequest(), res, makeRule());
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ ...UNAUTHORIZED_BODY, reason: 'unauthorised' });
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('does not write a second response when something upstream already answered', async () => {
+      mockGetSession.mockResolvedValue(undefined);
+      const res = makeResponse();
+      res.headersSent = true;
+
+      await expect(
+        service.handleSubmission(makeRequest(), res, makeRule()),
+      ).resolves.toBeUndefined();
+
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('proceeds with the submission for a valid session', async () => {
+      const session = { getUserId: () => 'user-123', getHandle: () => 'session-handle' };
+      mockGetSession.mockResolvedValue(session);
+      mockUserLookup([{ id: 'user-123', email: 'ada@example.com' }]);
+      const req = makeRequest();
+      const res = makeResponse();
+
+      await service.handleSubmission(req, res, makeRule());
+
+      expect((req as Request & { session?: unknown }).session).toBe(session);
+      expect(emailService.sendEmail).toHaveBeenCalledTimes(1);
+      const sent = emailService.sendEmail.mock.calls[0][0];
+      expect(sent.to).toBe('owner@example.com');
+      expect(sent.subject).toBe('Contact form');
+      expect(sent.text).toContain('ada@example.com');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        message: 'Form submitted successfully',
+      });
+    });
+
+    it('rejects a session whose user no longer exists', async () => {
+      mockGetSession.mockResolvedValue({ getUserId: () => 'gone', getHandle: () => 'h' });
+      mockUserLookup([]);
+      const res = makeResponse();
+
+      await service.handleSubmission(makeRequest(), res, makeRule());
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'Unauthorized',
+        message: 'User not found',
+      });
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleSubmission without requireAuth', () => {
+    it('never consults the session and sends the email', async () => {
+      const res = makeResponse();
+
+      await service.handleSubmission(makeRequest(), res, makeRule({ requireAuth: false }));
+
+      expect(mockGetSession).not.toHaveBeenCalled();
+      expect(emailService.sendEmail).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+});

--- a/apps/backend/src/proxy-rules/email-form-handler.service.ts
+++ b/apps/backend/src/proxy-rules/email-form-handler.service.ts
@@ -1,12 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Request, Response } from 'express';
-import { verifySession } from 'supertokens-node/recipe/session/framework/express';
-import { SessionContainer } from 'supertokens-node/recipe/session';
+import { getSession, SessionContainer } from 'supertokens-node/recipe/session';
 import { eq } from 'drizzle-orm';
 import { db } from '../db/client';
 import { users } from '../db/schema';
 import { EmailService } from '../email/email.service';
 import { ProxyRule } from '../db/schema/proxy-rules.schema';
+import { SESSION_401_NO_SESSION, sessionErrorMessage } from '../auth/session-auth.guard';
 
 interface AuthenticatedUser {
   id: string;
@@ -407,68 +407,85 @@ export class EmailFormHandlerService {
   /**
    * Validate the session and return authenticated user details.
    * Returns null and sends error response if not authenticated.
+   *
+   * Reads the session with getSession(sessionRequired: false). The express
+   * verifySession() middleware must NOT be used here: on a missing session it
+   * writes SuperTokens' own 401 and never calls back, so the returned promise
+   * never settled and the client saw SuperTokens' body instead of this handler's
+   * documented one (issue #777, same root cause as #775). getSession resolves
+   * undefined when there is no session and rejects for a present-but-invalid
+   * token (TRY_REFRESH_TOKEN) - both take the 401 path, which this handler owns.
    */
   private async validateSession(req: Request, res: Response): Promise<AuthenticatedUser | null> {
-    return new Promise((resolve) => {
-      verifySession()(req, res, async (err) => {
-        if (err) {
-          this.logger.debug(`Session validation failed: ${err.message}`);
-          res.status(401).json({
-            success: false,
-            error: 'Unauthorized',
-            message: 'Authentication required to submit this form',
-          });
-          resolve(null);
-          return;
-        }
+    let session: SessionContainer | undefined;
+    try {
+      session = await getSession(req, res, { sessionRequired: false });
+    } catch (error) {
+      this.logger.debug(`Session validation failed: ${(error as Error)?.message ?? error}`);
+      this.sendUnauthorized(res, sessionErrorMessage(error));
+      return null;
+    }
 
-        // Session is now available on request.session
-        const session = (req as Request & { session?: SessionContainer }).session;
+    if (!session) {
+      this.sendUnauthorized(res, SESSION_401_NO_SESSION);
+      return null;
+    }
 
-        if (!session) {
-          res.status(401).json({
-            success: false,
-            error: 'Unauthorized',
-            message: 'No active session',
-          });
-          resolve(null);
-          return;
-        }
+    // verifySession() used to set request.session as a side effect; getSession()
+    // does not. Nothing downstream of this handler reads it today, but keep the
+    // request shaped the same way as the auth guards leave it.
+    (req as Request & { session?: SessionContainer }).session = session;
 
-        const userId = session.getUserId();
+    const userId = session.getUserId();
 
-        // Fetch user details from database
-        try {
-          const [user] = await db
-            .select({ id: users.id, email: users.email })
-            .from(users)
-            .where(eq(users.id, userId))
-            .limit(1);
+    // Fetch user details from database
+    try {
+      const [user] = await db
+        .select({ id: users.id, email: users.email })
+        .from(users)
+        .where(eq(users.id, userId))
+        .limit(1);
 
-          if (!user) {
-            res.status(401).json({
-              success: false,
-              error: 'Unauthorized',
-              message: 'User not found',
-            });
-            resolve(null);
-            return;
-          }
+      if (!user) {
+        res.status(401).json({
+          success: false,
+          error: 'Unauthorized',
+          message: 'User not found',
+        });
+        return null;
+      }
 
-          resolve({
-            id: user.id,
-            email: user.email || undefined,
-          });
-        } catch (dbError) {
-          this.logger.error(`Failed to fetch user details: ${dbError}`);
-          res.status(500).json({
-            success: false,
-            error: 'Internal Server Error',
-            message: 'Failed to validate user',
-          });
-          resolve(null);
-        }
+      return {
+        id: user.id,
+        email: user.email || undefined,
+      };
+    } catch (dbError) {
+      this.logger.error(`Failed to fetch user details: ${dbError}`);
+      res.status(500).json({
+        success: false,
+        error: 'Internal Server Error',
+        message: 'Failed to validate user',
       });
+      return null;
+    }
+  }
+
+  /**
+   * The handler's documented 401 body for a form that requires auth. `reason`
+   * carries the same text SuperTokens' error handler used to answer these
+   * requests with ("unauthorised" / "try refresh token") so a client that keyed
+   * on it can still tell "no session" from "refresh and retry".
+   */
+  private sendUnauthorized(res: Response, reason: string): void {
+    // Never write over a response something upstream already sent.
+    if (res.headersSent) {
+      return;
+    }
+    res.status(401).json({
+      success: false,
+      error: 'Unauthorized',
+      message: 'Authentication required to submit this form',
+      reason,
     });
   }
 }


### PR DESCRIPTION
Closes #777

## Summary
A form rule with `requireAuth` enabled was supposed to answer anonymous submissions with the handler's own 401 JSON (`Authentication required to submit this form`). Instead, clients got SuperTokens' raw `{"message":"unauthorised"}` body, and on the server each such attempt left the handler's promise pending forever. This PR reads the session the same way the auth guards do since PR #776, so the handler now owns its 401 response and always completes. Authenticated submissions are unchanged.

## Behaviour changes
- Anonymous or expired-session POST to a `requireAuth` email form: before → `401 {"message":"unauthorised"}` (or `"try refresh token"`) written by SuperTokens, handler promise never settles; after → `401 {"success":false,"error":"Unauthorized","message":"Authentication required to submit this form","reason":"unauthorised"}` (or `"reason":"try refresh token"` for a present-but-expired access token), handler returns normally.
- The `reason` field is **additive**: it carries the exact text SuperTokens used to answer with, so a client that keyed on `"unauthorised"` / `"try refresh token"` can still tell "no session" from "refresh and retry". `success` / `error` / `message` are the handler's documented body.
- The previously unreachable `"No active session"` message variant is gone (it required `verifySession` to call `next` without a session, which it never does).
- Valid session, user-not-found, DB-error paths: unchanged bodies and statuses.
- `request.session` is now assigned after a successful `getSession()`, matching the guards. Nothing downstream of the handler reads it today (it is the terminal step in both `ProxyMiddleware` paths).

## Why
`supertokens-node` 17.x's express `verifySession()` middleware runs SuperTokens' own error handler on a missing/invalid session — it writes the 401 itself and never calls `next`. `validateSession()` wrapped that middleware in a `new Promise` resolved only inside `next`, so the documented 401 body was dead code and `handleSubmission()` leaked one pending promise per anonymous attempt. Same root cause as #775; the CI reviewer on #776 spotted this sibling and it was split out as #777. The fix mirrors #776: `getSession(req, res, { sessionRequired: false })` resolves `undefined` for no session and rejects for an invalid token, and both paths write the handler's body and return `null`.

## What changed
- **backend**: `apps/backend/src/proxy-rules/email-form-handler.service.ts` — `validateSession()` uses `getSession()` (no `new Promise` wrapper), reuses `sessionErrorMessage()` / `SESSION_401_NO_SESSION` from `auth/session-auth.guard.ts`, new `sendUnauthorized()` helper guarded by `res.headersSent`, assigns `req.session`.
- **tests**: `apps/backend/src/proxy-rules/email-form-handler.service.spec.ts` (new) — 7 specs: missing session resolves (does not hang) with the handler 401 and no rate-limit / email-service / DB work; `TRY_REFRESH_TOKEN` rejection → `reason: "try refresh token"`; other rejection → `"unauthorised"`; no second write when `headersSent`; valid session proceeds to `sendEmail` and sets `req.session`; user-not-found → 401; `requireAuth: false` never calls `getSession`.

## Compatibility
- **Pipeline / proxy-rule semantics (live customer data):** only the `requireAuth` failure path of `email_form_handler` rules changes, and only from a broken state (foreign body + hung promise) to the documented one. Success path untouched; the added `reason` field is additive.
- No migrations, env vars, CLI/API contract, nginx generation, or storage layout touched.
- `.claude/ce-pr-review-checklist.md` entry "A guard moved from `verifySession()` to `getSession()` must still set `request.session`" — honoured (assignment + spec assertion).

## Verification
Run in the worktree on top of `6abad3b`:
- `pnpm --filter backend exec tsc --noEmit` — clean, no output
- `pnpm --filter frontend exec tsc --noEmit` — clean, no output
- `pnpm --filter backend format:check` — "All matched files use Prettier code style!"
- `cd apps/backend && pnpm test -- email-form-handler.service.spec` — 1 suite, 7/7 passed
- `cd apps/backend && pnpm test -- "src/(proxy-rules|auth)/"` — 33 suites passed, 616/616 tests passed (129.6 s)

## Out of scope / follow-ups
- `EmailFormHandlerService`'s constructor schedules an un-`unref`'d `setInterval` for the rate-limit sweep; the spec stubs it. Harmless in the app, but it keeps a bare Jest worker alive — worth an `.unref()` in a separate chore.
- `parseJsonBody()` still uses a hand-rolled `new Promise` over `req.on('data')`; unrelated to this bug and left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NK2eaY4ZwmXRxifq22ELsV
