### PR TITLE
feat(proxy-rules): honour OUTBOUND_URL_GUARD on rules push, import and copy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -362,9 +362,11 @@ MINIO_USE_SSL=false
 #          (nothing written; the 400 lists every flagged rule), a failed
 #          preflight step on app install. A name that does not resolve, or
 #          whose lookup times out, is refused too.
-# On the UI/API create/update door a plain-http target to a non-internal host
-# has always been a hard 400; on push/import/copy that rule follows the mode
-# too, so existing rule sets with such targets keep pushing under warn.
+# Independent of this setting, a plain-http target to a non-internal host is
+# always a hard 400 on rule create/update, push and import (request
+# validation). Targets that name a private/link-local address outright
+# (e.g. https://10.0.0.1, https://169.254.169.254) are a hard 400 on
+# create/update and follow the mode on push, import and copy.
 # Any other value is treated as warn (warned about once at startup).
 # Does not apply to OAuth Client ID Metadata Documents, which always refuse
 # non-public hosts.

--- a/.env.example
+++ b/.env.example
@@ -349,14 +349,22 @@ MINIO_USE_SSL=false
 # APPS_REGISTRY_URL=https://apps.bffless.dev/registry.json
 
 # Outbound URL guard (SSRF defence in depth) for URLs the server fetches on
-# someone's behalf: proxy-rule targets (checked on rule create/update) and app
-# bundle URLs (checked at install preflight). The hostname is resolved and
+# someone's behalf: proxy-rule targets (checked on rule create/update in the
+# UI/API, and on every rule set pushed with `bffless rules push` / the
+# deploy-proxy-rules action, imported, or copied) and app bundle URLs (checked
+# at install preflight). The hostname is resolved (3 s budget per name) and
 # every address must be public. Hosts that are internal by declaration —
 # localhost, 127.0.0.1, *.svc, *.svc.cluster.local — are exempt.
 #   warn   (default) log a warning and allow — split-horizon or private
-#          targets that worked before keep working after upgrade
-#   reject refuse: HTTP 400 on rule create/update, a failed preflight step
-#          on app install. A name that does not resolve is refused too.
+#          targets that worked before keep working after upgrade. A push
+#          still succeeds; each flagged rule is one line in its warnings.
+#   reject refuse: HTTP 400 on rule create/update, a failed push/import/copy
+#          (nothing written; the 400 lists every flagged rule), a failed
+#          preflight step on app install. A name that does not resolve, or
+#          whose lookup times out, is refused too.
+# On the UI/API create/update door a plain-http target to a non-internal host
+# has always been a hard 400; on push/import/copy that rule follows the mode
+# too, so existing rule sets with such targets keep pushing under warn.
 # Any other value is treated as warn (warned about once at startup).
 # Does not apply to OAuth Client ID Metadata Documents, which always refuse
 # non-public hosts.

--- a/apps/backend/src/common/outbound-url.guard.spec.ts
+++ b/apps/backend/src/common/outbound-url.guard.spec.ts
@@ -1,12 +1,17 @@
 import { BadRequestException, Logger } from '@nestjs/common';
 import {
+  enforceOutboundVerdict,
   guardOutboundHost,
   isExplicitlyInternalHost,
   isPublicAddress,
   outboundUrlGuardMode,
+  OUTBOUND_LOOKUP_TIMEOUT_MS,
+  OutboundLookupTimeoutError,
   pinnedLookup,
   readCapped,
   vetOutboundHost,
+  vetOutboundHosts,
+  withLookupTimeout,
   type HostLookup,
 } from './outbound-url.guard';
 
@@ -237,6 +242,142 @@ describe('outbound-url.guard (#770)', () => {
         if (before === undefined) delete process.env.OUTBOUND_URL_GUARD;
         else process.env.OUTBOUND_URL_GUARD = before;
       }
+    });
+  });
+
+  describe('lookup timeout (#780)', () => {
+    const never: HostLookup = () => new Promise(() => undefined);
+
+    it('the default lookup budget is 3 s', () => {
+      expect(OUTBOUND_LOOKUP_TIMEOUT_MS).toBe(3000);
+    });
+
+    it('withLookupTimeout rejects with OutboundLookupTimeoutError once the budget is spent', async () => {
+      const bounded = withLookupTimeout(never, 20);
+      const attempt = bounded('slow.example');
+      await expect(attempt).rejects.toBeInstanceOf(OutboundLookupTimeoutError);
+      await expect(attempt).rejects.toThrow('lookup of slow.example timed out after 20 ms');
+    });
+
+    it('withLookupTimeout passes a prompt answer or error through unchanged', async () => {
+      const ok = withLookupTimeout(jest.fn().mockResolvedValue(PUBLIC), 1000);
+      await expect(ok('api.example.com')).resolves.toEqual(PUBLIC);
+      const bad = withLookupTimeout(jest.fn().mockRejectedValue(new Error('ENOTFOUND')), 1000);
+      await expect(bad('nope.example.com')).rejects.toThrow('ENOTFOUND');
+    });
+
+    it('vetOutboundHost reports a timed-out lookup as `timeout` — could not be verified — not `unresolved`', async () => {
+      const verdict = await vetOutboundHost('slow.example', withLookupTimeout(never, 20));
+      expect(verdict).toMatchObject({ ok: false, reason: 'timeout', addresses: [] });
+      if (verdict.ok) return;
+      expect(verdict.detail).toContain('slow.example could not be verified');
+      expect(verdict.detail).toContain('timed out after 20 ms');
+    });
+
+    it('guardOutboundHost: a timeout is allowed with a warning under warn and refused under reject', async () => {
+      const lookup = withLookupTimeout(never, 20);
+      const logger = { warn: jest.fn() };
+      await expect(
+        guardOutboundHost('slow.example', { subject: 's', mode: 'warn', lookup, logger }),
+      ).resolves.toMatchObject({ ok: false, reason: 'timeout' });
+      expect(String(logger.warn.mock.calls[0][0])).toMatch(
+        /could not be verified.*allowed because OUTBOUND_URL_GUARD=warn/,
+      );
+      await expect(
+        guardOutboundHost('slow.example', { subject: 's', mode: 'reject', lookup }),
+      ).rejects.toThrow(/could not be verified.*OUTBOUND_URL_GUARD=reject/);
+    });
+  });
+
+  describe('vetOutboundHosts — bulk, deduped, bounded (#780)', () => {
+    const byName: Record<string, { address: string; family: 4 | 6 }[]> = {
+      'a.example': PUBLIC,
+      'b.example': METADATA,
+    };
+
+    it('resolves each distinct hostname once and maps every input (as given) to its verdict', async () => {
+      const lookup: HostLookup = jest.fn(async (host) => byName[host] ?? []);
+      const out = await vetOutboundHosts(
+        ['a.example', 'b.example', 'A.example.', 'a.example', '10.0.0.1'],
+        { lookup },
+      );
+
+      expect(lookup).toHaveBeenCalledTimes(2);
+      expect(lookup).toHaveBeenCalledWith('a.example');
+      expect(lookup).toHaveBeenCalledWith('b.example');
+      expect(out.size).toBe(4);
+      expect(out.get('a.example')).toMatchObject({ ok: true });
+      expect(out.get('A.example.')).toBe(out.get('a.example'));
+      expect(out.get('b.example')).toMatchObject({ ok: false, reason: 'non-public' });
+      expect(out.get('10.0.0.1')).toMatchObject({ ok: false, reason: 'non-public' });
+    });
+
+    it('keeps at most `concurrency` lookups in flight', async () => {
+      let inFlight = 0;
+      let peak = 0;
+      const lookup: HostLookup = async () => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        inFlight -= 1;
+        return PUBLIC;
+      };
+      const hosts = Array.from({ length: 6 }, (_, i) => `h${i}.example`);
+
+      const out = await vetOutboundHosts(hosts, { lookup, concurrency: 2 });
+
+      expect(peak).toBe(2);
+      expect([...out.values()].every((v) => v.ok)).toBe(true);
+    });
+
+    it('one hanging name does not hide the others — each gets its own verdict', async () => {
+      const lookup: HostLookup = withLookupTimeout(
+        async (host) => (host === 'slow.example' ? new Promise(() => undefined) : PUBLIC),
+        20,
+      );
+      const out = await vetOutboundHosts(['slow.example', 'a.example'], { lookup });
+      expect(out.get('slow.example')).toMatchObject({ ok: false, reason: 'timeout' });
+      expect(out.get('a.example')).toMatchObject({ ok: true });
+    });
+
+    it('an empty input is an empty map with no lookup', async () => {
+      const lookup: HostLookup = jest.fn();
+      await expect(vetOutboundHosts([], { lookup })).resolves.toEqual(new Map());
+      expect(lookup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('enforceOutboundVerdict — the policy on a ready verdict (#780)', () => {
+    it('returns a passing verdict silently in either mode', () => {
+      const logger = { warn: jest.fn() };
+      for (const mode of ['warn', 'reject'] as const) {
+        expect(
+          enforceOutboundVerdict({ ok: true, addresses: PUBLIC }, { subject: 's', mode, logger }),
+        ).toEqual({ ok: true, addresses: PUBLIC });
+      }
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('warn: logs the subject and detail and returns the verdict; reject: throws naming the env var', () => {
+      const failing = {
+        ok: false as const,
+        reason: 'non-public' as const,
+        addresses: METADATA,
+        detail: 'api.example.com resolves to a non-public address (169.254.169.254)',
+      };
+      const logger = { warn: jest.fn() };
+      expect(enforceOutboundVerdict(failing, { subject: 'rule r1', mode: 'warn', logger })).toBe(
+        failing,
+      );
+      expect(String(logger.warn.mock.calls[0][0])).toBe(
+        'rule r1: api.example.com resolves to a non-public address (169.254.169.254); allowed because OUTBOUND_URL_GUARD=warn',
+      );
+      expect(() => enforceOutboundVerdict(failing, { subject: 'rule r1', mode: 'reject' })).toThrow(
+        BadRequestException,
+      );
+      expect(() => enforceOutboundVerdict(failing, { subject: 'rule r1', mode: 'reject' })).toThrow(
+        'rule r1: api.example.com resolves to a non-public address (169.254.169.254); refused by OUTBOUND_URL_GUARD=reject',
+      );
     });
   });
 

--- a/apps/backend/src/common/outbound-url.guard.ts
+++ b/apps/backend/src/common/outbound-url.guard.ts
@@ -18,6 +18,10 @@ import { isIP } from 'node:net';
  * (`warn`, the default, logs and allows; `reject` throws) for the places
  * where a hard refusal would break self-hosters whose targets legitimately
  * resolve to private space (split-horizon DNS, in-cluster services).
+ * {@link vetOutboundHosts} is 2 in bulk (one lookup per distinct name, a
+ * few in flight at a time) and {@link enforceOutboundVerdict} the policy on
+ * its own, for callers that vet a whole rule set before writing it (#780).
+ * Every lookup is bounded by {@link OUTBOUND_LOOKUP_TIMEOUT_MS}.
  * The CIMD guard does not use the policy: a client_id is never allowed to
  * point inward.
  */
@@ -34,11 +38,61 @@ export interface ResolvedAddress {
 /** Every address a name resolves to (`dns.lookup` with `all: true`), or throws. */
 export type HostLookup = (hostname: string) => Promise<ResolvedAddress[]>;
 
+/**
+ * How long one {@link lookupAddresses} call may take. `dns.lookup` has no
+ * timeout of its own (it is a blocking `getaddrinfo` on the libuv thread
+ * pool), so a resolver that hangs would hold a rule create — or a whole
+ * `rules push` — open indefinitely. A lookup that overruns is `timeout`:
+ * unverifiable, and the caller's policy decides what that means (#780).
+ */
+export const OUTBOUND_LOOKUP_TIMEOUT_MS = 3_000;
+
+/** Thrown by a {@link withLookupTimeout}-wrapped lookup that overran its budget. */
+export class OutboundLookupTimeoutError extends Error {
+  constructor(
+    public readonly hostname: string,
+    public readonly timeoutMs: number,
+  ) {
+    super(`lookup of ${hostname} timed out after ${timeoutMs} ms`);
+    this.name = 'OutboundLookupTimeoutError';
+  }
+}
+
+/**
+ * Bound a {@link HostLookup} to `timeoutMs`. The underlying lookup is not
+ * cancelled (Node offers no way to), only abandoned; the timer is unref'd so
+ * it never keeps the process alive.
+ */
+export function withLookupTimeout(
+  lookup: HostLookup,
+  timeoutMs: number = OUTBOUND_LOOKUP_TIMEOUT_MS,
+): HostLookup {
+  return (hostname) =>
+    new Promise<ResolvedAddress[]>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new OutboundLookupTimeoutError(hostname, timeoutMs)),
+        timeoutMs,
+      );
+      timer.unref?.();
+      lookup(hostname).then(
+        (addresses) => {
+          clearTimeout(timer);
+          resolve(addresses);
+        },
+        (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      );
+    });
+}
+
 export type OutboundHostVerdict =
   | { ok: true; addresses: ResolvedAddress[] }
   | {
       ok: false;
-      reason: 'unresolved' | 'non-public';
+      /** `timeout` — the lookup overran {@link OUTBOUND_LOOKUP_TIMEOUT_MS}; the host could not be verified either way. */
+      reason: 'unresolved' | 'non-public' | 'timeout';
       addresses: ResolvedAddress[];
       detail: string;
     };
@@ -82,17 +136,21 @@ export function isExplicitlyInternalHost(hostname: string): boolean {
   );
 }
 
-/** `dns.lookup` with every address, in resolver order; the default {@link HostLookup}. */
-export const lookupAddresses: HostLookup = async (hostname) => {
+/**
+ * `dns.lookup` with every address, in resolver order, bounded to
+ * {@link OUTBOUND_LOOKUP_TIMEOUT_MS}; the default {@link HostLookup}.
+ */
+export const lookupAddresses: HostLookup = withLookupTimeout(async (hostname) => {
   const found = await dnsLookup(hostname, { all: true, verbatim: true });
   return found.map((a) => ({ address: a.address, family: a.family as 4 | 6 }));
-};
+});
 
 /**
  * Resolve `hostname` and judge every address it has. An IP literal (with or
  * without IPv6 brackets) is judged as itself. A name that does not resolve,
- * or resolves to nothing, is `unresolved`: it cannot be vetted, and the
- * caller decides whether that is fatal.
+ * or resolves to nothing, is `unresolved`; one whose lookup overran the
+ * budget is `timeout`. Neither can be vetted, and the caller decides whether
+ * that is fatal.
  */
 export async function vetOutboundHost(
   hostname: string,
@@ -106,6 +164,14 @@ export async function vetOutboundHost(
     try {
       addresses = await lookup(host);
     } catch (error) {
+      if (error instanceof OutboundLookupTimeoutError) {
+        return {
+          ok: false,
+          reason: 'timeout',
+          addresses: [],
+          detail: `${host} could not be verified (${error.message})`,
+        };
+      }
       return {
         ok: false,
         reason: 'unresolved',
@@ -149,9 +215,23 @@ export async function guardOutboundHost(
   hostname: string,
   opts: GuardOutboundHostOptions,
 ): Promise<OutboundHostVerdict> {
-  const mode = opts.mode ?? outboundUrlGuardMode();
   const verdict = await vetOutboundHost(hostname, opts.lookup);
+  return enforceOutboundVerdict(verdict, opts);
+}
+
+/**
+ * The `OUTBOUND_URL_GUARD` policy applied to an already-computed verdict —
+ * the second half of {@link guardOutboundHost}, for callers that resolve in
+ * bulk ({@link vetOutboundHosts}) and judge afterwards. A passing verdict is
+ * returned silently; a failing one is logged and returned under `warn`, or
+ * thrown as a `BadRequestException` naming the env var under `reject`.
+ */
+export function enforceOutboundVerdict(
+  verdict: OutboundHostVerdict,
+  opts: Omit<GuardOutboundHostOptions, 'lookup'>,
+): OutboundHostVerdict {
   if (verdict.ok) return verdict;
+  const mode = opts.mode ?? outboundUrlGuardMode();
   if (mode === 'reject') {
     throw new BadRequestException(
       `${opts.subject}: ${verdict.detail}; refused by ${OUTBOUND_URL_GUARD_ENV}=reject`,
@@ -161,6 +241,52 @@ export async function guardOutboundHost(
     `${opts.subject}: ${verdict.detail}; allowed because ${OUTBOUND_URL_GUARD_ENV}=${mode}`,
   );
   return verdict;
+}
+
+/** How many names {@link vetOutboundHosts} resolves at once. */
+export const OUTBOUND_LOOKUP_CONCURRENCY = 4;
+
+export interface VetOutboundHostsOptions {
+  lookup?: HostLookup;
+  /** Defaults to {@link OUTBOUND_LOOKUP_CONCURRENCY}. */
+  concurrency?: number;
+}
+
+/**
+ * {@link vetOutboundHost} over many names at once — a rule set can carry
+ * dozens of targets, most sharing a few hosts. Each distinct hostname is
+ * resolved exactly once (keyed as given, after the same bracket/trailing-dot
+ * normalisation the single vet applies) and at most `concurrency` lookups are
+ * in flight at a time. The result maps every *input* hostname to its verdict.
+ */
+export async function vetOutboundHosts(
+  hostnames: Iterable<string>,
+  opts: VetOutboundHostsOptions = {},
+): Promise<Map<string, OutboundHostVerdict>> {
+  const normalise = (h: string) =>
+    h
+      .replace(/^\[|\]$/g, '')
+      .replace(/\.$/, '')
+      .toLowerCase();
+  const inputs = [...hostnames];
+  const byKey = new Map<string, Promise<OutboundHostVerdict>>();
+  const unique = [...new Set(inputs.map(normalise))];
+  const concurrency = Math.max(1, opts.concurrency ?? OUTBOUND_LOOKUP_CONCURRENCY);
+
+  let next = 0;
+  const worker = async () => {
+    while (next < unique.length) {
+      const key = unique[next++];
+      const verdict = vetOutboundHost(key, opts.lookup);
+      byKey.set(key, verdict);
+      await verdict;
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(concurrency, unique.length) }, worker));
+
+  const out = new Map<string, OutboundHostVerdict>();
+  for (const input of inputs) out.set(input, await byKey.get(normalise(input))!);
+  return out;
 }
 
 /**

--- a/apps/backend/src/proxy-rules/proxy-rule-sets-target-guard-http.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets-target-guard-http.spec.ts
@@ -1,0 +1,201 @@
+import 'reflect-metadata';
+import { ExecutionContext, INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { ProxyRuleSetsController } from './proxy-rule-sets.controller';
+import { ProxyRuleSetsService } from './proxy-rule-sets.service';
+import { ProxyRulesService } from './proxy-rules.service';
+import { ApiKeyGuard } from '../auth/api-key.guard';
+import { guardRuleTargets } from './target-url.guard';
+
+jest.mock('node:dns/promises', () => ({ lookup: jest.fn() }));
+const mockDnsLookup = dnsLookup as unknown as jest.Mock;
+
+/**
+ * What the outbound target guard (#780) can and cannot see on the two
+ * rules-as-code HTTP doors, through the SAME global ValidationPipe as
+ * main.ts. The sync and import DTOs already enforce the protocol rule
+ * (`IsValidSyncTargetUrl` / `IsValidTargetUrlOrPath`: HTTPS, or HTTP only to
+ * an explicitly internal host) as an unconditional 400 — so for a plain-http
+ * public target the service, and with it `OUTBOUND_URL_GUARD`, is never
+ * reached. The DTOs do NOT enforce the named-internal-host / IP-literal rules
+ * or the resolve check; those targets pass the pipe and the guard judges
+ * them by mode.
+ *
+ * The service is a stub that runs the real `guardRuleTargets` over the DTO
+ * the pipe delivered — the DB-backed composition is proxy-rule-sets.service.spec.ts's
+ * job; this spec pins what the pipe lets through.
+ */
+describe('rules-as-code HTTP doors × OUTBOUND_URL_GUARD (#780)', () => {
+  const PROJECT = '11111111-1111-4111-8111-111111111111';
+  const envBefore = process.env.OUTBOUND_URL_GUARD;
+  let app: INestApplication;
+
+  const syncRuleSet = jest.fn(async (_projectId: string, dto: { rules?: unknown[] }) => ({
+    ruleSetId: 'set-1',
+    created: [],
+    updated: [],
+    deleted: [],
+    unchanged: [],
+    pruneCandidates: [],
+    preserved: [],
+    merged: [],
+    conflicts: [],
+    schemaResolutions: [],
+    missingSecrets: [],
+    warnings: await guardRuleTargets((dto.rules ?? []) as never),
+    dryRun: false,
+    setCreated: true,
+  }));
+  const importRuleSet = jest.fn(async (_projectId: string, dto: { rules?: unknown[] }) => ({
+    id: 'set-1',
+    warnings: await guardRuleTargets((dto.rules ?? []) as never),
+  }));
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ProxyRuleSetsController],
+      providers: [
+        { provide: ProxyRuleSetsService, useValue: { syncRuleSet, importRuleSet } },
+        { provide: ProxyRulesService, useValue: {} },
+      ],
+    })
+      .overrideGuard(ApiKeyGuard)
+      .useValue({
+        canActivate: (ctx: ExecutionContext) => {
+          ctx.switchToHttp().getRequest().user = {
+            id: 'user-1',
+            role: 'admin',
+            apiKeyProjectId: null,
+          };
+          return true;
+        },
+      })
+      .compile();
+    app = moduleRef.createNestApplication();
+    // Exactly main.ts's pipe.
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDnsLookup.mockResolvedValue([{ address: '104.18.1.1', family: 4 }]);
+  });
+  afterEach(() => {
+    if (envBefore === undefined) delete process.env.OUTBOUND_URL_GUARD;
+    else process.env.OUTBOUND_URL_GUARD = envBefore;
+  });
+
+  const syncBody = (targetUrl: string) => ({
+    ruleSet: { name: 'api-backend' },
+    rules: [{ pathPattern: '/api/*', targetUrl }],
+  });
+  const importBody = (targetUrl: string) => ({
+    ruleSet: { name: 'Imported Set' },
+    rules: [{ pathPattern: '/api/*', targetUrl }],
+  });
+  const putSync = (targetUrl: string) =>
+    request(app.getHttpServer())
+      .put(`/api/proxy-rule-sets/project/${PROJECT}/sync`)
+      .send(syncBody(targetUrl));
+  const postImport = (targetUrl: string) =>
+    request(app.getHttpServer())
+      .post(`/api/proxy-rule-sets/project/${PROJECT}/import`)
+      .send(importBody(targetUrl));
+
+  describe('the protocol rule is the DTO’s, unconditional, before the service', () => {
+    it.each(['warn', 'reject'])(
+      'PUT …/sync with http://public.example is a 400 from the pipe in mode %s; the service never runs',
+      async (mode) => {
+        process.env.OUTBOUND_URL_GUARD = mode;
+        const res = await putSync('http://public.example');
+        expect(res.status).toBe(400);
+        expect(JSON.stringify(res.body.message)).toContain(
+          'targetUrl must be HTTPS, or HTTP for internal services',
+        );
+        expect(syncRuleSet).not.toHaveBeenCalled();
+        expect(mockDnsLookup).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each(['warn', 'reject'])(
+      'POST …/import with http://public.example is a 400 from the pipe in mode %s; the service never runs',
+      async (mode) => {
+        process.env.OUTBOUND_URL_GUARD = mode;
+        const res = await postImport('http://public.example');
+        expect(res.status).toBe(400);
+        expect(JSON.stringify(res.body.message)).toContain(
+          'targetUrl must be HTTPS, or HTTP for internal services',
+        );
+        expect(importRuleSet).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe('the named-internal-host / IP-literal rules pass the pipe and follow the mode', () => {
+    it('sync, warn: https://10.0.0.1 reaches the service and comes back as a warning', async () => {
+      delete process.env.OUTBOUND_URL_GUARD;
+      const res = await putSync('https://10.0.0.1');
+      expect(res.status).toBe(200);
+      expect(syncRuleSet).toHaveBeenCalledTimes(1);
+      expect(res.body.warnings).toEqual([
+        'Rule "/api/*": target https://10.0.0.1 — Target URL cannot point to internal IP ranges; allowed because OUTBOUND_URL_GUARD=warn',
+      ]);
+    });
+
+    it('sync, reject: https://10.0.0.1 reaches the service and is the guard’s 400', async () => {
+      process.env.OUTBOUND_URL_GUARD = 'reject';
+      const res = await putSync('https://10.0.0.1');
+      expect(res.status).toBe(400);
+      expect(syncRuleSet).toHaveBeenCalledTimes(1);
+      expect(res.body.message).toBe(
+        'Proxy rule targets refused by OUTBOUND_URL_GUARD=reject: Rule "/api/*": target https://10.0.0.1 — Target URL cannot point to internal IP ranges',
+      );
+    });
+
+    it('import, warn / reject: https://169.254.169.254 reaches the service and follows the mode', async () => {
+      delete process.env.OUTBOUND_URL_GUARD;
+      const warn = await postImport('https://169.254.169.254');
+      expect(warn.status).toBe(201);
+      expect(warn.body.warnings).toEqual([
+        'Rule "/api/*": target https://169.254.169.254 — Target URL cannot point to internal services; allowed because OUTBOUND_URL_GUARD=warn',
+      ]);
+
+      process.env.OUTBOUND_URL_GUARD = 'reject';
+      const reject = await postImport('https://169.254.169.254');
+      expect(reject.status).toBe(400);
+      expect(reject.body.message).toContain('refused by OUTBOUND_URL_GUARD=reject');
+      expect(importRuleSet).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('the resolve check passes the pipe and follows the mode', () => {
+    it('sync: a public name resolving to a private address is a warning under warn and a 400 under reject', async () => {
+      mockDnsLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+
+      delete process.env.OUTBOUND_URL_GUARD;
+      const warn = await putSync('https://intranet.example');
+      expect(warn.status).toBe(200);
+      expect(warn.body.warnings).toEqual([
+        'Rule "/api/*": target https://intranet.example — intranet.example resolves to a non-public address (10.0.0.5); allowed because OUTBOUND_URL_GUARD=warn',
+      ]);
+
+      process.env.OUTBOUND_URL_GUARD = 'reject';
+      const reject = await putSync('https://intranet.example');
+      expect(reject.status).toBe(400);
+      expect(reject.body.message).toContain('intranet.example resolves to a non-public address');
+      expect(mockDnsLookup).toHaveBeenCalledWith(
+        'intranet.example',
+        expect.objectContaining({ all: true }),
+      );
+    });
+  });
+});

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Logger, NotFoundException } from '@nestjs/common';
+import { lookup as dnsLookup } from 'node:dns/promises';
 import { ProxyRuleSetsService } from './proxy-rule-sets.service';
 import { ProxyRulesService } from './proxy-rules.service';
 import { PermissionsService } from '../permissions/permissions.service';
@@ -17,6 +18,11 @@ import {
   type RuleSetExport,
 } from './export-format.util';
 import type { ProxyRuleSetRevision } from '../db/schema/proxy-rule-set-revisions.schema';
+
+// The outbound target guard resolves external rule targets on sync / import /
+// copy (#780); no real DNS in tests. Defaults to a public answer in beforeEach.
+jest.mock('node:dns/promises', () => ({ lookup: jest.fn() }));
+const mockDnsLookup = dnsLookup as unknown as jest.Mock;
 
 // Mock the db client - using factory function for hoisting
 jest.mock('../db/client', () => {
@@ -184,6 +190,7 @@ describe('ProxyRuleSetsService', () => {
     mockDb.__reset();
     jest.clearAllMocks();
     mockPermissionsService.requireProjectAccess.mockResolvedValue(undefined);
+    mockDnsLookup.mockResolvedValue([{ address: '104.18.1.1', family: 4 }]);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -1036,6 +1043,56 @@ describe('ProxyRuleSetsService', () => {
       expect(insertedRule.headerConfig).toEqual(encryptedHeaderConfig);
       expect(insertedRule.headerConfig).not.toEqual(decryptedHeaderConfig);
     });
+
+    describe('outbound target guard (#780)', () => {
+      const envBefore = process.env.OUTBOUND_URL_GUARD;
+      let warnSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+        mockDnsLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+      });
+      afterEach(() => {
+        warnSpy.mockRestore();
+        // The reject case throws before arrangeCopy's second queued once-answer
+        // (the read-back) is consumed; clearAllMocks does not drain once-queues.
+        mockProxyRulesService.getRulesByRuleSetId.mockReset();
+        if (envBefore === undefined) delete process.env.OUTBOUND_URL_GUARD;
+        else process.env.OUTBOUND_URL_GUARD = envBefore;
+      });
+
+      it('warn (default): copies the set and logs one line per flagged rule, naming the copy', async () => {
+        delete process.env.OUTBOUND_URL_GUARD;
+        const { copiedRule } = arrangeCopy(
+          createMockRule({ method: 'GET', targetUrl: 'https://intranet.example' }),
+        );
+
+        const result = await service.copy('rule-set-1', 'user-1', 'admin', 'project-1');
+
+        expect(result.id).toBe('copy-set-id');
+        expect(result.rules).toEqual([copiedRule]);
+        expect(mockDb.insert).toHaveBeenCalledTimes(2); // set + rule
+        const lines = warnSpy.mock.calls.map((c) => String(c[0]));
+        expect(lines).toEqual([
+          'Rule set "api-backend (Copy)" (copy-set-id): Rule "GET /api/*": target https://intranet.example — intranet.example resolves to a non-public address (10.0.0.5); allowed because OUTBOUND_URL_GUARD=warn',
+        ]);
+      });
+
+      it('reject: a 400 listing the rule, and nothing is written', async () => {
+        process.env.OUTBOUND_URL_GUARD = 'reject';
+        arrangeCopy(createMockRule({ targetUrl: 'https://intranet.example' }));
+
+        const attempt = service.copy('rule-set-1', 'user-1', 'admin', 'project-1');
+
+        await expect(attempt).rejects.toThrow(BadRequestException);
+        await expect(attempt).rejects.toThrow(
+          /OUTBOUND_URL_GUARD=reject: Rule "\/api\/\*": target https:\/\/intranet\.example .*10\.0\.0\.5/,
+        );
+        expect(mockDb.insert).not.toHaveBeenCalled();
+        expect(mockProxyRuleSetRevisionsService.capture).not.toHaveBeenCalled();
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('importRuleSet', () => {
@@ -1073,6 +1130,72 @@ describe('ProxyRuleSetsService', () => {
         rules: insertedRules,
         trigger: 'import',
         userId: 'user-1',
+      });
+    });
+
+    describe('outbound target guard (#780)', () => {
+      const envBefore = process.env.OUTBOUND_URL_GUARD;
+      let warnSpy: jest.SpyInstance;
+
+      const importWith = (rules: Record<string, unknown>[], schemas?: unknown[]) =>
+        service.importRuleSet(
+          'project-1',
+          {
+            ruleSet: { name: 'Imported Set' },
+            rules,
+            ...(schemas ? { schemas } : {}),
+          } as unknown as Parameters<typeof service.importRuleSet>[1],
+          'user-1',
+          'admin',
+          'project-1',
+        );
+
+      beforeEach(() => {
+        warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+        mockDnsLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+      });
+      afterEach(() => {
+        warnSpy.mockRestore();
+        if (envBefore === undefined) delete process.env.OUTBOUND_URL_GUARD;
+        else process.env.OUTBOUND_URL_GUARD = envBefore;
+      });
+
+      it('warn (default): imports the set and logs one line per flagged rule with the new set id', async () => {
+        delete process.env.OUTBOUND_URL_GUARD;
+        const newRuleSet = createMockRuleSet({ id: 'imported-set-id', name: 'Imported Set' });
+        mockDb.__setResults([[{ id: 'project-1' }], [], [newRuleSet]]);
+        mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([]);
+
+        const result = await importWith([
+          { pathPattern: '/api/*', method: 'POST', targetUrl: 'https://intranet.example' },
+          { pathPattern: '/ok/*', targetUrl: 'http://localhost:3000' },
+        ]);
+
+        expect(result.id).toBe('imported-set-id');
+        expect(mockDb.insert).toHaveBeenCalledTimes(3); // set + 2 rules
+        const lines = warnSpy.mock.calls.map((c) => String(c[0]));
+        expect(lines).toEqual([
+          'Rule set "Imported Set" (imported-set-id): Rule "POST /api/*": target https://intranet.example — intranet.example resolves to a non-public address (10.0.0.5); allowed because OUTBOUND_URL_GUARD=warn',
+        ]);
+      });
+
+      it('reject: a 400 listing the rule, before the bundled schemas or any row are created', async () => {
+        process.env.OUTBOUND_URL_GUARD = 'reject';
+        mockDb.__setResults([[{ id: 'project-1' }]]);
+        mockPipelineSchemasService.getByProjectId.mockResolvedValue([]);
+
+        const attempt = importWith(
+          [{ pathPattern: '/api/*', targetUrl: 'https://intranet.example' }],
+          [{ sourceId: 'src-1', name: 'contacts', action: 'create', fields: [] }],
+        );
+
+        await expect(attempt).rejects.toThrow(BadRequestException);
+        await expect(attempt).rejects.toThrow(
+          /OUTBOUND_URL_GUARD=reject: Rule "\/api\/\*": target https:\/\/intranet\.example .*10\.0\.0\.5/,
+        );
+        expect(mockPipelineSchemasService.create).not.toHaveBeenCalled();
+        expect(mockDb.insert).not.toHaveBeenCalled();
+        expect(mockProxyRuleSetRevisionsService.capture).not.toHaveBeenCalled();
       });
     });
   });
@@ -2195,6 +2318,198 @@ describe('ProxyRuleSetsService', () => {
 
         expect(result.warnings).toEqual([]);
         expect(mockPipelineSchemasService.getByProjectId).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('outbound target guard (#780)', () => {
+      const envBefore = process.env.OUTBOUND_URL_GUARD;
+      let warnSpy: jest.SpyInstance;
+
+      /** project lookup, findByName (no set), insert … returning */
+      const freshSet = () =>
+        mockDb.__setResults([
+          [mockProject],
+          [],
+          [createMockRuleSet({ id: 'new-set-id', name: 'api-backend' })],
+        ]);
+      const rule = (pathPattern: string, targetUrl: string, method?: string) => ({
+        pathPattern,
+        targetUrl,
+        ...(method ? { method } : {}),
+      });
+      const PRIVATE = [{ address: '10.0.0.5', family: 4 }];
+
+      beforeEach(() => {
+        warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+        mockProxyRulesService.getRulesByRuleSetId.mockResolvedValue([]);
+      });
+      afterEach(() => {
+        jest.useRealTimers();
+        warnSpy.mockRestore();
+        if (envBefore === undefined) delete process.env.OUTBOUND_URL_GUARD;
+        else process.env.OUTBOUND_URL_GUARD = envBefore;
+      });
+
+      it.each([
+        'http://localhost:3000',
+        'http://127.0.0.1:3000',
+        'http://backend.default.svc:8080',
+        'http://backend.default.svc.cluster.local:8080',
+      ])(
+        'an explicitly internal target %s is neither resolved nor warned about, in reject mode too',
+        async (targetUrl) => {
+          process.env.OUTBOUND_URL_GUARD = 'reject';
+          freshSet();
+
+          const result = await sync(syncDto({ rules: [rule('/api/*', targetUrl)] }));
+
+          expect(result.warnings).toEqual([]);
+          expect(mockDnsLookup).not.toHaveBeenCalled();
+          expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+        },
+      );
+
+      it('warn (default): a public name resolving to a private address is one warning line and the rows are still written', async () => {
+        delete process.env.OUTBOUND_URL_GUARD;
+        mockDnsLookup.mockResolvedValue(PRIVATE);
+        freshSet();
+
+        const result = await sync(
+          syncDto({ rules: [rule('/api/*', 'https://public.example', 'GET')] }),
+        );
+
+        expect(result.warnings).toEqual([
+          'Rule "GET /api/*": target https://public.example — public.example resolves to a non-public address (10.0.0.5); allowed because OUTBOUND_URL_GUARD=warn',
+        ]);
+        expect(result.created).toEqual([{ pathPattern: '/api/*', method: 'GET' }]);
+        expect(result.setCreated).toBe(true);
+        expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+        expect(mockDb.insert).toHaveBeenCalledTimes(2); // set + rule
+      });
+
+      it('reject: a 400 listing the rule, and nothing is written — no set, no schema, no rule', async () => {
+        process.env.OUTBOUND_URL_GUARD = 'reject';
+        mockDnsLookup.mockResolvedValue(PRIVATE);
+        mockDb.__setResults([[mockProject]]);
+
+        const attempt = sync(
+          syncDto({
+            rules: [rule('/api/*', 'https://public.example', 'GET')],
+            schemas: [{ id: 'src-1', name: 'contacts', kind: 'data', fields: [] }],
+          }),
+        );
+
+        await expect(attempt).rejects.toThrow(BadRequestException);
+        await expect(attempt).rejects.toThrow(
+          'Proxy rule targets refused by OUTBOUND_URL_GUARD=reject: Rule "GET /api/*": target https://public.example — public.example resolves to a non-public address (10.0.0.5)',
+        );
+        expect(mockPipelineSchemasService.create).not.toHaveBeenCalled();
+        expect(mockDb.transaction).not.toHaveBeenCalled();
+        expect(mockDb.insert).not.toHaveBeenCalled();
+        expect(mockProxyRuleSetRevisionsService.capture).not.toHaveBeenCalled();
+      });
+
+      it('warn: a plain-http target to a public host (the protocol rule) is a warning on this door, not a 400', async () => {
+        delete process.env.OUTBOUND_URL_GUARD;
+        freshSet();
+
+        const result = await sync(syncDto({ rules: [rule('/api/*', 'http://public.example')] }));
+
+        expect(result.warnings).toEqual([
+          'Rule "/api/*": target http://public.example — Target URL must use HTTPS, or HTTP for internal services (*.svc, localhost); allowed because OUTBOUND_URL_GUARD=warn',
+        ]);
+        expect(mockDnsLookup).not.toHaveBeenCalled();
+        expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+      });
+
+      it('reject: the protocol rule fails the push like any other target failure', async () => {
+        process.env.OUTBOUND_URL_GUARD = 'reject';
+        mockDb.__setResults([[mockProject]]);
+
+        await expect(
+          sync(syncDto({ rules: [rule('/api/*', 'http://public.example')] })),
+        ).rejects.toThrow(/OUTBOUND_URL_GUARD=reject: Rule "\/api\/\*".*must use HTTPS/);
+        expect(mockDb.transaction).not.toHaveBeenCalled();
+      });
+
+      it('dryRun reports the same warnings without writing', async () => {
+        delete process.env.OUTBOUND_URL_GUARD;
+        mockDnsLookup.mockResolvedValue(PRIVATE);
+        mockDb.__setResults([[mockProject], []]);
+
+        const result = await sync(
+          syncDto({
+            rules: [rule('/api/*', 'https://public.example', 'GET')],
+            options: { dryRun: true },
+          }),
+        );
+
+        expect(result.dryRun).toBe(true);
+        expect(result.warnings).toEqual([
+          expect.stringMatching(
+            /^Rule "GET \/api\/\*": target https:\/\/public\.example — .*10\.0\.0\.5/,
+          ),
+        ]);
+        expect(mockDb.transaction).not.toHaveBeenCalled();
+        expect(mockDb.insert).not.toHaveBeenCalled();
+      });
+
+      it('reject: several bad rules are one error listing all of them, with one lookup per distinct host', async () => {
+        process.env.OUTBOUND_URL_GUARD = 'reject';
+        mockDnsLookup.mockImplementation(async (host: string) =>
+          host === 'one.example'
+            ? PRIVATE
+            : host === 'two.example'
+              ? [{ address: '192.168.1.1', family: 4 }]
+              : [{ address: '104.18.1.1', family: 4 }],
+        );
+        mockDb.__setResults([[mockProject]]);
+
+        const attempt = sync(
+          syncDto({
+            rules: [
+              rule('/a/*', 'https://one.example', 'GET'),
+              rule('/b/*', 'https://two.example', 'POST'),
+              rule('/c/*', 'https://one.example/other'),
+              rule('/ok/*', 'https://api.example.com'),
+            ],
+          }),
+        );
+
+        await expect(attempt).rejects.toThrow(
+          'Proxy rule targets refused by OUTBOUND_URL_GUARD=reject: ' +
+            'Rule "GET /a/*": target https://one.example — one.example resolves to a non-public address (10.0.0.5); ' +
+            'Rule "POST /b/*": target https://two.example — two.example resolves to a non-public address (192.168.1.1); ' +
+            'Rule "/c/*": target https://one.example/other — one.example resolves to a non-public address (10.0.0.5)',
+        );
+        expect(mockDnsLookup).toHaveBeenCalledTimes(3);
+        expect(mockDb.transaction).not.toHaveBeenCalled();
+      });
+
+      it('a lookup that overruns the 3 s budget is "could not be verified": a warning under warn, a 400 under reject', async () => {
+        jest.useFakeTimers();
+        mockDnsLookup.mockReturnValue(new Promise(() => undefined));
+
+        delete process.env.OUTBOUND_URL_GUARD;
+        freshSet();
+        const warnAttempt = sync(syncDto({ rules: [rule('/api/*', 'https://slow.example')] }));
+        await jest.advanceTimersByTimeAsync(3000);
+        const result = await warnAttempt;
+        expect(result.warnings).toEqual([
+          'Rule "/api/*": target https://slow.example — slow.example could not be verified (lookup of slow.example timed out after 3000 ms); allowed because OUTBOUND_URL_GUARD=warn',
+        ]);
+        expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+
+        process.env.OUTBOUND_URL_GUARD = 'reject';
+        mockDb.transaction.mockClear();
+        mockDb.__setResults([[mockProject]]);
+        const rejectAttempt = sync(syncDto({ rules: [rule('/api/*', 'https://slow.example')] }));
+        rejectAttempt.catch(() => undefined);
+        await jest.advanceTimersByTimeAsync(3000);
+        await expect(rejectAttempt).rejects.toThrow(
+          /OUTBOUND_URL_GUARD=reject: Rule "\/api\/\*".*could not be verified.*timed out after 3000 ms/,
+        );
+        expect(mockDb.transaction).not.toHaveBeenCalled();
       });
     });
 

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.spec.ts
@@ -2409,7 +2409,38 @@ describe('ProxyRuleSetsService', () => {
         expect(mockProxyRuleSetRevisionsService.capture).not.toHaveBeenCalled();
       });
 
-      it('warn: a plain-http target to a public host (the protocol rule) is a warning on this door, not a 400', async () => {
+      // The static rules the sync DTO does NOT enforce — a target that names a
+      // private / link-local address outright — reach this method over HTTP
+      // (proxy-rule-sets-target-guard-http.spec.ts proves the pipe lets them
+      // through) and follow the mode here, unlike the UI door's hard 400.
+      it('warn: a target naming a link-local address outright (a static rule the DTO does not enforce) is a warning on this door, not a 400', async () => {
+        delete process.env.OUTBOUND_URL_GUARD;
+        freshSet();
+
+        const result = await sync(syncDto({ rules: [rule('/api/*', 'https://169.254.169.254')] }));
+
+        expect(result.warnings).toEqual([
+          'Rule "/api/*": target https://169.254.169.254 — Target URL cannot point to internal services; allowed because OUTBOUND_URL_GUARD=warn',
+        ]);
+        expect(mockDnsLookup).not.toHaveBeenCalled();
+        expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+      });
+
+      it('reject: such a static failure fails the push like any other target failure', async () => {
+        process.env.OUTBOUND_URL_GUARD = 'reject';
+        mockDb.__setResults([[mockProject]]);
+
+        await expect(
+          sync(syncDto({ rules: [rule('/api/*', 'https://10.0.0.1')] })),
+        ).rejects.toThrow(/OUTBOUND_URL_GUARD=reject: Rule "\/api\/\*".*internal IP ranges/);
+        expect(mockDb.transaction).not.toHaveBeenCalled();
+      });
+
+      // Over HTTP the sync DTO (`IsValidSyncTargetUrl`) 400s a plain-http
+      // public target before this method runs. It still reaches here from
+      // rollbackToRevision, which builds its DTO by cast and replays a stored
+      // snapshot — there the protocol rule follows the mode.
+      it('warn: a plain-http public target arriving without the DTO pipe (rollback replay) is a warning, not a 400', async () => {
         delete process.env.OUTBOUND_URL_GUARD;
         freshSet();
 
@@ -2420,16 +2451,6 @@ describe('ProxyRuleSetsService', () => {
         ]);
         expect(mockDnsLookup).not.toHaveBeenCalled();
         expect(mockDb.transaction).toHaveBeenCalledTimes(1);
-      });
-
-      it('reject: the protocol rule fails the push like any other target failure', async () => {
-        process.env.OUTBOUND_URL_GUARD = 'reject';
-        mockDb.__setResults([[mockProject]]);
-
-        await expect(
-          sync(syncDto({ rules: [rule('/api/*', 'http://public.example')] })),
-        ).rejects.toThrow(/OUTBOUND_URL_GUARD=reject: Rule "\/api\/\*".*must use HTTPS/);
-        expect(mockDb.transaction).not.toHaveBeenCalled();
       });
 
       it('dryRun reports the same warnings without writing', async () => {

--- a/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
+++ b/apps/backend/src/proxy-rules/proxy-rule-sets.service.ts
@@ -28,6 +28,7 @@ import {
   ProxyRuleSetRevisionsService,
   computeRevisionHash,
 } from './proxy-rule-set-revisions.service';
+import { guardRuleTargets, logRuleTargetWarnings } from './target-url.guard';
 import {
   CreateProxyRuleSetDto,
   UpdateProxyRuleSetDto,
@@ -516,6 +517,11 @@ export class ProxyRuleSetsService {
     // Get the rules directly from database (with full schema type)
     const existingRules = await this.proxyRulesService.getRulesByRuleSetId(id);
 
+    // Outbound target guard (#780): the source rules were written through
+    // whichever door accepted them; the copy is a fresh write and is vetted
+    // like one, before the set row is inserted.
+    const targetWarnings = await guardRuleTargets(existingRules);
+
     // Generate a unique name for the copy
     let copyName = `${existingRuleSet.name} (Copy)`;
     let copyIndex = 1;
@@ -564,6 +570,8 @@ export class ProxyRuleSetsService {
     this.logger.log(
       `Copied proxy rule set ${id} to ${newRuleSet.id} with ${existingRules.length} rules`,
     );
+    // The copy response has no warnings channel; the log is the surface.
+    logRuleTargetWarnings(this.logger, `Rule set "${copyName}" (${newRuleSet.id})`, targetWarnings);
 
     // Read the rules back decrypted: both the revision snapshot and the API
     // response carry plaintext header values, not the stored ciphertext.
@@ -590,9 +598,12 @@ export class ProxyRuleSetsService {
    * Mirrors copy() — rules are inserted directly rather than going through
    * ProxyRulesService.create(), so there is no per-rule nginx regeneration
    * (a freshly imported set is not yet attached to any alias) and no
-   * email-service / SSRF re-validation beyond the DTO validation already
-   * performed at the controller boundary. Header `add` values are encrypted
-   * before storage so they round-trip correctly with the rest of the system.
+   * email-service re-validation beyond the DTO validation already performed
+   * at the controller boundary. External targets ARE vetted under
+   * `OUTBOUND_URL_GUARD` (#780, `guardRuleTargets`) before anything is
+   * written: `warn` logs one line per failing rule, `reject` is a 400 with
+   * no rows. Header `add` values are encrypted before storage so they
+   * round-trip correctly with the rest of the system.
    */
   async importRuleSet(
     projectId: string,
@@ -615,6 +626,10 @@ export class ProxyRuleSetsService {
       'contributor',
       apiKeyProjectId,
     );
+
+    // Outbound target guard (#780) — before schema creation below, which is
+    // the first write: under `reject` nothing at all must land.
+    const targetWarnings = await guardRuleTargets(dto.rules ?? []);
 
     // Resolve bundled schema dependencies to target-project schema ids.
     // Pipeline rules carry the original (source) schema ids; we build a map and
@@ -717,6 +732,8 @@ export class ProxyRuleSetsService {
     this.logger.log(
       `Imported proxy rule set "${name}" (${rules.length} rules) for project ${projectId}`,
     );
+    // The import response has no warnings channel; the log is the surface.
+    logRuleTargetWarnings(this.logger, `Rule set "${name}" (${newRuleSet.id})`, targetWarnings);
 
     const insertedRules = await this.proxyRulesService.getRulesByRuleSetId(newRuleSet.id);
 
@@ -1250,6 +1267,15 @@ export class ProxyRuleSetsService {
       throw new BadRequestException((error as Error).message);
     }
 
+    // Outbound target guard (#780): every incoming rule with an external
+    // target, under OUTBOUND_URL_GUARD — one warning line per failing rule
+    // (default `warn`; the CLI prints `warnings[]`), or one 400 listing them
+    // all under `reject`. Runs HERE, before schema resolution, for the same
+    // reason as the duplicate check above: `reject` must write nothing, and
+    // schema creation happens outside the rule transaction. `dryRun` reports
+    // the same result.
+    const targetWarnings = await guardRuleTargets(dtoRules);
+
     const { idMap, resolutions, warnings } = await this.resolveSchemasByName(
       projectId,
       dto.schemas?.map((schema) => ({
@@ -1288,6 +1314,7 @@ export class ProxyRuleSetsService {
         apiKeyProjectId,
       )),
     );
+    warnings.push(...targetWarnings);
 
     const existing = await this.findByName(projectId, name);
     const setCreated = !existing;

--- a/apps/backend/src/proxy-rules/proxy-rules.service.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.service.spec.ts
@@ -397,6 +397,23 @@ describe('ProxyRulesService', () => {
       await expect(createWith('https://169.254.169.254')).rejects.toThrow(BadRequestException);
       expect(mockDnsLookup).not.toHaveBeenCalled();
     });
+
+    // #780 moved the check into target-url.guard.ts and let rules push /
+    // import / copy gate the protocol rule by mode. This door must not follow:
+    // a plain-http target to a non-internal host has always been a hard 400.
+    it.each(['warn', 'reject'])(
+      'UI create with http://public.example is a 400 regardless of mode (%s)',
+      async (mode) => {
+        process.env.OUTBOUND_URL_GUARD = mode;
+        successfulCreate();
+
+        await expect(createWith('http://public.example')).rejects.toThrow(
+          'Target URL must use HTTPS, or HTTP for internal services (*.svc, localhost)',
+        );
+        expect(mockDnsLookup).not.toHaveBeenCalled();
+        expect(warnSpy).not.toHaveBeenCalled();
+      },
+    );
   });
 
   describe('create', () => {

--- a/apps/backend/src/proxy-rules/proxy-rules.service.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.service.ts
@@ -26,32 +26,8 @@ import type {
 import type { ProxyRuleSet } from '../db/schema/proxy-rule-sets.schema';
 import type { RevisionTrigger } from '../db/schema/proxy-rule-set-revisions.schema';
 import { methodSignature } from './method-match';
-import {
-  guardOutboundHost,
-  isExplicitlyInternalHost,
-  outboundUrlGuardMode,
-} from '../common/outbound-url.guard';
-
-// SSRF protection - blocked hostnames
-const BLOCKED_HOSTS = [
-  'localhost',
-  '127.0.0.1',
-  '::1',
-  '0.0.0.0',
-  'metadata.google.internal',
-  '169.254.169.254', // AWS/GCP metadata
-];
-
-// SSRF protection - blocked IP patterns (private networks)
-const BLOCKED_IP_PATTERNS = [
-  /^10\./, // 10.0.0.0/8
-  /^172\.(1[6-9]|2[0-9]|3[01])\./, // 172.16.0.0/12
-  /^192\.168\./, // 192.168.0.0/16
-  /^127\./, // 127.0.0.0/8
-  /^169\.254\./, // Link-local
-  /^fc00:/i, // IPv6 unique local
-  /^fe80:/i, // IPv6 link-local
-];
+import { enforceOutboundVerdict, outboundUrlGuardMode } from '../common/outbound-url.guard';
+import { vetTargetUrl } from './target-url.guard';
 
 @Injectable()
 export class ProxyRulesService {
@@ -863,66 +839,30 @@ export class ProxyRulesService {
   }
 
   /**
-   * Validate target URL for SSRF protection.
+   * Validate target URL for SSRF protection — the UI/REST create/update door.
    *
-   * The protocol and hostname-string rules reject outright. A hostname that
-   * is not explicitly internal (localhost / 127.0.0.1 / *.svc /
+   * The check itself lives in `target-url.guard.ts` (`vetTargetUrl`, shared
+   * with rules push / import / copy since #780); this method applies the
+   * door's historical policy to its verdict. The protocol and hostname-string
+   * rules (`check: 'static'`) reject outright, as they always have. A
+   * hostname that is not explicitly internal (localhost / 127.0.0.1 / *.svc /
    * *.svc.cluster.local, which are allowed as same-pod and in-cluster
-   * targets) is then resolved and every address must be public — under
+   * targets) is resolved and every address must be public — under
    * `OUTBOUND_URL_GUARD` (#770): `warn` (default) logs and allows, so a
    * self-hoster's split-horizon target keeps working after upgrade; `reject`
    * refuses with a 400. `subject` names the rule for the log line / error.
    */
   private async validateTargetUrl(url: string, subject: string): Promise<void> {
-    let parsed: URL;
-    try {
-      parsed = new URL(url);
-    } catch {
-      throw new BadRequestException('Invalid URL format');
+    const verdict = await vetTargetUrl(url);
+    if (verdict.ok) return;
+    if (verdict.check === 'static') {
+      throw new BadRequestException(verdict.reason);
     }
-
-    const hostname = parsed.hostname.toLowerCase();
-
-    // Allow HTTPS for any URL, or HTTP for internal services (K8s services, localhost)
-    if (parsed.protocol === 'https:') {
-      // HTTPS is allowed
-    } else if (parsed.protocol === 'http:') {
-      // HTTP allowed for internal K8s services (*.svc or *.svc.cluster.local)
-      // and localhost/127.0.0.1 for same-pod sidecar communication
-      const isInternalK8s = hostname.endsWith('.svc') || hostname.endsWith('.svc.cluster.local');
-      const isLocalhost = hostname === 'localhost' || hostname === '127.0.0.1';
-      if (!isInternalK8s && !isLocalhost) {
-        throw new BadRequestException(
-          'Target URL must use HTTPS, or HTTP for internal services (*.svc, localhost)',
-        );
-      }
-    } else {
-      throw new BadRequestException('Target URL must use HTTP or HTTPS protocol');
-    }
-
-    // Check blocked hosts (skip localhost since we allow it for same-pod sidecar)
-    const isLocalhostTarget = hostname === 'localhost' || hostname === '127.0.0.1';
-    if (!isLocalhostTarget && BLOCKED_HOSTS.includes(hostname)) {
-      throw new BadRequestException('Target URL cannot point to internal services');
-    }
-
-    // Check IP patterns (skip localhost since we allow it for same-pod sidecar)
-    if (!isLocalhostTarget) {
-      for (const pattern of BLOCKED_IP_PATTERNS) {
-        if (pattern.test(hostname)) {
-          throw new BadRequestException('Target URL cannot point to internal IP ranges');
-        }
-      }
-    }
-
-    // Resolve anything not declared internal and vet every address it has. A
-    // public name that resolves to 169.254.169.254 passes every check above.
-    if (!isExplicitlyInternalHost(hostname)) {
-      await guardOutboundHost(hostname, {
-        subject: `${subject}: target ${url}`,
-        logger: this.logger,
-      });
-    }
+    // A public name that resolves to 169.254.169.254 passes every static rule.
+    enforceOutboundVerdict(verdict.verdict, {
+      subject: `${subject}: target ${url}`,
+      logger: this.logger,
+    });
   }
 
   /**

--- a/apps/backend/src/proxy-rules/target-url.guard.spec.ts
+++ b/apps/backend/src/proxy-rules/target-url.guard.spec.ts
@@ -1,0 +1,205 @@
+import { BadRequestException } from '@nestjs/common';
+import type { HostLookup } from '../common/outbound-url.guard';
+import {
+  guardRuleTargets,
+  isExternalTargetRule,
+  ruleTargetLabel,
+  vetTargetUrl,
+  vetTargetUrls,
+} from './target-url.guard';
+
+const PUBLIC = [{ address: '104.18.1.1', family: 4 as const }];
+const PRIVATE = [{ address: '10.0.0.5', family: 4 as const }];
+
+/** A lookup answering by hostname; anything unlisted is public. */
+const lookupFor = (answers: Record<string, typeof PUBLIC>): jest.MockedFunction<HostLookup> =>
+  jest.fn(async (host: string) => answers[host] ?? PUBLIC);
+
+describe('target-url.guard (#780)', () => {
+  describe('vetTargetUrl — the static rules (a) never resolve', () => {
+    it.each([
+      ['not a url', 'Invalid URL format'],
+      ['ftp://files.example.com/x', 'Target URL must use HTTP or HTTPS protocol'],
+      [
+        'http://public.example',
+        'Target URL must use HTTPS, or HTTP for internal services (*.svc, localhost)',
+      ],
+      ['https://169.254.169.254', 'Target URL cannot point to internal services'],
+      ['https://metadata.google.internal', 'Target URL cannot point to internal services'],
+      ['https://10.0.0.1', 'Target URL cannot point to internal IP ranges'],
+      ['https://192.168.1.1:8443/api', 'Target URL cannot point to internal IP ranges'],
+    ])('%s → %s', async (url, reason) => {
+      const lookup = lookupFor({});
+      await expect(vetTargetUrl(url, lookup)).resolves.toEqual({
+        ok: false,
+        check: 'static',
+        reason,
+      });
+      expect(lookup).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      'http://localhost:3000',
+      'http://127.0.0.1:3000',
+      'http://backend.default.svc:8080',
+      'https://backend.default.svc.cluster.local',
+    ])('an explicitly internal host %s passes without a lookup', async (url) => {
+      const lookup = lookupFor({});
+      await expect(vetTargetUrl(url, lookup)).resolves.toEqual({ ok: true });
+      expect(lookup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('vetTargetUrl — resolve and vet (b)', () => {
+    it('passes a public name resolving to public addresses', async () => {
+      const lookup = lookupFor({});
+      await expect(vetTargetUrl('https://api.example.com/v1', lookup)).resolves.toEqual({
+        ok: true,
+      });
+      expect(lookup).toHaveBeenCalledWith('api.example.com');
+    });
+
+    it('fails with check "resolve" and the guard verdict when any address is non-public', async () => {
+      const lookup = lookupFor({ 'intranet.example': PRIVATE });
+      const verdict = await vetTargetUrl('https://intranet.example', lookup);
+      expect(verdict).toMatchObject({
+        ok: false,
+        check: 'resolve',
+        reason: 'intranet.example resolves to a non-public address (10.0.0.5)',
+        verdict: { ok: false, reason: 'non-public' },
+      });
+    });
+
+    it('judges a public IP literal as itself', async () => {
+      const lookup = lookupFor({});
+      await expect(vetTargetUrl('https://8.8.8.8', lookup)).resolves.toEqual({ ok: true });
+      expect(lookup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('vetTargetUrls — one lookup per hostname across many URLs', () => {
+    it('keys the result by URL and resolves each distinct host once', async () => {
+      const lookup = lookupFor({ 'intranet.example': PRIVATE });
+      const urls = [
+        'https://api.example.com/a',
+        'https://api.example.com/b',
+        'https://intranet.example',
+        'http://public.example',
+        'http://localhost:3000',
+        'https://api.example.com/a',
+      ];
+
+      const out = await vetTargetUrls(urls, { lookup });
+
+      expect(lookup).toHaveBeenCalledTimes(2);
+      expect(out.size).toBe(5);
+      expect(out.get('https://api.example.com/a')).toEqual({ ok: true });
+      expect(out.get('https://api.example.com/b')).toEqual({ ok: true });
+      expect(out.get('https://intranet.example')).toMatchObject({ ok: false, check: 'resolve' });
+      expect(out.get('http://public.example')).toMatchObject({ ok: false, check: 'static' });
+      expect(out.get('http://localhost:3000')).toEqual({ ok: true });
+    });
+  });
+
+  describe('isExternalTargetRule', () => {
+    const base = { pathPattern: '/api/*', targetUrl: 'https://api.example.com' };
+    it.each([
+      ['a plain external_proxy rule', { ...base }, true],
+      ['an explicit external_proxy', { ...base, proxyType: 'external_proxy' }, true],
+      ['an internal rewrite', { ...base, internalRewrite: true }, false],
+      ['a pipeline by proxyType', { ...base, proxyType: 'pipeline' }, false],
+      [
+        'a pipeline inferred from pipelineConfig with the internal default target',
+        { ...base, targetUrl: 'http://internal/pipeline', pipelineConfig: { steps: [] } },
+        false,
+      ],
+      ['an email handler', { ...base, emailHandlerConfig: { to: ['a@b'] } }, false],
+      ['no target', { pathPattern: '/api/*' }, false],
+      ['a null target', { pathPattern: '/api/*', targetUrl: null }, false],
+      ['an empty target', { pathPattern: '/api/*', targetUrl: '' }, false],
+    ])('%s → %s', (_name, rule, expected) => {
+      expect(isExternalTargetRule(rule)).toBe(expected);
+    });
+  });
+
+  describe('ruleTargetLabel', () => {
+    it('names the rule by method(s) and pathPattern, omitting the method for any-method rules', () => {
+      expect(ruleTargetLabel({ pathPattern: '/api/*', method: 'get' })).toBe('Rule "GET /api/*"');
+      expect(ruleTargetLabel({ pathPattern: '/api/*', methods: ['post', 'get'] })).toBe(
+        'Rule "GET,POST /api/*"',
+      );
+      expect(ruleTargetLabel({ pathPattern: '/api/*' })).toBe('Rule "/api/*"');
+    });
+  });
+
+  describe('guardRuleTargets', () => {
+    const rules = [
+      { pathPattern: '/a/*', method: 'GET', targetUrl: 'https://intranet.example' },
+      { pathPattern: '/b/*', method: 'POST', targetUrl: 'https://api.example.com' },
+      { pathPattern: '/c/*', targetUrl: 'http://public.example' },
+      { pathPattern: '/d/*', targetUrl: 'https://intranet.example/other' },
+      { pathPattern: '/pipe/*', targetUrl: 'http://internal/pipeline', proxyType: 'pipeline' },
+      { pathPattern: '/local/*', targetUrl: 'http://localhost:3000' },
+    ];
+
+    it('warn: one line per failing rule, in input order, in the schema-warning format', async () => {
+      const lookup = lookupFor({ 'intranet.example': PRIVATE });
+
+      const warnings = await guardRuleTargets(rules, { mode: 'warn', lookup });
+
+      expect(warnings).toEqual([
+        'Rule "GET /a/*": target https://intranet.example — intranet.example resolves to a non-public address (10.0.0.5); allowed because OUTBOUND_URL_GUARD=warn',
+        'Rule "/c/*": target http://public.example — Target URL must use HTTPS, or HTTP for internal services (*.svc, localhost); allowed because OUTBOUND_URL_GUARD=warn',
+        'Rule "/d/*": target https://intranet.example/other — intranet.example resolves to a non-public address (10.0.0.5); allowed because OUTBOUND_URL_GUARD=warn',
+      ]);
+      // intranet.example and api.example.com — one lookup each; nothing for the
+      // http:// rule (static), the pipeline or the localhost rule.
+      expect(lookup).toHaveBeenCalledTimes(2);
+    });
+
+    it('reject: one BadRequestException listing every failing rule', async () => {
+      const lookup = lookupFor({ 'intranet.example': PRIVATE });
+
+      const attempt = guardRuleTargets(rules, { mode: 'reject', lookup });
+
+      await expect(attempt).rejects.toThrow(BadRequestException);
+      await expect(attempt).rejects.toThrow(
+        'Proxy rule targets refused by OUTBOUND_URL_GUARD=reject: ' +
+          'Rule "GET /a/*": target https://intranet.example — intranet.example resolves to a non-public address (10.0.0.5); ' +
+          'Rule "/c/*": target http://public.example — Target URL must use HTTPS, or HTTP for internal services (*.svc, localhost); ' +
+          'Rule "/d/*": target https://intranet.example/other — intranet.example resolves to a non-public address (10.0.0.5)',
+      );
+    });
+
+    it('is silent when every external target passes, in reject mode too', async () => {
+      const lookup = lookupFor({});
+      await expect(
+        guardRuleTargets(rules.slice(1, 2), { mode: 'reject', lookup }),
+      ).resolves.toEqual([]);
+    });
+
+    it('skips a batch with no external-target rules without a lookup', async () => {
+      const lookup = lookupFor({});
+      await expect(guardRuleTargets(rules.slice(4), { mode: 'reject', lookup })).resolves.toEqual(
+        [],
+      );
+      expect(lookup).not.toHaveBeenCalled();
+    });
+
+    it('takes the mode from OUTBOUND_URL_GUARD when none is given', async () => {
+      const before = process.env.OUTBOUND_URL_GUARD;
+      const lookup = lookupFor({ 'intranet.example': PRIVATE });
+      try {
+        process.env.OUTBOUND_URL_GUARD = 'reject';
+        await expect(guardRuleTargets(rules.slice(0, 1), { lookup })).rejects.toThrow(
+          BadRequestException,
+        );
+        delete process.env.OUTBOUND_URL_GUARD;
+        await expect(guardRuleTargets(rules.slice(0, 1), { lookup })).resolves.toHaveLength(1);
+      } finally {
+        if (before === undefined) delete process.env.OUTBOUND_URL_GUARD;
+        else process.env.OUTBOUND_URL_GUARD = before;
+      }
+    });
+  });
+});

--- a/apps/backend/src/proxy-rules/target-url.guard.ts
+++ b/apps/backend/src/proxy-rules/target-url.guard.ts
@@ -1,0 +1,251 @@
+import { BadRequestException, Logger } from '@nestjs/common';
+import {
+  isExplicitlyInternalHost,
+  outboundUrlGuardMode,
+  vetOutboundHost,
+  vetOutboundHosts,
+  OUTBOUND_URL_GUARD_ENV,
+  type HostLookup,
+  type OutboundHostVerdict,
+  type OutboundUrlGuardMode,
+} from '../common/outbound-url.guard';
+import { methodSignature } from './method-match';
+
+/**
+ * The proxy-rule target check, as a verdict rather than a throw, so every
+ * writer of `proxy_rules` rows can run it and apply its own policy (#780):
+ *
+ *   (a) the static rules — a parseable http(s) URL; plain http only to an
+ *       explicitly internal host; no hostname that *names* the loopback,
+ *       metadata or private space outright — `check: 'static'`;
+ *   (b) resolve the host and require every address to be public
+ *       (`common/outbound-url.guard.ts`, #770) — `check: 'resolve'`.
+ *
+ * `ProxyRulesService.validateTargetUrl` (the UI/REST create/update door)
+ * keeps its historical behaviour on top of this: (a) is always a 400, (b) is
+ * warn/reject per `OUTBOUND_URL_GUARD`. The sync, import and copy doors
+ * ({@link guardRuleTargets}) had neither check until #780, so there *both*
+ * are gated by the mode — under the default `warn` an existing rule set with
+ * a plain-http target still pushes, with a warning line.
+ */
+
+// SSRF protection - hostnames that name internal services outright
+const BLOCKED_HOSTS = [
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '0.0.0.0',
+  'metadata.google.internal',
+  '169.254.169.254', // AWS/GCP metadata
+];
+
+// SSRF protection - IP-literal patterns for private networks
+const BLOCKED_IP_PATTERNS = [
+  /^10\./, // 10.0.0.0/8
+  /^172\.(1[6-9]|2[0-9]|3[01])\./, // 172.16.0.0/12
+  /^192\.168\./, // 192.168.0.0/16
+  /^127\./, // 127.0.0.0/8
+  /^169\.254\./, // Link-local
+  /^fc00:/i, // IPv6 unique local
+  /^fe80:/i, // IPv6 link-local
+];
+
+export type TargetUrlVerdict =
+  | { ok: true }
+  | { ok: false; check: 'static'; reason: string }
+  | { ok: false; check: 'resolve'; reason: string; verdict: OutboundHostVerdict };
+
+type StaticCheck =
+  | { ok: true; hostname: string; resolve: boolean }
+  | { ok: false; check: 'static'; reason: string };
+
+/**
+ * Rule (a). The messages are the ones the UI has always shown, verbatim.
+ * On success says whether the host still needs resolving — explicitly
+ * internal hosts (localhost / 127.0.0.1 / *.svc / *.svc.cluster.local) are
+ * allowed by declaration and never looked up.
+ */
+function checkTargetUrlStatic(url: string): StaticCheck {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, check: 'static', reason: 'Invalid URL format' };
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  // Allow HTTPS for any URL, or HTTP for internal services (K8s services, localhost)
+  if (parsed.protocol === 'https:') {
+    // HTTPS is allowed
+  } else if (parsed.protocol === 'http:') {
+    // HTTP allowed for internal K8s services (*.svc or *.svc.cluster.local)
+    // and localhost/127.0.0.1 for same-pod sidecar communication
+    const isInternalK8s = hostname.endsWith('.svc') || hostname.endsWith('.svc.cluster.local');
+    const isLocalhost = hostname === 'localhost' || hostname === '127.0.0.1';
+    if (!isInternalK8s && !isLocalhost) {
+      return {
+        ok: false,
+        check: 'static',
+        reason: 'Target URL must use HTTPS, or HTTP for internal services (*.svc, localhost)',
+      };
+    }
+  } else {
+    return { ok: false, check: 'static', reason: 'Target URL must use HTTP or HTTPS protocol' };
+  }
+
+  // Check blocked hosts (skip localhost since we allow it for same-pod sidecar)
+  const isLocalhostTarget = hostname === 'localhost' || hostname === '127.0.0.1';
+  if (!isLocalhostTarget && BLOCKED_HOSTS.includes(hostname)) {
+    return { ok: false, check: 'static', reason: 'Target URL cannot point to internal services' };
+  }
+
+  // Check IP patterns (skip localhost since we allow it for same-pod sidecar)
+  if (!isLocalhostTarget) {
+    for (const pattern of BLOCKED_IP_PATTERNS) {
+      if (pattern.test(hostname)) {
+        return {
+          ok: false,
+          check: 'static',
+          reason: 'Target URL cannot point to internal IP ranges',
+        };
+      }
+    }
+  }
+
+  return { ok: true, hostname, resolve: !isExplicitlyInternalHost(hostname) };
+}
+
+function resolveVerdict(verdict: OutboundHostVerdict): TargetUrlVerdict {
+  return verdict.ok
+    ? { ok: true }
+    : { ok: false, check: 'resolve', reason: verdict.detail, verdict };
+}
+
+/** Rules (a) then (b) for one target URL. Never throws. */
+export async function vetTargetUrl(url: string, lookup?: HostLookup): Promise<TargetUrlVerdict> {
+  const stat = checkTargetUrlStatic(url);
+  if (!stat.ok) return stat;
+  if (!stat.resolve) return { ok: true };
+  return resolveVerdict(await vetOutboundHost(stat.hostname, lookup));
+}
+
+export interface VetTargetUrlsOptions {
+  lookup?: HostLookup;
+  concurrency?: number;
+}
+
+/**
+ * {@link vetTargetUrl} over many URLs: the static rule runs per URL, then the
+ * hosts that need resolving go through `vetOutboundHosts` — one lookup per
+ * distinct hostname, a bounded number in flight. Keyed by the input URL.
+ */
+export async function vetTargetUrls(
+  urls: Iterable<string>,
+  opts: VetTargetUrlsOptions = {},
+): Promise<Map<string, TargetUrlVerdict>> {
+  const out = new Map<string, TargetUrlVerdict>();
+  const toResolve = new Map<string, string>(); // url → hostname
+  for (const url of new Set(urls)) {
+    const stat = checkTargetUrlStatic(url);
+    if (!stat.ok) out.set(url, stat);
+    else if (!stat.resolve) out.set(url, { ok: true });
+    else toResolve.set(url, stat.hostname);
+  }
+  if (toResolve.size > 0) {
+    const hosts = await vetOutboundHosts(toResolve.values(), opts);
+    for (const [url, hostname] of toResolve) out.set(url, resolveVerdict(hosts.get(hostname)!));
+  }
+  return out;
+}
+
+/** The fields of an incoming/stored rule the target guard needs. */
+export interface TargetGuardRule {
+  pathPattern: string;
+  method?: string | null;
+  methods?: string[] | null;
+  targetUrl?: string | null;
+  proxyType?: string | null;
+  internalRewrite?: boolean | null;
+  pipelineConfig?: unknown;
+  emailHandlerConfig?: unknown;
+}
+
+/**
+ * Does this rule make an outbound request to `targetUrl`? Mirrors the
+ * `skipUrlValidation` test in `ProxyRulesService.create`, with the proxyType
+ * inferred from config shape when absent exactly as the sync plan does
+ * (import stores a raw `proxyType ?? 'external_proxy'`, so the stored type
+ * alone cannot be trusted for a pipeline rule carrying the internal
+ * `http://internal/pipeline` default).
+ */
+export function isExternalTargetRule(rule: TargetGuardRule): boolean {
+  if (!rule.targetUrl || rule.internalRewrite) return false;
+  const proxyType =
+    rule.proxyType ||
+    (rule.pipelineConfig ? 'pipeline' : rule.emailHandlerConfig ? 'email_form_handler' : null) ||
+    'external_proxy';
+  return proxyType === 'external_proxy';
+}
+
+/** `Rule "GET /api/*"` — or `Rule "/api/*"` for an any-method rule. */
+export function ruleTargetLabel(rule: TargetGuardRule): string {
+  const sig = methodSignature({ method: rule.method ?? null, methods: rule.methods ?? null });
+  return `Rule "${sig ? `${sig} ` : ''}${rule.pathPattern}"`;
+}
+
+export interface GuardRuleTargetsOptions {
+  /** Defaults to the process-wide `OUTBOUND_URL_GUARD` setting. */
+  mode?: OutboundUrlGuardMode;
+  lookup?: HostLookup;
+  concurrency?: number;
+}
+
+/**
+ * Vet every external-target rule in a batch under `OUTBOUND_URL_GUARD` and
+ * return the failures as warning lines —
+ * `Rule "<method> <pathPattern>": target <url> — <reason>; allowed because
+ * OUTBOUND_URL_GUARD=warn` — one per failing rule, in input order, mirroring
+ * the sync response's schema warnings. Under `reject` a single
+ * `BadRequestException` lists every failing rule instead (mirroring
+ * `strictSchemas`), so the caller writes nothing. Internal rewrites,
+ * pipeline and email-handler rules, and rules without a target are skipped.
+ *
+ * The caller decides where the warnings go: the sync response already has a
+ * `warnings[]` channel the CLI prints; import and copy log them.
+ */
+export async function guardRuleTargets(
+  rules: Iterable<TargetGuardRule>,
+  opts: GuardRuleTargetsOptions = {},
+): Promise<string[]> {
+  const external = [...rules].filter(isExternalTargetRule);
+  if (external.length === 0) return [];
+  const mode = opts.mode ?? outboundUrlGuardMode();
+  const verdicts = await vetTargetUrls(
+    external.map((rule) => rule.targetUrl as string),
+    { lookup: opts.lookup, concurrency: opts.concurrency },
+  );
+  const failures: string[] = [];
+  for (const rule of external) {
+    const verdict = verdicts.get(rule.targetUrl as string)!;
+    if (!verdict.ok) {
+      failures.push(`${ruleTargetLabel(rule)}: target ${rule.targetUrl} — ${verdict.reason}`);
+    }
+  }
+  if (failures.length === 0) return [];
+  if (mode === 'reject') {
+    throw new BadRequestException(
+      `Proxy rule targets refused by ${OUTBOUND_URL_GUARD_ENV}=reject: ${failures.join('; ')}`,
+    );
+  }
+  return failures.map((line) => `${line}; allowed because ${OUTBOUND_URL_GUARD_ENV}=${mode}`);
+}
+
+/** Log each {@link guardRuleTargets} warning at warn level, prefixed with the rule set. */
+export function logRuleTargetWarnings(
+  logger: Pick<Logger, 'warn'>,
+  ruleSetLabel: string,
+  warnings: string[],
+): void {
+  for (const warning of warnings) logger.warn(`${ruleSetLabel}: ${warning}`);
+}


### PR DESCRIPTION
Closes #780

## Summary
`OUTBOUND_URL_GUARD` (added in #772) only guarded proxy-rule targets on the UI/REST create and update door. Rule sets that arrive as code — `bffless rules push`, the `deploy-proxy-rules` action, the app installer's sync step, the Import dialog and Copy — inserted rows without running the guard's resolve-and-vet check, and without the static "names a private address outright" rules either (their request DTOs enforce only the HTTPS-or-internal-host protocol rule). An operator who set `OUTBOUND_URL_GUARD=reject` was therefore only protected at one of four doors. After this PR every door runs the same check: under the default `warn` a push still succeeds and prints one `warning:` line per target that could not be verified as public; under `reject` the push fails with a single 400 that lists every offending rule and writes nothing.

## Behaviour changes
Additive; nothing existing stops working under the default mode.

- `PUT /api/proxy-rule-sets/project/:id/sync` (rules push), `warn` mode (default): before → targets were never resolved and IP-literal / named-internal-host targets (`https://10.0.0.1`, `https://169.254.169.254`, `https://metadata.google.internal`) were accepted silently; after → the response's existing `warnings[]` gains one entry per rule whose target names a private address outright, resolves to a non-public address, does not resolve, or whose lookup times out (`Rule "GET /api/*": target https://x — x resolves to a non-public address (10.0.0.5); allowed because OUTBOUND_URL_GUARD=warn`). The CLI already prints `warnings[]`, so `bffless rules push` shows these with no CLI change. Rows are written exactly as before. `dryRun` reports the same warnings.
- Same endpoint, `reject` mode: before → push succeeds regardless; after → one `400` listing every failing rule (`Proxy rule targets refused by OUTBOUND_URL_GUARD=reject: Rule "…": …; Rule "…": …`), thrown before schema creation and before the write transaction, so nothing is written. This also applies to `rollbackToRevision`, which replays through sync, and to the app installer / preflight sync steps (the `.env.example` text already documented `reject` as "a failed preflight step on app install").
- `POST …/import` and `POST …/:id/copy`: same semantics. Their responses have no warnings channel, so `warn` logs one line per flagged rule at warn level with the new set's name and id; `reject` is a 400 with no rows (import: before its bundled schemas are created).
- **Plain-http targets to a non-internal host: unchanged on every HTTP door.** The sync and import DTOs (`IsValidSyncTargetUrl` / `IsValidTargetUrlOrPath`) already 400 them unconditionally before the service runs, and UI create/update keeps its hard 400 too — this PR does not relax any of that. The protocol rule is newly mode-gated only where no DTO sits in front of the write: `copy` (reads stored rows) and `rollbackToRevision` (replays a snapshot). Pinned by the new supertest spec behind main.ts's `ValidationPipe`.
- UI/REST rule create/update: **unchanged**. Every error message string is byte-identical; the resolve check is still warn/reject per mode.
- Shared guard: every hostname lookup now has a 3 s budget (previously unbounded — a hung resolver held a rule create or a whole push open indefinitely). A timed-out lookup is a new `timeout` verdict reason meaning "could not verify": a warning under `warn`, a refusal under `reject`, the same treatment as an unresolvable name. This applies to the existing callers too (rule create/update, app bundle preflight); the CIMD path already had its own fetch timeout and is unaffected in behaviour.

## Why
Maintainer decision on #766 (option 2): the sync, import and copy paths should honour `OUTBOUND_URL_GUARD` exactly like create/update, rather than leaving rules-as-code as an unguarded side door. Where a static rule had never run on a path (the IP-literal / named-host rules on sync and import; all static rules on copy and rollback), it is gated by the mode rather than made a hard failure, so existing rule sets keep working under the default. Lookups are deduped by hostname and bounded in concurrency because a rule set can carry dozens of rules sharing a few hosts, and the #772 reviewer noted `dns.lookup` had no timeout.

## What changed
- **backend / shared guard** — `apps/backend/src/common/outbound-url.guard.ts`: `OUTBOUND_LOOKUP_TIMEOUT_MS` (3 s), `withLookupTimeout` (applied to the default `lookupAddresses`), `OutboundLookupTimeoutError`, `timeout` verdict reason, `enforceOutboundVerdict` (policy split out of `guardOutboundHost`, which is unchanged in behaviour), `vetOutboundHosts` (dedupe + `OUTBOUND_LOOKUP_CONCURRENCY` = 4).
- **backend / proxy-rules** — new `apps/backend/src/proxy-rules/target-url.guard.ts`: the static rules moved verbatim out of `ProxyRulesService` into non-throwing `vetTargetUrl` / bulk `vetTargetUrls`, plus `isExternalTargetRule` (skips internal rewrites, pipeline and email-handler rules, inferring `proxyType` from config shape as the sync plan does), `ruleTargetLabel`, and `guardRuleTargets` (the warn/reject policy for a batch). `proxy-rules.service.ts` `validateTargetUrl` is now a thin policy layer over `vetTargetUrl`. `proxy-rule-sets.service.ts` calls `guardRuleTargets` in `syncRuleSet` (before schema resolution), `importRuleSet` (before schema creation) and `copy` (before the set insert).
- **config docs** — `.env.example`: the `OUTBOUND_URL_GUARD` comment now describes push/import/copy behaviour, the lookup budget, and which static rules are unconditional DTO 400s versus mode-gated. No new variable, no changed default or accepted values.
- **tests** — `outbound-url.guard.spec.ts` (timeout path, bulk vet dedupe/concurrency/isolation, policy split), new `target-url.guard.spec.ts` (static rules, inference, label format, batch warn/reject), `proxy-rule-sets.service.spec.ts` (DNS mocked; sync: internal targets silent in reject mode, private-resolving public name → warning + rows / 400 + no rows, IP-literal / named-host static rules follow the mode, plain-http via the pipe-less rollback path, dryRun, multiple bad rules → one error with one lookup per host, hung lookup → unverifiable under both modes; import and copy: one warn and one reject case each), new `proxy-rule-sets-target-guard-http.spec.ts` (supertest behind main.ts's exact `ValidationPipe`: plain-http is the DTO's 400 in both modes and the service never runs; `https://10.0.0.1` / `https://169.254.169.254` and a private-resolving name pass the pipe and follow the mode on both sync and import), `proxy-rules.service.spec.ts` (UI create with `http://public.example` is a 400 in both modes).
- **CLI** — no change; verified `packages/cli/src/commands/push.ts` `formatSyncReport` already prints every `warnings[]` entry.

## Compatibility
- **Pipeline / proxy-rule semantics are live customer data**: no stored rule behaves differently at request time — there is no request-time re-resolution, and the check runs only when a rule set is written. Under the default `warn`, every rule set that pushes, imports or copies today still does after upgrade; the only visible change is new warning lines. `reject` is opt-in and now means the same thing at every door.
- **Env vars are an upgrade contract**: no new or renamed variable; `OUTBOUND_URL_GUARD` keeps its name, default (`warn`) and accepted values. A self-hoster who does not touch `.env` boots and behaves as before, plus warnings.
- **The published CLI is a pinned client**: the sync response shape is unchanged (`warnings: string[]` already existed); an old CLI prints the new lines, a new CLI needs nothing.
- Not touched: DB schema/migrations, routes, DTOs, the GitHub Actions upload contract, nginx generation, storage layout.

## Verification
- `pnpm --filter backend exec tsc --noEmit` — exit 0
- `pnpm --filter frontend exec tsc --noEmit` — exit 0
- `pnpm --filter backend format:check` — "All matched files use Prettier code style!"
- `jest src/common/outbound-url.guard.spec.ts src/proxy-rules/target-url.guard.spec.ts src/proxy-rules/proxy-rules.service.spec.ts src/proxy-rules/proxy-rule-sets.service.spec.ts` — 4 suites, **270 passed**, 0 failed
- `jest src/proxy-rules/proxy-rule-sets-target-guard-http.spec.ts src/proxy-rules/proxy-rule-sets.service.spec.ts` (after the review fix) — 2 suites, **118 passed**, 0 failed
- `jest src/proxy-rules src/oauth src/app-catalog src/common` (every caller of the shared guard) — 40 suites, **1143 passed**, 0 failed
- `pnpm --filter bffless test` (packages/cli) — 29 files, **424 passed** (unchanged package)

## Out of scope / follow-ups
- **docs-public**: the `OUTBOUND_URL_GUARD` section (bffless/docs#77) and the rules-as-code page need a sentence saying pushes warn by default and fail under `reject`, each flagged rule being one warning line / one entry in the 400.
- Under `warn`, an unchanged rule with a flagged target is warned about on every push (the issue asks for every incoming rule to be vetted). If that proves noisy, restricting the warning to rules in `created`/`updated` would be a small follow-up; `reject` should keep checking every rule.
- Worst-case push latency with many distinct slow hosts is bounded at `ceil(distinct hosts / 4) × 3 s` (review finding 2) — accepted for an authenticated, project-scoped endpoint; raising `OUTBOUND_LOOKUP_CONCURRENCY` is a one-constant change if it ever matters.
- Request-time re-resolution of targets remains out of scope, as in #770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NK2eaY4ZwmXRxifq22ELsV
