### PR TITLE
fix(auth): unify isApiRequest so SPA fetches are never answered with a 302

### DIFF
--- a/apps/backend/src/auth/auth.middleware.spec.ts
+++ b/apps/backend/src/auth/auth.middleware.spec.ts
@@ -1,0 +1,157 @@
+import { Request, Response } from 'express';
+
+jest.mock('supertokens-node/framework/express', () => ({
+  middleware: jest.fn(),
+}));
+jest.mock('jsonwebtoken', () => ({
+  decode: jest.fn(),
+}));
+
+import { middleware as supertokensMiddleware } from 'supertokens-node/framework/express';
+import * as jwt from 'jsonwebtoken';
+import { AuthMiddleware } from './auth.middleware';
+import { VisibilityService } from '../domains/visibility.service';
+
+const mockSupertokensMiddleware = supertokensMiddleware as jest.Mock;
+const mockDecode = jwt.decode as jest.Mock;
+
+describe('AuthMiddleware', () => {
+  let authMiddleware: AuthMiddleware;
+  let visibilityService: { resolveAccessControlByDomain: jest.Mock };
+  let supertokensHandler: jest.Mock;
+  let next: jest.Mock;
+
+  const request = (
+    originalUrl: string,
+    headers: Record<string, string> = {},
+    cookies: Record<string, string> = { sAccessToken: 'jwt' },
+  ): Request =>
+    ({
+      originalUrl,
+      path: originalUrl.split('?')[0],
+      method: 'GET',
+      headers,
+      cookies,
+    }) as unknown as Request;
+
+  const response = (): Response =>
+    ({
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    }) as unknown as Response;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    supertokensHandler = jest.fn((_req, _res, nextFn) => nextFn());
+    mockSupertokensMiddleware.mockReturnValue(supertokensHandler);
+    next = jest.fn();
+    visibilityService = { resolveAccessControlByDomain: jest.fn().mockResolvedValue(null) };
+    authMiddleware = new AuthMiddleware(visibilityService as unknown as VisibilityService);
+    // Expired one hour ago
+    mockDecode.mockReturnValue({ exp: Math.floor(Date.now() / 1000) - 3600 });
+  });
+
+  describe('expired access token: browser vs. API classification (issue #778)', () => {
+    it('answers a request with no Accept header at all with 401 "try refresh token"', async () => {
+      // The admin SPA's fetchBaseQuery and an app's own fetch() send no Accept
+      // header. They must get the SuperTokens-format 401 that
+      // baseQueryWithReauth keys on to refresh and retry.
+      const req = request('/api/projects');
+      const res = response();
+
+      await authMiddleware.use(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: 'try refresh token' });
+      expect(supertokensHandler).not.toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+      expect((req as any).tokenExpired).toBe(true);
+    });
+
+    it("answers the SPA's fetch() profile (Accept: */*, Sec-Fetch-Mode: cors) with 401", async () => {
+      const req = request('/api/projects', { accept: '*/*', 'sec-fetch-mode': 'cors' });
+      const res = response();
+
+      await authMiddleware.use(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: 'try refresh token' });
+    });
+
+    it('lets a browser navigation (Accept: text/html) continue so the guards can redirect', async () => {
+      const req = request('/dashboard', {
+        accept: 'text/html,application/xhtml+xml,*/*;q=0.8',
+        'sec-fetch-mode': 'navigate',
+      });
+      const res = response();
+
+      await authMiddleware.use(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalled();
+      expect(supertokensHandler).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledTimes(1);
+      expect((req as any).tokenExpired).toBe(true);
+    });
+
+    it('lets an API request through to the controller on a /public/* route of a public domain', async () => {
+      visibilityService.resolveAccessControlByDomain.mockResolvedValue({ isPublic: true });
+      const req = request('/public/owner/repo/alias/production/app.js', {
+        host: 'site.example.com',
+      });
+      const res = response();
+
+      await authMiddleware.use(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('answers an API request on a /public/* route of a private domain with 401', async () => {
+      visibilityService.resolveAccessControlByDomain.mockResolvedValue({ isPublic: false });
+      const req = request('/public/owner/repo/alias/production/data.json', {
+        host: 'site.example.com',
+      });
+      const res = response();
+
+      await authMiddleware.use(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: 'try refresh token' });
+    });
+  });
+
+  describe('pass-through cases', () => {
+    it('skips the expiry check on auth endpoints', async () => {
+      const req = request('/api/auth/session/refresh');
+      const res = response();
+
+      await authMiddleware.use(req, res, next);
+
+      expect(mockDecode).not.toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('continues when the token is still valid', async () => {
+      mockDecode.mockReturnValue({ exp: Math.floor(Date.now() / 1000) + 3600 });
+      const req = request('/api/projects');
+      const res = response();
+
+      await authMiddleware.use(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect((req as any).tokenExpired).toBeUndefined();
+    });
+
+    it('continues when there is no access token cookie at all', async () => {
+      const req = request('/api/projects', {}, {});
+      const res = response();
+
+      await authMiddleware.use(req, res, next);
+
+      expect(mockDecode).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/backend/src/auth/auth.middleware.ts
+++ b/apps/backend/src/auth/auth.middleware.ts
@@ -3,6 +3,7 @@ import { middleware } from 'supertokens-node/framework/express';
 import { Request, Response, NextFunction } from 'express';
 import * as jwt from 'jsonwebtoken';
 import { VisibilityService } from '../domains/visibility.service';
+import { isApiRequest } from '../common/request-kind';
 
 /**
  * Auth middleware that wraps SuperTokens middleware with additional
@@ -63,7 +64,7 @@ export class AuthMiddleware implements NestMiddleware {
           // UNLESS this is a public route on a public domain - then let it through
           // This prevents unnecessary pipeline/controller execution
           // Uses SuperTokens response format for consistency
-          if (this.isApiRequest(req)) {
+          if (isApiRequest(req)) {
             // Check if this is a public route on a public domain
             const isPublic = await this.isPublicRoute(req);
             if (isPublic) {
@@ -160,43 +161,6 @@ export class AuthMiddleware implements NestMiddleware {
     if (path.startsWith('/_bffless/auth')) {
       return true;
     }
-    return false;
-  }
-
-  /**
-   * Determines if this is an API request (expects JSON response)
-   * vs a browser request (can handle redirects)
-   */
-  private isApiRequest(req: Request): boolean {
-    const acceptHeader = req.headers.accept || '';
-    const contentType = req.headers['content-type'] || '';
-
-    // XHR/fetch requests typically want JSON
-    if (acceptHeader.includes('application/json')) {
-      return true;
-    }
-
-    // Requests sending JSON are likely API calls
-    if (contentType.includes('application/json')) {
-      return true;
-    }
-
-    // X-Requested-With header indicates AJAX
-    if (req.headers['x-requested-with'] === 'XMLHttpRequest') {
-      return true;
-    }
-
-    // API key header indicates programmatic access
-    if (req.headers['x-api-key']) {
-      return true;
-    }
-
-    // Accept header starts with application/* (not text/html) suggests API client
-    if (acceptHeader.startsWith('application/') && !acceptHeader.includes('text/html')) {
-      return true;
-    }
-
-    // Default: treat as browser request
     return false;
   }
 }

--- a/apps/backend/src/auth/email-verification.guard.spec.ts
+++ b/apps/backend/src/auth/email-verification.guard.spec.ts
@@ -1,0 +1,136 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+jest.mock('supertokens-node', () => ({
+  __esModule: true,
+  RecipeUserId: jest.fn().mockImplementation((id: string) => ({ getAsString: () => id })),
+}));
+jest.mock('supertokens-node/recipe/emailverification', () => ({
+  __esModule: true,
+  default: { isEmailVerified: jest.fn() },
+}));
+
+import EmailVerification from 'supertokens-node/recipe/emailverification';
+import { EmailVerificationGuard } from './email-verification.guard';
+import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+
+const mockIsEmailVerified = EmailVerification.isEmailVerified as jest.Mock;
+
+describe('EmailVerificationGuard', () => {
+  let guard: EmailVerificationGuard;
+  let reflector: Reflector;
+  let featureFlags: { isEnabled: jest.Mock };
+  let request: any;
+  let response: any;
+
+  const context = (): ExecutionContext =>
+    ({
+      switchToHttp: () => ({ getRequest: () => request, getResponse: () => response }),
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    reflector = { getAllAndOverride: jest.fn().mockReturnValue(false) } as unknown as Reflector;
+    featureFlags = { isEnabled: jest.fn().mockResolvedValue(true) };
+    guard = new EmailVerificationGuard(reflector, featureFlags as unknown as FeatureFlagsService);
+    request = {
+      headers: {},
+      session: { getUserId: () => 'user-1' },
+      user: { id: 'user-1' },
+      originalUrl: '/api/projects',
+    };
+    response = { redirect: jest.fn() };
+    mockIsEmailVerified.mockResolvedValue(false);
+  });
+
+  describe('skips', () => {
+    it('allows public routes without touching SuperTokens', async () => {
+      (reflector.getAllAndOverride as jest.Mock).mockReturnValueOnce(true);
+      await expect(guard.canActivate(context())).resolves.toBe(true);
+      expect(mockIsEmailVerified).not.toHaveBeenCalled();
+    });
+
+    it('allows requests with no session (other guards own those)', async () => {
+      request.session = undefined;
+      await expect(guard.canActivate(context())).resolves.toBe(true);
+      expect(mockIsEmailVerified).not.toHaveBeenCalled();
+    });
+
+    it('allows API-key authenticated requests', async () => {
+      request.user = { id: 'user-1', apiKeyId: 'key-1' };
+      await expect(guard.canActivate(context())).resolves.toBe(true);
+      expect(mockIsEmailVerified).not.toHaveBeenCalled();
+    });
+
+    it('allows everything when ENABLE_EMAIL_VERIFICATION is off', async () => {
+      featureFlags.isEnabled.mockResolvedValue(false);
+      await expect(guard.canActivate(context())).resolves.toBe(true);
+      expect(mockIsEmailVerified).not.toHaveBeenCalled();
+    });
+
+    it('allows a verified user', async () => {
+      mockIsEmailVerified.mockResolvedValue(true);
+      await expect(guard.canActivate(context())).resolves.toBe(true);
+    });
+
+    it('does not block the user when the verification lookup itself fails', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      mockIsEmailVerified.mockRejectedValue(new Error('core down'));
+      await expect(guard.canActivate(context())).resolves.toBe(true);
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('unverified user: browser vs. API classification (issue #778)', () => {
+    const expectForbiddenJson = async () => {
+      let thrown: unknown;
+      try {
+        await guard.canActivate(context());
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(ForbiddenException);
+      expect((thrown as ForbiddenException).getResponse()).toMatchObject({
+        statusCode: 403,
+        error: 'EMAIL_NOT_VERIFIED',
+      });
+      expect(response.redirect).not.toHaveBeenCalled();
+    };
+
+    it('answers a request with no Accept header at all with 403 EMAIL_NOT_VERIFIED, not a redirect', async () => {
+      // The admin SPA's fetchBaseQuery sets no Accept header. A 302 here would be
+      // followed by fetch() into /verify-email's HTML, and the frontend's 403
+      // EMAIL_NOT_VERIFIED handling (apps/frontend/src/services/api.ts) would
+      // never fire.
+      request.headers = {};
+      await expectForbiddenJson();
+    });
+
+    it("answers the SPA's fetch() profile (Accept: */*, Sec-Fetch-Mode: cors) with 403 EMAIL_NOT_VERIFIED", async () => {
+      request.headers = { accept: '*/*', 'sec-fetch-mode': 'cors' };
+      await expectForbiddenJson();
+    });
+
+    it('answers Accept: application/json with 403 EMAIL_NOT_VERIFIED', async () => {
+      request.headers = { accept: 'application/json' };
+      await expectForbiddenJson();
+    });
+
+    it('redirects a browser navigation (Accept: text/html) to /verify-email', async () => {
+      request.headers = { accept: 'text/html,application/xhtml+xml,*/*;q=0.8' };
+
+      await expect(guard.canActivate(context())).rejects.toThrow(ForbiddenException);
+      expect(response.redirect).toHaveBeenCalledTimes(1);
+      expect(response.redirect).toHaveBeenCalledWith(302, '/verify-email');
+    });
+
+    it('redirects a browser navigation (Sec-Fetch-Mode: navigate) to /verify-email', async () => {
+      request.headers = { accept: '*/*', 'sec-fetch-mode': 'navigate' };
+
+      await expect(guard.canActivate(context())).rejects.toThrow(ForbiddenException);
+      expect(response.redirect).toHaveBeenCalledWith(302, '/verify-email');
+    });
+  });
+});

--- a/apps/backend/src/auth/email-verification.guard.ts
+++ b/apps/backend/src/auth/email-verification.guard.ts
@@ -6,6 +6,7 @@ import { RecipeUserId } from 'supertokens-node';
 import { IS_PUBLIC_KEY } from './session-auth.guard';
 import { SKIP_EMAIL_VERIFICATION_KEY } from './decorators/skip-email-verification.decorator';
 import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
+import { isApiRequest } from '../common/request-kind';
 
 /**
  * Global guard that enforces email verification when the feature flag is enabled.
@@ -74,9 +75,12 @@ export class EmailVerificationGuard implements CanActivate {
         return true;
       }
 
-      // Email not verified - handle based on request type
+      // Email not verified - handle based on request type. Only a real browser
+      // navigation gets the redirect; the admin SPA's fetch() calls (no Accept
+      // header) must see the 403 EMAIL_NOT_VERIFIED body, which is what
+      // apps/frontend/src/services/api.ts routes to /verify-email on (#778).
       const response = context.switchToHttp().getResponse<Response>();
-      if (this.isApiRequest(request)) {
+      if (isApiRequest(request)) {
         throw new ForbiddenException({
           statusCode: 403,
           error: 'EMAIL_NOT_VERIFIED',
@@ -95,18 +99,5 @@ export class EmailVerificationGuard implements CanActivate {
       console.error('[EmailVerificationGuard] Error checking verification status:', error);
       return true;
     }
-  }
-
-  private isApiRequest(request: Request): boolean {
-    const acceptHeader = request.headers.accept || '';
-    const contentType = request.headers['content-type'] || '';
-
-    if (acceptHeader.includes('application/json')) return true;
-    if (contentType.includes('application/json')) return true;
-    if (request.headers['x-requested-with'] === 'XMLHttpRequest') return true;
-    if (request.headers['x-api-key']) return true;
-    if (acceptHeader.startsWith('application/') && !acceptHeader.includes('text/html')) return true;
-
-    return false;
   }
 }

--- a/apps/backend/src/auth/session-auth.guard.ts
+++ b/apps/backend/src/auth/session-auth.guard.ts
@@ -5,6 +5,7 @@ import { Request, Response } from 'express';
 import { eq } from 'drizzle-orm';
 import { db } from '../db/client';
 import { users } from '../db/schema';
+import { isApiRequest } from '../common/request-kind';
 
 export const IS_PUBLIC_KEY = 'isPublic';
 
@@ -112,7 +113,7 @@ export class SessionAuthGuard implements CanActivate {
    */
   private handleAuthFailure(request: Request, response: Response, message: string): never {
     // API requests should get a 401 JSON response, not a redirect
-    if (this.isApiRequest(request)) {
+    if (isApiRequest(request)) {
       throw new UnauthorizedException(message);
     }
 
@@ -131,53 +132,5 @@ export class SessionAuthGuard implements CanActivate {
     // After redirect, throw to prevent further processing
     // This exception will be caught by NestJS but the response is already sent
     throw new UnauthorizedException('Redirected for authentication');
-  }
-
-  /**
-   * Determines if this is an API request (expects a 401 JSON body) vs. a
-   * top-level browser navigation (can act on a redirect).
-   *
-   * Only a real navigation may get the redirect. The admin SPA's own fetch()
-   * calls send no Accept header (browser default `*\/*`) and `Sec-Fetch-Mode:
-   * cors`/`same-origin`; if those were redirected, fetch() would follow the 302
-   * to /login's HTML and the frontend's silent-refresh flow (which keys on a
-   * 401) would never run. So the default is API, and "browser" requires a
-   * positive signal: `Sec-Fetch-Mode: navigate` (set by browsers on navigation,
-   * never by fetch/XHR) or an Accept header that asks for text/html.
-   */
-  private isApiRequest(request: Request): boolean {
-    const acceptHeader = request.headers.accept || '';
-    const contentType = request.headers['content-type'] || '';
-
-    // XHR/fetch requests typically want JSON
-    if (acceptHeader.includes('application/json')) {
-      return true;
-    }
-
-    // Requests sending JSON are likely API calls
-    if (contentType.includes('application/json')) {
-      return true;
-    }
-
-    // X-Requested-With header indicates AJAX
-    if (request.headers['x-requested-with'] === 'XMLHttpRequest') {
-      return true;
-    }
-
-    // API key header indicates programmatic access
-    if (request.headers['x-api-key']) {
-      return true;
-    }
-
-    // Top-level browser navigation: can act on a redirect
-    if (request.headers['sec-fetch-mode'] === 'navigate') {
-      return false;
-    }
-    if (acceptHeader.includes('text/html')) {
-      return false;
-    }
-
-    // Default: API client (fetch()/XHR with Accept: */*, curl, no Accept at all)
-    return true;
   }
 }

--- a/apps/backend/src/common/request-kind.spec.ts
+++ b/apps/backend/src/common/request-kind.spec.ts
@@ -1,0 +1,69 @@
+import { Request } from 'express';
+import { isApiRequest, isBrowserNavigation } from './request-kind';
+
+const requestWith = (headers: Record<string, string>): Request =>
+  ({ headers }) as unknown as Request;
+
+describe('request-kind', () => {
+  describe('isApiRequest / isBrowserNavigation', () => {
+    it('treats a request with no headers at all as an API client', () => {
+      const req = requestWith({});
+      expect(isApiRequest(req)).toBe(true);
+      expect(isBrowserNavigation(req)).toBe(false);
+    });
+
+    it("treats the admin SPA's own fetch() profile (Accept: */*, Sec-Fetch-Mode: cors) as an API client", () => {
+      // apps/frontend/src/services/api.ts sets no Accept header; the browser fills
+      // in */* and marks the fetch as cors/same-origin, never navigate.
+      const req = requestWith({ accept: '*/*', 'sec-fetch-mode': 'cors' });
+      expect(isApiRequest(req)).toBe(true);
+    });
+
+    it('treats Accept: application/json as an API client', () => {
+      expect(isApiRequest(requestWith({ accept: 'application/json' }))).toBe(true);
+    });
+
+    it('treats a JSON request body as an API client', () => {
+      expect(isApiRequest(requestWith({ 'content-type': 'application/json' }))).toBe(true);
+    });
+
+    it('treats X-Requested-With: XMLHttpRequest as an API client', () => {
+      expect(isApiRequest(requestWith({ 'x-requested-with': 'XMLHttpRequest' }))).toBe(true);
+    });
+
+    it('treats an X-API-Key header as an API client', () => {
+      expect(isApiRequest(requestWith({ 'x-api-key': 'bff_abc' }))).toBe(true);
+    });
+
+    it("treats a browser's page-load Accept header (text/html,...) as a browser navigation", () => {
+      const req = requestWith({
+        accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      });
+      expect(isBrowserNavigation(req)).toBe(true);
+      expect(isApiRequest(req)).toBe(false);
+    });
+
+    it('treats Sec-Fetch-Mode: navigate as a browser navigation even with Accept: */*', () => {
+      const req = requestWith({ accept: '*/*', 'sec-fetch-mode': 'navigate' });
+      expect(isBrowserNavigation(req)).toBe(true);
+    });
+
+    it('lets explicit API signals win over navigation hints', () => {
+      expect(
+        isApiRequest(
+          requestWith({
+            accept: 'text/html',
+            'sec-fetch-mode': 'navigate',
+            'x-requested-with': 'XMLHttpRequest',
+          }),
+        ),
+      ).toBe(true);
+      expect(isApiRequest(requestWith({ accept: 'text/html', 'x-api-key': 'bff_abc' }))).toBe(true);
+      expect(isApiRequest(requestWith({ accept: 'text/html, application/json' }))).toBe(true);
+    });
+
+    it('does not mistake other application/* Accept values for a navigation', () => {
+      expect(isApiRequest(requestWith({ accept: 'application/xml' }))).toBe(true);
+    });
+  });
+});

--- a/apps/backend/src/common/request-kind.ts
+++ b/apps/backend/src/common/request-kind.ts
@@ -1,0 +1,66 @@
+import { Request } from 'express';
+
+/**
+ * Classifies a request as a top-level browser navigation (can act on a 302)
+ * or an API client (expects a JSON status, never a redirect).
+ *
+ * This is the one place that decides it. `SessionAuthGuard`,
+ * `EmailVerificationGuard`, `AuthMiddleware` and `ProxyMiddleware` all branch
+ * their failure response on it; they used to carry private copies that drifted
+ * apart (issues #775, #778).
+ *
+ * Only a real navigation may get a redirect. The admin SPA's own fetch() calls
+ * (`apps/frontend/src/services/api.ts`) send no Accept header at all - the
+ * browser fills in `*\/*` - together with `Sec-Fetch-Mode: cors`/`same-origin`.
+ * If those were redirected, fetch() would follow the 302 to the login or
+ * verify-email page's HTML with a 200, and the frontend's real handling (which
+ * keys on a 401 to silently refresh, or a 403 `EMAIL_NOT_VERIFIED` to route to
+ * /verify-email) would never run. So the default is API, and "browser" requires
+ * a positive signal: `Sec-Fetch-Mode: navigate` (set by browsers on navigation,
+ * never by fetch/XHR) or an Accept header that asks for text/html.
+ *
+ * Explicit API signals win over navigation hints.
+ */
+export function isBrowserNavigation(request: Request): boolean {
+  const acceptHeader = request.headers.accept || '';
+  const contentType = request.headers['content-type'] || '';
+
+  // XHR/fetch requests typically want JSON
+  if (acceptHeader.includes('application/json')) {
+    return false;
+  }
+
+  // Requests sending JSON are likely API calls
+  if (contentType.includes('application/json')) {
+    return false;
+  }
+
+  // X-Requested-With header indicates AJAX
+  if (request.headers['x-requested-with'] === 'XMLHttpRequest') {
+    return false;
+  }
+
+  // API key header indicates programmatic access
+  if (request.headers['x-api-key']) {
+    return false;
+  }
+
+  // Top-level browser navigation: can act on a redirect
+  if (request.headers['sec-fetch-mode'] === 'navigate') {
+    return true;
+  }
+  if (acceptHeader.includes('text/html')) {
+    return true;
+  }
+
+  // Default: API client (fetch()/XHR with Accept: */*, curl, no Accept at all)
+  return false;
+}
+
+/**
+ * The complement of {@link isBrowserNavigation}: true for anything that should
+ * be answered with a JSON status (401/403) rather than a redirect.
+ */
+export function isApiRequest(request: Request): boolean {
+  return !isBrowserNavigation(request);
+}

--- a/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
@@ -725,6 +725,55 @@ describe('ProxyMiddleware', () => {
       expect((res as any).redirect).not.toHaveBeenCalled();
     });
 
+    it('answers an anonymous fetch() caller with no Accept header with 401 JSON, never a redirect (#778)', async () => {
+      // An app's own fetch('/api/...') sends no Accept header (browser default */*)
+      // and Sec-Fetch-Mode: cors. A 302 here would be followed by fetch() into the
+      // login page's HTML with a 200 - the client never sees the 401 it keys on.
+      makePrivate();
+      const req = createMockRequest('/api/works', { accept: '*/*', 'sec-fetch-mode': 'cors' });
+      const res = createMockResponse();
+      (res as any).redirect = jest.fn();
+
+      const result = await (middleware as any).checkVisibilityAndAuth(
+        req,
+        res,
+        project,
+        'studio',
+        createMockRule({ pathPattern: '/api/*', proxyType: 'pipeline' }),
+      );
+
+      expect(result).toBe('blocked');
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: 'unauthorised' });
+      expect((res as any).redirect).not.toHaveBeenCalled();
+    });
+
+    it('still redirects an anonymous browser navigation to login', async () => {
+      makePrivate();
+      const req = createMockRequest('/api/works', {
+        accept: 'text/html,application/xhtml+xml,*/*;q=0.8',
+        'sec-fetch-mode': 'navigate',
+        'x-forwarded-proto': 'https',
+      });
+      (req as any).originalUrl = '/api/works';
+      (req as any).get = jest.fn().mockReturnValue('studio.example.com');
+      const res = createMockResponse();
+      (res as any).redirect = jest.fn();
+
+      const result = await (middleware as any).checkVisibilityAndAuth(
+        req,
+        res,
+        project,
+        'studio',
+        createMockRule({ pathPattern: '/api/*', proxyType: 'pipeline' }),
+      );
+
+      expect(result).toBe('blocked');
+      expect((res as any).redirect).toHaveBeenCalledTimes(1);
+      expect((res as any).redirect).toHaveBeenCalledWith(302, expect.stringContaining('/login'));
+      expect(res.status).not.toHaveBeenCalledWith(401);
+    });
+
     it('points an anonymous API caller at the resource metadata (RFC 9728) when the request came through a domain host', async () => {
       makePrivate();
       (mockVisibilityService as any).resolveAccessControlByDomain = jest

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -49,6 +49,7 @@ import {
   resolveRuleSetIdsForAlias as resolveRuleSetIdsForAliasShared,
 } from './rule-resolution';
 import { servesProtectedResourceDocument } from '../pipelines/mcp/protected-resource';
+import { isApiRequest } from '../common/request-kind';
 
 interface ParsedPublicPath {
   owner: string;
@@ -636,7 +637,9 @@ export class ProxyMiddleware implements NestMiddleware {
       // Not authenticated
       this.logger.debug(`Proxy blocked: not authenticated for private ${aliasName || 'project'}`);
 
-      if (this.isApiRequest(req)) {
+      // A bearer credential (an app token) is never a browser; otherwise the
+      // shared classifier decides (only a real navigation gets the redirect).
+      if (req.headers.authorization || isApiRequest(req)) {
         // RFC 9728 §5.1: tell a bearer client where the resource's OAuth metadata is
         // (a /.well-known rule — an `oauth_protected_resource` step or an app-shipped
         // document), so a connector can start its flow.
@@ -716,48 +719,6 @@ export class ProxyMiddleware implements NestMiddleware {
       'WWW-Authenticate',
       `Bearer resource_metadata="https://${host.split(',')[0].trim()}/.well-known/oauth-protected-resource"`,
     );
-  }
-
-  /**
-   * Determines if this is an API request (expects JSON response)
-   * vs a browser request (can handle redirects)
-   */
-  private isApiRequest(req: Request): boolean {
-    const acceptHeader = req.headers.accept || '';
-    const contentType = req.headers['content-type'] || '';
-
-    // XHR/fetch requests typically want JSON
-    if (acceptHeader.includes('application/json')) {
-      return true;
-    }
-
-    // Requests sending JSON are likely API calls
-    if (contentType.includes('application/json')) {
-      return true;
-    }
-
-    // X-Requested-With header indicates AJAX
-    if (req.headers['x-requested-with'] === 'XMLHttpRequest') {
-      return true;
-    }
-
-    // API key header indicates programmatic access
-    if (req.headers['x-api-key']) {
-      return true;
-    }
-
-    // A bearer credential (an app token) is never a browser: 401 JSON, not a redirect
-    if (req.headers.authorization) {
-      return true;
-    }
-
-    // Accept header starts with application/* (not text/html) suggests API client
-    if (acceptHeader.startsWith('application/') && !acceptHeader.includes('text/html')) {
-      return true;
-    }
-
-    // Default: treat as browser request
-    return false;
   }
 
   /**


### PR DESCRIPTION
Closes #778

## Summary
With `ENABLE_EMAIL_VERIFICATION=true`, an unverified user of the admin UI got a generic "request failed" error instead of being sent to the verification page. The backend decided the user's `fetch()` call was a "browser" (because it carried no `Accept: application/json`) and answered with a `302 /verify-email`; `fetch()` followed the redirect transparently, received the page's HTML with a 200, and the frontend's real handling (a `403` with `error: 'EMAIL_NOT_VERIFIED'`) never fired. Two middlewares had the same shape of mistake. This PR makes all four places that decide "browser or API caller?" use one shared classifier — the corrected one from #776 — so an SPA or app `fetch()` always gets a JSON status it can act on, and only a real top-level navigation gets a redirect.

## Behaviour changes
All additive/corrective; the browser-navigation path (`Sec-Fetch-Mode: navigate` or `Accept` naming `text/html`) is unchanged everywhere. Requests carrying `Accept: application/json`, a JSON body, `X-Requested-With: XMLHttpRequest`, or `X-API-Key` are unchanged everywhere (already API). What changes is the **default** — no `Accept`, or `Accept: */*` (the browser default for `fetch()`, `<script>`, `<img>`, curl):

- **`EmailVerificationGuard`** (global, unverified user): `302 /verify-email` → `403 { error: 'EMAIL_NOT_VERIFIED', ... }`. The admin SPA now lands on `/verify-email` via `baseQueryWithReauth` instead of showing an error.
- **`AuthMiddleware`** (every route; only fires when an `sAccessToken` / `bffless_access` cookie is present **and expired**): before, the request was let through as a "browser" for the downstream guard/controller; now it gets the early `401 { message: 'try refresh token' }`, unless it is a `/public/*` request on a public (or unknown) domain, which is still let through. Concretely:
  - `/api/*` admin routes: **no end-to-end change** — after #776 `SessionAuthGuard` already answered `401 try refresh token` for this profile; it is now short-circuited before SuperTokens middleware and the guard's DB lookup run.
  - proxy-rule routes on a private alias/domain: `302` to login → `401 try refresh token`. Clients keyed on the SuperTokens 401 format (the frontend, `use-bff-state`, app fetches) can refresh and retry instead of receiving login-page HTML.
  - `/public/*` on a **private** domain, non-navigation requests (the site's own scripts/images/fetches during the expired-token window): previously reached `PublicController` as anonymous and got the deployment's `unauthorizedBehavior` (404, or 302 to login); now `401 try refresh token`. Top-level navigations are unaffected and still get the controller's redirect/404, so a page reload still recovers.
- **`ProxyMiddleware`** (`checkVisibilityAndAuth`, private deployment, unauthenticated): `302` to the login URL → `401 { message: 'unauthorised' }` (or `try refresh token` when `AuthMiddleware` flagged an expired token), with the RFC 9728 `WWW-Authenticate: Bearer resource_metadata=...` hint when the request arrived via a domain host. An app's own `fetch('/api/...')` against a private alias now sees the 401 instead of following a redirect into HTML. The proxy-specific rule "a bearer `Authorization` header is never a browser" is kept as-is, in front of the shared classifier.
- **`SessionAuthGuard`**: no behaviour change — its classifier is the one that was lifted.

## Why
#776 fixed this classification in `SessionAuthGuard` after the CI reviewer found that the admin SPA's `fetchBaseQuery` sets no `Accept` header, so "default to browser" redirected exactly the caller that cannot use a redirect. The reviewer noted three sibling copies with the old default; #778 tracks them. Lifting the corrected version into one helper (rather than patching each copy) is what the issue asks for and what the review checklist entry from #776 warns about: private copies drift. The helper keeps the #776 semantics exactly, including the `X-API-Key` and `X-Requested-With` cases and "explicit API signals win over navigation hints".

## What changed
- backend: new `apps/backend/src/common/request-kind.ts` (`isBrowserNavigation` / `isApiRequest`); `auth/session-auth.guard.ts`, `auth/email-verification.guard.ts`, `auth/auth.middleware.ts`, `proxy-rules/proxy.middleware.ts` drop their private `isApiRequest` and import it.
- tests: new `common/request-kind.spec.ts`, `auth/email-verification.guard.spec.ts`, `auth/auth.middleware.spec.ts`; two cases added to `proxy-rules/proxy.middleware.spec.ts` (anonymous no-`Accept` fetch → 401 JSON; navigation → 302 login). `session-auth.guard.spec.ts` passes unchanged.

## Compatibility
- No migrations, env vars, nginx generation, storage layout, or CLI/Action contract touched.
- 401 body texts `unauthorised` / `try refresh token` and the `403 EMAIL_NOT_VERIFIED` body are preserved byte-for-byte (the frontend's `baseQueryWithReauth` keys on them).
- Pipeline/proxy-rule semantics: rule execution is untouched; only the pre-execution auth *response shape* for unauthenticated non-navigation callers on private deployments changes (302 → 401 JSON), which is the shape those callers are written to handle. Rules on public deployments are unaffected.

## Verification
```
pnpm --filter backend exec tsc --noEmit        # exit 0
pnpm --filter frontend exec tsc --noEmit       # exit 0
pnpm --filter backend format:check             # All matched files use Prettier code style!
cd apps/backend
pnpm test -- src/common/request-kind           # 1 suite, 10 passed
pnpm test -- src/auth                          # 16 suites, 175 passed
pnpm test -- src/proxy-rules                   # 17 suites, 445 passed (before the 2 added cases)
pnpm test -- src/proxy-rules/proxy.middleware.spec   # 44 passed (incl. the 2 new)
pnpm test -- src/auth/auth.middleware.spec src/auth/email-verification.guard.spec   # 19 passed
pnpm test                                      # 231 suites passed, 3978 tests passed (2 suites / 47 tests skipped, pre-existing)
```

## Out of scope / follow-ups
- `PublicController`'s own `unauthorizedBehavior: 'redirect_login'` still redirects any request kind (it never had an `isApiRequest` branch); if a private site's SPA `fetch()`es `/public/*` paths while logged out it still follows that redirect into HTML. Not part of #778; worth its own issue if it bites.
- `OptionalAuthGuard` swallows a `TRY_REFRESH_TOKEN` rejection as "anonymous"; `AuthMiddleware` now catches that case earlier for non-navigation callers, but a navigation with an expired token on a private domain still reaches the controller as anonymous (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NK2eaY4ZwmXRxifq22ELsV
