### PR TITLE
fix(oauth): defer every OAuthModule import with forwardRef; add two review-checklist entries

### DIFF
--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -323,10 +323,13 @@ then the downstream handler / `EmailVerificationGuard` on the same request objec
 the CI review before merge.
 
 ### A guard's "browser or API caller?" heuristic must default to API and match the bundled SPA's real headers
-**Surface:** `apps/backend/src/auth/session-auth.guard.ts` (`isApiRequest`) and any guard or middleware
-that branches response shape (401 JSON vs. redirect) on request headers — `email-verification.guard.ts`,
-`auth.middleware.ts`, `proxy.middleware.ts` carry sibling copies. The admin SPA's single `fetchBaseQuery`
-(`apps/frontend/src/services/api.ts`) sets no `Accept`, so its calls arrive as `Accept: */*`.
+**Surface:** `apps/backend/src/common/request-kind.ts` (`isApiRequest` / `isBrowserNavigation`) is the
+single classifier; `session-auth.guard.ts`, `email-verification.guard.ts`, `auth.middleware.ts` and
+`proxy.middleware.ts` import it (#783 removed their private copies). Any new guard, middleware or
+controller that branches response shape (401 JSON vs. redirect) on request headers must import it too —
+a diff that adds a private `isApiRequest`-style helper, or reads `Accept` to pick a redirect, is the thing
+to catch. The admin SPA's single `fetchBaseQuery` (`apps/frontend/src/services/api.ts`) sets no `Accept`,
+so its calls arrive as `Accept: */*`.
 **Check:** Does the "browser" branch require a positive navigation signal (`Sec-Fetch-Mode: navigate`,
 which browsers send only for top-level navigations and `fetch()`/XHR never do, or an `Accept` naming
 `text/html`), with everything else — bare `*/*`, no `Accept`, curl — treated as API? And does a spec

--- a/.claude/ce-pr-review-checklist.md
+++ b/.claude/ce-pr-review-checklist.md
@@ -342,6 +342,38 @@ classification branch live; the first cut redirected `Accept: */*` and replaced 
 
 ---
 
+### A Nest module cycle that only surfaces at boot passes every unit test
+**Surface:** any new `X` in a `@Module({ imports: [X] })` array under `apps/backend/src/*/*.module.ts`,
+especially a new cross-domain edge (PipelinesModule → OAuthModule in #761 was the one that bit).
+**Check:** Trace the CommonJS require order from `app.module.ts`: does the new edge close a cycle back to a
+module file that is still mid-evaluation? If so the referenced class is `undefined` when the decorator
+runs, and Nest refuses to boot with "The module at index [n] of the X imports array is undefined". The fix
+is `forwardRef(() => X)` on the edge inside the cycle. `apps/backend/src/app.module.spec.ts` walks every
+reachable imports array and fails on `undefined`; a PR that adds a module edge should leave it green and
+should not skip it. Unit suites that import one module in isolation never load enough of the graph to see
+this — CI was green for v0.4.52 and v0.4.53, both of which crash-looped on start.
+**Why:** The failure is total (the backend never listens), invisible in CI, and reaches self-hosters on the
+next `:latest` pull. #773 was the hotfix; v0.4.51 was the rollback target.
+**Learned from:** #761 → #773, 2026-09-07.
+
+---
+
+### A service-level spec that bypasses `ValidationPipe` can assert behaviour a DTO already forecloses
+**Surface:** any `*.service.spec.ts` that calls a service method directly with a hand-built DTO object,
+where the matching controller `@Body()` DTO carries `class-validator` rules (`IsValidTargetUrlOrPath`,
+`IsValidSyncTargetUrl`, `@ValidateNested`, …) and `main.ts` runs the global `ValidationPipe`.
+**Check:** When a PR claims a new behaviour at an HTTP endpoint ("under `warn` a plain-http target is now a
+warning, not a 400"), does a test exercise the *real* pipe — supertest with `main.ts`'s exact
+`ValidationPipe` options, as `oauth-register-http.spec.ts` and `proxy-rule-sets-target-guard-http.spec.ts`
+do — or only the service? A service spec can pass while asserting an outcome the endpoint can never
+produce, because the DTO rejected the payload first. Check the DTO before believing the PR body.
+**Why:** #782's first cut documented "push/import/copy now warn on plain-http targets" and shipped tests
+for it; the sync and import DTOs had always 400'd that payload, so the claim, the `.env.example` text and
+two tests were wrong until the reviewer traced the DTO.
+**Learned from:** #782, 2026-09-07.
+
+---
+
 ## Entry template
 
 ```

--- a/apps/backend/src/oauth/oauth.module.ts
+++ b/apps/backend/src/oauth/oauth.module.ts
@@ -8,10 +8,20 @@ import { PermissionsModule } from '../permissions/permissions.module';
 import { ProxyRulesModule } from '../proxy-rules/proxy-rules.module';
 
 @Module({
-  // forwardRef: ProxyRulesModule → PipelinesModule → OAuthModule (the
-  // oauth_protected_resource step names the issuer); RFC 8707 `resource`
-  // resolution reads that step's config through RuleInvokerService.
-  imports: [AppTokensModule, PermissionsModule, forwardRef(() => ProxyRulesModule)],
+  // forwardRef on every import: this module sits inside the require cycle
+  // app → … → projects → pipelines → oauth → app-tokens → projects (#773).
+  // Today AppTokensModule and PermissionsModule happen to be fully evaluated
+  // by the time this decorator runs, but that depends on AppModule's import
+  // order, which is reordered deliberately for route precedence. Deferring
+  // all three means no reordering can bake `undefined` into this array.
+  // ProxyRulesModule → PipelinesModule → OAuthModule is the original cycle
+  // (the oauth_protected_resource step names the issuer; RFC 8707
+  // `resource` resolution reads that step's config through RuleInvokerService).
+  imports: [
+    forwardRef(() => AppTokensModule),
+    forwardRef(() => PermissionsModule),
+    forwardRef(() => ProxyRulesModule),
+  ],
   controllers: [OAuthController, OAuthMetadataController],
   providers: [OAuthService, ClientMetadataService],
   exports: [OAuthService],


### PR DESCRIPTION
## OAuthModule

`OAuthModule` sits inside the CommonJS require cycle that crash-looped v0.4.52 / v0.4.53 at boot (`app → … → projects → pipelines → oauth → app-tokens → projects`, fixed in #773 by deferring `AppTokensModule`'s imports). Its own `AppTokensModule` and `PermissionsModule` imports are direct references that happen to be fully evaluated when the decorator runs — but only because of `AppModule`'s current import order, which `app.module.ts` reorders deliberately for route precedence. The #773 reviewer flagged this as the same latent pattern. All three imports are now `forwardRef`, with a comment recording the cycle. No runtime change once the graph resolves.

## Checklist entries (`.claude/ce-pr-review-checklist.md`)

Both proposed by the CI reviewer on the PRs they came from:

- **A Nest module cycle that only surfaces at boot passes every unit test** — trace the require order for any new `@Module({ imports })` edge; `app.module.spec.ts` is the guard. Learned from #761 → #773.
- **A service-level spec that bypasses `ValidationPipe` can assert behaviour a DTO already forecloses** — a claimed endpoint behaviour needs a supertest spec behind `main.ts`'s real pipe (`oauth-register-http.spec.ts`, `proxy-rule-sets-target-guard-http.spec.ts`). Learned from #782's first cut.

## Verification

- `pnpm --filter backend exec tsc --noEmit` — clean
- `jest src/app.module.spec.ts src/oauth` — 6 suites, 129 passed
- `pnpm --filter backend format:check` — clean
- `nest build` + `node dist/main.js` with stub env — passes the module scan, stops at the expected `JWT_SECRET` check

## Compatibility

No schema, env var, route, nginx, storage, CLI, or Action surface touched.

Refs #773, #782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NK2eaY4ZwmXRxifq22ELsV
