### PR TITLE
feat(pipelines): projectRole on PipelineUser — the caller's project role, resolved on every credential path

### DIFF
--- a/apps/backend/src/permissions/permissions.service.spec.ts
+++ b/apps/backend/src/permissions/permissions.service.spec.ts
@@ -898,4 +898,65 @@ describe('PermissionsService', () => {
       expect(m.ownerEmail).toBeNull();
     });
   });
+
+  describe('getEffectiveProjectRole', () => {
+    it('returns the direct project role for a global user', async () => {
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        limit: jest
+          .fn()
+          .mockResolvedValue([{ role: 'contributor', userId: 'u1', projectId: mockProjectId }]),
+      });
+
+      const result = await service.getEffectiveProjectRole(
+        { id: 'u1', role: 'user' },
+        mockProjectId,
+      );
+
+      expect(result).toBe('contributor');
+    });
+
+    it('treats a global admin as owner on every project without querying the db', async () => {
+      const result = await service.getEffectiveProjectRole(
+        { id: 'u1', role: 'admin' },
+        mockProjectId,
+      );
+
+      expect(result).toBe('owner');
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when the user has no role on the project', async () => {
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockResolvedValue([]),
+      });
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue([]),
+      });
+
+      const result = await service.getEffectiveProjectRole(
+        { id: 'u1', role: 'user' },
+        mockProjectId,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined (never throws) when the lookup fails', async () => {
+      (db.select as jest.Mock).mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockRejectedValue(new Error('connection lost')),
+      });
+
+      const result = await service.getEffectiveProjectRole({ id: 'u1' }, mockProjectId);
+
+      expect(result).toBeUndefined();
+    });
+  });
 });

--- a/apps/backend/src/permissions/permissions.service.ts
+++ b/apps/backend/src/permissions/permissions.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Injectable, ForbiddenException, NotFoundException, Logger } from '@nestjs/common';
 import { eq, and, sql, inArray } from 'drizzle-orm';
 import { db } from '../db/client';
 import {
@@ -85,6 +85,29 @@ function pickPrimaryUrl(rows: DomainMappingRow[]): string | null {
 
 @Injectable()
 export class PermissionsService {
+  private readonly logger = new Logger(PermissionsService.name);
+
+  /**
+   * The role `user` effectively holds on `projectId`: a global `admin` is `owner` on every
+   * project (the rule ProjectPermissionGuard applies), otherwise the highest of the direct and
+   * group rows (`getUserProjectRole`). Never throws — `undefined` on no role or on a failed lookup.
+   */
+  async getEffectiveProjectRole(
+    user: { id: string; role?: string },
+    projectId: string,
+  ): Promise<ProjectRole | undefined> {
+    // Global admins act as project owners on every project (project-permission.guard.ts).
+    // The API-key paths never carry `admin` (pinned to `user`, or no role at all), so a
+    // leaked key cannot widen through this line.
+    if (user.role === 'admin') return 'owner';
+    try {
+      return (await this.getUserProjectRole(user.id, projectId)) ?? undefined;
+    } catch (error) {
+      this.logger.warn(`Project role lookup failed for ${user.id} on ${projectId}: ${error}`);
+      return undefined;
+    }
+  }
+
   /**
    * Get user's effective role on a project
    * Checks direct user permission first, then group permissions

--- a/apps/backend/src/permissions/permissions.service.ts
+++ b/apps/backend/src/permissions/permissions.service.ts
@@ -97,8 +97,11 @@ export class PermissionsService {
     projectId: string,
   ): Promise<ProjectRole | undefined> {
     // Global admins act as project owners on every project (project-permission.guard.ts).
-    // The API-key paths never carry `admin` (pinned to `user`, or no role at all), so a
-    // leaked key cannot widen through this line.
+    // `X-API-Key` and guard-issued app tokens (requestUserFromAppToken(..., { pinRoleLikeApiKey: true }))
+    // are pinned to `user` (or carry no role), so a leaked key or guard-issued token cannot widen
+    // through this line. An app token presented directly to the proxy (getOptionalUser's Bearer
+    // branch) is NOT pinned — it carries the member's real global role, so a global admin's own
+    // token resolves to `owner` here, same standing as that admin's session would have.
     if (user.role === 'admin') return 'owner';
     try {
       return (await this.getUserProjectRole(user.id, projectId)) ?? undefined;

--- a/apps/backend/src/pipelines/dto/test-pipeline.dto.spec.ts
+++ b/apps/backend/src/pipelines/dto/test-pipeline.dto.spec.ts
@@ -1,0 +1,26 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { MockUserDto } from './test-pipeline.dto';
+
+describe('MockUserDto.projectRole', () => {
+  it('accepts a valid ProjectRole value', async () => {
+    const dto = plainToInstance(MockUserDto, { id: 'mock-user-123', projectRole: 'contributor' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects a value outside the ProjectRole union', async () => {
+    const dto = plainToInstance(MockUserDto, { id: 'mock-user-123', projectRole: 'superuser' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('projectRole');
+  });
+
+  it('leaves projectRole undefined when absent', async () => {
+    const dto = plainToInstance(MockUserDto, { id: 'mock-user-123' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+    expect(dto.projectRole).toBeUndefined();
+  });
+});

--- a/apps/backend/src/pipelines/dto/test-pipeline.dto.ts
+++ b/apps/backend/src/pipelines/dto/test-pipeline.dto.ts
@@ -9,6 +9,9 @@ import {
   IsArray,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import type { ProjectRole } from '../../permissions/permissions.service';
+
+const PROJECT_ROLES: ProjectRole[] = ['owner', 'admin', 'contributor', 'viewer', 'guest'];
 
 /**
  * Mock user configuration for testing pipelines
@@ -50,10 +53,11 @@ export class MockUserDto {
   @ApiPropertyOptional({
     description: "Project role to simulate (the caller's role on this project)",
     example: 'contributor',
+    enum: PROJECT_ROLES,
   })
   @IsOptional()
-  @IsString()
-  projectRole?: string;
+  @IsIn(PROJECT_ROLES)
+  projectRole?: ProjectRole;
 }
 
 export class TestPipelineDto {

--- a/apps/backend/src/pipelines/dto/test-pipeline.dto.ts
+++ b/apps/backend/src/pipelines/dto/test-pipeline.dto.ts
@@ -46,6 +46,14 @@ export class MockUserDto {
   @IsArray()
   @IsString({ each: true })
   groups?: string[];
+
+  @ApiPropertyOptional({
+    description: "Project role to simulate (the caller's role on this project)",
+    example: 'contributor',
+  })
+  @IsOptional()
+  @IsString()
+  projectRole?: string;
 }
 
 export class TestPipelineDto {

--- a/apps/backend/src/pipelines/execution/expression-evaluator.spec.ts
+++ b/apps/backend/src/pipelines/execution/expression-evaluator.spec.ts
@@ -20,3 +20,27 @@ describe('ExpressionEvaluator built-in time functions', () => {
     expect(value as number).toBeLessThanOrEqual(Date.now());
   });
 });
+
+describe('ExpressionEvaluator user.projectRole', () => {
+  const evaluator = new ExpressionEvaluator();
+
+  it('reads user.projectRole off the pipeline user', () => {
+    const withRole = {
+      user: { id: 'u1', projectRole: 'owner' },
+      stepOutputs: {},
+      metadata: {},
+      projectId: 'p',
+      pipelineId: 'x',
+    } as unknown as PipelineContext;
+    expect(evaluator.evaluateExpression('user.projectRole', withRole)).toBe('owner');
+
+    const withoutRole = {
+      user: { id: 'u1' },
+      stepOutputs: {},
+      metadata: {},
+      projectId: 'p',
+      pipelineId: 'x',
+    } as unknown as PipelineContext;
+    expect(evaluator.evaluateExpression('user.projectRole', withoutRole)).toBeUndefined();
+  });
+});

--- a/apps/backend/src/pipelines/execution/pipeline-context.interface.ts
+++ b/apps/backend/src/pipelines/execution/pipeline-context.interface.ts
@@ -1,4 +1,5 @@
 import { Request } from 'express';
+import type { ProjectRole } from '../../permissions/permissions.service';
 
 /**
  * User information available in pipeline context
@@ -15,6 +16,14 @@ export interface PipelineUser {
   scopes?: string[];
   /** Present only for app tokens: the project the token is bound to. */
   tokenProjectId?: string;
+  /**
+   * The caller's role on the PIPELINE's project (`project_permissions`, direct or
+   * via a group; a global `admin` is `owner` on every project, as
+   * ProjectPermissionGuard rules). Absent when the caller holds no role there or
+   * the lookup failed. Orthogonal to `role` (the global role) and to the API-key
+   * pinning: an API key's user resolves through their own permission rows.
+   */
+  projectRole?: ProjectRole;
 }
 
 /**

--- a/apps/backend/src/pipelines/execution/pipeline-context.interface.ts
+++ b/apps/backend/src/pipelines/execution/pipeline-context.interface.ts
@@ -22,6 +22,11 @@ export interface PipelineUser {
    * ProjectPermissionGuard rules). Absent when the caller holds no role there or
    * the lookup failed. Orthogonal to `role` (the global role) and to the API-key
    * pinning: an API key's user resolves through their own permission rows.
+   *
+   * This is a fact about the USER on this project, not about the credential
+   * presenting them — it says nothing about what the credential itself was
+   * scoped or delegated to do. A rule that cares about delegation must also
+   * read `credential`, `scopes`, and `tokenProjectId`.
    */
   projectRole?: ProjectRole;
 }

--- a/apps/backend/src/pipelines/execution/step-handler.interface.ts
+++ b/apps/backend/src/pipelines/execution/step-handler.interface.ts
@@ -305,7 +305,8 @@ export interface FunctionHandlerConfig extends BaseHandlerConfig {
    * The code should return the transformed data.
    * Available variables:
    * - data.input: The pipeline input
-   * - data.user: Current user info (id, email, role) if authenticated
+   * - data.user: id, email, role, groups, and — when present — credential,
+   *   scopes, projectRole (the caller's role on this project), if authenticated
    * - data.request: Request info (method, path, query)
    * - data.steps: Output from previous steps (keyed by step name)
    */

--- a/apps/backend/src/pipelines/handlers/function.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/function.handler.spec.ts
@@ -115,7 +115,7 @@ describe('FunctionHandler.execute — user.credential / user.scopes (app tokens)
   });
 });
 
-describe('FunctionHandler.execute — user.projectRole (spec 11)', () => {
+describe('FunctionHandler.execute — user.projectRole', () => {
   it('exposes the project role', async () => {
     const { handler, runnerMock } = createHandler();
     runnerMock.run.mockResolvedValue({ success: true, output: {}, executionTime: 1, logs: [] });

--- a/apps/backend/src/pipelines/handlers/function.handler.spec.ts
+++ b/apps/backend/src/pipelines/handlers/function.handler.spec.ts
@@ -114,3 +114,32 @@ describe('FunctionHandler.execute — user.credential / user.scopes (app tokens)
     expect(data.user).not.toHaveProperty('scopes');
   });
 });
+
+describe('FunctionHandler.execute — user.projectRole (spec 11)', () => {
+  it('exposes the project role', async () => {
+    const { handler, runnerMock } = createHandler();
+    runnerMock.run.mockResolvedValue({ success: true, output: {}, executionTime: 1, logs: [] });
+    const context = makeContext({
+      user: { id: 'u1', role: 'user', projectRole: 'admin' },
+    });
+
+    await handler.execute(context, makeStep({ code: 'export default () => ({})' }));
+
+    expect(runnerMock.run).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ user: expect.objectContaining({ projectRole: 'admin' }) }),
+      expect.anything(),
+    );
+  });
+
+  it('adds nothing without one', async () => {
+    const { handler, runnerMock } = createHandler();
+    runnerMock.run.mockResolvedValue({ success: true, output: {}, executionTime: 1, logs: [] });
+    const context = makeContext({ user: { id: 'u1', role: 'user' } });
+
+    await handler.execute(context, makeStep({ code: 'export default () => ({})' }));
+
+    const data = runnerMock.run.mock.calls[0][1] as { user: Record<string, unknown> };
+    expect(data.user).not.toHaveProperty('projectRole');
+  });
+});

--- a/apps/backend/src/pipelines/handlers/function.handler.ts
+++ b/apps/backend/src/pipelines/handlers/function.handler.ts
@@ -79,6 +79,7 @@ export class FunctionHandler implements StepHandler<FunctionHandlerConfig> {
             // App tokens: what the credential was delegated (absent for sessions/keys).
             ...(context.user.credential ? { credential: context.user.credential } : {}),
             ...(context.user.scopes ? { scopes: context.user.scopes } : {}),
+            ...(context.user.projectRole ? { projectRole: context.user.projectRole } : {}),
           }
         : undefined,
       request: {

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
@@ -23,7 +23,10 @@ describe('ProxyRulesController', () => {
     getCountByRuleId: jest.Mock;
     deleteByRuleId: jest.Mock;
   };
-  let mockPermissionsService: { requireProjectAccess: jest.Mock };
+  let mockPermissionsService: {
+    requireProjectAccess: jest.Mock;
+    getEffectiveProjectRole: jest.Mock;
+  };
 
   const mockRuleSet = { id: 'rule-set-1', projectId: 'project-1' };
 
@@ -95,7 +98,10 @@ describe('ProxyRulesController', () => {
       deleteByRuleId: jest.fn().mockResolvedValue(undefined),
     };
 
-    mockPermissionsService = { requireProjectAccess: jest.fn().mockResolvedValue(undefined) };
+    mockPermissionsService = {
+      requireProjectAccess: jest.fn().mockResolvedValue(undefined),
+      getEffectiveProjectRole: jest.fn().mockResolvedValue(undefined),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ProxyRulesController],
@@ -416,6 +422,73 @@ describe('ProxyRulesController', () => {
         expect.objectContaining({ id: 'user-1', groups: [] }),
         expect.anything(),
       );
+    });
+
+    it('passes mockUser.projectRole through to executePipelineWithDebug', async () => {
+      mockProxyRulesService.getRuleById.mockResolvedValue(createMockPipelineRule());
+
+      await controller.testPipelineRule(
+        'rule-1',
+        {
+          mockUser: {
+            id: 'mock-user-1',
+            email: 'mock@example.com',
+            role: 'user',
+            projectRole: 'contributor',
+          },
+        },
+        mockUser,
+        { file: undefined } as any,
+      );
+
+      expect(mockPipelineExecutionService.executePipelineWithDebug).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ id: 'mock-user-1', projectRole: 'contributor' }),
+        expect.anything(),
+      );
+    });
+
+    it("resolves the real caller's projectRole (contributor) for the test run", async () => {
+      mockProxyRulesService.getRuleById.mockResolvedValue(createMockPipelineRule());
+      mockPermissionsService.getEffectiveProjectRole.mockResolvedValue('contributor');
+
+      await controller.testPipelineRule('rule-1', {}, mockUser, { file: undefined } as any);
+
+      expect(mockPermissionsService.getEffectiveProjectRole).toHaveBeenCalledWith(
+        mockUser,
+        'project-1',
+      );
+      expect(mockPipelineExecutionService.executePipelineWithDebug).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ id: 'user-1', projectRole: 'contributor' }),
+        expect.anything(),
+      );
+    });
+
+    it('a global admin tests as owner', async () => {
+      mockProxyRulesService.getRuleById.mockResolvedValue(createMockPipelineRule());
+      mockPermissionsService.getEffectiveProjectRole.mockResolvedValue('owner');
+
+      await controller.testPipelineRule('rule-1', {}, mockUser, { file: undefined } as any);
+
+      expect(mockPipelineExecutionService.executePipelineWithDebug).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ id: 'user-1', projectRole: 'owner' }),
+        expect.anything(),
+      );
+    });
+
+    it('degrades to no projectRole when the lookup fails', async () => {
+      mockProxyRulesService.getRuleById.mockResolvedValue(createMockPipelineRule());
+      mockPermissionsService.getEffectiveProjectRole.mockResolvedValue(undefined);
+
+      await controller.testPipelineRule('rule-1', {}, mockUser, { file: undefined } as any);
+
+      const testUserArg = mockPipelineExecutionService.executePipelineWithDebug.mock.calls[0][2];
+      expect(testUserArg).not.toHaveProperty('projectRole');
     });
 
     // "Test" must load skills from the same deployment production would, or a

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.spec.ts
@@ -481,7 +481,7 @@ describe('ProxyRulesController', () => {
       );
     });
 
-    it('degrades to no projectRole when the lookup fails', async () => {
+    it('omits projectRole when the resolver answers undefined', async () => {
       mockProxyRulesService.getRuleById.mockResolvedValue(createMockPipelineRule());
       mockPermissionsService.getEffectiveProjectRole.mockResolvedValue(undefined);
 

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.ts
@@ -37,7 +37,7 @@ import { PipelineUser } from '../pipelines/execution/pipeline-context.interface'
 import { DeploymentsService } from '../deployments/deployments.service';
 import { ProjectsService } from '../projects/projects.service';
 import { UserGroupsService } from '../user-groups/user-groups.service';
-import { PermissionsService, ProjectRole } from '../permissions/permissions.service';
+import { PermissionsService } from '../permissions/permissions.service';
 
 /**
  * Controller for individual proxy rule operations.
@@ -314,9 +314,7 @@ export class ProxyRulesController {
           email: dto.mockUser.email,
           role: dto.mockUser.role,
           groups: dto.mockUser.groups,
-          ...(dto.mockUser.projectRole
-            ? { projectRole: dto.mockUser.projectRole as ProjectRole }
-            : {}),
+          ...(dto.mockUser.projectRole ? { projectRole: dto.mockUser.projectRole } : {}),
         };
       } else {
         // Enrich with the real user's group memberships and their role on this

--- a/apps/backend/src/proxy-rules/proxy-rules.controller.ts
+++ b/apps/backend/src/proxy-rules/proxy-rules.controller.ts
@@ -37,7 +37,7 @@ import { PipelineUser } from '../pipelines/execution/pipeline-context.interface'
 import { DeploymentsService } from '../deployments/deployments.service';
 import { ProjectsService } from '../projects/projects.service';
 import { UserGroupsService } from '../user-groups/user-groups.service';
-import { PermissionsService } from '../permissions/permissions.service';
+import { PermissionsService, ProjectRole } from '../permissions/permissions.service';
 
 /**
  * Controller for individual proxy rule operations.
@@ -314,11 +314,17 @@ export class ProxyRulesController {
           email: dto.mockUser.email,
           role: dto.mockUser.role,
           groups: dto.mockUser.groups,
+          ...(dto.mockUser.projectRole
+            ? { projectRole: dto.mockUser.projectRole as ProjectRole }
+            : {}),
         };
       } else {
-        // Enrich with the real user's group memberships so pipeline conditions
-        // gated on user.groups can be exercised from the test endpoint. Group
-        // lookup must never take the test down: on failure, degrade to "no groups".
+        // Enrich with the real user's group memberships and their role on this
+        // rule set's project, so pipeline conditions gated on user.groups or
+        // user.projectRole can be exercised from the test endpoint the same way
+        // they would in production. Neither lookup must ever take the test down:
+        // group lookup degrades to "no groups", project role to "absent" (see
+        // PermissionsService.getEffectiveProjectRole).
         let groups: string[] = [];
         try {
           groups = await this.userGroupsService.getGroupIdsForUser(user.id);
@@ -326,11 +332,16 @@ export class ProxyRulesController {
           this.logger.warn(`Group membership lookup failed for ${user.id}: ${error}`);
           groups = [];
         }
+        const projectRole = await this.permissionsService.getEffectiveProjectRole(
+          user,
+          ruleSet.projectId,
+        );
         testUser = {
           id: user.id,
           email: user.email,
           role: user.role,
           groups,
+          ...(projectRole ? { projectRole } : {}),
         };
       }
     }

--- a/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
@@ -1104,7 +1104,7 @@ describe('ProxyMiddleware', () => {
     });
   });
 
-  describe('handlePipelineExecution — projectRole (spec 11, D27)', () => {
+  describe("handlePipelineExecution — projectRole (the caller's role on the pipeline's project)", () => {
     const pipelineRule = (overrides: Record<string, unknown> = {}) =>
       createMockRule({
         proxyType: 'pipeline',
@@ -1183,6 +1183,28 @@ describe('ProxyMiddleware', () => {
       );
       const [, , passedUser] = mockPipelineExecutionService.executePipelineWithDebug.mock.calls[0];
       expect(passedUser).not.toHaveProperty('projectRole');
+    });
+
+    it('never resolves projectRole for an anonymous pipeline request, and still runs the pipeline', async () => {
+      jest.spyOn(middleware as any, 'getOptionalUser').mockResolvedValue(undefined);
+      const req = createMockRequest('/public/owner/repo/sha123/api/items');
+      const res = createPipelineResponse();
+
+      await (middleware as any).handlePipelineExecution(
+        req,
+        res,
+        pipelineRule(),
+        'proj-1',
+        undefined,
+      );
+
+      expect(mockPermissionsService.getEffectiveProjectRole).not.toHaveBeenCalled();
+      expect(mockPipelineExecutionService.executePipelineWithDebug).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        expect.anything(),
+      );
     });
   });
 });

--- a/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.spec.ts
@@ -83,6 +83,7 @@ describe('ProxyMiddleware', () => {
     mockPermissionsService = {
       getUserProjectRole: jest.fn().mockResolvedValue(null),
       meetsRoleRequirement: jest.fn().mockReturnValue(true),
+      getEffectiveProjectRole: jest.fn().mockResolvedValue(undefined),
     } as any;
 
     mockTrafficRoutingService = {
@@ -1100,6 +1101,88 @@ describe('ProxyMiddleware', () => {
           message: 'stream died',
         });
       });
+    });
+  });
+
+  describe('handlePipelineExecution — projectRole (spec 11, D27)', () => {
+    const pipelineRule = (overrides: Record<string, unknown> = {}) =>
+      createMockRule({
+        proxyType: 'pipeline',
+        targetUrl: 'pipeline',
+        pipelineConfig: {
+          name: 'test',
+          steps: [{ name: 'respond', handlerType: 'response_handler', config: {} }],
+        },
+        debugEnabled: true,
+        ...overrides,
+      });
+
+    const createPipelineResponse = (): Response & { headersSent: boolean } =>
+      ({
+        headersSent: false,
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+        send: jest.fn(),
+        setHeader: jest.fn(),
+        end: jest.fn(),
+      }) as unknown as Response & { headersSent: boolean };
+
+    it('enriches the pipeline user with projectRole resolved against the PIPELINE project', async () => {
+      jest.spyOn(middleware as any, 'getOptionalUser').mockResolvedValue({
+        id: 'u1',
+        role: 'user',
+        credential: 'session',
+      });
+      mockPermissionsService.getEffectiveProjectRole.mockResolvedValue('contributor');
+      const req = createMockRequest('/public/owner/repo/sha123/api/items');
+      const res = createPipelineResponse();
+
+      await (middleware as any).handlePipelineExecution(
+        req,
+        res,
+        pipelineRule(),
+        'proj-1',
+        undefined,
+      );
+
+      expect(mockPermissionsService.getEffectiveProjectRole).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'u1', role: 'user' }),
+        'proj-1',
+      );
+      expect(mockPipelineExecutionService.executePipelineWithDebug).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ id: 'u1', projectRole: 'contributor', groups: [] }),
+        expect.anything(),
+      );
+    });
+
+    it('leaves projectRole absent (not undefined-valued) when the resolver answers undefined', async () => {
+      jest.spyOn(middleware as any, 'getOptionalUser').mockResolvedValue({
+        id: 'u1',
+        role: 'user',
+        credential: 'session',
+      });
+      mockPermissionsService.getEffectiveProjectRole.mockResolvedValue(undefined);
+      const req = createMockRequest('/public/owner/repo/sha123/api/items');
+      const res = createPipelineResponse();
+
+      await (middleware as any).handlePipelineExecution(
+        req,
+        res,
+        pipelineRule(),
+        'proj-1',
+        undefined,
+      );
+
+      expect(mockPipelineExecutionService.executePipelineWithDebug).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ id: 'u1', groups: [] }),
+        expect.anything(),
+      );
+      const [, , passedUser] = mockPipelineExecutionService.executePipelineWithDebug.mock.calls[0];
+      expect(passedUser).not.toHaveProperty('projectRole');
     });
   });
 });

--- a/apps/backend/src/proxy-rules/proxy.middleware.ts
+++ b/apps/backend/src/proxy-rules/proxy.middleware.ts
@@ -1111,19 +1111,20 @@ export class ProxyMiddleware implements NestMiddleware {
       // Extract user from session if available (optional - don't fail if not authenticated)
       user = await this.getOptionalUser(req, res);
 
-      // Enrich with group memberships for the sandboxed pipeline context. Group
-      // lookup must never take the request down: on failure, degrade to "no groups".
+      // Enrich with group memberships and the caller's role on the PIPELINE's
+      // project for the sandboxed pipeline context. Neither lookup must ever
+      // take the request down: group lookup degrades to "no groups", project
+      // role degrades to "absent" (see PermissionsService.getEffectiveProjectRole).
       let pipelineUser: PipelineUser | undefined = user;
       if (user) {
+        let groups: string[] = [];
         try {
-          pipelineUser = {
-            ...user,
-            groups: await this.userGroupsService.getGroupIdsForUser(user.id),
-          };
+          groups = await this.userGroupsService.getGroupIdsForUser(user.id);
         } catch (error) {
           this.logger.warn(`Group membership lookup failed for ${user.id}: ${error}`);
-          pipelineUser = { ...user, groups: [] };
         }
+        const projectRole = await this.permissionsService.getEffectiveProjectRole(user, projectId);
+        pipelineUser = { ...user, groups, ...(projectRole ? { projectRole } : {}) };
       }
 
       // Execute the pipeline with deployment context for skills access


### PR DESCRIPTION
## What

`PipelineUser` gains one optional, derived field — `projectRole` — the caller's role on the **pipeline's** project (`owner | admin | contributor | viewer | guest`), resolved once per pipeline request and readable in expressions (`user.projectRole`) and in `function_handler` code (`data.user.projectRole`). Absent when the caller holds no role there.

## Why

Only the *global* role (`admin | user | member`) reached a pipeline. "Admin of this project" was not expressible in a rule, and the credential paths disagree about the global role by design (a session and an app token carry the real one; an `X-API-Key` caller gets none on the guard path and a pinned `user` on the middleware path). A project role is a project fact, orthogonal to that pinning, and every install can use it.

## How

- `PermissionsService.getEffectiveProjectRole(user, projectId)` — one resolver, two call sites: a global `admin` is `owner` on every project (the rule `ProjectPermissionGuard` already applies), otherwise the highest of the direct and group rows. Never throws: `undefined` on no role or on a failed lookup.
- `ProxyMiddleware.handlePipelineExecution` resolves it in the existing groups-enrichment block, against the pipeline's `projectId` (never a token's or key's), spread conditionally so a caller without a role has no `projectRole` key.
- `function_handler` projects it into the sandbox (conditional spread, like `credential`/`scopes`).
- The "test this rule" endpoint resolves it the same way for the real caller and accepts `mockUser.projectRole`.

Generic: CE learns nothing about any app. No schema change, no migration. Backwards compatible: rules that do not read the field see no change.

## Tests

`permissions.service.spec` (4 resolver cases incl. admin short-circuit with no db query, and a rejecting lookup), `proxy.middleware.spec` (enrichment; absent-key assertion), `function.handler.spec`, `expression-evaluator.spec` (`user.projectRole` resolves; missing leaf is `undefined`), `proxy-rules.controller.spec` (mock + real caller + degrade). `tsc --noEmit` and `format:check` clean.

Spec: bffless/apps `apps/workflow/docs/spec/11-run-ownership.md` §"Why `projectRole`, and why it needs CE" (the first consumer; the field itself is app-agnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xri41RaipgS3PE2QUyHKCA
