### PR TITLE
fix(frontend): show the selected handler type label in the pipeline step picker

### DIFF
--- a/apps/frontend/src/components/pipelines/PipelineConfig.terminalBranches.test.tsx
+++ b/apps/frontend/src/components/pipelines/PipelineConfig.terminalBranches.test.tsx
@@ -202,6 +202,28 @@ describe('PipelineConfig terminal response branches', () => {
     expect(steps.map((s) => s.name)).toEqual(['maybe_reply', 'log']);
   });
 
+  it('labels the handler type of a non-trailing response handler', () => {
+    const config: Partial<PipelineConfigData> = {
+      name: 'early_responder',
+      steps: [
+        { name: 'prep', handlerType: 'function_handler', config: { code: 'return 1;' } },
+        {
+          name: 'refuse',
+          handlerType: 'response_handler',
+          config: { condition: 'steps.prep.notOk', status: 400, body: '{}' },
+        },
+        { name: 'log', handlerType: 'function_handler', config: { code: 'return 1;' } },
+      ],
+    };
+    render(<PipelineConfig config={config} onChange={vi.fn()} projectId="p1" />);
+
+    fireEvent.click(header('refuse'));
+
+    // Used to render blank: response_handler has no item in the handler picker.
+    const trigger = screen.getByRole('combobox', { name: 'Handler Type' });
+    expect(trigger).toHaveTextContent(/^HTTP Response$/);
+  });
+
   it('still clears a single terminal step via the type dropdown', () => {
     const onChange = vi.fn();
     const single: Partial<PipelineConfigData> = {

--- a/apps/frontend/src/components/pipelines/PipelineConfig.tsx
+++ b/apps/frontend/src/components/pipelines/PipelineConfig.tsx
@@ -120,13 +120,22 @@ const HANDLER_GROUPS: { label: string; types: HandlerType[] }[] = [
 
 function HandlerTypeSelectContent({
   unsupported,
+  current,
 }: {
   /** Map of handler type → reason it's disabled (e.g. storage backend can't presign) */
   unsupported?: Partial<Record<HandlerType, string>>;
+  /** The step's current type. Terminal types (response/proxy) aren't offered in the
+   *  picker, but a non-trailing one still sits in this list, so it needs an item or
+   *  Radix has nothing to mark selected. */
+  current?: HandlerType;
 }) {
+  const groups =
+    current && !HANDLER_GROUPS.some((g) => g.types.includes(current))
+      ? [...HANDLER_GROUPS, { label: 'Current', types: [current] }]
+      : HANDLER_GROUPS;
   return (
     <>
-      {HANDLER_GROUPS.map((group, i) => (
+      {groups.map((group, i) => (
         <Fragment key={group.label}>
           {i > 0 && <SelectSeparator />}
           <SelectGroup>
@@ -772,10 +781,15 @@ export function PipelineConfig({
                               }}
                             >
                               <SelectTrigger id={`step-${key}-type`}>
-                                <SelectValue />
+                                {/* Explicit label: the item body is a two-line name + description
+                                    that Radix would otherwise mirror (clamped) into the trigger. */}
+                                <SelectValue>{getHandlerDisplayName(step.handlerType)}</SelectValue>
                               </SelectTrigger>
                               <SelectContent className="max-h-[400px]">
-                                <HandlerTypeSelectContent unsupported={unsupportedHandlers} />
+                                <HandlerTypeSelectContent
+                                  unsupported={unsupportedHandlers}
+                                  current={step.handlerType}
+                                />
                               </SelectContent>
                             </Select>
                           </div>
@@ -1278,10 +1292,13 @@ data: {"type":"text-delta","value":" world"}
                               }}
                             >
                               <SelectTrigger id={`post-step-${key}-type`}>
-                                <SelectValue />
+                                <SelectValue>{getHandlerDisplayName(step.handlerType)}</SelectValue>
                               </SelectTrigger>
                               <SelectContent className="max-h-[400px]">
-                                <HandlerTypeSelectContent unsupported={unsupportedHandlers} />
+                                <HandlerTypeSelectContent
+                                  unsupported={unsupportedHandlers}
+                                  current={step.handlerType}
+                                />
                               </SelectContent>
                             </Select>
                           </div>


### PR DESCRIPTION
## Problem
In the proxy-rule pipeline editor's step **Handler Type** select:

1. **Blank value for a mid-pipeline HTTP Response step.** A `response_handler` (or `proxy_forward`) that isn't in the trailing terminal run stays in the regular steps list (by design since #502), but those types aren't in `HANDLER_GROUPS`. Radix finds no matching item and renders an empty trigger — inviting the user to "fix" it by picking another type, which resets the step config.
2. **Selected value centred and truncated** (e.g. `Register Upload...`). The item body is a two-line name + description; Radix mirrors all of it into the trigger, where `[&>span]:line-clamp-1` squashes it.

## Fix
- `<SelectValue>{getHandlerDisplayName(step.handlerType)}</SelectValue>` on both the step and post-step pickers — the trigger shows just the name.
- `HandlerTypeSelectContent` takes a `current` type and appends it (under a "Current" label) when it isn't otherwise offered, so the open list marks it selected. Terminal types still aren't offered for new steps.

## Compatibility
Frontend-only, no config/wire changes.

## Tests
- New regression test in `PipelineConfig.terminalBranches.test.tsx` (fails on `main`, passes here).
- `vitest` pipeline suites 17/17, `tsc --noEmit` clean, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QjUMuSKLhbBrQzvztqk1N
